### PR TITLE
[CAMEL-17990] missing InputStream delegates for 3.14.x

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/converter/stream/FileInputStreamCache.java
+++ b/core/camel-support/src/main/java/org/apache/camel/converter/stream/FileInputStreamCache.java
@@ -127,6 +127,21 @@ public final class FileInputStreamCache extends InputStream implements StreamCac
         return getInputStream().read();
     }
 
+    @Override
+    public int read(byte[] b) throws IOException {
+        return getInputStream().read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return getInputStream().read(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        return getInputStream().skip(n);
+    }
+
     protected InputStream getInputStream() throws IOException {
         if (stream == null) {
             stream = createInputStream(file);


### PR DESCRIPTION
[CAMEL-17990] added missing java 8 InputStream delegates for readxxx  methods, mark and reset logic left out on purpose because of the existing StreamCache behaviour

