### PR TITLE
[Docs] See cq #3396 Camel 3.13.x remove cq bits

### DIFF
--- a/components/camel-activemq/src/main/docs/activemq-component.adoc
+++ b/components/camel-activemq/src/main/docs/activemq-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/activemq.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: activemq
 

--- a/components/camel-ahc-ws/src/main/docs/ahc-ws-component.adoc
+++ b/components/camel-ahc-ws/src/main/docs/ahc-ws-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.14
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ahc-ws.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ahc-ws
 

--- a/components/camel-ahc/src/main/docs/ahc-component.adoc
+++ b/components/camel-ahc/src/main/docs/ahc-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.8
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ahc.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ahc
 

--- a/components/camel-amqp/src/main/docs/amqp-component.adoc
+++ b/components/camel-amqp/src/main/docs/amqp-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.2
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/amqp.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: amqp
 

--- a/components/camel-any23/src/main/docs/any23-dataformat.adoc
+++ b/components/camel-any23/src/main/docs/any23-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Extract RDF data from HTML documents.
 :since: 3.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/any23.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: any23
 

--- a/components/camel-arangodb/src/main/docs/arangodb-component.adoc
+++ b/components/camel-arangodb/src/main/docs/arangodb-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.5
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/arangodb.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: arangodb
 

--- a/components/camel-as2/camel-as2-component/src/main/docs/as2-component.adoc
+++ b/components/camel-as2/camel-as2-component/src/main/docs/as2-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.22
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/as2.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: as2
 

--- a/components/camel-asn1/src/main/docs/asn1-dataformat.adoc
+++ b/components/camel-asn1/src/main/docs/asn1-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Encode and decode data structures using Abstract Syntax Notation One (ASN.1).
 :since: 2.20
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/asn1.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: asn1
 

--- a/components/camel-asterisk/src/main/docs/asterisk-component.adoc
+++ b/components/camel-asterisk/src/main/docs/asterisk-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/asterisk.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: asterisk
 

--- a/components/camel-atlasmap/src/main/docs/atlasmap-component.adoc
+++ b/components/camel-atlasmap/src/main/docs/atlasmap-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.7
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/atlasmap.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: atlasmap
 

--- a/components/camel-atmos/src/main/docs/atmos-component.adoc
+++ b/components/camel-atmos/src/main/docs/atmos-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/atmos.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: atmos
 

--- a/components/camel-atmosphere-websocket/src/main/docs/atmosphere-websocket-component.adoc
+++ b/components/camel-atmosphere-websocket/src/main/docs/atmosphere-websocket-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.14
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/atmosphere-websocket.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: atmosphere-websocket
 

--- a/components/camel-atom/src/main/docs/atom-component.adoc
+++ b/components/camel-atom/src/main/docs/atom-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.2
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/atom.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: atom
 

--- a/components/camel-atomix/src/main/docs/atomix-map-component.adoc
+++ b/components/camel-atomix/src/main/docs/atomix-map-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/atomix-map.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: atomix
 

--- a/components/camel-atomix/src/main/docs/atomix-messaging-component.adoc
+++ b/components/camel-atomix/src/main/docs/atomix-messaging-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/atomix-messaging.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: atomix
 

--- a/components/camel-atomix/src/main/docs/atomix-multimap-component.adoc
+++ b/components/camel-atomix/src/main/docs/atomix-multimap-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/atomix-multimap.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: atomix
 

--- a/components/camel-atomix/src/main/docs/atomix-queue-component.adoc
+++ b/components/camel-atomix/src/main/docs/atomix-queue-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/atomix-queue.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: atomix
 

--- a/components/camel-atomix/src/main/docs/atomix-set-component.adoc
+++ b/components/camel-atomix/src/main/docs/atomix-set-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/atomix-set.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: atomix
 

--- a/components/camel-atomix/src/main/docs/atomix-value-component.adoc
+++ b/components/camel-atomix/src/main/docs/atomix-value-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/atomix-value.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: atomix
 

--- a/components/camel-attachments/src/main/docs/attachments.adoc
+++ b/components/camel-attachments/src/main/docs/attachments.adoc
@@ -5,7 +5,6 @@
 :description: Support for attachments on Camel messages
 :since: 3.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/attachments.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-avro-rpc/camel-avro-rpc-component/src/main/docs/avro-component.adoc
+++ b/components/camel-avro-rpc/camel-avro-rpc-component/src/main/docs/avro-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/avro.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: avro-rpc
 

--- a/components/camel-avro/src/main/docs/avro-dataformat.adoc
+++ b/components/camel-avro/src/main/docs/avro-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Serialize and deserialize messages using Apache Avro binary data format.
 :since: 2.14
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/avro.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: avro
 

--- a/components/camel-aws/camel-aws-secrets-manager/src/main/docs/aws-secrets-manager-component.adoc
+++ b/components/camel-aws/camel-aws-secrets-manager/src/main/docs/aws-secrets-manager-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.9
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws-secrets-manager.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws-secrets-manager

--- a/components/camel-aws/camel-aws-xray/src/main/docs/aws-xray.adoc
+++ b/components/camel-aws/camel-aws-xray/src/main/docs/aws-xray.adoc
@@ -5,7 +5,6 @@
 :description: Distributed tracing using AWS XRay
 :since: 2.21
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/aws-xray.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: aws-xray
 

--- a/components/camel-aws/camel-aws2-athena/src/main/docs/aws2-athena-component.adoc
+++ b/components/camel-aws/camel-aws2-athena/src/main/docs/aws2-athena-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.4
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-athena.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-athena

--- a/components/camel-aws/camel-aws2-cw/src/main/docs/aws2-cw-component.adoc
+++ b/components/camel-aws/camel-aws2-cw/src/main/docs/aws2-cw-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-cw.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-cw

--- a/components/camel-aws/camel-aws2-ddb/src/main/docs/aws2-ddb-component.adoc
+++ b/components/camel-aws/camel-aws2-ddb/src/main/docs/aws2-ddb-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-ddb.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-ddb

--- a/components/camel-aws/camel-aws2-ddb/src/main/docs/aws2-ddbstream-component.adoc
+++ b/components/camel-aws/camel-aws2-ddb/src/main/docs/aws2-ddbstream-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-ddbstream.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-ddb

--- a/components/camel-aws/camel-aws2-ec2/src/main/docs/aws2-ec2-component.adoc
+++ b/components/camel-aws/camel-aws2-ec2/src/main/docs/aws2-ec2-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-ec2.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-ec2

--- a/components/camel-aws/camel-aws2-ecs/src/main/docs/aws2-ecs-component.adoc
+++ b/components/camel-aws/camel-aws2-ecs/src/main/docs/aws2-ecs-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-ecs.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-ecs

--- a/components/camel-aws/camel-aws2-eks/src/main/docs/aws2-eks-component.adoc
+++ b/components/camel-aws/camel-aws2-eks/src/main/docs/aws2-eks-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-eks.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-eks

--- a/components/camel-aws/camel-aws2-eventbridge/src/main/docs/aws2-eventbridge-component.adoc
+++ b/components/camel-aws/camel-aws2-eventbridge/src/main/docs/aws2-eventbridge-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.6
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-eventbridge.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-eventbridge

--- a/components/camel-aws/camel-aws2-iam/src/main/docs/aws2-iam-component.adoc
+++ b/components/camel-aws/camel-aws2-iam/src/main/docs/aws2-iam-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-iam.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-iam

--- a/components/camel-aws/camel-aws2-kinesis/src/main/docs/aws2-kinesis-component.adoc
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/docs/aws2-kinesis-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.2
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-kinesis.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-kinesis

--- a/components/camel-aws/camel-aws2-kinesis/src/main/docs/aws2-kinesis-firehose-component.adoc
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/docs/aws2-kinesis-firehose-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.2
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-kinesis-firehose.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-kinesis

--- a/components/camel-aws/camel-aws2-kms/src/main/docs/aws2-kms-component.adoc
+++ b/components/camel-aws/camel-aws2-kms/src/main/docs/aws2-kms-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-kms.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-kms

--- a/components/camel-aws/camel-aws2-lambda/src/main/docs/aws2-lambda-component.adoc
+++ b/components/camel-aws/camel-aws2-lambda/src/main/docs/aws2-lambda-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.2
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-lambda.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-lambda

--- a/components/camel-aws/camel-aws2-mq/src/main/docs/aws2-mq-component.adoc
+++ b/components/camel-aws/camel-aws2-mq/src/main/docs/aws2-mq-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-mq.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-mq

--- a/components/camel-aws/camel-aws2-msk/src/main/docs/aws2-msk-component.adoc
+++ b/components/camel-aws/camel-aws2-msk/src/main/docs/aws2-msk-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-msk.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-msk

--- a/components/camel-aws/camel-aws2-s3/src/main/docs/aws2-s3-component.adoc
+++ b/components/camel-aws/camel-aws2-s3/src/main/docs/aws2-s3-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.2
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-s3.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-s3

--- a/components/camel-aws/camel-aws2-ses/src/main/docs/aws2-ses-component.adoc
+++ b/components/camel-aws/camel-aws2-ses/src/main/docs/aws2-ses-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-ses.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-ses

--- a/components/camel-aws/camel-aws2-sns/src/main/docs/aws2-sns-component.adoc
+++ b/components/camel-aws/camel-aws2-sns/src/main/docs/aws2-sns-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-sns.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-sns

--- a/components/camel-aws/camel-aws2-sqs/src/main/docs/aws2-sqs-component.adoc
+++ b/components/camel-aws/camel-aws2-sqs/src/main/docs/aws2-sqs-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-sqs.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-sqs

--- a/components/camel-aws/camel-aws2-sts/src/main/docs/aws2-sts-component.adoc
+++ b/components/camel-aws/camel-aws2-sts/src/main/docs/aws2-sts-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.5
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-sts.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-sts

--- a/components/camel-aws/camel-aws2-translate/src/main/docs/aws2-translate-component.adoc
+++ b/components/camel-aws/camel-aws2-translate/src/main/docs/aws2-translate-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/aws2-translate.adoc[opts=optional]
 //Manually maintained attributes
 :group: AWS
 :camel-spring-boot-name: aws2-translate

--- a/components/camel-azure/camel-azure-cosmosdb/src/main/docs/azure-cosmosdb-component.adoc
+++ b/components/camel-azure/camel-azure-cosmosdb/src/main/docs/azure-cosmosdb-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.10
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/azure-cosmosdb.adoc[opts=optional]
 //Manually maintained attributes
 :group: Azure
 :camel-spring-boot-name: azure-cosmosdb

--- a/components/camel-azure/camel-azure-eventhubs/src/main/docs/azure-eventhubs-component.adoc
+++ b/components/camel-azure/camel-azure-eventhubs/src/main/docs/azure-eventhubs-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.5
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/azure-eventhubs.adoc[opts=optional]
 //Manually maintained attributes
 :group: Azure
 :camel-spring-boot-name: azure-eventhubs

--- a/components/camel-azure/camel-azure-servicebus/src/main/docs/azure-servicebus-component.adoc
+++ b/components/camel-azure/camel-azure-servicebus/src/main/docs/azure-servicebus-component.adoc
@@ -4,9 +4,8 @@
 :artifactid: camel-azure-servicebus
 :description: The azure-servicebus component that integrates Azure ServiceBus. Azure ServiceBus is a fully managed enterprise integration message broker. Service Bus can decouple applications and services. Service Bus offers a reliable and secure platform for asynchronous transfer of data and state. Data is transferred between different applications and services using messages.
 :since: 3.12
-:supportlevel: Preview
+:supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/azure-servicebus.adoc[opts=optional]
 //Manually maintained attributes
 :group: Azure
 :camel-spring-boot-name: azure-servicebus

--- a/components/camel-azure/camel-azure-storage-blob/src/main/docs/azure-storage-blob-component.adoc
+++ b/components/camel-azure/camel-azure-storage-blob/src/main/docs/azure-storage-blob-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.3
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/azure-storage-blob.adoc[opts=optional]
 //Manually maintained attributes
 :group: Azure
 :camel-spring-boot-name: azure-storage-blob

--- a/components/camel-azure/camel-azure-storage-datalake/src/main/docs/azure-storage-datalake-component.adoc
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/docs/azure-storage-datalake-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.8
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/azure-storage-datalake.adoc[opts=optional]
 //Manually maintained attributes
 :group: Azure
 :camel-spring-boot-name: azure-storage-datalake

--- a/components/camel-azure/camel-azure-storage-queue/src/main/docs/azure-storage-queue-component.adoc
+++ b/components/camel-azure/camel-azure-storage-queue/src/main/docs/azure-storage-queue-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.3
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/azure-storage-queue.adoc[opts=optional]
 //Manually maintained attributes
 :group: Azure
 :camel-spring-boot-name: azure-storage-queue

--- a/components/camel-barcode/src/main/docs/barcode-dataformat.adoc
+++ b/components/camel-barcode/src/main/docs/barcode-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Transform strings to various 1D/2D barcode bitmap formats and back.
 :since: 2.14
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/barcode.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: barcode
 

--- a/components/camel-base64/src/main/docs/base64-dataformat.adoc
+++ b/components/camel-base64/src/main/docs/base64-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Encode and decode data using Base64.
 :since: 2.11
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/base64.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: base64
 

--- a/components/camel-bean-validator/src/main/docs/bean-validator-component.adoc
+++ b/components/camel-bean-validator/src/main/docs/bean-validator-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.3
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/bean-validator.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: bean-validator
 

--- a/components/camel-bean/src/main/docs/bean-component.adoc
+++ b/components/camel-bean/src/main/docs/bean-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only producer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/bean.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: bean
 

--- a/components/camel-bean/src/main/docs/bean-language.adoc
+++ b/components/camel-bean/src/main/docs/bean-language.adoc
@@ -5,7 +5,6 @@
 :description: Calls a Java bean method.
 :since: 1.3
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/bean.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: bean
 

--- a/components/camel-bean/src/main/docs/class-component.adoc
+++ b/components/camel-bean/src/main/docs/class-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only producer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/class.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: bean
 

