### PR TITLE
CAMEL-18040 Added support for oneOf, anyOf and allOf OpenAPI annotations for Rest OpenApi spec generation

### DIFF
--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiV3XOfTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiV3XOfTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.openapi;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.openapi.models.OasDocument;
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.engine.DefaultClassResolver;
+import org.apache.camel.model.rest.RestBindingMode;
+import org.apache.camel.openapi.model.AllOfFormWrapper;
+import org.apache.camel.openapi.model.AnyOfFormWrapper;
+import org.apache.camel.openapi.model.OneOfFormWrapper;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RestOpenApiV3XOfTest extends CamelTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RestOpenApiV3XOfTest.class);
+
+    @BindToRegistry("dummy-rest")
+    private DummyRestConsumerFactory factory = new DummyRestConsumerFactory();
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                rest("/form")
+                        .post("/oneOf")
+                        .tag("OneOf")
+                        .bindingMode(RestBindingMode.json)
+                        .description("OneOf rest service")
+
+                        .consumes("application/json")
+                        .produces("application/json")
+                        .type(OneOfFormWrapper.class)
+                        .responseMessage()
+                        .code(200).message("Ok")
+                        .endResponseMessage()
+
+                        .to("direct:res");
+
+                rest("/form")
+                        .post("/allOf")
+                        .tag("AllOf")
+                        .bindingMode(RestBindingMode.json)
+                        .description("AllOf rest service")
+
+                        .consumes("application/json")
+                        .produces("application/json")
+                        .type(AllOfFormWrapper.class)
+                        .responseMessage()
+                        .code(200).message("Ok")
+                        .endResponseMessage()
+
+                        .to("direct:res");
+
+                rest("/form")
+                        .post("/anyOf")
+                        .tag("AnyOf")
+                        .bindingMode(RestBindingMode.json)
+                        .description("AnyOf rest service")
+
+                        .consumes("application/json")
+                        .produces("application/json")
+                        .type(AnyOfFormWrapper.class)
+                        .responseMessage()
+                        .code(200).message("Ok")
+                        .endResponseMessage()
+
+                        .to("direct:res");
+
+                from("direct:res")
+                        .setBody(constant("{\"result\": \"Ok\"}"));
+            }
+        };
+    }
+
+    @Test
+    public void testReaderReadOneOf() throws Exception {
+        BeanConfig config = new BeanConfig();
+        config.setHost("localhost:8080");
+        config.setSchemes(new String[] { "http" });
+        config.setBasePath("/api");
+        config.setTitle("Camel User store");
+        config.setLicense("Apache 2.0");
+        config.setLicenseUrl("https://www.apache.org/licenses/LICENSE-2.0.html");
+
+        RestOpenApiReader reader = new RestOpenApiReader();
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
+                new DefaultClassResolver());
+        assertNotNull(openApi);
+        assertNotNull(openApi);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        Object dump = Library.writeNode(openApi);
+        String json = mapper.writeValueAsString(dump);
+
+        LOG.info(json);
+        json = json.replace("\n", " ").replaceAll("\\s+", " ");
+
+        assertTrue(json.contains(
+                "\"XOfFormA\" : { \"type\" : \"object\", \"properties\" : { \"code\" : { \"type\" : \"string\" }, \"a\" : { \"type\" : \"string\" }, \"b\" : { \"format\" : \"int32\", \"type\" : \"integer\" } },"));
+        assertTrue(json.contains(
+                "\"XOfFormB\" : { \"type\" : \"object\", \"properties\" : { \"code\" : { \"type\" : \"string\" }, \"x\" : { \"format\" : \"int32\", \"type\" : \"integer\" }, \"y\" : { \"type\" : \"string\" } },"));
+
+        assertTrue(json.contains(
+                "\"OneOfFormWrapper\" : { \"type\" : \"object\", \"properties\" : { \"formType\" : { \"type\" : \"string\" }, \"form\" : { \"$ref\" : \"#/components/schemas/OneOfForm\" } },"));
+        assertTrue(json.contains(
+                "\"OneOfForm\" : { \"oneOf\" : [ { \"$ref\" : \"#/components/schemas/XOfFormA\" }, { \"$ref\" : \"#/components/schemas/XOfFormB\" } ]"));
+
+        context.stop();
+    }
+
+    @Test
+    public void testReaderReadAllOf() throws Exception {
+        BeanConfig config = new BeanConfig();
+        config.setHost("localhost:8080");
+        config.setSchemes(new String[] { "http" });
+        config.setBasePath("/api");
+        config.setTitle("Camel User store");
+        config.setLicense("Apache 2.0");
+        config.setLicenseUrl("https://www.apache.org/licenses/LICENSE-2.0.html");
+
+        RestOpenApiReader reader = new RestOpenApiReader();
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
+                new DefaultClassResolver());
+        assertNotNull(openApi);
+        assertNotNull(openApi);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        Object dump = Library.writeNode(openApi);
+        String json = mapper.writeValueAsString(dump);
+
+        LOG.info(json);
+        json = json.replace("\n", " ").replaceAll("\\s+", " ");
+
+        assertTrue(json.contains(
+                "\"AllOfFormWrapper\" : { \"type\" : \"object\", \"properties\" : { \"fullForm\" : { \"$ref\" : \"#/components/schemas/AllOfForm\" } },"));
+        assertTrue(json.contains(
+                "\"AllOfForm\" : { \"allOf\" : [ { \"$ref\" : \"#/components/schemas/XOfFormA\" }, { \"$ref\" : \"#/components/schemas/XOfFormB\" } ],"));
+
+        context.stop();
+    }
+
+    @Test
+    public void testReaderReadAnyOf() throws Exception {
+        BeanConfig config = new BeanConfig();
+        config.setHost("localhost:8080");
+        config.setSchemes(new String[] { "http" });
+        config.setBasePath("/api");
+        config.setTitle("Camel User store");
+        config.setLicense("Apache 2.0");
+        config.setLicenseUrl("https://www.apache.org/licenses/LICENSE-2.0.html");
+
+        RestOpenApiReader reader = new RestOpenApiReader();
+        OasDocument openApi = reader.read(context, context.getRestDefinitions(), config, context.getName(),
+                new DefaultClassResolver());
+        assertNotNull(openApi);
+        assertNotNull(openApi);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        Object dump = Library.writeNode(openApi);
+        String json = mapper.writeValueAsString(dump);
+
+        LOG.info(json);
+        json = json.replace("\n", " ").replaceAll("\\s+", " ");
+
+        assertTrue(json.contains(
+                "\"AnyOfFormWrapper\" : { \"type\" : \"object\", \"properties\" : { \"formElements\" : { \"$ref\" : \"#/components/schemas/AnyOfForm\" } },"));
+        assertTrue(json.contains(
+                "\"AnyOfForm\" : { \"anyOf\" : [ { \"$ref\" : \"#/components/schemas/XOfFormA\" }, { \"$ref\" : \"#/components/schemas/XOfFormB\" } ],"));
+
+        context.stop();
+    }
+
+}

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/AllOfForm.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/AllOfForm.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.openapi.model;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// Combination of both classes flattened out
+@Schema(allOf = { XOfFormA.class, XOfFormB.class })
+public class AllOfForm {
+    @JsonUnwrapped
+    XOfFormA formA;
+
+    @JsonUnwrapped
+    XOfFormB formB;
+
+    public XOfFormA getFormA() {
+        return this.formA;
+    }
+
+    public void setFormA(XOfFormA formA) {
+        this.formA = formA;
+    }
+
+    public XOfFormB getFormB() {
+        return this.formB;
+    }
+
+    public void setFormB(XOfFormB formB) {
+        this.formB = formB;
+    }
+
+}

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/AllOfFormWrapper.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/AllOfFormWrapper.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.openapi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AllOfFormWrapper {
+
+    @JsonProperty("fullForm")
+    AllOfForm fullForm;
+
+    public AllOfForm getFullForm() {
+        return this.fullForm;
+    }
+
+    public void setFullForm(AllOfForm fullForm) {
+        this.fullForm = fullForm;
+    }
+
+}

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/AnyOfForm.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/AnyOfForm.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.openapi.model;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// Combination of both classes flattened out
+@Schema(anyOf = { XOfFormA.class, XOfFormB.class })
+public class AnyOfForm {
+    @JsonUnwrapped
+    XOfFormA formA;
+
+    @JsonUnwrapped
+    XOfFormB formB;
+
+    public XOfFormA getFormA() {
+        return this.formA;
+    }
+
+    public void setFormA(XOfFormA formA) {
+        this.formA = formA;
+    }
+
+    public XOfFormB getFormB() {
+        return this.formB;
+    }
+
+    public void setFormB(XOfFormB formB) {
+        this.formB = formB;
+    }
+
+}

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/AnyOfFormWrapper.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/AnyOfFormWrapper.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.openapi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AnyOfFormWrapper {
+
+    @JsonProperty("formElements")
+    AnyOfForm formPeices;
+
+    public AnyOfForm getFormPeices() {
+        return this.formPeices;
+    }
+
+    public void setFormPeices(AnyOfForm formPeices) {
+        this.formPeices = formPeices;
+    }
+}

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/OneOfForm.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/OneOfForm.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.openapi.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(oneOf = { XOfFormA.class, XOfFormB.class })
+public interface OneOfForm {
+
+}

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/OneOfFormWrapper.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/OneOfFormWrapper.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.openapi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+public class OneOfFormWrapper {
+
+    @JsonProperty("formType")
+    String formType;
+
+    @JsonProperty("form")
+    @JsonTypeInfo(
+                  use = JsonTypeInfo.Id.NAME,
+                  include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                  property = "system")
+    @JsonSubTypes({
+            @Type(value = XOfFormA.class, name = "Form A"),
+            @Type(value = XOfFormB.class, name = "Form B")
+    })
+    OneOfForm form;
+
+    public String getFormType() {
+        return this.formType;
+    }
+
+    public void setFormType(String formType) {
+        this.formType = formType;
+    }
+
+    public OneOfForm getForm() {
+        return this.form;
+    }
+
+    public void setForm(OneOfForm form) {
+        this.form = form;
+    }
+}

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/XOfFormA.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/XOfFormA.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.openapi.model;
+
+public class XOfFormA implements OneOfForm {
+    String code;
+
+    String a;
+    int b;
+
+    public String getCode() {
+        return this.code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getA() {
+        return this.a;
+    }
+
+    public void setA(String a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return this.b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+}

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/XOfFormB.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/model/XOfFormB.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.openapi.model;
+
+public class XOfFormB implements OneOfForm {
+    String code;
+
+    int x;
+    String y;
+
+    public String getCode() {
+        return this.code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public int getX() {
+        return this.x;
+    }
+
+    public void setX(int x) {
+        this.x = x;
+    }
+
+    public String getY() {
+        return this.y;
+    }
+
+    public void setY(String y) {
+        this.y = y;
+    }
+
+}


### PR DESCRIPTION
Added support for oneOf, anyOf and allOf OpenAPI annotations for Rest OpenApi spec generation

OpenAPI specification reference:
https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not

