### PR TITLE
Align doc regarding ref beans from Endpoint URI

### DIFF
--- a/components/camel-cdi/src/main/docs/cdi.adoc
+++ b/components/camel-cdi/src/main/docs/cdi.adoc
@@ -410,13 +410,17 @@ from("direct:inbound").bean("foo");
 === Referring beans from Endpoint URIs
 
 When configuring endpoints using the URI syntax you can refer to beans
-in the Registry using the `pass:[#]` notation. If the URI
-parameter value starts with a `pass:[#]` sign then Camel CDI will lookup for a
+in the Registry using the `#bean:name` notation.
+
+NOTE: The older syntax with just `#name` has been deprecated due to ambiguity
+as Camel supports a number of additional functions that start with the # notation.
+
+If the URI parameter value starts with `#bean:` then Camel CDI will lookup for a
 bean of the given type by name, e.g.:
 
 [source,java]
 ----
-from("jms:queue:{{destination}}?transacted=true&transactionManager=#jtaTransactionManager").to("...");
+from("jms:queue:{{destination}}?transacted=true&transactionManager=#bean:jtaTransactionManager").to("...");
 ----
 
 Having the following CDI bean qualified

--- a/docs/user-manual/modules/faq/pages/how-do-i-configure-endpoints.adoc
+++ b/docs/user-manual/modules/faq/pages/how-do-i-configure-endpoints.adoc
@@ -117,15 +117,14 @@ pop3://host:port?password=foo
 [[HowdoIconfigureendpoints-ReferringbeansfromEndpointURIs]]
 === Referring beans from Endpoint URIs
 
-When configuring endpoints using URI syntax you can now refer to beans
+When configuring endpoints using the URI syntax you can refer to beans
 in the Registry using the `#bean:id` notation.
 
 NOTE: The older syntax with just `#id` has been deprecated due to ambiguity
 as Camel supports a number of additional functions that start with the # notation.
 
-If the parameter value starts with a `#bean:` sign then Camel will lookup in
-the Registry for a bean of the given type. For
-instance:
+If the URI parameter value starts with `#bean:` then Camel will lookup in
+the Registry for a bean of the given type by id. For instance:
 
 [source]
 ----


### PR DESCRIPTION
## Motivation

The way to reference a bean from an Endpoint URI has changed and should be described the same way in the documentation.

## Modifications

* Align the sections `Referring beans from Endpoint URIs` in the doc to remain consistent

**NB:** In case of CDI, I changed `#bean:id` for `#bean:name` because in CDI, we refer a bean by its name so it was confusing. Hopping that you agree with me 😃  