### PR TITLE
CAMEL-17924: Only expose public headers in the documentation

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojo.java
@@ -32,13 +32,11 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -319,20 +317,7 @@ public class EndpointSchemaGeneratorMojo extends AbstractGeneratorMojo {
             getLog().debug(String.format("The endpoint %s has not defined any headers class", uriEndpoint.scheme()));
             return;
         }
-        // A header class has been defined
-        boolean foundHeader = false;
-        final Deque<Class<?>> classes = new ArrayDeque<>();
-        classes.add(headersClass);
-        Class<?> currentHeadersClass;
-        while ((currentHeadersClass = classes.poll()) != null) {
-            foundHeader |= addEndpointHeaders(componentModel, scheme, currentHeadersClass, uriEndpoint.headersNameProvider());
-            final Class<?> superclass = currentHeadersClass.getSuperclass();
-            if (superclass != null && !superclass.equals(Object.class)) {
-                classes.add(superclass);
-            }
-            classes.addAll(Arrays.asList(currentHeadersClass.getInterfaces()));
-        }
-        if (!foundHeader) {
+        if (!addEndpointHeaders(componentModel, scheme, headersClass, uriEndpoint.headersNameProvider())) {
             getLog().debug(String.format("No headers have been detected in the headers class %s", headersClass.getName()));
         }
     }
@@ -355,7 +340,7 @@ public class EndpointSchemaGeneratorMojo extends AbstractGeneratorMojo {
             ComponentModel componentModel, String scheme, Class<?> headersClass, String headersNameProvider) {
         final boolean isEnum = headersClass.isEnum();
         boolean foundHeader = false;
-        for (Field field : headersClass.getDeclaredFields()) {
+        for (Field field : headersClass.getFields()) {
             if ((isEnum || isStatic(field.getModifiers()) && field.getType() == String.class)
                     && field.isAnnotationPresent(Metadata.class)) {
                 getLog().debug(
@@ -487,7 +472,6 @@ public class EndpointSchemaGeneratorMojo extends AbstractGeneratorMojo {
             }
             return field.getName();
         }
-        field.trySetAccessible();
         return (String) field.get(null);
     }
 

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeCommonConstants.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeCommonConstants.java
@@ -21,7 +21,7 @@ import org.apache.camel.spi.Metadata;
 public class SomeCommonConstants {
 
     @Metadata
-    static final String KEY_FROM_COMMON = "KEY_FROM_COMMON";
+    public static final String KEY_FROM_COMMON = "KEY_FROM_COMMON";
 
     protected SomeCommonConstants() {
     }

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeConstants.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeConstants.java
@@ -25,12 +25,12 @@ public final class SomeConstants {
               defaultValue = "VAL1", deprecationNote = "my deprecated note", secret = true)
     public static final String KEY_FULL = "KEY_FULL";
     @Metadata
-    static final String KEY_EMPTY = "KEY_EMPTY";
+    public static final String KEY_EMPTY = "KEY_EMPTY";
     /**
      * Some description
      */
     @Metadata
-    static final String KEY_EMPTY_WITH_JAVA_DOC = "KEY_EMPTY_WITH_JAVA_DOC";
+    public static final String KEY_EMPTY_WITH_JAVA_DOC = "KEY_EMPTY_WITH_JAVA_DOC";
 
     private SomeConstants() {
     }

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointWithFilter.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointWithFilter.java
@@ -23,11 +23,11 @@ import org.apache.camel.spi.UriEndpoint;
 public final class SomeEndpointWithFilter {
 
     @Metadata(description = "some description")
-    static final String KEEP_1 = "keep-1";
+    public static final String KEEP_1 = "keep-1";
     @Metadata(description = "some description", applicableFor = "some")
-    static final String KEEP_2 = "keep-2";
+    public static final String KEEP_2 = "keep-2";
     @Metadata(description = "some description", applicableFor = "other")
-    static final String IGNORE = "ignore";
+    public static final String IGNORE = "ignore";
 
     private SomeEndpointWithFilter() {
     }

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointWithJavadocAsDescription.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeEndpointWithJavadocAsDescription.java
@@ -26,7 +26,7 @@ public final class SomeEndpointWithJavadocAsDescription {
      * Some description about {@link #NO_DESCRIPTION}.
      */
     @Metadata
-    static final String NO_DESCRIPTION = "no-description";
+    public static final String NO_DESCRIPTION = "no-description";
 
     private SomeEndpointWithJavadocAsDescription() {
 

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeSpecificConstants.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/endpoint/SomeSpecificConstants.java
@@ -21,7 +21,10 @@ import org.apache.camel.spi.Metadata;
 public final class SomeSpecificConstants extends SomeCommonConstants {
 
     @Metadata
-    static final String KEY_FROM_SPECIFIC = "KEY_FROM_SPECIFIC";
+    public static final String KEY_FROM_SPECIFIC = "KEY_FROM_SPECIFIC";
+
+    @Metadata
+    static final String INTERNAL_KEY_FROM_SPECIFIC = "INTERNAL_KEY_FROM_SPECIFIC";
 
     private SomeSpecificConstants() {
     }


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17924

## Motivation

Some static fields holding the name of an header that are not public are still exposed in the documentation of the component which is not expected as they should rather be seen as internal headers.

## Modifications

* Only check public fields if they are declared as headers