--- a/components/camel-beanio/src/main/docs/beanio-dataformat.adoc
+++ b/components/camel-beanio/src/main/docs/beanio-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal and unmarshal Java beans to and from flat files (such as CSV, delimited, or fixed length formats).
 :since: 2.10
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/beanio.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: beanio
 

--- a/components/camel-beanstalk/src/main/docs/beanstalk-component.adoc
+++ b/components/camel-beanstalk/src/main/docs/beanstalk-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/beanstalk.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: beanstalk
 

--- a/components/camel-bindy/src/main/docs/bindy-dataformat.adoc
+++ b/components/camel-bindy/src/main/docs/bindy-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal and unmarshal between POJOs and key-value pair (KVP) format using Camel Bindy
 :since: 2.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/bindy.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: bindy
 

--- a/components/camel-bonita/src/main/docs/bonita-component.adoc
+++ b/components/camel-bonita/src/main/docs/bonita-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/bonita.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: bonita
 

--- a/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
+++ b/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.14
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/box.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: box
 

--- a/components/camel-braintree/src/main/docs/braintree-component.adoc
+++ b/components/camel-braintree/src/main/docs/braintree-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/braintree.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: braintree
 

--- a/components/camel-browse/src/main/docs/browse-component.adoc
+++ b/components/camel-browse/src/main/docs/browse-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/browse.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: browse
 

--- a/components/camel-caffeine-lrucache/src/main/docs/caffeine-lrucache.adoc
+++ b/components/camel-caffeine-lrucache/src/main/docs/caffeine-lrucache.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable-deprecated
 :deprecated: *deprecated*
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/caffeine-lrucache.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: caffeine-lrucache
 

--- a/components/camel-caffeine/src/main/docs/caffeine-cache-component.adoc
+++ b/components/camel-caffeine/src/main/docs/caffeine-cache-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/caffeine-cache.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: caffeine
 

--- a/components/camel-caffeine/src/main/docs/caffeine-loadcache-component.adoc
+++ b/components/camel-caffeine/src/main/docs/caffeine-loadcache-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/caffeine-loadcache.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: caffeine
 

--- a/components/camel-cassandraql/src/main/docs/cql-component.adoc
+++ b/components/camel-cassandraql/src/main/docs/cql-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/cql.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: cassandraql
 

--- a/components/camel-cbor/src/main/docs/cbor-dataformat.adoc
+++ b/components/camel-cbor/src/main/docs/cbor-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Unmarshal a CBOR payload to POJO and back.
 :since: 3.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/cbor.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: cbor
 

--- a/components/camel-cdi/src/main/docs/cdi.adoc
+++ b/components/camel-cdi/src/main/docs/cdi.adoc
@@ -5,7 +5,6 @@
 :description: Using Camel with CDI
 :since: 2.10
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/cdi.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-chatscript/src/main/docs/chatscript-component.adoc
+++ b/components/camel-chatscript/src/main/docs/chatscript-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/chatscript.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: chatscript
 

--- a/components/camel-chunk/src/main/docs/chunk-component.adoc
+++ b/components/camel-chunk/src/main/docs/chunk-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/chunk.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: chunk
 

--- a/components/camel-cm-sms/src/main/docs/cm-sms-component.adoc
+++ b/components/camel-cm-sms/src/main/docs/cm-sms-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/cm-sms.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: cm-sms
 

--- a/components/camel-cmis/src/main/docs/cmis-component.adoc
+++ b/components/camel-cmis/src/main/docs/cmis-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.11
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/cmis.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: cmis
 

--- a/components/camel-coap/src/main/docs/coap-component.adoc
+++ b/components/camel-coap/src/main/docs/coap-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.16
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/coap.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: coap
 

--- a/components/camel-cometd/src/main/docs/cometd-component.adoc
+++ b/components/camel-cometd/src/main/docs/cometd-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/cometd.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: cometd
 

--- a/components/camel-consul/src/main/docs/consul-component.adoc
+++ b/components/camel-consul/src/main/docs/consul-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/consul.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: consul
 

--- a/components/camel-controlbus/src/main/docs/controlbus-component.adoc
+++ b/components/camel-controlbus/src/main/docs/controlbus-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only producer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/controlbus.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: controlbus
 

--- a/components/camel-corda/src/main/docs/corda-component.adoc
+++ b/components/camel-corda/src/main/docs/corda-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.23
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/corda.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: corda
 

--- a/components/camel-couchbase/src/main/docs/couchbase-component.adoc
+++ b/components/camel-couchbase/src/main/docs/couchbase-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/couchbase.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: couchbase
 

--- a/components/camel-couchdb/src/main/docs/couchdb-component.adoc
+++ b/components/camel-couchdb/src/main/docs/couchdb-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.11
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/couchdb.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: couchdb
 

--- a/components/camel-cron/src/main/docs/cron-component.adoc
+++ b/components/camel-cron/src/main/docs/cron-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/cron.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: cron
 

--- a/components/camel-crypto/src/main/docs/crypto-component.adoc
+++ b/components/camel-crypto/src/main/docs/crypto-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.3
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/crypto.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: crypto
 

--- a/components/camel-crypto/src/main/docs/crypto-dataformat.adoc
+++ b/components/camel-crypto/src/main/docs/crypto-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Encrypt and decrypt messages using Java Cryptography Extension (JCE).
 :since: 2.3
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/crypto.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: crypto
 

--- a/components/camel-crypto/src/main/docs/pgp-dataformat.adoc
+++ b/components/camel-crypto/src/main/docs/pgp-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Encrypt and decrypt messages using Java Cryptographic Extension (JCE) and PGP.
 :since: 2.9
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/pgp.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: crypto
 

--- a/components/camel-csimple-joor/src/main/docs/csimple-joor.adoc
+++ b/components/camel-csimple-joor/src/main/docs/csimple-joor.adoc
@@ -5,7 +5,6 @@
 :description: jOOR compiler for csimple language
 :since: 3.7
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/csimple-joor.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: csimple-joor
 

--- a/components/camel-csv/src/main/docs/csv-dataformat.adoc
+++ b/components/camel-csv/src/main/docs/csv-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Handle CSV (Comma Separated Values) payloads.
 :since: 1.3
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/csv.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: csv
 

--- a/components/camel-cxf-transport/src/main/docs/cxf-transport.adoc
+++ b/components/camel-cxf-transport/src/main/docs/cxf-transport.adoc
@@ -5,7 +5,6 @@
 :description: Camel Transport for Apache CXF
 :since: 2.8
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/cxf-transport.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: cxf-transport
 

--- a/components/camel-cxf/src/main/docs/cxf-component.adoc
+++ b/components/camel-cxf/src/main/docs/cxf-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/cxf.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: cxf
 

--- a/components/camel-cxf/src/main/docs/cxfrs-component.adoc
+++ b/components/camel-cxf/src/main/docs/cxfrs-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/cxfrs.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: cxf
 

--- a/components/camel-dataformat/src/main/docs/dataformat-component.adoc
+++ b/components/camel-dataformat/src/main/docs/dataformat-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only producer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/dataformat.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: dataformat
 

--- a/components/camel-dataset/src/main/docs/dataset-component.adoc
+++ b/components/camel-dataset/src/main/docs/dataset-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/dataset.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: dataset
 

--- a/components/camel-dataset/src/main/docs/dataset-test-component.adoc
+++ b/components/camel-dataset/src/main/docs/dataset-test-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only producer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/dataset-test.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: dataset
 

--- a/components/camel-datasonnet/src/main/docs/datasonnet-language.adoc
+++ b/components/camel-datasonnet/src/main/docs/datasonnet-language.adoc
@@ -5,7 +5,6 @@
 :description: To use DataSonnet scripts for message transformations.
 :since: 3.7
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/datasonnet.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: datasonnet
 

--- a/components/camel-debezium/camel-debezium-mongodb/src/main/docs/debezium-mongodb-component.adoc
+++ b/components/camel-debezium/camel-debezium-mongodb/src/main/docs/debezium-mongodb-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/debezium-mongodb.adoc[opts=optional]
 //Manually maintained attributes
 :group: Debezium
 :camel-spring-boot-name: debezium-mongodb

--- a/components/camel-debezium/camel-debezium-mysql/src/main/docs/debezium-mysql-component.adoc
+++ b/components/camel-debezium/camel-debezium-mysql/src/main/docs/debezium-mysql-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/debezium-mysql.adoc[opts=optional]
 //Manually maintained attributes
 :group: Debezium
 :camel-spring-boot-name: debezium-mysql

--- a/components/camel-debezium/camel-debezium-postgres/src/main/docs/debezium-postgres-component.adoc
+++ b/components/camel-debezium/camel-debezium-postgres/src/main/docs/debezium-postgres-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/debezium-postgres.adoc[opts=optional]
 //Manually maintained attributes
 :group: Debezium
 :camel-spring-boot-name: debezium-postgres

--- a/components/camel-debezium/camel-debezium-sqlserver/src/main/docs/debezium-sqlserver-component.adoc
+++ b/components/camel-debezium/camel-debezium-sqlserver/src/main/docs/debezium-sqlserver-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/debezium-sqlserver.adoc[opts=optional]
 //Manually maintained attributes
 :group: Debezium
 :camel-spring-boot-name: debezium-sqlserver

--- a/components/camel-digitalocean/src/main/docs/digitalocean-component.adoc
+++ b/components/camel-digitalocean/src/main/docs/digitalocean-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/digitalocean.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: digitalocean
 

--- a/components/camel-direct/src/main/docs/direct-component.adoc
+++ b/components/camel-direct/src/main/docs/direct-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/direct.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: direct
 

--- a/components/camel-directvm/src/main/docs/direct-vm-component.adoc
+++ b/components/camel-directvm/src/main/docs/direct-vm-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/direct-vm.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: directvm
 

--- a/components/camel-disruptor/src/main/docs/disruptor-component.adoc
+++ b/components/camel-disruptor/src/main/docs/disruptor-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/disruptor.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: disruptor
 

--- a/components/camel-disruptor/src/main/docs/disruptor-vm-component.adoc
+++ b/components/camel-disruptor/src/main/docs/disruptor-vm-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/disruptor-vm.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: disruptor
 

--- a/components/camel-djl/src/main/docs/djl-component.adoc
+++ b/components/camel-djl/src/main/docs/djl-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.3
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/djl.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: djl
 

--- a/components/camel-dns/src/main/docs/dns-component.adoc
+++ b/components/camel-dns/src/main/docs/dns-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.7
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/dns.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: dns
 

--- a/components/camel-docker/src/main/docs/docker-component.adoc
+++ b/components/camel-docker/src/main/docs/docker-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/docker.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: docker
 

--- a/components/camel-dozer/src/main/docs/dozer-component.adoc
+++ b/components/camel-dozer/src/main/docs/dozer-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/dozer.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: dozer
 

--- a/components/camel-drill/src/main/docs/drill-component.adoc
+++ b/components/camel-drill/src/main/docs/drill-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/drill.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: drill
 

--- a/components/camel-dropbox/src/main/docs/dropbox-component.adoc
+++ b/components/camel-dropbox/src/main/docs/dropbox-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.14
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/dropbox.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: dropbox
 

--- a/components/camel-ehcache/src/main/docs/ehcache-component.adoc
+++ b/components/camel-ehcache/src/main/docs/ehcache-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ehcache.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ehcache
 

--- a/components/camel-elasticsearch-rest/src/main/docs/elasticsearch-rest-component.adoc
+++ b/components/camel-elasticsearch-rest/src/main/docs/elasticsearch-rest-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.21
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/elasticsearch-rest.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: elasticsearch-rest
 

--- a/components/camel-elsql/src/main/docs/elsql-component.adoc
+++ b/components/camel-elsql/src/main/docs/elsql-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.16
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/elsql.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: elsql
 

--- a/components/camel-elytron/src/main/docs/elytron.adoc
+++ b/components/camel-elytron/src/main/docs/elytron.adoc
@@ -5,7 +5,6 @@
 :description: Elytron Security Provider for camel-undertow
 :since: 3.1
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/elytron.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-etcd/src/main/docs/etcd-keys-component.adoc
+++ b/components/camel-etcd/src/main/docs/etcd-keys-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/etcd-keys.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: etcd
 

--- a/components/camel-etcd/src/main/docs/etcd-stats-component.adoc
+++ b/components/camel-etcd/src/main/docs/etcd-stats-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/etcd-stats.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: etcd
 

--- a/components/camel-etcd/src/main/docs/etcd-watch-component.adoc
+++ b/components/camel-etcd/src/main/docs/etcd-watch-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/etcd-watch.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: etcd
 

--- a/components/camel-etcd3/src/main/docs/etcd3.adoc
+++ b/components/camel-etcd3/src/main/docs/etcd3.adoc
@@ -5,7 +5,6 @@
 :description: Aggregation repository using EtcD as datastore
 :since: 3.5
 :supportlevel: Preview
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/etcd3.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: etcd3
 

--- a/components/camel-exec/src/main/docs/exec-component.adoc
+++ b/components/camel-exec/src/main/docs/exec-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.3
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/exec.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: exec
 

--- a/components/camel-facebook/src/main/docs/facebook-component.adoc
+++ b/components/camel-facebook/src/main/docs/facebook-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.14
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/facebook.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: facebook
 

--- a/components/camel-fastjson/src/main/docs/json-fastjson-dataformat.adoc
+++ b/components/camel-fastjson/src/main/docs/json-fastjson-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal POJOs to JSON and back using Fastjson
 :since: 2.20
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/json-fastjson.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: fastjson
 

--- a/components/camel-fhir/camel-fhir-component/src/main/docs/fhir-component.adoc
+++ b/components/camel-fhir/camel-fhir-component/src/main/docs/fhir-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.23
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/fhir.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: fhir
 

--- a/components/camel-fhir/camel-fhir-component/src/main/docs/fhirJson-dataformat.adoc
+++ b/components/camel-fhir/camel-fhir-component/src/main/docs/fhirJson-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshall and unmarshall FHIR objects to/from JSON.
 :since: 2.21
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/fhirJson.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: fhir
 

