### PR TITLE
CAMEL-17898: Allow to retrieve header definitions from super classes

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojo.java
@@ -320,21 +320,26 @@ public class EndpointSchemaGeneratorMojo extends AbstractGeneratorMojo {
         // A header class has been defined
         boolean foundHeader = false;
         final boolean isEnum = headersClass.isEnum();
-        for (Field field : headersClass.getDeclaredFields()) {
-            if ((isEnum || isStatic(field.getModifiers()) && field.getType() == String.class)
-                    && field.isAnnotationPresent(Metadata.class)) {
-                getLog().debug(
-                        String.format("Trying to add the constant %s in the class %s as header.", field.getName(),
-                                headersClass.getName()));
-                if (addEndpointHeader(componentModel, field, scheme)) {
-                    foundHeader = true;
-                    continue;
+        Class<?> currentClass = headersClass;
+        do {
+            for (Field field : currentClass.getDeclaredFields()) {
+                if ((isEnum || isStatic(field.getModifiers()) && field.getType() == String.class)
+                        && field.isAnnotationPresent(Metadata.class)) {
+                    getLog().debug(
+                            String.format("Trying to add the constant %s in the class %s as header.", field.getName(),
+                                    currentClass.getName()));
+                    if (addEndpointHeader(componentModel, field, scheme)) {
+                        foundHeader = true;
+                        continue;
+                    }
                 }
+                getLog().debug(
+                        String.format(
+                                "The field %s of the class %s is not considered as a name of a header, thus it is skipped",
+                                field.getName(), currentClass.getName()));
             }
-            getLog().debug(
-                    String.format("The field %s of the class %s is not considered as a name of a header, thus it is skipped",
-                            field.getName(), headersClass.getName()));
-        }
+            currentClass = currentClass.getSuperclass();
+        } while (!currentClass.equals(Object.class));
         if (!foundHeader) {
             getLog().debug(String.format("No headers have been detected in the headers class %s", headersClass.getName()));
         }

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojo.java
@@ -32,11 +32,13 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -300,10 +302,10 @@ public class EndpointSchemaGeneratorMojo extends AbstractGeneratorMojo {
     }
 
     /**
-     * Retrieve the metadata added to all the {@code String} constants defined in class corresponding to the element
-     * {@code headersClass} of the annotation {@code UriEndpoint}, convert the metadata found into instances of
-     * {@link EndpointHeaderModel} and finally add the instances of {@link EndpointHeaderModel} to the given component
-     * model.
+     * Retrieve the metadata added to all the {@code String} constants defined in the class corresponding to the element
+     * {@code headersClass} of the annotation {@code UriEndpoint} along with all its super classes and implemented
+     * interfaces, convert the metadata found into instances of {@link EndpointHeaderModel} and finally add the
+     * instances of {@link EndpointHeaderModel} to the given component model.
      * <p/>
      * Only headers applicable for the given scheme are added.
      *
@@ -319,30 +321,54 @@ public class EndpointSchemaGeneratorMojo extends AbstractGeneratorMojo {
         }
         // A header class has been defined
         boolean foundHeader = false;
-        final boolean isEnum = headersClass.isEnum();
-        Class<?> currentClass = headersClass;
-        do {
-            for (Field field : currentClass.getDeclaredFields()) {
-                if ((isEnum || isStatic(field.getModifiers()) && field.getType() == String.class)
-                        && field.isAnnotationPresent(Metadata.class)) {
-                    getLog().debug(
-                            String.format("Trying to add the constant %s in the class %s as header.", field.getName(),
-                                    currentClass.getName()));
-                    if (addEndpointHeader(componentModel, field, scheme)) {
-                        foundHeader = true;
-                        continue;
-                    }
-                }
-                getLog().debug(
-                        String.format(
-                                "The field %s of the class %s is not considered as a name of a header, thus it is skipped",
-                                field.getName(), currentClass.getName()));
+        final Deque<Class<?>> classes = new ArrayDeque<>();
+        classes.add(headersClass);
+        Class<?> currentHeadersClass;
+        while ((currentHeadersClass = classes.poll()) != null) {
+            foundHeader |= addEndpointHeaders(componentModel, scheme, currentHeadersClass);
+            final Class<?> superclass = currentHeadersClass.getSuperclass();
+            if (superclass != null && !superclass.equals(Object.class)) {
+                classes.add(superclass);
             }
-            currentClass = currentClass.getSuperclass();
-        } while (!currentClass.equals(Object.class));
+            classes.addAll(Arrays.asList(currentHeadersClass.getInterfaces()));
+        }
         if (!foundHeader) {
             getLog().debug(String.format("No headers have been detected in the headers class %s", headersClass.getName()));
         }
+    }
+
+    /**
+     * Retrieve the metadata added to all the {@code String} constants defined in the given headers class, convert the
+     * metadata found into instances of {@link EndpointHeaderModel} and finally add the instances of
+     * {@link EndpointHeaderModel} to the given component model.
+     * <p/>
+     * Only headers applicable for the given scheme are added.
+     *
+     * @param  componentModel the component model to which the headers should be added.
+     * @param  scheme         the scheme for which we want to add the headers.
+     * @param  headersClass   the class from which we extract the headers.
+     * @return                {@code true} if at least one header has been added, {@code false} otherwise.
+     */
+    private boolean addEndpointHeaders(ComponentModel componentModel, String scheme, Class<?> headersClass) {
+        final boolean isEnum = headersClass.isEnum();
+        boolean foundHeader = false;
+        for (Field field : headersClass.getDeclaredFields()) {
+            if ((isEnum || isStatic(field.getModifiers()) && field.getType() == String.class)
+                    && field.isAnnotationPresent(Metadata.class)) {
+                getLog().debug(
+                        String.format("Trying to add the constant %s in the class %s as header.", field.getName(),
+                                headersClass.getName()));
+                if (addEndpointHeader(componentModel, field, scheme)) {
+                    foundHeader = true;
+                    continue;
+                }
+            }
+            getLog().debug(
+                    String.format(
+                            "The field %s of the class %s is not considered as a name of a header, thus it is skipped",
+                            field.getName(), headersClass.getName()));
+        }
+        return foundHeader;
     }
 
     /**

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojoTest.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojoTest.java
@@ -21,9 +21,11 @@ import java.util.List;
 
 import org.apache.camel.maven.packaging.endpoint.SomeEndpoint;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointUsingEnumConstants;
+import org.apache.camel.maven.packaging.endpoint.SomeEndpointUsingInterfaceConstants;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithBadHeaders;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithFilter;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithHeaderClassHierarchy;
+import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithHeaderInterfaceHierarchy;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithJavadocAsDescription;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithoutHeaders;
 import org.apache.camel.spi.UriEndpoint;
@@ -58,7 +60,8 @@ class EndpointSchemaGeneratorMojoTest {
     }
 
     @ParameterizedTest
-    @ValueSource(classes = { SomeEndpoint.class, SomeEndpointUsingEnumConstants.class })
+    @ValueSource(classes = {
+            SomeEndpoint.class, SomeEndpointUsingEnumConstants.class, SomeEndpointUsingInterfaceConstants.class })
     void testCanRetrieveMetadataOfHeaders(Class<?> clazz) {
         mojo.addEndpointHeaders(model, clazz.getAnnotation(UriEndpoint.class), "some");
         List<EndpointHeaderModel> endpointHeaders = model.getEndpointHeaders();
@@ -148,9 +151,11 @@ class EndpointSchemaGeneratorMojoTest {
         assertEquals("Some description about NO_DESCRIPTION.", headerEmpty.getDescription());
     }
 
-    @Test
-    void testEndpointWithHeaderClassHierarchy() {
-        mojo.addEndpointHeaders(model, SomeEndpointWithHeaderClassHierarchy.class.getAnnotation(UriEndpoint.class), "some");
+    @ParameterizedTest
+    @ValueSource(classes = {
+            SomeEndpointWithHeaderClassHierarchy.class, SomeEndpointWithHeaderInterfaceHierarchy.class })
+    void testEndpointWithHeadersInHierarchy(Class<?> clazz) {
+        mojo.addEndpointHeaders(model, clazz.getAnnotation(UriEndpoint.class), "some");
         List<EndpointHeaderModel> endpointHeaders = model.getEndpointHeaders();
         assertEquals(2, endpointHeaders.size());
         EndpointHeaderModel header = endpointHeaders.get(0);

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojoTest.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojoTest.java
@@ -23,6 +23,7 @@ import org.apache.camel.maven.packaging.endpoint.SomeEndpoint;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointUsingEnumConstants;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithBadHeaders;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithFilter;
+import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithHeaderClassHierarchy;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithJavadocAsDescription;
 import org.apache.camel.maven.packaging.endpoint.SomeEndpointWithoutHeaders;
 import org.apache.camel.spi.UriEndpoint;
@@ -145,5 +146,18 @@ class EndpointSchemaGeneratorMojoTest {
         assertEquals("header", headerEmpty.getKind());
         assertEquals("no-description", headerEmpty.getName());
         assertEquals("Some description about NO_DESCRIPTION.", headerEmpty.getDescription());
+    }
+
+    @Test
+    void testEndpointWithHeaderClassHierarchy() {
+        mojo.addEndpointHeaders(model, SomeEndpointWithHeaderClassHierarchy.class.getAnnotation(UriEndpoint.class), "some");
+        List<EndpointHeaderModel> endpointHeaders = model.getEndpointHeaders();
+        assertEquals(2, endpointHeaders.size());
+        EndpointHeaderModel header = endpointHeaders.get(0);
+        assertEquals("header", header.getKind());
+        assertEquals("KEY_FROM_SPECIFIC", header.getName());
+        header = endpointHeaders.get(1);
+        assertEquals("header", header.getKind());
+        assertEquals("KEY_FROM_COMMON", header.getName());
     }
 }

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeCommonConstants.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeCommonConstants.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven.packaging.endpoint;
+
+import org.apache.camel.spi.Metadata;
+
+public class SomeCommonConstants {
+
+    @Metadata
+    static final String KEY_FROM_COMMON = "KEY_FROM_COMMON";
+
+    protected SomeCommonConstants() {
+    }
+}

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointUsingInterfaceConstants.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointUsingInterfaceConstants.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven.packaging.endpoint;
+
+import org.apache.camel.spi.UriEndpoint;
+
+@UriEndpoint(scheme = "some", syntax = "some", title = "some", headersClass = SomeInterfaceConstants.class)
+public class SomeEndpointUsingInterfaceConstants {
+}

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointWithHeaderClassHierarchy.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointWithHeaderClassHierarchy.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven.packaging.endpoint;
+
+import org.apache.camel.spi.UriEndpoint;
+
+@UriEndpoint(scheme = "some", syntax = "some", title = "some", headersClass = SomeSpecificConstants.class)
+public class SomeEndpointWithHeaderClassHierarchy {
+}

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointWithHeaderInterfaceHierarchy.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointWithHeaderInterfaceHierarchy.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven.packaging.endpoint;
+
+import org.apache.camel.spi.UriEndpoint;
+
+@UriEndpoint(scheme = "some", syntax = "some", title = "some", headersClass = SomeInterfaceWithSpecificConstants.class)
+public class SomeEndpointWithHeaderInterfaceHierarchy {
+}

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeInterfaceConstants.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeInterfaceConstants.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven.packaging.endpoint;
+
+import org.apache.camel.spi.Metadata;
+
+public interface SomeInterfaceConstants {
+    @Deprecated
+    @Metadata(description = "key full desc", label = "my label", displayName = "my display name",
+              javaType = "org.apache.camel.maven.packaging.endpoint.SomeEndpoint$MyEnum", required = true,
+              defaultValue = "VAL1", deprecationNote = "my deprecated note", secret = true)
+    String KEY_FULL = "KEY_FULL";
+    @Metadata
+    String KEY_EMPTY = "KEY_EMPTY";
+    /**
+     * Some description
+     */
+    @Metadata
+    String KEY_EMPTY_WITH_JAVA_DOC = "KEY_EMPTY_WITH_JAVA_DOC";
+}

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeInterfaceWithCommonConstants.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeInterfaceWithCommonConstants.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven.packaging.endpoint;
+
+import org.apache.camel.spi.Metadata;
+
+public interface SomeInterfaceWithCommonConstants {
+
+    @Metadata
+    String KEY_FROM_COMMON = "KEY_FROM_COMMON";
+}

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeInterfaceWithSpecificConstants.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeInterfaceWithSpecificConstants.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven.packaging.endpoint;
+
+import org.apache.camel.spi.Metadata;
+
+public interface SomeInterfaceWithSpecificConstants extends SomeInterfaceWithCommonConstants {
+
+    @Metadata
+    String KEY_FROM_SPECIFIC = "KEY_FROM_SPECIFIC";
+
+}

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeSpecificConstants.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeSpecificConstants.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven.packaging.endpoint;
+
+import org.apache.camel.spi.Metadata;
+
+public final class SomeSpecificConstants extends SomeCommonConstants {
+
+    @Metadata
+    static final String KEY_FROM_SPECIFIC = "KEY_FROM_SPECIFIC";
+
+    private SomeSpecificConstants() {
+    }
+}


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17898

## Motivation

Some components define their common headers in base class and the specific headers in specific classes that extend the base class. So we need to make evolve the code extracting the metadata of the headers in order to retrieve header definitions from the super classes and implemented interfaces too.

## Modifications

* Retrieve the header definitions in a loop that iterates over all the super classes until `Object.class` and all the implemented interfaces