### PR TITLE
CAMEL-17894: stop running impsort and checkstyle by default

### DIFF
--- a/.github/workflows/master-pr-build.yml
+++ b/.github/workflows/master-pr-build.yml
@@ -72,7 +72,7 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: maven build
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -l build.log -Dmvnd.threads=2 -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 --no-transfer-progress -Pfastinstall -Dcheckstyle.skip=true -DskipTests install
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -l build.log -Dmvnd.threads=2 -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 --no-transfer-progress -Pfastinstall -DskipTests install
       - name: archive logs
         uses: actions/upload-artifact@v3
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,9 @@ Then follow these simple guidelines for working on the code and committing your 
 
 - Build the project using Maven:
 
-    mvn clean install -Pfastinstall
+    mvn clean install -Pfastinstall,format
+
+Note: the `format` profile will ensure that the code is properly formatted according to the project standards:
 
 - Add a unit test with assertions for your changes.
 

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -503,10 +503,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -189,10 +189,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/docs/user-manual/modules/ROOT/pages/building.adoc
+++ b/docs/user-manual/modules/ROOT/pages/building.adoc
@@ -55,11 +55,11 @@ the unit tests, which can complete in less than 10 minutes.
 mvn clean install -Pfastinstall
 -------------------------------
 
-== A normal build without running tests but checkstyle verification enabled
+== A normal build without running tests but auto formatting and checkstyle verification enabled
 
 [source,bash]
 -------------------------------------------
-mvn clean install -Pfastinstall,sourcecheck
+mvn clean install -Pfastinstall,format,sourcecheck
 -------------------------------------------
 
 == Building with checkstyle

--- a/dsl/camel-componentdsl/pom.xml
+++ b/dsl/camel-componentdsl/pom.xml
@@ -160,6 +160,10 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/dsl/camel-endpointdsl/pom.xml
+++ b/dsl/camel-endpointdsl/pom.xml
@@ -167,6 +167,10 @@
                     <maxmem>1024M</maxmem>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/dsl/pom.xml
+++ b/dsl/pom.xml
@@ -178,10 +178,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4695,6 +4695,25 @@
         </profile>
 
         <profile>
+            <id>format</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.revelc.code</groupId>
+                        <artifactId>impsort-maven-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>sourcecheck</id>
             <build>
                 <plugins>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4571,14 +4571,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>net.revelc.code</groupId>
-                <artifactId>impsort-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -4684,7 +4677,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
         </profile>
-
+        
         <profile>
             <id>fastinstall</id>
             <activation>

--- a/test-infra/pom.xml
+++ b/test-infra/pom.xml
@@ -74,13 +74,4 @@
         <module>camel-test-infra-openldap</module>
         <module>camel-test-infra-ignite</module>
     </modules>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -65,10 +65,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -47,13 +47,4 @@
     <properties>
         <camel.osgi.export.pkg />
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
Folks, I'd like to hear your opinions about this rather disruptive
change. 

The motivation for removing those 2 plugins from the default build
execution is because they are very slow. On my test machine, this
reduces the build time by between 3 to 4 minutes with "normal Maven"
(roughly 7.6% improvement). The numbers with Maven Daemon are not so 
dramatic, but still reduces a bit (varying a lot here, but roughly
between 20 to 60 seconds). 

The (possible) downside is that this stops the code from automatically
reformatting the code and sorting the imports by default (ie.: when
running `mvn -Pfastinstall install`). 

Instead, this introduces a new profile `format` that can be run
along side the `fastinstall` to do the same. 

Because this can be disruptive to the workflow of others, I'd like to
hear some thoughts about this.


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->