### PR TITLE
CAMEL-17579: Use mocks instead of concrete implementations to avoid maintaining them on change

### DIFF
--- a/core/camel-support/src/test/java/org/apache/camel/support/AbstractExchangeTest.java
+++ b/core/camel-support/src/test/java/org/apache/camel/support/AbstractExchangeTest.java
@@ -59,6 +59,7 @@ import org.apache.camel.spi.BeanProxyFactory;
 import org.apache.camel.spi.BootstrapCloseable;
 import org.apache.camel.spi.CamelBeanPostProcessor;
 import org.apache.camel.spi.CamelContextNameStrategy;
+import org.apache.camel.spi.CamelDependencyInjectionAnnotationFactory;
 import org.apache.camel.spi.ClassResolver;
 import org.apache.camel.spi.ComponentNameResolver;
 import org.apache.camel.spi.ComponentResolver;
@@ -1235,6 +1236,16 @@ class AbstractExchangeTest {
 
         @Override
         public void setBeanPostProcessor(CamelBeanPostProcessor beanPostProcessor) {
+
+        }
+
+        @Override
+        public CamelDependencyInjectionAnnotationFactory getDependencyInjectionAnnotationFactory() {
+            return null;
+        }
+
+        @Override
+        public void setDependencyInjectionAnnotationFactory(CamelDependencyInjectionAnnotationFactory factory) {
 
         }
 


### PR DESCRIPTION
## Motivation

The build fails due to a method that has not been implemented in the concrete implementations of `ExtendedCamelContext` used for the tests.

```
MyCamelContext is not abstract and does not override abstract method setDependencyInjectionAnnotationFactory(CamelDependencyInjectionAnnotationFactory) in ExtendedCamelContext
```

## Modifications:

* Replace the concrete implementations of interfaces by mocks to avoid having to maintain them when the interfaces are modified