### PR TITLE
CAMEL-17922: Fix default value supplier for header MIX_DIGEST

### DIFF
--- a/components/camel-web3j/src/main/java/org/apache/camel/component/web3j/Web3jProducer.java
+++ b/components/camel-web3j/src/main/java/org/apache/camel/component/web3j/Web3jProducer.java
@@ -730,7 +730,7 @@ public class Web3jProducer extends HeaderSelectorProducer {
     void ethSubmitWork(Message message) throws IOException {
         String nonce = message.getHeader(Web3jConstants.NONCE, configuration::getNonce, String.class);
         String headerPowHash = message.getHeader(Web3jConstants.HEADER_POW_HASH, configuration::getHeaderPowHash, String.class);
-        String mixDigest = message.getHeader(Web3jConstants.MIX_DIGEST, configuration::getHeaderPowHash, String.class);
+        String mixDigest = message.getHeader(Web3jConstants.MIX_DIGEST, configuration::getMixDigest, String.class);
         Request<?, EthSubmitWork> request = web3j.ethSubmitWork(nonce, headerPowHash, mixDigest);
         setRequestId(message, request);
         EthSubmitWork response = request.send();


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17922

## Motivation

The default value supplier of the header MIX_DIGEST is the value of the option headerPowHash while we would rather expect mixDigest.

## Modifications

* Set the proper method name as default value supplier