### PR TITLE
CAMEL-18346 Remove xalan-specific code / references

### DIFF
--- a/buildingtools/src/main/resources/notice-supplements.xml
+++ b/buildingtools/src/main/resources/notice-supplements.xml
@@ -139,23 +139,6 @@
   </supplement>
   <supplement>
     <project>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <name>Apache Xalan-Java</name>
-      <organization>
-        <name>The Apache Software Foundation</name>
-        <url>http://www.apache.org</url>
-      </organization>
-      <licenses>
-        <license>
-          <name>The Apache Software License, Version 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-        </license>
-      </licenses>
-    </project>
-  </supplement>
-  <supplement>
-    <project>
       <groupId>net.java.dev.stax-utils</groupId>
       <artifactId>stax-utils</artifactId>
       <name>StAX Utilities</name>

--- a/components/camel-cxf/camel-cxf-common/src/main/java/org/apache/camel/component/cxf/converter/CachedCxfPayload.java
+++ b/components/camel-cxf/camel-cxf-common/src/main/java/org/apache/camel/component/cxf/converter/CachedCxfPayload.java
@@ -129,11 +129,6 @@ public class CachedCxfPayload<T> extends CxfPayload<T> implements StreamCache {
                 outputProperties.put("omit-xml-declaration", "yes");
 
                 transformer.setOutputProperties(outputProperties);
-                if (factory.getClass().getName().equals("org.apache.xalan.processor.TransformerFactoryImpl")
-                        && source instanceof StAXSource) {
-                    source = new StAX2SAXSource(((StAXSource) source).getXMLStreamReader());
-                }
-
                 transformer.transform(source, result);
             }
         }

--- a/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceHelper.java
+++ b/components/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/SpringWebserviceHelper.java
@@ -49,11 +49,6 @@ public final class SpringWebserviceHelper {
                 outputProperties.put("omit-xml-declaration", "yes");
 
                 transformer.setOutputProperties(outputProperties);
-                if (factory.getClass().getName().equals("org.apache.xalan.processor.TransformerFactoryImpl")
-                        && source instanceof StAXSource) {
-                    source = new StAX2SAXSource(((StAXSource) source).getXMLStreamReader());
-                }
-
                 transformer.transform(source, result);
             }
         }

--- a/core/camel-core/src/test/java/org/apache/camel/builder/xml/XPathTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/builder/xml/XPathTest.java
@@ -306,33 +306,6 @@ public class XPathTest extends ContextTestSupport {
         assertTrue(result.toString().contains("James"));
     }
 
-    @Test
-    public void testUsingJavaExtensions() throws Exception {
-        Object instance = null;
-
-        // we may not have Xalan on the classpath
-        try {
-            instance = Class.forName("org.apache.xalan.extensions.XPathFunctionResolverImpl").getDeclaredConstructor()
-                    .newInstance();
-        } catch (Throwable e) {
-
-            log.debug("Could not find Xalan on the classpath so ignoring this test case: " + e);
-        }
-        if (instance instanceof XPathFunctionResolver) {
-            XPathFunctionResolver functionResolver = (XPathFunctionResolver) instance;
-
-            XPathBuilder builder = xpath("java:" + getClass().getName() + ".func(string(/header/value))")
-                    .namespace("java", "http://xml.apache.org/xalan/java")
-                    .functionResolver(functionResolver).stringResult();
-
-            String xml = "<header><value>12</value></header>";
-            // it can throw the exception if we put the xalan into the test
-            // class path
-            assertExpression(builder, xml, "modified12");
-        }
-
-    }
-
     public static String func(String message) {
         return "modified" + message;
     }

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/XmlConverter.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/XmlConverter.java
@@ -93,7 +93,6 @@ public class XmlConverter {
 
     private static final String JDK_FALLBACK_TRANSFORMER_FACTORY
             = "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl";
-    private static final String XALAN_TRANSFORMER_FACTORY = "org.apache.xalan.processor.TransformerFactoryImpl";
     private static final Logger LOG = LoggerFactory.getLogger(XmlConverter.class);
     private static final ErrorHandler DOCUMENT_BUILDER_LOGGING_ERROR_HANDLER = new DocumentBuilderLoggingErrorHandler();
 
@@ -138,11 +137,6 @@ public class XmlConverter {
             throw new TransformerException("Could not create a transformer - JAXP is misconfigured!");
         }
         transformer.setOutputProperties(outputProperties);
-        if (this.transformerFactory.getClass().getName().equals(XALAN_TRANSFORMER_FACTORY)
-                && source instanceof StAXSource) {
-            //external xalan can't handle StAXSource, so convert StAXSource to SAXSource.
-            source = new StAX2SAXSource(((StAXSource) source).getXMLStreamReader());
-        }
         transformer.transform(source, result);
     }
 


### PR DESCRIPTION
https://github.com/apache/camel/compare/main...cunningt:camel:morexalanremoval?expand=1#diff-a45e30e0e6a08fbf84385cefeb5061c392f999feb13cb1d0aefb49b2eeadfad0 : I think the xalan entry can be removed now that xalan is not being included in camel-eip-documentation-enricher-maven-plugin (xalan is not used anywhere else inside of tooling)

https://github.com/apache/camel/compare/main...cunningt:camel:morexalanremoval?expand=1#diff-6e42f7bb9284d62714d0b1dac53fb58b16cfae965a91e7e87f3461037841bc51 : I think can be removed because this is a xalan-specific / non-JDK case?

https://github.com/apache/camel/compare/main...cunningt:camel:morexalanremoval?expand=1#diff-761b735e3a131740e351452e7430479cc3fa479e80bb8b7ba43c56c877dc83ae : I think can be removed because this is a xalan-specific / non-JDK case?

https://github.com/apache/camel/compare/main...cunningt:camel:morexalanremoval?expand=1#diff-e289658633654b0a6aec69da77bbdc0b7a060cd5e0bab977fea678ed8e7ed6a1 : I think can be removed because this is a xalan-specific / non-JDK case?


