### PR TITLE
Revert "CAMEL-18203: Upgrade to Kotlin 1.7.0"

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -363,7 +363,7 @@
     <jzlib-version>1.1.3</jzlib-version>
     <kafka-version>3.1.1</kafka-version>
     <kafka-vertx-version>2.8.1</kafka-vertx-version>
-    <kotlin-version>1.7.0</kotlin-version>
+    <kotlin-version>1.6.21</kotlin-version>
     <kubernetes-client-version>5.12.2</kubernetes-client-version>
     <kubernetes-model-version>5.12.2</kubernetes-model-version>
     <kudu-version>1.15.0</kudu-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -347,7 +347,7 @@
         <jzlib-version>1.1.3</jzlib-version>
         <kafka-version>3.1.1</kafka-version>
         <kafka-vertx-version>2.8.1</kafka-vertx-version>
-        <kotlin-version>1.7.0</kotlin-version>
+        <kotlin-version>1.6.21</kotlin-version>
         <kubernetes-client-version>5.12.2</kubernetes-client-version>
         <kubernetes-model-version>5.12.2</kubernetes-model-version>
         <kudu-version>1.15.0</kudu-version>


### PR DESCRIPTION
There is no support for Kotlin 1.7.x in Camel Quarkus yet & I couldn't find any workaround to make things work. Hence reverting the upgrade until there is support for 1.7.