### PR TITLE
test(dsl): Adding on-completion test for camel yaml dsl

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RouteConfigurationTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RouteConfigurationTest.groovy
@@ -92,7 +92,12 @@ class RouteConfigurationTest extends YamlTestSupport {
                         steps:
                           - transform:
                               constant: "Activated"
-                          - to: "mock:on-exception"  
+                          - to: "mock:on-exception"
+                    - on-completion:
+                        steps:
+                          - transform:
+                              constant: "Completed"
+                          - to: "mock:on-completion"
                 - from:
                     uri: "direct:start"
                     steps:
@@ -102,6 +107,10 @@ class RouteConfigurationTest extends YamlTestSupport {
 
         withMock('mock:on-exception') {
             expectedBodiesReceived 'Activated'
+        }
+
+        withMock('mock:on-completion') {
+            expectedBodiesReceived 'Completed'
         }
 
         when:


### PR DESCRIPTION
I just realized there is no test checking the on-completion part on yaml dsl, so I added this small piece to the existing tests.