### PR TITLE
CAMEL-17452 Fix bug in URISupport#sanitizeUri

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -43,7 +43,7 @@ public final class URISupport {
     // "passphrase" or "password" or secret key (case-insensitive).
     // First capture group is the key, second is the value.
     private static final Pattern SECRETS = Pattern.compile(
-            "([?&][^=]*(?:passphrase|password|secretKey|accessToken|clientSecret|authorizationToken|saslJaasConfig)[^=]*)=(RAW[({].*[)}]|[^&]*)",
+            "([?&][^=]*(?:passphrase|password|secretKey|accessToken|clientSecret|authorizationToken|saslJaasConfig)[^=]*)=(RAW(([{][^}]*[}])|([(][^)]*[)]))|[^&]*)",
             Pattern.CASE_INSENSITIVE);
 
     // Match the user password in the URI as second capture group

--- a/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
@@ -316,6 +316,18 @@ public class URISupportTest {
     }
 
     @Test
+    public void testSanitizeUriWithRawPasswordAndSimpleExpression() {
+        String uriPlain
+                = "http://foo?username=me&password=RAW(me#@123)&foo=bar&port=21&tempFileName=${file:name.noext}.tmp&anotherOption=true";
+        String uriCurly
+                = "http://foo?username=me&password=RAW{me#@123}&foo=bar&port=21&tempFileName=${file:name.noext}.tmp&anotherOption=true";
+        String expected
+                = "http://foo?username=me&password=xxxxxx&foo=bar&port=21&tempFileName=${file:name.noext}.tmp&anotherOption=true";
+        assertEquals(expected, URISupport.sanitizeUri(uriPlain));
+        assertEquals(expected, URISupport.sanitizeUri(uriCurly));
+    }
+
+    @Test
     public void testSanitizeSaslJaasConfig() throws Exception {
         String out1 = URISupport.sanitizeUri(
                 "kafka://MY-TOPIC-NAME?saslJaasConfig=org.apache.kafka.common.security.plain.PlainLoginModule required username=scott password=tiger");


### PR DESCRIPTION
The unintended behaviour is described in issue CAMEL-17452. I am making this PR as per the suggestion of Claus Ibsen.

This pull request is a slight modification of the SECRETS regular expression pattern in URISupport, to be more strict when masking passwords, so as to not mask whole subsets of the URI.

Short summary is that the SECRETS regex-pattern will match on braces (")" or "}"), even if they are not a part of the password parameter.