### PR TITLE
CAMEL-17555: Flag to include/exclude routes in route templates

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
@@ -10762,6 +10762,7 @@ Whether message history is enabled on this route. Default value: true
             ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="precondition" type="xs:string"/>
         <xs:attribute name="rest" type="xs:boolean"/>
         <xs:attribute name="routeConfigurationId" type="xs:string"/>
         <xs:attribute name="routePolicyRef" type="xs:string">

--- a/components/camel-spring-xml/src/test/java/org/apache/camel/spring/RoutePreconditionTest.java
+++ b/components/camel-spring-xml/src/test/java/org/apache/camel/spring/RoutePreconditionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.AbstractXmlApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The test ensuring that the precondition set on a rule determines if the route is included or not.
+ */
+class RoutePreconditionTest extends SpringTestSupport {
+
+    @Override
+    protected AbstractXmlApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("org/apache/camel/spring/RoutePreconditionTest.xml");
+    }
+
+    @Test
+    void testRoutesAreIncludedOrExcludedAsExpected() throws Exception {
+        assertCollectionSize(context.getRouteDefinitions(), 2);
+        assertCollectionSize(context.getRoutes(), 2);
+        assertNotNull(context.getRoute("templatedRouteIncluded"));
+        assertNotNull(context.getRoute("routeIncluded"));
+        assertNull(context.getRoute("templatedRouteExcluded"));
+        assertNull(context.getRoute("routeExcluded"));
+
+        getMockEndpoint("mock:out").expectedMessageCount(1);
+        getMockEndpoint("mock:outT").expectedMessageCount(1);
+
+        template.sendBody("direct:in", "Hello Included Route");
+        template.sendBody("direct:inT", "Hello Included Templated Route");
+
+        assertMockEndpointsSatisfied();
+    }
+}

--- a/components/camel-spring-xml/src/test/resources/org/apache/camel/spring/RoutePreconditionTest.properties
+++ b/components/camel-spring-xml/src/test/resources/org/apache/camel/spring/RoutePreconditionTest.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+activate=true

--- a/components/camel-spring-xml/src/test/resources/org/apache/camel/spring/RoutePreconditionTest.xml
+++ b/components/camel-spring-xml/src/test/resources/org/apache/camel/spring/RoutePreconditionTest.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+            http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <propertyPlaceholder id="properties" location="classpath:org/apache/camel/spring/RoutePreconditionTest.properties"/>
+        <routeTemplate id="myTemplate">
+            <templateParameter name="activateT"/>
+            <route precondition="{{activateT}}">
+                <from uri="direct:inT"/>
+                <to uri="mock:outT"/>
+            </route>
+        </routeTemplate>
+        <templatedRoute routeTemplateRef="myTemplate" routeId="templatedRouteIncluded">
+            <parameter name="activateT" value="true"/>
+        </templatedRoute>
+        <templatedRoute routeTemplateRef="myTemplate" routeId="templatedRouteExcluded">
+            <parameter name="activateT" value="false"/>
+        </templatedRoute>
+        <route precondition="{{activate}}" id="routeIncluded">
+            <from uri="direct:in"/>
+            <to uri="mock:out"/>
+        </route>
+        <route precondition="{{!activate}}" id="routeExcluded">
+            <from uri="direct:in"/>
+            <to uri="mock:out"/>
+        </route>
+    </camelContext>
+
+</beans>

