### PR TITLE
CAMEL-18582: Update timeouts to prevent write lock issues

### DIFF
--- a/.github/workflows/main-checkstyle-build.yml
+++ b/.github/workflows/main-checkstyle-build.yml
@@ -48,10 +48,6 @@ jobs:
           cache: 'maven'
       - name: mvn sourcecheck
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -l checkstyle.log -Dmvnd.threads=2 -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 --no-transfer-progress -Psourcecheck -Dcheckstyle.failOnViolation=true -e -DskipTests checkstyle:checkstyle verify
-      - name: Generate a thread dump in case of a lock issue
-        if: failure()
-        run: cat checkstyle.log | grep "Could not acquire write lock for '.*.resolverlock'" > /dev/null && jstack $(jcmd | grep MavenDaemon | awk '{print $1;}') >> checkstyle.log
-        shell: bash
       - name: archive logs
         uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/main-push-build.yml
+++ b/.github/workflows/main-push-build.yml
@@ -55,10 +55,6 @@ jobs:
           cache: 'maven'
       - name: mvn formatter and build
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -l build.log -Dmvnd.threads=2 -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 --no-transfer-progress -e -Pformat,fastinstall -DskipTests verify
-      - name: Generate a thread dump in case of a lock issue
-        if: failure()
-        run: cat build.log | grep "Could not acquire write lock for '.*.resolverlock'" > /dev/null && jstack $(jcmd | grep MavenDaemon | awk '{print $1;}') >> build.log
-        shell: bash
       - name: archive logs
         uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -48,10 +48,6 @@ jobs:
         cache: 'maven'
     - name: mvn checkstyle
       run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -l checkstyle.log -Dmvnd.threads=2 -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 --no-transfer-progress  -Dcheckstyle.failOnViolation=true -e checkstyle:checkstyle
-    - name: Generate a thread dump in case of a lock issue
-      if: failure()
-      run: cat checkstyle.log | grep "Could not acquire write lock for '.*.resolverlock'" > /dev/null && jstack $(jcmd | grep MavenDaemon | awk '{print $1;}') >> checkstyle.log
-      shell: bash
     - name: archive logs
       uses: actions/upload-artifact@v3
       if: always()
@@ -81,10 +77,6 @@ jobs:
           cache: 'maven'
       - name: maven build
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -l build.log -Dmvnd.threads=2 -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 --no-transfer-progress -e -Pfastinstall -DskipTests install
-      - name: Generate a thread dump in case of a lock issue
-        if: failure()
-        run: cat build.log | grep "Could not acquire write lock for '.*.resolverlock'" > /dev/null && jstack $(jcmd | grep MavenDaemon | awk '{print $1;}') >> build.log
-        shell: bash
       - name: archive logs
         uses: actions/upload-artifact@v3
         if: always()

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx3584m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication -Daether.syncContext.named.factory=rwlock-local -Daether.syncContext.named.time=900
+-Xmx3584m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication -Daether.syncContext.named.factory=rwlock-local -Daether.syncContext.named.time=900 -Dmaven.wagon.rto=300000

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx3584m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication -Daether.syncContext.named.factory=rwlock-local -Daether.syncContext.named.time=300
+-Xmx3584m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication -Daether.syncContext.named.factory=rwlock-local -Daether.syncContext.named.time=900


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-18582

## Motivation

After a deeper analysis, it appears that the build failures are indirectly due to errors of type `I/O exception (java.net.SocketException) caught when processing request to {s}->https://repo.maven.apache.org:443: Connection timed out (Read failed)`  which has for consequences to keep the lock on the artifacts for more than 15 minutes such that the build ends up with a lock issue since the lock timeout is only of 5 minutes.

## Modifications:

* Increase the lock timeout to 15 minutes
* Set the read timeout to 5 minutes
* Remove the step that generates a thread dump since it is not due to a deadlock