### PR TITLE
CAMEL-18516: camel-yaml-dsl - bannedDefinitions doesn't work for gene…

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
@@ -102,6 +102,11 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
                     .map(values -> Stream.of(values).collect(Collectors.toCollection(TreeSet::new)))
                     .orElseGet(TreeSet::new);
 
+            final DotName name = DotName.createSimple(entry.getKey());
+            final ClassInfo info = view.getClassByName(name);
+            if (isBanned(info)) {
+                continue;
+            }
             if (hasAnnotation(entry.getValue(), YAML_IN_ANNOTATION)) {
                 nodes.forEach(node -> {
                     items.with("properties")
@@ -109,9 +114,6 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
                             .put("$ref", "#/items/definitions/" + entry.getKey());
                 });
             } else {
-                final DotName name = DotName.createSimple(entry.getKey());
-                final ClassInfo info = view.getClassByName(name);
-
                 if (extendsType(info, PROCESSOR_DEFINITION_CLASS)) {
                     nodes.forEach(node -> {
                         step.with("properties")

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/pom.xml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/pom.xml
@@ -266,9 +266,6 @@
                         <configuration>
                             <kebabCase>false</kebabCase>
                             <outputFile>src/generated/resources/schema/camelYamlDsl.json</outputFile>
-                            <bannedDefinitions>
-                                <bannedDefinition>org.apache.camel.model.FromDefinition</bannedDefinition>
-                            </bannedDefinitions>
                         </configuration>
                     </execution>
                     <!-- kebab-case -->
@@ -281,9 +278,6 @@
                         <configuration>
                             <kebabCase>true</kebabCase>
                             <outputFile>src/generated/resources/schema/camel-yaml-dsl.json</outputFile>
-                            <bannedDefinitions>
-                                <bannedDefinition>org.apache.camel.model.FromDefinition</bannedDefinition>
-                            </bannedDefinitions>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
…rate-yaml-schema

Following up #8383 
Cc: @lburgazzoli 

This fix enables the `bannedDefinitions` configuration for `generate-yaml-schema` as well. As a result, generated schema removes the `FromDefinition` which is not expected, so removed the `FromDefinition` from the `bannedDefinitions` in the POM for generating YAML schema.

`FromDefinition` is excluded when deserializers are generated here
https://github.com/apache/camel/blob/main/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/pom.xml#L127
And the custom/handmade `FromDefinitionDeserializer` is honored
https://github.com/apache/camel/blob/main/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/main/java/org/apache/camel/dsl/yaml/deserializers/FromDefinitionDeserializer.java
There's no `FromDefinitionDeserializer` in the generated deserializers
https://github.com/apache/camel/blob/main/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/generated/java/org/apache/camel/dsl/yaml/deserializers/ModelDeserializers.java

So I think we don't need to exclude `FromDefinition` when generating the YAML schema.