--- a/components/camel-fhir/camel-fhir-component/src/main/docs/fhirXml-dataformat.adoc
+++ b/components/camel-fhir/camel-fhir-component/src/main/docs/fhirXml-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshall and unmarshall FHIR objects to/from XML.
 :since: 2.21
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/fhirXml.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: fhir
 

--- a/components/camel-file-watch/src/main/docs/file-watch-component.adoc
+++ b/components/camel-file-watch/src/main/docs/file-watch-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/file-watch.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: file-watch
 

--- a/components/camel-file/src/main/docs/file-component.adoc
+++ b/components/camel-file/src/main/docs/file-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/file.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: file
 

--- a/components/camel-flatpack/src/main/docs/flatpack-component.adoc
+++ b/components/camel-flatpack/src/main/docs/flatpack-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.4
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/flatpack.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: flatpack
 

--- a/components/camel-flatpack/src/main/docs/flatpack-dataformat.adoc
+++ b/components/camel-flatpack/src/main/docs/flatpack-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal and unmarshal Java lists and maps to/from flat files (such as CSV, delimited, or fixed length formats) using Flatpack library.
 :since: 2.1
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/flatpack.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: flatpack
 

--- a/components/camel-flink/src/main/docs/flink-component.adoc
+++ b/components/camel-flink/src/main/docs/flink-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/flink.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: flink
 

--- a/components/camel-fop/src/main/docs/fop-component.adoc
+++ b/components/camel-fop/src/main/docs/fop-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/fop.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: fop
 

--- a/components/camel-freemarker/src/main/docs/freemarker-component.adoc
+++ b/components/camel-freemarker/src/main/docs/freemarker-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/freemarker.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: freemarker
 

--- a/components/camel-ftp/src/main/docs/ftp-component.adoc
+++ b/components/camel-ftp/src/main/docs/ftp-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.1
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ftp.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ftp
 

--- a/components/camel-ftp/src/main/docs/ftps-component.adoc
+++ b/components/camel-ftp/src/main/docs/ftps-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.2
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ftps.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ftp
 

--- a/components/camel-ftp/src/main/docs/sftp-component.adoc
+++ b/components/camel-ftp/src/main/docs/sftp-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.1
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/sftp.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ftp
 

--- a/components/camel-ganglia/src/main/docs/ganglia-component.adoc
+++ b/components/camel-ganglia/src/main/docs/ganglia-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ganglia.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ganglia
 

--- a/components/camel-geocoder/src/main/docs/geocoder-component.adoc
+++ b/components/camel-geocoder/src/main/docs/geocoder-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/geocoder.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: geocoder
 

--- a/components/camel-git/src/main/docs/git-component.adoc
+++ b/components/camel-git/src/main/docs/git-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.16
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/git.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: git
 

--- a/components/camel-github/src/main/docs/github-component.adoc
+++ b/components/camel-github/src/main/docs/github-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/github.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: github
 

--- a/components/camel-google/camel-google-bigquery/src/main/docs/google-bigquery-component.adoc
+++ b/components/camel-google/camel-google-bigquery/src/main/docs/google-bigquery-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/google-bigquery.adoc[opts=optional]
 //Manually maintained attributes
 :group: Google
 :camel-spring-boot-name: google-bigquery

--- a/components/camel-google/camel-google-bigquery/src/main/docs/google-bigquery-sql-component.adoc
+++ b/components/camel-google/camel-google-bigquery/src/main/docs/google-bigquery-sql-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.23
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/google-bigquery-sql.adoc[opts=optional]
 //Manually maintained attributes
 :group: Google
 :camel-spring-boot-name: google-bigquery

--- a/components/camel-google/camel-google-calendar/src/main/docs/google-calendar-component.adoc
+++ b/components/camel-google/camel-google-calendar/src/main/docs/google-calendar-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/google-calendar.adoc[opts=optional]
 //Manually maintained attributes
 :group: Google
 :camel-spring-boot-name: google-calendar

--- a/components/camel-google/camel-google-calendar/src/main/docs/google-calendar-stream-component.adoc
+++ b/components/camel-google/camel-google-calendar/src/main/docs/google-calendar-stream-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.23
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/google-calendar-stream.adoc[opts=optional]
 //Manually maintained attributes
 :group: Google
 :camel-spring-boot-name: google-calendar

--- a/components/camel-google/camel-google-drive/src/main/docs/google-drive-component.adoc
+++ b/components/camel-google/camel-google-drive/src/main/docs/google-drive-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.14
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/google-drive.adoc[opts=optional]
 //Manually maintained attributes
 :group: Google
 :camel-spring-boot-name: google-drive

--- a/components/camel-google/camel-google-functions/src/main/docs/google-functions-component.adoc
+++ b/components/camel-google/camel-google-functions/src/main/docs/google-functions-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.9
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/google-functions.adoc[opts=optional]
 //Manually maintained attributes
 :group: Google
 :camel-spring-boot-name: google-functions

--- a/components/camel-google/camel-google-mail/src/main/docs/google-mail-component.adoc
+++ b/components/camel-google/camel-google-mail/src/main/docs/google-mail-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/google-mail.adoc[opts=optional]
 //Manually maintained attributes
 :group: Google
 :camel-spring-boot-name: google-mail

--- a/components/camel-google/camel-google-mail/src/main/docs/google-mail-stream-component.adoc
+++ b/components/camel-google/camel-google-mail/src/main/docs/google-mail-stream-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.22
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/google-mail-stream.adoc[opts=optional]
 //Manually maintained attributes
 :group: Google
 :camel-spring-boot-name: google-mail

--- a/components/camel-google/camel-google-pubsub/src/main/docs/google-pubsub-component.adoc
+++ b/components/camel-google/camel-google-pubsub/src/main/docs/google-pubsub-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/google-pubsub.adoc[opts=optional]
 //Manually maintained attributes
 :group: Google
 :camel-spring-boot-name: google-pubsub

--- a/components/camel-google/camel-google-sheets/src/main/docs/google-sheets-component.adoc
+++ b/components/camel-google/camel-google-sheets/src/main/docs/google-sheets-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.23
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/google-sheets.adoc[opts=optional]
 //Manually maintained attributes
 :group: Google
 :camel-spring-boot-name: google-sheets

--- a/components/camel-google/camel-google-sheets/src/main/docs/google-sheets-stream-component.adoc
+++ b/components/camel-google/camel-google-sheets/src/main/docs/google-sheets-stream-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.23
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/google-sheets-stream.adoc[opts=optional]
 //Manually maintained attributes
 :group: Google
 :camel-spring-boot-name: google-sheets

--- a/components/camel-google/camel-google-storage/src/main/docs/google-storage-component.adoc
+++ b/components/camel-google/camel-google-storage/src/main/docs/google-storage-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.9
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/google-storage.adoc[opts=optional]
 //Manually maintained attributes
 :group: Google
 :camel-spring-boot-name: google-storage

--- a/components/camel-gora/src/main/docs/gora-component.adoc
+++ b/components/camel-gora/src/main/docs/gora-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.14
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/gora.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: gora
 

--- a/components/camel-grape/src/main/docs/grape-component.adoc
+++ b/components/camel-grape/src/main/docs/grape-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.16
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/grape.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: grape
 

--- a/components/camel-graphql/src/main/docs/graphql-component.adoc
+++ b/components/camel-graphql/src/main/docs/graphql-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/graphql.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: graphql
 

--- a/components/camel-grok/src/main/docs/grok-dataformat.adoc
+++ b/components/camel-grok/src/main/docs/grok-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Unmarshal unstructured data to objects using Logstash based Grok patterns.
 :since: 3.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/grok.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: grok
 

--- a/components/camel-groovy/src/main/docs/groovy-language.adoc
+++ b/components/camel-groovy/src/main/docs/groovy-language.adoc
@@ -5,7 +5,6 @@
 :description: Evaluates a Groovy script.
 :since: 1.3
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/groovy.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: groovy
 

--- a/components/camel-grpc/src/main/docs/grpc-component.adoc
+++ b/components/camel-grpc/src/main/docs/grpc-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/grpc.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: grpc
 

--- a/components/camel-gson/src/main/docs/json-gson-dataformat.adoc
+++ b/components/camel-gson/src/main/docs/json-gson-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal POJOs to JSON and back using Gson
 :since: 2.10
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/json-gson.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: gson
 

--- a/components/camel-guava-eventbus/src/main/docs/guava-eventbus-component.adoc
+++ b/components/camel-guava-eventbus/src/main/docs/guava-eventbus-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/guava-eventbus.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: guava-eventbus
 

--- a/components/camel-hazelcast/src/main/docs/hazelcast-atomicvalue-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-atomicvalue-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.7
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hazelcast-atomicvalue.adoc[opts=optional]
 //Manually maintained attributes
 :group: Hazelcast
 :camel-spring-boot-name: hazelcast

--- a/components/camel-hazelcast/src/main/docs/hazelcast-instance-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-instance-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.7
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hazelcast-instance.adoc[opts=optional]
 //Manually maintained attributes
 :group: Hazelcast
 :camel-spring-boot-name: hazelcast

--- a/components/camel-hazelcast/src/main/docs/hazelcast-list-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-list-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.7
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hazelcast-list.adoc[opts=optional]
 //Manually maintained attributes
 :group: Hazelcast
 :camel-spring-boot-name: hazelcast

--- a/components/camel-hazelcast/src/main/docs/hazelcast-map-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-map-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.7
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hazelcast-map.adoc[opts=optional]
 //Manually maintained attributes
 :group: Hazelcast
 :camel-spring-boot-name: hazelcast

--- a/components/camel-hazelcast/src/main/docs/hazelcast-multimap-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-multimap-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.7
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hazelcast-multimap.adoc[opts=optional]
 //Manually maintained attributes
 :group: Hazelcast
 :camel-spring-boot-name: hazelcast

--- a/components/camel-hazelcast/src/main/docs/hazelcast-queue-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-queue-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.7
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hazelcast-queue.adoc[opts=optional]
 //Manually maintained attributes
 :group: Hazelcast
 :camel-spring-boot-name: hazelcast

--- a/components/camel-hazelcast/src/main/docs/hazelcast-replicatedmap-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-replicatedmap-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.16
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hazelcast-replicatedmap.adoc[opts=optional]
 //Manually maintained attributes
 :group: Hazelcast
 :camel-spring-boot-name: hazelcast

--- a/components/camel-hazelcast/src/main/docs/hazelcast-ringbuffer-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-ringbuffer-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.16
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hazelcast-ringbuffer.adoc[opts=optional]
 //Manually maintained attributes
 :group: Hazelcast
 :camel-spring-boot-name: hazelcast

--- a/components/camel-hazelcast/src/main/docs/hazelcast-seda-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-seda-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.7
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hazelcast-seda.adoc[opts=optional]
 //Manually maintained attributes
 :group: Hazelcast
 :camel-spring-boot-name: hazelcast

--- a/components/camel-hazelcast/src/main/docs/hazelcast-set-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-set-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.7
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hazelcast-set.adoc[opts=optional]
 //Manually maintained attributes
 :group: Hazelcast
 :camel-spring-boot-name: hazelcast

--- a/components/camel-hazelcast/src/main/docs/hazelcast-topic-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-topic-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hazelcast-topic.adoc[opts=optional]
 //Manually maintained attributes
 :group: Hazelcast
 :camel-spring-boot-name: hazelcast

--- a/components/camel-hbase/src/main/docs/hbase-component.adoc
+++ b/components/camel-hbase/src/main/docs/hbase-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hbase.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: hbase
 

--- a/components/camel-hdfs/src/main/docs/hdfs-component.adoc
+++ b/components/camel-hdfs/src/main/docs/hdfs-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.14
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hdfs.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: hdfs
 

--- a/components/camel-headersmap/src/main/docs/headersmap.adoc
+++ b/components/camel-headersmap/src/main/docs/headersmap.adoc
@@ -5,7 +5,6 @@
 :description: Fast case-insensitive headers map implementation
 :since: 2.20
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/headersmap.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-hl7/src/main/docs/hl7-dataformat.adoc
+++ b/components/camel-hl7/src/main/docs/hl7-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal and unmarshal HL7 (Health Care) model objects using the HL7 MLLP codec.
 :since: 2.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/hl7.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: hl7
 

--- a/components/camel-hl7/src/main/docs/hl7terser-language.adoc
+++ b/components/camel-hl7/src/main/docs/hl7terser-language.adoc
@@ -5,7 +5,6 @@
 :description: Get the value of a HL7 message field specified by terse location specification syntax.
 :since: 2.11
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/hl7terser.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: hl7
 

--- a/components/camel-http/src/main/docs/http-component.adoc
+++ b/components/camel-http/src/main/docs/http-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.3
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/http.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: http
 

--- a/components/camel-huawei/camel-huaweicloud-dms/src/main/docs/hwcloud-dms-component.adoc
+++ b/components/camel-huawei/camel-huaweicloud-dms/src/main/docs/hwcloud-dms-component.adoc
@@ -4,9 +4,8 @@
 :artifactid: camel-huaweicloud-dms
 :description: To integrate with a fully managed, high-performance message queuing service on Huawei Cloud
 :since: 3.12
-:supportlevel: Preview
+:supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hwcloud-dms.adoc[opts=optional]
 //Manually maintained attributes
 :group: Huawei Cloud
 :camel-spring-boot-name: huaweicloud-dms

--- a/components/camel-huawei/camel-huaweicloud-functiongraph/src/main/docs/hwcloud-functiongraph-component.adoc
+++ b/components/camel-huawei/camel-huaweicloud-functiongraph/src/main/docs/hwcloud-functiongraph-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.11
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hwcloud-functiongraph.adoc[opts=optional]
 //Manually maintained attributes
 :group: Huawei Cloud
 :camel-spring-boot-name: huaweicloud-functiongraph

--- a/components/camel-huawei/camel-huaweicloud-iam/src/main/docs/hwcloud-iam-component.adoc
+++ b/components/camel-huawei/camel-huaweicloud-iam/src/main/docs/hwcloud-iam-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.11
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hwcloud-iam.adoc[opts=optional]
 //Manually maintained attributes
 :group: Huawei Cloud
 :camel-spring-boot-name: huaweicloud-iam

