### PR TITLE
CAMEL-18516: camel-yaml-dsl - bannedDefinitions doesn't work for gene…

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
@@ -102,6 +102,11 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
                     .map(values -> Stream.of(values).collect(Collectors.toCollection(TreeSet::new)))
                     .orElseGet(TreeSet::new);
 
+            final DotName name = DotName.createSimple(entry.getKey());
+            final ClassInfo info = view.getClassByName(name);
+            if (isBanned(info)) {
+                continue;
+            }
             if (hasAnnotation(entry.getValue(), YAML_IN_ANNOTATION)) {
                 nodes.forEach(node -> {
                     items.with("properties")
@@ -109,9 +114,6 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
                             .put("$ref", "#/items/definitions/" + entry.getKey());
                 });
             } else {
-                final DotName name = DotName.createSimple(entry.getKey());
-                final ClassInfo info = view.getClassByName(name);
-
                 if (extendsType(info, PROCESSOR_DEFINITION_CLASS)) {
                     nodes.forEach(node -> {
                         step.with("properties")

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camel-yaml-dsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camel-yaml-dsl.json
@@ -1010,30 +1010,6 @@
           }
         }
       },
-      "org.apache.camel.model.FromDefinition" : {
-        "type" : "object",
-        "properties" : {
-          "description" : {
-            "type" : "string"
-          },
-          "id" : {
-            "type" : "string"
-          },
-          "parameters" : {
-            "type" : "object"
-          },
-          "steps" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
-            }
-          },
-          "uri" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "steps", "uri" ]
-      },
       "org.apache.camel.model.GlobalOptionDefinition" : {
         "type" : "object",
         "properties" : {

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
@@ -914,30 +914,6 @@
           }
         }
       },
-      "org.apache.camel.model.FromDefinition" : {
-        "type" : "object",
-        "properties" : {
-          "description" : {
-            "type" : "string"
-          },
-          "id" : {
-            "type" : "string"
-          },
-          "parameters" : {
-            "type" : "object"
-          },
-          "steps" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
-            }
-          },
-          "uri" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "steps", "uri" ]
-      },
       "org.apache.camel.model.GlobalOptionDefinition" : {
         "type" : "object",
         "properties" : {


### PR DESCRIPTION
…rate-yaml-schema

Submitting a draft PR - currently it has test failures due to `FromDefinition` missing and looking into whether we have to adjust the test cases or remove `FromDefinition` from ban list.
```
[INFO] Running org.apache.camel.dsl.yaml.RouteConfigurationTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.004 s <<< FAILURE! - in org.apache.camel.dsl.yaml.RouteConfigurationTest
[ERROR] org.apache.camel.dsl.yaml.RouteConfigurationTest.route-configuration-id  Time elapsed: 0.003 s  <<< ERROR!
com.github.fge.jsonschema.core.exceptions.ProcessingException: 
fatal: JSON Reference "#/items/definitions/org.apache.camel.model.FromDefinition" cannot be resolved
    level: "fatal"
    schema: {"loadingURI":"#","pointer":"/items/definitions/org.apache.camel.model.RouteDefinition/properties/from"}
    ref: "#/items/definitions/org.apache.camel.model.FromDefinition"

	at com.github.fge.jsonschema.core.load.RefResolver.rawProcess(RefResolver.java:123)
	at com.github.fge.jsonschema.core.load.RefResolver.rawProcess(RefResolver.java:51)
	at com.github.fge.jsonschema.core.processing.RawProcessor.process(RawProcessor.java:77)
	at com.github.fge.jsonschema.core.processing.RawProcessor.process(RawProcessor.java:41)
	at com.github.fge.jsonschema.core.processing.ProcessorChain$ProcessorMerger.process(ProcessorChain.java:189)
	at com.github.fge.jsonschema.core.processing.ProcessingResult.of(ProcessingResult.java:79)
	at com.github.fge.jsonschema.core.processing.CachingProcessor$1.load(CachingProcessor.java:141)
	at com.github.fge.jsonschema.core.processing.CachingProcessor$1.load(CachingProcessor.java:133)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3628)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2336)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2295)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2208)
	at com.google.common.cache.LocalCache.get(LocalCache.java:4053)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4057)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4986)
	at com.github.fge.jsonschema.core.processing.CachingProcessor.process(CachingProcessor.java:122)
	at com.github.fge.jsonschema.processors.validation.ValidationChain.process(ValidationChain.java:107)
	at com.github.fge.jsonschema.processors.validation.ValidationChain.process(ValidationChain.java:57)
	at com.github.fge.jsonschema.core.processing.ProcessorMap$Mapper.process(ProcessorMap.java:166)
	at com.github.fge.jsonschema.core.processing.ProcessingResult.of(ProcessingResult.java:79)
	at com.github.fge.jsonschema.core.processing.CachingProcessor$1.load(CachingProcessor.java:141)
	at com.github.fge.jsonschema.core.processing.CachingProcessor$1.load(CachingProcessor.java:133)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3628)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2336)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2295)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2208)
	at com.google.common.cache.LocalCache.get(LocalCache.java:4053)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4057)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4986)
	at com.github.fge.jsonschema.core.processing.CachingProcessor.process(CachingProcessor.java:122)
	at com.github.fge.jsonschema.processors.validation.InstanceValidator.process(InstanceValidator.java:109)
	at com.github.fge.jsonschema.processors.validation.InstanceValidator.processObject(InstanceValidator.java:217)
	at com.github.fge.jsonschema.processors.validation.InstanceValidator.process(InstanceValidator.java:150)
	at com.github.fge.jsonschema.processors.validation.InstanceValidator.processObject(InstanceValidator.java:217)
	at com.github.fge.jsonschema.processors.validation.InstanceValidator.process(InstanceValidator.java:150)
	at com.github.fge.jsonschema.processors.validation.InstanceValidator.processArray(InstanceValidator.java:187)
	at com.github.fge.jsonschema.processors.validation.InstanceValidator.process(InstanceValidator.java:148)
	at com.github.fge.jsonschema.processors.validation.ValidationProcessor.process(ValidationProcessor.java:56)
	at com.github.fge.jsonschema.processors.validation.ValidationProcessor.process(ValidationProcessor.java:34)
	at com.github.fge.jsonschema.core.processing.ProcessingResult.of(ProcessingResult.java:79)
	at com.github.fge.jsonschema.main.JsonSchemaImpl.doValidate(JsonSchemaImpl.java:77)
	at com.github.fge.jsonschema.main.JsonSchemaImpl.validate(JsonSchemaImpl.java:100)
	at com.github.fge.jsonschema.main.JsonSchemaImpl.validate(JsonSchemaImpl.java:110)
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:318)
	at org.apache.camel.dsl.yaml.support.YamlTestSupport.loadRoutes(YamlTestSupport.groovy:54)
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:318)
	at org.apache.camel.dsl.yaml.support.YamlTestSupport.loadRoutes(YamlTestSupport.groovy:84)
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:318)
	at org.apache.camel.dsl.yaml.RouteConfigurationTest.route-configuration-id(RouteConfigurationTest.groovy:198)
```
@lburgazzoli does this ring your bell?