### PR TITLE
CAMEL-18560: camel-etcd3 - Align the grpc version of jetcd-grpc with vertx-grpc

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -314,6 +314,7 @@
     <jcr-version>2.0</jcr-version>
     <jedis-client-version>3.7.1</jedis-client-version>
     <jetcd-version>0.7.3</jetcd-version>
+    <jetcd-grpc-version>1.47.0</jetcd-grpc-version>
     <jettison-version>1.5.0</jettison-version>
     <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
     <jetty-runner-groupId>org.eclipse.jetty</jetty-runner-groupId>

--- a/components/camel-etcd3/pom.xml
+++ b/components/camel-etcd3/pom.xml
@@ -49,6 +49,18 @@
             <groupId>io.etcd</groupId>
             <artifactId>jetcd-core</artifactId>
             <version>${jetcd-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-core</artifactId>
+            <version>${jetcd-grpc-version}</version>
         </dependency>
 
         <!-- testing -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -299,6 +299,7 @@
         <jcr-version>2.0</jcr-version>
         <jedis-client-version>3.7.1</jedis-client-version>
         <jetcd-version>0.7.3</jetcd-version>
+        <jetcd-grpc-version>1.47.0</jetcd-grpc-version>
         <jetty9-version>9.4.48.v20220622</jetty9-version>
         <jetty-version>${jetty9-version}</jetty-version>
         <jetty-plugin-version>${jetty-version}</jetty-plugin-version>


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-18560

## Motivation

Merging https://github.com/apache/camel/pull/8436 causes a build failure in camel-spring-boot project with an error or type:
```
[INFO] --- camel-spring-boot-generator-maven-plugin:3.19.0-SNAPSHOT:prepare-spring-boot-starter (generate) @ camel-etcd3-starter ---
org.apache.maven.artifact.versioning.OverConstrainedVersionException: The artifact has no valid ranges
  io.grpc:grpc-core:jar:1.47.0

Path to dependency: 
	1) org.apache.camel:camel-etcd3:pom:3.19.0-SNAPSHOT
	2) io.etcd:jetcd-core:jar:0.7.3
	3) io.etcd:jetcd-grpc:jar:0.7.3
```

## Modifications

This is due to a conflict of grpc version used by jetcd-grpc (1.48.0) and the one used by vertx-grpc (1.47.0).

* Align the grpc versions to `1.47.0`
* Exclude grpc from jetcd-core

## Result

The build passes:

```
[INFO] ----------< org.apache.camel.springboot:camel-etcd3-starter >-----------
[INFO] Building Camel SB Starters :: Etcd 3 3.19.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ camel-etcd3-starter ---
[INFO] 
[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-maven-version) @ camel-etcd3-starter ---
[INFO] 
[INFO] --- camel-spring-boot-generator-maven-plugin:3.19.0-SNAPSHOT:prepare-spring-boot-starter (generate) @ camel-etcd3-starter ---
Sep 28, 2022 3:10:39 PM freemarker.log._JULLoggerFactory$JULLogger error
SEVERE: DefaultObjectWrapper.incompatibleImprovements was set to the object returned by Configuration.getVersion(). That defeats the purpose of incompatibleImprovements, and makes upgrading FreeMarker a potentially breaking change. Also, this probably won't be allowed starting from 2.4.0. Instead, set incompatibleImprovements to the highest concrete version that's known to be compatible with your application.
Sep 28, 2022 3:10:39 PM freemarker.log._JULLoggerFactory$JULLogger error
SEVERE: Configuration.incompatibleImprovements was set to the object returned by Configuration.getVersion(). That defeats the purpose of incompatibleImprovements, and makes upgrading FreeMarker a potentially breaking change. Also, this probably won't be allowed starting from 2.4.0. Instead, set incompatibleImprovements to the highest concrete version that's known to be compatible with your application.
[INFO] 
[INFO] --- camel-spring-boot-generator-maven-plugin:3.19.0-SNAPSHOT:prepare-spring-boot-auto-configuration (generate) @ camel-etcd3-starter ---
[INFO] 
[INFO] --- camel-spring-boot-generator-maven-plugin:3.19.0-SNAPSHOT:prepare-catalog-springboot (generate) @ camel-etcd3-starter ---
[INFO] Others found: etcd3, other.prope
[INFO] 
[INFO] --- maven-resources-plugin:3.1.0:resources (default-resources) @ camel-etcd3-starter ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 3 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.10.1:compile (default-compile) @ camel-etcd3-starter ---
[INFO] No sources to compile
[INFO] 
[INFO] --- maven-resources-plugin:3.1.0:testResources (default-testResources) @ camel-etcd3-starter ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Users/nicolasfilotto/projects/camel/camel-spring-boot/components-starter/camel-etcd3-starter/src/test/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.10.1:testCompile (default-testCompile) @ camel-etcd3-starter ---
[INFO] No sources to compile
[INFO] 
[INFO] --- maven-surefire-plugin:3.0.0-M4:test (default-test) @ camel-etcd3-starter ---
[INFO] No tests to run.
[INFO] 
[INFO] --- maven-jar-plugin:3.2.0:jar (default-jar) @ camel-etcd3-starter ---
[INFO] Building jar: /Users/nicolasfilotto/projects/camel/camel-spring-boot/components-starter/camel-etcd3-starter/target/camel-etcd3-starter-3.19.0-SNAPSHOT.jar
[INFO] 
[INFO] --- maven-site-plugin:3.7.1:attach-descriptor (attach-descriptor) @ camel-etcd3-starter ---
[INFO] Skipping because packaging 'jar' is not pom.
[INFO] 
[INFO] --- camel-spring-boot-generator-maven-plugin:3.19.0-SNAPSHOT:update-spring-boot-auto-configuration-readme (readme) @ camel-etcd3-starter ---
[INFO] 
[INFO] --- maven-install-plugin:2.5.2:install (default-install) @ camel-etcd3-starter ---
[INFO] Installing /Users/nicolasfilotto/projects/camel/camel-spring-boot/components-starter/camel-etcd3-starter/target/camel-etcd3-starter-3.19.0-SNAPSHOT.jar to /Users/nicolasfilotto/.m2/repository/org/apache/camel/springboot/camel-etcd3-starter/3.19.0-SNAPSHOT/camel-etcd3-starter-3.19.0-SNAPSHOT.jar
[INFO] Installing /Users/nicolasfilotto/projects/camel/camel-spring-boot/components-starter/camel-etcd3-starter/pom.xml to /Users/nicolasfilotto/.m2/repository/org/apache/camel/springboot/camel-etcd3-starter/3.19.0-SNAPSHOT/camel-etcd3-starter-3.19.0-SNAPSHOT.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.608 s
[INFO] Finished at: 2022-09-28T15:10:40+02:00
[INFO] ------------------------------------------------------------------------
```