### PR TITLE
CAMEL-16787: Align apache-any23 version with version in parent pom

### DIFF
--- a/camel-dependencies/camel-dependencies-pom-template.xml
+++ b/camel-dependencies/camel-dependencies-pom-template.xml
@@ -36,7 +36,7 @@
     <activemq-artemis-version>2.19.0</activemq-artemis-version>
     <activemq-version>5.16.3</activemq-version>
     <ahc-version>2.12.3</ahc-version>
-    <apache-any23-version>2.4</apache-any23-version>
+    <apache-any23-version>2.6</apache-any23-version>
     <apache-drill-version>1.19.0</apache-drill-version>
     <apache-gora-version>0.9</apache-gora-version>
     <apacheds-version>2.0.0.AM26</apacheds-version>


### PR DESCRIPTION
This proposed file change is kind of related to "[_3rd party dependency or pom.xml refers to bintray_](https://bit.ly/caml16787)". 

It is not obvious exactly which artifacts in Camel's dependency graph have a transient dependency on `org.apache.any23:apache-any23:2.4`

For some reason or another though, at least three dependencies trigger an attempt to download `org.apache.any23:apache-any23:2.4`:

1. `com.google.guava:guava`
2. `com.google.code.findbugs:jsr305`
3. `org.slf4j:slf4j-api`

Those download attempts try to resolve `apache-any23:2.4`'s pom. That pom is [_configured with a bintray repository that is unreachable_](https://bit.ly/any2324).

That unreachable bintray repository [_has been removed from `org.apache.any23:apache-any23:2.6`_](https://bit.ly/any2326).

This pull request proposes that [_camel-dependencies-pom-template.xml_](https://bit.ly/camDepPom) be upgraded from `apache-any23:2.4` to `2.6` — [_like the parent/pom.xml was_](https://bit.ly/papaPom).

That previous upgrade to `apache-any23:2.6` in the parent pom will have resolved [_the WARNING reported in 16787_](https://bit.ly/caml16787).