### PR TITLE
Prevent CI workflows from running on forks

### DIFF
--- a/.github/workflows/alternative-os-build.yml
+++ b/.github/workflows/alternative-os-build.yml
@@ -29,6 +29,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'apache/camel'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/component-pr.yaml
+++ b/.github/workflows/component-pr.yaml
@@ -32,6 +32,7 @@ on:
 permissions: {}
 jobs:
   process:
+    if: github.repository == 'apache/camel'
     permissions:
       pull-requests: write # to comment on a pull request
       actions: read # to download artifact

--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -6,6 +6,7 @@ permissions:
 
 jobs:
   dependency-review:
+    if: github.repository == 'apache/camel'
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'

--- a/.github/workflows/generic-pr.yaml
+++ b/.github/workflows/generic-pr.yaml
@@ -29,6 +29,7 @@ permissions:
 
 jobs:
   process:
+    if: github.repository == 'apache/camel'
     permissions:
       contents: read  # for actions/labeler to determine modified files
       pull-requests: write  # for actions/labeler to add labels to PRs

--- a/.github/workflows/main-checkstyle-build.yml
+++ b/.github/workflows/main-checkstyle-build.yml
@@ -29,6 +29,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'apache/camel'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/main-push-build.yml
+++ b/.github/workflows/main-push-build.yml
@@ -32,6 +32,7 @@ on:
 permissions: {}
 jobs:
   build:
+    if: github.repository == 'apache/camel'
     permissions:
       contents: write # to create branch (peter-evans/create-pull-request)
       pull-requests: write # to create a PR (peter-evans/create-pull-request)

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -32,6 +32,7 @@ on:
 
 jobs:
   checkstyle:
+    if: github.repository == 'apache/camel'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -54,6 +55,7 @@ jobs:
         name: checkstyle.log
         path: checkstyle.log
   build:
+    if: github.repository == 'apache/camel'
     permissions:
       issues: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
Prevent camel workflows from running on forks like camel-quarkus does https://github.com/apache/camel-quarkus/commit/a4174460f67bfb792d331512abbab928c7d71dd5