### PR TITLE
adding an example to setHeader-eip.adoc

### DIFF
--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/setHeader-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/setHeader-eip.adoc
@@ -61,6 +61,16 @@ And in XML:
 </route>
 ----
 
+Header can be set using fluent syntax.
+
+[source,java]
+----
+from("direct:a")
+    .setHeader("randomNumber").simple("${random(1,100)}")
+    .to("direct:b");
+----
+See xref:components:languages:jsonpath-language.adoc#_using_header_as_input[JSONPath] for another example.
+
 === Setting a header from another header
 
 You can also set a header with the value from another header.


### PR DESCRIPTION
Updating setHeader-eip.adoc to include a sample of fluent syntax.
