### PR TITLE
CAMEL-18215: camel-test - Enable JMX when camel-debug is detected

### DIFF
--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -84,6 +84,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
+import static org.apache.camel.test.junit5.TestSupport.isCamelDebugPresent;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -415,10 +416,9 @@ public abstract class CamelTestSupport
 
     protected void doSetUp() throws Exception {
         LOG.debug("setUp test");
-        // jmx is enabled if we have configured to use it, or if dump route
-        // coverage is enabled (it requires JMX)
-        boolean jmx = useJmx() || isRouteCoverageEnabled();
-        if (jmx) {
+        // jmx is enabled if we have configured to use it, if dump route coverage is enabled (it requires JMX) or if
+        // the component camel-debug is in the classpath
+        if (useJmx() || isRouteCoverageEnabled() || isCamelDebugPresent()) {
             enableJMX();
         } else {
             disableJMX();

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/TestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/TestSupport.java
@@ -36,6 +36,8 @@ import org.apache.camel.builder.Builder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.builder.ValueBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.spi.Debugger;
+import org.apache.camel.spi.FactoryFinder;
 import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.support.PredicateAssertHelper;
 import org.slf4j.Logger;
@@ -601,4 +603,16 @@ public final class TestSupport {
         }
     }
 
+    /**
+     * Indicates whether the component {@code camel-debug} is present in the classpath of the test.
+     *
+     * @return {@code true} if it is present, {@code false} otherwise.
+     */
+    public static boolean isCamelDebugPresent() {
+        // Needs to be detected before initializing and starting the camel context
+        return Thread.currentThread()
+                .getContextClassLoader()
+                .getResource(String.format("%s%s", FactoryFinder.DEFAULT_PATH, Debugger.FACTORY))
+               != null;
+    }
 }

--- a/components/camel-test/camel-test-main-junit5/src/main/java/org/apache/camel/test/main/junit5/CamelMainExtension.java
+++ b/components/camel-test/camel-test-main-junit5/src/main/java/org/apache/camel/test/main/junit5/CamelMainExtension.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.test.junit5.CamelTestSupport.ROUTE_COVERAGE_ENABLED;
+import static org.apache.camel.test.junit5.TestSupport.isCamelDebugPresent;
 import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.create;
 
 /**
@@ -72,7 +73,7 @@ final class CamelMainExtension
     private final CamelRouteCoverageDumper routeCoverageDumper = new CamelRouteCoverageDumper();
 
     @Override
-    public void beforeEach(ExtensionContext context) throws Exception {
+    public void beforeEach(ExtensionContext context) {
         getContextStore(context).getOrComputeIfAbsent(CONTEXT, k -> createCamelMainContextAndStart(context));
     }
 
@@ -109,7 +110,7 @@ final class CamelMainExtension
     private CamelMainContext createCamelMainContextAndStart(ExtensionContext context) {
         try {
             final CamelMainContext camelMainContext = CamelMainContext.builder(context)
-                    .useJmx(useJmx(context) || isRouteCoverageEnabled(context))
+                    .useJmx(useJmx(context) || isRouteCoverageEnabled(context) || isCamelDebugPresent())
                     .build();
             camelMainContext.start();
             return camelMainContext;

--- a/components/camel-test/camel-test-spring-junit5/src/main/java/org/apache/camel/test/spring/junit5/CamelAnnotationsHandler.java
+++ b/components/camel-test/camel-test-spring-junit5/src/main/java/org/apache/camel/test/spring/junit5/CamelAnnotationsHandler.java
@@ -44,6 +44,8 @@ import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.annotation.AnnotationUtils;
 
+import static org.apache.camel.test.junit5.TestSupport.isCamelDebugPresent;
+
 public final class CamelAnnotationsHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CamelAnnotationsHandler.class);
@@ -93,7 +95,10 @@ public final class CamelAnnotationsHandler {
      * @param testClass the test class being executed
      */
     public static void handleDisableJmx(ConfigurableApplicationContext context, Class<?> testClass) {
-        if (testClass.isAnnotationPresent(DisableJmx.class)) {
+        if (isCamelDebugPresent()) {
+            LOGGER.info("Enabling Camel JMX as camel-debug has been found in the classpath.");
+            DefaultCamelContext.setDisableJmx(false);
+        } else if (testClass.isAnnotationPresent(DisableJmx.class)) {
             if (testClass.getAnnotation(DisableJmx.class).value()) {
                 LOGGER.info("Disabling Camel JMX globally as DisableJmx annotation was found and disableJmx is set to true.");
                 DefaultCamelContext.setDisableJmx(true);


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18215

## Motivation

When `camel-debug` is on the classpath, the intent is to use the `Camel Backlog Debugger` which is based on JMX.
It would be nice in tests that we do not need to override the method `useJmx` as it is implicitly needed by `camel-debug`.

## Modifications:

* Adds the method `isCamelDebugPresent` to the utility class `CamelTestSupport` to detect `camel-debug` before initializing the Camel context.
* Calls this new method in all Camel test JUnit 5 components to automatically enable JMX when `camel-debug` is detected

## Result

Tested with success with `camel-test-junit5`, `camel-test-main-junit5` and `camel-test-spring-junit5`. Won't work with all Camel test JUnit 4 components.