### PR TITLE
CAMEL-18291: SSLContextParameters parsePropertyValue support for cert…

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/support/jsse/SSLContextParameters.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/jsse/SSLContextParameters.java
@@ -276,7 +276,7 @@ public class SSLContextParameters extends BaseSSLContextParameters {
                 if (keyManagers[idx] instanceof X509KeyManager) {
                     try {
                         keyManagers[idx] = new AliasedX509ExtendedKeyManager(
-                                this.getCertAlias(),
+                                this.parsePropertyValue(this.getCertAlias()),
                                 (X509KeyManager) keyManagers[idx]);
                     } catch (Exception e) {
                         throw new GeneralSecurityException(e);


### PR DESCRIPTION
Issue - https://issues.apache.org/jira/browse/CAMEL-18291

Added support of parsePropertyValue for certAlias property.