### PR TITLE
CAMEL-17713: camel-aws2-s3 - Add support for S3 custom metadata in file uploads

### DIFF
--- a/components/camel-aws/camel-aws2-s3/src/main/docs/aws2-s3-component.adoc
+++ b/components/camel-aws/camel-aws2-s3/src/main/docs/aws2-s3-component.adoc
@@ -111,13 +111,12 @@ values.
 |`CamelAwsS3Acl` |`software.amazon.awssdk.services.s3.model.BucketCannedACL` |A well constructed Amazon S3 Access Control List object.
 see `software.amazon.awssdk.services.s3.model.BucketCannedACL` for more details
 
-|`CamelAwsS3Headers` |`Map<String,String>` |Support to get or set custom objectMetadata headers.
-
 |`CamelAwsS3ServerSideEncryption` |String |Sets the server-side encryption algorithm when encrypting
 the object using AWS-managed keys. For example use AES256.
 
 |`CamelAwsS3VersionId` |`String` |The version Id of the object to be stored or returned from the current operation
-|`CamelAwsS3Metadata` |`Map<String, String>` |A map of metadata stored with the object in S3.
+|`CamelAwsS3Metadata` |`Map<String, String>` |A map of metadata to be stored with the object in S3. More details about
+metadata https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html[here].
 |=======================================================================
 
 === Message headers set by the S3 producer
@@ -179,6 +178,8 @@ specify caching behavior along the HTTP request/reply chain.
 
 |`CamelAwsS3ServerSideEncryption` |String |The server-side encryption algorithm when encrypting the
 object using AWS-managed keys.
+|`CamelAwsS3Metadata` |`Map<String, String>` |A map of metadata stored with the object in S3. More details about
+metadata https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html[here].
 |=======================================================================
 
 === S3 Producer operations

--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
@@ -628,6 +628,11 @@ public class AWS2S3Producer extends DefaultProducer {
             objectMetadata.put("Content-Md5", contentMD5);
         }
 
+        Map<String, String> metadata = exchange.getIn().getHeader(AWS2S3Constants.METADATA, Map.class);
+        if (metadata != null) {
+            objectMetadata.putAll(metadata);
+        }
+
         return objectMetadata;
     }
 

--- a/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3UploadWithUserMetadataIT.java
+++ b/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3UploadWithUserMetadataIT.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.s3.integration;
+
+import java.util.Map;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws2.s3.AWS2S3Constants;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class S3UploadWithUserMetadataIT extends Aws2S3Base {
+
+    @EndpointInject
+    private ProducerTemplate template;
+
+    @EndpointInject("mock:result")
+    private MockEndpoint result;
+
+    @Test
+    public void sendInWithUserMetadata() throws Exception {
+        result.expectedMessageCount(1);
+
+        template.send("direct:putObject", exchange -> {
+            exchange.getIn().setHeader(AWS2S3Constants.KEY, "camel-content-type.txt");
+            exchange.getIn().setHeader(AWS2S3Constants.METADATA, Map.of("user-metadata-example", "MetadataFromCamel"));
+            exchange.getIn().setBody("Camel rocks!");
+        });
+
+        S3Client s = AWSSDKClientUtils.newS3Client();
+        ResponseInputStream<GetObjectResponse> response
+                = s.getObject(GetObjectRequest.builder().bucket("mycamel").key("camel-content-type.txt").build());
+        assertTrue(response.response().hasMetadata());
+        assertEquals("MetadataFromCamel", response.response().metadata().get("user-metadata-example"));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                String awsEndpoint = "aws2-s3://mycamel?autoCreateBucket=true";
+
+                from("direct:putObject").to(awsEndpoint);
+
+            }
+        };
+    }
+}


### PR DESCRIPTION
Add support for providing custom metadata to files when uploading.
Makes use of the `CamelAwsS3Metadata` -header that is also used with the consumer endpoint.

As there is no specific user metadata field in the request model, this just adds all metadata from the `CamelAwsS3Metadata` -header into the metadata map.

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
