### PR TITLE
CAMEL-17892: perform binding even when declarations were skipped

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
@@ -57,6 +57,11 @@ public class RabbitMQDeclareSupport {
             // declare
             declareAndBindQueue(channel, endpoint.getQueue(), endpoint.getExchangeName(), endpoint.getRoutingKey(),
                     resolvedQueueArguments(), endpoint.getBindingArgs());
+        } else if (shouldBindQueue()) {
+            // we skipped declarations because they should exist, but we still
+            // want to bind both. Forced passive declaration
+            passivelyDeclareExchangeAndQueueAndBindThem(channel, endpoint.getQueue(), endpoint.getExchangeName(),
+                    endpoint.getRoutingKey(), endpoint.getBindingArgs());
         }
     }
 
@@ -148,6 +153,18 @@ public class RabbitMQDeclareSupport {
         if (shouldBindQueue()) {
             channel.queueBind(queue, exchange, emptyIfNull(routingKey), bindingArgs);
         }
+    }
+
+    private void passivelyDeclareExchangeAndQueueAndBindThem(
+            final Channel channel, final String queue, final String exchange, final String routingKey,
+            final Map<String, Object> bindingArgs)
+
+            throws IOException {
+
+        //if (!endpoint.isPassive()) { log.warn("Forcing passive because declaration was skipped"); }
+        channel.exchangeDeclarePassive(exchange);
+        channel.queueDeclarePassive(queue);
+        channel.queueBind(queue, exchange, emptyIfNull(routingKey), bindingArgs);
     }
 
     private String emptyIfNull(final String routingKey) {

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQDeclareSupport.java
@@ -161,7 +161,6 @@ public class RabbitMQDeclareSupport {
 
             throws IOException {
 
-        //if (!endpoint.isPassive()) { log.warn("Forcing passive because declaration was skipped"); }
         channel.exchangeDeclarePassive(exchange);
         channel.queueDeclarePassive(queue);
         channel.queueBind(queue, exchange, emptyIfNull(routingKey), bindingArgs);

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -433,8 +433,8 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     }
 
     /**
-     * If true the producer will not declare and bind a queue. This can be used for directing messages via an existing
-     * routing key.
+     * If true the producer will not declare the queue. This can be used for directing messages via an existing routing
+     * key. If you still want to bind the queue to the exchange, set skipQueueBind to false.
      */
     public void setSkipQueueDeclare(boolean skipQueueDeclare) {
         this.skipQueueDeclare = skipQueueDeclare;

--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQEndpoint.java
@@ -433,8 +433,8 @@ public class RabbitMQEndpoint extends DefaultEndpoint implements AsyncEndpoint {
     }
 
     /**
-     * If true the producer will not declare the queue. This can be used for directing messages via an existing routing
-     * key. If you still want to bind the queue to the exchange, set skipQueueBind to false.
+     * If true the producer will not declare and bind a queue. This can be used for directing messages via an existing
+     * routing key.
      */
     public void setSkipQueueDeclare(boolean skipQueueDeclare) {
         this.skipQueueDeclare = skipQueueDeclare;

--- a/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/integration/RabbitMQProducerIT.java
+++ b/components/camel-rabbitmq/src/test/java/org/apache/camel/component/rabbitmq/integration/RabbitMQProducerIT.java
@@ -89,7 +89,7 @@ public class RabbitMQProducerIT extends AbstractRabbitMQIT {
     private String getBasicURI(String route) {
         ConnectionProperties connectionProperties = service.connectionProperties();
 
-        return String.format("rabbitmq:%s:%d/%s?routingKey=%s&username=%s&password=%s&skipQueueDeclare=true",
+        return String.format("rabbitmq:%s:%d/%s?routingKey=%s&username=%s&password=%s&skipQueueDeclare=true&skipQueueBind=true",
                 connectionProperties.hostname(), connectionProperties.port(),
                 EXCHANGE, route, connectionProperties.username(), connectionProperties.password());
     }


### PR DESCRIPTION
Force passive declaration before binding pre-existing queue and exchange.

Will only be applied when skipQueueBind=false and the other skip declarations are set to true

Issue tracker: https://issues.apache.org/jira/browse/CAMEL-17892
