### PR TITLE
Exclude org.slf4j:slf4j-reload4j to avoid logback warnings/errors

### DIFF
--- a/components/camel-hdfs/pom.xml
+++ b/components/camel-hdfs/pom.xml
@@ -73,6 +73,10 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>


### PR DESCRIPTION
Exclude org.slf4j:slf4j-reload4j coming in from hadoop common - it is causing multiple SLF4J bindings in the camel-hdfs tests and logback errors in the camel-spring-boot camel-hdfs-starter tests.

Excluding slf4j-reload4j removes the multiple SLF4J bindings logging and the logback error in camel-spring-boot integration tests.     Tests pass locally for me with this change.

```
[INFO] Running org.apache.camel.component.hdfs.integration.HdfsConsumerIntegrationIT
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/Users/tcunning/.m2/repository/org/slf4j/slf4j-reload4j/1.7.36/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/Users/tcunning/.m2/repository/org/apache/logging/log4j/log4j-slf4j-impl/2.18.0/log4j-slf4j-impl-2.18.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
```
