### PR TITLE
CAMEL-17774 Added check for null inputStream

### DIFF
--- a/components/camel-zipfile/src/main/java/org/apache/camel/dataformat/zipfile/ZipIterator.java
+++ b/components/camel-zipfile/src/main/java/org/apache/camel/dataformat/zipfile/ZipIterator.java
@@ -48,6 +48,11 @@ public class ZipIterator implements Iterator<Message>, Closeable {
     public ZipIterator(Exchange exchange, InputStream inputStream) {
         this.exchange = exchange;
         this.allowEmptyDirectory = false;
+
+        if (inputStream == null) {
+            throw new IllegalStateException("Input stream cannot be null");
+        }
+
         if (inputStream instanceof ZipInputStream) {
             zipInputStream = (ZipInputStream) inputStream;
         } else {

--- a/components/camel-zipfile/src/main/java/org/apache/camel/dataformat/zipfile/ZipIterator.java
+++ b/components/camel-zipfile/src/main/java/org/apache/camel/dataformat/zipfile/ZipIterator.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -49,9 +50,7 @@ public class ZipIterator implements Iterator<Message>, Closeable {
         this.exchange = exchange;
         this.allowEmptyDirectory = false;
 
-        if (inputStream == null) {
-            throw new IllegalStateException("Input stream cannot be null");
-        }
+        Objects.requireNonNull(inputStream);
 
         if (inputStream instanceof ZipInputStream) {
             zipInputStream = (ZipInputStream) inputStream;


### PR DESCRIPTION
<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
This PR is to add a check for null during `ZipIterator` creation which will prevent the assignment of a `new ZipInputStream(new BufferedInputStream(inputStream))` to `zipInputStream` variable. 
Such case may occur when a message is converted to `InputStream` but no `TypeConverter` is present (e.g in `ZipSplitter`)
