### PR TITLE
Doc fix: Update code examples to correctly use advice argument 

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/advice-with.adoc
+++ b/docs/user-manual/modules/ROOT/pages/advice-with.adoc
@@ -128,7 +128,7 @@ Then you advise the routes followed by starting Camel:
 @Test
 public void testMockEndpoints() throws Exception {
     AdviceWith.adviceWith(context, "myRoute", a ->
-         mockEndpoints();
+         a.mockEndpoints();
     );
 
     context.start();
@@ -179,7 +179,7 @@ The following illustrates how to do this:
 @Test
 public void testReplaceFrom() throws Exception {
     AdviceWith.adviceWith(context, "myRoute", a ->
-        replaceFromWith("direct:start");
+        a.replaceFromWith("direct:start");
     );
 
     context.start();


### PR DESCRIPTION
Fixes errors as seen [here](https://camel.apache.org/manual/advice-with.html#_replacing_route_endpoints)