--- a/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -1000,7 +1000,7 @@ public class DefaultCamelContext extends SimpleCamelContext implements ModelCame
     private boolean includedRoute(RouteDefinition definition) {
         final String precondition = definition.getPrecondition();
         if (precondition == null) {
-            LOG.debug("No precondition found, the route is included by default");
+            LOG.trace("No precondition found, the route is included by default");
             return true;
         }
         final ExpressionDefinition expression = new SimpleExpression(precondition);
@@ -1010,8 +1010,8 @@ public class DefaultCamelContext extends SimpleCamelContext implements ModelCame
         predicate.initPredicate(this);
 
         boolean matches = predicate.matches(new DefaultExchange(this));
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("The precondition has been evaluated to {}, thus the route is {}", matches,
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("The precondition has been evaluated to {}, consequently the route is {}", matches,
                     matches ? "included" : "excluded");
         }
         return matches;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/RouteDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/RouteDefinition.java
@@ -458,10 +458,10 @@ public class RouteDefinition extends OutputDefinition<RouteDefinition> implement
     }
 
     /**
-     * Sets the expression of the precondition in simple language to evaluate to determine if this route should be
-     * included or not.
+     * Sets the predicate of the precondition in simple language to evaluate in order to determine if this route should
+     * be included or not.
      *
-     * @param  precondition the expression corresponding to the test to evaluate.
+     * @param  precondition the predicate corresponding to the test to evaluate.
      * @return              the builder
      */
     public RouteDefinition precondition(String precondition) {
@@ -926,16 +926,16 @@ public class RouteDefinition extends OutputDefinition<RouteDefinition> implement
     }
 
     /**
-     * The expression of the precondition in simple language to evaluate to determine if this given route should be
-     * included or not.
+     * The predicate of the precondition in simple language to evaluate in order to determine if this given route should
+     * be included or not.
      */
     public String getPrecondition() {
         return precondition;
     }
 
     /**
-     * The expression of the precondition in simple language to evaluate to determine if this route should be included
-     * or not.
+     * The predicate of the precondition in simple language to evaluate in order to determine if this route should be
+     * included or not.
      */
     @XmlAttribute
     @Metadata(label = "advanced")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/RouteDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/RouteDefinition.java
@@ -90,6 +90,7 @@ public class RouteDefinition extends OutputDefinition<RouteDefinition> implement
     private Map<String, Object> templateParameters;
     private RouteTemplateContext routeTemplateContext;
     private Resource resource;
+    private String precondition;
 
     public RouteDefinition() {
     }
@@ -453,6 +454,18 @@ public class RouteDefinition extends OutputDefinition<RouteDefinition> implement
      */
     public RouteDefinition autoStartup(boolean autoStartup) {
         setAutoStartup(Boolean.toString(autoStartup));
+        return this;
+    }
+
+    /**
+     * Sets the expression of the precondition in simple language to evaluate to determine if this route should be
+     * included or not.
+     *
+     * @param  precondition the expression corresponding to the test to evaluate.
+     * @return              the builder
+     */
+    public RouteDefinition precondition(String precondition) {
+        setPrecondition(precondition);
         return this;
     }
 
