### PR TITLE
CAMEL-17607: Close streams created from the class Files to avoid leaks

### DIFF
--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvMarshalHeaderTest.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvMarshalHeaderTest.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Produce;
@@ -68,10 +69,12 @@ public class CsvMarshalHeaderTest extends CamelTestSupport {
         body.put("first_name", "Max");
         body.put("last_name", "Mustermann");
         producerTemplate.sendBodyAndHeader(body, Exchange.FILE_NAME, fileName);
-        List<String> lines = Files.lines(Paths.get(outputFile.toURI()))
-                .filter(l -> l.trim().length() > 0).collect(Collectors.toList());
-        // We got twice the headers... :(
-        assertEquals(4, lines.size());
+        try (Stream<String> stream = Files.lines(Paths.get(outputFile.toURI()))
+                .filter(l -> l.trim().length() > 0)) {
+            List<String> lines = stream.collect(Collectors.toList());
+            // We got twice the headers... :(
+            assertEquals(4, lines.size());
+        }
     }
 
     @Test
@@ -82,10 +85,12 @@ public class CsvMarshalHeaderTest extends CamelTestSupport {
         producerTemplate.sendBodyAndHeader(body, Exchange.FILE_NAME, fileName);
         body = Collections.singletonList(Arrays.asList("Max", "Mustermann"));
         producerTemplate.sendBodyAndHeader(body, Exchange.FILE_NAME, fileName);
-        List<String> lines = Files.lines(Paths.get(outputFile.toURI()))
-                .filter(l -> l.trim().length() > 0).collect(Collectors.toList());
-        // We got twice the headers... :(
-        assertEquals(4, lines.size());
+        try (Stream<String> stream = Files.lines(Paths.get(outputFile.toURI()))
+                .filter(l -> l.trim().length() > 0)) {
+            List<String> lines = stream.collect(Collectors.toList());
+            // We got twice the headers... :(
+            assertEquals(4, lines.size());
+        }
     }
 
     @Override

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvMarshalHeaderWithCustomMarshallFactoryTest.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvMarshalHeaderWithCustomMarshallFactoryTest.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Produce;
@@ -74,9 +75,11 @@ public class CsvMarshalHeaderWithCustomMarshallFactoryTest extends CamelTestSupp
         body.put("first_name", "Max");
         body.put("last_name", "Mustermann");
         producerTemplate.sendBodyAndHeader(body, Exchange.FILE_NAME, fileName);
-        List<String> lines = Files.lines(Paths.get(outputFile.toURI()))
-                .filter(l -> l.trim().length() > 0).collect(Collectors.toList());
-        assertEquals(3, lines.size());
+        try (Stream<String> stream = Files.lines(Paths.get(outputFile.toURI()))
+                .filter(l -> l.trim().length() > 0)) {
+            List<String> lines = stream.collect(Collectors.toList());
+            assertEquals(3, lines.size());
+        }
     }
 
     @Override

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/test/java/org/apache/camel/maven/CamelSalesforceMojoIntegrationTest.java
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/test/java/org/apache/camel/maven/CamelSalesforceMojoIntegrationTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.tools.JavaFileObject;
 
