### PR TITLE
CAMEL-17524 fix resource loading so it works in OSGi

### DIFF
--- a/components/camel-graphql/src/main/java/org/apache/camel/component/graphql/GraphqlEndpoint.java
+++ b/components/camel-graphql/src/main/java/org/apache/camel/component/graphql/GraphqlEndpoint.java
@@ -189,7 +189,7 @@ public class GraphqlEndpoint extends DefaultEndpoint {
     public String getQuery() {
         if (query == null && queryFile != null) {
             try {
-                query = IOHelper.loadText(ObjectHelper.loadResourceAsStream(queryFile));
+                query = IOHelper.loadText(ObjectHelper.loadResourceAsStream(queryFile, getClass().getClassLoader()));
             } catch (IOException e) {
                 throw new RuntimeCamelException("Failed to read query file: " + queryFile, e);
             }

--- a/components/camel-jbpm/src/main/java/org/apache/camel/component/jbpm/server/CamelKieServerExtension.java
+++ b/components/camel-jbpm/src/main/java/org/apache/camel/component/jbpm/server/CamelKieServerExtension.java
@@ -97,7 +97,8 @@ public class CamelKieServerExtension implements KieServerExtension {
             this.camelContext.setName("KIE Server Camel context");
 
             try (InputStream is
-                    = getCamelContext().getClassResolver().loadResourceAsStream("/global-camel-routes.xml")) {
+                    = org.apache.camel.util.ObjectHelper.loadResourceAsStream("/global-camel-routes.xml",
+                            getClass().getClassLoader())) {
                 if (is != null) {
                     ExtendedCamelContext ecc = camelContext.adapt(ExtendedCamelContext.class);
                     RoutesDefinition routes
@@ -129,7 +130,8 @@ public class CamelKieServerExtension implements KieServerExtension {
     public void createContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
 
         ClassLoader classloader = kieContainerInstance.getKieContainer().getClassLoader();
-        try (InputStream is = getCamelContext().getClassResolver().loadResourceAsStream("camel-routes.xml")) {
+        try (InputStream is
+                = org.apache.camel.util.ObjectHelper.loadResourceAsStream("camel-routes.xml", getClass().getClassLoader())) {
             if (is != null) {
 
                 DefaultCamelContext context = (DefaultCamelContext) buildDeploymentContext(id, classloader);

--- a/components/camel-jira/src/main/java/org/apache/camel/component/jira/oauth/OAuthAsynchronousHttpClientFactory.java
+++ b/components/camel-jira/src/main/java/org/apache/camel/component/jira/oauth/OAuthAsynchronousHttpClientFactory.java
@@ -161,7 +161,8 @@ public class OAuthAsynchronousHttpClientFactory {
         static String getVersion(String groupId, String artifactId) {
             final Properties props = new Properties();
             String pomProps = String.format("/META-INF/maven/%s/%s/pom.properties", groupId, artifactId);
-            try (InputStream resourceAsStream = org.apache.camel.util.ObjectHelper.loadResourceAsStream(pomProps)) {
+            try (InputStream resourceAsStream = org.apache.camel.util.ObjectHelper.loadResourceAsStream(pomProps,
+                    OAuthAsynchronousHttpClientFactory.class.getClassLoader())) {
                 props.load(resourceAsStream);
                 return props.getProperty("version", UNKNOWN_VERSION);
             } catch (Exception e) {

--- a/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/ClassPathURIResolver.java
+++ b/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/processor/ClassPathURIResolver.java
@@ -42,7 +42,8 @@ public class ClassPathURIResolver implements URIResolver {
     @Override
     public Source resolve(String href, String base) throws TransformerException {
         InputStream stream
-                = org.apache.camel.util.ObjectHelper.loadResourceAsStream(rulesDir.concat("/").concat(href));
+            = org.apache.camel.util.ObjectHelper.loadResourceAsStream(rulesDir.concat("/").concat(href),
+                                                                      getClass().getClassLoader());
         if (stream != null) {
             return new StreamSource(stream);
         } else {


### PR DESCRIPTION

Fix resource loading calls to pass in calling classes class loader so that they work as expected in OSGi enviroments.

- [ x ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-17524) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ x] Each commit in the pull request should have a meaningful subject line and body.
- [ x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
