### PR TITLE
DefaultComponent misses initialization of autowired properties.

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultComponent.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultComponent.java
@@ -386,6 +386,10 @@ public abstract class DefaultComponent extends ServiceSupport implements Compone
     @Override
     protected void doInit() throws Exception {
         ObjectHelper.notNull(getCamelContext(), "camelContext");
+
+        if (autowiredEnabled) {
+            EndpointHelper.configureAutowired(getComponentPropertyConfigurer(), camelContext, this);
+        }
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultEndpoint.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultEndpoint.java
@@ -33,7 +33,6 @@ import org.apache.camel.spi.HasId;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.PropertyConfigurer;
 import org.apache.camel.spi.PropertyConfigurerAware;
-import org.apache.camel.spi.PropertyConfigurerGetter;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.ObjectHelper;
@@ -486,35 +485,7 @@ public abstract class DefaultEndpoint extends ServiceSupport implements Endpoint
 
         if (autowiredEnabled && getComponent() != null) {
             PropertyConfigurer configurer = getComponent().getEndpointPropertyConfigurer();
-            if (configurer instanceof PropertyConfigurerGetter) {
-                PropertyConfigurerGetter getter = (PropertyConfigurerGetter) configurer;
-                String[] names = getter.getAutowiredNames();
-                if (names != null) {
-                    for (String name : names) {
-                        // is there already a configured value?
-                        Object value = getter.getOptionValue(this, name, true);
-                        if (value == null) {
-                            Class<?> type = getter.getOptionType(name, true);
-                            if (type != null) {
-                                Set<?> set = camelContext.getRegistry().findByType(type);
-                                if (set.size() == 1) {
-                                    value = set.iterator().next();
-                                }
-                            }
-                            if (value != null) {
-                                boolean hit = configurer.configure(camelContext, this, name, value, true);
-                                if (hit) {
-                                    if (LOG.isDebugEnabled()) {
-                                        LOG.debug(
-                                                "Autowired property: {} on endpoint: {} as exactly one instance of type: {} ({}) found in the registry",
-                                                name, toString(), type.getName(), value.getClass().getName());
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            EndpointHelper.configureAutowired(configurer, camelContext, this);
         }
     }
 


### PR DESCRIPTION
Linked to https://issues.apache.org/jira/browse/CAMEL-17437 and https://github.com/apache/camel-quarkus/issues/3436

I'm investigating the reason, why aws2-sqs component (created via camel-quarkus with sqs client from quarkus) fails on validation error. I originally thought, that problem is happening also in camel alone, but that was wrong.

I discovered, that autowired properties in endpoints are initialized via `DefaultEndpoint.doInit`. Unfortunately `DefaultComponent.doInit` does not contain such logic. I would say that it should also be there.

I prepared this **draft** with a minimal change (junit tests are missing).

@davsclaus What do you think? is similar change acceptable? (It fixes error scenario which could be simulated through camel-quarkus, but mostly this makes sense and I think that it should be added) 


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
