### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/alternative-os-build.yml
+++ b/.github/workflows/alternative-os-build.yml
@@ -22,6 +22,9 @@ on:
 # Every 5th minute every 3 hours during working days
     - cron: '20 * * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/generic-pr.yaml
+++ b/.github/workflows/generic-pr.yaml
@@ -24,8 +24,14 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   process:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     name: Process
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
