### PR TITLE
Fix camel-knative endpoint for events

### DIFF
--- a/components/camel-knative/camel-knative-component/src/test/resources/environment.json
+++ b/components/camel-knative/camel-knative-component/src/test/resources/environment.json
@@ -29,6 +29,39 @@
         "knative.event.type": "",
         "camel.endpoint.kind": "source"
       }
+    },
+    {
+      "type": "event",
+      "name": "example-broker",
+      "url": "http://broker-example/default/example-broker",
+      "metadata": {
+        "camel.endpoint.kind": "sink",
+        "knative.apiVersion": "eventing.knative.dev/v1",
+        "knative.kind": "Broker",
+        "knative.name": "example-broker"
+      }
+    },
+    {
+      "type": "event",
+      "name": "evt1",
+      "path": "/events/evt1",
+      "metadata": {
+        "camel.endpoint.kind": "source",
+        "knative.apiVersion": "eventing.knative.dev/v1",
+        "knative.kind": "Broker",
+        "knative.name": "example-broker"
+      }
+    },
+    {
+      "type": "event",
+      "name": "default",
+      "path": "/events/",
+      "metadata": {
+        "camel.endpoint.kind": "source",
+        "knative.apiVersion": "eventing.knative.dev/v1",
+        "knative.kind": "Broker",
+        "knative.name": "example-broker"
+      }
     }
   ]
 }

--- a/components/camel-knative/camel-knative-component/src/test/resources/environment_classic.json
+++ b/components/camel-knative/camel-knative-component/src/test/resources/environment_classic.json
@@ -29,6 +29,39 @@
         "knative.event.type": "",
         "camel.endpoint.kind": "source"
       }
+    },
+    {
+      "type": "event",
+      "name": "example-broker",
+      "url": "http://broker-example/default/example-broker",
+      "metadata": {
+        "camel.endpoint.kind": "sink",
+        "knative.apiVersion": "eventing.knative.dev/v1",
+        "knative.kind": "Broker",
+        "knative.name": "example-broker"
+      }
+    },
+    {
+      "type": "event",
+      "name": "evt1",
+      "path": "/events/evt1",
+      "metadata": {
+        "camel.endpoint.kind": "source",
+        "knative.apiVersion": "eventing.knative.dev/v1",
+        "knative.kind": "Broker",
+        "knative.name": "example-broker"
+      }
+    },
+    {
+      "type": "event",
+      "name": "default",
+      "path": "/events/",
+      "metadata": {
+        "camel.endpoint.kind": "source",
+        "knative.apiVersion": "eventing.knative.dev/v1",
+        "knative.kind": "Broker",
+        "knative.name": "example-broker"
+      }
     }
   ]
 }


### PR DESCRIPTION
* Only use the configuration name when endpoint.kind=sink
* Log a debug message when using a "default" knative resource name
* Set a "default" name when there is no name
* [camel k PR #3373](https://github.com/apache/camel-k/pull/3373) depends on this fix