### PR TITLE
Errors in Unit-tests for camel-jetty component are solved

### DIFF
--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/ExcludeCipherSuitesTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/ExcludeCipherSuitesTest.java
@@ -31,7 +31,7 @@ public class ExcludeCipherSuitesTest extends BaseJettyTest {
 
     private SSLContextParameters createSslContextParameters() {
         KeyStoreParameters ksp = new KeyStoreParameters();
-        ksp.setResource(this.getClass().getClassLoader().getResource("jsse/localhost.p12").toString());
+        ksp.setResource("file://" + this.getClass().getClassLoader().getResource("jsse/localhost.p12").toString());
         ksp.setPassword(pwd);
 
         KeyManagersParameters kmp = new KeyManagersParameters();

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/ExplicitHttpsSslContextParametersRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/ExplicitHttpsSslContextParametersRouteTest.java
@@ -35,7 +35,7 @@ public class ExplicitHttpsSslContextParametersRouteTest extends HttpsRouteTest {
     // START SNIPPET: e2
     private Connector createSslSocketConnector(CamelContext context, int port) {
         KeyStoreParameters ksp = new KeyStoreParameters();
-        ksp.setResource(this.getClass().getClassLoader().getResource("jsse/localhost.p12").toString());
+        ksp.setResource("file://" + this.getClass().getClassLoader().getResource("jsse/localhost.p12").toString());
         ksp.setPassword(pwd);
 
         KeyManagersParameters kmp = new KeyManagersParameters();

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsAsyncRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsAsyncRouteTest.java
@@ -60,7 +60,7 @@ public class HttpsAsyncRouteTest extends HttpsRouteTest {
         // cert,
         // use the server keystore as the trust store for these tests
         URL trustStoreUrl = this.getClass().getClassLoader().getResource("jsse/localhost.p12");
-        setSystemProp("javax.net.ssl.trustStore", trustStoreUrl.toURI().getPath());
+        setSystemProp("javax.net.ssl.trustStore", "file://" + trustStoreUrl.toURI().getPath());
         setSystemProp("javax.net.ssl.trustStorePassword", "changeit");
         setSystemProp("javax.net.ssl.trustStoreType", "PKCS12");
     }
@@ -193,7 +193,7 @@ public class HttpsAsyncRouteTest extends HttpsRouteTest {
                 componentJetty.setSslPassword(pwd);
                 componentJetty.setSslKeyPassword(pwd);
                 URL keyStoreUrl = this.getClass().getClassLoader().getResource("jsse/localhost.p12");
-                componentJetty.setKeystore(keyStoreUrl.toURI().getPath());
+                componentJetty.setKeystore("file://" + keyStoreUrl.toURI().getPath());
 
                 from("jetty:https://localhost:" + port1 + "/test?async=true&useContinuation=false").to("mock:a");
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteAddSslConnectorPropertiesTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteAddSslConnectorPropertiesTest.java
@@ -36,7 +36,7 @@ public class HttpsRouteAddSslConnectorPropertiesTest extends HttpsRouteTest {
                 // START SNIPPET: e1
                 // keystore path
                 URL keyStoreUrl = this.getClass().getClassLoader().getResource("jsse/localhost.p12");
-                String path = keyStoreUrl.toURI().getPath();
+                String path = "file://" + keyStoreUrl.toURI().getPath();
 
                 JettyHttpComponent jetty = context.getComponent("jetty", JettyHttpComponent.class);
                 setSSLProps(jetty, path, pwd, pwd);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteSetupWithSystemPropsTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteSetupWithSystemPropsTest.java
@@ -36,11 +36,11 @@ public class HttpsRouteSetupWithSystemPropsTest extends HttpsRouteTest {
         // cert,
         // use the server keystore as the trust store for these tests
         URL trustStoreUrl = this.getClass().getClassLoader().getResource("jsse/localhost.p12");
-        setSystemProp("javax.net.ssl.trustStore", trustStoreUrl.getPath());
+        setSystemProp("javax.net.ssl.trustStore", "file://" + trustStoreUrl.getPath());
 
         // START SNIPPET: e1
         // setup SSL using system properties
-        setSystemProp("org.eclipse.jetty.ssl.keystore", trustStoreUrl.getPath());
+        setSystemProp("org.eclipse.jetty.ssl.keystore", "file://" + trustStoreUrl.getPath());
         setSystemProp("org.eclipse.jetty.ssl.keypassword", pwd);
         setSystemProp("org.eclipse.jetty.ssl.password", pwd);
         setSystemProp("jdk.tls.client.protocols", "TLSv1.2");

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteTest.java
@@ -187,7 +187,7 @@ public class HttpsRouteTest extends BaseJettyTest {
         sslContextFactory.setKeyStorePassword(pwd);
         URL keyStoreUrl = this.getClass().getClassLoader().getResource("jsse/localhost.p12");
         try {
-            sslContextFactory.setKeyStorePath(keyStoreUrl.toURI().getPath());
+            sslContextFactory.setKeyStorePath("file://" + keyStoreUrl.toURI().getPath());
         } catch (URISyntaxException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -203,7 +203,7 @@ public class HttpsRouteTest extends BaseJettyTest {
                 componentJetty.setSslPassword(pwd);
                 componentJetty.setSslKeyPassword(pwd);
                 URL keyStoreUrl = this.getClass().getClassLoader().getResource("jsse/localhost.p12");
-                componentJetty.setKeystore(keyStoreUrl.toURI().getPath());
+                componentJetty.setKeystore("file://" + keyStoreUrl.toURI().getPath());
 
                 from("jetty:https://localhost:" + port1 + "/test").to("mock:a");
 

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteWithSslConnectorPropertiesTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteWithSslConnectorPropertiesTest.java
@@ -32,7 +32,7 @@ public class HttpsRouteWithSslConnectorPropertiesTest extends HttpsRouteTest {
                 // START SNIPPET: e1
                 // keystore path
                 URL keyStoreUrl = this.getClass().getClassLoader().getResource("jsse/localhost.p12");
-                String path = keyStoreUrl.toURI().getPath();
+                String path = "file://" + keyStoreUrl.toURI().getPath();
 
                 JettyHttpComponent jetty = getContext().getComponent("jetty", JettyHttpComponent.class);
                 setSSLProps(jetty, path, pwd, pwd);

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/SpringHttpsRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/SpringHttpsRouteTest.java
@@ -72,7 +72,7 @@ public class SpringHttpsRouteTest {
         // cert,
         // use the server keystore as the trust store for these tests
         URL trustStoreUrl = Thread.currentThread().getContextClassLoader().getResource("jsse/localhost.p12");
-        setSystemProp("javax.net.ssl.trustStore", trustStoreUrl.getPath());
+        setSystemProp("javax.net.ssl.trustStore", "file://" + trustStoreUrl.getPath());
     }
 
     @AfterEach

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/TwoCamelContextWithJettyRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/TwoCamelContextWithJettyRouteTest.java
@@ -16,17 +16,18 @@
  */
 package org.apache.camel.component.jetty;
 
+import java.io.IOException;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.http.NoHttpResponseException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TwoCamelContextWithJettyRouteTest extends BaseJettyTest {
 
@@ -60,7 +61,7 @@ public class TwoCamelContextWithJettyRouteTest extends BaseJettyTest {
 
         Exception ex = assertThrows(Exception.class,
                 () -> template.requestBody("direct:b", "Moon", String.class));
-        assertTrue(ex.getCause() instanceof NoHttpResponseException, "Should get the ConnectException");
+        assertInstanceOf(IOException.class, ex.getCause(), "Should get the IOException");
     }
 
     @Override


### PR DESCRIPTION
Some of junit-tests in component camel-jetty are broken. In this PR their functionality is restored.
Note: these unit-tests will be very helpful for some big changes like [Migration to Jakarta EE ](https://github.com/apache/camel/pull/7116).