### PR TITLE
Fix wrong link in stub component docs

### DIFF
--- a/components/camel-stub/src/main/docs/stub-component.adoc
+++ b/components/camel-stub/src/main/docs/stub-component.adoc
@@ -21,7 +21,7 @@ xref:mail-component.adoc[SMTP] or xref:mail-component.adoc[Http] endpoint. Just 
 in front of any endpoint URI to stub out the endpoint.
 
 Internally the Stub component creates xref:vm-component.adoc[VM] endpoints. The
-main difference between xref:stub-component.adoc[Stub] and xref:stub-component.adoc[VM] is
+main difference between xref:stub-component.adoc[Stub] and xref:vm-component.adoc[VM] is
 that xref:vm-component.adoc[VM] will validate the URI and parameters you give it,
 so putting vm: in front of a typical URI with query arguments will
 usually fail. Stub won't though, as it basically ignores all query


### PR DESCRIPTION
In the Stub component docs, one of the links to the VM component mistakenly points to the Stub component.
This PR fixes this reference to point to the VM component page.