### PR TITLE
CAMEL-18514: camel-health - health check for not automatically started routes should always be up

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/impl/health/RouteHealthCheckTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/health/RouteHealthCheckTest.java
@@ -21,8 +21,10 @@ import java.util.Collections;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Route;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckResultBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class RouteHealthCheckTest {
@@ -46,6 +48,30 @@ public class RouteHealthCheckTest {
         final HealthCheckResultBuilder builder = HealthCheckResultBuilder.on(healthCheck);
 
         healthCheck.doCall(builder, Collections.emptyMap());
+
+        context.stop();
+    }
+
+     @Test
+     public void testHealthCheckIsUpWhenRouteIsNotAutoStartup() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:input").id(TEST_ROUTE_ID).autoStartup(false).log("Message");
+            }
+        });
+        context.start();
+
+        Route route = context.getRoute(TEST_ROUTE_ID);
+
+        RouteHealthCheck healthCheck = new RouteHealthCheck(route);
+        final HealthCheckResultBuilder builder = HealthCheckResultBuilder.on(healthCheck);
+
+        healthCheck.doCall(builder, Collections.emptyMap());
+        HealthCheck.Result result = builder.build();
+
+        Assertions.assertEquals(HealthCheck.State.UP, result.getState());
 
         context.stop();
     }

--- a/core/camel-health/src/main/java/org/apache/camel/impl/health/RouteHealthCheck.java
+++ b/core/camel-health/src/main/java/org/apache/camel/impl/health/RouteHealthCheck.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Route;
 import org.apache.camel.ServiceStatus;
-import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckResultBuilder;
 
 /**
@@ -63,7 +62,7 @@ public class RouteHealthCheck extends AbstractHealthCheck {
                     builder.message(String.format("Route %s has status %s", route.getId(), status.name()));
                 }
             } else {
-                if (route.isAutoStartup()) {
+                if (!route.isAutoStartup()) {
                     // if a route is configured to not to automatically start, then the
                     // route is always up as it is externally managed.
                     builder.up();


### PR DESCRIPTION
Fixes bug [CAMEL-18514](https://issues.apache.org/jira/browse/CAMEL-18514).