### PR TITLE
CAMEL-18201 Enhance CamelTestSupport to turn off context stopping

### DIFF
--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -413,7 +413,7 @@ public abstract class CamelTestSupport
         }
     }
 
-    private void doSetUp() throws Exception {
+    protected void doSetUp() throws Exception {
         LOG.debug("setUp test");
         // jmx is enabled if we have configured to use it, or if dump route
         // coverage is enabled (it requires JMX)
@@ -706,7 +706,7 @@ public abstract class CamelTestSupport
         doStopCamelContext(context, camelContextService);
     }
 
-    private static void doStopCamelContext(CamelContext context, Service camelContextService) {
+    protected void doStopCamelContext(CamelContext context, Service camelContextService) {
         if (camelContextService != null) {
             if (camelContextService == threadService.get()) {
                 threadService.remove();

--- a/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/CamelTestSupporOneContextForAllTest.java
+++ b/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/CamelTestSupporOneContextForAllTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.junit5;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.Service;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.support.DefaultRegistry;
+import org.apache.camel.test.junit5.patterns.CreateCamelContextPerTestTrueTest;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CamelTestSupporOneContextForAllTest extends CamelTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CreateCamelContextPerTestTrueTest.class);
+
+    private static final CamelContext CUSTOM_CONTEXT;
+
+    static {
+        CUSTOM_CONTEXT = new MockContext();
+    }
+
+    @EndpointInject("mock:result")
+    protected MockEndpoint resultEndpoint;
+
+    @Produce("direct:start")
+    protected ProducerTemplate template;
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        return CUSTOM_CONTEXT;
+    }
+
+    @Override
+    protected void doStopCamelContext(CamelContext context, Service camelContextService) {
+        //don't stop
+    }
+
+    @Override
+    protected void doSetUp() throws Exception {
+        if (context == null) {
+            super.doSetUp();
+        }
+    }
+
+    @Test
+    @Order(1)
+    public void initContextTest() throws Exception {
+        String expectedBody = "<matched/>";
+
+        resultEndpoint.expectedBodiesReceived(expectedBody);
+
+        template.sendBodyAndHeader(expectedBody, "foo", "bar");
+
+        resultEndpoint.assertIsSatisfied();
+        resultEndpoint.reset();
+
+    }
+
+    @Test
+    @Order(2)
+    public void stopNotEnabledTest() throws Exception {
+        String expectedBody = "<matched/>";
+
+        resultEndpoint.expectedBodiesReceived(expectedBody);
+
+        template.sendBodyAndHeader(expectedBody, "foo", "bar");
+
+        resultEndpoint.assertIsSatisfied();
+        resultEndpoint.reset();
+
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:start").filter(header("foo").isEqualTo("bar")).to("mock:result");
+            }
+        };
+    }
+
+    private static class MockContext extends DefaultCamelContext {
+
+        boolean initialized;
+
+        @Override
+        protected Registry createRegistry() {
+            if (initialized) {
+                throw new UnsupportedOperationException();
+            }
+            if (!initialized) {
+                initialized = true;
+            }
+            return new DefaultRegistry();
+        }
+
+        @Override
+        public void addRoutes(RoutesBuilder builder) throws Exception {
+            //if routes are already added, do not add them again
+            if (getRoutes().isEmpty()) {
+                super.addRoutes(builder);
+            }
+        }
+    }
+}


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-18201

This PR adds an option to turn  off the context stopping. It is possible by junit5's `ConfigurationProperty` (which falls back also to system variable - used in the junit test). If context does not stop automatically method `doSetUp` is not called if context already exists.

I added 2 tests to cover both option values (off and on).

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