@@ -910,6 +923,24 @@ public class RouteDefinition extends OutputDefinition<RouteDefinition> implement
     @Metadata(javaType = "java.lang.Boolean", defaultValue = "true")
     public void setAutoStartup(String autoStartup) {
         this.autoStartup = autoStartup;
+    }
+
+    /**
+     * The expression of the precondition in simple language to evaluate to determine if this given route should be
+     * included or not.
+     */
+    public String getPrecondition() {
+        return precondition;
+    }
+
+    /**
+     * The expression of the precondition in simple language to evaluate to determine if this route should be included
+     * or not.
+     */
+    @XmlAttribute
+    @Metadata(label = "advanced")
+    public void setPrecondition(String precondition) {
+        this.precondition = precondition;
     }
 
     /**

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/RouteTemplateDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/RouteTemplateDefinition.java
@@ -417,7 +417,7 @@ public class RouteTemplateDefinition extends OptionalIdentifiedDefinition {
         } else {
             copy.setDescription(getDescription());
         }
-
+        copy.setPrecondition(route.getPrecondition());
         return copy;
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/builder/RouteTemplatePreconditionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/builder/RouteTemplatePreconditionTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.builder;
+
+import org.apache.camel.ContextTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The test ensuring that the precondition set on a rule determines if the route is included or not
+ */
+class RouteTemplatePreconditionTest extends ContextTestSupport {
+
+    @Test
+    void testRouteIncluded() throws Exception {
+        TemplatedRouteBuilder.builder(context, "myTemplateWithPrecondition")
+                .parameter("protocol", "json")
+                .routeId("myRoute")
+                .add();
+
+        assertCollectionSize(context.getRouteDefinitions(), 1);
+        assertCollectionSize(context.getRoutes(), 1);
+        assertNotNull(context.getRoute("myRoute"));
+
+        getMockEndpoint("mock:out").expectedMessageCount(1);
+
+        template.sendBody("direct:in", "Hello Included Route");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    void testRouteExcluded() {
+        TemplatedRouteBuilder.builder(context, "myTemplateWithPrecondition")
+                .parameter("protocol", "avro")
+                .routeId("myRoute")
+                .add();
+
+        assertCollectionSize(context.getRouteDefinitions(), 0);
+        assertCollectionSize(context.getRoutes(), 0);
+        assertNull(context.getRoute("myRoute"));
+    }
+
+    @Test
+    void testRouteIncludedByDefault() throws Exception {
+        TemplatedRouteBuilder.builder(context, "myTemplateWithoutPrecondition")
+                .routeId("myRoute")
+                .add();
+
+        assertCollectionSize(context.getRouteDefinitions(), 1);
+        assertCollectionSize(context.getRoutes(), 1);
+        assertNotNull(context.getRoute("myRoute"));
+
+        getMockEndpoint("mock:out").expectedMessageCount(1);
+
+        template.sendBody("direct:in", "Hello Included Route");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                routeTemplate("myTemplateWithPrecondition")
+                        .templateParameter("protocol")
+                        .from("direct:in").precondition("'{{protocol}}' == 'json'")
+                        .to("mock:out");
+                routeTemplate("myTemplateWithoutPrecondition")
+                        .from("direct:in")
+                        .to("mock:out");
+            }
+        };
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/processor/RoutePreconditionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/RoutePreconditionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor;
+
+import java.util.Properties;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The test ensuring that the precondition set on a rule determines if the route is included or not
+ */
+class RoutePreconditionTest extends ContextTestSupport {
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Test
+    void testRouteIncluded() throws Exception {
+        Properties init = new Properties();
+        init.setProperty("protocol", "json");
+        context.getPropertiesComponent().setInitialProperties(init);
+
+        context.addRoutes(createRouteBuilder());
+        context.start();
+
+        assertCollectionSize(context.getRouteDefinitions(), 2);
+        assertCollectionSize(context.getRoutes(), 2);
+        assertNotNull(context.getRoute("myRoute"));
+        assertNotNull(context.getRoute("myRouteNP"));
+
+        getMockEndpoint("mock:out").expectedMessageCount(1);
+
+        template.sendBody("direct:in", "Hello Included Route");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    void testRouteExcluded() throws Exception {
+        Properties init = new Properties();
+        init.setProperty("protocol", "avro");
+        context.getPropertiesComponent().setInitialProperties(init);
+
+        context.addRoutes(createRouteBuilder());
+        context.start();
+
+        assertCollectionSize(context.getRouteDefinitions(), 1);
+        assertCollectionSize(context.getRoutes(), 1);
+        assertNull(context.getRoute("myRoute"));
+        assertNotNull(context.getRoute("myRouteNP"));
+    }
+
+    @Test
+    void testRouteIncludedByDefault() throws Exception {
+        Properties init = new Properties();
+        init.setProperty("protocol", "foo");
+        context.getPropertiesComponent().setInitialProperties(init);
+
+        context.addRoutes(createRouteBuilder());
+        context.start();
+
+        assertCollectionSize(context.getRouteDefinitions(), 1);
+        assertCollectionSize(context.getRoutes(), 1);
+        assertNotNull(context.getRoute("myRouteNP"));
+
+        getMockEndpoint("mock:outNP").expectedMessageCount(1);
+
+        template.sendBody("direct:inNP", "Hello Included Route");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:in").routeId("myRoute").precondition("'{{protocol}}' == 'json'")
+                        .to("mock:out");
+                from("direct:inNP").routeId("myRouteNP")
+                        .to("mock:outNP");
+            }
+        };
+    }
+
+}

