### PR TITLE
CAMEL-18560: camel-etcd3 - Upgrade jetcd to 0.7.3

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -313,7 +313,7 @@
     <jcommander-version>1.72</jcommander-version>
     <jcr-version>2.0</jcr-version>
     <jedis-client-version>3.7.1</jedis-client-version>
-    <jetcd-version>0.5.11</jetcd-version>
+    <jetcd-version>0.7.3</jetcd-version>
     <jettison-version>1.5.0</jettison-version>
     <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
     <jetty-runner-groupId>org.eclipse.jetty</jetty-runner-groupId>

--- a/components/camel-etcd3/pom.xml
+++ b/components/camel-etcd3/pom.xml
@@ -47,7 +47,7 @@
 
         <dependency>
             <groupId>io.etcd</groupId>
-            <artifactId>jetcd-all</artifactId>
+            <artifactId>jetcd-core</artifactId>
             <version>${jetcd-version}</version>
         </dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -298,7 +298,7 @@
         <jcommander-version>1.72</jcommander-version>
         <jcr-version>2.0</jcr-version>
         <jedis-client-version>3.7.1</jedis-client-version>
-        <jetcd-version>0.5.11</jetcd-version>
+        <jetcd-version>0.7.3</jetcd-version>
         <jetty9-version>9.4.48.v20220622</jetty9-version>
         <jetty-version>${jetty9-version}</jetty-version>
         <jetty-plugin-version>${jetty-version}</jetty-plugin-version>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18560

## Motivation

Since the latest version of jetcd-all (0.5.11), new versions of jetcd have been released but as individual artifacts.

## Modifications

* Set the new version of jetcd in the parent and dependencies pom
* Change the name of the artifact for  `jetcd-core`