### PR TITLE
Delete StringHelper#replaceAll and use String#replace instead as it is …

### DIFF
--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/DefaultJmsKeyFormatStrategy.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/DefaultJmsKeyFormatStrategy.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.component.jms;
 
-import org.apache.camel.util.StringHelper;
-
 /**
  * Default strategy that handles dots and hyphens.
  * <p/>
@@ -32,15 +30,15 @@ public class DefaultJmsKeyFormatStrategy implements JmsKeyFormatStrategy {
 
     @Override
     public String encodeKey(String key) {
-        String answer = StringHelper.replaceAll(key, DOT, DOT_REPLACEMENT);
-        answer = StringHelper.replaceAll(answer, HYPHEN, HYPHEN_REPLACEMENT);
+        String answer = key.replace(DOT, DOT_REPLACEMENT);
+        answer = answer.replace(HYPHEN, HYPHEN_REPLACEMENT);
         return answer;
     }
 
     @Override
     public String decodeKey(String key) {
-        String answer = StringHelper.replaceAll(key, DOT_REPLACEMENT, DOT);
-        answer = StringHelper.replaceAll(answer, HYPHEN_REPLACEMENT, HYPHEN);
+        String answer = key.replace(DOT_REPLACEMENT, DOT);
+        answer = answer.replace(HYPHEN_REPLACEMENT, HYPHEN);
         return answer;
     }
 

--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorCompiler.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorCompiler.java
@@ -31,7 +31,6 @@ import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.ScriptHelper;
 import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.StopWatch;
-import org.apache.camel.util.StringHelper;
 import org.joor.Reflect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -258,7 +257,7 @@ public class JoorCompiler extends ServiceSupport implements StaticService {
         for (Map.Entry<String, String> entry : aliases.entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
-            script = StringHelper.replaceAll(script, key, value);
+            script = script.replace(key, value);
         }
         return script;
     }

--- a/components/camel-netty/src/main/java/org/apache/camel/component/netty/NettyConfiguration.java
+++ b/components/camel-netty/src/main/java/org/apache/camel/component/netty/NettyConfiguration.java
@@ -42,7 +42,6 @@ import org.apache.camel.support.EndpointHelper;
 import org.apache.camel.support.PropertyBindingSupport;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.PropertiesHelper;
-import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -277,7 +276,7 @@ public class NettyConfiguration extends NettyServerBootstrapConfiguration implem
         if (value == null) {
             value = defaultValue;
         } else if (value instanceof String && EndpointHelper.isReferenceParameter((String) value)) {
-            String name = StringHelper.replaceAll((String) value, "#", "");
+            String name = ((String) value).replace("#", "");
             value = CamelContextHelper.mandatoryLookup(component.getCamelContext(), name);
         }
         if (value instanceof File) {

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/BaseExecutorServiceManager.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/BaseExecutorServiceManager.java
@@ -137,7 +137,11 @@ public class BaseExecutorServiceManager extends ServiceSupport implements Execut
     @Override
     public void setThreadNamePattern(String threadNamePattern) {
         // must set camel id here in the pattern and let the other placeholders be resolved on demand
-        this.threadNamePattern = StringHelper.replaceAll(threadNamePattern, "#camelId#", this.camelContext.getName());
+        if (threadNamePattern != null) {
+            this.threadNamePattern = threadNamePattern.replace("#camelId#", this.camelContext.getName());
+        } else {
+            this.threadNamePattern = threadNamePattern;
+        }
     }
 
     @Override

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultManagementNameStrategy.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultManagementNameStrategy.java
@@ -118,11 +118,11 @@ public class DefaultManagementNameStrategy implements ManagementNameStrategy {
         String answer = pattern;
         if (pattern.contains("#counter#")) {
             // only increment the counter on-demand
-            answer = StringHelper.replaceAll(pattern, "#counter#", "" + nextNameCounter());
+            answer = pattern.replace("#counter#", "" + nextNameCounter());
         }
         // camelId and name is the same tokens
-        answer = StringHelper.replaceAll(answer, "#camelId#", name);
-        answer = StringHelper.replaceAll(answer, "#name#", name);
+        answer = answer.replace("#camelId#", name);
+        answer = answer.replace("#name#", name);
 
         // allow custom name resolution as well. For example with camel-core-osgi we have a custom
         // name strategy that supports OSGI specific tokens such as #bundleId# etc.

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultStreamCachingStrategy.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultStreamCachingStrategy.java
@@ -32,7 +32,6 @@ import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.FilePathResolver;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
-import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -247,8 +246,8 @@ public class DefaultStreamCachingStrategy extends ServiceSupport implements Came
 
         // replace tokens
         String answer = path;
-        answer = StringHelper.replaceAll(answer, "#camelId#", name);
-        answer = StringHelper.replaceAll(answer, "#name#", name);
+        answer = answer.replace("#camelId#", name);
+        answer = answer.replace("#name#", name);
         // replace custom
         answer = customResolveManagementName(answer);
         return answer;
@@ -257,7 +256,7 @@ public class DefaultStreamCachingStrategy extends ServiceSupport implements Came
     protected String customResolveManagementName(String pattern) {
         if (pattern.contains("#uuid#")) {
             String uuid = camelContext.getUuidGenerator().generateUuid();
-            pattern = StringHelper.replaceAll(pattern, "#uuid#", uuid);
+            pattern = pattern.replace("#uuid#", uuid);
         }
         return FilePathResolver.resolvePath(pattern);
     }

--- a/core/camel-base/src/main/java/org/apache/camel/component/properties/DefaultPropertiesParser.java
+++ b/core/camel-base/src/main/java/org/apache/camel/component/properties/DefaultPropertiesParser.java
@@ -66,8 +66,8 @@ public class DefaultPropertiesParser implements PropertiesParser {
         String answer = context.parse(text);
         if (keepUnresolvedOptional && answer != null && answer.contains(UNRESOLVED_PREFIX_TOKEN)) {
             // replace temporary unresolved keys back to with placeholders so they are kept as-is
-            answer = StringHelper.replaceAll(answer, UNRESOLVED_PREFIX_TOKEN, PREFIX_TOKEN);
-            answer = StringHelper.replaceAll(answer, UNRESOLVED_SUFFIX_TOKEN, SUFFIX_TOKEN);
+            answer = answer.replace(UNRESOLVED_PREFIX_TOKEN, PREFIX_TOKEN);
+            answer = answer.replace(UNRESOLVED_SUFFIX_TOKEN, SUFFIX_TOKEN);
         }
         return answer;
     }

--- a/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -153,7 +153,7 @@ public class DefaultCamelContext extends SimpleCamelContext implements ModelCame
                 // lets separate routes with empty line
                 xml = StringHelper.replaceFirst(xml, "xmlns=\"http://camel.apache.org/schema/spring\">",
                         "xmlns=\"http://camel.apache.org/schema/spring\">\n");
-                xml = StringHelper.replaceAll(xml, "</route>", "</route>\n");
+                xml = xml.replace("</route>", "</route>\n");
                 LOG.info("\n\n{}\n", xml);
             } catch (Exception e) {
                 LOG.warn("Error dumping routes to XML due to {}. This exception is ignored.", e.getMessage(), e);
@@ -171,7 +171,7 @@ public class DefaultCamelContext extends SimpleCamelContext implements ModelCame
                 // lets separate rests with empty line
                 xml = StringHelper.replaceFirst(xml, "xmlns=\"http://camel.apache.org/schema/spring\">",
                         "xmlns=\"http://camel.apache.org/schema/spring\">\n");
-                xml = StringHelper.replaceAll(xml, "</rest>", "</rest>\n");
+                xml = xml.replace("</rest>", "</rest>\n");
                 LOG.info("\n\n{}\n", xml);
             } catch (Exception e) {
                 LOG.warn("Error dumping rests to XML due to {}. This exception is ignored.", e.getMessage(), e);
@@ -189,7 +189,7 @@ public class DefaultCamelContext extends SimpleCamelContext implements ModelCame
                 // lets separate rests with empty line
                 xml = StringHelper.replaceFirst(xml, "xmlns=\"http://camel.apache.org/schema/spring\">",
                         "xmlns=\"http://camel.apache.org/schema/spring\">\n");
-                xml = StringHelper.replaceAll(xml, "</routeTemplate>", "</routeTemplate>\n");
+                xml = xml.replace("</routeTemplate>", "</routeTemplate>\n");
                 LOG.info("\n\n{}\n", xml);
             } catch (Exception e) {
                 LOG.warn("Error dumping route-templates to XML due to {}. This exception is ignored.", e.getMessage(), e);

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/csimple/CSimpleCodeGenerator.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/csimple/CSimpleCodeGenerator.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.camel.util.StringHelper;
-
 /**
  * Source code generate for csimple language.
  *
@@ -112,9 +110,9 @@ public class CSimpleCodeGenerator {
         sb.append("    @Override\n");
         sb.append("    public String getText() {\n");
         // \ should be escaped
-        String escaped = StringHelper.replaceAll(text, "\\", "\\\\");
+        String escaped = text.replace("\\", "\\\\");
         // we need to escape all " so its a single literal string
-        escaped = StringHelper.replaceAll(escaped, "\"", "\\\"");
+        escaped = escaped.replace("\"", "\\\"");
         sb.append("        return \"").append(escaped).append("\";\n");
         sb.append("    }\n");
         sb.append("\n");
@@ -170,7 +168,7 @@ public class CSimpleCodeGenerator {
         for (Map.Entry<String, String> entry : aliases.entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
-            script = StringHelper.replaceAll(script, key, value);
+            script = script.replace(key, value);
         }
         return script;
     }

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/csimple/CSimpleHelper.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/csimple/CSimpleHelper.java
@@ -175,7 +175,7 @@ public final class CSimpleHelper {
         if (body == null) {
             return null;
         }
-        body = StringHelper.replaceAll(body, System.lineSeparator(), "");
+        body = body.replace(System.lineSeparator(), "");
         return body;
     }
 

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/BinaryExpression.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/BinaryExpression.java
@@ -322,11 +322,11 @@ public class BinaryExpression extends BaseSimpleNode {
             return "!is(exchange, " + leftExp + ", " + type + ")";
         } else if (operator == BinaryOperatorType.REGEX) {
             // regexp is a pain with escapes
-            String escaped = StringHelper.replaceAll(rightExp, "\\", "\\\\");
+            String escaped = rightExp.replace("\\", "\\\\");
             return "regexp(exchange, " + leftExp + ", " + escaped + ")";
         } else if (operator == BinaryOperatorType.NOT_REGEX) {
             // regexp is a pain with escapes
-            String escaped = StringHelper.replaceAll(rightExp, "\\", "\\\\");
+            String escaped = rightExp.replace("\\", "\\\\");
             return "!regexp(exchange, " + leftExp + ", " + escaped + ")";
         } else if (operator == BinaryOperatorType.IN) {
             return "in(exchange, " + leftExp + ", " + rightExp + ")";

--- a/core/camel-core/src/test/java/org/apache/camel/util/StringHelperTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/util/StringHelperTest.java
@@ -177,22 +177,6 @@ public class StringHelperTest {
     }
 
     @Test
-    public void testReplaceAll() throws Exception {
-        assertEquals("", StringHelper.replaceAll("", "", ""));
-        assertEquals(null, StringHelper.replaceAll(null, "", ""));
-        assertEquals("foobar", StringHelper.replaceAll("foobar", "###", "DOT"));
-
-        assertEquals("foobar", StringHelper.replaceAll("foo.bar", ".", ""));
-        assertEquals("fooDOTbar", StringHelper.replaceAll("foo.bar", ".", "DOT"));
-        assertEquals("fooDOTbar", StringHelper.replaceAll("foo###bar", "###", "DOT"));
-        assertEquals("foobar", StringHelper.replaceAll("foo###bar", "###", ""));
-        assertEquals("fooDOTbarDOTbaz", StringHelper.replaceAll("foo.bar.baz", ".", "DOT"));
-        assertEquals("fooDOTbarDOTbazDOT", StringHelper.replaceAll("foo.bar.baz.", ".", "DOT"));
-        assertEquals("DOTfooDOTbarDOTbazDOT", StringHelper.replaceAll(".foo.bar.baz.", ".", "DOT"));
-        assertEquals("fooDOT", StringHelper.replaceAll("foo.", ".", "DOT"));
-    }
-
-    @Test
     public void testRemoveInitialCharacters() throws Exception {
         assertEquals("foo", StringHelper.removeStartingCharacters("foo", '/'));
         assertEquals("foo", StringHelper.removeStartingCharacters("/foo", '/'));

--- a/core/camel-support/src/main/java/org/apache/camel/support/EndpointHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/EndpointHelper.java
@@ -370,8 +370,8 @@ public final class EndpointHelper {
                 throw new NoSuchBeanException(value, e);
             }
         } else {
-            String valueNoHash = StringHelper.replaceAll(value, "#bean:", "");
-            valueNoHash = StringHelper.replaceAll(valueNoHash, "#", "");
+            String valueNoHash = value.replace("#bean:", "");
+            valueNoHash = valueNoHash.replace("#", "");
             if (mandatory) {
                 return CamelContextHelper.mandatoryLookupAndConvert(context, valueNoHash, type);
             } else {

--- a/core/camel-support/src/main/java/org/apache/camel/support/IntrospectionSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/IntrospectionSupport.java
@@ -654,7 +654,7 @@ public final class IntrospectionSupport {
             if (obj instanceof Map) {
                 Map map = (Map) obj;
                 if (context != null && refName != null && value == null) {
-                    String s = StringHelper.replaceAll(refName, "#", "");
+                    String s = refName.replace("#", "");
                     value = CamelContextHelper.lookup(context, s);
                 }
                 map.put(lookupKey, value);
@@ -662,7 +662,7 @@ public final class IntrospectionSupport {
             } else if (obj instanceof List) {
                 List list = (List) obj;
                 if (context != null && refName != null && value == null) {
-                    String s = StringHelper.replaceAll(refName, "#", "");
+                    String s = refName.replace("#", "");
                     value = CamelContextHelper.lookup(context, s);
                 }
                 if (isNotEmpty(lookupKey)) {
@@ -692,7 +692,7 @@ public final class IntrospectionSupport {
                 return true;
             } else if (obj.getClass().isArray() && lookupKey != null) {
                 if (context != null && refName != null && value == null) {
-                    String s = StringHelper.replaceAll(refName, "#", "");
+                    String s = refName.replace("#", "");
                     value = CamelContextHelper.lookup(context, s);
                 }
                 int idx = Integer.parseInt(lookupKey);
@@ -748,7 +748,7 @@ public final class IntrospectionSupport {
             Object ref = value;
             // try and lookup the reference based on the method
             if (context != null && refName != null && ref == null) {
-                String s = StringHelper.replaceAll(refName, "#", "");
+                String s = refName.replace("#", "");
                 ref = CamelContextHelper.lookup(context, s);
                 if (ref == null) {
                     // try the next method if nothing was found

--- a/core/camel-support/src/main/java/org/apache/camel/support/builder/ExpressionBuilder.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/builder/ExpressionBuilder.java
@@ -1806,7 +1806,7 @@ public class ExpressionBuilder {
                 if (body == null) {
                     return null;
                 }
-                body = StringHelper.replaceAll(body, System.lineSeparator(), "");
+                body = body.replace(System.lineSeparator(), "");
                 return body;
             }
 

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/DefaultExchangeFormatter.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/DefaultExchangeFormatter.java
@@ -31,7 +31,6 @@ import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriParams;
 import org.apache.camel.support.MessageHelper;
 import org.apache.camel.util.ObjectHelper;
-import org.apache.camel.util.StringHelper;
 
 /**
  * Default {@link ExchangeFormatter} that have fine grained options to configure what to include in the output.
@@ -167,8 +166,8 @@ public class DefaultExchangeFormatter implements ExchangeFormatter {
                 sb.append(SEPARATOR);
             }
             String body = getBodyAsString(in);
-            if (skipBodyLineSeparator) {
-                body = StringHelper.replaceAll(body, LS, "");
+            if (skipBodyLineSeparator && body != null) {
+                body = body.replace(LS, "");
             }
             style(sb, "Body").append(body);
         }

--- a/core/camel-util/src/main/java/org/apache/camel/util/SensitiveUtils.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/SensitiveUtils.java
@@ -122,7 +122,7 @@ public final class SensitiveUtils {
             text = text.substring(lastPeriod + 1);
         }
         text = text.toLowerCase(Locale.ENGLISH);
-        text = StringHelper.replaceAll(text, "-", "");
+        text = text.replace("-", "");
         return SENSITIVE_KEYS.contains(text);
     }
 

--- a/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
@@ -129,8 +129,8 @@ public final class StringHelper {
             return s;
         }
 
-        s = replaceAll(s, "'", "");
-        s = replaceAll(s, "\"", "");
+        s = s.replace("'", "");
+        s = s.replace("\"", "");
         return s;
     }
 
@@ -192,10 +192,10 @@ public final class StringHelper {
             return "";
         }
         // must replace amp first, so we dont replace &lt; to amp later
-        text = replaceAll(text, "&", "&amp;");
-        text = replaceAll(text, "\"", "&quot;");
-        text = replaceAll(text, "<", "&lt;");
-        text = replaceAll(text, ">", "&gt;");
+        text = text.replace("&", "&amp;");
+        text = text.replace("\"", "&quot;");
+        text = text.replace("<", "&lt;");
+        text = text.replace(">", "&gt;");
         return text;
     }
 
@@ -259,58 +259,6 @@ public final class StringHelper {
         }
 
         return false;
-    }
-
-    /**
-     * Replaces all the from tokens in the given input string.
-     * <p/>
-     * This implementation is not recursive, not does it check for tokens in the replacement string.
-     *
-     * @param  input                    the input string
-     * @param  from                     the from string, must <b>not</b> be <tt>null</tt> or empty
-     * @param  to                       the replacement string, must <b>not</b> be empty
-     * @return                          the replaced string, or the input string if no replacement was needed
-     * @throws IllegalArgumentException if the input arguments is invalid
-     */
-    public static String replaceAll(String input, String from, String to) {
-        // TODO: Use String.replace instead of this method when using JDK11 as minimum (as its much faster in JDK 11 onwards)
-
-        if (ObjectHelper.isEmpty(input)) {
-            return input;
-        }
-        if (from == null) {
-            throw new IllegalArgumentException("from cannot be null");
-        }
-        if (to == null) {
-            // to can be empty, so only check for null
-            throw new IllegalArgumentException("to cannot be null");
-        }
-
-        // fast check if there is any from at all
-        if (!input.contains(from)) {
-            return input;
-        }
-
-        final int len = from.length();
-        final int max = input.length();
-        StringBuilder sb = new StringBuilder(max);
-        for (int i = 0; i < max;) {
-            if (i + len <= max) {
-                String token = input.substring(i, i + len);
-                if (from.equals(token)) {
-                    sb.append(to);
-                    // fast forward
-                    i = i + len;
-                    continue;
-                }
-            }
-
-            // append single char
-            sb.append(input.charAt(i));
-            // forward to next
-            i++;
-        }
-        return sb.toString();
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/URIScanner.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URIScanner.java
@@ -172,7 +172,7 @@ class URIScanner {
             text = value.toString();
         } else {
             // need to replace % with %25 to avoid losing "%" when decoding
-            String s = StringHelper.replaceAll(value.toString(), "%", "%25");
+            String s = value.toString().replace("%", "%25");
             text = URLDecoder.decode(s, CHARSET);
         }
 

--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -507,7 +507,7 @@ public final class URISupport {
         if (raw != null) {
             // do not encode RAW parameters unless it has %
             // need to replace % with %25 to avoid losing "%" when decoding
-            String s = StringHelper.replaceAll(value, "%", "%25");
+            String s = value.replace("%", "%25");
             rc.append(s);
         } else {
             if (encode) {
@@ -631,7 +631,7 @@ public final class URISupport {
             String after = path.substring(max);
 
             // replace the @ with %40
-            before = StringHelper.replaceAll(before, "@", "%40");
+            before = before.replace("@", "%40");
             path = before + after;
         }
 

--- a/core/camel-util/src/main/java/org/apache/camel/util/concurrent/ThreadHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/concurrent/ThreadHelper.java
@@ -56,9 +56,9 @@ public final class ThreadHelper {
         String shortName = name.contains("?") ? StringHelper.before(name, "?") : name;
 
         // replace tokens
-        String answer = StringHelper.replaceAll(pattern, "#counter#", "" + nextThreadCounter());
-        answer = StringHelper.replaceAll(answer, "#longName#", longName);
-        answer = StringHelper.replaceAll(answer, "#name#", shortName);
+        String answer = pattern.replace("#counter#", Long.toString(nextThreadCounter()));
+        answer = answer.replace("#longName#", longName);
+        answer = answer.replace("#name#", shortName);
 
         // are there any #word# combos left, if so they should be considered invalid tokens
         if (INVALID_PATTERN.matcher(answer).matches()) {

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_15.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_15.adoc
@@ -37,6 +37,10 @@ node in the JMX MBean tree.
 
 Removed deprecated operations on `CamelContextMBean` and `CamelRouteMBean`.
 
+=== camel-util
+
+Deleted the `replaceAll` method of `org.apache.camel.util.StringHelper`. Please use the `replace` method of `java.lang.String` instead, as it is much faster from Java 11 onward.
+
 === camel-yaml-dsl
 
 Removed `steps` from `route` because steps should only be configured on `from` making


### PR DESCRIPTION
…much faster from Java 11 onward.

Should the method be deprecated instead (my understanding is that methods like this were deleted in the past, but maybe this policy has changed)?

It may be that some additional null checks are needed, e.g. in `BinaryExpression`. 
