### PR TITLE
Remove the link to CDI JUnit5 as not yet released

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/testing.adoc
+++ b/docs/user-manual/modules/ROOT/pages/testing.adoc
@@ -29,8 +29,13 @@ class for all your configuration and routing without.
 
 |xref:components:others:test-spring.adoc[camel-test-spring] | *JUnit 4 (deprecated)*: Used for testing Camel with Spring / Spring Boot
 |xref:components:others:test-spring-junit5.adoc[camel-test-spring-junit5] | *JUnit 5*: Used for testing Camel with Spring / Spring Boot
-|xref:components:others:test-cdi.adoc[camel-test-cdi] | *JUnit 4 (deprecated)*: Used for testing Camel on xref:components:others:cdi.adoc[CDI]
-|xref:components:others:test-cdi-junit5.adoc[camel-test-cdi-junit5] | *JUnit 5*: Used for testing Camel on xref:components:others:cdi.adoc[CDI]
+// Remove me once 3.16.x is out -- START
+|xref:components:others:test-cdi.adoc[camel-test-cdi] | Used for testing Camel on xref:components:others:cdi.adoc[CDI]
+// Remove me once 3.16.x is out -- STOP
+// Un-comment me once 3.16.x is out -- START
+//|xref:components:others:test-cdi.adoc[camel-test-cdi] | *JUnit 4 (deprecated)*: Used for testing Camel on xref:components:others:cdi.adoc[CDI]
+//|xref:components:others:test-cdi-junit5.adoc[camel-test-cdi-junit5] | *JUnit 5*: Used for testing Camel on xref:components:others:cdi.adoc[CDI]
+// Un-comment me once 3.16.x is out -- STOP
 
 |xref:test-infra.adoc[camel-test-infra] | *Camel Test Infra*: Camel Test Infra is a set of modules that leverage Test Containers and abstract the provisioning and execution of test infrastructure. It is the successor of the camel-testcontainers components.
 


### PR DESCRIPTION
## Motivation

The website build is [broken](https://ci-builds.apache.org/job/Camel/job/Camel.website/job/main/753/) due the next error:
```
➤ YN0000: [09:01:06.980] ERROR (asciidoctor): target of xref not found: components:others:test-cdi-junit5.adoc
➤ YN0000:     file: docs/user-manual/modules/ROOT/pages/testing.adoc
➤ YN0000:     source: https://github.com/apache/camel.git (refname: main, start path: docs/user-manual)
```
## Modifications

After a deeper investigation, it is due to the fact that the page `testing` from `user-manual` tries to access to the page `test-cdi-junit5` from the latest release while it is new and thus not yet released so not yet available.

* Revert the changes in the page `testing` from `user-manual`
* Prepare the changes to apply once 3.16 is released