### PR TITLE
CAMEL-16628: Add applicableFor to Metadata to filter header by scheme

### DIFF
--- a/core/camel-api/src/generated/java/org/apache/camel/spi/Metadata.java
+++ b/core/camel-api/src/generated/java/org/apache/camel/spi/Metadata.java
@@ -132,4 +132,21 @@ public @interface Metadata {
      * specify which options each implementation only supports.
      */
     String includeProperties() default "";
+
+    /**
+     * Indicates the list of schemes for which this metadata is applicable. This is used to filter out message headers
+     * that are shared with several endpoints but only applicable for some of them.
+     * <p/>
+     * In the next example, the header {@code SOME_HEADER} is only applicable for endpoints whose scheme is "foo" or
+     * "bar".
+     *
+     * <pre>
+     * <code>
+     *
+     * &#64;Metadata(description = "some description", javaType = "String", applicableFor = {"foo", "bar"})
+     * public static final String SOME_HEADER = "someHeaderName";
+     * </code>
+     * </pre>
+     */
+    String[] applicableFor() default {};
 }

--- a/tooling/maven/camel-package-maven-plugin/pom.xml
+++ b/tooling/maven/camel-package-maven-plugin/pom.xml
@@ -188,8 +188,6 @@
                     </mojoDependencies>
                 </configuration>
             </plugin>
-
-<!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
@@ -230,8 +228,6 @@
                     </dependency>
                 </dependencies>
             </plugin>
--->
-
         </plugins>
     </build>
 

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojoTest.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojoTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.camel.maven.packaging.endpoint.SomeEndpoint;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithBadHeaders;
+import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithFilter;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithoutHeaders;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.tooling.model.ComponentModel;
@@ -53,7 +54,7 @@ class EndpointSchemaGeneratorMojoTest {
 
     @Test
     void testCanRetrieveMetadataOfHeaders() {
-        mojo.addEndpointHeaders(model, SomeEndpoint.class.getAnnotation(UriEndpoint.class));
+        mojo.addEndpointHeaders(model, SomeEndpoint.class.getAnnotation(UriEndpoint.class), "some");
         List<EndpointHeaderModel> endpointHeaders = model.getEndpointHeaders();
         assertEquals(2, endpointHeaders.size());
         // Full
@@ -91,13 +92,25 @@ class EndpointSchemaGeneratorMojoTest {
 
     @Test
     void testHeadersNotProperlyDefinedAreIgnored() {
-        mojo.addEndpointHeaders(model, SomeEndpointWithBadHeaders.class.getAnnotation(UriEndpoint.class));
+        mojo.addEndpointHeaders(model, SomeEndpointWithBadHeaders.class.getAnnotation(UriEndpoint.class), "some");
         assertEquals(0, model.getEndpointHeaders().size());
     }
 
     @Test
     void testEndpointWithoutHeadersAreIgnored() {
-        mojo.addEndpointHeaders(model, SomeEndpointWithoutHeaders.class.getAnnotation(UriEndpoint.class));
+        mojo.addEndpointHeaders(model, SomeEndpointWithoutHeaders.class.getAnnotation(UriEndpoint.class), "some");
         assertEquals(0, model.getEndpointHeaders().size());
+    }
+
+    @Test
+    void testEndpointWithFilterKeepOnlyApplicableHeaders() {
+        mojo.addEndpointHeaders(model, SomeEndpointWithFilter.class.getAnnotation(UriEndpoint.class), "some");
+        List<EndpointHeaderModel> endpointHeaders = model.getEndpointHeaders();
+        assertEquals(2, endpointHeaders.size());
+        for (int i = 0; i < endpointHeaders.size(); i++) {
+            EndpointHeaderModel headerEmpty = endpointHeaders.get(i);
+            assertEquals("header", headerEmpty.getKind());
+            assertEquals(String.format("keep-%d", i + 1), headerEmpty.getName());
+        }
     }
 }

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointWithFilter.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointWithFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven.packaging.endpoint;
+
+import org.apache.camel.spi.Metadata;
+import org.apache.camel.spi.UriEndpoint;
+
+@UriEndpoint(scheme = "some", syntax = "some", title = "some", headersClass = SomeEndpointWithFilter.class)
+public final class SomeEndpointWithFilter {
+
+    @Metadata(description = "some description")
+    static final String KEEP_1 = "keep-1";
+    @Metadata(description = "some description", applicableFor = "some")
+    static final String KEEP_2 = "keep-2";
+    @Metadata(description = "some description", applicableFor = "other")
+    static final String IGNORE = "ignore";
+
+    private SomeEndpointWithFilter() {
+    }
+}

--- a/tooling/spi-annotations/src/main/java/org/apache/camel/spi/Metadata.java
+++ b/tooling/spi-annotations/src/main/java/org/apache/camel/spi/Metadata.java
@@ -132,4 +132,21 @@ public @interface Metadata {
      * specify which options each implementation only supports.
      */
     String includeProperties() default "";
+
+    /**
+     * Indicates the list of schemes for which this metadata is applicable. This is used to filter out message headers
+     * that are shared with several endpoints but only applicable for some of them.
+     * <p/>
+     * In the next example, the header {@code SOME_HEADER} is only applicable for endpoints whose scheme is "foo" or
+     * "bar".
+     *
+     * <pre>
+     * <code>
+     *
+     * &#64;Metadata(description = "some description", javaType = "String", applicableFor = {"foo", "bar"})
+     * public static final String SOME_HEADER = "someHeaderName";
+     * </code>
+     * </pre>
+     */
+    String[] applicableFor() default {};
 }


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-16628 (part 2)

## Motivation

Some Constants class are shared with several endpoints, we need a mechanism allowing to filter the message headers by endpoint's scheme.

## Modifications

* Add the new element `applicableFor` to `@Metadata` to provide the list of schemes for which the metadata is applicable.
* Enable the IT as the plugin updates have been published (not related to this need)