### PR TITLE
CAMEL-18278: Get outputs from last abstract parent

### DIFF
--- a/components/camel-test/camel-test-spring-junit5/src/test/java/org/apache/camel/test/issues/AdviceWithOnExceptionTransacted.java
+++ b/components/camel-test/camel-test-spring-junit5/src/test/java/org/apache/camel/test/issues/AdviceWithOnExceptionTransacted.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.issues;
+
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+
+import static org.apache.camel.builder.Builder.constant;
+
+public class AdviceWithOnExceptionTransacted extends CamelSpringTestSupport {
+
+    @Override
+    protected AbstractApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("org/apache/camel/test/issues/AdviceWithOnExceptionTransacted.xml");
+    }
+
+    @Override
+    public boolean isUseAdviceWith() {
+        return true;
+    }
+
+    @Override
+    protected void bindToRegistry(Registry registry) throws Exception {
+        registry.bind("tx", new PlatformTransactionManager() {
+            @Override
+            public TransactionStatus getTransaction(TransactionDefinition definition) throws TransactionException {
+                return null;
+            }
+
+            @Override
+            public void commit(TransactionStatus status) throws TransactionException {
+            }
+
+            @Override
+            public void rollback(TransactionStatus status) throws TransactionException {
+            }
+        });
+    }
+
+    @Test
+    public void testAddFirstWithOnException() throws Exception {
+        AdviceWith.adviceWith(context, "advice-with-on-exception-transacted-test-route", a -> {
+            a.weaveAddFirst().transform(constant("Bye World"));
+        });
+
+        context.start();
+
+        getMockEndpoint("mock:result").expectedBodiesReceived("Bye World");
+
+        template.sendBody("direct:start", "Hello World");
+
+        assertMockEndpointsSatisfied();
+    }
+}

--- a/components/camel-test/camel-test-spring-junit5/src/test/resources/org/apache/camel/test/issues/AdviceWithOnExceptionTransacted.xml
+++ b/components/camel-test/camel-test-spring-junit5/src/test/resources/org/apache/camel/test/issues/AdviceWithOnExceptionTransacted.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:camel="http://camel.apache.org/schema/spring"
+       xsi:schemaLocation="
+        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd ">
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <route id="advice-with-on-exception-transacted-test-route">
+            <from uri="direct:start"/>
+            <onException>
+                <exception>java.lang.Exception</exception>
+                <handled>
+                    <constant>true</constant>
+                </handled>
+            </onException>
+            <transacted/>
+            <log message="${body}"/>
+            <to uri="mock:result"/>
+        </route>
+    </camelContext>
+</beans>

--- a/core/camel-core-model/src/main/java/org/apache/camel/builder/AdviceWithTasks.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/builder/AdviceWithTasks.java
@@ -465,9 +465,16 @@ public final class AdviceWithTasks {
             return node.getOutputs();
         }
         List<ProcessorDefinition<?>> outputs = parent.getOutputs();
-        if (outputs.size() == 1 && outputs.get(0).isAbstract()) {
-            // if the output is abstract then get its output, as
-            outputs = outputs.get(0).getOutputs();
+        boolean allAbstract = true;
+        for (ProcessorDefinition<?> def : outputs) {
+            allAbstract &= def.isAbstract();
+            if (!allAbstract) {
+                break;
+            }
+        }
+        if (outputs.size() >= 1 && allAbstract) {
+            // if all outputs are abstract then get its last output, as
+            outputs = outputs.get(outputs.size() - 1).getOutputs();
         }
         return outputs;
     }


### PR DESCRIPTION
If node parent is of type RouteDefinition and every output is abstract, then use last output for further advice processing.