### PR TITLE
[CAMEL-17371] Set and remove Exchange Properties

### DIFF
--- a/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedBacklogDebuggerMBean.java
+++ b/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedBacklogDebuggerMBean.java
@@ -163,4 +163,13 @@ public interface ManagedBacklogDebuggerMBean {
 
     @ManagedOperation(description = "Evaluates the expression at a given breakpoint node id and returns the result as String")
     String evaluateExpressionAtBreakpoint(String nodeId, String language, String expression);
+
+    @ManagedOperation(description = "Updates/adds the exchange property (uses same type as old exchange property  value) on the suspended breakpoint at the given node id")
+    void setExchangePropertyOnBreakpoint(String nodeId, String exchangePropertyName, Object value);
+
+    @ManagedOperation(description = "Removes the exchange property on the suspended breakpoint at the given node id")
+    void removeExchangePropertyOnBreakpoint(String nodeId, String exchangePropertyName);
+
+    @ManagedOperation(description = "Updates/adds the exchange property (with a new type) on the suspended breakpoint at the given node id")
+    void setExchangePropertyOnBreakpoint(String nodeId, String exchangePropertyName, Object value, String type);
 }

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedBacklogDebugger.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedBacklogDebugger.java
@@ -301,6 +301,41 @@ public class ManagedBacklogDebugger implements ManagedBacklogDebuggerMBean {
     }
 
     @Override
+    public void setExchangePropertyOnBreakpoint(String nodeId, String exchangePropertyName, Object value) {
+        Exchange suspendedExchange = backlogDebugger.getSuspendedExchange(nodeId);
+        if (suspendedExchange != null) {
+            suspendedExchange.setProperty(exchangePropertyName, value);
+        }
+    }
+
+    @Override
+    public void removeExchangePropertyOnBreakpoint(String nodeId, String exchangePropertyName) {
+        Exchange suspendedExchange = backlogDebugger.getSuspendedExchange(nodeId);
+        if (suspendedExchange != null) {
+            suspendedExchange.removeProperty(exchangePropertyName);
+        }
+    }
+
+    @Override
+    public void setExchangePropertyOnBreakpoint(String nodeId, String exchangePropertyName, Object value, String type) {
+        try {
+            Class<?> classType = camelContext.getClassResolver().resolveMandatoryClass(type);
+            if (type != null) {
+                Exchange suspendedExchange = backlogDebugger.getSuspendedExchange(nodeId);
+                if (suspendedExchange != null) {
+                    value = suspendedExchange.getContext().getTypeConverter().mandatoryConvertTo(classType, suspendedExchange,
+                            value);
+                    suspendedExchange.setProperty(exchangePropertyName, value);
+                }
+            } else {
+                this.setExchangePropertyOnBreakpoint(nodeId, exchangePropertyName, value);
+            }
+        } catch (Exception e) {
+            throw RuntimeCamelException.wrapRuntimeCamelException(e);
+        }
+    }
+
+    @Override
     public Object evaluateExpressionAtBreakpoint(String nodeId, String language, String expression, String resultType) {
         Exchange suspendedExchange;
         try {

--- a/core/camel-management/src/test/java/org/apache/camel/management/BacklogDebuggerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/BacklogDebuggerTest.java
@@ -100,7 +100,7 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testBacklogDebuggerUpdateBodyAndHeader() throws Exception {
+    public void testBacklogDebuggerUpdateBodyExchangePropertyAndHeader() throws Exception {
         MBeanServer mbeanServer = getMBeanServer();
         ObjectName on = new ObjectName(
                 "org.apache.camel:context=" + context.getManagementName() + ",type=tracer,name=BacklogDebugger");
@@ -139,6 +139,8 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
                 new String[] { "java.lang.String", "java.lang.Object" });
         mbeanServer.invoke(on, "setMessageHeaderOnBreakpoint", new Object[] { "foo", "beer", "Carlsberg" },
                 new String[] { "java.lang.String", "java.lang.String", "java.lang.Object" });
+        mbeanServer.invoke(on, "setExchangePropertyOnBreakpoint", new Object[] { "foo", "food", "Bratwurst" },
+                new String[] { "java.lang.String", "java.lang.String", "java.lang.Object" });
 
         // resume breakpoint
         mbeanServer.invoke(on, "resumeBreakpoint", new Object[] { "foo" }, new String[] { "java.lang.String" });
@@ -152,8 +154,8 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
         });
 
         // the message should be ours
-        String xml = (String) mbeanServer.invoke(on, "dumpTracedMessagesAsXml", new Object[] { "bar" },
-                new String[] { "java.lang.String" });
+        String xml = (String) mbeanServer.invoke(on, "dumpTracedMessagesAsXml", new Object[] { "bar", true },
+                new String[] { "java.lang.String", "boolean" });
         assertNotNull(xml);
         log.info(xml);
 
@@ -161,6 +163,8 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
         assertTrue(xml.contains("<toNode>bar</toNode>"), "Should contain bar node");
         assertTrue(xml.contains("<header key=\"beer\" type=\"java.lang.String\">Carlsberg</header>"),
                 "Should contain our added header");
+        assertTrue(xml.contains("<exchangeProperty name=\"food\" type=\"java.lang.String\">Bratwurst</exchangeProperty>"),
+                "Should contain our added exchange property");
 
         resetMocks();
         mock.expectedMessageCount(1);
@@ -178,7 +182,7 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testBacklogDebuggerUpdateBodyAndHeaderType() throws Exception {
+    public void testBacklogDebuggerUpdateBodyExchangePropertyAndHeaderType() throws Exception {
         MBeanServer mbeanServer = getMBeanServer();
         ObjectName on = new ObjectName(
                 "org.apache.camel:context=" + context.getManagementName() + ",type=tracer,name=BacklogDebugger");
@@ -217,6 +221,8 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
                 new String[] { "java.lang.String", "java.lang.Object", "java.lang.String" });
         mbeanServer.invoke(on, "setMessageHeaderOnBreakpoint", new Object[] { "foo", "beer", "123", "java.lang.Integer" },
                 new String[] { "java.lang.String", "java.lang.String", "java.lang.Object", "java.lang.String" });
+        mbeanServer.invoke(on, "setExchangePropertyOnBreakpoint", new Object[] { "foo", "food", "987", "java.lang.Integer" },
+                new String[] { "java.lang.String", "java.lang.String", "java.lang.Object", "java.lang.String" });
 
         // resume breakpoint
         mbeanServer.invoke(on, "resumeBreakpoint", new Object[] { "foo" }, new String[] { "java.lang.String" });
@@ -230,8 +236,8 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
         });
 
         // the message should be ours
