### PR TITLE
[CAMEL-18503] Configure max ack extension period in PubSub subscriber

### DIFF
--- a/components/camel-google/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubComponent.java
+++ b/components/camel-google/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubComponent.java
@@ -55,6 +55,7 @@ import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.threeten.bp.Duration;
 
 /**
  * Represents the component that manages {@link GooglePubsubEndpoint}.
@@ -187,6 +188,7 @@ public class GooglePubsubComponent extends DefaultComponent {
             builder.setChannelProvider(channelProvider);
         }
         builder.setCredentialsProvider(getCredentialsProvider(googlePubsubEndpoint));
+        builder.setMaxAckExtensionPeriod(Duration.ofSeconds(googlePubsubEndpoint.getMaxAckExtensionPeriod()));
         return builder.build();
     }
 

--- a/components/camel-google/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubEndpoint.java
+++ b/components/camel-google/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubEndpoint.java
@@ -86,6 +86,11 @@ public class GooglePubsubEndpoint extends DefaultEndpoint {
               description = "AUTO = exchange gets ack'ed/nack'ed on completion. NONE = downstream process has to ack/nack explicitly")
     private GooglePubsubConstants.AckMode ackMode = GooglePubsubConstants.AckMode.AUTO;
 
+    @UriParam(label = "consumer", name = "maxAckExtensionPeriod",
+              description = "Set the maximum period a message ack deadline will be extended. Value in seconds",
+              defaultValue = "3600")
+    private int maxAckExtensionPeriod = 3600;
+
     @UriParam(defaultValue = "false",
               description = "Should message ordering be enabled",
               label = "producer,advanced")
@@ -223,6 +228,14 @@ public class GooglePubsubEndpoint extends DefaultEndpoint {
 
     public void setAckMode(GooglePubsubConstants.AckMode ackMode) {
         this.ackMode = ackMode;
+    }
+
+    public int getMaxAckExtensionPeriod() {
+        return maxAckExtensionPeriod;
+    }
+
+    public void setMaxAckExtensionPeriod(int maxAckExtensionPeriod) {
+        this.maxAckExtensionPeriod = maxAckExtensionPeriod;
     }
 
     public GooglePubsubSerializer getSerializer() {


### PR DESCRIPTION
As described in CAMEL-18503, this PR provides the possibility to configure the max ack extension period on a Google PubSub consumer route.
