### PR TITLE
CAMEL-18157: fix settings provided by the query parameter "parameters…

### DIFF
--- a/components/camel-jdbc/src/main/java/org/apache/camel/component/jdbc/JdbcProducer.java
+++ b/components/camel-jdbc/src/main/java/org/apache/camel/component/jdbc/JdbcProducer.java
@@ -159,6 +159,8 @@ public class JdbcProducer extends DefaultProducer {
                 ps = conn.prepareStatement(preparedQuery);
             }
 
+            bindParameters(exchange,ps);
+
             int expectedCount = ps.getParameterMetaData().getParameterCount();
 
             if (expectedCount > 0) {
@@ -208,10 +210,7 @@ public class JdbcProducer extends DefaultProducer {
                 }
             });
 
-            if (parameters != null && !parameters.isEmpty()) {
-                Map<String, Object> copy = new HashMap<>(parameters);
-                PropertyBindingSupport.bindProperties(exchange.getContext(), stmt, copy);
-            }
+            bindParameters(exchange, stmt);
 
             LOG.debug("Executing JDBC Statement: {}", sql);
 
@@ -254,6 +253,13 @@ public class JdbcProducer extends DefaultProducer {
             }
         }
         return shouldCloseResources;
+    }
+
+    private void bindParameters(Exchange exchange, Statement stmt) {
+        if (parameters != null && !parameters.isEmpty()) {
+            Map<String, Object> copy = new HashMap<>(parameters);
+            PropertyBindingSupport.bindProperties(exchange.getContext(), stmt, copy);
+        }
     }
 
     private void closeQuietly(ResultSet rs) {

--- a/components/camel-jdbc/src/test/java/org/apache/camel/component/jdbc/JdbcFix18157Test.java
+++ b/components/camel-jdbc/src/test/java/org/apache/camel/component/jdbc/JdbcFix18157Test.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jdbc;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit test based on user forum request about this component
+ */
+public class JdbcFix18157Test extends AbstractJdbcTestSupport {
+
+    @EndpointInject("mock:result")
+    private MockEndpoint mock;
+
+
+    @Test
+
+    public void whenUseHeadersAsParametersOthersParametersShouldNotBeIgnored() throws Exception {
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:useHeadersAsParameters", "select * from customer");
+
+        assertMockEndpointsSatisfied();
+        assertEquals(1, mock.getReceivedExchanges().get(0).getIn().getBody(List.class).size());
+
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                //statement.maxRows=1 is provided as additional parameter in combination with useHeadersAsParameters=true
+                from("direct:useHeadersAsParameters").to("jdbc:testdb?statement.maxRows=1&useHeadersAsParameters=true").to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
CAMEL-18157: fix settings provided by the query parameter "parameters" are ignored when useHeadersAsParameters=true
