### PR TITLE
CAMEL-18000: camel-johnzon - Upgrade to 1.2.17

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -331,7 +331,7 @@
     <jira-rest-client-api-version>5.2.2</jira-rest-client-api-version>
     <jnats-version>2.14.0</jnats-version>
     <jodatime2-version>2.10.11</jodatime2-version>
-    <johnzon-version>1.2.16</johnzon-version>
+    <johnzon-version>1.2.17</johnzon-version>
     <jolt-version>0.1.6</jolt-version>
     <jool-version>0.9.14</jool-version>
     <jooq-version>3.16.4</jooq-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -321,7 +321,7 @@
         <jool-version>0.9.14</jool-version>
         <jooq-version>3.16.4</jooq-version>
         <joor-version>0.9.14</joor-version>
-        <johnzon-version>1.2.16</johnzon-version>
+        <johnzon-version>1.2.17</johnzon-version>
         <jose4j-version>0.6.4</jose4j-version>
         <jslt-version>0.1.11</jslt-version>
         <jsmpp-version>2.3.11</jsmpp-version>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18000

## Motivation

osgi should work again with this release

## Modifications:

* Upgrade the version of johnzon in all the related pom files