### PR TITLE
CAMEL-17658 camel-debezium: additionalProperties are trimmed

### DIFF
--- a/components/camel-debezium/camel-debezium-mysql/src/test/java/org/apache/camel/component/debezium/DebeziumMySqlComponentTest.java
+++ b/components/camel-debezium/camel-debezium-mysql/src/test/java/org/apache/camel/component/debezium/DebeziumMySqlComponentTest.java
@@ -39,6 +39,7 @@ public class DebeziumMySqlComponentTest {
         params.put("databaseServerName", "test");
         params.put("databaseServerId", "1234");
         params.put("databaseHistoryFileFilename", "/db_history_file_test");
+        params.put("additionalProperties.database.connectionTimeZone", "CET");
 
         final String remaining = "test_name";
         final String uri = "debezium:mysql?name=test_name&offsetStorageFileName=/test&"
@@ -62,6 +63,7 @@ public class DebeziumMySqlComponentTest {
             assertEquals("test", configuration.getDatabaseServerName());
             assertEquals(1234L, configuration.getDatabaseServerId());
             assertEquals("/db_history_file_test", configuration.getDatabaseHistoryFileFilename());
+            assertEquals("CET", configuration.getAdditionalProperties().get("database.connectionTimeZone"));
         }
     }
 

--- a/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
@@ -33,6 +33,8 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.ExtendedCamelContext;
@@ -335,8 +337,14 @@ public final class PropertyBindingSupport {
                 // prepare for next iterator
                 newTarget = prop;
                 newClass = newTarget.getClass();
-                newName = parts[i + 1];
-
+                //do not ignore remaining parts, which was not traversed
+                if (parts.length > 1 && i < parts.length - 2) {
+                    newName = IntStream.range(i + 1, parts.length)
+                            .mapToObj(j -> parts[j])
+                            .collect(Collectors.joining("."));
+                } else {
+                    newName = parts[i + 1];
+                }
                 // if we have not yet found a configurer for the new target
                 if (configurer == null) {
                     configurer = PropertyConfigurerHelper.resolvePropertyConfigurer(camelContext, newTarget);


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-17658

Problem is caused not entirely by debezium component. Automatic properties configuration can "trim" property in specific cases.

- Let say, that we have a property **map.A.B=value**, where  **map** is an URI property defined as ` @UriParam(label = "common", prefix = "map.", multiValue = true,`. Automatic configuration initialization will detect a HashMap object as a **map** property, but then it executes "set property A=value into HashMap (and property B is ignored)"
- I'm trying to change mechanism to not ignore the remaining part of the property name and execute "set property A.B=value into HashMap"

I'm not sure whether this change could be approved, Therefore this is only draft and I'd like to see whether there will be some failing tests.

In case that this approach is not desired or potentially dangerous, I will fix it directly on debezium components - which is safe.


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
