### PR TITLE
[CAMEL-17130] camel-file - Use NIO

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/FileEndpoint.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/FileEndpoint.java
@@ -19,7 +19,9 @@ package org.apache.camel.component.file;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -250,14 +252,14 @@ public class FileEndpoint extends GenericFileEndpoint<File> {
     }
 
     @Override
-    public char getFileSeparator() {
-        return File.separatorChar;
+    public String getFileSeparator() {
+        return FileSystems.getDefault().getSeparator();
     }
 
     @Override
     public boolean isAbsolute(String name) {
         // relative or absolute path?
-        return FileUtil.isAbsolute(new File(name));
+        return FileUtil.isAbsolute(Path.of(name));
     }
 
     public boolean isCopyAndDeleteOnRenameFail() {

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileDefaultMoveExistingFileStrategy.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileDefaultMoveExistingFileStrategy.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.component.file;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.component.file.strategy.FileMoveExistingStrategy;
@@ -66,11 +66,11 @@ public class GenericFileDefaultMoveExistingFileStrategy implements FileMoveExist
         // ensure any paths is created before we rename as the renamed file may
         // be in a different path (which may be non exiting)
         // use java.io.File to compute the file path
-        File toFile = new File(to);
-        String directory = toFile.getParent();
-        boolean absolute = FileUtil.isAbsolute(toFile);
+        Path toPath = Path.of(to);
+        Path directory = toPath.getParent();
+        boolean absolute = FileUtil.isAbsolute(toPath);
         if (directory != null) {
-            if (!operations.buildDirectory(directory, absolute)) {
+            if (!operations.buildDirectory(directory.toString(), absolute)) {
                 LOG.debug("Cannot build directory [{}] (could be because of denied permissions)", directory);
             }
         }

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileEndpoint.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileEndpoint.java
@@ -456,7 +456,7 @@ public abstract class GenericFileEndpoint<T> extends ScheduledPollEndpoint imple
 
     public abstract String getScheme();
 
-    public abstract char getFileSeparator();
+    public abstract String getFileSeparator();
 
     public abstract boolean isAbsolute(String name);
 

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
@@ -16,7 +16,8 @@
  */
 package org.apache.camel.component.file;
 
-import java.io.File;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
@@ -53,7 +54,7 @@ public class GenericFileProducer<T> extends DefaultProducer {
     }
 
     public String getFileSeparator() {
-        return File.separator;
+        return FileSystems.getDefault().getSeparator();
     }
 
     public String normalizePath(String name) {
@@ -272,11 +273,11 @@ public class GenericFileProducer<T> extends DefaultProducer {
             String name = FileUtil.normalizePath(fileName);
 
             // use java.io.File to compute the file path
-            File file = new File(name);
-            String directory = file.getParent();
-            boolean absolute = FileUtil.isAbsolute(file);
+            Path path = Path.of(name);
+            Path directory = path.getParent();
+            boolean absolute = FileUtil.isAbsolute(path);
             if (directory != null) {
-                if (!operations.buildDirectory(directory, absolute)) {
+                if (!operations.buildDirectory(directory.toString(), absolute)) {
                     LOG.debug("Cannot build directory [{}] (could be because of denied permissions)", directory);
                 }
             }

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/MoveExistingFileStrategyUtils.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/MoveExistingFileStrategyUtils.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.component.file;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.ObjectHelper;
@@ -50,7 +50,7 @@ public final class MoveExistingFileStrategyUtils {
         }
 
         if (ObjectHelper.isNotEmpty(directoryName) && !destinationPath.startsWith(directoryName)
-                && !FileUtil.isAbsolute(new File(destinationPath))) {
+                && !FileUtil.isAbsolute(Path.of(destinationPath))) {
             destinationPath = directoryName + "/" + destinationPath;
         }
 

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/consumer/adapters/DefaultDirectoryEntriesResumeAdapter.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/consumer/adapters/DefaultDirectoryEntriesResumeAdapter.java
@@ -59,7 +59,7 @@ class DefaultDirectoryEntriesResumeAdapter extends AbstractFileResumeAdapter imp
     }
 
     private void resumeDirectoryEntries() {
-        DirectoryEntries.doResume(fileSet, f -> notProcessed(fileSet.getDirectory(), f));
+        DirectoryEntries.doResume(fileSet, path -> notProcessed(fileSet.getDirectory(), path.toFile()));
     }
 
     @Override

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileChangedExclusiveReadLockStrategy.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileChangedExclusiveReadLockStrategy.java
@@ -17,6 +17,8 @@
 package org.apache.camel.component.file.strategy;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Date;
 
 import org.apache.camel.Exchange;
@@ -50,7 +52,7 @@ public class FileChangedExclusiveReadLockStrategy extends MarkerFileExclusiveRea
             return false;
         }
 
-        File target = new File(file.getAbsoluteFilePath());
+        Path target = Path.of(file.getAbsoluteFilePath());
         boolean exclusive = false;
 
         LOG.trace("Waiting for exclusive read lock to file: {}", file);
@@ -73,14 +75,14 @@ public class FileChangedExclusiveReadLockStrategy extends MarkerFileExclusiveRea
                 }
             }
 
-            if (!target.exists()) {
+            if (!Files.exists(target)) {
                 CamelLogger.log(LOG, readLockLoggingLevel,
                         "Cannot acquire read lock as file no longer exists. Will skip the file: " + file);
                 return false;
             }
 
-            long newLastModified = target.lastModified();
-            long newLength = target.length();
+            long newLastModified = Files.getLastModifiedTime(target).toMillis();
+            long newLength = Files.size(target);
             long newOlderThan = startTime + watch.taken() - minAge;
 
             LOG.trace("Previous last modified: {}, new last modified: {}", lastModified, newLastModified);

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileLockExclusiveReadLockStrategy.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileLockExclusiveReadLockStrategy.java
@@ -22,6 +22,8 @@ import java.io.RandomAccessFile;
 import java.nio.channels.Channel;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
@@ -60,7 +62,7 @@ public class FileLockExclusiveReadLockStrategy extends MarkerFileExclusiveReadLo
             return false;
         }
 
-        File target = new File(file.getAbsoluteFilePath());
+        Path target = Path.of(file.getAbsoluteFilePath());
 
         LOG.trace("Waiting for exclusive read lock to file: {}", target);
 
@@ -71,7 +73,7 @@ public class FileLockExclusiveReadLockStrategy extends MarkerFileExclusiveReadLo
         FileLock lock = null;
 
         try {
-            randomAccessFile = new RandomAccessFile(target, "rw");
+            randomAccessFile = new RandomAccessFile(target.toFile(), "rw");
             // try to acquire rw lock on the file before we can consume it
             channel = randomAccessFile.getChannel();
 
@@ -90,7 +92,7 @@ public class FileLockExclusiveReadLockStrategy extends MarkerFileExclusiveReadLo
                     }
                 }
 
-                if (!target.exists()) {
+                if (!Files.exists(target)) {
                     CamelLogger.log(LOG, readLockLoggingLevel,
                             "Cannot acquire read lock as file no longer exists. Will skip the file: " + file);
                     return false;

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpEndpoint.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpEndpoint.java
@@ -377,16 +377,16 @@ public class FtpEndpoint<T extends FTPFile> extends RemoteFileEndpoint<FTPFile> 
     }
 
     @Override
-    public char getFileSeparator() {
+    public String getFileSeparator() {
         // the regular ftp component should use the configured separator
         // as FTP servers may require you to use windows or unix style
         // and therefore you need to be able to control that
         PathSeparator pathSeparator = getConfiguration().getSeparator();
         switch (pathSeparator) {
             case Windows:
-                return '\\';
+                return "\\";
             case UNIX:
-                return '/';
+                return "/";
             default:
                 return super.getFileSeparator();
         }

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileEndpoint.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileEndpoint.java
@@ -234,8 +234,8 @@ public abstract class RemoteFileEndpoint<T> extends GenericFileEndpoint<T> {
     }
 
     @Override
-    public char getFileSeparator() {
-        return '/';
+    public String getFileSeparator() {
+        return "/";
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerResumeFromOffsetStrategyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerResumeFromOffsetStrategyTest.java
@@ -65,7 +65,7 @@ public class FileConsumerResumeFromOffsetStrategyTest extends ContextTestSupport
             }
 
             if (fileSet != null) {
-                DirectoryEntries.doResume(fileSet, f -> !f.getName().equals("resume-from-offset"));
+                DirectoryEntries.doResume(fileSet, path -> !path.getFileName().toString().equals("resume-from-offset"));
                 LOG.debug("Fileset: {}", fileSet);
                 LOG.debug("Fileset: {}", fileSet.resumed());
 
@@ -85,7 +85,7 @@ public class FileConsumerResumeFromOffsetStrategyTest extends ContextTestSupport
 
         @Override
         public void setResumePayload(DirectoryEntries fileSet) {
-            DirectoryEntries.doResume(fileSet, f -> true);
+            DirectoryEntries.doResume(fileSet, path -> true);
         }
 
         @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerResumeStrategyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerResumeStrategyTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.file;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -34,14 +35,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("Tests whether file consumer works with the resume strategy")
 public class FileConsumerResumeStrategyTest extends ContextTestSupport {
 
     private static class TestFileSetResumeAdapter implements FileResumeAdapter, DirectoryEntriesResumeAdapter {
-        private final List<String> processedFiles = Arrays.asList("0.txt", "1.txt", "2.txt");
+        private final List<Path> processedFiles = Arrays.asList(Path.of("0.txt"), Path.of("1.txt"), Path.of("2.txt"));
         private DirectoryEntries resumeSet;
 
         @Override
@@ -51,8 +50,9 @@ public class FileConsumerResumeStrategyTest extends ContextTestSupport {
 
         @Override
         public void resume() {
-            DirectoryEntries.doResume(resumeSet, f -> !processedFiles.contains(f.getName()));
+            DirectoryEntries.doResume(resumeSet, path -> !processedFiles.contains(path.getFileName()));
         }
+
     }
 
     private final TestFileSetResumeAdapter adapter = new TestFileSetResumeAdapter();
@@ -80,9 +80,7 @@ public class FileConsumerResumeStrategyTest extends ContextTestSupport {
         // only expect 4 of the 6 sent
         assertMockEndpointsSatisfied();
 
-        assertTrue(adapter.resumeSet.hasResumables(), "The resume set should have resumables in this scenario");
-        assertNotNull(adapter.resumeSet.resumed(), "The list of resumables should not be null");
-        assertEquals(4, adapter.resumeSet.resumed().length, "There should be exactly 4 resumables");
+        assertEquals(4, adapter.resumeSet.resumed().count(), "There should be exactly 4 resumables");
     }
 
     private void setOffset(Exchange exchange) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/FileUtil.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/FileUtil.java
@@ -19,6 +19,7 @@ package org.apache.camel.util;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -402,6 +403,19 @@ public final class FileUtil {
      * @return                           <tt>true</tt> if the file was renamed, otherwise <tt>false</tt>
      * @throws java.io.IOException       is thrown if error renaming file
      */
+    public static boolean renameFile(Path from, Path to, boolean copyAndDeleteOnRenameFail) throws IOException {
+        return renameFile(from.toFile(), to.toFile(), copyAndDeleteOnRenameFail);
+    }
+
+    /**
+     * Renames a file.
+     *
+     * @param  from                      the from file
+     * @param  to                        the to file
+     * @param  copyAndDeleteOnRenameFail whether to fallback and do copy and delete, if renameTo fails
+     * @return                           <tt>true</tt> if the file was renamed, otherwise <tt>false</tt>
+     * @throws java.io.IOException       is thrown if error renaming file
+     */
     public static boolean renameFile(File from, File to, boolean copyAndDeleteOnRenameFail) throws IOException {
         // do not try to rename non existing files
         if (!from.exists()) {
@@ -451,6 +465,19 @@ public final class FileUtil {
      * @return             <tt>true</tt> if the file was renamed successfully, otherwise <tt>false</tt>
      * @throws IOException If an I/O error occurs during copy or delete operations.
      */
+    public static boolean renameFileUsingCopy(Path from, Path to) throws IOException {
+        return renameFileUsingCopy(from.toFile(), to.toFile());
+    }
+
+    /**
+     * Rename file using copy and delete strategy. This is primarily used in environments where the regular rename
+     * operation is unreliable.
+     *
+     * @param  from        the file to be renamed
+     * @param  to          the new target file
+     * @return             <tt>true</tt> if the file was renamed successfully, otherwise <tt>false</tt>
+     * @throws IOException If an I/O error occurs during copy or delete operations.
+     */
     public static boolean renameFileUsingCopy(File from, File to) throws IOException {
         // do not try to rename non existing files
         if (!from.exists()) {
@@ -478,6 +505,18 @@ public final class FileUtil {
      */
     public static void copyFile(File from, File to) throws IOException {
         Files.copy(from.toPath(), to.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    /**
+     * Deletes the file.
+     * <p/>
+     * This implementation will attempt to delete the file up till three times with one second delay, which can mitigate
+     * problems on deleting files on some platforms such as Windows.
+     *
+     * @param path the path to delete
+     */
+    public static boolean deleteFile(Path path) {
+        return deleteFile(path.toFile());
     }
 
     /**
@@ -524,6 +563,19 @@ public final class FileUtil {
      * Will also work around issue on Windows to consider files on Windows starting with a \ as absolute files. This
      * makes the logic consistent across all OS platforms.
      *
+     * @param  path the path
+     * @return      <tt>true</ff> if its an absolute path, <tt>false</tt> otherwise.
+     */
+    public static boolean isAbsolute(Path path) {
+        return isAbsolute(path.toFile());
+    }
+
+    /**
+     * Is the given file an absolute file.
+     * <p/>
+     * Will also work around issue on Windows to consider files on Windows starting with a \ as absolute files. This
+     * makes the logic consistent across all OS platforms.
+     *
      * @param  file the file
      * @return      <tt>true</ff> if its an absolute path, <tt>false</tt> otherwise.
      */
@@ -536,6 +588,17 @@ public final class FileUtil {
             }
         }
         return file.isAbsolute();
+    }
+
+    /**
+     * Creates a new file.
+     *
+     * @param  path        the path
+     * @return             <tt>true</tt> if created a new file, <tt>false</tt> otherwise
+     * @throws IOException is thrown if error creating the new file
+     */
+    public static boolean createNewFile(Path path) throws IOException {
+        return createNewFile(path.toFile());
     }
 
     /**


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-17130

Changes:
1. There are simple Java IO -> NIO upgrades such as replace File usage with Path (in places it actually helps and doesn't make the code less readable)
2. FileConsumer - changed pollDirectory() and listFiles() methods to stream processing
3. FileResumeSet - completely rewritten to suit the stream processing above
4. FileUtils - some methods oveloads for Path for convenient usage

Notes:
- I've kept File as a class that is being transferred in an Exchange. I tried to replace it with Path, but run into problems with converters. If it makes sence, we can add this change in a next step
- the changes might not handle corner cases well, since for example File#getName() might return an empty string and Path#getFileName() return null in the same case. I suppose this doesn't pose much problem so I left it as it is.