### PR TITLE
CAMEL-18549: Changed filter list in the DynamicRouterProcessor to a m…

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
@@ -489,7 +489,7 @@ Enriches a message with data from a secondary resource
     <xs:annotation>
       <xs:documentation xml:lang="en">
         <![CDATA[
-Camel error handling.
+Error handler settings
       ]]>
       </xs:documentation>
     </xs:annotation>

--- a/components/camel-dynamic-router/src/main/java/org/apache/camel/component/dynamicrouter/DynamicRouterProcessor.java
+++ b/components/camel-dynamic-router/src/main/java/org/apache/camel/component/dynamicrouter/DynamicRouterProcessor.java
@@ -62,8 +62,8 @@ public class DynamicRouterProcessor extends AsyncProcessorSupport implements Tra
     private static final String LOG_ENDPOINT = "log:%s.%s?level=%s&showAll=true&multiline=true";
 
     /**
-     * {@link FilterProcessor}s, mapped by subscription ID, to determine if the incoming exchange
-     * should be routed based on the content.
+     * {@link FilterProcessor}s, mapped by subscription ID, to determine if the incoming exchange should be routed based
+     * on the content.
      */
     private final TreeMap<String, PrioritizedFilterProcessor> filterMap;
 
@@ -227,7 +227,8 @@ public class DynamicRouterProcessor extends AsyncProcessorSupport implements Tra
     }
 
     /**
-     * Match the exchange against all {@link #filterMap} to determine if any of them are suitable to handle the exchange.
+     * Match the exchange against all {@link #filterMap} to determine if any of them are suitable to handle the
+     * exchange.
      *
      * @param  exchange the message exchange
      * @return          list of filters that match for the exchange; if "firstMatch" mode, it is a singleton list of
@@ -245,8 +246,8 @@ public class DynamicRouterProcessor extends AsyncProcessorSupport implements Tra
 
     /**
      * Processes the message exchange, where the caller supports having the exchange asynchronously processed. The
-     * exchange is matched against all {@link #filterMap} to determine if any of them are suitable to handle the exchange.
-     * When the first suitable filter is found, it processes the exchange.
+     * exchange is matched against all {@link #filterMap} to determine if any of them are suitable to handle the
+     * exchange. When the first suitable filter is found, it processes the exchange.
      * <p/>
      * If there was any failure in processing, then the caused {@link Exception} would be set on the {@link Exchange}.
      *

--- a/components/camel-dynamic-router/src/test/java/org/apache/camel/component/dynamicrouter/DynamicRouterProcessorTest.java
+++ b/components/camel-dynamic-router/src/test/java/org/apache/camel/component/dynamicrouter/DynamicRouterProcessorTest.java
@@ -23,7 +23,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.apache.camel.component.dynamicrouter.DynamicRouterConstants.MODE_FIRST_MATCH;
+import java.util.List;
+
+import static org.apache.camel.component.dynamicrouter.DynamicRouterConstants.MODE_ALL_MATCH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -34,7 +36,7 @@ class DynamicRouterProcessorTest extends DynamicRouterTestSupport {
     @BeforeEach
     void localSetup() throws Exception {
         super.setup();
-        processor = new DynamicRouterProcessor(PROCESSOR_ID, context, MODE_FIRST_MATCH, false, () -> filterProcessorFactory);
+        processor = new DynamicRouterProcessor(PROCESSOR_ID, context, MODE_ALL_MATCH, false, () -> filterProcessorFactory);
         processor.doInit();
     }
 
@@ -57,6 +59,16 @@ class DynamicRouterProcessorTest extends DynamicRouterTestSupport {
         processor.addFilter(filterProcessor);
         PrioritizedFilterProcessor result = processor.getFilter(TEST_ID);
         assertEquals(filterProcessor, result);
+    }
+
+    @Test
+    void addMultipleFiltersWithSameId() {
+        processor.addFilter(filterProcessor);
+        processor.addFilter(filterProcessor);
+        processor.addFilter(filterProcessor);
+        processor.addFilter(filterProcessor);
+        List<PrioritizedFilterProcessor> matchingFilters = processor.matchFilters(exchange);
+        assertEquals(1, matchingFilters.size());
     }
 
     @Test

--- a/components/camel-dynamic-router/src/test/java/org/apache/camel/component/dynamicrouter/DynamicRouterProcessorTest.java
+++ b/components/camel-dynamic-router/src/test/java/org/apache/camel/component/dynamicrouter/DynamicRouterProcessorTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.component.dynamicrouter;
 
+import java.util.List;
+
 import org.apache.camel.AsyncCallback;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.dynamicrouter.support.DynamicRouterTestSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static org.apache.camel.component.dynamicrouter.DynamicRouterConstants.MODE_ALL_MATCH;
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
Trivial pull request where dynamic router processor filters are changed from a list to a map where filters are mapped by filter id to prevent accumulating multiple instances of the same filter if a component restarts multiple times and registers their filter each time.
