### PR TITLE
ManagedDebugger exposes Message History 

### DIFF
--- a/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedBacklogDebuggerMBean.java
+++ b/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedBacklogDebuggerMBean.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.api.management.mbean;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.camel.api.management.ManagedAttribute;
@@ -172,4 +174,7 @@ public interface ManagedBacklogDebuggerMBean {
 
     @ManagedOperation(description = "Updates/adds the exchange property (with a new type) on the suspended breakpoint at the given node id")
     void setExchangePropertyOnBreakpoint(String nodeId, String exchangePropertyName, Object value, String type);
+
+    @ManagedOperation(description = "Returns the message history at the given node id")
+    List<HashMap<String, String>> getMessageHistory(String nodeId);
 }

--- a/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedBacklogDebuggerMBean.java
+++ b/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedBacklogDebuggerMBean.java
@@ -174,5 +174,5 @@ public interface ManagedBacklogDebuggerMBean {
     void setExchangePropertyOnBreakpoint(String nodeId, String exchangePropertyName, Object value, String type);
 
     @ManagedOperation(description = "Returns the message history at the given node id as XML")
-    String getMessageHistory(String nodeId);
+    String messageHistoryOnBreakpointAsXml(String nodeId);
 }

--- a/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedBacklogDebuggerMBean.java
+++ b/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedBacklogDebuggerMBean.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.api.management.mbean;
 
-import java.util.HashMap;
-import java.util.List;
 import java.util.Set;
 
 import org.apache.camel.api.management.ManagedAttribute;
@@ -175,6 +173,6 @@ public interface ManagedBacklogDebuggerMBean {
     @ManagedOperation(description = "Updates/adds the exchange property (with a new type) on the suspended breakpoint at the given node id")
     void setExchangePropertyOnBreakpoint(String nodeId, String exchangePropertyName, Object value, String type);
 
-    @ManagedOperation(description = "Returns the message history at the given node id")
-    List<HashMap<String, String>> getMessageHistory(String nodeId);
+    @ManagedOperation(description = "Returns the message history at the given node id as XML")
+    String getMessageHistory(String nodeId);
 }

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedBacklogDebugger.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedBacklogDebugger.java
@@ -18,14 +18,20 @@ package org.apache.camel.management.mbean;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePropertyKey;
 import org.apache.camel.Expression;
+import org.apache.camel.MessageHistory;
 import org.apache.camel.NoTypeConversionAvailableException;
 import org.apache.camel.Predicate;
+import org.apache.camel.Route;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.api.management.mbean.BacklogTracerEventMessage;
@@ -33,8 +39,11 @@ import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
 import org.apache.camel.impl.debugger.BacklogDebugger;
 import org.apache.camel.spi.Language;
 import org.apache.camel.spi.ManagementStrategy;
