### PR TITLE
CAMEL-17948: Fix regression in WsProducerConsumerTest

### DIFF
--- a/components/camel-ahc-ws/src/test/java/org/apache/camel/component/ahc/ws/WsProducerConsumerTest.java
+++ b/components/camel-ahc-ws/src/test/java/org/apache/camel/component/ahc/ws/WsProducerConsumerTest.java
@@ -150,12 +150,11 @@ public class WsProducerConsumerTest extends CamelTestSupport {
         mock.expectedBodiesReceived(TEST_CONNECTED_MESSAGE);
 
         mock.assertIsSatisfied();
+        resetMocks();
 
         LOG.info("Restarting Test Server");
         stopTestServer();
         startTestServer();
-
-        resetMocks();
 
         mock.expectedBodiesReceived(TEST_CONNECTED_MESSAGE);
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-17948 (regression in test)

## Motivation

The changes made in https://github.com/apache/camel/pull/7430 caused a regression in `WsProducerConsumerTest` that needs to be fixed

## Modifications:

* Reset the mocks directly after the assertion checks to avoid race conditions issues in the rest of the test