### PR TITLE
CAMEL-17437 Camel-aws2-sqs: Deadletter fails with sqs client from registry 

### DIFF
--- a/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2Component.java
+++ b/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2Component.java
@@ -68,10 +68,6 @@ public class Sqs2Component extends DefaultComponent {
         }
         Sqs2Endpoint sqsEndpoint = new Sqs2Endpoint(uri, this, configuration);
         setProperties(sqsEndpoint, parameters);
-        if (!configuration.isUseDefaultCredentialsProvider() && configuration.getAmazonSQSClient() == null
-                && (configuration.getAccessKey() == null || configuration.getSecretKey() == null)) {
-            throw new IllegalArgumentException("AmazonSQSClient or accessKey and secretKey must be specified.");
-        }
 
         // Verify that visibilityTimeout is set if extendMessageVisibility is
         // set to true.

--- a/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2Endpoint.java
+++ b/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2Endpoint.java
@@ -147,6 +147,14 @@ public class Sqs2Endpoint extends ScheduledPollEndpoint implements HeaderFilterS
     @Override
     protected void doInit() throws Exception {
         super.doInit();
+
+        //validation of client has to be done after endpoint initialization (in case that sqs client is autowired)
+        // - covered by SqsDeadletterWithClientRegistryLocalstackIT
+        if (!configuration.isUseDefaultCredentialsProvider() && configuration.getAmazonSQSClient() == null
+                && (configuration.getAccessKey() == null || configuration.getSecretKey() == null)) {
+            throw new IllegalArgumentException("AmazonSQSClient or accessKey and secretKey must be specified.");
+        }
+
         client = configuration.getAmazonSQSClient() != null
                 ? configuration.getAmazonSQSClient() : Sqs2ClientFactory.getSqsClient(configuration).getSQSClient();
 

--- a/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/SqsComponentClientRegistryTest.java
+++ b/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/SqsComponentClientRegistryTest.java
@@ -42,6 +42,7 @@ public class SqsComponentClientRegistryTest extends CamelTestSupport {
         Sqs2Component component = context.getComponent("aws2-sqs", Sqs2Component.class);
         assertThrows(IllegalArgumentException.class, () -> {
             Sqs2Endpoint endpoint = (Sqs2Endpoint) component.createEndpoint("aws2-sqs://MyQueue");
+            endpoint.start();
         });
     }
 

--- a/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/SqsComponentConfigurationTest.java
+++ b/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/SqsComponentConfigurationTest.java
@@ -213,7 +213,7 @@ public class SqsComponentConfigurationTest extends CamelTestSupport {
     public void createEndpointWithoutAccessKeyConfiguration() throws Exception {
         Sqs2Component component = context.getComponent("aws2-sqs", Sqs2Component.class);
         assertThrows(IllegalArgumentException.class, () -> {
-            component.createEndpoint("aws2-sqs://MyQueue?secretKey=yyy");
+            component.createEndpoint("aws2-sqs://MyQueue?secretKey=yyy").start();
         });
     }
 
@@ -221,7 +221,7 @@ public class SqsComponentConfigurationTest extends CamelTestSupport {
     public void createEndpointWithoutSecretKeyConfiguration() throws Exception {
         Sqs2Component component = context.getComponent("aws2-sqs", Sqs2Component.class);
         assertThrows(IllegalArgumentException.class, () -> {
-            component.createEndpoint("aws2-sqs://MyQueue?accessKey=xxx");
+            component.createEndpoint("aws2-sqs://MyQueue?accessKey=xxx").start();
         });
     }
 

--- a/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/integration/SqsDeadletterWithClientRegistryLocalstackIT.java
+++ b/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/integration/SqsDeadletterWithClientRegistryLocalstackIT.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.sqs.integration;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.Processor;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws2.sqs.Sqs2Component;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Test;
+
+public class SqsDeadletterWithClientRegistryLocalstackIT extends Aws2SQSBaseTest {
+
+    @EndpointInject("direct:start")
+    private ProducerTemplate template;
+
+    @EndpointInject("mock:result")
+    private MockEndpoint result;
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext ctx = super.createCamelContext();
+
+        Sqs2Component sqs = ctx.getComponent("aws2-sqs", Sqs2Component.class);
+
+        ctx.getRegistry().bind("awsSQSClient", sqs.getConfiguration().getAmazonSQSClient());
+        sqs.getConfiguration().setAmazonSQSClient(null);
+
+        return ctx;
+    }
+
+    @Test
+    public void deadletter() throws Exception {
+        result.expectedMessageCount(1);
+
+        template.send("direct:start", ExchangePattern.InOnly, new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setBody("test1");
+            }
+        });
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                String deadletterName = sharedNameGenerator.getName() + "_deadletter";
+
+                errorHandler(deadLetterChannel(String.format("aws2-sqs://%s?autoCreateQueue=true", deadletterName))
+                        .useOriginalMessage());
+
+                from("direct:start").startupOrder(2).process(e -> {
+                    throw new IllegalStateException();
+                }).toF("aws2-sqs://%s?autoCreateQueue=true", sharedNameGenerator.getName());
+
+                fromF("aws2-sqs://%s", deadletterName).to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-17437

Problem was caused by less severe problem - one validation was executed too early. 
Validation of sqs client has to be done after endpoint configuration, to cover a case when client is autowired.
I fixed several tests which covers this validation + added a new junit integration test using deadletter and autowired client.

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
