### PR TITLE
CAMEL-17320: Upgrade maven-plugin-plugin to 3.6.4

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -398,8 +398,8 @@
     <maven-jboss-as-maven-plugin-version>7.9.Final</maven-jboss-as-maven-plugin-version>
     <maven-model-version>3.2.5</maven-model-version>
     <maven-owasp-plugin-version>6.5.0</maven-owasp-plugin-version>
-    <maven-plugin-annotations-version>3.6.1</maven-plugin-annotations-version>
-    <maven-plugin-plugin-version>3.6.1</maven-plugin-plugin-version>
+    <maven-plugin-annotations-version>3.6.4</maven-plugin-annotations-version>
+    <maven-plugin-plugin-version>3.6.4</maven-plugin-plugin-version>
     <maven-plugin-testing-harness-version>3.3.0</maven-plugin-testing-harness-version>
     <maven-remote-resources-plugin-version>1.7.0</maven-remote-resources-plugin-version>
     <maven-reporting-api-version>2.2.1</maven-reporting-api-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -384,8 +384,8 @@
         <maven-javadoc-plugin-version>3.2.0</maven-javadoc-plugin-version>
         <maven-jboss-as-maven-plugin-version>7.9.Final</maven-jboss-as-maven-plugin-version>
         <maven-model-version>3.2.5</maven-model-version>
-        <maven-plugin-plugin-version>3.6.1</maven-plugin-plugin-version>
-        <maven-plugin-annotations-version>3.6.1</maven-plugin-annotations-version>
+        <maven-plugin-plugin-version>3.6.4</maven-plugin-plugin-version>
+        <maven-plugin-annotations-version>3.6.4</maven-plugin-annotations-version>
         <maven-plugin-testing-harness-version>3.3.0</maven-plugin-testing-harness-version>
         <maven-remote-resources-plugin-version>1.7.0</maven-remote-resources-plugin-version>
         <!-- resources plugin needed by Camel maven archetypes -->

--- a/tooling/maven/camel-component-maven-plugin/pom.xml
+++ b/tooling/maven/camel-component-maven-plugin/pom.xml
@@ -44,7 +44,14 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
-
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-package-maven-plugin</artifactId>

--- a/tooling/parent/pom.xml
+++ b/tooling/parent/pom.xml
@@ -38,7 +38,7 @@
         <maven-maven-plugin-descriptor-version>2.2.1</maven-maven-plugin-descriptor-version>
         <maven-project-version>2.2.1</maven-project-version>
         <maven-dependency-tree-version>2.2</maven-dependency-tree-version>
-        <maven-plugin-annotations-version>3.6.0</maven-plugin-annotations-version>
+        <maven-plugin-annotations-version>3.6.4</maven-plugin-annotations-version>
         <maven-reporting-api-version>3.0</maven-reporting-api-version>
         <maven-reporting-impl-version>2.4</maven-reporting-impl-version>
         <maven-resolver-version>1.0.3</maven-resolver-version>
@@ -55,6 +55,7 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
                 <version>${maven-version}</version>
+                <scope>provided</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
@@ -72,18 +73,51 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
+                <artifactId>maven-model</artifactId>
+                <version>${maven-version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings</artifactId>
+                <version>${maven-version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-repository-metadata</artifactId>
+                <version>${maven-version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-toolchain</artifactId>
+                <version>${maven-project-version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact-manager</artifactId>
+                <version>${maven-project-version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
                 <artifactId>maven-artifact</artifactId>
                 <version>${maven-version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
                 <version>${maven-version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-compat</artifactId>
                 <version>${maven-version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.plugin-tools</groupId>
@@ -94,6 +128,7 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-descriptor</artifactId>
                 <version>${maven-maven-plugin-descriptor-version}</version>
+                <scope>provided</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>log4j</groupId>
@@ -105,6 +140,7 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-project</artifactId>
                 <version>${maven-project-version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17320

## Motivation

Upgrading `maven-plugin-plugin` add warnings in the log of the build due to the scope of Maven dependencies that must always be `provided`

## Modifications:

* Upgrade `maven-plugin-plugin` and `maven-plugin-annotations` to the latest existing version which is `3.6.4`
* Set the scope of the Maven dependencies to `provided` directly into the dependency management section to have it fix globally in one file
* Add missing dependencies in `camel-component-maven-plugin` to avoid compilation failures
* Add some Maven dependencies to the dependency management section to enforce the scope to `provided` that were initially transitive dependencies

## Result

The log of the build doesn't contain anymore warning messages complaining about the scope of Maven dependencies