### PR TITLE
[3.14.x] Upgrade to com.alibaba:fastjson:1.2.83, fix CVE-2022-25845 fastjson: …

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -193,7 +193,7 @@
     <etcd4j-version>2.18.0</etcd4j-version>
     <exec-maven-plugin-version>1.6.0</exec-maven-plugin-version>
     <facebook4j-core-version>2.4.13</facebook4j-core-version>
-    <fastjson-version>1.2.78</fastjson-version>
+    <fastjson-version>1.2.83</fastjson-version>
     <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
     <flatpack-version>4.0.5</flatpack-version>
     <flink-version>1.14.0</flink-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -174,7 +174,7 @@
         <etcd4j-version>2.18.0</etcd4j-version>
         <exec-maven-plugin-version>1.6.0</exec-maven-plugin-version>
         <facebook4j-core-version>2.4.13</facebook4j-core-version>
-        <fastjson-version>1.2.78</fastjson-version>
+        <fastjson-version>1.2.83</fastjson-version>
         <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
         <google-maps-services-version>0.10.1</google-maps-services-version>
         <flatpack-version>4.0.5</flatpack-version>


### PR DESCRIPTION
…autoType shutdown restriction bypass leads to deserialization

Note that fastjson is already on 1.2.83 in the main branch