--- a/core/camel-xml-io/src/generated/java/org/apache/camel/xml/in/ModelParser.java
+++ b/core/camel-xml-io/src/generated/java/org/apache/camel/xml/in/ModelParser.java
@@ -1048,6 +1048,7 @@ public class ModelParser extends BaseParser {
                 case "group": def.setGroup(val); break;
                 case "logMask": def.setLogMask(val); break;
                 case "messageHistory": def.setMessageHistory(val); break;
+                case "precondition": def.setPrecondition(val); break;
                 case "routeConfigurationId": def.setRouteConfigurationId(val); break;
                 case "routePolicyRef": def.setRoutePolicyRef(val); break;
                 case "shutdownRoute": def.setShutdownRoute(val); break;

--- a/docs/user-manual/modules/ROOT/pages/routes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/routes.adoc
@@ -54,6 +54,44 @@ rb -> rb.from("kafka:cheese").to("jms:queue:foo");
 There is a bit more to this as the lambda route must be coded in a Java method that returns an instance of `LambdaRouteBuilder`.
 See more at the xref:lambda-route-builder.adoc[LambdaRouteBuilder] documentation.
 
+== Route Precondition
+
+The routes can be included or not according to the result of a test expressed in simple language that is evaluated only once during the initialization phase.
+
+In the next example, the route is only included if the parameter `format` has been set to `xml`.
+
+[source,java]
+----
+from("direct:in").precondition("'{{format}}' == 'xml'")
+   .unmarshal().jaxb()
+   .to("direct:out");
+----
+
+And the same example using XML DSL:
+
+[source,xml]
+----
+<route precondition="'{{format}}' == 'xml'">
+  <from uri="direct:in"/>
+  <unmarshal><jaxb/></unmarshal>
+  <to uri="direct:out"/>
+</route>
+----
+
+And in YAML DS:
+
+[source,yaml]
+----
+- route:
+    precondition: "'{{format}}' == 'xml'"
+    from:
+      uri: "direct:in"
+      steps:
+        - unmarshal:
+            jaxb: {}
+        - to: "direct:out"
+----
+
 == More Information
 
 See xref:route-builder.adoc[RouteBuilder] and xref:dsl.adoc[DSL] for a list of supported languages you can use for coding Camel routes.

--- a/docs/user-manual/modules/ROOT/pages/routes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/routes.adoc
@@ -78,7 +78,7 @@ And the same example using XML DSL:
 </route>
 ----
 
-And in YAML DS:
+And in YAML DSL:
 
 [source,yaml]
 ----

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/main/java/org/apache/camel/dsl/yaml/deserializers/RouteDefinitionDeserializer.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/main/java/org/apache/camel/dsl/yaml/deserializers/RouteDefinitionDeserializer.java
@@ -38,6 +38,7 @@ import org.snakeyaml.engine.v2.nodes.NodeTuple;
           properties = {
                   @YamlProperty(name = "id", type = "string"),
                   @YamlProperty(name = "description", type = "string"),
+                  @YamlProperty(name = "precondition", type = "string"),
                   @YamlProperty(name = "group", type = "string"),
                   @YamlProperty(name = "route-configuration-id", type = "string"),
                   @YamlProperty(name = "from", type = "object:org.apache.camel.model.FromDefinition", required = true)
@@ -69,6 +70,9 @@ public class RouteDefinitionDeserializer extends YamlDeserializerBase<RouteDefin
                     break;
                 case "description":
                     target.setDescription(new DescriptionDefinition(asText(val)));
+                    break;
+                case "precondition":
+                    target.setPrecondition(asText(val));
                     break;
                 case "group":
                     target.setGroup(asText(val));

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camel-yaml-dsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camel-yaml-dsl.json
@@ -2514,6 +2514,9 @@
           "id" : {
             "type" : "string"
           },
+          "precondition" : {
+            "type" : "string"
+          },
           "route-configuration-id" : {
             "type" : "string"
           }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camelYamlDsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camelYamlDsl.json
@@ -2415,6 +2415,9 @@
           "id" : {
             "type" : "string"
           },
+          "precondition" : {
+            "type" : "string"
+          },
           "routeConfigurationId" : {
             "type" : "string"
           }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RoutesTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RoutesTest.groovy
@@ -186,4 +186,31 @@ class RoutesTest extends YamlTestSupport {
             }
         }
     }
+
+    def "load route description with precondition"() {
+        when:
+        loadRoutes '''
+                - route:
+                    id: demo-route
+                    description: something cool
+                    precondition: "{{?red}}"
+                    from:
+                      uri: "direct:info"
+                      steps:
+                        - log: "message"
+            '''
+        then:
+        context.routeDefinitions.size() == 1
+
+        with(context.routeDefinitions[0], RouteDefinition) {
+            routeId == 'demo-route'
+            description.text == 'something cool'
+            input.endpointUri == 'direct:info'
+            precondition == '{{?red}}'
+
+            with (outputs[0], LogDefinition) {
+                message == 'message'
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17555

## Motivation

To make route templates (aka kamelets) more flexible it can benefit that we allow to declare routes whether they should be included or excluded. This allows to parameterize these routes and therefore only include them if the template has a parameter included for this.

## Modifications

* Add a new parameter called `precondition` allowing to provide a predicate in Simple language to evaluate in order to know if a given route should be excluded or not.
* Remove the definition of the route if the `precondition` fails