### PR TITLE
CAMEL-17861

### DIFF
--- a/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/BlobUtils.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/BlobUtils.java
@@ -16,13 +16,13 @@
  */
 package org.apache.camel.component.azure.storage.blob;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.util.ObjectHelper;
-import org.apache.commons.io.IOUtils;
 
 public final class BlobUtils {
 
@@ -33,11 +33,26 @@ public final class BlobUtils {
         return ObjectHelper.isEmpty(exchange) ? null : exchange.getIn();
     }
 
-    public static Long getInputStreamLength(final InputStream inputStream) throws IOException {
-        final long length = IOUtils.toByteArray(inputStream).length;
-        inputStream.reset();
-
-        return length;
+    public static long getInputStreamLength(InputStream is) throws IOException {
+        if (!is.markSupported()) {
+            return -1;
+        }
+        if (is instanceof ByteArrayInputStream) {
+            return is.available();
+        }
+        long size = 0;
+        try {
+            is.mark(1024);
+            int i = is.available();
+            while (i > 0) {
+                long skip = is.skip(i);
+                size += skip;
+                i = is.available();
+            }
+        } finally {
+            is.reset();
+        }
+        return size;
     }
 
     public static String getContainerName(final BlobConfiguration configuration, final Exchange exchange) {


### PR DESCRIPTION
CAMEL-17861: adapt method to determine size of stream
the old version loaded the entire bytestream into memory to determine its length
new implementation is copied from: 
https://github.com/apache/camel/blob/abb1ad84fac520b00339533a2eafdeb901e22d87/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/utils/AWS2S3Utils.java#L83
