### PR TITLE
Unit-tests improvements

### DIFF
--- a/components/camel-bean-validator/src/test/java/org/apache/camel/component/bean/validator/BeanValidatorConfigurationTest.java
+++ b/components/camel-bean-validator/src/test/java/org/apache/camel/component/bean/validator/BeanValidatorConfigurationTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.condition.OS.AIX;
 
+@DisabledOnOs(AIX)
 public class BeanValidatorConfigurationTest extends CamelTestSupport {
 
     @BindToRegistry("myMessageInterpolator")
@@ -56,14 +57,12 @@ public class BeanValidatorConfigurationTest extends CamelTestSupport {
         super.setUp();
     }
 
-    @DisabledOnOs(AIX)
     @Test
     void configureWithDefaults() {
         BeanValidatorEndpoint endpoint = context.getEndpoint("bean-validator://x", BeanValidatorEndpoint.class);
         assertNull(endpoint.getGroup());
     }
 
-    @DisabledOnOs(AIX)
     @Test
     void configureBeanValidator() {
         BeanValidatorEndpoint endpoint = context

--- a/components/camel-bean-validator/src/test/java/org/apache/camel/component/bean/validator/BeanValidatorRouteTest.java
+++ b/components/camel-bean-validator/src/test/java/org/apache/camel/component/bean/validator/BeanValidatorRouteTest.java
@@ -42,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.condition.OS.AIX;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisabledOnOs(AIX)
 class BeanValidatorRouteTest extends CamelTestSupport {
     private Locale origLocale;
 
@@ -56,7 +57,6 @@ class BeanValidatorRouteTest extends CamelTestSupport {
         Locale.setDefault(origLocale);
     }
 
-    @DisabledOnOs(AIX)
     @ParameterizedTest
     @MethodSource("provideValidCars")
     void validateShouldSuccessWithImpliciteDefaultGroup(Object cars) {
@@ -70,7 +70,6 @@ class BeanValidatorRouteTest extends CamelTestSupport {
         assertNotNull(exchange);
     }
 
-    @DisabledOnOs(AIX)
     @ParameterizedTest
     @MethodSource("provideValidCars")
     void validateShouldSuccessWithExpliciteDefaultGroup(Object cars) {
@@ -84,7 +83,6 @@ class BeanValidatorRouteTest extends CamelTestSupport {
         assertNotNull(exchange);
     }
 
-    @DisabledOnOs(AIX)
     @ParameterizedTest
     @MethodSource("provideInvalidCarsWithoutLicensePlate")
     void validateShouldFailWithImpliciteDefaultGroup(Object cars, int numberOfViolations) {
@@ -119,7 +117,6 @@ class BeanValidatorRouteTest extends CamelTestSupport {
         assertNotNull(exchange);
     }
 
-    @DisabledOnOs(AIX)
     @ParameterizedTest
     @MethodSource("provideInvalidCarsWithoutLicensePlate")
     void validateShouldFailWithExpliciteDefaultGroup(Object cars, int numberOfViolations) {
@@ -154,7 +151,6 @@ class BeanValidatorRouteTest extends CamelTestSupport {
         assertNotNull(exchange);
     }
 
-    @DisabledOnOs(AIX)
     @ParameterizedTest
     @MethodSource("provideInvalidCarsWithShortLicensePlate")
     void validateShouldFailWithOptionalChecksGroup(Object cars, int numberOfViolations) {
@@ -189,7 +185,6 @@ class BeanValidatorRouteTest extends CamelTestSupport {
         assertNotNull(exchange);
     }
 
-    @DisabledOnOs(AIX)
     @ParameterizedTest
     @MethodSource("provideInvalidCarsWithoutManufacturer")
     void validateShouldFailWithOrderedChecksGroup(Object cars, int numberOfViolations) {
@@ -243,7 +238,6 @@ class BeanValidatorRouteTest extends CamelTestSupport {
         assertNotNull(exchange);
     }
 
-    @DisabledOnOs(AIX)
     @ParameterizedTest
     @MethodSource("provideCarsWithRedefinedDefaultGroup")
     void validateShouldSuccessWithRedefinedDefaultGroup(Object cars) {
@@ -259,7 +253,6 @@ class BeanValidatorRouteTest extends CamelTestSupport {
         assertNotNull(exchange);
     }
 
-    @DisabledOnOs(AIX)
     @ParameterizedTest
     @MethodSource("provideCarsWithRedefinedDefaultGroupAndShortLicencePlate")
     void validateShouldFailWithRedefinedDefaultGroup(Object cars, int numberOfViolations) {

--- a/components/camel-bean-validator/src/test/java/org/apache/camel/component/bean/validator/ValidatorFactoryAutowireTest.java
+++ b/components/camel-bean-validator/src/test/java/org/apache/camel/component/bean/validator/ValidatorFactoryAutowireTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.condition.OS.AIX;
 
+@DisabledOnOs(AIX)
 public class ValidatorFactoryAutowireTest extends CamelTestSupport {
 
     @BindToRegistry("myValidatorFactory")
@@ -45,7 +46,6 @@ public class ValidatorFactoryAutowireTest extends CamelTestSupport {
         super.setUp();
     }
 
-    @DisabledOnOs(AIX)
     @Test
     void configureValidatorFactoryAutowired() throws Exception {
         BeanValidatorEndpoint endpoint

--- a/components/camel-bean-validator/src/test/java/org/apache/camel/component/bean/validator/ValidatorFactoryRegistryTest.java
+++ b/components/camel-bean-validator/src/test/java/org/apache/camel/component/bean/validator/ValidatorFactoryRegistryTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.condition.OS.AIX;
 
+@DisabledOnOs(AIX)
 public class ValidatorFactoryRegistryTest extends CamelTestSupport {
 
     @BindToRegistry("myValidatorFactory")
@@ -49,7 +50,6 @@ public class ValidatorFactoryRegistryTest extends CamelTestSupport {
         super.setUp();
     }
 
-    @DisabledOnOs(AIX)
     @Test
     void configureValidatorFactoryFromRegistry() throws Exception {
         BeanValidatorEndpoint endpoint

--- a/components/camel-bean-validator/src/test/java/org/apache/camel/component/bean/validator/ValidatorFactoryTest.java
+++ b/components/camel-bean-validator/src/test/java/org/apache/camel/component/bean/validator/ValidatorFactoryTest.java
@@ -24,9 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.condition.OS.AIX;
 
+@DisabledOnOs(AIX)
 public class ValidatorFactoryTest extends CamelTestSupport {
 
-    @DisabledOnOs(AIX)
     @Test
     void configureValidatorFactory() throws Exception {
 

--- a/components/camel-crypto/src/test/java/org/apache/camel/component/crypto/ECDSASignatureTest.java
+++ b/components/camel-crypto/src/test/java/org/apache/camel/component/crypto/ECDSASignatureTest.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.test.junit5.TestSupport.isJavaVendor;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class ECDSASignatureTest extends CamelTestSupport {
 
@@ -94,9 +95,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     void testECDSASHA1() throws Exception {
-        if (ibmJDK || !canRun) {
-            return;
-        }
+        assumeFalse(ibmJDK || !canRun, "Test preconditions failed: ibmJDK=" + ibmJDK + ", canRun=" + canRun);
 
         setupMock();
         sendBody("direct:ecdsa-sha1", payload);

--- a/components/camel-crypto/src/test/java/org/apache/camel/component/crypto/SignatureTest.java
+++ b/components/camel-crypto/src/test/java/org/apache/camel/component/crypto/SignatureTest.java
@@ -47,6 +47,7 @@ import static org.apache.camel.component.crypto.DigitalSignatureConstants.SIGNAT
 import static org.apache.camel.test.junit5.TestSupport.isJavaVendor;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class SignatureTest extends CamelTestSupport {
 
@@ -242,10 +243,7 @@ public class SignatureTest extends CamelTestSupport {
 
     @Test
     void testSetProviderInRouteDefinition() throws Exception {
-        if (isJavaVendor("ibm")) {
-            return;
-        }
-        // can only be run on SUN JDK
+        assumeFalse(isJavaVendor("ibm"), "can only be run on SUN JDK");
         setupMock();
         sendBody("direct:provider", payload);
         assertMockEndpointsSatisfied();

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsAsyncRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsAsyncRouteTest.java
@@ -61,7 +61,7 @@ public class HttpsAsyncRouteTest extends HttpsRouteTest {
         // cert,
         // use the server keystore as the trust store for these tests
         URL trustStoreUrl = this.getClass().getClassLoader().getResource("jsse/localhost.p12");
-        setSystemProp("javax.net.ssl.trustStore", "file://" + trustStoreUrl.toURI().getPath());
+        setSystemProp("javax.net.ssl.trustStore", trustStoreUrl.toURI().getPath());
         setSystemProp("javax.net.ssl.trustStorePassword", "changeit");
         setSystemProp("javax.net.ssl.trustStoreType", "PKCS12");
     }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsAsyncRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsAsyncRouteTest.java
@@ -36,19 +36,20 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.component.jetty.BaseJettyTest.SSL_SYSPROPS;
-import static org.apache.camel.test.junit5.TestSupport.isPlatform;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @ResourceLock(SSL_SYSPROPS)
+@DisabledOnOs(OS.WINDOWS)
 public class HttpsAsyncRouteTest extends HttpsRouteTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(HttpsAsyncRouteTest.class);
@@ -94,9 +95,6 @@ public class HttpsAsyncRouteTest extends HttpsRouteTest {
     @Override
     @Test
     public void testEndpoint() throws Exception {
-        // these tests does not run well on Windows
-        assumeFalse(isPlatform("windows"), "Test is not intended for windows");
-
         MockEndpoint mockEndpointA = resolveMandatoryEndpoint("mock:a", MockEndpoint.class);
         mockEndpointA.expectedBodiesReceived(expectedBody);
         MockEndpoint mockEndpointB = resolveMandatoryEndpoint("mock:b", MockEndpoint.class);
@@ -123,9 +121,6 @@ public class HttpsAsyncRouteTest extends HttpsRouteTest {
     @Override
     @Test
     public void testEndpointWithoutHttps() {
-        // these tests does not run well on Windows
-        assumeFalse(isPlatform("windows"), "Test is not intended for windows");
-
         MockEndpoint mockEndpoint = resolveMandatoryEndpoint("mock:a", MockEndpoint.class);
         try {
             template.sendBodyAndHeader("http://localhost:" + port1 + "/test", expectedBody, "Content-Type", "application/xml");
@@ -138,9 +133,6 @@ public class HttpsAsyncRouteTest extends HttpsRouteTest {
     @Override
     @Test
     public void testHelloEndpoint() throws Exception {
-        // these tests does not run well on Windows
-        assumeFalse(isPlatform("windows"), "Test is not intended for windows");
-
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         URL url = new URL("https://localhost:" + port1 + "/hello");
         HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
@@ -160,9 +152,6 @@ public class HttpsAsyncRouteTest extends HttpsRouteTest {
     @Override
     @Test
     public void testHelloEndpointWithoutHttps() throws Exception {
-        // these tests does not run well on Windows
-        assumeFalse(isPlatform("windows"), "Test is not intended for windows");
-
         try {
             new URL("http://localhost:" + port1 + "/hello").openStream();
             fail("expected SocketException on use ot http");

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsAsyncRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsAsyncRouteTest.java
@@ -46,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @ResourceLock(SSL_SYSPROPS)
 public class HttpsAsyncRouteTest extends HttpsRouteTest {
@@ -94,9 +95,7 @@ public class HttpsAsyncRouteTest extends HttpsRouteTest {
     @Test
     public void testEndpoint() throws Exception {
         // these tests does not run well on Windows
-        if (isPlatform("windows")) {
-            return;
-        }
+        assumeFalse(isPlatform("windows"), "Test is not intended for windows");
 
         MockEndpoint mockEndpointA = resolveMandatoryEndpoint("mock:a", MockEndpoint.class);
         mockEndpointA.expectedBodiesReceived(expectedBody);
@@ -125,9 +124,7 @@ public class HttpsAsyncRouteTest extends HttpsRouteTest {
     @Test
     public void testEndpointWithoutHttps() {
         // these tests does not run well on Windows
-        if (isPlatform("windows")) {
-            return;
-        }
+        assumeFalse(isPlatform("windows"), "Test is not intended for windows");
 
         MockEndpoint mockEndpoint = resolveMandatoryEndpoint("mock:a", MockEndpoint.class);
         try {
@@ -142,9 +139,7 @@ public class HttpsAsyncRouteTest extends HttpsRouteTest {
     @Test
     public void testHelloEndpoint() throws Exception {
         // these tests does not run well on Windows
-        if (isPlatform("windows")) {
-            return;
-        }
+        assumeFalse(isPlatform("windows"), "Test is not intended for windows");
 
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         URL url = new URL("https://localhost:" + port1 + "/hello");
@@ -166,9 +161,7 @@ public class HttpsAsyncRouteTest extends HttpsRouteTest {
     @Test
     public void testHelloEndpointWithoutHttps() throws Exception {
         // these tests does not run well on Windows
-        if (isPlatform("windows")) {
-            return;
-        }
+        assumeFalse(isPlatform("windows"), "Test is not intended for windows");
 
         try {
             new URL("http://localhost:" + port1 + "/hello").openStream();

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyRouteWithUnknownSocketPropertiesTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyRouteWithUnknownSocketPropertiesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class JettyRouteWithUnknownSocketPropertiesTest extends BaseJettyTest {
 
@@ -36,10 +37,7 @@ public class JettyRouteWithUnknownSocketPropertiesTest extends BaseJettyTest {
 
     @Test
     public void testUnknownProperty() throws Exception {
-        if (!Server.getVersion().startsWith("8")) {
-            // SocketConnector props do not work for jetty 9
-            return;
-        }
+        assumeTrue(Server.getVersion().startsWith("8"), "SocketConnector props do not work for jetty 9");
         context.addRoutes(new RouteBuilder() {
             @Override
             public void configure() {

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyRouteWithUnknownSslSocketPropertiesTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/JettyRouteWithUnknownSslSocketPropertiesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class JettyRouteWithUnknownSslSocketPropertiesTest extends BaseJettyTest {
 
@@ -36,10 +37,7 @@ public class JettyRouteWithUnknownSslSocketPropertiesTest extends BaseJettyTest 
 
     @Test
     public void testUnknownProperty() throws Exception {
-        if (!Server.getVersion().startsWith("8")) {
-            // SocketConnector props do not work for jetty 9
-            return;
-        }
+        assumeTrue(Server.getVersion().startsWith("8"), "SocketConnector props do not work for jetty 9");
         context.addRoutes(new RouteBuilder() {
             @Override
             public void configure() {

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/SpringHttpsRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/SpringHttpsRouteTest.java
@@ -72,7 +72,7 @@ public class SpringHttpsRouteTest {
         // cert,
         // use the server keystore as the trust store for these tests
         URL trustStoreUrl = Thread.currentThread().getContextClassLoader().getResource("jsse/localhost.p12");
-        setSystemProp("javax.net.ssl.trustStore", "file://" + trustStoreUrl.getPath());
+        setSystemProp("javax.net.ssl.trustStore", trustStoreUrl.getPath());
     }
 
     @AfterEach

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tuning/PerformanceRouteTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tuning/PerformanceRouteTest.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Disabled
 public class PerformanceRouteTest extends CamelTestSupport {
@@ -36,9 +37,7 @@ public class PerformanceRouteTest extends CamelTestSupport {
 
     @Test
     public void testPerformance() throws Exception {
-        if (!canRunOnThisPlatform()) {
-            return;
-        }
+        assumeTrue(canRunOnThisPlatform(), "Test is not intended for this platform");
 
         long start = System.currentTimeMillis();
 

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/ManagedNettyEndpointTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/ManagedNettyEndpointTest.java
@@ -25,11 +25,12 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
-import static org.apache.camel.test.junit5.TestSupport.isPlatform;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+@DisabledOnOs(OS.AIX)
 public class ManagedNettyEndpointTest extends BaseNettyTest {
 
     @Override
@@ -49,9 +50,6 @@ public class ManagedNettyEndpointTest extends BaseNettyTest {
 
     @Test
     public void testManagement() throws Exception {
-        // JMX tests dont work well on AIX CI servers (hangs them)
-        assumeFalse(isPlatform("aix"));
-
         // should not add 10 endpoints
         getMockEndpoint("mock:foo").expectedMessageCount(10);
         for (int i = 0; i < 10; i++) {

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpSuspendResume503Test.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpSuspendResume503Test.java
@@ -20,24 +20,22 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
-import static org.apache.camel.test.junit5.TestSupport.isPlatform;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+@DisabledOnOs(OS.WINDOWS)
 public class NettyHttpSuspendResume503Test extends BaseNettyTest {
 
     private String serverUri = "netty-http:http://localhost:" + getPort() + "/cool?disconnect=true";
 
     @Test
     public void testNettySuspendResume() throws Exception {
-        // these tests does not run well on Windows
-        assumeFalse(isPlatform("windows"));
-
         context.getShutdownStrategy().setTimeout(50);
 
         String reply = template.requestBody(serverUri, "World", String.class);

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpSuspendResumeTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpSuspendResumeTest.java
@@ -20,24 +20,22 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
-import static org.apache.camel.test.junit5.TestSupport.isPlatform;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+@DisabledOnOs(OS.WINDOWS)
 public class NettyHttpSuspendResumeTest extends BaseNettyTest {
 
     private String serverUri = "netty-http:http://localhost:" + getPort() + "/cool?disconnect=true&send503whenSuspended=false";
 
     @Test
     public void testNettySuspendResume() throws Exception {
-        // these tests does not run well on Windows
-        assumeFalse(isPlatform("windows"));
-
         context.getShutdownStrategy().setTimeout(50);
 
         String reply = template.requestBody(serverUri, "World", String.class);

--- a/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/QuartzManagementTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/QuartzManagementTest.java
@@ -21,12 +21,13 @@ import javax.management.ObjectName;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
-import static org.apache.camel.test.junit5.TestSupport.isPlatform;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+@DisabledOnOs(OS.AIX)
 public class QuartzManagementTest extends BaseQuartzTest {
 
     protected MBeanServer getMBeanServer() {
@@ -35,9 +36,6 @@ public class QuartzManagementTest extends BaseQuartzTest {
 
     @Test
     public void testQuartzRoute() throws Exception {
-        // JMX tests dont work well on AIX CI servers (hangs them)
-        assumeFalse(isPlatform("aix"));
-
         getMockEndpoint("mock:result").expectedMessageCount(2);
 
         assertMockEndpointsSatisfied();

--- a/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartRouteTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartRouteTest.java
@@ -22,11 +22,11 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 
-import static org.apache.camel.test.junit5.TestSupport.isPlatform;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
+@DisabledOnOs(OS.AIX)
 public class SpringQuartzPersistentStoreRestartRouteTest extends CamelSpringTestSupport {
 
     @Override
@@ -36,9 +36,6 @@ public class SpringQuartzPersistentStoreRestartRouteTest extends CamelSpringTest
 
     @Test
     public void testQuartzPersistentStore() throws Exception {
-        // skip testing on aix
-        assumeFalse(isPlatform("aix"));
-
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMinimumMessageCount(2);
 

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/CompositeApiIntegrationTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/CompositeApiIntegrationTest.java
@@ -208,7 +208,8 @@ public class CompositeApiIntegrationTest extends AbstractSalesforceTestBase {
 
     @Test
     public void shouldSupportRelatedObjectRetrieval() {
-        assumeFalse(Version.create(version).compareTo(Version.create("36.0")) < 0, "Version must be greater than or equal to 36.0");
+        assumeFalse(Version.create(version).compareTo(Version.create("36.0")) < 0,
+                "Version must be greater than or equal to 36.0");
 
         final SObjectComposite composite = new SObjectComposite("36.0", true);
         composite.addGetRelated("Account", accountId, "CreatedBy", "GetRelatedAccountReferenceId");

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/CompositeApiIntegrationTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/CompositeApiIntegrationTest.java
@@ -43,6 +43,8 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
 @Parameterized
 public class CompositeApiIntegrationTest extends AbstractSalesforceTestBase {
 
@@ -206,9 +208,7 @@ public class CompositeApiIntegrationTest extends AbstractSalesforceTestBase {
 
     @Test
     public void shouldSupportRelatedObjectRetrieval() {
-        if (Version.create(version).compareTo(Version.create("36.0")) < 0) {
-            return;
-        }
+        assumeFalse(Version.create(version).compareTo(Version.create("36.0")) < 0, "Version must be less than 36.0");
 
         final SObjectComposite composite = new SObjectComposite("36.0", true);
         composite.addGetRelated("Account", accountId, "CreatedBy", "GetRelatedAccountReferenceId");

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/CompositeApiIntegrationTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/CompositeApiIntegrationTest.java
@@ -208,7 +208,7 @@ public class CompositeApiIntegrationTest extends AbstractSalesforceTestBase {
 
     @Test
     public void shouldSupportRelatedObjectRetrieval() {
-        assumeFalse(Version.create(version).compareTo(Version.create("36.0")) < 0, "Version must be less than 36.0");
+        assumeFalse(Version.create(version).compareTo(Version.create("36.0")) < 0, "Version must be greater than or equal to 36.0");
 
         final SObjectComposite composite = new SObjectComposite("36.0", true);
         composite.addGetRelated("Account", accountId, "CreatedBy", "GetRelatedAccountReferenceId");

--- a/components/camel-saxon/src/test/java/org/apache/camel/language/xpath/XPathLanguageDefaultSettingsTest.java
+++ b/components/camel-saxon/src/test/java/org/apache/camel/language/xpath/XPathLanguageDefaultSettingsTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.parallel.Resources;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 
 import static org.apache.camel.test.junit5.TestSupport.isJavaVendor;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Tests that verify the usage of default settings in the XPath language by declaring a bean called xpath in the
@@ -71,9 +72,7 @@ public class XPathLanguageDefaultSettingsTest extends CamelSpringTestSupport {
 
     @Test
     public void testSpringDSLXPathLanguageDefaultSettings() throws Exception {
-        if (!jvmAdequate) {
-            return;
-        }
+        assumeTrue(jvmAdequate, "JVM is not adequate");
 
         MockEndpoint mockEndpointResult = getMockEndpoint("mock:testDefaultXPathSettingsResult");
         MockEndpoint mockEndpointException = getMockEndpoint("mock:testDefaultXPathSettingsResultException");

--- a/components/camel-saxon/src/test/java/org/apache/camel/language/xpath/XPathLanguageTest.java
+++ b/components/camel-saxon/src/test/java/org/apache/camel/language/xpath/XPathLanguageTest.java
@@ -31,6 +31,7 @@ import org.springframework.context.support.AbstractXmlApplicationContext;
 
 import static org.apache.camel.test.junit5.TestSupport.isJavaVendor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  *
@@ -73,9 +74,7 @@ public class XPathLanguageTest extends CamelSpringTestSupport {
 
     @Test
     public void testSpringDSLXPathSaxonFlag() throws Exception {
-        if (!jvmAdequate) {
-            return;
-        }
+        assumeTrue(jvmAdequate, "JVM is not adequate");
 
         MockEndpoint mockEndpoint = getMockEndpoint("mock:testSaxonWithFlagResult");
         mockEndpoint.expectedMessageCount(1);
@@ -90,9 +89,7 @@ public class XPathLanguageTest extends CamelSpringTestSupport {
 
     @Test
     public void testSpringDSLXPathFactory() throws Exception {
-        if (!jvmAdequate) {
-            return;
-        }
+        assumeTrue(jvmAdequate, "JVM is not adequate");
 
         MockEndpoint mockEndpoint = getMockEndpoint("mock:testSaxonWithFactoryResult");
         mockEndpoint.expectedMessageCount(1);
@@ -108,9 +105,7 @@ public class XPathLanguageTest extends CamelSpringTestSupport {
     @Disabled("See http://www.saxonica.com/documentation/index.html#!xpath-api/jaxp-xpath/factory")
     @Test
     public void testSpringDSLXPathObjectModel() throws Exception {
-        if (!jvmAdequate) {
-            return;
-        }
+        assumeTrue(jvmAdequate, "JVM is not adequate");
 
         MockEndpoint mockEndpoint = getMockEndpoint("mock:testSaxonWithObjectModelResult");
         mockEndpoint.expectedMessageCount(1);
@@ -125,9 +120,7 @@ public class XPathLanguageTest extends CamelSpringTestSupport {
 
     @Test
     public void testSpringDSLXPathSaxonFlagPredicate() throws Exception {
-        if (!jvmAdequate) {
-            return;
-        }
+        assumeTrue(jvmAdequate, "JVM is not adequate");
 
         MockEndpoint mockEndpoint = getMockEndpoint("mock:testSaxonWithFlagResultPredicate");
         mockEndpoint.expectedMessageCount(1);
@@ -139,9 +132,7 @@ public class XPathLanguageTest extends CamelSpringTestSupport {
 
     @Test
     public void testSpringDSLXPathFactoryPredicate() throws Exception {
-        if (!jvmAdequate) {
-            return;
-        }
+        assumeTrue(jvmAdequate, "JVM is not adequate");
 
         MockEndpoint mockEndpoint = getMockEndpoint("mock:testSaxonWithFactoryResultPredicate");
         mockEndpoint.expectedMessageCount(1);
@@ -154,9 +145,7 @@ public class XPathLanguageTest extends CamelSpringTestSupport {
     @Disabled("See http://www.saxonica.com/documentation/index.html#!xpath-api/jaxp-xpath/factory")
     @Test
     public void testSpringDSLXPathObjectModelPredicate() throws Exception {
-        if (!jvmAdequate) {
-            return;
-        }
+        assumeTrue(jvmAdequate, "JVM is not adequate");
 
         MockEndpoint mockEndpoint = getMockEndpoint("mock:testSaxonWithObjectModelResultPredicate");
         mockEndpoint.expectedMessageCount(1);

--- a/components/camel-servlet/src/test/java/org/apache/camel/component/servlet/HttpClientRouteTest.java
+++ b/components/camel-servlet/src/test/java/org/apache/camel/component/servlet/HttpClientRouteTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class HttpClientRouteTest extends ServletCamelRouterTestSupport {
 
@@ -113,10 +114,7 @@ public class HttpClientRouteTest extends ServletCamelRouterTestSupport {
 
     @Test
     public void testCreateSerlvetEndpointProducer() throws Exception {
-        if (!startCamelContext) {
-            // don't test it with web.xml configure
-            return;
-        }
+        assumeTrue(startCamelContext, "don't test it with web.xml configure");
         try {
             context.addRoutes(new RouteBuilder() {
                 @Override

--- a/components/camel-spring-xml/src/test/java/org/apache/camel/spring/management/ManagedEndpointInjectRefEndpointTest.java
+++ b/components/camel-spring-xml/src/test/java/org/apache/camel/spring/management/ManagedEndpointInjectRefEndpointTest.java
@@ -50,12 +50,6 @@ public class ManagedEndpointInjectRefEndpointTest extends SpringTestSupport {
         return context.getManagementStrategy().getManagementAgent().getMBeanServer();
     }
 
-    @Override
-    protected boolean canRunOnThisPlatform() {
-        // JMX tests dont work well on AIX CI servers (hangs them)
-        return !isPlatform("aix");
-    }
-
     @Test
     public void testRef() throws Exception {
         // fire a message to get it running

--- a/components/camel-spring-xml/src/test/java/org/apache/camel/spring/management/ManagedRefEndpointTest.java
+++ b/components/camel-spring-xml/src/test/java/org/apache/camel/spring/management/ManagedRefEndpointTest.java
@@ -49,12 +49,6 @@ public class ManagedRefEndpointTest extends SpringTestSupport {
         return context.getManagementStrategy().getManagementAgent().getMBeanServer();
     }
 
-    @Override
-    protected boolean canRunOnThisPlatform() {
-        // JMX tests dont work well on AIX CI servers (hangs them)
-        return !isPlatform("aix");
-    }
-
     @Test
     public void testRef() throws Exception {
         // fire a message to get it running

--- a/components/camel-xmlsecurity/src/test/java/org/apache/camel/component/xmlsecurity/ECDSASignatureTest.java
+++ b/components/camel-xmlsecurity/src/test/java/org/apache/camel/component/xmlsecurity/ECDSASignatureTest.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.test.junit5.TestSupport.isJavaVendor;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Test for the ECDSA algorithms
@@ -178,9 +179,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     public void testECDSASHA1() throws Exception {
-        if (!canTest) {
-            return;
-        }
+        assumeTrue(canTest, "Test preconditions failed: canTest="+canTest);
         setupMock();
         sendBody("direct:ecdsa_sha1", payload);
         assertMockEndpointsSatisfied();
@@ -188,9 +187,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     public void testECDSASHA224() throws Exception {
-        if (!canTest) {
-            return;
-        }
+        assumeTrue(canTest, "Test preconditions failed: canTest="+canTest);
         setupMock();
         sendBody("direct:ecdsa_sha224", payload);
         assertMockEndpointsSatisfied();
@@ -198,9 +195,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     public void testECDSASHA256() throws Exception {
-        if (!canTest) {
-            return;
-        }
+        assumeTrue(canTest, "Test preconditions failed: canTest="+canTest);
         setupMock();
         sendBody("direct:ecdsa_sha256", payload);
         assertMockEndpointsSatisfied();
@@ -208,9 +203,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     public void testECDSASHA384() throws Exception {
-        if (!canTest) {
-            return;
-        }
+        assumeTrue(canTest, "Test preconditions failed: canTest="+canTest);
         setupMock();
         sendBody("direct:ecdsa_sha384", payload);
         assertMockEndpointsSatisfied();
@@ -218,9 +211,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     public void testECDSASHA512() throws Exception {
-        if (!canTest) {
-            return;
-        }
+        assumeTrue(canTest, "Test preconditions failed: canTest="+canTest);
         setupMock();
         sendBody("direct:ecdsa_sha512", payload);
         assertMockEndpointsSatisfied();
@@ -228,9 +219,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     public void testECDSARIPEMD160() throws Exception {
-        if (!canTest) {
-            return;
-        }
+        assumeTrue(canTest, "Test preconditions failed: canTest="+canTest);
         setupMock();
         sendBody("direct:ecdsa_ripemd160", payload);
         assertMockEndpointsSatisfied();

--- a/components/camel-xmlsecurity/src/test/java/org/apache/camel/component/xmlsecurity/ECDSASignatureTest.java
+++ b/components/camel-xmlsecurity/src/test/java/org/apache/camel/component/xmlsecurity/ECDSASignatureTest.java
@@ -179,7 +179,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     public void testECDSASHA1() throws Exception {
-        assumeTrue(canTest, "Test preconditions failed: canTest="+canTest);
+        assumeTrue(canTest, "Test preconditions failed: canTest=" + canTest);
         setupMock();
         sendBody("direct:ecdsa_sha1", payload);
         assertMockEndpointsSatisfied();
@@ -187,7 +187,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     public void testECDSASHA224() throws Exception {
-        assumeTrue(canTest, "Test preconditions failed: canTest="+canTest);
+        assumeTrue(canTest, "Test preconditions failed: canTest=" + canTest);
         setupMock();
         sendBody("direct:ecdsa_sha224", payload);
         assertMockEndpointsSatisfied();
@@ -195,7 +195,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     public void testECDSASHA256() throws Exception {
-        assumeTrue(canTest, "Test preconditions failed: canTest="+canTest);
+        assumeTrue(canTest, "Test preconditions failed: canTest=" + canTest);
         setupMock();
         sendBody("direct:ecdsa_sha256", payload);
         assertMockEndpointsSatisfied();
@@ -203,7 +203,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     public void testECDSASHA384() throws Exception {
-        assumeTrue(canTest, "Test preconditions failed: canTest="+canTest);
+        assumeTrue(canTest, "Test preconditions failed: canTest=" + canTest);
         setupMock();
         sendBody("direct:ecdsa_sha384", payload);
         assertMockEndpointsSatisfied();
@@ -211,7 +211,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     public void testECDSASHA512() throws Exception {
-        assumeTrue(canTest, "Test preconditions failed: canTest="+canTest);
+        assumeTrue(canTest, "Test preconditions failed: canTest=" + canTest);
         setupMock();
         sendBody("direct:ecdsa_sha512", payload);
         assertMockEndpointsSatisfied();
@@ -219,7 +219,7 @@ public class ECDSASignatureTest extends CamelTestSupport {
 
     @Test
     public void testECDSARIPEMD160() throws Exception {
-        assumeTrue(canTest, "Test preconditions failed: canTest="+canTest);
+        assumeTrue(canTest, "Test preconditions failed: canTest=" + canTest);
         setupMock();
         sendBody("direct:ecdsa_ripemd160", payload);
         assertMockEndpointsSatisfied();

--- a/components/camel-xmlsecurity/src/test/java/org/apache/camel/dataformat/xmlsecurity/EncryptionAlgorithmTest.java
+++ b/components/camel-xmlsecurity/src/test/java/org/apache/camel/dataformat/xmlsecurity/EncryptionAlgorithmTest.java
@@ -32,6 +32,8 @@ import org.apache.xml.security.encryption.XMLCipher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 /**
  * Test all available encryption algorithms
  */
@@ -113,9 +115,7 @@ public class EncryptionAlgorithmTest extends CamelTestSupport {
 
     @Test
     public void testAES192() throws Exception {
-        if (!TestHelper.UNRESTRICTED_POLICIES_INSTALLED) {
-            return;
-        }
+        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED, "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED="+TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
 
         // Set up the Key
         KeyGenerator keygen = KeyGenerator.getInstance("AES");
@@ -141,9 +141,7 @@ public class EncryptionAlgorithmTest extends CamelTestSupport {
 
     @Test
     public void testAES192GCM() throws Exception {
-        if (!TestHelper.UNRESTRICTED_POLICIES_INSTALLED) {
-            return;
-        }
+        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED, "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED="+TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
 
         // Set up the Key
         KeyGenerator keygen = KeyGenerator.getInstance("AES");
@@ -169,9 +167,7 @@ public class EncryptionAlgorithmTest extends CamelTestSupport {
 
     @Test
     public void testAES256() throws Exception {
-        if (!TestHelper.UNRESTRICTED_POLICIES_INSTALLED) {
-            return;
-        }
+        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED, "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED="+TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
 
         // Set up the Key
         KeyGenerator keygen = KeyGenerator.getInstance("AES");
@@ -197,6 +193,7 @@ public class EncryptionAlgorithmTest extends CamelTestSupport {
 
     @Test
     public void testAES256GCM() throws Exception {
+        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED, "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED="+TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
         if (!TestHelper.UNRESTRICTED_POLICIES_INSTALLED) {
             return;
         }

--- a/components/camel-xmlsecurity/src/test/java/org/apache/camel/dataformat/xmlsecurity/EncryptionAlgorithmTest.java
+++ b/components/camel-xmlsecurity/src/test/java/org/apache/camel/dataformat/xmlsecurity/EncryptionAlgorithmTest.java
@@ -115,7 +115,8 @@ public class EncryptionAlgorithmTest extends CamelTestSupport {
 
     @Test
     public void testAES192() throws Exception {
-        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED, "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED="+TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
+        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED,
+                "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED=" + TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
 
         // Set up the Key
         KeyGenerator keygen = KeyGenerator.getInstance("AES");
@@ -141,7 +142,8 @@ public class EncryptionAlgorithmTest extends CamelTestSupport {
 
     @Test
     public void testAES192GCM() throws Exception {
-        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED, "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED="+TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
+        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED,
+                "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED=" + TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
 
         // Set up the Key
         KeyGenerator keygen = KeyGenerator.getInstance("AES");
@@ -167,7 +169,8 @@ public class EncryptionAlgorithmTest extends CamelTestSupport {
 
     @Test
     public void testAES256() throws Exception {
-        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED, "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED="+TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
+        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED,
+                "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED=" + TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
 
         // Set up the Key
         KeyGenerator keygen = KeyGenerator.getInstance("AES");
@@ -193,10 +196,8 @@ public class EncryptionAlgorithmTest extends CamelTestSupport {
 
     @Test
     public void testAES256GCM() throws Exception {
-        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED, "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED="+TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
-        if (!TestHelper.UNRESTRICTED_POLICIES_INSTALLED) {
-            return;
-        }
+        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED,
+                "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED=" + TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
 
         // Set up the Key
         KeyGenerator keygen = KeyGenerator.getInstance("AES");
@@ -294,9 +295,8 @@ public class EncryptionAlgorithmTest extends CamelTestSupport {
 
     @Test
     public void testCAMELLIA192() throws Exception {
-        if (!TestHelper.UNRESTRICTED_POLICIES_INSTALLED) {
-            return;
-        }
+        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED,
+                "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED=" + TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
 
         // Set up the Key
         KeyGenerator keygen = KeyGenerator.getInstance("CAMELLIA");
@@ -322,9 +322,8 @@ public class EncryptionAlgorithmTest extends CamelTestSupport {
 
     @Test
     public void testCAMELLIA256() throws Exception {
-        if (!TestHelper.UNRESTRICTED_POLICIES_INSTALLED) {
-            return;
-        }
+        assumeTrue(TestHelper.UNRESTRICTED_POLICIES_INSTALLED,
+                "Test preconditions failed: UNRESTRICTED_POLICIES_INSTALLED=" + TestHelper.UNRESTRICTED_POLICIES_INSTALLED);
 
         // Set up the Key
         KeyGenerator keygen = KeyGenerator.getInstance("CAMELLIA");

--- a/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/XmppRobustConnectionTest.java
+++ b/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/XmppRobustConnectionTest.java
@@ -20,23 +20,19 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import static org.apache.camel.test.junit5.TestSupport.isPlatform;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /**
  * Test to verify that the XMPP consumer will reconnect when the connection is lost. Also verifies that the XMPP
  * producer will lazily re-establish a lost connection.
  */
+@DisabledOnOs({ OS.AIX, OS.SOLARIS })
 public class XmppRobustConnectionTest extends XmppBaseContainerTest {
 
     @Disabled("Since upgrade to smack 4.2.0 the robust connection handling doesn't seem to work, as consumerEndpoint below receives only 5 payloads instead of the expected 9")
     @Test
     public void testXmppChatWithRobustConnection() throws Exception {
-        // does not work well on aix or solaris
-        if (isPlatform("aix") || isPlatform("sunos")) {
-            return;
-        }
-
         MockEndpoint consumerEndpoint = context.getEndpoint("mock:out", MockEndpoint.class);
         MockEndpoint errorEndpoint = context.getEndpoint("mock:error", MockEndpoint.class);
 

--- a/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ManagedZipkinSimpleRouteTest.java
+++ b/components/camel-zipkin/src/test/java/org/apache/camel/zipkin/ManagedZipkinSimpleRouteTest.java
@@ -27,13 +27,15 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import zipkin2.reporter.Reporter;
 
-import static org.apache.camel.test.junit5.TestSupport.isPlatform;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(OS.AIX)
 public class ManagedZipkinSimpleRouteTest extends CamelTestSupport {
 
     private ZipkinTracer zipkin;
@@ -67,11 +69,6 @@ public class ManagedZipkinSimpleRouteTest extends CamelTestSupport {
 
     @Test
     public void testZipkinRoute() throws Exception {
-        // JMX tests dont work well on AIX CI servers (hangs them)
-        if (isPlatform("aix")) {
-            return;
-        }
-
         MBeanServer mbeanServer = getMBeanServer();
         ObjectName on = new ObjectName(
                 "org.apache.camel:context=" + context.getManagementName() + ",type=services,name=ZipkinTracer");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerChmodOptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerChmodOptionTest.java
@@ -31,25 +31,23 @@ import org.apache.camel.ResolveEndpointFailedException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+@DisabledOnOs(OS.WINDOWS)
 public class FileProducerChmodOptionTest extends ContextTestSupport {
 
     @Test
     public void testWriteValidChmod0755() throws Exception {
-        assumeFalse(isPlatform("windows"));
-
         runChmodCheck("0755", "rwxr-xr-x");
     }
 
     @Test
     public void testWriteValidChmod666() throws Exception {
-        assumeFalse(isPlatform("windows"));
-
         runChmodCheck("666", "rw-rw-rw-");
     }
 
@@ -71,8 +69,6 @@ public class FileProducerChmodOptionTest extends ContextTestSupport {
 
     @Test
     public void testInvalidChmod() throws Exception {
-        assumeFalse(isPlatform("windows"));
-
         try {
             context.addRoutes(new RouteBuilder() {
 
@@ -98,8 +94,6 @@ public class FileProducerChmodOptionTest extends ContextTestSupport {
      */
     @Test
     public void testWriteNoChmod() throws Exception {
-        assumeFalse(isPlatform("windows"));
-
         MockEndpoint mock = getMockEndpoint("mock:noChmod");
         mock.expectedMessageCount(1);
         String testFileName = "noChmod.txt";

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerDirectoryChmodOptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerDirectoryChmodOptionTest.java
@@ -28,30 +28,26 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+@DisabledOnOs(OS.WINDOWS)
 public class FileProducerDirectoryChmodOptionTest extends ContextTestSupport {
 
     @Test
     public void testWriteValidNoDir() throws Exception {
-        assumeFalse(isPlatform("windows"));
-
         runChmodCheck("NoDir", null, "rwxr-xr-x");
     }
 
     @Test
     public void testWriteValidChmod0755() throws Exception {
-        assumeFalse(isPlatform("windows"));
-
         runChmodCheck("0755", "rwxrwxrwx", "rwxr-xr-x");
     }
 
     @Test
     public void testWriteValidChmod666() throws Exception {
-        assumeFalse(isPlatform("windows"));
-
         runChmodCheck("666", "rwxrwxrwx", "rw-rw-rw-");
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerExpressionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerExpressionTest.java
@@ -24,8 +24,8 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.Registry;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /**
  * Unit test for expression option for file producer.
@@ -39,10 +39,9 @@ public class FileProducerExpressionTest extends ContextTestSupport {
         return jndi;
     }
 
+    @DisabledOnOs(OS.WINDOWS)
     @Test
     public void testProducerFileNameHeaderNotEvaluated() {
-        assumeFalse(isPlatform("windows"));
-
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME,
                 "$simple{myfile-${id}}.txt");
         assertFileExists(testFile("$simple{myfile-${id}}.txt"));

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistTryRenameTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistTryRenameTest.java
@@ -21,16 +21,14 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
+@DisabledOnOs(OS.WINDOWS)
 public class FileProducerFileExistTryRenameTest extends ContextTestSupport {
 
     @Test
     public void testIgnore() throws Exception {
-        // Does not work on Windows
-        if (isPlatform("windows")) {
-            return;
-        }
-
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Bye World");
         mock.expectedFileExists(testFile("hello.txt"), "Bye World");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/stress/FileAsyncStressFileDropperManualTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/stress/FileAsyncStressFileDropperManualTest.java
@@ -22,10 +22,11 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 @Disabled("Manual test")
+@DisabledOnOs(OS.WINDOWS)
 public class FileAsyncStressFileDropperManualTest extends ContextTestSupport {
 
     private static int counter;
@@ -36,9 +37,6 @@ public class FileAsyncStressFileDropperManualTest extends ContextTestSupport {
 
     @Test
     public void testDropInNewFiles() throws Exception {
-        // do not test on windows
-        assumeFalse(isPlatform("windows"));
-
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMinimumMessageCount(250);
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/stress/FileAsyncStressManualTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/stress/FileAsyncStressManualTest.java
@@ -26,10 +26,11 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 @Disabled("Manual test")
+@DisabledOnOs(OS.WINDOWS)
 public class FileAsyncStressManualTest extends ContextTestSupport {
 
     private int files = 150;
@@ -37,8 +38,6 @@ public class FileAsyncStressManualTest extends ContextTestSupport {
     @Override
     @BeforeEach
     public void setUp() throws Exception {
-        // do not test on windows
-        assumeFalse(isPlatform("windows"));
         super.setUp();
         for (int i = 0; i < files; i++) {
             template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, i + ".txt");
@@ -47,9 +46,6 @@ public class FileAsyncStressManualTest extends ContextTestSupport {
 
     @Test
     public void testAsyncStress() throws Exception {
-        // do not test on windows
-        assumeFalse(isPlatform("windows"));
-
         // start route when all the files have been written
         context.getRouteController().startRoute("foo");
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/stress/FileAsyncStressManuallyManualTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/stress/FileAsyncStressManuallyManualTest.java
@@ -25,17 +25,15 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 @Disabled("Manual test")
+@DisabledOnOs(OS.WINDOWS)
 public class FileAsyncStressManuallyManualTest extends ContextTestSupport {
 
     @Test
     public void testAsyncStress() throws Exception {
-        // do not test on windows
-        assumeFalse(isPlatform("windows"));
-
         // test by starting the unit test FileAsyncStressFileDropper in another
         // JVM
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/stress/FileConsumerPollManyFilesManualTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/stress/FileConsumerPollManyFilesManualTest.java
@@ -23,10 +23,13 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Disabled("Manual test")
+@DisabledOnOs(OS.WINDOWS)
 public class FileConsumerPollManyFilesManualTest extends ContextTestSupport {
 
     private static final int FILES = 200;
@@ -34,9 +37,6 @@ public class FileConsumerPollManyFilesManualTest extends ContextTestSupport {
     @Override
     @BeforeEach
     public void setUp() throws Exception {
-        // do not test on windows
-        assumeFalse(isPlatform("windows"));
-
         super.setUp();
 
         // create files
@@ -52,9 +52,6 @@ public class FileConsumerPollManyFilesManualTest extends ContextTestSupport {
 
     @Test
     public void testPollManyFiles() throws Exception {
-        // do not test on windows
-        assumeFalse(isPlatform("windows"));
-
         context.addRoutes(new RouteBuilder() {
             @Override
             public void configure() throws Exception {

--- a/core/camel-core/src/test/java/org/apache/camel/impl/StopRouteAbortAfterTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/StopRouteAbortAfterTimeoutTest.java
@@ -22,18 +22,16 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@DisabledOnOs(OS.WINDOWS)
 public class StopRouteAbortAfterTimeoutTest extends ContextTestSupport {
 
     @Test
     public void testStopRouteWithAbortAfterTimeoutTrue() throws Exception {
-        // doesnt test to well on all Windows
-        if (isPlatform("windows")) {
-            return;
-        }
-
         MockEndpoint mockEP = getMockEndpoint("mock:result");
         mockEP.setExpectedMessageCount(10);
 
@@ -60,11 +58,6 @@ public class StopRouteAbortAfterTimeoutTest extends ContextTestSupport {
 
     @Test
     public void testStopRouteWithAbortAfterTimeoutFalse() throws Exception {
-        // doesnt test to well on all Windows
-        if (isPlatform("windows")) {
-            return;
-        }
-
         MockEndpoint mockEP = getMockEndpoint("mock:result");
 
         // send some message through the route

--- a/core/camel-core/src/test/java/org/apache/camel/processor/SplitterParallelAggregateTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/SplitterParallelAggregateTest.java
@@ -31,6 +31,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 public class SplitterParallelAggregateTest extends ContextTestSupport {
 
     // run this test manually as it takes some time to process, but shows that
@@ -56,27 +58,21 @@ public class SplitterParallelAggregateTest extends ContextTestSupport {
 
     @Test
     public void test1() throws Exception {
-        if (!enabled) {
-            return;
-        }
+        assumeTrue(enabled);
         int numberOfRequests = 1;
         timeSplitRoutes(numberOfRequests);
     }
 
     @Test
     public void test2() throws Exception {
-        if (!enabled) {
-            return;
-        }
+        assumeTrue(enabled);
         int numberOfRequests = 2;
         timeSplitRoutes(numberOfRequests);
     }
 
     @Test
     public void test4() throws Exception {
-        if (!enabled) {
-            return;
-        }
+        assumeTrue(enabled);
         int numberOfRequests = 4;
         timeSplitRoutes(numberOfRequests);
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/SplitterWithScannerIoExceptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/SplitterWithScannerIoExceptionTest.java
@@ -19,14 +19,16 @@ package org.apache.camel.processor;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+@DisabledOnOs(OS.AIX)
 public class SplitterWithScannerIoExceptionTest extends ContextTestSupport {
 
     @Test
     public void testSplitterStreamingWithError() throws Exception {
-        assumeFalse(isPlatform("aix"));
         assumeFalse(isJavaVendor("ibm"));
 
         getMockEndpoint("mock:a").expectedMinimumMessageCount(250);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/SplitterWithScannerIoExceptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/SplitterWithScannerIoExceptionTest.java
@@ -20,13 +20,14 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
 public class SplitterWithScannerIoExceptionTest extends ContextTestSupport {
 
     @Test
     public void testSplitterStreamingWithError() throws Exception {
-        if (isPlatform("aix") || isJavaVendor("ibm")) {
-            return;
-        }
+        assumeFalse(isPlatform("aix"));
+        assumeFalse(isJavaVendor("ibm"));
 
         getMockEndpoint("mock:a").expectedMinimumMessageCount(250);
         getMockEndpoint("mock:b").expectedMessageCount(0);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerDslTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerDslTest.java
@@ -25,6 +25,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ThrottlerDslTest extends ContextTestSupport {
     private static final int INTERVAL = 500;
@@ -37,9 +38,7 @@ public class ThrottlerDslTest extends ContextTestSupport {
 
     @Test
     public void testDsl() throws Exception {
-        if (!canTest()) {
-            return;
-        }
+        assumeTrue(canTest());
 
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         resultEndpoint.expectedMessageCount(messageCount);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerDslTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerDslTest.java
@@ -23,23 +23,18 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@DisabledOnOs(OS.WINDOWS)
 public class ThrottlerDslTest extends ContextTestSupport {
     private static final int INTERVAL = 500;
     protected int messageCount = 9;
 
-    protected boolean canTest() {
-        // skip test on windows as it does not run well there
-        return !isPlatform("windows");
-    }
-
     @Test
     public void testDsl() throws Exception {
-        assumeTrue(canTest());
-
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         resultEndpoint.expectedMessageCount(messageCount);
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerMethodCallTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerMethodCallTest.java
@@ -27,6 +27,7 @@ import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ThrottlerMethodCallTest extends ContextTestSupport {
     private static final int INTERVAL = 100;
@@ -50,9 +51,7 @@ public class ThrottlerMethodCallTest extends ContextTestSupport {
 
     @Test
     public void testConfigurationWithMethodCallExpression() throws Exception {
-        if (!canTest()) {
-            return;
-        }
+        assumeTrue(canTest());
 
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         resultEndpoint.expectedMessageCount(messageCount);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerMethodCallTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerMethodCallTest.java
@@ -25,18 +25,15 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spi.Registry;
 import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@DisabledOnOs(OS.WINDOWS)
 public class ThrottlerMethodCallTest extends ContextTestSupport {
     private static final int INTERVAL = 100;
     protected int messageCount = 10;
-
-    protected boolean canTest() {
-        // skip test on windows as it does not run well there
-        return !isPlatform("windows");
-    }
 
     @Override
     protected Registry createRegistry() throws Exception {
@@ -51,8 +48,6 @@ public class ThrottlerMethodCallTest extends ContextTestSupport {
 
     @Test
     public void testConfigurationWithMethodCallExpression() throws Exception {
-        assumeTrue(canTest());
-
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         resultEndpoint.expectedMessageCount(messageCount);
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerTest.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ThrottlerTest extends ContextTestSupport {
     private static final int INTERVAL = 500;
@@ -39,9 +40,7 @@ public class ThrottlerTest extends ContextTestSupport {
 
     @Test
     public void testSendLotsOfMessagesButOnly3GetThroughWithin2Seconds() throws Exception {
-        if (!canTest()) {
-            return;
-        }
+        assumeTrue(canTest());
 
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         resultEndpoint.expectedMessageCount(3);
@@ -58,9 +57,7 @@ public class ThrottlerTest extends ContextTestSupport {
 
     @Test
     public void testSendLotsOfMessagesWithRejectExecution() throws Exception {
-        if (!canTest()) {
-            return;
-        }
+        assumeTrue(canTest());
 
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         resultEndpoint.expectedMessageCount(2);
@@ -79,9 +76,7 @@ public class ThrottlerTest extends ContextTestSupport {
 
     @Test
     public void testSendLotsOfMessagesSimultaneouslyButOnly3GetThrough() throws Exception {
-        if (!canTest()) {
-            return;
-        }
+        assumeTrue(canTest());
 
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         long elapsed = sendMessagesAndAwaitDelivery(MESSAGE_COUNT, "direct:a", MESSAGE_COUNT, resultEndpoint);
@@ -90,9 +85,7 @@ public class ThrottlerTest extends ContextTestSupport {
 
     @Test
     public void testConfigurationWithConstantExpression() throws Exception {
-        if (!canTest()) {
-            return;
-        }
+        assumeTrue(canTest());
 
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         long elapsed = sendMessagesAndAwaitDelivery(MESSAGE_COUNT, "direct:expressionConstant", MESSAGE_COUNT, resultEndpoint);
@@ -101,9 +94,7 @@ public class ThrottlerTest extends ContextTestSupport {
 
     @Test
     public void testConfigurationWithHeaderExpression() throws Exception {
-        if (!canTest()) {
-            return;
-        }
+        assumeTrue(canTest());
 
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         resultEndpoint.expectedMessageCount(MESSAGE_COUNT);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerTest.java
@@ -24,24 +24,19 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@DisabledOnOs(OS.WINDOWS)
 public class ThrottlerTest extends ContextTestSupport {
     private static final int INTERVAL = 500;
     private static final int TOLERANCE = 50;
     private static final int MESSAGE_COUNT = 9;
 
-    protected boolean canTest() {
-        // skip test on windows as it does not run well there
-        return !isPlatform("windows");
-    }
-
     @Test
     public void testSendLotsOfMessagesButOnly3GetThroughWithin2Seconds() throws Exception {
-        assumeTrue(canTest());
-
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         resultEndpoint.expectedMessageCount(3);
         resultEndpoint.setResultWaitTime(2000);
@@ -57,8 +52,6 @@ public class ThrottlerTest extends ContextTestSupport {
 
     @Test
     public void testSendLotsOfMessagesWithRejectExecution() throws Exception {
-        assumeTrue(canTest());
-
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         resultEndpoint.expectedMessageCount(2);
 
@@ -76,8 +69,6 @@ public class ThrottlerTest extends ContextTestSupport {
 
     @Test
     public void testSendLotsOfMessagesSimultaneouslyButOnly3GetThrough() throws Exception {
-        assumeTrue(canTest());
-
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         long elapsed = sendMessagesAndAwaitDelivery(MESSAGE_COUNT, "direct:a", MESSAGE_COUNT, resultEndpoint);
         assertThrottlerTiming(elapsed, 5, INTERVAL, MESSAGE_COUNT);
@@ -85,8 +76,6 @@ public class ThrottlerTest extends ContextTestSupport {
 
     @Test
     public void testConfigurationWithConstantExpression() throws Exception {
-        assumeTrue(canTest());
-
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         long elapsed = sendMessagesAndAwaitDelivery(MESSAGE_COUNT, "direct:expressionConstant", MESSAGE_COUNT, resultEndpoint);
         assertThrottlerTiming(elapsed, 5, INTERVAL, MESSAGE_COUNT);
@@ -94,8 +83,6 @@ public class ThrottlerTest extends ContextTestSupport {
 
     @Test
     public void testConfigurationWithHeaderExpression() throws Exception {
-        assumeTrue(canTest());
-
         MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         resultEndpoint.expectedMessageCount(MESSAGE_COUNT);
 
@@ -109,10 +96,6 @@ public class ThrottlerTest extends ContextTestSupport {
 
     @Test
     public void testConfigurationWithChangingHeaderExpression() throws Exception {
-        if (!canTest()) {
-            return;
-        }
-
         ExecutorService executor = Executors.newFixedThreadPool(5);
         try {
             MockEndpoint resultEndpoint = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerThreadPoolProfileTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerThreadPoolProfileTest.java
@@ -21,20 +21,14 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.builder.ThreadPoolProfileBuilder;
 import org.apache.camel.spi.ThreadPoolProfile;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
+@DisabledOnOs(OS.WINDOWS)
 public class ThrottlerThreadPoolProfileTest extends ContextTestSupport {
-
-    protected boolean canTest() {
-        // skip test on windows as it does not run well there
-        return !isPlatform("windows");
-    }
 
     @Test
     public void testThreadPool() throws Exception {
-        assumeTrue(canTest());
-
         getMockEndpoint("mock:result").expectedMessageCount(2);
 
         template.sendBody("direct:start", "Hello");

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerThreadPoolProfileTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerThreadPoolProfileTest.java
@@ -22,6 +22,8 @@ import org.apache.camel.builder.ThreadPoolProfileBuilder;
 import org.apache.camel.spi.ThreadPoolProfile;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 public class ThrottlerThreadPoolProfileTest extends ContextTestSupport {
 
     protected boolean canTest() {
@@ -31,9 +33,7 @@ public class ThrottlerThreadPoolProfileTest extends ContextTestSupport {
 
     @Test
     public void testThreadPool() throws Exception {
-        if (!canTest()) {
-            return;
-        }
+        assumeTrue(canTest());
 
         getMockEndpoint("mock:result").expectedMessageCount(2);
 

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedPooledExchangeTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedPooledExchangeTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.condition.OS;
 import static org.apache.camel.management.DefaultManagementObjectNameStrategy.TYPE_SERVICE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @DisabledOnOs(OS.AIX)
 public class ManagedPooledExchangeTest extends ManagementTestSupport {
@@ -59,9 +58,6 @@ public class ManagedPooledExchangeTest extends ManagementTestSupport {
 
     @Test
     public void testSameExchange() throws Exception {
-        // JMX tests dont work well on AIX CI servers (hangs them)
-        assumeFalse(isPlatform("aix"));
-
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(3);
         mock.expectedPropertyValuesReceivedInAnyOrder("myprop", 1, 3, 5);

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedPooledExchangeTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedPooledExchangeTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.condition.OS;
 import static org.apache.camel.management.DefaultManagementObjectNameStrategy.TYPE_SERVICE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @DisabledOnOs(OS.AIX)
 public class ManagedPooledExchangeTest extends ManagementTestSupport {
@@ -59,9 +60,7 @@ public class ManagedPooledExchangeTest extends ManagementTestSupport {
     @Test
     public void testSameExchange() throws Exception {
         // JMX tests dont work well on AIX CI servers (hangs them)
-        if (isPlatform("aix")) {
-            return;
-        }
+        assumeFalse(isPlatform("aix"));
 
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(3);

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedRouteGetPropertiesTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedRouteGetPropertiesTest.java
@@ -37,9 +37,6 @@ public class ManagedRouteGetPropertiesTest extends ManagementTestSupport {
 
     @Test
     public void testGetProperties() throws Exception {
-        // JMX tests don't work well on AIX CI servers (hangs them)
-        assumeFalse(isPlatform("aix"));
-
         MBeanServer mbeanServer = getMBeanServer();
         ObjectName on = getRouteObjectName(mbeanServer);
 

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedRouteStopWithAbortAfterTimeoutTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedRouteStopWithAbortAfterTimeoutTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.condition.OS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @DisabledOnOs(OS.AIX)
 public class ManagedRouteStopWithAbortAfterTimeoutTest extends ManagementTestSupport {
@@ -40,9 +41,8 @@ public class ManagedRouteStopWithAbortAfterTimeoutTest extends ManagementTestSup
     @Test
     public void testStopRouteWithAbortAfterTimeoutTrue() throws Exception {
         // JMX tests dont work well on AIX or windows CI servers (hangs them)
-        if (isPlatform("aix") || isPlatform("windows")) {
-            return;
-        }
+        assumeFalse(isPlatform("aix"));
+        assumeFalse(isPlatform("windows"));
 
         MockEndpoint mockEP = getMockEndpoint("mock:result");
         mockEP.setExpectedMessageCount(10);
@@ -82,9 +82,8 @@ public class ManagedRouteStopWithAbortAfterTimeoutTest extends ManagementTestSup
     @Test
     public void testStopRouteWithAbortAfterTimeoutFalse() throws Exception {
         // JMX tests dont work well on AIX or windows CI servers (hangs them)
-        if (isPlatform("aix") || isPlatform("windows")) {
-            return;
-        }
+        assumeFalse(isPlatform("aix"));
+        assumeFalse(isPlatform("windows"));
 
         MockEndpoint mockEP = getMockEndpoint("mock:result");
 

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedRouteStopWithAbortAfterTimeoutTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedRouteStopWithAbortAfterTimeoutTest.java
@@ -33,17 +33,12 @@ import org.junit.jupiter.api.condition.OS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-@DisabledOnOs(OS.AIX)
+@DisabledOnOs({ OS.WINDOWS, OS.AIX })
 public class ManagedRouteStopWithAbortAfterTimeoutTest extends ManagementTestSupport {
 
     @Test
     public void testStopRouteWithAbortAfterTimeoutTrue() throws Exception {
-        // JMX tests dont work well on AIX or windows CI servers (hangs them)
-        assumeFalse(isPlatform("aix"));
-        assumeFalse(isPlatform("windows"));
-
         MockEndpoint mockEP = getMockEndpoint("mock:result");
         mockEP.setExpectedMessageCount(10);
 
@@ -81,10 +76,6 @@ public class ManagedRouteStopWithAbortAfterTimeoutTest extends ManagementTestSup
 
     @Test
     public void testStopRouteWithAbortAfterTimeoutFalse() throws Exception {
-        // JMX tests dont work well on AIX or windows CI servers (hangs them)
-        assumeFalse(isPlatform("aix"));
-        assumeFalse(isPlatform("windows"));
-
         MockEndpoint mockEP = getMockEndpoint("mock:result");
 
         MBeanServer mbeanServer = getMBeanServer();

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedThrottlerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedThrottlerTest.java
@@ -113,10 +113,7 @@ public class ManagedThrottlerTest extends ManagementTestSupport {
     public void testThrottleVisableViaJmx() throws Exception {
         // JMX tests dont work well on AIX CI servers (hangs them)
         assumeFalse(isPlatform("aix"));
-        if (isPlatform("windows")) {
-            // windows needs more sleep to read updated jmx values so we skip as we dont want further delays in core tests
-            return;
-        }
+        assumeFalse(isPlatform("windows"));
 
         // get the stats for the route
         MBeanServer mbeanServer = getMBeanServer();
@@ -146,10 +143,7 @@ public class ManagedThrottlerTest extends ManagementTestSupport {
     public void testThrottleAsyncVisableViaJmx() throws Exception {
         // JMX tests dont work well on AIX CI servers (hangs them)
         assumeFalse(isPlatform("aix"));
-        if (isPlatform("windows")) {
-            // windows needs more sleep to read updated jmx values so we skip as we dont want further delays in core tests
-            return;
-        }
+        assumeFalse(isPlatform("windows"));
 
         // get the stats for the route
         MBeanServer mbeanServer = getMBeanServer();
@@ -181,10 +175,7 @@ public class ManagedThrottlerTest extends ManagementTestSupport {
     public void testThrottleAsyncExceptionVisableViaJmx() throws Exception {
         // JMX tests dont work well on AIX CI servers (hangs them)
         assumeFalse(isPlatform("aix"));
-        if (isPlatform("windows")) {
-            // windows needs more sleep to read updated jmx values so we skip as we dont want further delays in core tests
-            return;
-        }
+        assumeFalse(isPlatform("windows"));
 
         // get the stats for the route
         MBeanServer mbeanServer = getMBeanServer();

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedThrottlerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedThrottlerTest.java
@@ -39,7 +39,6 @@ import static org.apache.camel.management.DefaultManagementObjectNameStrategy.TY
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @DisabledOnOs(OS.AIX)
 public class ManagedThrottlerTest extends ManagementTestSupport {
@@ -109,12 +108,9 @@ public class ManagedThrottlerTest extends ManagementTestSupport {
         assertTrue(total > 1000, "Should be around 1 sec now: was " + total);
     }
 
+    @DisabledOnOs(OS.WINDOWS)
     @Test
     public void testThrottleVisableViaJmx() throws Exception {
-        // JMX tests dont work well on AIX CI servers (hangs them)
-        assumeFalse(isPlatform("aix"));
-        assumeFalse(isPlatform("windows"));
-
         // get the stats for the route
         MBeanServer mbeanServer = getMBeanServer();
 
@@ -139,12 +135,9 @@ public class ManagedThrottlerTest extends ManagementTestSupport {
         assertEquals(10, completed.longValue());
     }
 
+    @DisabledOnOs(OS.WINDOWS)
     @Test
     public void testThrottleAsyncVisableViaJmx() throws Exception {
-        // JMX tests dont work well on AIX CI servers (hangs them)
-        assumeFalse(isPlatform("aix"));
-        assumeFalse(isPlatform("windows"));
-
         // get the stats for the route
         MBeanServer mbeanServer = getMBeanServer();
 
@@ -171,12 +164,9 @@ public class ManagedThrottlerTest extends ManagementTestSupport {
         assertEquals(10, completed.longValue());
     }
 
+    @DisabledOnOs(OS.WINDOWS)
     @Test
     public void testThrottleAsyncExceptionVisableViaJmx() throws Exception {
-        // JMX tests dont work well on AIX CI servers (hangs them)
-        assumeFalse(isPlatform("aix"));
-        assumeFalse(isPlatform("windows"));
-
         // get the stats for the route
         MBeanServer mbeanServer = getMBeanServer();
 

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagementTestSupport.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagementTestSupport.java
@@ -32,8 +32,6 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.NamedNode;
 import org.apache.camel.impl.engine.AbstractCamelContext;
 import org.apache.camel.spi.NodeIdFactory;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import static org.apache.camel.management.DefaultManagementAgent.DEFAULT_DOMAIN;
 import static org.apache.camel.management.DefaultManagementObjectNameStrategy.KEY_CONTEXT;
@@ -50,7 +48,6 @@ import static org.apache.camel.management.DefaultManagementObjectNameStrategy.TY
 /**
  * Base class for JMX tests.
  */
-@DisabledOnOs(OS.AIX)
 public abstract class ManagementTestSupport extends ContextTestSupport {
 
     @Override

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/ftp/SpringFileAntPathMatcherRemoteFileFilterTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/ftp/SpringFileAntPathMatcherRemoteFileFilterTest.java
@@ -36,6 +36,7 @@ import org.springframework.test.context.ContextConfiguration;
  */
 @CamelSpringTest
 @ContextConfiguration
+@DisabledOnOs({ OS.AIX, OS.WINDOWS, OS.SOLARIS })
 public class SpringFileAntPathMatcherRemoteFileFilterTest {
     @RegisterExtension
     public static FtpServiceExtension ftpServiceExtension
@@ -51,7 +52,6 @@ public class SpringFileAntPathMatcherRemoteFileFilterTest {
     @EndpointInject("mock:result")
     protected MockEndpoint result;
 
-    @DisabledOnOs({ OS.AIX, OS.WINDOWS, OS.SOLARIS })
     @Test
     void testAntPatchMatherFilter() throws Exception {
 


### PR DESCRIPTION
With [PR 8084](https://github.com/apache/camel/pull/8084) 3 errors comes in unit-tests for camel-jetty component, they are fixed in this PR.
And this PR contains small unit-test improvement in different components: instead of "success" execution of some unit-tests they are marked as "skipped" (using JUnit5 Assumptions mechanism)