### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/component-pr.yaml
+++ b/.github/workflows/component-pr.yaml
@@ -29,8 +29,13 @@ on:
     types:
       - completed
 
+permissions: {}
 jobs:
   process:
+    permissions:
+      pull-requests: write # to comment on a pull request
+      actions: read # to download artifact
+
     name: Process
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main-checkstyle-build.yml
+++ b/.github/workflows/main-checkstyle-build.yml
@@ -24,6 +24,9 @@ on:
 # Every 6 hours during weekends ... we don't want to be flooded with emails
     - cron: '30 */6 * * 6,0'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-push-build.yml
+++ b/.github/workflows/main-push-build.yml
@@ -29,8 +29,13 @@ on:
       - Jenkinsfile.*
       - NOTICE.txt
 
+permissions: {}
 jobs:
   build:
+    permissions:
+      contents: write # to create branch (peter-evans/create-pull-request)
+      pull-requests: write # to create a PR (peter-evans/create-pull-request)
+
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.