### PR TITLE
CAMEL-18141: camel-endpoint-dsl - Generate fluent builders for endpoint headers

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/Endpoint-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/Endpoint-dsl.adoc
@@ -13,11 +13,11 @@ The following is an example of an FTP route using the standard `RouteBuilder` Ja
 ----
 public class MyRoutes extends RouteBuilder {
     @Override
-    public void configure() throws Exception {
-        from("ftp://foo@myserver?password=secret&recursive=true&
-               ftpClient.dataTimeout=30000&
-               ftpClientConfig.serverLanguageCode=fr")
-        .to("bean:doSomething");
+    public void configure() {
+        from("ftp://foo@myserver?password=secret&recursive=true&" +
+                "ftpClient.dataTimeout=30000&" +
+                "ftpClientConfig.serverLanguageCode=fr")
+                .to("bean:doSomething");
     }
 }
 ----
@@ -62,6 +62,28 @@ from(jms("myWMQ", "cheese").concurrentConsumers(5))
 
 Notice how we can refer to their names as the first parameter in the `jms` fluent builder.
 The example would then consume messages from WebSphereMQ queue named cheese and route to ActiveMQ on a queue named smelly.
+
+=== Headers' name
+
+The endpoint-dsl can also be used to be assisted when selecting the name of a header to set or to get. The headers' name builder
+is accessible directly from the method of the class `EndpointRouteBuilder` without argument whose name is the scheme of
+the target component.
+
+In the example below the method `file()` available from `EndpointRouteBuilder`, gives access to the methods corresponding to the name of the headers of the file component. Here the method `fileName()` is called to get the name of the header for the name of the file.
+
+[source,java]
+----
+public class MyRoutes extends EndpointRouteBuilder {
+    @Override
+    public void configure() {
+        from(/*some endpoint*/)
+            // Some route start
+            .setHeader(file().fileName(), constant("foo.txt"))
+            // Some route end
+            ;
+    }
+}
+----
 
 === Using Endpoint-DSL outside route builders
 

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/generics/JavadocUtil.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/generics/JavadocUtil.java
@@ -31,7 +31,21 @@ public final class JavadocUtil {
 
     }
 
+    /**
+     * @param  model the model from which the information are extracted.
+     * @return       the description of the given component with all the possible details.
+     */
     public static String getMainDescription(ComponentModel model) {
+        return getMainDescription(model, true);
+    }
+
+    /**
+     * @param  model                    the model from which the information are extracted.
+     * @param  withPathParameterDetails indicates whether the information about the path parameters should be added to
+     *                                  the description.
+     * @return                          the description of the given component.
+     */
+    public static String getMainDescription(ComponentModel model, boolean withPathParameterDetails) {
         StringBuilder descSb = new StringBuilder(512);
 
         descSb.append(model.getTitle()).append(" (").append(model.getArtifactId()).append(")");
@@ -40,26 +54,28 @@ public final class JavadocUtil {
         descSb.append("\nSince: ").append(model.getFirstVersionShort());
         descSb.append("\nMaven coordinates: ").append(model.getGroupId()).append(":").append(model.getArtifactId());
 
-        // include javadoc for all path parameters and mark which are required
-        descSb.append("\n\nSyntax: <code>").append(model.getSyntax()).append("</code>");
-        for (ComponentModel.EndpointOptionModel option : model.getEndpointOptions()) {
-            if ("path".equals(option.getKind())) {
-                descSb.append("\n\nPath parameter: ").append(option.getName());
-                if (option.isRequired()) {
-                    descSb.append(" (required)");
-                }
-                if (option.isDeprecated()) {
-                    descSb.append(" <strong>deprecated</strong>");
-                }
-                descSb.append("\n").append(option.getDescription());
-                if (option.getDefaultValue() != null) {
-                    descSb.append("\nDefault value: ").append(option.getDefaultValue());
-                }
-                // TODO: default value note ?
-                if (option.getEnums() != null && !option.getEnums().isEmpty()) {
-                    descSb.append("\nThere are ").append(option.getEnums().size())
-                            .append(" enums and the value can be one of: ")
-                            .append(wrapEnumValues(option.getEnums()));
+        if (withPathParameterDetails) {
+            // include javadoc for all path parameters and mark which are required
+            descSb.append("\n\nSyntax: <code>").append(model.getSyntax()).append("</code>");
+            for (ComponentModel.EndpointOptionModel option : model.getEndpointOptions()) {
+                if ("path".equals(option.getKind())) {
+                    descSb.append("\n\nPath parameter: ").append(option.getName());
+                    if (option.isRequired()) {
+                        descSb.append(" (required)");
+                    }
+                    if (option.isDeprecated()) {
+                        descSb.append(" <strong>deprecated</strong>");
+                    }
+                    descSb.append("\n").append(option.getDescription());
+                    if (option.getDefaultValue() != null) {
+                        descSb.append("\nDefault value: ").append(option.getDefaultValue());
+                    }
+                    // TODO: default value note ?
+                    if (option.getEnums() != null && !option.getEnums().isEmpty()) {
+                        descSb.append("\nThere are ").append(option.getEnums().size())
+                                .append(" enums and the value can be one of: ")
+                                .append(wrapEnumValues(option.getEnums()));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-18141

## Motivation

Now that every component has marked up the headers it supports, we can use that to generate fluent builders in camel-endpointdsl.

## Modifications:

* Generates a new static inner class to propose all the headers' name of a component in the corresponding `EndpointBuilderFactory` interface
* Generates a new method without parameter into the `Builders` interface to have access to the builder of the headers' name. 
* Adds some doc about this feature
* Fixes an example of from `Endpoint-dsl.adoc` (not related to the initial issue)

## Result

Example of what is generated for the file component:

```
...
@Generated("org.apache.camel.maven.packaging.EndpointDslMojo")
public interface FileEndpointBuilderFactory {
...
    public interface FileBuilders {
        /**
         * File (camel-file)
         * Read and write files.
         * 
         * Category: file,core
         * Since: 1.0
         * Maven coordinates: org.apache.camel:camel-file
         * 
         * @return the dsl builder for the headers' name.
         */
        default FileHeaderNameBuilder file() {
            return FileHeaderNameBuilder.INSTANCE;
        }
        ...
    }

    /**
     * The builder of headers' name for the File component.
     */
    public static class FileHeaderNameBuilder {
        /**
         * The internal instance of the builder used to access to all the
         * methods representing the name of headers.
         */
        private static final FileHeaderNameBuilder INSTANCE = new FileHeaderNameBuilder();

        /**
         * A long value containing the file size.
         * 
         * The option is a: {@code long} type.
         * 
         * Group: consumer
         * 
         * @return the name of the header {@code FileLength}.
         */
        public String fileLength() {
            return "FileLength";
        }
        ...
```