-        String xml = (String) mbeanServer.invoke(on, "dumpTracedMessagesAsXml", new Object[] { "bar" },
-                new String[] { "java.lang.String" });
+        String xml = (String) mbeanServer.invoke(on, "dumpTracedMessagesAsXml", new Object[] { "bar", true },
+                new String[] { "java.lang.String", "boolean" });
         assertNotNull(xml);
         log.info(xml);
 
@@ -239,7 +245,8 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
         assertTrue(xml.contains("<toNode>bar</toNode>"), "Should contain bar node");
         assertTrue(xml.contains("<header key=\"beer\" type=\"java.lang.Integer\">123</header>"),
                 "Should contain our added header");
-
+        assertTrue(xml.contains("<exchangeProperty name=\"food\" type=\"java.lang.Integer\">987</exchangeProperty>"),
+                "Should contain our added exchange property");
         resetMocks();
         mock.expectedMessageCount(1);
 
@@ -294,6 +301,8 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
         mbeanServer.invoke(on, "removeMessageBodyOnBreakpoint", new Object[] { "foo" }, new String[] { "java.lang.String" });
         mbeanServer.invoke(on, "removeMessageHeaderOnBreakpoint", new Object[] { "foo", "beer" },
                 new String[] { "java.lang.String", "java.lang.String" });
+        mbeanServer.invoke(on, "removeExchangePropertyOnBreakpoint", new Object[] { "foo", "food" },
+                new String[] { "java.lang.String", "java.lang.String" });
 
         // resume breakpoint
         mbeanServer.invoke(on, "resumeBreakpoint", new Object[] { "foo" }, new String[] { "java.lang.String" });
@@ -307,14 +316,15 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
         });
 
         // the message should be ours
-        String xml = (String) mbeanServer.invoke(on, "dumpTracedMessagesAsXml", new Object[] { "bar" },
-                new String[] { "java.lang.String" });
+        String xml = (String) mbeanServer.invoke(on, "dumpTracedMessagesAsXml", new Object[] { "bar", true },
+                new String[] { "java.lang.String", "boolean" });
         assertNotNull(xml);
         log.info(xml);
 
         assertTrue(xml.contains("<body>[Body is null]</body>"), "Should not contain our body");
         assertTrue(xml.contains("<toNode>bar</toNode>"), "Should contain bar node");
         assertFalse(xml.contains("<header"), "Should not contain any headers");
+        assertFalse(xml.contains("<exchangeProperty name=\"food\""), "Should not contain exchange property 'food'");
 
         resetMocks();
         mock.expectedMessageCount(1);

--- a/docs/user-manual/modules/ROOT/pages/backlog-debugger.adoc
+++ b/docs/user-manual/modules/ROOT/pages/backlog-debugger.adoc
@@ -48,6 +48,7 @@ NOTE: This requires to enabled JMX by including `camel-management` JAR in the cl
 |`resetDebuggerCounter` |`void` |To reset the debugger counter.
 |`resumeAll` |`void` |To resume all suspended breakpoints.
 |`resumeBreakpoint(nodeId)` |`void` |To resume a suspend breakpoint, which will then continue routing the Exchange.
+|`setExchangePropertyOnBreakpoint(nodeId,exchangePropertyName,value)` |`void` |To update/add the Exchange property on the suspended Exchange at the node.
 |`setFallbackTimeout(value)` |`long` |Fallback Timeout in seconds (300 seconds as default) when block the message processing in Camel. A timeout used for waiting for a message to arrive at a given breakpoint. `
 |`setMessageBodyOnBreakpoint(nodeId,body)` |`void` |To update the message body on the suspended Exchange at the node.
 |`setMessageHeaderOnBreakpoint(nodeId,headerName,value)` |`void` |To update/add the message header on the suspended Exchange at the node.


### PR DESCRIPTION
Just like setting and removing message headers, there should be a setting and removing exchange properties functionality. This PR adds the implementation.