### PR TITLE
CAMEL-17961: Re-add the JS file for the documentation

### DIFF
--- a/docs/components/modules/ROOT/examples/js/camel.js
+++ b/docs/components/modules/ROOT/examples/js/camel.js
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  extractConstantDisplayName: (name) => {
+    return name.split('#').pop().split('@').join('.')
+  },
+
+  extractConstantName: (name) => {
+    return name.split('#').pop().split('@').shift()
+  },
+
+  extractHeadersClass: (name) => {
+    return name.split('#').shift()
+  },
+
+  constantLink: (artifactId, name) => {
+      try {
+        return `https://javadoc.io/doc/org.apache.camel/${artifactId}/latest/`
+          + module.exports.extractHeadersClass(name).split('.').join('/') + '.html#'
+          + module.exports.extractConstantName(name)
+          + '[`' + module.exports.extractConstantDisplayName(name) + '`]'
+      } catch (e) {
+        console.log('error', e)
+        return e.msg()
+      }
+  },
+}

--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -423,7 +423,7 @@ const tasks = Array.from(sourcesMap).flatMap(([type, definition]) => {
   if (example) {
     allTasks.push(
       series(
-        named(`clean:example:${type}`, clean, example.destination, ['json']),
+        named(`clean:example:${type}`, clean, example.destination, ['json', 'js']),
         named(`symlink:example:${type}`, createExampleSymlinks, example.source, example.destination)
       )
     )


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17961

## Motivation

The build of the website fails due to a missing JS file that has actually been removed by the Regen for commit https://github.com/apache/camel/commit/23c90548a3d1386176c59d7489c94c4b1506e291 when executing the gulpfile script.

## Modifications:

* Re-add the JS file
* Add `js` as type of file to keep by the gulpfile script