### PR TITLE
CAMEL-17803: Fix/reimplement automatic complete/abandon of messages

### DIFF
--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/client/ServiceBusClientFactory.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/client/ServiceBusClientFactory.java
@@ -42,6 +42,7 @@ public final class ServiceBusClientFactory {
                 .subQueue(configuration.getSubQueue())
                 .maxAutoLockRenewDuration(configuration.getMaxAutoLockRenewDuration())
                 .subscriptionName(configuration.getSubscriptionName())
+                .disableAutoComplete()
                 .buildAsyncClient();
     }
 


### PR DESCRIPTION
updates to manually call complete/abandon on the service bus client for a service bus consumer.

Opening to get some feedback on this, I'm unsure about some implementation details, mainly:
- is there a better way to get the original message than saving it as an exchange property?
- the combination of the `OnConsumerCompletion.onFailure` and the `onErrorListener` subscription on the `receiveMessages.subscribe()` was causing the error handler to be invoked twice, so i wasn't sure the best way to handle that.
- I also wasn't sure how creating a custom exception handler would interact with a user-specified exception handler. would marking an exchange as `handled` within a custom error handler call back to the given `ConsumerOnCompletion.onComplete`?


- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