--- a/components/camel-huawei/camel-huaweicloud-imagerecognition/src/main/docs/hwcloud-imagerecognition-component.adoc
+++ b/components/camel-huawei/camel-huaweicloud-imagerecognition/src/main/docs/hwcloud-imagerecognition-component.adoc
@@ -4,9 +4,8 @@
 :artifactid: camel-huaweicloud-imagerecognition
 :description: To identify objects, scenes, and concepts in images on Huawei Cloud
 :since: 3.12
-:supportlevel: Preview
+:supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hwcloud-imagerecognition.adoc[opts=optional]
 //Manually maintained attributes
 :group: Huawei Cloud
 :camel-spring-boot-name: huaweicloud-imagerecognition

--- a/components/camel-huawei/camel-huaweicloud-obs/src/main/docs/hwcloud-obs-component.adoc
+++ b/components/camel-huawei/camel-huaweicloud-obs/src/main/docs/hwcloud-obs-component.adoc
@@ -4,9 +4,8 @@
 :artifactid: camel-huaweicloud-obs
 :description: To provide stable, secure, efficient, and easy-to-use cloud storage service on Huawei Cloud
 :since: 3.12
-:supportlevel: Preview
+:supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hwcloud-obs.adoc[opts=optional]
 //Manually maintained attributes
 :group: Huawei Cloud
 :camel-spring-boot-name: huaweicloud-obs

--- a/components/camel-huawei/camel-huaweicloud-smn/src/main/docs/hwcloud-smn-component.adoc
+++ b/components/camel-huawei/camel-huaweicloud-smn/src/main/docs/hwcloud-smn-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.8
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/hwcloud-smn.adoc[opts=optional]
 //Manually maintained attributes
 :group: Huawei Cloud
 :camel-spring-boot-name: huaweicloud-smn

--- a/components/camel-hystrix/src/main/docs/hystrix.adoc
+++ b/components/camel-hystrix/src/main/docs/hystrix.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable-deprecated
 :deprecated: *deprecated*
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/hystrix.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: hystrix
 

--- a/components/camel-ical/src/main/docs/ical-dataformat.adoc
+++ b/components/camel-ical/src/main/docs/ical-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal and unmarshal iCal (.ics) documents to/from model objects provided by the iCal4j library.
 :since: 2.12
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/ical.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ical
 

--- a/components/camel-iec60870/src/main/docs/iec60870-client-component.adoc
+++ b/components/camel-iec60870/src/main/docs/iec60870-client-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/iec60870-client.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: iec60870
 

--- a/components/camel-iec60870/src/main/docs/iec60870-server-component.adoc
+++ b/components/camel-iec60870/src/main/docs/iec60870-server-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/iec60870-server.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: iec60870
 

--- a/components/camel-ignite/src/main/docs/ignite-cache-component.adoc
+++ b/components/camel-ignite/src/main/docs/ignite-cache-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ignite-cache.adoc[opts=optional]
 //Manually maintained attributes
 :group: Ignite
 :camel-spring-boot-name: ignite

--- a/components/camel-ignite/src/main/docs/ignite-compute-component.adoc
+++ b/components/camel-ignite/src/main/docs/ignite-compute-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ignite-compute.adoc[opts=optional]
 //Manually maintained attributes
 :group: Ignite
 :camel-spring-boot-name: ignite

--- a/components/camel-ignite/src/main/docs/ignite-events-component.adoc
+++ b/components/camel-ignite/src/main/docs/ignite-events-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ignite-events.adoc[opts=optional]
 //Manually maintained attributes
 :group: Ignite
 :camel-spring-boot-name: ignite

--- a/components/camel-ignite/src/main/docs/ignite-idgen-component.adoc
+++ b/components/camel-ignite/src/main/docs/ignite-idgen-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ignite-idgen.adoc[opts=optional]
 //Manually maintained attributes
 :group: Ignite
 :camel-spring-boot-name: ignite

--- a/components/camel-ignite/src/main/docs/ignite-messaging-component.adoc
+++ b/components/camel-ignite/src/main/docs/ignite-messaging-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ignite-messaging.adoc[opts=optional]
 //Manually maintained attributes
 :group: Ignite
 :camel-spring-boot-name: ignite

--- a/components/camel-ignite/src/main/docs/ignite-queue-component.adoc
+++ b/components/camel-ignite/src/main/docs/ignite-queue-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ignite-queue.adoc[opts=optional]
 //Manually maintained attributes
 :group: Ignite
 :camel-spring-boot-name: ignite

--- a/components/camel-ignite/src/main/docs/ignite-set-component.adoc
+++ b/components/camel-ignite/src/main/docs/ignite-set-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ignite-set.adoc[opts=optional]
 //Manually maintained attributes
 :group: Ignite
 :camel-spring-boot-name: ignite

--- a/components/camel-infinispan/camel-infinispan-embedded/src/main/docs/infinispan-embedded-component.adoc
+++ b/components/camel-infinispan/camel-infinispan-embedded/src/main/docs/infinispan-embedded-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.13
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/infinispan-embedded.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: infinispan-embedded
 

--- a/components/camel-infinispan/camel-infinispan/src/main/docs/infinispan-component.adoc
+++ b/components/camel-infinispan/camel-infinispan/src/main/docs/infinispan-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.13
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/infinispan.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: infinispan
 

--- a/components/camel-influxdb/src/main/docs/influxdb-component.adoc
+++ b/components/camel-influxdb/src/main/docs/influxdb-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/influxdb.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: influxdb
 

--- a/components/camel-iota/src/main/docs/iota-component.adoc
+++ b/components/camel-iota/src/main/docs/iota-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.23
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/iota.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: iota
 

--- a/components/camel-ipfs/src/main/docs/ipfs-component.adoc
+++ b/components/camel-ipfs/src/main/docs/ipfs-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.23
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ipfs.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ipfs
 

--- a/components/camel-irc/src/main/docs/irc-component.adoc
+++ b/components/camel-irc/src/main/docs/irc-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.1
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/irc.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: irc
 

--- a/components/camel-ironmq/src/main/docs/ironmq-component.adoc
+++ b/components/camel-ironmq/src/main/docs/ironmq-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ironmq.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ironmq
 

--- a/components/camel-jackson-avro/src/main/docs/avro-jackson-dataformat.adoc
+++ b/components/camel-jackson-avro/src/main/docs/avro-jackson-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal POJOs to Avro and back using Jackson.
 :since: 3.10
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/avro-jackson.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jackson-avro
 

--- a/components/camel-jackson-protobuf/src/main/docs/protobuf-jackson-dataformat.adoc
+++ b/components/camel-jackson-protobuf/src/main/docs/protobuf-jackson-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal POJOs to Protobuf and back using Jackson.
 :since: 3.10
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/protobuf-jackson.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jackson-protobuf
 

--- a/components/camel-jackson/src/main/docs/json-jackson-dataformat.adoc
+++ b/components/camel-jackson/src/main/docs/json-jackson-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal POJOs to JSON and back using Jackson
 :since: 2.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/json-jackson.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jackson
 

--- a/components/camel-jacksonxml/src/main/docs/jacksonxml-dataformat.adoc
+++ b/components/camel-jacksonxml/src/main/docs/jacksonxml-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Unmarshal a XML payloads to POJOs and back using XMLMapper extension of Jackson.
 :since: 2.16
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/jacksonxml.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jacksonxml
 

--- a/components/camel-jasypt/src/main/docs/jasypt.adoc
+++ b/components/camel-jasypt/src/main/docs/jasypt.adoc
@@ -5,7 +5,6 @@
 :description: Security using Jasypt
 :since: 2.5
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/jasypt.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jasypt
 

--- a/components/camel-jaxb/src/main/docs/jaxb-dataformat.adoc
+++ b/components/camel-jaxb/src/main/docs/jaxb-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Unmarshal XML payloads to POJOs and back using JAXB2 XML marshalling standard.
 :since: 1.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/jaxb.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jaxb
 

--- a/components/camel-jbpm/src/main/docs/jbpm-component.adoc
+++ b/components/camel-jbpm/src/main/docs/jbpm-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.6
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jbpm.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jbpm
 

--- a/components/camel-jcache/src/main/docs/jcache-component.adoc
+++ b/components/camel-jcache/src/main/docs/jcache-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jcache.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jcache
 

--- a/components/camel-jclouds/src/main/docs/jclouds-component.adoc
+++ b/components/camel-jclouds/src/main/docs/jclouds-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.9
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jclouds.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jclouds
 

--- a/components/camel-jcr/src/main/docs/jcr-component.adoc
+++ b/components/camel-jcr/src/main/docs/jcr-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.3
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jcr.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jcr
 

--- a/components/camel-jdbc/src/main/docs/jdbc-component.adoc
+++ b/components/camel-jdbc/src/main/docs/jdbc-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.2
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jdbc.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jdbc
 

--- a/components/camel-jetty/src/main/docs/jetty-component.adoc
+++ b/components/camel-jetty/src/main/docs/jetty-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.2
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jetty.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jetty
 

--- a/components/camel-jfr/src/main/docs/jfr.adoc
+++ b/components/camel-jfr/src/main/docs/jfr.adoc
@@ -5,7 +5,6 @@
 :description: Diagnose Camel applications with Java Flight Recorder
 :since: 3.8
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/jfr.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jfr
 

--- a/components/camel-jgroups-raft/src/main/docs/jgroups-raft-component.adoc
+++ b/components/camel-jgroups-raft/src/main/docs/jgroups-raft-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.24
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jgroups-raft.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jgroups-raft
 

--- a/components/camel-jgroups/src/main/docs/jgroups-component.adoc
+++ b/components/camel-jgroups/src/main/docs/jgroups-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.13
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jgroups.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jgroups
 

--- a/components/camel-jing/src/main/docs/jing-component.adoc
+++ b/components/camel-jing/src/main/docs/jing-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jing.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jing
 

--- a/components/camel-jira/src/main/docs/jira-component.adoc
+++ b/components/camel-jira/src/main/docs/jira-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jira.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jira
 

--- a/components/camel-jms/src/main/docs/jms-component.adoc
+++ b/components/camel-jms/src/main/docs/jms-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jms.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jms
 

--- a/components/camel-jmx/src/main/docs/jmx-component.adoc
+++ b/components/camel-jmx/src/main/docs/jmx-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.6
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jmx.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jmx
 

--- a/components/camel-johnzon/src/main/docs/json-johnzon-dataformat.adoc
+++ b/components/camel-johnzon/src/main/docs/json-johnzon-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal POJOs to JSON and back using Johnzon
 :since: 2.18
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/json-johnzon.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: johnzon
 

--- a/components/camel-jolt/src/main/docs/jolt-component.adoc
+++ b/components/camel-jolt/src/main/docs/jolt-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.16
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jolt.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jolt
 

--- a/components/camel-jooq/src/main/docs/jooq-component.adoc
+++ b/components/camel-jooq/src/main/docs/jooq-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jooq.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jooq
 

--- a/components/camel-joor/src/main/docs/joor-language.adoc
+++ b/components/camel-joor/src/main/docs/joor-language.adoc
@@ -5,7 +5,6 @@
 :description: Evaluates a jOOR (Java compiled once at runtime) expression.
 :since: 3.7
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/joor.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: joor
 

--- a/components/camel-jpa/src/main/docs/jpa-component.adoc
+++ b/components/camel-jpa/src/main/docs/jpa-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jpa.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jpa
 

--- a/components/camel-jsch/src/main/docs/scp-component.adoc
+++ b/components/camel-jsch/src/main/docs/scp-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/scp.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jsch
 

--- a/components/camel-jslt/src/main/docs/jslt-component.adoc
+++ b/components/camel-jslt/src/main/docs/jslt-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jslt.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jslt
 

--- a/components/camel-json-patch/src/main/docs/json-patch-component.adoc
+++ b/components/camel-json-patch/src/main/docs/json-patch-component.adoc
@@ -4,9 +4,8 @@
 :artifactid: camel-json-patch
 :description: JsonPatch component which transform JSON using JSON patch (RFC 6902).
 :since: 3.12
-:supportlevel: Preview
+:supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/json-patch.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: json-patch
 

--- a/components/camel-json-validator/src/main/docs/json-validator-component.adoc
+++ b/components/camel-json-validator/src/main/docs/json-validator-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/json-validator.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: json-validator
 

--- a/components/camel-jsonapi/src/main/docs/jsonApi-dataformat.adoc
+++ b/components/camel-jsonapi/src/main/docs/jsonApi-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal and unmarshal JSON:API resources using JSONAPI-Converter library.
 :since: 3.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/jsonApi.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jsonapi
 

--- a/components/camel-jsonata/src/main/docs/jsonata-component.adoc
+++ b/components/camel-jsonata/src/main/docs/jsonata-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.5
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jsonata.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jsonata
 

--- a/components/camel-jsonb/src/main/docs/json-jsonb-dataformat.adoc
+++ b/components/camel-jsonb/src/main/docs/json-jsonb-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal POJOs to JSON and back using JSON-B.
 :since: 3.7
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/json-jsonb.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jsonb
 

--- a/components/camel-jsonpath/src/main/docs/jsonpath-language.adoc
+++ b/components/camel-jsonpath/src/main/docs/jsonpath-language.adoc
@@ -5,7 +5,6 @@
 :description: Evaluates a JSONPath expression against a JSON message body.
 :since: 2.13
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/jsonpath.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jsonpath
 

--- a/components/camel-jt400/src/main/docs/jt400-component.adoc
+++ b/components/camel-jt400/src/main/docs/jt400-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.5
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/jt400.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: jt400
 

--- a/components/camel-jta/src/main/docs/jta.adoc
+++ b/components/camel-jta/src/main/docs/jta.adoc
@@ -5,7 +5,6 @@
 :description: Using Camel With JTA Transaction Manager
 :since: 3.4
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/jta.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-kafka/src/main/docs/kafka-component.adoc
+++ b/components/camel-kafka/src/main/docs/kafka-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.13
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kafka.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: kafka
 

