### PR TITLE
CAMEL-17537: camel-djl - Upgrade to 0.16.0

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -176,7 +176,7 @@
     <djl-mxnet-native-version>1.8.0</djl-mxnet-native-version>
     <djl-pytorch-native-version>1.8.1</djl-pytorch-native-version>
     <djl-tensorflow-native-version>2.4.1</djl-tensorflow-native-version>
-    <djl-version>0.11.0</djl-version>
+    <djl-version>0.16.0</djl-version>
     <dnsjava-version>3.5.0</dnsjava-version>
     <docker-java-version>3.2.13</docker-java-version>
     <dozer-version>6.5.2</dozer-version>

--- a/components/camel-djl/src/test/java/org/apache/camel/component/djl/training/MnistTraining.java
+++ b/components/camel-djl/src/test/java/org/apache/camel/component/djl/training/MnistTraining.java
@@ -20,10 +20,10 @@ package org.apache.camel.component.djl.training;
 import java.io.IOException;
 import java.nio.file.Paths;
 
-import ai.djl.Device;
 import ai.djl.Model;
 import ai.djl.basicdataset.cv.classification.Mnist;
 import ai.djl.basicmodelzoo.basic.Mlp;
+import ai.djl.engine.Engine;
 import ai.djl.metric.Metrics;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Block;
@@ -37,13 +37,9 @@ import ai.djl.training.listener.TrainingListener;
 import ai.djl.training.loss.Loss;
 import ai.djl.training.util.ProgressBar;
 import ai.djl.translate.TranslateException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 // Helper to train mnist model for tests
 public final class MnistTraining {
-    private static final Logger LOG = LoggerFactory.getLogger(MnistTraining.class);
-
     private static final String MODEL_DIR = "src/test/resources/models/mnist";
     private static final String MODEL_NAME = "mlp";
 
@@ -62,9 +58,10 @@ public final class MnistTraining {
             RandomAccessDataset trainingSet = prepareDataset(Dataset.Usage.TRAIN, 64, Long.MAX_VALUE);
             RandomAccessDataset validateSet = prepareDataset(Dataset.Usage.TEST, 64, Long.MAX_VALUE);
 
+            final Engine engine = Engine.getInstance();
             // setup training configuration
             DefaultTrainingConfig config = new DefaultTrainingConfig(Loss.softmaxCrossEntropyLoss())
-                    .addEvaluator(new Accuracy()).optDevices(Device.getDevices(Device.getGpuCount()))
+                    .addEvaluator(new Accuracy()).optDevices(engine.getDevices(engine.getGpuCount()))
                     .addTrainingListeners(TrainingListener.Defaults.logging());
 
             try (Trainer trainer = model.newTrainer(config)) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -154,7 +154,7 @@
         <directory-watcher-version>0.15.1</directory-watcher-version>
         <disruptor-version>3.4.4</disruptor-version>
         <dnsjava-version>3.5.0</dnsjava-version>
-        <djl-version>0.11.0</djl-version>
+        <djl-version>0.16.0</djl-version>
         <djl-mxnet-native-version>1.8.0</djl-mxnet-native-version>
         <djl-pytorch-native-version>1.8.1</djl-pytorch-native-version>
         <djl-tensorflow-native-version>2.4.1</djl-tensorflow-native-version>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-17537

## Motivation

There is newer version of deep learning, we should upgrade

## Modifications:

* Upgrade the version of djl in all the related pom files
* Call `Engine` instead of `Device` as stated in [the release note of the 0.13.0](https://github.com/deepjavalibrary/djl/releases/tag/v0.13.0)
* Remove the unused logger (not related to the current issue)