### PR TITLE
Try Catch WireTap OnPrepare issue

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/TryCatchWireTapOnPrepareTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/TryCatchWireTapOnPrepareTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Test;
+
+public class TryCatchWireTapOnPrepareTest extends ContextTestSupport {
+
+    @Test
+    public void testTryCatchWireTapOnPrepare() throws Exception {
+        MockEndpoint wireTapMockEndpoint = getMockEndpoint("mock:wireTap");
+        wireTapMockEndpoint.expectedMessageCount(1);
+        wireTapMockEndpoint.expectedPropertyReceived("valid", "false");
+        getMockEndpoint("mock:valid").expectedMessageCount(0);
+        getMockEndpoint("mock:invalid").expectedMessageCount(1);
+
+        template.sendBody("direct:start", "Hello World");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start")
+                        .doTry()
+                            .to("direct:validator")
+                            .wireTap("mock:wireTap").onPrepare(exchange -> exchange.setProperty("valid", "true")).end()
+                            .to("mock:valid")
+                        .doCatch(IllegalArgumentException.class)
+                            .wireTap("mock:wireTap").onPrepare(exchange -> exchange.setProperty("valid", "false")).end()
+                            .to("mock:invalid")
+                        .end();
+
+                from("direct:validator").throwException(new IllegalArgumentException("Not Valid"));
+            }
+        };
+    }
+}


### PR DESCRIPTION
issue when `wireTap` is inside a `doCatch`, and has `.end()` - removing `.end()` fixes issue but then it's confusing why exactly same wireTap inside `doTry` MUST have `.end()` and inside `doCatch` MUST NOT!