### PR TITLE
CAMEL-17579: Add the missing implementation of setBeanPostProcessor in MyCamelContext

### DIFF
--- a/core/camel-support/src/test/java/org/apache/camel/support/AbstractExchangeTest.java
+++ b/core/camel-support/src/test/java/org/apache/camel/support/AbstractExchangeTest.java
@@ -1198,6 +1198,11 @@ class AbstractExchangeTest {
         }
 
         @Override
+        public void setBeanPostProcessor(CamelBeanPostProcessor beanPostProcessor) {
+            
+        }
+
+        @Override
         public ManagementMBeanAssembler getManagementMBeanAssembler() {
             return null;
         }


### PR DESCRIPTION
Backport of #6866 for 3.14 (part 2)