### PR TITLE
CAMEL-18125 fix multi node Kafka resume strategy empty cache

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/processor/resume/kafka/MultiNodeKafkaResumeStrategy.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/processor/resume/kafka/MultiNodeKafkaResumeStrategy.java
@@ -66,9 +66,7 @@ public class MultiNodeKafkaResumeStrategy<K extends Resumable> extends SingleNod
                                         ExecutorService executorService) {
         super(resumeStrategyConfiguration);
 
-        // We need to keep refreshing the cache
         this.executorService = executorService;
-        executorService.submit(() -> refresh());
     }
 
     protected void poll() {
@@ -96,10 +94,17 @@ public class MultiNodeKafkaResumeStrategy<K extends Resumable> extends SingleNod
         } while (true);
     }
 
+    @Override
+    public void loadCache() throws Exception {
+        super.loadCache();
+
+        executorService.submit(() -> refresh());
+    }
+
     /**
      * Launch a thread to refresh the offsets periodically
      */
-    protected void refresh() {
+    private void refresh() {
         LOG.trace("Creating a offset cache refresher");
         try {
             Properties prop = (Properties) getResumeStrategyConfiguration().getConsumerProperties().clone();


### PR DESCRIPTION
In multi-node setups (clustering), loading the cache should also be delayed until the component is starting


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->