### PR TITLE
CAMEL-17896: Extract the description of an header from the Javadoc by default

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojoTest.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojoTest.java
@@ -23,6 +23,7 @@ import org.apache.camel.maven.packaging.endpoint.SomeEndpoint;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointUsingEnumConstants;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithBadHeaders;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithFilter;
+import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithJavadocAsDescription;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithoutHeaders;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.tooling.model.ComponentModel;
@@ -60,7 +61,7 @@ class EndpointSchemaGeneratorMojoTest {
     void testCanRetrieveMetadataOfHeaders(Class<?> clazz) {
         mojo.addEndpointHeaders(model, clazz.getAnnotation(UriEndpoint.class), "some");
         List<EndpointHeaderModel> endpointHeaders = model.getEndpointHeaders();
-        assertEquals(2, endpointHeaders.size());
+        assertEquals(3, endpointHeaders.size());
         // Full
         EndpointHeaderModel headerFull = endpointHeaders.get(0);
         assertEquals("header", headerFull.getKind());
@@ -92,6 +93,22 @@ class EndpointSchemaGeneratorMojoTest {
         assertTrue(headerEmpty.getLabel().isEmpty());
         assertNull(headerEmpty.getEnums());
         assertEquals("common", headerEmpty.getGroup());
+        // Empty with Javadoc as description
+        EndpointHeaderModel headerEmptyWithJavadoc = endpointHeaders.get(2);
+        assertEquals("header", headerEmptyWithJavadoc.getKind());
+        assertEquals("KEY_EMPTY_WITH_JAVA_DOC", headerEmptyWithJavadoc.getName());
+        assertEquals("Some description", headerEmptyWithJavadoc.getDescription());
+        assertTrue(headerEmptyWithJavadoc.getDisplayName().isEmpty());
+        assertTrue(headerEmptyWithJavadoc.getJavaType().isEmpty());
+        assertFalse(headerEmptyWithJavadoc.isRequired());
+        assertInstanceOf(String.class, headerEmptyWithJavadoc.getDefaultValue());
+        assertTrue(((String) headerEmptyWithJavadoc.getDefaultValue()).isEmpty());
+        assertFalse(headerEmptyWithJavadoc.isDeprecated());
+        assertTrue(headerEmptyWithJavadoc.getDeprecationNote().isEmpty());
+        assertFalse(headerEmptyWithJavadoc.isSecret());
+        assertTrue(headerEmptyWithJavadoc.getLabel().isEmpty());
+        assertNull(headerEmptyWithJavadoc.getEnums());
+        assertEquals("common", headerEmptyWithJavadoc.getGroup());
     }
 
     @Test
@@ -116,5 +133,17 @@ class EndpointSchemaGeneratorMojoTest {
             assertEquals("header", headerEmpty.getKind());
             assertEquals(String.format("keep-%d", i + 1), headerEmpty.getName());
         }
+    }
+
+    @Test
+    void testEndpointWithCleanedJavadocAsDescription() {
+        mojo.addEndpointHeaders(model, SomeEndpointWithJavadocAsDescription.class.getAnnotation(UriEndpoint.class), "some");
+        mojo.enhanceComponentModel(model, null, "", "");
+        List<EndpointHeaderModel> endpointHeaders = model.getEndpointHeaders();
+        assertEquals(1, endpointHeaders.size());
+        EndpointHeaderModel headerEmpty = endpointHeaders.get(0);
+        assertEquals("header", headerEmpty.getKind());
+        assertEquals("no-description", headerEmpty.getName());
+        assertEquals("Some description about NO_DESCRIPTION.", headerEmpty.getDescription());
     }
 }

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointWithJavadocAsDescription.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointWithJavadocAsDescription.java
@@ -17,21 +17,18 @@
 package org.apache.camel.maven.packaging.endpoint;
 
 import org.apache.camel.spi.Metadata;
+import org.apache.camel.spi.UriEndpoint;
 
-public final class SomeConstants {
-    @Deprecated
-    @Metadata(description = "key full desc", label = "my label", displayName = "my display name",
-              javaType = "org.apache.camel.maven.packaging.endpoint.SomeEndpoint$MyEnum", required = true,
-              defaultValue = "VAL1", deprecationNote = "my deprecated note", secret = true)
-    public static final String KEY_FULL = "KEY_FULL";
-    @Metadata
-    static final String KEY_EMPTY = "KEY_EMPTY";
+@UriEndpoint(scheme = "some", syntax = "some", title = "some", headersClass = SomeEndpointWithJavadocAsDescription.class)
+public final class SomeEndpointWithJavadocAsDescription {
+
     /**
-     * Some description
+     * Some description about {@link #NO_DESCRIPTION}.
      */
     @Metadata
-    static final String KEY_EMPTY_WITH_JAVA_DOC = "KEY_EMPTY_WITH_JAVA_DOC";
+    static final String NO_DESCRIPTION = "no-description";
 
-    private SomeConstants() {
+    private SomeEndpointWithJavadocAsDescription() {
+
     }
 }

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEnumConstants.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEnumConstants.java
@@ -25,5 +25,10 @@ public enum SomeEnumConstants {
               defaultValue = "VAL1", deprecationNote = "my deprecated note", secret = true)
     KEY_FULL,
     @Metadata
-    KEY_EMPTY;
+    KEY_EMPTY,
+    /**
+     * Some description
+     */
+    @Metadata
+    KEY_EMPTY_WITH_JAVA_DOC;
 }


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17896

## Motivation

There are components that describe already their headers in the Javadoc so it could be interesting to be able to extract the Javadoc of those header and use it as description of the header instead of duplicating the description.

## Modifications

* Adapt the code to be able to parse not only `JavaClassSource` but `JavaSource` to be able to support enumerations too. 
* Add a new method called `getHeaderFieldJavadoc` to extract the Javadoc from a field in case of a class or interface or an Enum constant in case of an enum
