### PR TITLE
CAMEL-17780: camel-elasticsearch - Add doc about the SB component

### DIFF
--- a/components/camel-elasticsearch/src/main/docs/elasticsearch-component.adoc
+++ b/components/camel-elasticsearch/src/main/docs/elasticsearch-component.adoc
@@ -6,6 +6,8 @@
 :since: 3.19
 :supportlevel: Preview
 :component-header: Only producer is supported
+//Manually maintained attributes
+:camel-spring-boot-name: elasticsearch
 
 *Since Camel {since}*
 
@@ -275,3 +277,16 @@ List<MultiSearchResponseItem<?>> response = template.requestBody("direct:multiSe
 For all the search operations, it is possible to indicate the type of document to retrieve in order to get the result already unmarshalled with the expected type.
 
 The document type can be set using the header "documentClass" or via the uri parameter of the same name.
+
+== Disable Sniffer when using Spring Boot
+
+When Spring Boot is on the classpath the Sniffer client for Elasticsearch is enabled by default. This option can be disabled in the Spring Boot Configuration:
+
+[source,yaml]
+----
+spring:
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration
+----
+
+include::spring-boot:partial$starter.adoc[]


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-17780 (spring-boot doc part)

## Motivation

A new component `camel-elasticsearch-starter` is available, and we would like to have the corresponding doc about it.

## Modifications:

* Add the doc section about the corresponding starter
* Replicate the doc related to the configuration of the sniffer