--- a/components/camel-kamelet-reify/src/main/docs/kamelet-reify-component.adoc
+++ b/components/camel-kamelet-reify/src/main/docs/kamelet-reify-component.adoc
@@ -8,7 +8,6 @@
 :deprecated: *deprecated*
 :component-header: Both producer and consumer are supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kamelet-reify.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: kamelet-reify
 

--- a/components/camel-kamelet/src/main/docs/kamelet-component.adoc
+++ b/components/camel-kamelet/src/main/docs/kamelet-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kamelet.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: kamelet
 

--- a/components/camel-kubernetes/src/main/docs/kubernetes-config-maps-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-config-maps-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-config-maps.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-custom-resources-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-custom-resources-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.7
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-custom-resources.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-deployments-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-deployments-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-deployments.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-hpa-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-hpa-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.23
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-hpa.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-job-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-job-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.23
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-job.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-namespaces-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-namespaces-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-namespaces.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-nodes-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-nodes-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-nodes.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-persistent-volumes-claims-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-persistent-volumes-claims-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-persistent-volumes-claims.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-persistent-volumes-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-persistent-volumes-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-persistent-volumes.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-pods-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-pods-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-pods.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-replication-controllers-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-replication-controllers-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-replication-controllers.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-resources-quota-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-resources-quota-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-resources-quota.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-secrets-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-secrets-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-secrets.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-service-accounts-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-service-accounts-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-service-accounts.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/kubernetes-services-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-services-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kubernetes-services.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/openshift-build-configs-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/openshift-build-configs-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/openshift-build-configs.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kubernetes/src/main/docs/openshift-builds-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/openshift-builds-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/openshift-builds.adoc[opts=optional]
 //Manually maintained attributes
 :group: Kubernetes
 :camel-spring-boot-name: kubernetes

--- a/components/camel-kudu/src/main/docs/kudu-component.adoc
+++ b/components/camel-kudu/src/main/docs/kudu-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/kudu.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: kudu
 

--- a/components/camel-language/src/main/docs/language-component.adoc
+++ b/components/camel-language/src/main/docs/language-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only producer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/language.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: language
 

--- a/components/camel-ldap/src/main/docs/ldap-component.adoc
+++ b/components/camel-ldap/src/main/docs/ldap-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.5
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ldap.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ldap
 

--- a/components/camel-ldif/src/main/docs/ldif-component.adoc
+++ b/components/camel-ldif/src/main/docs/ldif-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ldif.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ldif
 

--- a/components/camel-leveldb-legacy/src/main/docs/leveldb-legacy.adoc
+++ b/components/camel-leveldb-legacy/src/main/docs/leveldb-legacy.adoc
@@ -5,7 +5,6 @@
 :description: Using LevelDB as persistent EIP store
 :since: 2.10
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/leveldb-legacy.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: leveldb-legacy
 

--- a/components/camel-leveldb/src/main/docs/leveldb.adoc
+++ b/components/camel-leveldb/src/main/docs/leveldb.adoc
@@ -5,7 +5,6 @@
 :description: Using LevelDB as persistent EIP store
 :since: 2.10
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/leveldb.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: leveldb
 

--- a/components/camel-log/src/main/docs/log-component.adoc
+++ b/components/camel-log/src/main/docs/log-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only producer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/log.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: log
 

--- a/components/camel-lra/src/main/docs/lra.adoc
+++ b/components/camel-lra/src/main/docs/lra.adoc
@@ -5,7 +5,6 @@
 :description: Camel saga binding for Long-Running-Action framework
 :since: 2.21
 :supportlevel: Preview
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/lra.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: lra
 

--- a/components/camel-lucene/src/main/docs/lucene-component.adoc
+++ b/components/camel-lucene/src/main/docs/lucene-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.2
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/lucene.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: lucene
 

--- a/components/camel-lumberjack/src/main/docs/lumberjack-component.adoc
+++ b/components/camel-lumberjack/src/main/docs/lumberjack-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/lumberjack.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: lumberjack
 

--- a/components/camel-lzf/src/main/docs/lzf-dataformat.adoc
+++ b/components/camel-lzf/src/main/docs/lzf-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Compress and decompress streams using LZF deflate algorithm.
 :since: 2.17
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/lzf.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: lzf
 

--- a/components/camel-mail/src/main/docs/mail-component.adoc
+++ b/components/camel-mail/src/main/docs/mail-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/mail.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: mail
 

--- a/components/camel-mail/src/main/docs/mime-multipart-dataformat.adoc
+++ b/components/camel-mail/src/main/docs/mime-multipart-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal Camel messages with attachments into MIME-Multipart messages and back.
 :since: 2.17
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/mime-multipart.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: mail
 

--- a/components/camel-master/src/main/docs/master-component.adoc
+++ b/components/camel-master/src/main/docs/master-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/master.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: master
 

--- a/components/camel-metrics/src/main/docs/metrics-component.adoc
+++ b/components/camel-metrics/src/main/docs/metrics-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.14
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/metrics.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: metrics
 

--- a/components/camel-micrometer/src/main/docs/micrometer-component.adoc
+++ b/components/camel-micrometer/src/main/docs/micrometer-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.22
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/micrometer.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: micrometer
 

--- a/components/camel-microprofile/camel-microprofile-config/src/main/docs/microprofile-config.adoc
+++ b/components/camel-microprofile/camel-microprofile-config/src/main/docs/microprofile-config.adoc
@@ -5,7 +5,6 @@
 :description: Bridging Eclipse MicroProfile Config with Camel properties
 :since: 3.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/microprofile-config.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-microprofile/camel-microprofile-fault-tolerance/src/main/docs/microprofile-fault-tolerance.adoc
+++ b/components/camel-microprofile/camel-microprofile-fault-tolerance/src/main/docs/microprofile-fault-tolerance.adoc
@@ -5,7 +5,6 @@
 :description: Circuit Breaker EIP using MicroProfile Fault Tolerance
 :since: 3.3
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/microprofile-fault-tolerance.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-microprofile/camel-microprofile-health/src/main/docs/microprofile-health.adoc
+++ b/components/camel-microprofile/camel-microprofile-health/src/main/docs/microprofile-health.adoc
@@ -5,7 +5,6 @@
 :description: Expose Camel health checks via MicroProfile Health
 :since: 3.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/microprofile-health.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-microprofile/camel-microprofile-metrics/src/main/docs/microprofile-metrics-component.adoc
+++ b/components/camel-microprofile/camel-microprofile-metrics/src/main/docs/microprofile-metrics-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/microprofile-metrics.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-milo/src/main/docs/milo-client-component.adoc
+++ b/components/camel-milo/src/main/docs/milo-client-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/milo-client.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: milo
 

--- a/components/camel-milo/src/main/docs/milo-server-component.adoc
+++ b/components/camel-milo/src/main/docs/milo-server-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/milo-server.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: milo
 

--- a/components/camel-mina/src/main/docs/mina-component.adoc
+++ b/components/camel-mina/src/main/docs/mina-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/mina.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: mina
 

--- a/components/camel-minio/src/main/docs/minio-component.adoc
+++ b/components/camel-minio/src/main/docs/minio-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.5
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/minio.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: minio
 

--- a/components/camel-mllp/src/main/docs/mllp-component.adoc
+++ b/components/camel-mllp/src/main/docs/mllp-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/mllp.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: mllp
 

--- a/components/camel-mock/src/main/docs/mock-component.adoc
+++ b/components/camel-mock/src/main/docs/mock-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only producer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/mock.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: mock
 

--- a/components/camel-mongodb-gridfs/src/main/docs/mongodb-gridfs-component.adoc
+++ b/components/camel-mongodb-gridfs/src/main/docs/mongodb-gridfs-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/mongodb-gridfs.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: mongodb-gridfs
 

--- a/components/camel-mongodb/src/main/docs/mongodb-component.adoc
+++ b/components/camel-mongodb/src/main/docs/mongodb-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/mongodb.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: mongodb
 

--- a/components/camel-msv/src/main/docs/msv-component.adoc
+++ b/components/camel-msv/src/main/docs/msv-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/msv.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: msv
 

--- a/components/camel-mustache/src/main/docs/mustache-component.adoc
+++ b/components/camel-mustache/src/main/docs/mustache-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/mustache.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: mustache
 

--- a/components/camel-mvel/src/main/docs/mvel-component.adoc
+++ b/components/camel-mvel/src/main/docs/mvel-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/mvel.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: mvel
 

--- a/components/camel-mvel/src/main/docs/mvel-language.adoc
+++ b/components/camel-mvel/src/main/docs/mvel-language.adoc
@@ -5,7 +5,6 @@
 :description: Evaluates a MVEL template.
 :since: 2.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/mvel.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: mvel
 

--- a/components/camel-mybatis/src/main/docs/mybatis-bean-component.adoc
+++ b/components/camel-mybatis/src/main/docs/mybatis-bean-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.22
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/mybatis-bean.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: mybatis
 

--- a/components/camel-mybatis/src/main/docs/mybatis-component.adoc
+++ b/components/camel-mybatis/src/main/docs/mybatis-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.7
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/mybatis.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: mybatis
 

--- a/components/camel-nagios/src/main/docs/nagios-component.adoc
+++ b/components/camel-nagios/src/main/docs/nagios-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.3
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/nagios.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: nagios
 

--- a/components/camel-nats/src/main/docs/nats-component.adoc
+++ b/components/camel-nats/src/main/docs/nats-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/nats.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: nats
 

--- a/components/camel-netty-http/src/main/docs/netty-http-component.adoc
+++ b/components/camel-netty-http/src/main/docs/netty-http-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.14
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/netty-http.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: netty-http
 

--- a/components/camel-netty/src/main/docs/netty-component.adoc
+++ b/components/camel-netty/src/main/docs/netty-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.14
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/netty.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: netty
 

--- a/components/camel-nitrite/src/main/docs/nitrite-component.adoc
+++ b/components/camel-nitrite/src/main/docs/nitrite-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/nitrite.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: nitrite
 

--- a/components/camel-nsq/src/main/docs/nsq-component.adoc
+++ b/components/camel-nsq/src/main/docs/nsq-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.23
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/nsq.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: nsq
 

--- a/components/camel-oaipmh/src/main/docs/oaipmh-component.adoc
+++ b/components/camel-oaipmh/src/main/docs/oaipmh-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.5
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/oaipmh.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: oaipmh
 

--- a/components/camel-ognl/src/main/docs/ognl-language.adoc
+++ b/components/camel-ognl/src/main/docs/ognl-language.adoc
@@ -5,7 +5,6 @@
 :description: Evaluates an OGNL expression (Apache Commons OGNL).
 :since: 1.1
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/ognl.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ognl
 

--- a/components/camel-olingo2/camel-olingo2-component/src/main/docs/olingo2-component.adoc
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/docs/olingo2-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.14
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/olingo2.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: olingo2
 

--- a/components/camel-olingo4/camel-olingo4-component/src/main/docs/olingo4-component.adoc
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/docs/olingo4-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/olingo4.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: olingo4
 

--- a/components/camel-openapi-java/src/main/docs/openapi-java.adoc
+++ b/components/camel-openapi-java/src/main/docs/openapi-java.adoc
@@ -5,7 +5,6 @@
 :description: Rest-dsl support for using openapi doc
 :since: 3.1
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/openapi-java.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: openapi-java
 

--- a/components/camel-openapi-java/src/main/docs/springdoc.adoc
+++ b/components/camel-openapi-java/src/main/docs/springdoc.adoc
@@ -6,7 +6,6 @@
 :description: Springdoc Swagger UI for openapi-java in spring boot
 :since: 3.14
 //:supportlevel: Stable
-//include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/openapi-java.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: springdoc
 :starter-artifactid: camel-springdoc-starter

--- a/components/camel-openstack/src/main/docs/openstack-cinder-component.adoc
+++ b/components/camel-openstack/src/main/docs/openstack-cinder-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/openstack-cinder.adoc[opts=optional]
 //Manually maintained attributes
 :group: OpenStack
 :camel-spring-boot-name: openstack

--- a/components/camel-openstack/src/main/docs/openstack-glance-component.adoc
+++ b/components/camel-openstack/src/main/docs/openstack-glance-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/openstack-glance.adoc[opts=optional]
 //Manually maintained attributes
 :group: OpenStack
 :camel-spring-boot-name: openstack

--- a/components/camel-openstack/src/main/docs/openstack-keystone-component.adoc
+++ b/components/camel-openstack/src/main/docs/openstack-keystone-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/openstack-keystone.adoc[opts=optional]
 //Manually maintained attributes
 :group: OpenStack
 :camel-spring-boot-name: openstack

--- a/components/camel-openstack/src/main/docs/openstack-neutron-component.adoc
+++ b/components/camel-openstack/src/main/docs/openstack-neutron-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/openstack-neutron.adoc[opts=optional]
 //Manually maintained attributes
 :group: OpenStack
 :camel-spring-boot-name: openstack

--- a/components/camel-openstack/src/main/docs/openstack-nova-component.adoc
+++ b/components/camel-openstack/src/main/docs/openstack-nova-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/openstack-nova.adoc[opts=optional]
 //Manually maintained attributes
 :group: OpenStack
 :camel-spring-boot-name: openstack

--- a/components/camel-openstack/src/main/docs/openstack-swift-component.adoc
+++ b/components/camel-openstack/src/main/docs/openstack-swift-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/openstack-swift.adoc[opts=optional]
 //Manually maintained attributes
 :group: OpenStack
 :camel-spring-boot-name: openstack

--- a/components/camel-opentelemetry/src/main/docs/opentelemetry.adoc
+++ b/components/camel-opentelemetry/src/main/docs/opentelemetry.adoc
@@ -5,7 +5,6 @@
 :description: Distributed tracing using OpenTelemetry
 :since: 3.5
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/opentelemetry.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: opentelemetry
 

--- a/components/camel-opentracing/src/main/docs/opentracing.adoc
+++ b/components/camel-opentracing/src/main/docs/opentracing.adoc
@@ -5,7 +5,6 @@
 :description: Distributed tracing using OpenTracing
 :since: 2.19
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/opentracing.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: opentracing
 

