### PR TITLE
CAMEL-16628: Allow to define headers in an enum

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojo.java
@@ -316,8 +316,9 @@ public class EndpointSchemaGeneratorMojo extends AbstractGeneratorMojo {
         }
         // A header class has been defined
         boolean foundHeader = false;
+        final boolean isEnum = headersClass.isEnum();
         for (Field field : headersClass.getDeclaredFields()) {
-            if (isStatic(field.getModifiers()) && field.getType() == String.class
+            if ((isEnum || isStatic(field.getModifiers()) && field.getType() == String.class)
                     && field.isAnnotationPresent(Metadata.class)) {
                 getLog().debug(
                         String.format("Trying to add the constant %s in the class %s as header.", field.getName(),
@@ -381,7 +382,9 @@ public class EndpointSchemaGeneratorMojo extends AbstractGeneratorMojo {
         }
         try {
             field.trySetAccessible();
-            header.setName((String) field.get(null));
+            // The name of the header is either the name of the field in case of an enum, otherwise it is the value
+            // of the field as we assume that it is a String constant
+            header.setName(field.getType().isEnum() ? field.getName() : (String) field.get(null));
             componentModel.addEndpointHeader(header);
         } catch (IllegalAccessException e) {
             getLog().debug(String.format("The field %s in class %s cannot be accessed", field.getName(),

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojoTest.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojoTest.java
@@ -20,6 +20,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import org.apache.camel.maven.packaging.endpoint.SomeEndpoint;
+import org.apache.camel.maven.packaging.endpoint.SomeEndpointUsingEnumConstants;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithBadHeaders;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithFilter;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithoutHeaders;
@@ -29,6 +30,8 @@ import org.apache.camel.tooling.model.ComponentModel.EndpointHeaderModel;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -52,15 +55,16 @@ class EndpointSchemaGeneratorMojoTest {
         mojo.project = new MavenProject();
     }
 
-    @Test
-    void testCanRetrieveMetadataOfHeaders() {
-        mojo.addEndpointHeaders(model, SomeEndpoint.class.getAnnotation(UriEndpoint.class), "some");
+    @ParameterizedTest
+    @ValueSource(classes = { SomeEndpoint.class, SomeEndpointUsingEnumConstants.class })
+    void testCanRetrieveMetadataOfHeaders(Class<?> clazz) {
+        mojo.addEndpointHeaders(model, clazz.getAnnotation(UriEndpoint.class), "some");
         List<EndpointHeaderModel> endpointHeaders = model.getEndpointHeaders();
         assertEquals(2, endpointHeaders.size());
         // Full
         EndpointHeaderModel headerFull = endpointHeaders.get(0);
         assertEquals("header", headerFull.getKind());
-        assertEquals("name-full", headerFull.getName());
+        assertEquals("KEY_FULL", headerFull.getName());
         assertEquals("key full desc", headerFull.getDescription());
         assertEquals("my display name", headerFull.getDisplayName());
         assertEquals("org.apache.camel.maven.packaging.endpoint.SomeEndpoint$MyEnum", headerFull.getJavaType());
@@ -75,7 +79,7 @@ class EndpointSchemaGeneratorMojoTest {
         // Empty
         EndpointHeaderModel headerEmpty = endpointHeaders.get(1);
         assertEquals("header", headerEmpty.getKind());
-        assertEquals("name-empty", headerEmpty.getName());
+        assertEquals("KEY_EMPTY", headerEmpty.getName());
         assertTrue(headerEmpty.getDescription().isEmpty());
         assertTrue(headerEmpty.getDisplayName().isEmpty());
         assertTrue(headerEmpty.getJavaType().isEmpty());

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointUsingEnumConstants.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointUsingEnumConstants.java
@@ -16,17 +16,8 @@
  */
 package org.apache.camel.maven.packaging.endpoint;
 
-import org.apache.camel.spi.Metadata;
+import org.apache.camel.spi.UriEndpoint;
 
-public final class SomeConstants {
-    @Deprecated
-    @Metadata(description = "key full desc", label = "my label", displayName = "my display name",
-              javaType = "org.apache.camel.maven.packaging.endpoint.SomeEndpoint$MyEnum", required = true,
-              defaultValue = "VAL1", deprecationNote = "my deprecated note", secret = true)
-    public static final String KEY_FULL = "KEY_FULL";
-    @Metadata
-    static final String KEY_EMPTY = "KEY_EMPTY";
-
-    private SomeConstants() {
-    }
+@UriEndpoint(scheme = "some", syntax = "some", title = "some", headersClass = SomeEnumConstants.class)
+public class SomeEndpointUsingEnumConstants {
 }

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEnumConstants.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEnumConstants.java
@@ -18,15 +18,12 @@ package org.apache.camel.maven.packaging.endpoint;
 
 import org.apache.camel.spi.Metadata;
 
-public final class SomeConstants {
+public enum SomeEnumConstants {
     @Deprecated
     @Metadata(description = "key full desc", label = "my label", displayName = "my display name",
               javaType = "org.apache.camel.maven.packaging.endpoint.SomeEndpoint$MyEnum", required = true,
               defaultValue = "VAL1", deprecationNote = "my deprecated note", secret = true)
-    public static final String KEY_FULL = "KEY_FULL";
+    KEY_FULL,
     @Metadata
-    static final String KEY_EMPTY = "KEY_EMPTY";
-
-    private SomeConstants() {
-    }
+    KEY_EMPTY;
 }


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-16628 (part 3)

## Motivation

There are components that define their constants in an enum so it should be supported too.

## Modifications

* Check if the header class is an enum and if so accept any field annotated with `@Metadata`
* Use the name of the field as header name in case of an enum