### PR TITLE
aws2-ses: Add support for CC and BCC addresses

### DIFF
--- a/components/camel-aws/camel-aws2-ses/src/main/java/org/apache/camel/component/aws2/ses/Ses2Configuration.java
+++ b/components/camel-aws/camel-aws2-ses/src/main/java/org/apache/camel/component/aws2/ses/Ses2Configuration.java
@@ -42,6 +42,10 @@ public class Ses2Configuration implements Cloneable {
     @UriParam
     private String to;
     @UriParam
+    private String cc;
+    @UriParam
+    private String bcc;
+    @UriParam
     private String returnPath;
     @UriParam
     private String replyToAddresses;
@@ -106,6 +110,29 @@ public class Ses2Configuration implements Cloneable {
      */
     public void setTo(String to) {
         this.to = to;
+    }
+
+    public String getCc() {
+        return cc;
+    }
+
+    /**
+     * List of comma separated destination carbon copy (cc) email address. Can be overriden with 'CamelAwsSesCc' header.
+     */
+    public void setCc(String cc) {
+        this.cc = cc;
+    }
+
+    public String getBcc() {
+        return bcc;
+    }
+
+    /**
+     * List of comma separated destination blind carbon copy (bcc) email address. Can be overriden with 'CamelAwsSesBcc'
+     * header.
+     */
+    public void setBcc(String bcc) {
+        this.bcc = bcc;
     }
 
     public String getSecretKey() {

--- a/components/camel-aws/camel-aws2-ses/src/main/java/org/apache/camel/component/aws2/ses/Ses2Constants.java
+++ b/components/camel-aws/camel-aws2-ses/src/main/java/org/apache/camel/component/aws2/ses/Ses2Constants.java
@@ -27,6 +27,8 @@ public interface Ses2Constants {
     String RETURN_PATH = "CamelAwsSesReturnPath";
     String SUBJECT = "CamelAwsSesSubject";
     String TO = "CamelAwsSesTo";
+    String CC = "CamelAwsSesCc";
+    String BCC = "CamelAwsSesBcc";
     String HTML_EMAIL = "CamelAwsSesHtmlEmail";
     String CONFIGURATION_SET = "CamelAwsSesConfigurationSet";
 }

--- a/components/camel-aws/camel-aws2-ses/src/main/java/org/apache/camel/component/aws2/ses/Ses2Producer.java
+++ b/components/camel-aws/camel-aws2-ses/src/main/java/org/apache/camel/component/aws2/ses/Ses2Producer.java
@@ -78,7 +78,7 @@ public class Ses2Producer extends DefaultProducer {
     private SendEmailRequest createMailRequest(Exchange exchange) {
         SendEmailRequest.Builder request = SendEmailRequest.builder();
         request.source(determineFrom(exchange));
-        request.destination(determineTo(exchange));
+        request.destination(determineDestination(exchange));
         request.returnPath(determineReturnPath(exchange));
         request.replyToAddresses(determineReplyToAddresses(exchange));
         request.message(createMessage(exchange));
@@ -148,15 +148,39 @@ public class Ses2Producer extends DefaultProducer {
         return returnPath;
     }
 
-    private Destination determineTo(Exchange exchange) {
-        String to = exchange.getIn().getHeader(Ses2Constants.TO, String.class);
-        if (to == null) {
-            to = getConfiguration().getTo();
+    private Destination determineDestination(Exchange exchange) {
+        List<String> to = determineRawTo(exchange);
+        List<String> cc = determineRawCc(exchange);
+        List<String> bcc = determineRawBcc(exchange);
+        return Destination.builder().toAddresses(to).ccAddresses(cc).bccAddresses(bcc).build();
+    }
+
+    private List<String> determineRawCc(Exchange exchange) {
+        String cc = exchange.getIn().getHeader(Ses2Constants.CC, String.class);
+        if (cc == null) {
+            cc = getConfiguration().getCc();
         }
-        List<String> destinations = Stream.of(to.split(","))
-                .map(String::trim)
-                .collect(Collectors.toList());
-        return Destination.builder().toAddresses(destinations).build();
+        if (ObjectHelper.isNotEmpty(cc)) {
+            return Stream.of(cc.split(","))
+                    .map(String::trim)
+                    .collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    private List<String> determineRawBcc(Exchange exchange) {
+        String bcc = exchange.getIn().getHeader(Ses2Constants.BCC, String.class);
+        if (bcc == null) {
+            bcc = getConfiguration().getBcc();
+        }
+        if (ObjectHelper.isNotEmpty(bcc)) {
+            return Stream.of(bcc.split(","))
+                    .map(String::trim)
+                    .collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     private List<String> determineRawTo(Exchange exchange) {

--- a/components/camel-aws/camel-aws2-ses/src/main/java/org/apache/camel/component/aws2/ses/Ses2Producer.java
+++ b/components/camel-aws/camel-aws2-ses/src/main/java/org/apache/camel/component/aws2/ses/Ses2Producer.java
@@ -157,7 +157,7 @@ public class Ses2Producer extends DefaultProducer {
 
     private List<String> determineRawCc(Exchange exchange) {
         String cc = exchange.getIn().getHeader(Ses2Constants.CC, String.class);
-        if (cc == null) {
+        if (ObjectHelper.isEmpty(cc)) {
             cc = getConfiguration().getCc();
         }
         if (ObjectHelper.isNotEmpty(cc)) {
@@ -171,7 +171,7 @@ public class Ses2Producer extends DefaultProducer {
 
     private List<String> determineRawBcc(Exchange exchange) {
         String bcc = exchange.getIn().getHeader(Ses2Constants.BCC, String.class);
-        if (bcc == null) {
+        if (ObjectHelper.isEmpty(bcc)) {
             bcc = getConfiguration().getBcc();
         }
         if (ObjectHelper.isNotEmpty(bcc)) {

--- a/components/camel-aws/camel-aws2-ses/src/test/java/org/apache/camel/component/aws2/ses/SesComponentConfigurationTest.java
+++ b/components/camel-aws/camel-aws2-ses/src/test/java/org/apache/camel/component/aws2/ses/SesComponentConfigurationTest.java
@@ -49,6 +49,8 @@ public class SesComponentConfigurationTest extends CamelTestSupport {
         assertEquals("yyy", endpoint.getConfiguration().getSecretKey());
         assertNotNull(endpoint.getConfiguration().getAmazonSESClient());
         assertNull(endpoint.getConfiguration().getTo());
+        assertNull(endpoint.getConfiguration().getCc());
+        assertNull(endpoint.getConfiguration().getBcc());
         assertNull(endpoint.getConfiguration().getSubject());
         assertNull(endpoint.getConfiguration().getReturnPath());
         assertNull(endpoint.getConfiguration().getReplyToAddresses());
@@ -66,6 +68,8 @@ public class SesComponentConfigurationTest extends CamelTestSupport {
         assertEquals("yyy", endpoint.getConfiguration().getSecretKey());
         assertNull(endpoint.getConfiguration().getAmazonSESClient());
         assertNull(endpoint.getConfiguration().getTo());
+        assertNull(endpoint.getConfiguration().getCc());
+        assertNull(endpoint.getConfiguration().getBcc());
         assertNull(endpoint.getConfiguration().getSubject());
         assertNull(endpoint.getConfiguration().getReturnPath());
         assertNull(endpoint.getConfiguration().getReplyToAddresses());
@@ -87,6 +91,8 @@ public class SesComponentConfigurationTest extends CamelTestSupport {
         assertNull(endpoint.getConfiguration().getSecretKey());
         assertSame(mock, endpoint.getConfiguration().getAmazonSESClient());
         assertNull(endpoint.getConfiguration().getTo());
+        assertNull(endpoint.getConfiguration().getCc());
+        assertNull(endpoint.getConfiguration().getBcc());
         assertNull(endpoint.getConfiguration().getSubject());
         assertNull(endpoint.getConfiguration().getReturnPath());
         assertNull(endpoint.getConfiguration().getReplyToAddresses());
@@ -108,6 +114,7 @@ public class SesComponentConfigurationTest extends CamelTestSupport {
         Ses2Endpoint endpoint = (Ses2Endpoint) component
                 .createEndpoint("aws2-ses://from@example.com?amazonSESClient=#amazonSESClient&accessKey=xxx"
                                 + "&secretKey=yyy&to=to1@example.com,to2@example.com&subject=Subject"
+                                + "&cc=cc1@example.com,cc2@example.com&bcc=bcc1@example.com,bcc2@example.com"
                                 + "&returnPath=bounce@example.com&replyToAddresses=replyTo1@example.com,replyTo2@example.com"
                                 + "&configurationSet=development-set");
 
@@ -117,6 +124,10 @@ public class SesComponentConfigurationTest extends CamelTestSupport {
         assertNotNull(endpoint.getConfiguration().getAmazonSESClient());
         assertTrue(endpoint.getConfiguration().getTo().contains("to1@example.com"));
         assertTrue(endpoint.getConfiguration().getTo().contains("to2@example.com"));
+        assertTrue(endpoint.getConfiguration().getCc().contains("cc1@example.com"));
+        assertTrue(endpoint.getConfiguration().getCc().contains("cc2@example.com"));
+        assertTrue(endpoint.getConfiguration().getBcc().contains("bcc1@example.com"));
+        assertTrue(endpoint.getConfiguration().getBcc().contains("bcc2@example.com"));
         assertEquals("Subject", endpoint.getConfiguration().getSubject());
         assertEquals("bounce@example.com", endpoint.getConfiguration().getReturnPath());
         assertTrue(endpoint.getConfiguration().getReplyToAddresses().contains("replyTo1@example.com"));
@@ -224,6 +235,8 @@ public class SesComponentConfigurationTest extends CamelTestSupport {
         assertEquals("yyy", endpoint.getConfiguration().getSecretKey());
         assertNull(endpoint.getConfiguration().getAmazonSESClient());
         assertNull(endpoint.getConfiguration().getTo());
+        assertNull(endpoint.getConfiguration().getCc());
+        assertNull(endpoint.getConfiguration().getBcc());
         assertNull(endpoint.getConfiguration().getSubject());
         assertNull(endpoint.getConfiguration().getReturnPath());
         assertNull(endpoint.getConfiguration().getReplyToAddresses());


### PR DESCRIPTION
Implements [camel-17610](https://issues.apache.org/jira/browse/CAMEL-17610)


Adds support for CC and BCC type of destinations. Updates tests too.