--- a/components/camel-optaplanner/src/main/docs/optaplanner-component.adoc
+++ b/components/camel-optaplanner/src/main/docs/optaplanner-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.13
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/optaplanner.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: optaplanner
 

--- a/components/camel-paho-mqtt5/src/main/docs/paho-mqtt5-component.adoc
+++ b/components/camel-paho-mqtt5/src/main/docs/paho-mqtt5-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.8
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/paho-mqtt5.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: paho-mqtt5
 

--- a/components/camel-paho/src/main/docs/paho-component.adoc
+++ b/components/camel-paho/src/main/docs/paho-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.16
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/paho.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: paho
 

--- a/components/camel-pdf/src/main/docs/pdf-component.adoc
+++ b/components/camel-pdf/src/main/docs/pdf-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.16
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/pdf.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: pdf
 

--- a/components/camel-pg-replication-slot/src/main/docs/pg-replication-slot-component.adoc
+++ b/components/camel-pg-replication-slot/src/main/docs/pg-replication-slot-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/pg-replication-slot.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: pg-replication-slot
 

--- a/components/camel-pgevent/src/main/docs/pgevent-component.adoc
+++ b/components/camel-pgevent/src/main/docs/pgevent-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/pgevent.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: pgevent
 

--- a/components/camel-platform-http-vertx/src/main/docs/platform-http-vertx.adoc
+++ b/components/camel-platform-http-vertx/src/main/docs/platform-http-vertx.adoc
@@ -5,7 +5,6 @@
 :description: Implementation of the Platform HTTP Engine based on Vert.x Web
 :since: 3.2
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/platform-http-vertx.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-platform-http/src/main/docs/platform-http-component.adoc
+++ b/components/camel-platform-http/src/main/docs/platform-http-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/platform-http.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: platform-http
 

--- a/components/camel-printer/src/main/docs/lpr-component.adoc
+++ b/components/camel-printer/src/main/docs/lpr-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/lpr.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: printer
 

--- a/components/camel-protobuf/src/main/docs/protobuf-dataformat.adoc
+++ b/components/camel-protobuf/src/main/docs/protobuf-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Serialize and deserialize Java objects using Google's Protocol buffers.
 :since: 2.2
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/protobuf.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: protobuf
 

--- a/components/camel-pubnub/src/main/docs/pubnub-component.adoc
+++ b/components/camel-pubnub/src/main/docs/pubnub-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/pubnub.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: pubnub
 

--- a/components/camel-pulsar/src/main/docs/pulsar-component.adoc
+++ b/components/camel-pulsar/src/main/docs/pulsar-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.24
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/pulsar.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: pulsar
 

--- a/components/camel-quartz/src/main/docs/quartz-component.adoc
+++ b/components/camel-quartz/src/main/docs/quartz-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/quartz.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: quartz
 

--- a/components/camel-quickfix/src/main/docs/quickfix-component.adoc
+++ b/components/camel-quickfix/src/main/docs/quickfix-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.1
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/quickfix.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: quickfix
 

--- a/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
+++ b/components/camel-rabbitmq/src/main/docs/rabbitmq-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/rabbitmq.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: rabbitmq
 

--- a/components/camel-reactive-executor-vertx/src/main/docs/reactive-executor-vertx.adoc
+++ b/components/camel-reactive-executor-vertx/src/main/docs/reactive-executor-vertx.adoc
@@ -5,7 +5,6 @@
 :description: Reactive Executor for camel-core using Vert.x
 :since: 3.0
 :supportlevel: Experimental
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/reactive-executor-vertx.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-reactive-streams/src/main/docs/reactive-streams-component.adoc
+++ b/components/camel-reactive-streams/src/main/docs/reactive-streams-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/reactive-streams.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: reactive-streams
 

--- a/components/camel-reactor/src/main/docs/reactor.adoc
+++ b/components/camel-reactor/src/main/docs/reactor.adoc
@@ -5,7 +5,6 @@
 :description: Reactor based back-end for Camel's reactive streams component
 :since: 2.20
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/reactor.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: reactor
 

--- a/components/camel-redis/src/main/docs/redis.adoc
+++ b/components/camel-redis/src/main/docs/redis.adoc
@@ -5,7 +5,6 @@
 :description: Aggregation repository using Redis as datastore
 :since: 3.5
 :supportlevel: Preview
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/redis.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-ref/src/main/docs/ref-component.adoc
+++ b/components/camel-ref/src/main/docs/ref-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ref.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ref
 

--- a/components/camel-resilience4j/src/main/docs/resilience4j.adoc
+++ b/components/camel-resilience4j/src/main/docs/resilience4j.adoc
@@ -5,7 +5,6 @@
 :description: Circuit Breaker EIP using Resilience4j
 :since: 3.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/resilience4j.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: resilience4j
 

--- a/components/camel-resourceresolver-github/src/main/docs/resourceresolver-github.adoc
+++ b/components/camel-resourceresolver-github/src/main/docs/resourceresolver-github.adoc
@@ -5,7 +5,6 @@
 :description: Resource resolver to load files from GitHub
 :since: 3.11
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/resourceresolver-github.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-rest-openapi/src/main/docs/rest-openapi-component.adoc
+++ b/components/camel-rest-openapi/src/main/docs/rest-openapi-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/rest-openapi.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: rest-openapi
 

--- a/components/camel-rest-swagger/src/main/docs/rest-swagger-component.adoc
+++ b/components/camel-rest-swagger/src/main/docs/rest-swagger-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/rest-swagger.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: rest-swagger
 

--- a/components/camel-rest/src/main/docs/rest-api-component.adoc
+++ b/components/camel-rest/src/main/docs/rest-api-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only consumer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/rest-api.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: rest
 

--- a/components/camel-rest/src/main/docs/rest-component.adoc
+++ b/components/camel-rest/src/main/docs/rest-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/rest.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: rest
 

--- a/components/camel-resteasy/src/main/docs/resteasy-component.adoc
+++ b/components/camel-resteasy/src/main/docs/resteasy-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.4
 :supportlevel: Preview
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/resteasy.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: resteasy
 

--- a/components/camel-ribbon/src/main/docs/ribbon.adoc
+++ b/components/camel-ribbon/src/main/docs/ribbon.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable-deprecated
 :deprecated: *deprecated*
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/ribbon.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ribbon
 

--- a/components/camel-robotframework/src/main/docs/robotframework-component.adoc
+++ b/components/camel-robotframework/src/main/docs/robotframework-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/robotframework.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: robotframework
 

--- a/components/camel-rss/src/main/docs/rss-component.adoc
+++ b/components/camel-rss/src/main/docs/rss-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.0
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/rss.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: rss
 

--- a/components/camel-rss/src/main/docs/rss-dataformat.adoc
+++ b/components/camel-rss/src/main/docs/rss-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Transform from ROME SyndFeed Java Objects to XML and vice-versa.
 :since: 2.1
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/rss.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: rss
 

--- a/components/camel-rxjava/src/main/docs/rxjava.adoc
+++ b/components/camel-rxjava/src/main/docs/rxjava.adoc
@@ -5,7 +5,6 @@
 :description: RxJava based back-end for Camel's reactive streams component
 :since: 2.22
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/rxjava.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: rxjava
 

--- a/components/camel-saga/src/main/docs/saga-component.adoc
+++ b/components/camel-saga/src/main/docs/saga-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only producer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/saga.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: saga
 

--- a/components/camel-salesforce/camel-salesforce-component/src/main/docs/salesforce-component.adoc
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/docs/salesforce-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/salesforce.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: salesforce
 

--- a/components/camel-sap-netweaver/src/main/docs/sap-netweaver-component.adoc
+++ b/components/camel-sap-netweaver/src/main/docs/sap-netweaver-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/sap-netweaver.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: sap-netweaver
 

--- a/components/camel-saxon/src/main/docs/xquery-component.adoc
+++ b/components/camel-saxon/src/main/docs/xquery-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/xquery.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: saxon
 

--- a/components/camel-saxon/src/main/docs/xquery-language.adoc
+++ b/components/camel-saxon/src/main/docs/xquery-language.adoc
@@ -5,7 +5,6 @@
 :description: Evaluates an XQuery expressions against an XML payload.
 :since: 1.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/xquery.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: saxon
 

--- a/components/camel-scheduler/src/main/docs/scheduler-component.adoc
+++ b/components/camel-scheduler/src/main/docs/scheduler-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only consumer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/scheduler.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: scheduler
 

--- a/components/camel-schematron/src/main/docs/schematron-component.adoc
+++ b/components/camel-schematron/src/main/docs/schematron-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.15
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/schematron.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: schematron
 

--- a/components/camel-seda/src/main/docs/seda-component.adoc
+++ b/components/camel-seda/src/main/docs/seda-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/seda.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: seda
 

--- a/components/camel-service/src/main/docs/service-component.adoc
+++ b/components/camel-service/src/main/docs/service-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.22
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/service.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: service
 

--- a/components/camel-servicenow/camel-servicenow-component/src/main/docs/servicenow-component.adoc
+++ b/components/camel-servicenow/camel-servicenow-component/src/main/docs/servicenow-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/servicenow.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: servicenow
 

--- a/components/camel-servlet/src/main/docs/servlet-component.adoc
+++ b/components/camel-servlet/src/main/docs/servlet-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.0
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/servlet.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: servlet
 

--- a/components/camel-shiro/src/main/docs/shiro.adoc
+++ b/components/camel-shiro/src/main/docs/shiro.adoc
@@ -5,7 +5,6 @@
 :description: Security using Shiro
 :since: 2.5
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/shiro.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: shiro
 

--- a/components/camel-sip/src/main/docs/sip-component.adoc
+++ b/components/camel-sip/src/main/docs/sip-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.5
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/sip.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: sip
 

--- a/components/camel-sjms/src/main/docs/sjms-component.adoc
+++ b/components/camel-sjms/src/main/docs/sjms-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.11
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/sjms.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: sjms
 

--- a/components/camel-sjms2/src/main/docs/sjms2-component.adoc
+++ b/components/camel-sjms2/src/main/docs/sjms2-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/sjms2.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: sjms2
 

--- a/components/camel-slack/src/main/docs/slack-component.adoc
+++ b/components/camel-slack/src/main/docs/slack-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.16
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/slack.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: slack
 

--- a/components/camel-smpp/src/main/docs/smpp-component.adoc
+++ b/components/camel-smpp/src/main/docs/smpp-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.2
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/smpp.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: smpp
 

--- a/components/camel-snakeyaml/src/main/docs/yaml-snakeyaml-dataformat.adoc
+++ b/components/camel-snakeyaml/src/main/docs/yaml-snakeyaml-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal and unmarshal Java objects to and from YAML using SnakeYAML
 :since: 2.17
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/yaml-snakeyaml.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: snakeyaml
 

--- a/components/camel-snmp/src/main/docs/snmp-component.adoc
+++ b/components/camel-snmp/src/main/docs/snmp-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.1
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/snmp.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: snmp
 

--- a/components/camel-soap/src/main/docs/soapjaxb-dataformat.adoc
+++ b/components/camel-soap/src/main/docs/soapjaxb-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal Java objects to SOAP messages and back.
 :since: 2.3
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/soapjaxb.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: soap
 

--- a/components/camel-solr/src/main/docs/solr-component.adoc
+++ b/components/camel-solr/src/main/docs/solr-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.9
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/solr.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: solr
 

--- a/components/camel-soroush/src/main/docs/soroush-component.adoc
+++ b/components/camel-soroush/src/main/docs/soroush-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/soroush.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: soroush
 

--- a/components/camel-spark/src/main/docs/spark-component.adoc
+++ b/components/camel-spark/src/main/docs/spark-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/spark.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: spark
 

--- a/components/camel-splunk-hec/src/main/docs/splunk-hec-component.adoc
+++ b/components/camel-splunk-hec/src/main/docs/splunk-hec-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.3
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/splunk-hec.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: splunk
 

--- a/components/camel-splunk/src/main/docs/splunk-component.adoc
+++ b/components/camel-splunk/src/main/docs/splunk-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.13
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/splunk.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: splunk
 

--- a/components/camel-spring-batch/src/main/docs/spring-batch-component.adoc
+++ b/components/camel-spring-batch/src/main/docs/spring-batch-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/spring-batch.adoc[opts=optional]
 //Manually maintained attributes
 :group: Spring
 :camel-spring-boot-name: spring-batch

--- a/components/camel-spring-integration/src/main/docs/spring-integration-component.adoc
+++ b/components/camel-spring-integration/src/main/docs/spring-integration-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.4
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/spring-integration.adoc[opts=optional]
 //Manually maintained attributes
 :group: Spring
 :camel-spring-boot-name: spring-integration

--- a/components/camel-spring-javaconfig/src/main/docs/spring-javaconfig.adoc
+++ b/components/camel-spring-javaconfig/src/main/docs/spring-javaconfig.adoc
@@ -6,7 +6,6 @@
 :since: 2.0
 :supportlevel: Stable-deprecated
 :deprecated: *deprecated*
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/spring-javaconfig.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: spring-javaconfig
 

--- a/components/camel-spring-jdbc/src/main/docs/spring-jdbc-component.adoc
+++ b/components/camel-spring-jdbc/src/main/docs/spring-jdbc-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.10
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/spring-jdbc.adoc[opts=optional]
 //Manually maintained attributes
 :group: Spring
 :camel-spring-boot-name: spring-jdbc

--- a/components/camel-spring-ldap/src/main/docs/spring-ldap-component.adoc
+++ b/components/camel-spring-ldap/src/main/docs/spring-ldap-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.11
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/spring-ldap.adoc[opts=optional]
 //Manually maintained attributes
 :group: Spring
 :camel-spring-boot-name: spring-ldap

--- a/components/camel-spring-main/src/main/docs/spring-main.adoc
+++ b/components/camel-spring-main/src/main/docs/spring-main.adoc
@@ -5,7 +5,6 @@
 :description: Camel Spring Main support
 :since: 3.2
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/spring-main.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-spring-rabbitmq/src/main/docs/spring-rabbitmq-component.adoc
+++ b/components/camel-spring-rabbitmq/src/main/docs/spring-rabbitmq-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.8
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/spring-rabbitmq.adoc[opts=optional]
 //Manually maintained attributes
 :group: Spring
 :camel-spring-boot-name: spring-rabbitmq

