### PR TITLE
CAMEL-17308: Remove "verb" as an allowed CAMEL REST YAML element.

### DIFF
--- a/core/camel-core-model/src/generated/resources/org/apache/camel/model/rest/jaxb.index
+++ b/core/camel-core-model/src/generated/resources/org/apache/camel/model/rest/jaxb.index
@@ -26,4 +26,3 @@ RestSecurityOAuth2
 RestSecurityOpenIdConnect
 RestsDefinition
 SecurityDefinition
-VerbDefinition

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/rest/VerbDefinition.java
@@ -25,7 +25,6 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementRef;
 import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
 import org.apache.camel.model.Block;
@@ -41,7 +40,6 @@ import org.apache.camel.spi.Metadata;
  * Rest command
  */
 @Metadata(label = "rest")
-@XmlRootElement(name = "verb")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class VerbDefinition extends OptionalIdentifiedDefinition<VerbDefinition> implements Block, OutputNode {
 

--- a/core/camel-xml-io/src/generated/java/org/apache/camel/xml/in/ModelParser.java
+++ b/core/camel-xml-io/src/generated/java/org/apache/camel/xml/in/ModelParser.java
@@ -1087,7 +1087,6 @@ public class ModelParser extends BaseParser {
         }, (def, key) -> {
             switch (key) {
                 case "delete": doAdd(doParseDeleteVerbDefinition(), def.getVerbs(), def::setVerbs); break;
-                case "verb": doAdd(doParseVerbDefinition(), def.getVerbs(), def::setVerbs); break;
                 case "get": doAdd(doParseGetVerbDefinition(), def.getVerbs(), def::setVerbs); break;
                 case "head": doAdd(doParseHeadVerbDefinition(), def.getVerbs(), def::setVerbs); break;
                 case "patch": doAdd(doParsePatchVerbDefinition(), def.getVerbs(), def::setVerbs); break;

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_16.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_16.adoc
@@ -100,6 +100,10 @@ The option `camel.main.packageScanRouteBuilders` has been renamed to `camel.main
 Using configuration classes must now implement the interface `org.apache.camel.main.CamelConfiguration`
 and the `configure` method now takes a `CamelContext` as argument.
 
+=== camel-yaml-dsl and camel-xml-dsl REST services
+The verb-based definition is no longer supported for defining a REST service in YAML or XML.
+Only the method-based definitions (get, post, etc) are supported.
+
 === camel-any23
 
 The option `baseURI` is renamed to `baseUri`.

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/generated/java/org/apache/camel/dsl/yaml/deserializers/ModelDeserializers.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/generated/java/org/apache/camel/dsl/yaml/deserializers/ModelDeserializers.java
@@ -221,7 +221,6 @@ import org.apache.camel.model.rest.RestSecurityOAuth2;
 import org.apache.camel.model.rest.RestSecurityOpenIdConnect;
 import org.apache.camel.model.rest.RestsDefinition;
 import org.apache.camel.model.rest.SecurityDefinition;
-import org.apache.camel.model.rest.VerbDefinition;
 import org.apache.camel.model.transformer.CustomTransformerDefinition;
 import org.apache.camel.model.transformer.DataFormatTransformerDefinition;
 import org.apache.camel.model.transformer.EndpointTransformerDefinition;
@@ -11880,7 +11879,7 @@ public final class ModelDeserializers extends YamlDeserializerSupport {
                     @YamlProperty(name = "security-requirements", type = "object:org.apache.camel.model.rest.RestSecuritiesRequirement"),
                     @YamlProperty(name = "skip-binding-on-error-code", type = "string"),
                     @YamlProperty(name = "tag", type = "string"),
-                    @YamlProperty(name = "verb", type = "array:org.apache.camel.model.rest.VerbDefinition")
+                    @YamlProperty(name = "verbs", type = "array:org.apache.camel.model.rest.VerbDefinition")
             }
     )
     public static class RestDefinitionDeserializer extends YamlDeserializerBase<RestDefinition> {
@@ -12012,7 +12011,7 @@ public final class ModelDeserializers extends YamlDeserializerSupport {
                     target.setVerbs(existing);
                     break;
                 }
-                case "verb": {
+                case "verbs": {
                     java.util.List<org.apache.camel.model.rest.VerbDefinition> val = asFlatList(node, org.apache.camel.model.rest.VerbDefinition.class);
                     target.setVerbs(val);
                     break;
@@ -17475,171 +17474,6 @@ public final class ModelDeserializers extends YamlDeserializerSupport {
                     }
                     existing.add(val);
                     target.setValidators(existing);
-                    break;
-                }
-                default: {
-                    return false;
-                }
-            }
-            return true;
-        }
-    }
-
-    @YamlType(
-            types = org.apache.camel.model.rest.VerbDefinition.class,
-            order = org.apache.camel.dsl.yaml.common.YamlDeserializerResolver.ORDER_LOWEST - 1,
-            nodes = "verb",
-            properties = {
-                    @YamlProperty(name = "api-docs", type = "string"),
-                    @YamlProperty(name = "binding-mode", type = "string"),
-                    @YamlProperty(name = "client-request-validation", type = "string"),
-                    @YamlProperty(name = "consumes", type = "string"),
-                    @YamlProperty(name = "deprecated", type = "boolean"),
-                    @YamlProperty(name = "description", type = "string"),
-                    @YamlProperty(name = "enable-cors", type = "string"),
-                    @YamlProperty(name = "id", type = "string"),
-                    @YamlProperty(name = "method", type = "string"),
-                    @YamlProperty(name = "out-type", type = "string"),
-                    @YamlProperty(name = "param", type = "array:org.apache.camel.model.rest.RestOperationParamDefinition"),
-                    @YamlProperty(name = "produces", type = "string"),
-                    @YamlProperty(name = "response-message", type = "array:org.apache.camel.model.rest.RestOperationResponseMsgDefinition"),
-                    @YamlProperty(name = "route", type = "object:org.apache.camel.model.RouteDefinition"),
-                    @YamlProperty(name = "route-id", type = "string"),
-                    @YamlProperty(name = "security", type = "array:org.apache.camel.model.rest.SecurityDefinition"),
-                    @YamlProperty(name = "skip-binding-on-error-code", type = "string"),
-                    @YamlProperty(name = "steps", type = "array:org.apache.camel.model.ProcessorDefinition"),
-                    @YamlProperty(name = "to", type = "object:org.apache.camel.model.ToDefinition"),
-                    @YamlProperty(name = "to-d", type = "object:org.apache.camel.model.ToDynamicDefinition"),
-                    @YamlProperty(name = "type", type = "string"),
-                    @YamlProperty(name = "uri", type = "string")
-            }
-    )
-    public static class VerbDefinitionDeserializer extends YamlDeserializerBase<VerbDefinition> {
-        public VerbDefinitionDeserializer() {
-            super(VerbDefinition.class);
-        }
-
-        @Override
-        protected VerbDefinition newInstance() {
-            return new VerbDefinition();
-        }
-
-        @Override
-        protected boolean setProperty(VerbDefinition target, String propertyKey,
-                String propertyName, Node node) {
-            switch(propertyKey) {
-                case "api-docs": {
-                    String val = asText(node);
-                    target.setApiDocs(val);
-                    break;
-                }
-                case "binding-mode": {
-                    String val = asText(node);
-                    target.setBindingMode(val);
-                    break;
-                }
-                case "client-request-validation": {
-                    String val = asText(node);
-                    target.setClientRequestValidation(val);
-                    break;
-                }
-                case "consumes": {
-                    String val = asText(node);
-                    target.setConsumes(val);
-                    break;
-                }
-                case "deprecated": {
-                    String val = asText(node);
-                    target.setDeprecated(java.lang.Boolean.valueOf(val));
-                    break;
-                }
-                case "enable-cors": {
-                    String val = asText(node);
-                    target.setEnableCORS(val);
-                    break;
-                }
-                case "method": {
-                    String val = asText(node);
-                    target.setMethod(val);
-                    break;
-                }
-                case "out-type": {
-                    String val = asText(node);
-                    target.setOutType(val);
-                    break;
-                }
-                case "param": {
-                    java.util.List<org.apache.camel.model.rest.RestOperationParamDefinition> val = asFlatList(node, org.apache.camel.model.rest.RestOperationParamDefinition.class);
-                    target.setParams(val);
-                    break;
-                }
-                case "produces": {
-                    String val = asText(node);
-                    target.setProduces(val);
-                    break;
-                }
-                case "response-message": {
-                    java.util.List<org.apache.camel.model.rest.RestOperationResponseMsgDefinition> val = asFlatList(node, org.apache.camel.model.rest.RestOperationResponseMsgDefinition.class);
-                    target.setResponseMsgs(val);
-                    break;
-                }
-                case "route-id": {
-                    String val = asText(node);
-                    target.setRouteId(val);
-                    break;
-                }
-                case "security": {
-                    java.util.List<org.apache.camel.model.rest.SecurityDefinition> val = asFlatList(node, org.apache.camel.model.rest.SecurityDefinition.class);
-                    target.setSecurity(val);
-                    break;
-                }
-                case "skip-binding-on-error-code": {
-                    String val = asText(node);
-                    target.setSkipBindingOnErrorCode(val);
-                    break;
-                }
-                case "to-or-route": {
-                    MappingNode val = asMappingNode(node);
-                    setProperties(target, val);
-                    break;
-                }
-                case "to": {
-                    org.apache.camel.model.ToDefinition val = asType(node, org.apache.camel.model.ToDefinition.class);
-                    target.setToOrRoute(val);
-                    break;
-                }
-                case "to-d": {
-                    org.apache.camel.model.ToDynamicDefinition val = asType(node, org.apache.camel.model.ToDynamicDefinition.class);
-                    target.setToOrRoute(val);
-                    break;
-                }
-                case "route": {
-                    org.apache.camel.model.RouteDefinition val = asType(node, org.apache.camel.model.RouteDefinition.class);
-                    target.setToOrRoute(val);
-                    break;
-                }
-                case "type": {
-                    String val = asText(node);
-                    target.setType(val);
-                    break;
-                }
-                case "uri": {
-                    String val = asText(node);
-                    target.setUri(val);
-                    break;
-                }
-                case "id": {
-                    String val = asText(node);
-                    target.setId(val);
-                    break;
-                }
-                case "description": {
-                    org.apache.camel.model.DescriptionDefinition val = asType(node, org.apache.camel.model.DescriptionDefinition.class);
-                    target.setDescription(val);
-                    break;
-                }
-                case "steps": {
-                    setSteps(target, node);
                     break;
                 }
                 default: {

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/generated/java/org/apache/camel/dsl/yaml/deserializers/ModelDeserializersResolver.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/generated/java/org/apache/camel/dsl/yaml/deserializers/ModelDeserializersResolver.java
@@ -509,8 +509,6 @@ public final class ModelDeserializersResolver implements YamlDeserializerResolve
             case "org.apache.camel.model.ValidateDefinition": return new ModelDeserializers.ValidateDefinitionDeserializer();
             case "validators": return new ModelDeserializers.ValidatorsDefinitionDeserializer();
             case "org.apache.camel.model.validator.ValidatorsDefinition": return new ModelDeserializers.ValidatorsDefinitionDeserializer();
-            case "verb": return new ModelDeserializers.VerbDefinitionDeserializer();
-            case "org.apache.camel.model.rest.VerbDefinition": return new ModelDeserializers.VerbDefinitionDeserializer();
             case "weighted": return new ModelDeserializers.WeightedLoadBalancerDefinitionDeserializer();
             case "org.apache.camel.model.loadbalancer.WeightedLoadBalancerDefinition": return new ModelDeserializers.WeightedLoadBalancerDefinitionDeserializer();
             case "when": return new ModelDeserializers.WhenDefinitionDeserializer();

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camel-yaml-dsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camel-yaml-dsl.json
@@ -7279,7 +7279,7 @@
           "tag" : {
             "type" : "string"
           },
-          "verb" : {
+          "verbs" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/items/definitions/org.apache.camel.model.rest.VerbDefinition"
@@ -7574,89 +7574,6 @@
           }
         },
         "required" : [ "key" ]
-      },
-      "org.apache.camel.model.rest.VerbDefinition" : {
-        "type" : "object",
-        "properties" : {
-          "api-docs" : {
-            "type" : "string"
-          },
-          "binding-mode" : {
-            "type" : "string"
-          },
-          "client-request-validation" : {
-            "type" : "string"
-          },
-          "consumes" : {
-            "type" : "string"
-          },
-          "deprecated" : {
-            "type" : "boolean"
-          },
-          "description" : {
-            "type" : "string"
-          },
-          "enable-cors" : {
-            "type" : "string"
-          },
-          "id" : {
-            "type" : "string"
-          },
-          "method" : {
-            "type" : "string"
-          },
-          "out-type" : {
-            "type" : "string"
-          },
-          "param" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestOperationParamDefinition"
-            }
-          },
-          "produces" : {
-            "type" : "string"
-          },
-          "response-message" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestOperationResponseMsgDefinition"
-            }
-          },
-          "route" : {
-            "$ref" : "#/items/definitions/org.apache.camel.model.RouteDefinition"
-          },
-          "route-id" : {
-            "type" : "string"
-          },
-          "security" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
-            }
-          },
-          "skip-binding-on-error-code" : {
-            "type" : "string"
-          },
-          "steps" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
-            }
-          },
-          "to" : {
-            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
-          },
-          "to-d" : {
-            "$ref" : "#/items/definitions/org.apache.camel.model.ToDynamicDefinition"
-          },
-          "type" : {
-            "type" : "string"
-          },
-          "uri" : {
-            "type" : "string"
-          }
-        }
       },
       "org.apache.camel.model.transformer.CustomTransformerDefinition" : {
         "type" : "object",

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camelYamlDsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camelYamlDsl.json
@@ -7177,7 +7177,7 @@
           "tag" : {
             "type" : "string"
           },
-          "verb" : {
+          "verbs" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/items/definitions/org.apache.camel.model.rest.VerbDefinition"
@@ -7472,89 +7472,6 @@
           }
         },
         "required" : [ "key" ]
-      },
-      "org.apache.camel.model.rest.VerbDefinition" : {
-        "type" : "object",
-        "properties" : {
-          "apiDocs" : {
-            "type" : "string"
-          },
-          "bindingMode" : {
-            "type" : "string"
-          },
-          "clientRequestValidation" : {
-            "type" : "string"
-          },
-          "consumes" : {
-            "type" : "string"
-          },
-          "deprecated" : {
-            "type" : "boolean"
-          },
-          "description" : {
-            "type" : "string"
-          },
-          "enableCors" : {
-            "type" : "string"
-          },
-          "id" : {
-            "type" : "string"
-          },
-          "method" : {
-            "type" : "string"
-          },
-          "outType" : {
-            "type" : "string"
-          },
-          "param" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestOperationParamDefinition"
-            }
-          },
-          "produces" : {
-            "type" : "string"
-          },
-          "responseMessage" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestOperationResponseMsgDefinition"
-            }
-          },
-          "route" : {
-            "$ref" : "#/items/definitions/org.apache.camel.model.RouteDefinition"
-          },
-          "routeId" : {
-            "type" : "string"
-          },
-          "security" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
-            }
-          },
-          "skipBindingOnErrorCode" : {
-            "type" : "string"
-          },
-          "steps" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
-            }
-          },
-          "to" : {
-            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
-          },
-          "toD" : {
-            "$ref" : "#/items/definitions/org.apache.camel.model.ToDynamicDefinition"
-          },
-          "type" : {
-            "type" : "string"
-          },
-          "uri" : {
-            "type" : "string"
-          }
-        }
       },
       "org.apache.camel.model.transformer.CustomTransformerDefinition" : {
         "type" : "object",

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RestTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RestTest.groovy
@@ -50,9 +50,8 @@ class RestTest extends YamlTestSupport {
                   - name: myRestConsumerFactory
                     type: ${MockRestConsumerFactory.name}
                 - rest:
-                    verb:
-                      - method: get
-                        uri: "/foo"
+                    get:
+                      - uri: "/foo"
                         type: ${MyFooBar.name}
                         out-type: ${MyBean.name}
                         to: "direct:bar"
@@ -86,9 +85,8 @@ class RestTest extends YamlTestSupport {
                   - name: myRestConsumerFactory
                     type: ${MockRestConsumerFactory.name}
                 - rest:
-                    verb:
-                      - method: get
-                        uri: "/foo"
+                    get:
+                     -  uri: "/foo"
                         type: ${MyFooBar.name}
                         out-type: ${MyBean.name}
                         steps:


### PR DESCRIPTION
This also affects the generated XML model which also will only accept
the XML elements for different methods such as get, put and post.
Remove test cases in RestTest.groovy using verb.

