### PR TITLE
Upgrade log4j and pax-logging

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -462,7 +462,7 @@
     <!-- virtual dependency only used by Eclipse m2e -->
     <lifecycle-mapping-version>1.0.0</lifecycle-mapping-version>
     <log4j-version>1.2.17</log4j-version>
-    <log4j2-version>2.17.0</log4j2-version>
+    <log4j2-version>2.17.1</log4j2-version>
     <lucene3-bundle-version>3.6.0_1</lucene3-bundle-version>
     <lucene3-version>3.6.0</lucene3-version>
     <lucene-bundle-version>7.5.0_1</lucene-bundle-version>
@@ -569,7 +569,7 @@
     <pax-cdi-version>1.0.0</pax-cdi-version>
     <pax-exam-version>4.13.0</pax-exam-version>
     <pax-tiny-bundle-version>1.3.2</pax-tiny-bundle-version>
-    <pax-logging-version>1.8.6</pax-logging-version>
+    <pax-logging-version>1.11.13</pax-logging-version>
     <pdfbox-version>2.0.17</pdfbox-version>
     <pgjdbc-ng-driver-version>0.7.1</pgjdbc-ng-driver-version>
     <protobuf-version>3.5.1</protobuf-version>


### PR DESCRIPTION
Upgrade log4j - > 2.17.1 and pax logging to 1.11.13 (version which contains log4j 2.17.1)