### PR TITLE
CAMEL-18535: Upgrade HBase to 2.5.0

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -254,7 +254,7 @@
     <hawtbuf-version>1.11</hawtbuf-version>
     <hawtdispatch-version>1.22</hawtdispatch-version>
     <hazelcast-version>5.1.2</hazelcast-version>
-    <hbase-version>2.4.12</hbase-version>
+    <hbase-version>2.5.0</hbase-version>
     <hdrhistrogram-version>2.1.11</hdrhistrogram-version>
     <hibernate-validator-version>6.2.4.Final</hibernate-validator-version>
     <hibernate-version>5.6.10.Final</hibernate-version>

--- a/components/camel-hbase/pom.xml
+++ b/components/camel-hbase/pom.xml
@@ -46,6 +46,10 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -235,7 +235,7 @@
         <hawtbuf-version>1.11</hawtbuf-version>
         <hawtdispatch-version>1.22</hawtdispatch-version>
         <hazelcast-version>5.1.2</hazelcast-version>
-        <hbase-version>2.4.12</hbase-version>
+        <hbase-version>2.5.0</hbase-version>
         <hdrhistrogram-version>2.1.11</hdrhistrogram-version>
         <hibernate-validator-version>6.2.4.Final</hibernate-validator-version>
         <hibernate-version>5.6.10.Final</hibernate-version>

--- a/test-infra/camel-test-infra-hbase/pom.xml
+++ b/test-infra/camel-test-infra-hbase/pom.xml
@@ -53,6 +53,10 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>


### PR DESCRIPTION
Thought it'd be good to backport to 3.18.x if possible as there's a few security related fixes.