### PR TITLE
(chores) ci: fixes invalid log instantiation

### DIFF
--- a/dsl/camel-endpointdsl/pom.xml
+++ b/dsl/camel-endpointdsl/pom.xml
@@ -83,6 +83,10 @@
                     <groupId>org.apache.drill.exec</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
The hadoop-common dependency causes the code to instantiate a different
Logger type which, leads to an invalid evaluation of the log level. This
causes the exchange formatter to not run which causes the test to fail.

This was introduced by upgrading hadoop libraries in 7fdf3ac65fb8d57682a565b9f31a03d046a182e0

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->