### PR TITLE
Fix the javadoc paths

### DIFF
--- a/components/camel-mock/src/main/docs/mock-component.adoc
+++ b/components/camel-mock/src/main/docs/mock-component.adoc
@@ -190,7 +190,7 @@ resultEndpoint.expectedBodiesReceived("firstMessageBody", "secondMessageBody", "
 == Adding expectations to specific messages
 
 In addition, you can use the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/component/mock/MockEndpoint.html#message(int)[`message(int
+http://javadoc.io/doc/org.apache.camel/camel-mock/latest/org/apache/camel/component/mock/MockEndpoint.html#message-int-[`message(int
 messageIndex)`] method to add assertions about a specific message that is
 received.
 

--- a/components/camel-spring-xml/pom.xml
+++ b/components/camel-spring-xml/pom.xml
@@ -619,8 +619,8 @@
                         <link>http://download.oracle.com/javase/7/docs/api/</link>
                         <link>http://download.oracle.com/javaee/7/api/</link>
                         <link>http://static.springsource.org/spring/docs/${spring-version}/javadoc-api/</link>
-                        <link>http://camel.apache.org/maven/current/camel-core-model/apidocs/</link>
-                        <link>http://camel.apache.org/maven/current/camel-core-engine/apidocs/</link>
+                        <link>http://javadoc.io/doc/org.apache.camel/camel-core-model/latest/</link>
+                        <link>http://javadoc.io/doc/org.apache.camel/camel-core-engine/latest/</link>
                     </links>
                     <linksource>true</linksource>
                     <maxmemory>256m</maxmemory>

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/eventDrivenConsumer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/eventDrivenConsumer-eip.adoc
@@ -14,7 +14,7 @@ TIP: The alternative consumer mode is xref:pollEnrich-eip.adoc[Polling Consumer]
 image::eip/EventDrivenConsumerSolution.gif[image]
 
 The Event Driven Consumer is implemented by consumers implementing the
-http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
+http://javadoc.io/doc/org.apache.camel/camel-api/latest/org/apache/camel/Processor.html[Processor]
 interface which is invoked by the xref:message-endpoint.adoc[Message Endpoint]
 when a xref:message.adoc[Message] is available for processing.
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/process-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/process-eip.adoc
@@ -5,7 +5,7 @@
 :since: 
 :supportlevel: Stable
 
-The http://camel.apache.org/maven/current/camel-core/apidocs/org/apache/camel/Processor.html[Processor]
+The http://javadoc.io/doc/org.apache.camel/camel-api/latest/org/apache/camel/Processor.html[Processor]
 is used for processing message xref:manual::exchange.adoc[Exchanges].
 
 The processor is a core Camel concept that represents a node capable of using, creating,

--- a/docs/user-manual/modules/ROOT/pages/book-getting-started.adoc
+++ b/docs/user-manual/modules/ROOT/pages/book-getting-started.adoc
@@ -158,9 +158,9 @@ xref:book-getting-started.adoc[Section ("Online Javadoc
 documentation")], Camel provides a separate Javadoc hierarchy for each
 communications technology supported by Camel. Because of this, you will
 find documentation on, say, the `JmsEndpoint` class in the
-http://camel.apache.org/maven/current/camel-jms/apidocs/[JMS Javadoc
+http://javadoc.io/doc/org.apache.camel/camel-jms/latest/[JMS Javadoc
 hierarchy], while documentation for, say, the `FtpEndpoint` class is in
-the http://camel.apache.org/maven/current/camel-ftp/apidocs/[FTP Javadoc
+the http://javadoc.io/doc/org.apache.camel/camel-ftp/latest/[FTP Javadoc
 hierarchy].
 
 [[BookGettingStarted-CamelContext]]


### PR DESCRIPTION
## Motivation

While reading the getting started page, I realized that some links pointed to the Javadoc were broken.

## Modifications:

* Replace URLs of type `http://camel.apache.org/maven/current/${component-name}/apidocs` with `http://javadoc.io/doc/org.apache.camel/${component-name}/latest` everywhere in the project