--- a/components/camel-spring-redis/src/main/docs/spring-redis-component.adoc
+++ b/components/camel-spring-redis/src/main/docs/spring-redis-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.11
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/spring-redis.adoc[opts=optional]
 //Manually maintained attributes
 :group: Spring
 :camel-spring-boot-name: spring-redis

--- a/components/camel-spring-security/src/main/docs/spring-security.adoc
+++ b/components/camel-spring-security/src/main/docs/spring-security.adoc
@@ -5,7 +5,6 @@
 :description: Security using Spring Security
 :since: 2.3
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/spring-security.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: spring-security
 

--- a/components/camel-spring-ws/src/main/docs/spring-ws-component.adoc
+++ b/components/camel-spring-ws/src/main/docs/spring-ws-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.6
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/spring-ws.adoc[opts=optional]
 //Manually maintained attributes
 :group: Spring
 :camel-spring-boot-name: spring-ws

--- a/components/camel-spring-xml/src/main/docs/spring-xml.adoc
+++ b/components/camel-spring-xml/src/main/docs/spring-xml.adoc
@@ -5,7 +5,6 @@
 :description: Camel Spring with XML DSL
 :since: 3.9
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/spring-xml.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-spring/src/main/docs/spel-language.adoc
+++ b/components/camel-spring/src/main/docs/spel-language.adoc
@@ -5,7 +5,6 @@
 :description: Evaluates a Spring expression (SpEL).
 :since: 2.7
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/spel.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: spring
 

--- a/components/camel-spring/src/main/docs/spring-event-component.adoc
+++ b/components/camel-spring/src/main/docs/spring-event-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.4
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/spring-event.adoc[opts=optional]
 //Manually maintained attributes
 :group: Spring
 :camel-spring-boot-name: spring

--- a/components/camel-sql/src/main/docs/sql-component.adoc
+++ b/components/camel-sql/src/main/docs/sql-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.4
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/sql.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: sql
 

--- a/components/camel-sql/src/main/docs/sql-stored-component.adoc
+++ b/components/camel-sql/src/main/docs/sql-stored-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.17
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/sql-stored.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: sql
 

--- a/components/camel-ssh/src/main/docs/ssh-component.adoc
+++ b/components/camel-ssh/src/main/docs/ssh-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/ssh.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: ssh
 

--- a/components/camel-stax/src/main/docs/stax-component.adoc
+++ b/components/camel-stax/src/main/docs/stax-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.9
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/stax.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: stax
 

--- a/components/camel-stitch/src/main/docs/stitch-component.adoc
+++ b/components/camel-stitch/src/main/docs/stitch-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.8
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/stitch.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: stitch
 

--- a/components/camel-stomp/src/main/docs/stomp-component.adoc
+++ b/components/camel-stomp/src/main/docs/stomp-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/stomp.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: stomp
 

--- a/components/camel-stream/src/main/docs/stream-component.adoc
+++ b/components/camel-stream/src/main/docs/stream-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.3
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/stream.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: stream
 

--- a/components/camel-stringtemplate/src/main/docs/string-template-component.adoc
+++ b/components/camel-stringtemplate/src/main/docs/string-template-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.2
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/string-template.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: stringtemplate
 

--- a/components/camel-stub/src/main/docs/stub-component.adoc
+++ b/components/camel-stub/src/main/docs/stub-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/stub.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: stub
 

--- a/components/camel-swagger-java/src/main/docs/swagger-java.adoc
+++ b/components/camel-swagger-java/src/main/docs/swagger-java.adoc
@@ -5,7 +5,6 @@
 :description: Rest-dsl support for using swagger api-doc
 :since: 2.16
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/swagger-java.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: swagger-java
 

--- a/components/camel-syslog/src/main/docs/syslog-dataformat.adoc
+++ b/components/camel-syslog/src/main/docs/syslog-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshall SyslogMessages to RFC3164 and RFC5424 messages and back.
 :since: 2.6
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/syslog.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: syslog
 

--- a/components/camel-tagsoup/src/main/docs/tidyMarkup-dataformat.adoc
+++ b/components/camel-tagsoup/src/main/docs/tidyMarkup-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Parse (potentially invalid) HTML into valid HTML or DOM.
 :since: 2.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/tidyMarkup.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: tagsoup
 

--- a/components/camel-tarfile/src/main/docs/tarfile-dataformat.adoc
+++ b/components/camel-tarfile/src/main/docs/tarfile-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Archive files into tarballs or extract files from tarballs.
 :since: 2.16
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/tarfile.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: tarfile
 

--- a/components/camel-telegram/src/main/docs/telegram-component.adoc
+++ b/components/camel-telegram/src/main/docs/telegram-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.18
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/telegram.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: telegram
 

--- a/components/camel-test/camel-test-cdi/src/main/docs/test-cdi.adoc
+++ b/components/camel-test/camel-test-cdi/src/main/docs/test-cdi.adoc
@@ -5,7 +5,6 @@
 :description: Camel unit testing with CDI
 :since: 2.17
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/test-cdi.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-test/camel-test-junit5/src/main/docs/test-junit5.adoc
+++ b/components/camel-test/camel-test-junit5/src/main/docs/test-junit5.adoc
@@ -5,7 +5,6 @@
 :description: Camel unit testing with JUnit 5
 :since: 3.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/test-junit5.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-test/camel-test-spring-junit5/src/main/docs/test-spring-junit5.adoc
+++ b/components/camel-test/camel-test-spring-junit5/src/main/docs/test-spring-junit5.adoc
@@ -5,7 +5,6 @@
 :description: Camel unit testing with Spring and JUnit 5
 :since: 3.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/test-spring-junit5.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-test/camel-test-spring/src/main/docs/test-spring.adoc
+++ b/components/camel-test/camel-test-spring/src/main/docs/test-spring.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable-deprecated
 :deprecated: *deprecated*
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/test-spring.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-test/camel-test/src/main/docs/test.adoc
+++ b/components/camel-test/camel-test/src/main/docs/test.adoc
@@ -6,7 +6,6 @@
 :since: 2.9
 :supportlevel: Stable-deprecated
 :deprecated: *deprecated*
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/test.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-test/camel-testcontainers-junit5/src/main/docs/testcontainers-junit5.adoc
+++ b/components/camel-test/camel-testcontainers-junit5/src/main/docs/testcontainers-junit5.adoc
@@ -5,7 +5,6 @@
 :description: Camel support for testcontainers with JUnit 5
 :since: 3.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/testcontainers-junit5.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-test/camel-testcontainers-spring-junit5/src/main/docs/testcontainers-spring-junit5.adoc
+++ b/components/camel-test/camel-testcontainers-spring-junit5/src/main/docs/testcontainers-spring-junit5.adoc
@@ -5,7 +5,6 @@
 :description: Camel unit testing with Spring, testcontainers and JUnit 5
 :since: 3.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/testcontainers-spring-junit5.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-test/camel-testcontainers-spring/src/main/docs/testcontainers-spring.adoc
+++ b/components/camel-test/camel-testcontainers-spring/src/main/docs/testcontainers-spring.adoc
@@ -6,7 +6,6 @@
 :since: 2.22
 :supportlevel: Stable-deprecated
 :deprecated: *deprecated*
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/testcontainers-spring.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-test/camel-testcontainers/src/main/docs/testcontainers.adoc
+++ b/components/camel-test/camel-testcontainers/src/main/docs/testcontainers.adoc
@@ -6,7 +6,6 @@
 :since: 2.22
 :supportlevel: Stable-deprecated
 :deprecated: *deprecated*
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/testcontainers.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-threadpoolfactory-vertx/src/main/docs/threadpoolfactory-vertx.adoc
+++ b/components/camel-threadpoolfactory-vertx/src/main/docs/threadpoolfactory-vertx.adoc
@@ -5,7 +5,6 @@
 :description: ThreadPoolFactory for camel-core using Vert.x
 :since: 3.5
 :supportlevel: Preview
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/threadpoolfactory-vertx.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-thrift/src/main/docs/thrift-component.adoc
+++ b/components/camel-thrift/src/main/docs/thrift-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/thrift.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: thrift
 

--- a/components/camel-thrift/src/main/docs/thrift-dataformat.adoc
+++ b/components/camel-thrift/src/main/docs/thrift-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Serialize and deserialize messages using Apache Thrift binary data format.
 :since: 2.20
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/thrift.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: thrift
 

--- a/components/camel-tika/src/main/docs/tika-component.adoc
+++ b/components/camel-tika/src/main/docs/tika-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/tika.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: tika
 

--- a/components/camel-timer/src/main/docs/timer-component.adoc
+++ b/components/camel-timer/src/main/docs/timer-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only consumer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/timer.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: timer
 

--- a/components/camel-tracing/src/main/docs/tracing.adoc
+++ b/components/camel-tracing/src/main/docs/tracing.adoc
@@ -5,7 +5,6 @@
 :description: Distributed tracing common interfaces
 :since: 3.5
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/tracing.adoc[opts=optional]
 
 *Since Camel {since}*
 

--- a/components/camel-twilio/src/main/docs/twilio-component.adoc
+++ b/components/camel-twilio/src/main/docs/twilio-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.20
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/twilio.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: twilio
 

--- a/components/camel-twitter/src/main/docs/twitter-directmessage-component.adoc
+++ b/components/camel-twitter/src/main/docs/twitter-directmessage-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/twitter-directmessage.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: twitter
 

--- a/components/camel-twitter/src/main/docs/twitter-search-component.adoc
+++ b/components/camel-twitter/src/main/docs/twitter-search-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/twitter-search.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: twitter
 

--- a/components/camel-twitter/src/main/docs/twitter-timeline-component.adoc
+++ b/components/camel-twitter/src/main/docs/twitter-timeline-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/twitter-timeline.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: twitter
 

--- a/components/camel-undertow-spring-security/src/main/docs/undertow-spring-security.adoc
+++ b/components/camel-undertow-spring-security/src/main/docs/undertow-spring-security.adoc
@@ -5,7 +5,6 @@
 :description: Spring Security Provider for camel-undertow
 :since: 3.3
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/undertow-spring-security.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: undertow-spring-security
 

--- a/components/camel-undertow/src/main/docs/undertow-component.adoc
+++ b/components/camel-undertow/src/main/docs/undertow-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.16
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/undertow.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: undertow
 

--- a/components/camel-univocity-parsers/src/main/docs/univocity-csv-dataformat.adoc
+++ b/components/camel-univocity-parsers/src/main/docs/univocity-csv-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal and unmarshal Java objects from and to CSV (Comma Separated Values) using UniVocity Parsers.
 :since: 2.15
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/univocity-csv.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: univocity-parsers
 

--- a/components/camel-univocity-parsers/src/main/docs/univocity-fixed-dataformat.adoc
+++ b/components/camel-univocity-parsers/src/main/docs/univocity-fixed-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal and unmarshal Java objects from and to fixed length records using UniVocity Parsers.
 :since: 2.15
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/univocity-fixed.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: univocity-parsers
 

--- a/components/camel-univocity-parsers/src/main/docs/univocity-tsv-dataformat.adoc
+++ b/components/camel-univocity-parsers/src/main/docs/univocity-tsv-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal and unmarshal Java objects from and to TSV (Tab-Separated Values) records using UniVocity Parsers.
 :since: 2.15
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/univocity-tsv.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: univocity-parsers
 

--- a/components/camel-validator/src/main/docs/validator-component.adoc
+++ b/components/camel-validator/src/main/docs/validator-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only producer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/validator.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: validator
 

--- a/components/camel-velocity/src/main/docs/velocity-component.adoc
+++ b/components/camel-velocity/src/main/docs/velocity-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.2
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/velocity.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: velocity
 

--- a/components/camel-vertx/camel-vertx-http/src/main/docs/vertx-http-component.adoc
+++ b/components/camel-vertx/camel-vertx-http/src/main/docs/vertx-http-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.5
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/vertx-http.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: vertx-http
 

--- a/components/camel-vertx/camel-vertx-kafka/camel-vertx-kafka-component/src/main/docs/vertx-kafka-component.adoc
+++ b/components/camel-vertx/camel-vertx-kafka/camel-vertx-kafka-component/src/main/docs/vertx-kafka-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.7
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/vertx-kafka.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: vertx-kafka
 

--- a/components/camel-vertx/camel-vertx-websocket/src/main/docs/vertx-websocket-component.adoc
+++ b/components/camel-vertx/camel-vertx-websocket/src/main/docs/vertx-websocket-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.5
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/vertx-websocket.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: vertx-websocket
 

--- a/components/camel-vertx/camel-vertx/src/main/docs/vertx-component.adoc
+++ b/components/camel-vertx/camel-vertx/src/main/docs/vertx-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/vertx.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: vertx
 

--- a/components/camel-vm/src/main/docs/vm-component.adoc
+++ b/components/camel-vm/src/main/docs/vm-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/vm.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: vm
 

--- a/components/camel-weather/src/main/docs/weather-component.adoc
+++ b/components/camel-weather/src/main/docs/weather-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/weather.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: weather
 

--- a/components/camel-web3j/src/main/docs/web3j-component.adoc
+++ b/components/camel-web3j/src/main/docs/web3j-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.22
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/web3j.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: web3j
 

--- a/components/camel-webhook/src/main/docs/webhook-component.adoc
+++ b/components/camel-webhook/src/main/docs/webhook-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/webhook.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: webhook
 

--- a/components/camel-websocket-jsr356/src/main/docs/websocket-jsr356-component.adoc
+++ b/components/camel-websocket-jsr356/src/main/docs/websocket-jsr356-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.23
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/websocket-jsr356.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: websocket-jsr356
 

--- a/components/camel-websocket/src/main/docs/websocket-component.adoc
+++ b/components/camel-websocket/src/main/docs/websocket-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.10
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/websocket.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: websocket
 

--- a/components/camel-weka/src/main/docs/weka-component.adoc
+++ b/components/camel-weka/src/main/docs/weka-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/weka.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: weka
 

