### PR TITLE
CAMEL-17864: Fix the scope of the deps of the camel-bundle-plugin

### DIFF
--- a/init/camel-bundle-plugin/pom.xml
+++ b/init/camel-bundle-plugin/pom.xml
@@ -38,6 +38,7 @@
         <sourcecheckExcludesComma>
             **/*.java,
         </sourcecheckExcludesComma>
+        <maven-version>3.3.9</maven-version>
     </properties>
 
     <dependencies>
@@ -46,7 +47,30 @@
             <artifactId>maven-bundle-plugin</artifactId>
             <version>${maven-bundle-plugin-version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven-version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${maven-version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${maven-version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${maven-version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17864

## Motivation

The scope of some dependencies of the plugin camel-bundle-plugin should be `provided` instead of `compile` which causes an error message in the build log that should be fixed.

## Modifications

* Forces the scope of the problematic dependencies by adding them explicitly as dependencies of the plugin

## Result

The error message is absent from the build log