### PR TITLE
camel-jbang. profile option for *.properties

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelJBangMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelJBangMain.java
@@ -26,6 +26,9 @@ import picocli.CommandLine.Command;
 @Command(name = "camel", description = "Apache Camel CLI", mixinStandardHelpOptions = true)
 public class CamelJBangMain implements Callable<Integer> {
     private static CommandLine commandLine;
+    @CommandLine.Option(names = { "--profile" }, scope = CommandLine.ScopeType.INHERIT, defaultValue = "application",
+                        description = "Profile")
+    private String profile;
 
     public static void run(String... args) {
         commandLine = new CommandLine(new CamelJBangMain())
@@ -55,7 +58,7 @@ public class CamelJBangMain implements Callable<Integer> {
             return new String[] { v };
         });
 
-        PropertiesHelper.augmentWithProperties(commandLine);
+        PropertiesHelper.augmentWithProperties(commandLine, args);
         int exitCode = commandLine.execute(args);
         System.exit(exitCode);
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Profile.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Profile.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine;
+
+@CommandLine.Command()
+public class Profile implements Callable<Integer> {
+
+    @CommandLine.Option(names = { "--profile" }, scope = CommandLine.ScopeType.INHERIT, defaultValue = "application",
+                        description = "Profile")
+    private String profile;
+    @CommandLine.Unmatched
+    private List<String> unmatched;
+
+    @Override
+    public Integer call() throws Exception {
+        return 0;
+    }
+}


### PR DESCRIPTION
`camel@apache/camel package uber-jar` by default uses `application.properties`
`camel@apache/camel package uber-jar --profile dev` uses `dev.properties`
`camel@apache/camel package uber-jar --profile test` uses `test.properties` 
`camel@apache/camel package uber-jar --profile prod` uses `prod.properties` 
 filename=profile