### PR TITLE
CAMEL-18582: Prevent build failures due to write lock issues

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -48,6 +48,10 @@ jobs:
         cache: 'maven'
     - name: mvn checkstyle
       run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -l checkstyle.log -Dmvnd.threads=2 -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 --no-transfer-progress  -Dcheckstyle.failOnViolation=true -e checkstyle:checkstyle
+    - name: Generate a thread dump in case of a lock issue
+      if: failure()
+      run: cat checkstyle.log | grep "Could not acquire write lock for '.*.resolverlock'" > /dev/null && jstack $(jcmd | grep MavenDaemon | awk '{print $1;}') >> checkstyle.log
+      shell: bash
     - name: archive logs
       uses: actions/upload-artifact@v3
       if: always()
@@ -77,6 +81,10 @@ jobs:
           cache: 'maven'
       - name: maven build
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -l build.log -Dmvnd.threads=2 -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 --no-transfer-progress -e -Pfastinstall -DskipTests install
+      - name: Generate a thread dump in case of a lock issue
+        if: failure()
+        run: cat build.log | grep "Could not acquire write lock for '.*.resolverlock'" > /dev/null && jstack $(jcmd | grep MavenDaemon | awk '{print $1;}') >> build.log
+        shell: bash
       - name: archive logs
         uses: actions/upload-artifact@v3
         if: always()

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx3584m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication 
+-Xmx3584m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication -Daether.syncContext.named.factory=rwlock-local

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx3584m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication -Daether.syncContext.named.factory=rwlock-local
+-Xmx3584m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication -Daether.syncContext.named.factory=rwlock-local -Daether.syncContext.named.time=300


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18582

## Motivation

Since we upgraded mvnd to 0.8, the locking of the artifacts is now made by default with a file locking (https://github.com/apache/maven-mvnd/pull/508) which causes regular build failures due to write lock issues.

## Modifications

* Change the named lock factory for a JVM-local implementation based on `ReentrantReadWriteLocks` which is more or less what we had in version 0.7
* Increase the lock timeout to 5 minutes
* Generate a thread dump on lock issue