--- a/components/camel-wordpress/src/main/docs/wordpress-component.adoc
+++ b/components/camel-wordpress/src/main/docs/wordpress-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.21
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/wordpress.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: wordpress
 

--- a/components/camel-workday/src/main/docs/workday-component.adoc
+++ b/components/camel-workday/src/main/docs/workday-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.1
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/workday.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: workday
 

--- a/components/camel-xchange/src/main/docs/xchange-component.adoc
+++ b/components/camel-xchange/src/main/docs/xchange-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.21
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/xchange.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: xchange
 

--- a/components/camel-xj/src/main/docs/xj-component.adoc
+++ b/components/camel-xj/src/main/docs/xj-component.adoc
@@ -6,7 +6,6 @@
 :since: 3.0
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/xj.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: xj
 

--- a/components/camel-xmlsecurity/src/main/docs/secureXML-dataformat.adoc
+++ b/components/camel-xmlsecurity/src/main/docs/secureXML-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Encrypt and decrypt XML payloads using Apache Santuario.
 :since: 2.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/secureXML.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: xmlsecurity
 

--- a/components/camel-xmlsecurity/src/main/docs/xmlsecurity-sign-component.adoc
+++ b/components/camel-xmlsecurity/src/main/docs/xmlsecurity-sign-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/xmlsecurity-sign.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: xmlsecurity
 

--- a/components/camel-xmlsecurity/src/main/docs/xmlsecurity-verify-component.adoc
+++ b/components/camel-xmlsecurity/src/main/docs/xmlsecurity-verify-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Only producer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/xmlsecurity-verify.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: xmlsecurity
 

--- a/components/camel-xmpp/src/main/docs/xmpp-component.adoc
+++ b/components/camel-xmpp/src/main/docs/xmpp-component.adoc
@@ -6,7 +6,6 @@
 :since: 1.0
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/xmpp.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: xmpp
 

--- a/components/camel-xpath/src/main/docs/xpath-language.adoc
+++ b/components/camel-xpath/src/main/docs/xpath-language.adoc
@@ -5,7 +5,6 @@
 :description: Evaluates an XPath expression against an XML payload.
 :since: 1.1
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/xpath.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: xpath
 

--- a/components/camel-xslt-saxon/src/main/docs/xslt-saxon-component.adoc
+++ b/components/camel-xslt-saxon/src/main/docs/xslt-saxon-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only producer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/xslt-saxon.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: xslt-saxon
 

--- a/components/camel-xslt/src/main/docs/xslt-component.adoc
+++ b/components/camel-xslt/src/main/docs/xslt-component.adoc
@@ -7,7 +7,6 @@
 :supportlevel: Stable
 :component-header: Only producer is supported
 :core:
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/xslt.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: xslt
 

--- a/components/camel-xstream/src/main/docs/json-xstream-dataformat.adoc
+++ b/components/camel-xstream/src/main/docs/json-xstream-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal POJOs to JSON and back using XStream
 :since: 2.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/json-xstream.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: xstream
 

--- a/components/camel-xstream/src/main/docs/xstream-dataformat.adoc
+++ b/components/camel-xstream/src/main/docs/xstream-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Marshal and unmarshal POJOs to/from XML using XStream library.
 :since: 1.3
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/xstream.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: xstream
 

--- a/components/camel-yammer/src/main/docs/yammer-component.adoc
+++ b/components/camel-yammer/src/main/docs/yammer-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.12
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/yammer.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: yammer
 

--- a/components/camel-zendesk/src/main/docs/zendesk-component.adoc
+++ b/components/camel-zendesk/src/main/docs/zendesk-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/zendesk.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: zendesk
 

--- a/components/camel-zip-deflater/src/main/docs/gzipdeflater-dataformat.adoc
+++ b/components/camel-zip-deflater/src/main/docs/gzipdeflater-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Compress and decompress messages using java.util.zip.GZIPStream.
 :since: 2.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/gzipdeflater.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: zip-deflater
 

--- a/components/camel-zip-deflater/src/main/docs/zipdeflater-dataformat.adoc
+++ b/components/camel-zip-deflater/src/main/docs/zipdeflater-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Compress and decompress streams using java.util.zip.Deflater and java.util.zip.Inflater.
 :since: 2.12
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/zipdeflater.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: zip-deflater
 

--- a/components/camel-zipfile/src/main/docs/zipfile-dataformat.adoc
+++ b/components/camel-zipfile/src/main/docs/zipfile-dataformat.adoc
@@ -5,7 +5,6 @@
 :description: Compression and decompress streams using java.util.zip.ZipStream.
 :since: 2.11
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/dataformats/zipfile.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: zipfile
 

--- a/components/camel-zipkin/src/main/docs/zipkin.adoc
+++ b/components/camel-zipkin/src/main/docs/zipkin.adoc
@@ -5,7 +5,6 @@
 :description: Distributed message tracing using Zipkin
 :since: 2.18
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/zipkin.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: zipkin
 

--- a/components/camel-zookeeper-master/src/main/docs/zookeeper-master-component.adoc
+++ b/components/camel-zookeeper-master/src/main/docs/zookeeper-master-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.19
 :supportlevel: Stable
 :component-header: Only consumer is supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/zookeeper-master.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: zookeeper-master
 

--- a/components/camel-zookeeper/src/main/docs/zookeeper-component.adoc
+++ b/components/camel-zookeeper/src/main/docs/zookeeper-component.adoc
@@ -6,7 +6,6 @@
 :since: 2.9
 :supportlevel: Stable
 :component-header: Both producer and consumer are supported
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/components/zookeeper.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: zookeeper
 

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/constant-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/constant-language.adoc
@@ -5,7 +5,6 @@
 :description: A fixed value set only once during the route startup.
 :since: 1.5
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/constant.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: core
 :starter-artifactid: camel-core-starter

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/csimple-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/csimple-language.adoc
@@ -5,7 +5,6 @@
 :description: Evaluate a compiled simple expression.
 :since: 3.7
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/csimple.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: core
 :starter-artifactid: camel-core-starter

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/exchangeProperty-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/exchangeProperty-language.adoc
@@ -5,7 +5,6 @@
 :description: Gets a property from the Exchange.
 :since: 2.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/exchangeProperty.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: core
 :starter-artifactid: camel-core-starter

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/file-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/file-language.adoc
@@ -5,7 +5,6 @@
 :description: File related capabilities for the Simple language
 :since: 1.1
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/file.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: core
 :starter-artifactid: camel-core-starter

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/header-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/header-language.adoc
@@ -5,7 +5,6 @@
 :description: Gets a header from the Exchange.
 :since: 1.5
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/header.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: core
 :starter-artifactid: camel-core-starter

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/ref-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/ref-language.adoc
@@ -5,7 +5,6 @@
 :description: Uses an existing expression from the registry.
 :since: 2.8
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/ref.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: core
 :starter-artifactid: camel-core-starter

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/simple-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/simple-language.adoc
@@ -5,7 +5,6 @@
 :description: Evaluates a Camel simple expression.
 :since: 1.1
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/simple.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: core
 :starter-artifactid: camel-core-starter

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/tokenize-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/tokenize-language.adoc
@@ -5,7 +5,6 @@
 :description: Tokenize text payloads using delimiter patterns.
 :since: 2.0
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/tokenize.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: core
 :starter-artifactid: camel-core-starter

--- a/core/camel-xml-jaxp/src/main/docs/modules/languages/pages/xtokenize-language.adoc
+++ b/core/camel-xml-jaxp/src/main/docs/modules/languages/pages/xtokenize-language.adoc
@@ -5,7 +5,6 @@
 :description: Tokenize XML payloads.
 :since: 2.14
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/languages/xtokenize.adoc[opts=optional]
 //Manually maintained attributes
 :camel-spring-boot-name: xml-jaxp
 

--- a/docs/components/antora.yml
+++ b/docs/components/antora.yml
@@ -34,4 +34,3 @@ asciidoc:
   attributes:
     index-table-format: width="100%",cols="4,3,3,3,6",options="header"
 #  | Data Format | Artifact | Support Level | Since | Description
-    cq-version: next

--- a/docs/local-build.sh
+++ b/docs/local-build.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+CW=./../../camel-website
+LOCAL=./../camel
+
+cd $CW || (echo 'camel-website not in expected location $CW' && exit)
+cp antora-playbook.yml local-antora-playbook-full.yml
+cat $LOCAL/docs/source-map.yml >> local-antora-playbook-full.yml
+cat playbook-patch-full.yml >> local-antora-playbook-full.yml
+
+cp antora-playbook.yml local-antora-playbook-partial.yml
+cat $LOCAL/docs/source-map.yml >> local-antora-playbook-partial.yml
+cat $LOCAL/docs/source-watch.yml >> local-antora-playbook-partial.yml
+
+if [ "$1" = "full" ] || [ "$1" = "1" ]
+then
+  yarn build:antora-local-full
+else
+  yarn build:antora-local-partial
+fi

--- a/docs/source-map.yml
+++ b/docs/source-map.yml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+    - require: '@djencks/antora-source-map'
+#      log_level: trace
+      source_map:
+        - url: 'https://github.com/apache/camel.git'
+          mapped_url: './../camel'
+          branches:
+            - branch: camel-3.13.x
+              mapped_branch: HEAD

--- a/docs/source-watch.yml
+++ b/docs/source-watch.yml
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+    - require: '@djencks/antora-source-watch'
+#      log_level: debug
+      sources:
+        - url: ./../camel
+
+        - url: https://github.com/apache/camel-spring-boot.git
+          branch_includes: camel-spring-boot-3.13.x
+          start_path_includes: docs/components,components-starter
+      components:
+
+    - require: "@djencks/antora-site-manifest"
+      import_manifests:
+        - primary_site_manifest_url: ./documentation/site-manifest.json
+      partial_components: true
+      local-urls: true
+
+    - require: '@djencks/antora-timer'
+      log_level: info
+
+  generator: '@djencks/antora-source-watch'

--- a/dsl/camel-groovy-dsl/camel-groovy-dsl/src/main/docs/groovy-dsl.adoc
+++ b/dsl/camel-groovy-dsl/camel-groovy-dsl/src/main/docs/groovy-dsl.adoc
@@ -6,7 +6,6 @@
 :description: Camel DSL with Groovy
 :supportlevel: Experimental/Preview
 :since: 3
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/groovy-dsl.adoc[opts=optional]
 //Manually maintained attributes
 :group: DSL
 

--- a/dsl/camel-java-joor-dsl/src/main/docs/java-joor-dsl.adoc
+++ b/dsl/camel-java-joor-dsl/src/main/docs/java-joor-dsl.adoc
@@ -6,7 +6,6 @@
 :description: Camel DSL with YAML
 :supportlevel: Stable/Preview
 :since: 3
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/java-joor-dsl.adoc[opts=optional]
 //Manually maintained attributes
 :group: DSL
 

--- a/dsl/camel-js-dsl/src/main/docs/js-dsl.adoc
+++ b/dsl/camel-js-dsl/src/main/docs/js-dsl.adoc
@@ -6,7 +6,6 @@
 :description: Camel DSL with JavaScript
 :supportlevel: Experimental/Preview
 :since: 3
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/js-dsl.adoc[opts=optional]
 //Manually maintained attributes
 :group: DSL
 

--- a/dsl/camel-kamelet-main/src/main/docs/kamelet-main.adoc
+++ b/dsl/camel-kamelet-main/src/main/docs/kamelet-main.adoc
@@ -6,7 +6,6 @@
 :description: Main to run Kamelet standalone
 :since: 3.11
 :supportlevel: Preview
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/kamelet-main.adoc[opts=optional]
 //Manually maintained attributes
 :group: DSL
 

--- a/dsl/camel-kotlin-dsl/src/main/docs/kotlin-dsl.adoc
+++ b/dsl/camel-kotlin-dsl/src/main/docs/kotlin-dsl.adoc
@@ -6,7 +6,6 @@
 :description: Camel DSL with Kotlin
 :supportlevel: Experimental/Preview
 :since: 3
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/kotlin-dsl.adoc[opts=optional]
 //Manually maintained attributes
 :group: DSL
 

--- a/dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc
+++ b/dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc
@@ -5,7 +5,6 @@
 :artifactid: camel-xml-io-dsl
 :description: Camel DSL with YAML
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/xml-io-dsl.adoc[opts=optional]
 //Manually maintained attributes
 :group: DSL
 

--- a/dsl/camel-xml-jaxb-dsl/src/main/docs/java-xml-jaxb-dsl.adoc
+++ b/dsl/camel-xml-jaxb-dsl/src/main/docs/java-xml-jaxb-dsl.adoc
@@ -5,7 +5,6 @@
 :artifactid: camel-xml-jaxb-dsl
 :description: Camel DSL with YAML
 :supportlevel: Stable
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/xml-jaxb-dsl.adoc[opts=optional]
 //Manually maintained attributes
 :group: DSL
 

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/main/docs/yaml-dsl.adoc
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/main/docs/yaml-dsl.adoc
@@ -6,7 +6,6 @@
 :description: Camel DSL with YAML
 :since: 3.9
 :supportlevel: Preview
-include::{cq-version}@camel-quarkus:ROOT:partial$reference/others/yaml-dsl.adoc[opts=optional]
 //Manually maintained attributes
 :group: DSL
 

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/UpdateReadmeMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/UpdateReadmeMojo.java
@@ -505,13 +505,6 @@ public class UpdateReadmeMojo extends AbstractGeneratorMojo {
                 }
             }
 
-            // quarkus include pages should not be for EIP models
-            if (!"model".equals(model.getKind())) {
-                newLines.add(
-                        "include::{cq-version}@camel-quarkus:ROOT:partial$reference/" + kind + "s/" + name
-                             + ".adoc[opts=optional]");
-            }
-
             if (!manualAttributes.isEmpty()) {
                 newLines.add("//Manually maintained attributes");
                 for (Map.Entry<String, String> entry : manualAttributes.entrySet()) {


### PR DESCRIPTION
See apache/camel-quarkus#3396
This must be applied after apache/camel-quarkus#3397 or 8

Remove the header include of cq bits in component adocs as the bits are gone and not used.