### PR TITLE
Try to discover the jsonDir if it is null

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/ComponentDslMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/ComponentDslMojo.java
@@ -122,8 +122,12 @@ public class ComponentDslMojo extends AbstractGeneratorMojo {
         }
 
         if (jsonDir == null) {
-            getLog().debug("No json directory folder found, skipping execution");
-            return;
+            jsonDir = findCamelDirectory(baseDir, "catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components");
+
+            if (jsonDir == null) {
+                getLog().debug("No json directory folder found, skipping execution");
+                return;
+            }
         }
 
         Path root = camelDir.toPath();


### PR DESCRIPTION
Running ComponentDslMojo programmatically outside of camel-package-maven-plugin is difficult because of how jsonDir is being set.     Need to check if jsonDir is null, camelDirectory() provides a mechanism for discovering it if it is not set correctly.