### PR TITLE
CAMEL-17253: Remove misleading docs

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/main/docs/yaml-dsl.adoc
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/main/docs/yaml-dsl.adoc
@@ -89,21 +89,9 @@ filter:
 
 - *Data Format Aware Steps*
 +
-The EIP `marshal` and `unmarshal` supports the definition of data formats through the `data-format-type` field:
+The EIP `marshal` and `unmarshal` supports the definition of data formats:
 +
 [source,yaml]
-.Explicit Data Format field
-----
-marshal:
-    data-format-type:
-      json:
-        library: Gson
-----
-+
-To make the DSL less verbose, the `data-format` field can be omitted:
-+
-[source,yaml]
-.Implicit Data Format field
 ----
 marshal:
     json:


### PR DESCRIPTION
Same issue https://issues.apache.org/jira/browse/CAMEL-17253
marshal and unmarshal do not have data-format-type field