### PR TITLE
Adds tests to demonstrate bug within the toD optimisation

### DIFF
--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpSendDynamicAwareUriWithSpacesTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpSendDynamicAwareUriWithSpacesTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.http;
+
+import java.util.Map;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.ExchangeBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.http.handler.BasicValidationHandler;
+import org.apache.http.impl.bootstrap.HttpServer;
+import org.apache.http.impl.bootstrap.ServerBootstrap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HttpSendDynamicAwareUriWithSpacesTest extends BaseHttpTest {
+
+    private HttpServer localServer;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        localServer = ServerBootstrap.bootstrap().setHttpProcessor(getBasicHttpProcessor())
+            .setConnectionReuseStrategy(getConnectionReuseStrategy()).setResponseFactory(getHttpResponseFactory())
+            .setExpectationVerifier(getHttpExpectationVerifier()).setSslContext(getSSLContext())
+            .registerHandler("/users/*", new BasicValidationHandler("GET", null, null, "a user")).create();
+        localServer.start();
+
+        super.setUp();
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        if (localServer != null) {
+            localServer.stop();
+        }
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:usersDrink")
+                    .toD("http:localhost:" + localServer.getLocalPort()
+                        + "/users/${exchangeProperty.user}");
+            }
+        };
+    }
+    
+    @Test
+    public void testDynamicAware() throws Exception {
+        Exchange out = fluentTemplate.to("direct:usersDrink")
+            .withExchange(ExchangeBuilder.anExchange(context).withProperty("user", "joes moes").build()).send();
+        assertEquals("a user", out.getMessage().getBody(String.class));
+
+        out = fluentTemplate.to("direct:usersDrink")
+            .withExchange(ExchangeBuilder.anExchange(context).withProperty("user", "moes joes").build()).send();
+        assertEquals("a user", out.getMessage().getBody(String.class));
+
+        // and there should only be one http endpoint as they are both on same host
+        Map<String, Endpoint> endpointMap = context.getEndpointMap();
+        assertEquals(2, endpointMap.size());
+        assertTrue(endpointMap.containsKey("http://localhost:" + localServer.getLocalPort()), "Should find static uri");
+        assertTrue(endpointMap.containsKey("direct://usersDrink"), "Should find direct");
+    }
+    
+}


### PR DESCRIPTION
The toD optimisation does not work when a path variable contains a space.

The HTTP component correctly encodes spaces to %20, but the HttpSendDynamicAware does not follow this logic.
This triggers an URISyntaxException because java.net.URI  (on line 168) does not accept an unencoded URL.

It might be worthwhile to add some logging when an URISyntaxException is handled. Currently, it goes unnoticed.
