### PR TITLE
CAMEL-18217: debugger - Allow to suspend messages using a system property

### DIFF
--- a/core/camel-management/src/test/java/org/apache/camel/management/BacklogDebuggerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/BacklogDebuggerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.junitpioneer.jupiter.SetSystemProperty;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -893,11 +894,35 @@ public class BacklogDebuggerTest extends ManagementTestSupport {
     }
 
     /**
-     * Ensure that the suspend mode works as expected.
+     * Ensure that the suspend mode works as expected when it is set using an environment variable.
      */
     @Test
     @SetEnvironmentVariable(key = BacklogDebugger.SUSPEND_MODE_ENV_VAR_NAME, value = "true")
-    public void testSuspendMode() throws Exception {
+    public void testSuspendModeConfiguredWithEnvVariable() throws Exception {
+        testSuspendMode();
+    }
+
+    /**
+     * Ensure that the suspend mode works as expected when it is set using a system property.
+     */
+    @Test
+    @SetSystemProperty(key = BacklogDebugger.SUSPEND_MODE_SYSTEM_PROP_NAME, value = "true")
+    public void testSuspendModeConfiguredWithSystemProperty() throws Exception {
+        testSuspendMode();
+    }
+
+    /**
+     * Ensure that the suspend mode works as expected when it is configured by relying on the precedence of the env
+     * variable over the system property.
+     */
+    @Test
+    @SetEnvironmentVariable(key = BacklogDebugger.SUSPEND_MODE_ENV_VAR_NAME, value = "true")
+    @SetSystemProperty(key = BacklogDebugger.SUSPEND_MODE_SYSTEM_PROP_NAME, value = "false")
+    public void testSuspendModeConfiguredWithBoth() throws Exception {
+        testSuspendMode();
+    }
+
+    private void testSuspendMode() throws Exception {
         MBeanServer mbeanServer = getMBeanServer();
         ObjectName on = new ObjectName(
                 "org.apache.camel:context=" + context.getManagementName() + ",type=tracer,name=BacklogDebugger");

--- a/docs/user-manual/modules/ROOT/pages/debugger.adoc
+++ b/docs/user-manual/modules/ROOT/pages/debugger.adoc
@@ -93,8 +93,9 @@ which can be used to extend for custom implementations.
 There is also a xref:backlog-debugger.adoc[Backlog Debugger] which allows debugging from JMX that is included into `camel-debug`.
 
 To be able to have enough time to add your breakpoints, you could need to suspend the message processing of Camel to make sure
-that you won't miss any messages. For this kind of need, you have to set the environment variable `CAMEL_DEBUGGER_SUSPEND` to `true`
-within the context of your application, then the `Backlog Debugger` suspends the message processing until the JMX operation `attach` is called. Calling the JMX operation `detach` suspends again the message processing.
+that you won't miss any messages. For this kind of need, you have to set either the environment variable `CAMEL_DEBUGGER_SUSPEND` or the system property `org.apache.camel.debugger.suspend` to `true` within the context of your application, then the `Backlog Debugger` suspends the message processing until the JMX operation `attach` is called. Calling the JMX operation `detach` suspends again the message processing.
+
+In case the environment variable and the system property are both set, the value of the environment variable is used.
 
 Several 3rd party tooling are using it:
 - https://hawt.io/[hawtio] uses this for its web based debugging functionality


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18217 (part 2)

## Motivation

What has been done in the first part of this feature is good but for the sake of simplicity it is also interesting to have the ability to configure it using a System property.

## Modifications:

* Allow to use the system property `org.apache.camel.debugger.suspend` to configure the `suspend mode`
* Ensure that the environment variable takes precedence over the system property
* Add the corresponding test and doc.
* Remove the log message that was for debugging purpose

## Result

It is now possible to configure the `suspend mode` using the system property `org.apache.camel.debugger.suspend`.