### PR TITLE
CAMEL-18130: Fix move-file post-processing

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFile.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFile.java
@@ -111,19 +111,41 @@ public class GenericFile<T> implements WrappedFile<T>, GenericFileResumable<T> {
      * Bind this GenericFile to an Exchange
      */
     public void bindToExchange(Exchange exchange) {
-        GenericFileMessage<T> msg = commonBindToExchange(exchange);
-        populateHeaders(msg, false);
+        bindToExchange(exchange, false);
+    }
+
+    /**
+     * Bind this GenericFile to an Exchange and overwrite the inMessage with the outMessage (if there is a outMessage)
+     */
+    public void bindToExchangeForceInMessageUpdate(Exchange exchange) {
+        bindToExchange(exchange, false, true);
     }
 
     /**
      * Bind this GenericFile to an Exchange
      */
     public void bindToExchange(Exchange exchange, boolean isProbeContentTypeFromEndpoint) {
-        GenericFileMessage<T> msg = commonBindToExchange(exchange);
+        bindToExchange(exchange, isProbeContentTypeFromEndpoint, false);
+    }
+
+    /**
+     * @param exchange
+     * @param isProbeContentTypeFromEndpoint
+     * @param forceInMessageUpdate           Set to true, to overwrite the inMessage with the outMessage (if there is a
+     *                                       outMessage)
+     */
+    public void bindToExchange(Exchange exchange, boolean isProbeContentTypeFromEndpoint, boolean forceInMessageUpdate) {
+        GenericFileMessage<T> msg = commonBindToExchange(exchange, forceInMessageUpdate);
         populateHeaders(msg, isProbeContentTypeFromEndpoint);
     }
 
-    private GenericFileMessage<T> commonBindToExchange(Exchange exchange) {
+    /**
+     * @param  exchange
+     * @param  forceInMessageUpdate: Set to true, to overwrite the inMessage with the outMessage (if there is a
+     *                               outMessage)
+     * @return
+     */
+    private GenericFileMessage<T> commonBindToExchange(Exchange exchange, boolean forceInMessageUpdate) {
         Map<String, Object> headers;
 
         exchange.setProperty(FileComponent.FILE_EXCHANGE_FILE, this);
@@ -131,6 +153,9 @@ public class GenericFile<T> implements WrappedFile<T>, GenericFileResumable<T> {
 
         headers = exchange.getMessage().hasHeaders() ? exchange.getMessage().getHeaders() : null;
         exchange.setMessage(msg);
+        if (forceInMessageUpdate) {
+            exchange.setIn(msg);
+        }
 
         // preserve any existing (non file) headers, before we re-populate
         // headers

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/GenericFileRenameProcessStrategy.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/GenericFileRenameProcessStrategy.java
@@ -109,9 +109,9 @@ public class GenericFileRenameProcessStrategy<T> extends GenericFileProcessStrat
                 FileEndpoint fe = null;
                 if (endpoint instanceof FileEndpoint) {
                     fe = (FileEndpoint) endpoint;
-                    file.bindToExchange(copy, fe.isProbeContentType());
+                    file.bindToExchange(copy, fe.isProbeContentType(), true);
                 } else {
-                    file.bindToExchange(copy);
+                    file.bindToExchangeForceInMessageUpdate(copy);
                 }
                 // must preserve message id
                 copy.getIn().setMessageId(exchange.getIn().getMessageId());

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/SftpMoveWithOutMessage.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/SftpMoveWithOutMessage.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file.remote.integration;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.file.remote.sftp.integration.SftpServerTestSupport;
+import org.apache.camel.support.DefaultMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test that the existence of a outMessage in an exchange will not break the move-file post-processing
+ */
+@EnabledIf(value = "org.apache.camel.component.file.remote.services.SftpEmbeddedService#hasRequiredAlgorithms")
+public class SftpMoveWithOutMessage extends SftpServerTestSupport {
+    @Timeout(value = 30)
+    @Test
+    public void testMoveFileForMultiplePollEnrich() throws Exception {
+        String expected = "Hello World";
+
+        // create two files using regular file
+        template.sendBodyAndHeader("file://" + service.getFtpRootDir(), expected, Exchange.FILE_NAME, "hello1.txt");
+        template.sendBodyAndHeader("file://" + service.getFtpRootDir(), expected, Exchange.FILE_NAME, "hello2.txt");
+
+        ProducerTemplate triggerTemplate = context.createProducerTemplate();
+        triggerTemplate.sendBody("vm:trigger", "");
+
+        File fileInArchive = ftpFile("archive/hello1.txt").toFile();
+        await().atMost(15, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertTrue(fileInArchive.exists(), "The file should exist in the archive folder"));
+
+        File fileInArchive2 = ftpFile("archive/hello2.txt").toFile();
+        await().atMost(15, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertTrue(fileInArchive2.exists(), "The file should exist in the archive folder"));
+
+        File originalFile = ftpFile("hello1.txt").toFile();
+        await().atMost(15, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertFalse(originalFile.exists(), "The file should have been moved"));
+
+        File originalFile2 = ftpFile("hello2.txt").toFile();
+        await().atMost(15, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertFalse(originalFile2.exists(), "The file should have been moved"));
+    }
+
+    @Override
+    protected RouteBuilder[] createRouteBuilders() throws Exception {
+        TestProcessor processor = new TestProcessor();
+        return new RouteBuilder[] { new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("vm:trigger")
+                        .pollEnrich(
+                                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&delay=10000&disconnect=true&move=archive")
+                        .pollEnrich(
+                                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&delay=10000&disconnect=true&move=archive")
+                        .process(processor);
+            }
+        } };
+    }
+
+    private static class TestProcessor implements Processor {
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            DefaultMessage msg = new DefaultMessage(exchange);
+            msg.setBody(exchange.getIn().getBody());
+            msg.setHeaders(exchange.getIn().getHeaders());
+            exchange.setOut(msg);
+        }
+    }
+}


### PR DESCRIPTION
Evaluation of file-expressions work on the inMessage. This changes makes sure that the properties of a file are bound to the inMessage of a exchange. This makes sure that the file-expressions can be evaluated correctly and post-processing can be executed.