### PR TITLE
CAMEL-18505 Camel-coap: Version conflict (californium-legal and californium-connector)

### DIFF
--- a/components/camel-coap/pom.xml
+++ b/components/camel-coap/pom.xml
@@ -44,6 +44,16 @@
             <groupId>org.eclipse.californium</groupId>
             <artifactId>californium-core</artifactId>
             <version>${californium-version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>element-connector</artifactId>
+                    <groupId>org.eclipse.californium</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>californium-legal</artifactId>
+                    <groupId>org.eclipse.californium</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.californium</groupId>
@@ -54,7 +64,29 @@
             <groupId>org.eclipse.californium</groupId>
             <artifactId>element-connector-tcp-netty</artifactId>
             <version>${californium-version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>element-connector</artifactId>
+                    <groupId>org.eclipse.californium</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>californium-legal</artifactId>
+                    <groupId>org.eclipse.californium</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+        <dependency>
+            <artifactId>element-connector</artifactId>
+            <groupId>org.eclipse.californium</groupId>
+            <version>${californium-scandium-version}</version>
+        </dependency>
+        <dependency>
+            <artifactId>californium-legal</artifactId>
+            <groupId>org.eclipse.californium</groupId>
+            <version>${californium-scandium-version}</version>
+        </dependency>
+
 
         <!-- logging -->
         <dependency>


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-18505

I'm excluding californium-legal and element-connector with version 2.7.2 and adding it as 2.7.3 to prevent conflict.
(I can not change  <californium-version>2.7.2</californium-version> to 2.7.3, because org.eclipse.californium:element-connector-tcp-netty:jar:2.7.3 does not exists)

I used `californium-scandium-version` as a version number for   californium-legal and element-connector, I can not find a better name of that property. But in the future, once all californium dependencies will have the same version, property will be removed. So I think it is acceptable.

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