+import org.apache.camel.support.LoggerHelper;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.StringHelper;
+import org.apache.camel.util.URISupport;
 
 @ManagedResource(description = "Managed BacklogDebugger")
 public class ManagedBacklogDebugger implements ManagedBacklogDebuggerMBean {
@@ -366,6 +375,73 @@ public class ManagedBacklogDebugger implements ManagedBacklogDebuggerMBean {
             return e.getMessage();
         }
         return null;
+    }
+
+    @Override
+    public List<HashMap<String, String>> getMessageHistory(String nodeId) {
+        Exchange suspendedExchange = backlogDebugger.getSuspendedExchange(nodeId);
+        if (suspendedExchange == null) {
+            return null;
+        }
+        List<MessageHistory> list = suspendedExchange.getProperty(ExchangePropertyKey.MESSAGE_HISTORY, List.class);
+        if (list == null) {
+            return null;
+        }
+
+        List<HashMap<String, String>> messageHistory = new ArrayList<>();
+
+        // add incoming origin of message on the top
+        String routeId = suspendedExchange.getFromRouteId();
+        Route route = suspendedExchange.getContext().getRoute(routeId);
+        String loc = route != null ? route.getSourceLocation() : "";
+        String id = routeId;
+        String label = "";
+        if (suspendedExchange.getFromEndpoint() != null) {
+            label = "from["
+                    + URISupport
+                            .sanitizeUri(StringHelper.limitLength(suspendedExchange.getFromEndpoint().getEndpointUri(), 100))
+                    + "]";
+        }
+        long elapsed = new StopWatch(suspendedExchange.getCreated()).taken();
+
+        HashMap<String, String> historyLine = new HashMap<>();
+        historyLine.put("location", loc);
+        historyLine.put("routeId", routeId);
+        historyLine.put("processorId", id);
+        historyLine.put("processor", label);
+        historyLine.put("elapsed", String.valueOf(elapsed));
+
+        messageHistory.add(historyLine);
+
+        for (MessageHistory history : list) {
+            // and then each history
+            loc = LoggerHelper.getLineNumberLoggerName(history.getNode());
+            if (loc == null) {
+                loc = "";
+            }
+            routeId = history.getRouteId() != null ? history.getRouteId() : "";
+            id = history.getNode().getId();
+            // we need to avoid leak the sensible information here
+            // the sanitizeUri takes a very long time for very long string
+            // and the format cuts this to
+            // 78 characters, anyway. Cut this to 100 characters. This will
+            // give enough space for removing
+            // characters in the sanitizeUri method and will be reasonably
+            // fast
+            label = URISupport.sanitizeUri(StringHelper.limitLength(history.getNode().getLabel(), 100));
+            elapsed = history.getElapsed();
+
+            historyLine = new HashMap<>();
+            historyLine.put("location", loc);
+            historyLine.put("routeId", routeId);
+            historyLine.put("processorId", id);
+            historyLine.put("processor", label);
+            historyLine.put("elapsed", String.valueOf(elapsed));
+
+            messageHistory.add(historyLine);
+        }
+
+        return messageHistory;
     }
 
     private String dumpExchangePropertiesAsXml(String id) {

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedBacklogDebugger.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedBacklogDebugger.java
@@ -376,7 +376,7 @@ public class ManagedBacklogDebugger implements ManagedBacklogDebuggerMBean {
     }
 
     @Override
-    public String getMessageHistory(String nodeId) {
+    public String messageHistoryOnBreakpointAsXml(String nodeId) {
         StringBuffer messageHistoryBuffer = new StringBuffer();
         messageHistoryBuffer.append("<messageHistory>\n");
 

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedBacklogDebugger.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedBacklogDebugger.java
@@ -401,10 +401,10 @@ public class ManagedBacklogDebugger implements ManagedBacklogDebuggerMBean {
 
                 messageHistoryBuffer
                         .append("    <messageHistoryEntry")
-                        .append(" location=\"").append(loc).append("\"")
-                        .append(" routeId=\"").append(routeId).append("\"")
-                        .append(" processorId=\"").append(id).append("\"")
-                        .append(" processor=\"").append(label).append("\"")
+                        .append(" location=\"").append(StringHelper.xmlEncode(loc)).append("\"")
+                        .append(" routeId=\"").append(StringHelper.xmlEncode(routeId)).append("\"")
+                        .append(" processorId=\"").append(StringHelper.xmlEncode(id)).append("\"")
+                        .append(" processor=\"").append(StringHelper.xmlEncode(label)).append("\"")
                         .append(" elapsed=\"").append(elapsed).append("\"")
                         .append("/>\n");
 
@@ -428,10 +428,10 @@ public class ManagedBacklogDebugger implements ManagedBacklogDebuggerMBean {
 
                     messageHistoryBuffer
                             .append("    <messageHistoryEntry")
-                            .append(" location=\"").append(loc).append("\"")
-                            .append(" routeId=\"").append(routeId).append("\"")
-                            .append(" processorId=\"").append(id).append("\"")
-                            .append(" processor=\"").append(label).append("\"")
+                            .append(" location=\"").append(StringHelper.xmlEncode(loc)).append("\"")
+                            .append(" routeId=\"").append(StringHelper.xmlEncode(routeId)).append("\"")
+                            .append(" processorId=\"").append(StringHelper.xmlEncode(id)).append("\"")
+                            .append(" processor=\"").append(StringHelper.xmlEncode(label)).append("\"")
                             .append(" elapsed=\"").append(elapsed).append("\"")
                             .append("/>\n");
                 }

--- a/core/camel-management/src/test/java/org/apache/camel/management/BacklogDebuggerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/BacklogDebuggerTest.java
@@ -861,7 +861,7 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
             assertEquals("bar", suspended.iterator().next());
         });
 
-        Object response = mbeanServer.invoke(on, "getMessageHistory",
+        Object response = mbeanServer.invoke(on, "messageHistoryOnBreakpointAsXml",
                 new Object[] { "bar" },
                 new String[] { "java.lang.String" });
 

--- a/core/camel-management/src/test/java/org/apache/camel/management/BacklogDebuggerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/BacklogDebuggerTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.management;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -824,6 +826,76 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
         assertEquals(0, nodes.size());
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testBacklogDebuggerMessageHistory() throws Exception {
+        MBeanServer mbeanServer = getMBeanServer();
+        ObjectName on = new ObjectName(
+                "org.apache.camel:context=" + context.getManagementName() + ",type=tracer,name=BacklogDebugger");
+        assertNotNull(on);
+        mbeanServer.isRegistered(on);
+
+        Boolean enabled = (Boolean) mbeanServer.getAttribute(on, "Enabled");
+        assertEquals(Boolean.FALSE, enabled, "Should not be enabled");
+
+        // enable debugger
+        mbeanServer.invoke(on, "enableDebugger", null, null);
+
+        enabled = (Boolean) mbeanServer.getAttribute(on, "Enabled");
+        assertEquals(Boolean.TRUE, enabled, "Should be enabled");
+
+        // add breakpoint at bar
+        mbeanServer.invoke(on, "addBreakpoint", new Object[] { "bar" }, new String[] { "java.lang.String" });
+
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(0);
+        mock.setSleepForEmptyTest(100);
+
+        template.sendBody("seda:start", "Hello World");
+
+        assertMockEndpointsSatisfied();
+
+        // wait for breakpoint at bar
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+            Set<String> suspended = (Set<String>) mbeanServer.invoke(on, "getSuspendedBreakpointNodeIds", null, null);
+            assertNotNull(suspended);
+            assertEquals(1, suspended.size());
+            assertEquals("bar", suspended.iterator().next());
+        });
+
+        Object response = mbeanServer.invoke(on, "getMessageHistory",
+                new Object[] { "bar" },
+                new String[] { "java.lang.String" });
+
+        assertNotNull(response);
+        assertTrue(response instanceof ArrayList);
+        ArrayList responseList = (ArrayList) response;
+        assertEquals(4, responseList.size());
+        Object firstEntry = responseList.get(0);
+        assertNotNull(firstEntry);
+        assertTrue(firstEntry instanceof HashMap);
+        HashMap firstEntryMap = (HashMap) firstEntry;
+        assertEquals(5, firstEntryMap.entrySet().size());
+        assertEquals("route1", firstEntryMap.get("routeId"));
+        assertEquals("from[seda://start?concurrentConsumers=2]", firstEntryMap.get("processor"));
+        assertEquals("route1", firstEntryMap.get("processorId"));
+        assertNotNull(firstEntryMap.get("elapsed"));
+        assertNotNull(firstEntryMap.get("location"));
+
+        resetMocks();
+        mock.expectedMessageCount(1);
+
+        // resume breakpoint
+        mbeanServer.invoke(on, "resumeBreakpoint", new Object[] { "bar" }, new String[] { "java.lang.String" });
+
+        assertMockEndpointsSatisfied();
+
+        // and no suspended anymore
+        Set<String> nodes = (Set<String>) mbeanServer.invoke(on, "getSuspendedBreakpointNodeIds", null, null);
+        assertNotNull(nodes);
+        assertEquals(0, nodes.size());
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
@@ -831,6 +903,7 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
             public void configure() throws Exception {
                 context.setUseBreadcrumb(false);
                 context.setDebugging(true);
+                context.setMessageHistory(true);
 
                 from("seda:start?concurrentConsumers=2")
                         .setProperty("myProperty", constant("myValue")).id("setProp")

--- a/core/camel-management/src/test/java/org/apache/camel/management/BacklogDebuggerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/BacklogDebuggerTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.management;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -868,19 +866,15 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
                 new String[] { "java.lang.String" });
 
         assertNotNull(response);
-        assertTrue(response instanceof ArrayList);
-        ArrayList responseList = (ArrayList) response;
-        assertEquals(4, responseList.size());
-        Object firstEntry = responseList.get(0);
-        assertNotNull(firstEntry);
-        assertTrue(firstEntry instanceof HashMap);
-        HashMap firstEntryMap = (HashMap) firstEntry;
-        assertEquals(5, firstEntryMap.entrySet().size());
-        assertEquals("route1", firstEntryMap.get("routeId"));
-        assertEquals("from[seda://start?concurrentConsumers=2]", firstEntryMap.get("processor"));
-        assertEquals("route1", firstEntryMap.get("processorId"));
-        assertNotNull(firstEntryMap.get("elapsed"));
-        assertNotNull(firstEntryMap.get("location"));
+        assertTrue(response.getClass().isAssignableFrom(String.class));
+        String history = (String) response;
+        int count = (history.split("messageHistoryEntry", -1).length) - 1;
+        assertEquals(4, count);
+        assertTrue(history.contains("processor=\"from[seda://start?concurrentConsumers=2]\""));
+        assertTrue(history.contains("routeId=\"route1\""));
+        assertTrue(history.contains("processorId=\"route1\""));
+        assertTrue(history.contains("location=\""));
+        assertTrue(history.contains("elapsed=\""));
 
         resetMocks();
         mock.expectedMessageCount(1);

--- a/docs/user-manual/modules/ROOT/pages/backlog-debugger.adoc
+++ b/docs/user-manual/modules/ROOT/pages/backlog-debugger.adoc
@@ -55,7 +55,7 @@ NOTE: This requires to enabled JMX by including `camel-management` JAR in the cl
 |`stepBreakpoint(nodeId)` |`void` |To start single step mode from a suspended breakpoint at the given node. Then invoke `step` to step to next node in the route.
 |`step` |`void` |To step to next node when in single step mode.
 |`validateConditionalBreakpoint` |`String` |Used for validating if a given predicate is valid or not. Returns null if valid, otherwise a string with the error message.
-|`getMessageHistory(nodeId)` |`List<HashMap<String, String>>` |Returns message history as a list of HashMaps each containing the following entries: `location`, `routeId`, `processorId`, `processor` and `elapsed`
+|`getMessageHistory(nodeId)` |`String` |Returns message history at the given node Id in XML format
 |=======================================================================
 
 == Enabling

--- a/docs/user-manual/modules/ROOT/pages/backlog-debugger.adoc
+++ b/docs/user-manual/modules/ROOT/pages/backlog-debugger.adoc
@@ -55,6 +55,7 @@ NOTE: This requires to enabled JMX by including `camel-management` JAR in the cl
 |`stepBreakpoint(nodeId)` |`void` |To start single step mode from a suspended breakpoint at the given node. Then invoke `step` to step to next node in the route.
 |`step` |`void` |To step to next node when in single step mode.
 |`validateConditionalBreakpoint` |`String` |Used for validating if a given predicate is valid or not. Returns null if valid, otherwise a string with the error message.
+|`getMessageHistory(nodeId)` |`List<HashMap<String, String>>` |Returns message history as a list of HashMaps each containing the following entries: `location`, `routeId`, `processorId`, `processor` and `elapsed`
 |=======================================================================
 
 == Enabling

--- a/docs/user-manual/modules/ROOT/pages/backlog-debugger.adoc
+++ b/docs/user-manual/modules/ROOT/pages/backlog-debugger.adoc
@@ -55,7 +55,7 @@ NOTE: This requires to enabled JMX by including `camel-management` JAR in the cl
 |`stepBreakpoint(nodeId)` |`void` |To start single step mode from a suspended breakpoint at the given node. Then invoke `step` to step to next node in the route.
 |`step` |`void` |To step to next node when in single step mode.
 |`validateConditionalBreakpoint` |`String` |Used for validating if a given predicate is valid or not. Returns null if valid, otherwise a string with the error message.
-|`getMessageHistory(nodeId)` |`String` |Returns message history at the given node Id in XML format
+|`messageHistoryOnBreakpointAsXml(nodeId)` |`String` |Returns message history at the given node Id in XML format
 |=======================================================================
 
 == Enabling


### PR DESCRIPTION
This PR resolves the https://issues.apache.org/jira/browse/CAMEL-17444
The message history is exposed as a List of Maps containing String pairs, so that the tooling can use it in debugging and displaying stack traces.