@@ -53,15 +54,17 @@ public class CamelSalesforceMojoIntegrationTest {
         assertThat(packagePath).as("Package directory was not created").exists();
 
         // test that the generated sources can be compiled
-        final List<JavaFileObject> sources = Files.list(packagePath).map(p -> {
-            try {
-                return JavaFileObjects.forResource(p.toUri().toURL());
-            } catch (final MalformedURLException e) {
-                throw new IllegalArgumentException(e);
-            }
-        }).collect(Collectors.toList());
-        final Compilation compilation = Compiler.javac().compile(sources);
-        assertThat(compilation.status()).isEqualTo(Status.SUCCESS);
+        try (Stream<Path> list = Files.list(packagePath)) {
+            final List<JavaFileObject> sources = list.map(p -> {
+                try {
+                    return JavaFileObjects.forResource(p.toUri().toURL());
+                } catch (final MalformedURLException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            }).collect(Collectors.toList());
+            final Compilation compilation = Compiler.javac().compile(sources);
+            assertThat(compilation.status()).isEqualTo(Status.SUCCESS);
+        }
     }
 
     GenerateMojo createMojo() throws IOException {

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrCloudFixture.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/SolrCloudFixture.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.apache.camel.util.IOHelper;
 import org.apache.log4j.Logger;
@@ -162,8 +163,9 @@ public class SolrCloudFixture {
     public void teardown() throws Exception {
         solrClient.close();
         miniCluster.shutdown();
-        Files.walk(TEMP_DIR).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-
+        try (Stream<File> stream = Files.walk(TEMP_DIR).sorted(Comparator.reverseOrder()).map(Path::toFile)) {
+            stream.forEach(File::delete);
+        }
         solrClient = null;
         miniCluster = null;
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerSuspendAndResumeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerSuspendAndResumeTest.java
@@ -17,6 +17,8 @@
 package org.apache.camel.component.file;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import org.apache.camel.Consumer;
 import org.apache.camel.ContextTestSupport;
@@ -45,8 +47,10 @@ public class FileConsumerSuspendAndResumeTest extends ContextTestSupport {
         oneExchangeDone.matchesWaitTime();
 
         // the route is suspended by the policy so we should only receive one
-        long files = Files.list(testDirectory()).count();
-        assertEquals(1, files, "The file should exists");
+        try (Stream<Path> list = Files.list(testDirectory())) {
+            long files = list.count();
+            assertEquals(1, files, "The file should exists");
+        }
 
         // reset mock
         oneExchangeDone.reset();
@@ -60,8 +64,10 @@ public class FileConsumerSuspendAndResumeTest extends ContextTestSupport {
         oneExchangeDone.matchesWaitTime();
 
         // and the file is now deleted
-        files = Files.list(testDirectory()).count();
-        assertEquals(0, files, "The file should exists");
+        try (Stream<Path> list = Files.list(testDirectory())) {
+            long files = list.count();
+            assertEquals(0, files, "The file should exists");
+        }
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerSuspendTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerSuspendTest.java
@@ -17,6 +17,8 @@
 package org.apache.camel.component.file;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -42,8 +44,10 @@ public class FileConsumerSuspendTest extends ContextTestSupport {
         oneExchangeDone.matchesWaitTime();
 
         // the route is suspended by the policy so we should only receive one
-        long files = Files.list(testDirectory()).count();
-        assertEquals(1, files, "The file should exists");
+        try (Stream<Path> list = Files.list(testDirectory())) {
+            long files = list.count();
+            assertEquals(1, files, "The file should exists");
+        }
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/processor/FileIdempotentTrunkStoreTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/FileIdempotentTrunkStoreTest.java
@@ -70,11 +70,11 @@ public class FileIdempotentTrunkStoreTest extends ContextTestSupport {
         assertTrue(repo.contains("XXXXXXXXXX"));
 
         // check the file should only have the last 2 entries as it was trunked
-        Stream<String> fileContent = Files.lines(store.toPath());
-        List<String> fileEntries = fileContent.collect(Collectors.toList());
-        fileContent.close();
-        // expected order
-        MatcherAssert.assertThat(fileEntries, IsIterableContainingInOrder.contains("ZZZZZZZZZZ", "XXXXXXXXXX"));
+        try (Stream<String> fileContent = Files.lines(store.toPath())) {
+            List<String> fileEntries = fileContent.collect(Collectors.toList());
+            // expected order
+            MatcherAssert.assertThat(fileEntries, IsIterableContainingInOrder.contains("ZZZZZZZZZZ", "XXXXXXXXXX"));
+        }
     }
 
     protected void sendMessage(final Object messageId, final Object body) {

--- a/core/camel-core/src/test/java/org/apache/camel/processor/FileRollbackOnCompletionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/FileRollbackOnCompletionTest.java
@@ -18,8 +18,10 @@ package org.apache.camel.processor;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.ContextTestSupport;
@@ -77,8 +79,10 @@ public class FileRollbackOnCompletionTest extends ContextTestSupport {
     public void testOk() throws Exception {
         template.sendBodyAndHeader("direct:confirm", "bumper", "to", "someone@somewhere.org");
 
-        long files = Files.list(testDirectory()).count();
-        assertEquals(1, files, "There should be one file");
+        try (Stream<Path> list = Files.list(testDirectory())) {
+            long files = list.count();
+            assertEquals(1, files, "There should be one file");
+        }
     }
 
     @Test
@@ -97,8 +101,10 @@ public class FileRollbackOnCompletionTest extends ContextTestSupport {
         // deleted
         assertTrue(LATCH.await(5, TimeUnit.SECONDS), "Should countdown the latch");
 
-        long files = Files.list(testDirectory()).count();
-        assertEquals(0, files, "There should be no files");
+        try (Stream<Path> list = Files.list(testDirectory())) {
+            long files = list.count();
+            assertEquals(0, files, "There should be no files");
+        }
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/support/processor/idempotent/FileIdempotentStoreOrderingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/processor/idempotent/FileIdempotentStoreOrderingTest.java
@@ -57,15 +57,15 @@ public class FileIdempotentStoreOrderingTest extends TestSupport {
         fileIdempotentRepository.stop();
 
         // then
-        Stream<String> fileContent = Files.lines(fileStore.toPath());
-        List<String> fileEntries = fileContent.collect(Collectors.toList());
-        fileContent.close();
-        // expected order
-        MatcherAssert.assertThat(fileEntries,
-                IsIterableContainingInOrder.contains("file1.txt.20171123", "file2.txt.20171123", "file1.txt.20171124",
-                        "file3.txt.20171125", "file2.txt.20171126",
-                        "fixed.income.lamr.out.20171126", "pricing.px.20171126", "test.out.20171126",
-                        "processing.source.lamr.out.20171126"));
+        try (Stream<String> fileContent = Files.lines(fileStore.toPath())) {
+            List<String> fileEntries = fileContent.collect(Collectors.toList());
+            // expected order
+            MatcherAssert.assertThat(fileEntries,
+                    IsIterableContainingInOrder.contains("file1.txt.20171123", "file2.txt.20171123", "file1.txt.20171124",
+                            "file3.txt.20171125", "file2.txt.20171126",
+                            "fixed.income.lamr.out.20171126", "pricing.px.20171126", "test.out.20171126",
+                            "processing.source.lamr.out.20171126"));
+        }
     }
 
     @Test
@@ -81,15 +81,15 @@ public class FileIdempotentStoreOrderingTest extends TestSupport {
         fileIdempotentRepository.stop();
 
         // then
-        Stream<String> fileContent = Files.lines(fileStore.toPath());
-        List<String> fileEntries = fileContent.collect(Collectors.toList());
-        fileContent.close();
-        // expected order
-        MatcherAssert.assertThat(fileEntries,
-                IsIterableContainingInOrder.contains("file1.txt.20171123", "file2.txt.20171123", "file1.txt.20171124",
-                        "file3.txt.20171125", "file2.txt.20171126",
-                        "fixed.income.lamr.out.20171126", "pricing.px.20171126", "test.out.20171126",
-                        "processing.source.lamr.out.20171126"));
+        try (Stream<String> fileContent = Files.lines(fileStore.toPath())) {
+            List<String> fileEntries = fileContent.collect(Collectors.toList());
+            // expected order
+            MatcherAssert.assertThat(fileEntries,
+                    IsIterableContainingInOrder.contains("file1.txt.20171123", "file2.txt.20171123", "file1.txt.20171124",
+                            "file3.txt.20171125", "file2.txt.20171126",
+                            "fixed.income.lamr.out.20171126", "pricing.px.20171126", "test.out.20171126",
+                            "processing.source.lamr.out.20171126"));
+        }
     }
 
     @Test
@@ -111,12 +111,12 @@ public class FileIdempotentStoreOrderingTest extends TestSupport {
         fileIdempotentRepository.stop();
 
         // then
-        Stream<String> fileContent = Files.lines(fileStore.toPath());
-        List<String> fileEntries = fileContent.collect(Collectors.toList());
-        fileContent.close();
+        try (Stream<String> fileContent = Files.lines(fileStore.toPath())) {
+            List<String> fileEntries = fileContent.collect(Collectors.toList());
 
-        // all old entries is removed
-        assertEquals(0, fileEntries.size());
+            // all old entries is removed
+            assertEquals(0, fileEntries.size());
+        }
     }
 
 }

--- a/core/camel-xml-io/src/test/java/org/apache/camel/xml/in/ModelParserTest.java
+++ b/core/camel-xml-io/src/test/java/org/apache/camel/xml/in/ModelParserTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.RouteTemplatesDefinition;
@@ -77,24 +78,26 @@ public class ModelParserTest {
     @Test
     public void testFiles() throws Exception {
         Path dir = getResourceFolder();
-        List<Path> files = Files.list(dir).sorted().filter(Files::isRegularFile).collect(Collectors.toList());
-        for (Path path : files) {
-            ModelParser parser = new ModelParser(Files.newInputStream(path), NAMESPACE);
-            boolean isRest = REST_XMLS.contains(path.getFileName().toString());
-            boolean isTemplate = TEMPLATE_XMLS.contains(path.getFileName().toString());
-            boolean isTemplatedRoute = TEMPLATED_ROUTE_XMLS.contains(path.getFileName().toString());
-            if (isRest) {
-                RestsDefinition rests = parser.parseRestsDefinition().orElse(null);
-                assertNotNull(rests);
-            } else if (isTemplate) {
-                RouteTemplatesDefinition templates = parser.parseRouteTemplatesDefinition().orElse(null);
-                assertNotNull(templates);
-            } else if (isTemplatedRoute) {
-                TemplatedRoutesDefinition templatedRoutes = parser.parseTemplatedRoutesDefinition().orElse(null);
-                assertNotNull(templatedRoutes);
-            } else {
-                RoutesDefinition routes = parser.parseRoutesDefinition().orElse(null);
-                assertNotNull(routes);
+        try (Stream<Path> list = Files.list(dir)) {
+            List<Path> files = list.sorted().filter(Files::isRegularFile).collect(Collectors.toList());
+            for (Path path : files) {
+                ModelParser parser = new ModelParser(Files.newInputStream(path), NAMESPACE);
+                boolean isRest = REST_XMLS.contains(path.getFileName().toString());
+                boolean isTemplate = TEMPLATE_XMLS.contains(path.getFileName().toString());
+                boolean isTemplatedRoute = TEMPLATED_ROUTE_XMLS.contains(path.getFileName().toString());
+                if (isRest) {
+                    RestsDefinition rests = parser.parseRestsDefinition().orElse(null);
+                    assertNotNull(rests);
+                } else if (isTemplate) {
+                    RouteTemplatesDefinition templates = parser.parseRouteTemplatesDefinition().orElse(null);
+                    assertNotNull(templates);
+                } else if (isTemplatedRoute) {
+                    TemplatedRoutesDefinition templatedRoutes = parser.parseTemplatedRoutesDefinition().orElse(null);
+                    assertNotNull(templatedRoutes);
+                } else {
+                    RoutesDefinition routes = parser.parseRoutesDefinition().orElse(null);
+                    assertNotNull(routes);
+                }
             }
         }
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Project.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Project.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -88,11 +89,14 @@ public class Project implements Callable<Integer> {
             if (!file.endsWith(".java")) {
                 Files.copy(Paths.get(file), projectPath.resolve(routesFolder).resolve(Paths.get(file).getFileName()));
             } else {
-                String packageName = Files.lines(Paths.get(file))
-                        .map(fileContent -> getPackage(fileContent))
-                        .filter(Objects::nonNull)
-                        .findFirst()
-                        .orElse("");
+                String packageName;
+                try (Stream<String> stream = Files.lines(Paths.get(file))
+                        .map(this::getPackage)
+                        .filter(Objects::nonNull)) {
+                    packageName = stream
+                            .findFirst()
+                            .orElse("");
+                }
                 try {
                     Path packageDirectory
                             = projectPath.resolve(sourcesFolder).resolve(packageName.replace(".", File.separator));

--- a/tooling/camel-tooling-util/src/main/java/org/apache/camel/tooling/util/PackageHelper.java
+++ b/tooling/camel-tooling-util/src/main/java/org/apache/camel/tooling/util/PackageHelper.java
@@ -111,7 +111,9 @@ public final class PackageHelper {
     }
 
     public static Set<File> findJsonFiles(File rootDir, Set<File> files) {
-        findJsonFiles(rootDir.toPath()).forEach(p -> files.add(p.toFile()));
+        try (Stream<Path> stream = findJsonFiles(rootDir.toPath())) {
+            stream.forEach(p -> files.add(p.toFile()));
+        }
         return files;
     }
 

--- a/tooling/camel-tooling-util/src/test/java/org/apache/camel/tooling/util/PackageHelperTest.java
+++ b/tooling/camel-tooling-util/src/test/java/org/apache/camel/tooling/util/PackageHelperTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,9 +39,12 @@ public class PackageHelperTest {
     @Test
     public void testFindJsonFiles() throws Exception {
         Path dir = ResourceUtils.getResourceAsFile("json").toPath();
-        List<String> jsonFiles = PackageHelper.findJsonFiles(dir)
-                .map(PackageHelper::asName)
-                .collect(Collectors.toList());
+        List<String> jsonFiles;
+        try (Stream<Path> stream = PackageHelper.findJsonFiles(dir)) {
+            jsonFiles = stream
+                    .map(PackageHelper::asName)
+                    .collect(Collectors.toList());
+        }
 
         assertTrue(jsonFiles.contains("a"), "Files a.json must be found");
         assertTrue(jsonFiles.contains("b"), "Files b.json must be found");

--- a/tooling/maven/camel-api-component-maven-plugin/src/main/java/org/apache/camel/maven/ApiComponentGeneratorMojo.java
+++ b/tooling/maven/camel-api-component-maven-plugin/src/main/java/org/apache/camel/maven/ApiComponentGeneratorMojo.java
@@ -116,13 +116,16 @@ public class ApiComponentGeneratorMojo extends AbstractApiMethodBaseMojo {
                 .hash("excludeConfigTypes", excludeConfigTypes)
                 .hash("extraOptions", extraOptions)
                 .toString();
-        Instant newDate = Stream.of(generatedSrcDir, generatedTestDir)
-                .map(File::toPath)
-                .flatMap(this::walk)
-                .filter(Files::isRegularFile)
-                .map(this::lastModified)
-                .max(Comparator.naturalOrder())
-                .orElse(Instant.now());
+        Instant newDate;
+        try (Stream<File> stream = Stream.of(this.generatedSrcDir, generatedTestDir)) {
+            newDate = stream
+                    .map(File::toPath)
+                    .flatMap(this::walk)
+                    .filter(Files::isRegularFile)
+                    .map(this::lastModified)
+                    .max(Comparator.naturalOrder())
+                    .orElse(Instant.now());
+        }
 
         List<String> cache = readCacheFile();
         String prevHash = cache.stream().filter(s -> s.startsWith("hash=")).findFirst()
@@ -191,13 +194,15 @@ public class ApiComponentGeneratorMojo extends AbstractApiMethodBaseMojo {
         // generate ApiName
         mergeTemplate(getApiContext(), getApiNameFile(), "/api-name-enum.vm");
 
-        newDate = Stream.of(generatedSrcDir, generatedTestDir)
-                .map(File::toPath)
-                .flatMap(this::walk)
-                .filter(Files::isRegularFile)
-                .map(this::lastModified)
-                .max(Comparator.naturalOrder())
-                .orElse(Instant.now());
+        try (Stream<File> stream = Stream.of(this.generatedSrcDir, generatedTestDir)) {
+            newDate = stream
+                    .map(File::toPath)
+                    .flatMap(this::walk)
+                    .filter(Files::isRegularFile)
+                    .map(this::lastModified)
+                    .max(Comparator.naturalOrder())
+                    .orElse(Instant.now());
+        }
         writeCacheFile(Arrays.asList(
                 "# ApiComponentGenerator cache file",
                 "hash=" + newHash,

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PackageModelMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PackageModelMojo.java
@@ -17,8 +17,10 @@
 package org.apache.camel.maven.packaging;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.camel.tooling.util.PackageHelper;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -63,12 +65,16 @@ public class PackageModelMojo extends AbstractGeneratorMojo {
         camelMetaDir.mkdirs();
 
         // find all json files in camel-core
-        List<String> models = PackageHelper.findJsonFiles(buildDir.toPath().resolve("classes/org/apache/camel/model"))
-                .map(p -> p.getFileName().toString())
-                // strip out .json from the name
-                .map(s -> s.substring(0, s.length() - PackageHelper.JSON_SUFIX.length()))
-                // sort
-                .sorted().collect(Collectors.toList());
+        List<String> models;
+        try (Stream<Path> jsonFiles
+                = PackageHelper.findJsonFiles(buildDir.toPath().resolve("classes/org/apache/camel/model"))) {
+            models = jsonFiles
+                    .map(p -> p.getFileName().toString())
+                    // strip out .json from the name
+                    .map(s -> s.substring(0, s.length() - PackageHelper.JSON_SUFIX.length()))
+                    // sort
+                    .sorted().collect(Collectors.toList());
+        }
 
         if (!models.isEmpty()) {
             StringBuilder sb = new StringBuilder();

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/UpdateSensitizeHelper.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/UpdateSensitizeHelper.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.camel.tooling.model.ComponentModel;
 import org.apache.camel.tooling.model.DataFormatModel;
@@ -74,8 +75,10 @@ public class UpdateSensitizeHelper extends AbstractGeneratorMojo {
             getLog().debug("No core/camel-util folder found, skipping execution");
             return;
         }
-
-        List<Path> jsonFiles = PackageHelper.findJsonFiles(jsonDir.toPath()).collect(Collectors.toList());
+        List<Path> jsonFiles;
+        try (Stream<Path> stream = PackageHelper.findJsonFiles(jsonDir.toPath())) {
+            jsonFiles = stream.collect(Collectors.toList());
+        }
         Set<String> secrets = new TreeSet<>();
 
         for (Path file : jsonFiles) {

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/ValidateComponentMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/ValidateComponentMojo.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.camel.tooling.util.PackageHelper;
 import org.apache.camel.tooling.util.Strings;
@@ -71,7 +72,10 @@ public class ValidateComponentMojo extends AbstractGeneratorMojo {
         if (!validate) {
             getLog().info("Validation disabled");
         } else {
-            List<Path> jsonFiles = PackageHelper.findJsonFiles(outDir.toPath()).collect(Collectors.toList());
+            List<Path> jsonFiles;
+            try (Stream<Path> stream = PackageHelper.findJsonFiles(outDir.toPath())) {
+                jsonFiles = stream.collect(Collectors.toList());
+            }
             boolean failed = false;
 
             for (Path file : jsonFiles) {

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/XRefCheckMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/XRefCheckMojo.java
@@ -112,12 +112,14 @@ public class XRefCheckMojo extends AbstractMojo {
                             .forEach(module -> {
                                 String m = module.getFileName().toString();
                                 Path pagesDir = module.resolve("pages");
-                                walk(pagesDir)
-                                        .filter(Files::isRegularFile)
-                                        .forEach(page -> {
-                                            Path rel = pagesDir.relativize(page);
-                                            pages.put(component + ":" + m + ":" + rel, page);
-                                        });
+                                try (Stream<Path> pageStream = walk(pagesDir)
+                                        .filter(Files::isRegularFile)) {
+                                    pageStream
+                                            .forEach(page -> {
+                                                Path rel = pagesDir.relativize(page);
+                                                pages.put(component + ":" + m + ":" + rel, page);
+                                            });
+                                }
                             });
                 }
             }


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17607

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md

## Motivation

The methods  `walk`, `lines`, `newDirectoryStream` and `list` of the class `Files` produce a `Stream`  that needs to be closed otherwise we end-up with a resource leak. 

## Modifications:

The goal of this PR is to spot the places in the code where those methods are used without closing the stream and fix the leaks by closing the streams thanks to a try-with-resource-statement.

**NB:** No need to close a `Stream` opened while calling a `flatMap` as it will be closed automatically.