### PR TITLE
Revert "CAMEL-17433 fix JavadocHelper (3.14.x)"

### DIFF
--- a/tooling/camel-tooling-util/src/main/java/org/apache/camel/tooling/util/JavadocHelper.java
+++ b/tooling/camel-tooling-util/src/main/java/org/apache/camel/tooling/util/JavadocHelper.java
@@ -20,7 +20,7 @@ import static org.apache.camel.tooling.util.Strings.isNullOrEmpty;
 
 public final class JavadocHelper {
 
-    private static final String VALID_CHARS = ".,-='/\\!&%():;#${}<>";
+    private static final String VALID_CHARS = ".,-='/\\!&%():;#${}";
 
     private JavadocHelper() {
     }
@@ -87,9 +87,8 @@ public final class JavadocHelper {
         }
 
         String s = sb.toString();
-        // remove all XML tags. This isn't complete but likely to find anything actually used.
-        s = s.replaceAll("<(\\w|:|_)(\\w|:|_|-|\\.|\\d)*\\s.*/?>", "");
-        s = s.replaceAll("</(\\w|:|_)(\\w|:|_|-|\\.|\\d)*\\s*>", "");
+        // remove all XML tags
+        s = s.replaceAll("<.*?>", "");
         // remove {@link inlined javadoc links which is special handled
         s = s.replaceAll("\\{@link\\s\\w+\\s(\\w+)}", "$1");
         s = s.replaceAll("\\{@link\\s([\\w]+)}", "$1");
@@ -131,7 +130,7 @@ public final class JavadocHelper {
             return "";
         }
         // must replace amp first, so we dont replace &lt; to amp later
-        text = text.replaceAll("&(?!(amp;)|(lt;)|(gt;)|(quot;))", "&amp;");
+        text = text.replace("&", "&amp;");
         text = text.replace("\"", "&quot;");
         text = text.replace("<", "&lt;");
         text = text.replace(">", "&gt;");

--- a/tooling/camel-tooling-util/src/test/java/org/apache/camel/tooling/util/JavadocHelperTest.java
+++ b/tooling/camel-tooling-util/src/test/java/org/apache/camel/tooling/util/JavadocHelperTest.java
@@ -99,40 +99,4 @@ public class JavadocHelperTest {
         Assertions.assertEquals("Provides methods to interact with Transactions. E.g. sales, credits, refunds, searches, etc.",
                 s3);
     }
-
-    @Test
-    public void testltgtInJavaDoc() throws Exception {
-        String s = " * valid for versions < 26.0.";
-        String s2 = JavadocHelper.sanitizeDescription(s, false);
-        Assertions.assertEquals(s.substring(3), s2);
-        String s3 = " * valid for versions >= 26.0.";
-        String s4 = JavadocHelper.sanitizeDescription(s3, false);
-        Assertions.assertEquals(s3.substring(3), s4);
-    }
-
-    @Test
-    public void testRemoveXmlTagsInJavaDoc() throws Exception {
-        String s = " * foo <xs:foo a=\"x\" b=\"y\"> bar";
-        String s2 = JavadocHelper.sanitizeDescription(s, false);
-        Assertions.assertEquals("foo bar", s2);
-        String s3 = " * foo </xs:foo> bar";
-        String s4 = JavadocHelper.sanitizeDescription(s3, false);
-        Assertions.assertEquals("foo bar", s4);
-        String s5 = " * foo </xs:foo > bar";
-        String s6 = JavadocHelper.sanitizeDescription(s5, false);
-        Assertions.assertEquals("foo bar", s6);
-        String s7 = " * this < is not an xml > tag";
-        String s8 = JavadocHelper.sanitizeDescription(s7, false);
-        Assertions.assertEquals(s7.substring(3), s8);
-    }
-
-    @Test
-    public void testXmlEncode() throws Exception {
-        String s = "foo &amp; bar &gt; baz &lt; foo &quot; bar";
-        String s2 = JavadocHelper.xmlEncode(s);
-        Assertions.assertEquals(s, s2);
-        String s3 = "foo & bar > baz < foo \" bar";
-        String s4 = JavadocHelper.xmlEncode(s3);
-        Assertions.assertEquals(s, s4);
-    }
 }


### PR DESCRIPTION
Reverts apache/camel#6643

This is breaking catalog generation.

FYI @davsclaus @jamesnetherton @djencks 