### PR TITLE
Fix the links in the import routes page

### DIFF
--- a/docs/user-manual/modules/faq/pages/how-do-i-import-routes-from-other-xml-files.adoc
+++ b/docs/user-manual/modules/faq/pages/how-do-i-import-routes-from-other-xml-files.adoc
@@ -4,8 +4,8 @@
 
 When defining routes in Camel using Spring XML
 you may want to define some routes in other XML files.
-For example you may have many routes and it may help to maintain the
-application if some of the routes are in separate XML files. You may
+For example, you may have many routes, and it may help to maintain the
+application if some routes are in separate XML files. You may
 also want to store common and reusable routes in other XML files, which
 you can simply import when needed.
 
@@ -16,22 +16,20 @@ In *Camel 2.3* it is now possible to define routes outside
 ====
 When you use `<routeContext>` then they are separated, and
 cannot reuse existing `<onException>`,
-`<intercept>`, `<dataFormats>` and similar cross cutting
+`<intercept>`, `<dataFormats>` and similar cross-cutting
 functionality defined in the `<camelContext>`. In other words
 the `<routeContext>` is currently isolated. This may change in Camel
 3.x.
 ====
 
-For example we could have a file named `myCoolRoutes.xml` which
-contains a couple of routes as shown:
+For example, we could have a file named `myCoolRoutes.xml` which
+contains a couple of routes as shown in https://github.com/apache/camel/tree/main/components/camel-spring-xml/src/test/resources/org/apache/camel/spring/config/myCoolRoutes.xml[this example].
 
-https://github.com/apache/camel/tree/main/components/camel-spring/src/test/resources/org/apache/camel/spring/config/myCoolRoutes.xml
 
 Then in your XML file which contains the CamelContext you can use Spring to
 import the `myCoolRoute.xml` file. And then inside `<camelContext/>`
-you can refer to the `<routeContext/>` by its `id` as shown below:
+you can refer to the `<routeContext/>` by its `id` as shown below in https://github.com/apache/camel/tree/main/components/camel-spring-xml/src/test/resources/org/apache/camel/spring/config/RouteRefIncludeXmlFileTest.xml[this example].
 
-https://github.com/apache/camel/tree/main/components/camel-spring/src/test/resources/org/apache/camel/spring/config/RouteRefIncludeXmlFileTest.xml
 
 Also notice that you can mix and match, having routes inside `CamelContext`
 and also externalized in `RouteContext`.
@@ -41,6 +39,6 @@ You can have as many `<routeContextRef/>` as you like.
 == Reusable routes
 
 The routes defined in `<routeContext/>` can be reused by multiple
-`<camelContext/>`. However its only the definition which is reused. At
+`<camelContext/>`. However, it is only the definition which is reused. At
 runtime each `CamelContext` will create its own instance of the route
 based on the definition.


### PR DESCRIPTION
## Motivation

The links to the example of how to import routes from another XML files are broken.

## Modifications:

* Fix typos
* Improve grammar
* Fix links to the examples that are now in `camel-spring-xml` instead of `camel-spring`