### PR TITLE
CAMEL-18223: camel-plugin - Propose a goal to debug with the textual route debugger

### DIFF
--- a/tooling/maven/camel-maven-plugin/src/main/docs/camel-maven-plugin.adoc
+++ b/tooling/maven/camel-maven-plugin/src/main/docs/camel-maven-plugin.adoc
@@ -114,6 +114,19 @@ The maven plugin *dev* goal supports the following options which can be configur
 | loggingLevel | OFF | Whether to use built-in console logging (uses log4j), which does not require to add any logging dependency to your project. However, the logging is fixed to log to the console, with a color style that is similar to Spring Boot. You can change the root logging level to: FATAL, ERROR, WARN, INFO, DEBUG, TRACE, OFF
 |===
 
+== camel:debug
+
+The `camel:debug` is an extension to `camel:dev` to run the Camel application in debug mode which allows to debug the Camel routes thanks to the Camel textual route debugger.
+
+=== Options
+
+The maven plugin *debug* goal supports the following options which can be configured from the command line (use `-D` syntax), or defined in the `pom.xml` file in the `<configuration>` tag.
+
+|===
+| Parameter | Default Value | Description
+| suspend | true | Indicates whether the message processing done by Camel should be suspended as long as a debugger is not attached.
+|===
+
 == camel:prepare-fatjar
 
 The `camel:prepare-fatjar` goal of the Camel Maven Plugin is used to prepare your Camel application

--- a/tooling/maven/camel-maven-plugin/src/main/java/org/apache/camel/maven/DebugMojo.java
+++ b/tooling/maven/camel-maven-plugin/src/main/java/org/apache/camel/maven/DebugMojo.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.camel.impl.debugger.BacklogDebugger;
+import org.apache.camel.util.CastUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
+import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * The maven goal allowing to automatically set up the Camel application in order to debug the Camel routes thanks to
+ * the Camel textual Route Debugger.
+ */
+@Mojo(name = "debug", defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
+      requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+public class DebugMojo extends DevMojo {
+
+    /**
+     * Indicates whether the message processing done by Camel should be suspended as long as a debugger is not attached.
+     */
+    @Parameter(property = "camel.suspend", defaultValue = "true")
+    private boolean suspend;
+
+    @Parameter(defaultValue = "${mojoExecution}", readonly = true)
+    private MojoExecution mojo;
+
+    @Parameter(defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    @Override
+    protected void beforeBootstrapCamel() throws Exception {
+        super.beforeBootstrapCamel();
+
+        // Enable JMX
+        System.setProperty("org.apache.camel.jmx.disabled", "false");
+        // Enable the suspend mode.
+        System.setProperty(BacklogDebugger.SUSPEND_MODE_SYSTEM_PROP_NAME, Boolean.toString(suspend));
+        String suspendMode = System.getenv(BacklogDebugger.SUSPEND_MODE_ENV_VAR_NAME);
+        if (suspendMode != null && Boolean.parseBoolean(suspendMode) != suspend) {
+            throw new MojoExecutionException(
+                    String.format(
+                            "The environment variable %s has been set and prevents to configure the suspend mode. Please remove it first.",
+                            BacklogDebugger.SUSPEND_MODE_ENV_VAR_NAME));
+        }
+    }
+
+    @Override
+    protected String goal() {
+        return "camel:debug";
+    }
+
+    @Override
+    protected List<Artifact> getClasspath() throws MojoExecutionException, MojoFailureException {
+        List<Artifact> classpath = super.getClasspath();
+        if (classpath.stream().anyMatch(artifact -> "org.apache.camel".equals(artifact.getGroupId())
+                && "camel-debug".equals(artifact.getArtifactId()))) {
+            getLog().debug("The component camel-debug has been detected in the classpath so no need to add it");
+            return classpath;
+        }
+        getLog().info("The component camel-debug is not available in the classpath, it will be added automatically");
+        Optional<String> camelCoreVersion = classpath.stream()
+                .filter(artifact -> "org.apache.camel".equals(artifact.getGroupId())
+                        && Objects.nonNull(artifact.getArtifactId()) && artifact.getArtifactId().startsWith("camel-core"))
+                .map(Artifact::getBaseVersion)
+                .filter(Objects::nonNull)
+                .findAny();
+        if (camelCoreVersion.isEmpty()) {
+            getLog().info("The version of Camel could not be detected, the version of the plugin will be used instead");
+            addCamelDebug(classpath, mojo.getVersion());
+            return classpath;
+        }
+        addCamelDebug(classpath, camelCoreVersion.get());
+        return classpath;
+    }
+
+    /**
+     * Automatically retrieve the given version of camel-debug and add it to the classpath if it can be found.
+     *
+     * @param classpath the classpath to which camel-debug and its dependencies are added.
+     * @param version   the version of camel-debug to retrieve.
+     */
+    private void addCamelDebug(List<Artifact> classpath, String version) {
+        getLog().debug(String.format("Trying to retrieve the version %s of camel-debug", version));
+        ArtifactResolutionRequest request = new ArtifactResolutionRequest();
+        request.setResolveRoot(true);
+        request.setResolveTransitively(true);
+        request.setLocalRepository(session.getLocalRepository());
+        request.setRemoteRepositories(session.getCurrentProject().getRemoteArtifactRepositories());
+        request.setOffline(session.isOffline());
+        request.setForceUpdate(session.getRequest().isUpdateSnapshots());
+        request.setServers(session.getRequest().getServers());
+        request.setMirrors(session.getRequest().getMirrors());
+        request.setProxies(session.getRequest().getProxies());
+        request.setManagedVersionMap(Collections.emptyMap());
+        request.setArtifact(
+                new DefaultArtifact(
+                        "org.apache.camel", "camel-debug", version, Artifact.SCOPE_RUNTIME, "jar", null,
+                        new DefaultArtifactHandler("jar")));
+        request.setResolutionFilter(new ScopeArtifactFilter(Artifact.SCOPE_RUNTIME));
+        ArtifactResolutionResult result = artifactResolver.resolve(request);
+        if (result.isSuccess()) {
+            getLog().info(String.format("Adding the version %s of camel-debug", version));
+            classpath.addAll(CastUtils.cast(result.getArtifacts()));
+            return;
+        }
+
+        if (result.hasMissingArtifacts()) {
+            getLog().warn(
+                    String.format(
+                            "Could not find the artifacts: %s",
+                            result.getMissingArtifacts().stream().map(Objects::toString).collect(Collectors.joining(", "))));
+        }
+        if (result.hasExceptions()) {
+            result.getExceptions().forEach(
+                    ex -> getLog().warn(String.format("An error occurred while retrieving camel-debug: %s", ex.getMessage())));
+        }
+    }
+}


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18223

## Motivation

The textual route Debugger has several requirements to make it work properly thus it could be interesting to propose a new maven goal to the camel plugin to set up everything automatically. 

## Modifications:

* Add `DebugMojo` for the goal `debug` to add `camel-debug` to the classpath automatically, to enable JMX and to configure the suspend mode
* Rewrite `RunMojo` to have access to all the artifacts that we have in the classpath in order to easily detect `camel-debug` and retrieve the Camel version.

## Result

Launching an application with `mvn camel:debug` is enough to debug Camel routes. Tested successfully with https://github.com/apache/camel-examples/tree/main/examples/main 