### PR TITLE
CAMEL-17682: Use the new test-main module in camel-archetype-main

### DIFF
--- a/archetypes/camel-archetype-main/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/camel-archetype-main/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -33,6 +33,9 @@
     <requiredProperty key="maven-resources-plugin-version">
       <defaultValue>${maven-resources-plugin-version}</defaultValue>
     </requiredProperty>
+    <requiredProperty key="maven-surefire-plugin-version">
+      <defaultValue>${maven-surefire-plugin-version}</defaultValue>
+    </requiredProperty>
   </requiredProperties>
   <fileSets>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">

--- a/archetypes/camel-archetype-main/src/main/resources/archetype-resources/ReadMe.txt
+++ b/archetypes/camel-archetype-main/src/main/resources/archetype-resources/ReadMe.txt
@@ -9,6 +9,12 @@ via Camel built-in dependency-injection that supports binding via the
 
 Also notice how you can configure Camel in the `application.properties` file.
 
+=== How to build
+
+To build this project use
+
+    mvn install
+
 === How to run
 
 You can run this example using

--- a/archetypes/camel-archetype-main/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-main/src/main/resources/archetype-resources/pom.xml
@@ -84,7 +84,7 @@
     <!-- testing -->
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-test</artifactId>
+      <artifactId>camel-test-main-junit5</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -122,6 +122,14 @@
       </plugin>
 
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin-version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
 </project>

--- a/archetypes/camel-archetype-main/src/main/resources/archetype-resources/src/test/java/MyApplicationTest.java
+++ b/archetypes/camel-archetype-main/src/main/resources/archetype-resources/src/test/java/MyApplicationTest.java
@@ -16,20 +16,31 @@
 ## ------------------------------------------------------------------------
 package ${package};
 
-import org.apache.camel.BindToRegistry;
-import org.apache.camel.Configuration;
-import org.apache.camel.PropertyInject;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Class to configure the Camel application.
+ * A simple unit test showing how to test the application {@link MyApplication}.
  */
-@Configuration
-public class MyConfiguration {
+class MyApplicationTest extends CamelMainTestSupport {
 
-    @BindToRegistry
-    public MyBean myBean(@PropertyInject("hi") String hi, @PropertyInject("bye") String bye) {
-        // this will create an instance of this bean with the name of the method (eg myBean)
-        return new MyBean(hi, bye);
+    @Override
+    protected Class<?> getMainClass() {
+        // The main class of the application to test
+        return MyApplication.class;
     }
 
+    @Test
+    void should_complete_the_auto_detected_route() {
+        NotifyBuilder notify = new NotifyBuilder(context)
+                .whenCompleted(1).whenBodiesDone("Goodbye World").create();
+        assertTrue(
+                notify.matches(20, TimeUnit.SECONDS), "1 message should be completed"
+        );
+    }
 }

--- a/archetypes/camel-archetype-main/src/test/resources/projects/build-it/archetype.properties
+++ b/archetypes/camel-archetype-main/src/test/resources/projects/build-it/archetype.properties
@@ -24,3 +24,4 @@ camel-version=${project.version}
 logback-version=${logback-version}
 maven-compiler-plugin-version=${maven-compiler-plugin-version}
 maven-resources-plugin-version=${maven-resources-plugin-version}
+maven-surefire-plugin-version=${maven-surefire-plugin-version}

--- a/archetypes/camel-archetype-main/src/test/resources/projects/run-it/archetype.properties
+++ b/archetypes/camel-archetype-main/src/test/resources/projects/run-it/archetype.properties
@@ -26,3 +26,4 @@ maven-compiler-plugin-version=${maven-compiler-plugin-version}
 maven-resources-plugin-version=${maven-resources-plugin-version}
 camel-bundle-plugin-version=${camel-bundle-plugin-version}
 maven-jar-plugin-version=${maven-jar-plugin-version}
+maven-surefire-plugin-version=${maven-surefire-plugin-version}


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17682

## Motivation

A new module has been added allowing to test Camel Main applications, so an example of test should be added to the corresponding archetype.

## Modifications:

* Use the test dependency `camel-test-main-junit5` instead of `camel-test` to test the application
* Configure surefire to use a version that supports JUnit 5
* Remove an unused import
