### PR TITLE
CAMEL-18002

### DIFF
--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/handlers/HttpServerChannelHandler.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/handlers/HttpServerChannelHandler.java
@@ -37,6 +37,7 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePropertyKey;
+import org.apache.camel.ExtendedExchange;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.Message;
 import org.apache.camel.component.netty.NettyConverter;
@@ -344,6 +345,8 @@ public class HttpServerChannelHandler extends ServerChannelHandler {
     @Override
     protected Exchange createExchange(ChannelHandlerContext ctx, Object message) throws Exception {
         Exchange exchange = this.consumer.createExchange(false);
+
+        exchange.adapt(ExtendedExchange.class).setUnitOfWork(null);
 
         // create a new IN message as we cannot reuse with netty
         Message in;


### PR DESCRIPTION
Prevent a reused Exchange with non-null UoW from causing loss of onCompletion
which is added in DefaultNettyHttpBinding.toCamelMessage().
This onCompletion releases the ByteBuf in the FullHttpRequest.

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
