### PR TITLE
[CAMEL-17857] camel-validator: remote xsd import

### DIFF
--- a/components/camel-validator/src/main/java/org/apache/camel/component/validator/DefaultLSResourceResolver.java
+++ b/components/camel-validator/src/main/java/org/apache/camel/component/validator/DefaultLSResourceResolver.java
@@ -50,7 +50,8 @@ public class DefaultLSResourceResolver implements LSResourceResolver {
     }
 
     private String getUri(String systemId) {
-        if (resourcePath != null) {
+        if (resourcePath != null && !systemId.toLowerCase().startsWith("http:")
+                && !systemId.toLowerCase().startsWith("https:")) {
             return FileUtil.onlyPath(resourceUri) + "/" + systemId;
         } else {
             return systemId;

--- a/core/camel-core/src/test/java/org/apache/camel/ValidatorExternalResourceTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/ValidatorExternalResourceTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Test;
+
+public class ValidatorExternalResourceTest extends ContextTestSupport {
+
+    @Test
+    public void testExternalResource() throws InterruptedException {
+        final MockEndpoint mock = getMockEndpoint("mock:out");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:start", "<ord:order  xmlns:ord=\"http://example.org/ord\"\n" +
+                                          "   xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                                          "   xsi:schemaLocation=\"http://example.org/ord order.xsd\">\n" +
+                                          "  <customer>\n" +
+                                          "    <name>Priscilla Walmsley</name>\n" +
+                                          "    <number>12345</number>\n" +
+                                          "  </customer>\n" +
+                                          "  <items>\n" +
+                                          "    <product>\n" +
+                                          "      <number>98765</number>\n" +
+                                          "      <name>Short-Sleeved Linen Blouse</name>\n" +
+                                          "      <size system=\"US-DRESS\">10</size>\n" +
+                                          "      <color value=\"blue\"/>\n" +
+                                          "    </product>\n" +
+                                          "  </items>\n" +
+                                          "</ord:order>");
+
+        mock.assertIsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start")
+                        .toD("validator:https://raw.githubusercontent.com/apache/camel/main/core/camel-core/src/test/resources/org/apache/camel/component/validator/xsds/order.xsd")
+                        .to("mock:out");
+            }
+        };
+    }
+}

--- a/core/camel-core/src/test/resources/org/apache/camel/component/validator/xsds/customer.xsd
+++ b/core/camel-core/src/test/resources/org/apache/camel/component/validator/xsds/customer.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:complexType name="CustomerType">
+		<xs:sequence>
+			<xs:element name="name" type="CustNameType"/>
+			<xs:element name="number" type="xs:integer"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="CustNameType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+</xs:schema>

--- a/core/camel-core/src/test/resources/org/apache/camel/component/validator/xsds/order.xsd
+++ b/core/camel-core/src/test/resources/org/apache/camel/component/validator/xsds/order.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		targetNamespace="http://example.org/ord"
+		xmlns="http://example.org/ord"
+		xmlns:prod="http://example.org/prod">
+	<xs:include schemaLocation="https://raw.githubusercontent.com/apache/camel/main/core/camel-core/src/test/resources/org/apache/camel/component/validator/xsds/customer.xsd"/>
+	<xs:import namespace="http://example.org/prod"
+			schemaLocation="https://raw.githubusercontent.com/apache/camel/main/core/camel-core/src/test/resources/org/apache/camel/component/validator/xsds/product.xsd"/>
+	<xs:element name="order" type="OrderType"/>
+	<xs:complexType name="OrderType">
+		<xs:sequence>
+			<xs:element name="customer" type="CustomerType"/>
+			<xs:element name="items" type="prod:ItemsType"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/core/camel-core/src/test/resources/org/apache/camel/component/validator/xsds/product.xsd
+++ b/core/camel-core/src/test/resources/org/apache/camel/component/validator/xsds/product.xsd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		xmlns="http://example.org/prod"
+		targetNamespace="http://example.org/prod">
+	<xs:complexType name="ItemsType">
+		<xs:sequence>
+			<xs:element name="product" type="ProductType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ProductType">
+		<xs:sequence>
+			<xs:element name="number" type="xs:integer"/>
+			<xs:element name="name" type="xs:string"/>
+			<xs:element name="size" type="SizeType"/>
+			<xs:element name="color" type="ColorType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SizeType">
+		<xs:simpleContent>
+			<xs:extension base="xs:integer">
+				<xs:attribute name="system" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="ColorType">
+		<xs:attribute name="value" type="xs:string"/>
+	</xs:complexType>
+</xs:schema>


### PR DESCRIPTION
In order to reproduce this issue I had to expose xsd from my github https://raw.githubusercontent.com/Croway/test-xsd/main/chapter04ord1.xsd I don't know if it is worth to move those xsd's into camel-validator resource folder and reference those, in case I'll update this PR.

@luigidemasi 
