### PR TITLE
CAMEL-17832: camel-grpc - Upgrade to Netty 4.1.76

### DIFF
--- a/components/camel-grpc/pom.xml
+++ b/components/camel-grpc/pom.xml
@@ -35,8 +35,6 @@
     <properties>
         <!-- gRPC requires strong own of the Google Guava version -->
         <google-guava-version>${grpc-guava-version}</google-guava-version>
-        <!-- https://issues.apache.org/jira/browse/CAMEL-17832 -->
-        <netty-version>4.1.72.Final</netty-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17832

## Motivation

The Grpc component doesn't work with Netty 4.1.75.

## Modifications

* Don't force anymore the version of Netty to `4.1.72.Final` in order to use `4.1.76.Final` instead as it works properly with it