### PR TITLE
CAMEL-18344: camel-google-pubsub - Open guava version for OSGI bundle

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -226,7 +226,8 @@
     <google-cloud-bom-version>25.4.0</google-cloud-bom-version>
     <google-cloud-functions-bom-version>1.0.8</google-cloud-functions-bom-version>
     <google-cloud-functions-gax-grpc-version>1.62.0</google-cloud-functions-gax-grpc-version>
-    <google-cloud-guava-version>30.1-jre</google-cloud-guava-version>
+    <google-cloud-guava-version>${google-cloud-guava-version-prefix}-jre</google-cloud-guava-version>
+    <google-cloud-guava-version-prefix>30.1</google-cloud-guava-version-prefix>
     <google-cloud-secretmanager-bom-version>2.1.1</google-cloud-secretmanager-bom-version>
     <google-guava-version>20.0</google-guava-version>
     <google-maps-services-version>0.10.1</google-maps-services-version>

--- a/components/camel-google/camel-google-pubsub/pom.xml
+++ b/components/camel-google/camel-google-pubsub/pom.xml
@@ -36,6 +36,7 @@
         <schemeName>google-pubsub</schemeName>
         <componentName>GooglePubSub</componentName>
         <componentPackage>org.apache.camel.component.google.pubsub</componentPackage>
+        <camel.osgi.import>com.google.common*;version="${google-cloud-guava-version-prefix}",*</camel.osgi.import>
     </properties>
 
     <dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -210,7 +210,8 @@
         <google-cloud-bom-version>25.4.0</google-cloud-bom-version>
         <google-cloud-functions-bom-version>1.0.8</google-cloud-functions-bom-version>
         <google-cloud-functions-gax-grpc-version>1.62.0</google-cloud-functions-gax-grpc-version>
-        <google-cloud-guava-version>30.1-jre</google-cloud-guava-version>
+        <google-cloud-guava-version-prefix>30.1</google-cloud-guava-version-prefix>
+        <google-cloud-guava-version>${google-cloud-guava-version-prefix}-jre</google-cloud-guava-version>
         <google-cloud-secretmanager-bom-version>2.1.1</google-cloud-secretmanager-bom-version>
         <graaljs-version>22.1.0</graaljs-version>
         <graphql-java-version>18.2</graphql-java-version>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18344 (backport 3.18)

## Motivation

To be able to re-include the feature `camel-google-pubsub` in camel-karaf, I would need to make the bundle more flexible by opening the version of guava

## Modifications

* Indicates a starting version of google guava to allow more recent versions that are also compatible 