### PR TITLE
CAMEL-18263: Fix tests of BacklogDebuggerTest failing on Java 17

### DIFF
--- a/core/camel-management/pom.xml
+++ b/core/camel-management/pom.xml
@@ -317,5 +317,21 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>jdk17-build</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18263

## Motivation

The tests `testSuspendModeConfiguredWithBoth` and `testSuspendModeConfiguredWithEnvVariable` of `BacklogDebuggerTest` are both failing on Java 17 as we can see here https://ci-builds.apache.org/job/Camel/job/Camel%20JDK16/job/main/334/testReport/junit/org.apache.camel.management/

## Modifications:

* Adds a new maven profile enabled on Java 17+ to open the required packages