### PR TITLE
[CAMEL-18119] Allow Simple expressions to render any Object that can be converted to Date

### DIFF
--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleExpressionBuilder.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleExpressionBuilder.java
@@ -481,7 +481,10 @@ public final class SimpleExpressionBuilder {
                     } else if (obj instanceof Long) {
                         date = new Date((Long) obj);
                     } else {
-                        throw new IllegalArgumentException("Cannot find Date/long object at command: " + command);
+                        date = exchange.getContext().getTypeConverter().tryConvertTo(Date.class, exchange, obj);
+                        if (date == null) {
+                            throw new IllegalArgumentException("Cannot find Date/long object at command: " + command);
+                        }
                     }
                 } else if (command.startsWith("exchangeProperty.")) {
                     String key = command.substring(command.lastIndexOf('.') + 1);
@@ -491,7 +494,10 @@ public final class SimpleExpressionBuilder {
                     } else if (obj instanceof Long) {
                         date = new Date((Long) obj);
                     } else {
-                        throw new IllegalArgumentException("Cannot find Date/long object at command: " + command);
+                        date = exchange.getContext().getTypeConverter().tryConvertTo(Date.class, exchange, obj);
+                        if (date == null) {
+                            throw new IllegalArgumentException("Cannot find Date/long object at command: " + command);
+                        }
                     }
                 } else if ("file".equals(command)) {
                     Long num = exchange.getIn().getHeader(Exchange.FILE_LAST_MODIFIED, Long.class);

--- a/core/camel-core/src/test/java/org/apache/camel/language/simple/SimpleTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/simple/SimpleTest.java
@@ -38,6 +38,7 @@ import org.apache.camel.LanguageTestSupport;
 import org.apache.camel.Predicate;
 import org.apache.camel.component.bean.MethodNotFoundException;
 import org.apache.camel.language.bean.RuntimeBeanExpressionException;
+import org.apache.camel.language.simple.myconverter.MyCustomDate;
 import org.apache.camel.language.simple.types.SimpleIllegalSyntaxException;
 import org.apache.camel.spi.Language;
 import org.apache.camel.spi.Registry;
@@ -602,6 +603,23 @@ public class SimpleTest extends LanguageTestSupport {
 
         assertExpression("${date:header.birthday - 10s:yyyy-MM-dd'T'HH:mm:ss:SSS}", "1974-04-20T08:55:37:123");
         assertExpression("${date:header.birthday:yyyy-MM-dd'T'HH:mm:ss:SSS}", "1974-04-20T08:55:47:123");
+    }
+
+    @Test
+    public void testDateWithConverterExpressions() throws Exception {
+        exchange.getIn().setHeader("birthday", new MyCustomDate(1974, Calendar.APRIL, 20));
+        exchange.setProperty("birthday", new MyCustomDate(1974, Calendar.APRIL, 20));
+        exchange.getIn().setHeader("other", new ArrayList<>());
+
+        assertExpression("${date:header.birthday:yyyyMMdd}", "19740420");
+        assertExpression("${date:exchangeProperty.birthday:yyyyMMdd}", "19740420");
+
+        try {
+            assertExpression("${date:header.other:yyyyMMdd}", "19740420");
+            fail("Should thrown an exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Cannot find Date/long object at command: header.other", e.getMessage());
+        }
     }
 
     @Test

--- a/core/camel-core/src/test/java/org/apache/camel/language/simple/myconverter/MyCustomDate.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/simple/myconverter/MyCustomDate.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.language.simple.myconverter;
+
+/**
+ * This custom date object allows to check that Simple expressions can call
+ * custom type converters when needing real java.util.Date instances
+ */
+public final class MyCustomDate {
+
+    private final int year;
+    private final int month;
+    private final int date;
+
+    public MyCustomDate(int year, int month, int date) {
+        this.year = year;
+        this.month = month;
+        this.date = date;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getMonth() {
+        return month;
+    }
+
+    public int getDate() {
+        return date;
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/language/simple/myconverter/MyCustomDateConverter.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/simple/myconverter/MyCustomDateConverter.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.language.simple.myconverter;
+
+import java.util.*;
+
+import org.apache.camel.Converter;
+
+@Converter
+public final class MyCustomDateConverter {
+    private MyCustomDateConverter() {
+        // Prevent instantiation
+    }
+
+    @Converter
+    public static Date toDate(MyCustomDate value) {
+        Calendar cal = Calendar.getInstance();
+        cal.set(value.getYear(), value.getMonth(), value.getDate());
+        return cal.getTime();
+    }
+}

--- a/core/camel-core/src/test/resources/META-INF/services/org/apache/camel/TypeConverter
+++ b/core/camel-core/src/test/resources/META-INF/services/org/apache/camel/TypeConverter
@@ -16,3 +16,4 @@
 #
 
 org.apache.camel.converter.myconverter
+org.apache.camel.language.simple.myconverter


### PR DESCRIPTION
Here's the pull request fixing https://issues.apache.org/jira/browse/CAMEL-18119

FYI, I have the following error when running sourcecheck, I have not idea what's wrong with my formatting.
```
File 'camel\core\camel-core\src\test\java\org\apache\camel\language\simple\myconverter\MyCustomDate.java' has not been previously formatted.  Please format file and commit before running validation!
```

Thank you