### PR TITLE
CAMEL-18596: Use async checkpoint updating method from Azure EventCon…

### DIFF
--- a/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsCheckpointUpdaterTimerTask.java
+++ b/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsCheckpointUpdaterTimerTask.java
@@ -39,8 +39,13 @@ public class EventHubsCheckpointUpdaterTimerTask extends TimerTask {
     public void run() {
         if (processedEvents.get() > 0) {
             LOG.debug("checkpointing offset after reaching timeout, with a batch of {}", processedEvents.get());
-            eventContext.updateCheckpoint();
-            processedEvents.set(0);
+            eventContext.updateCheckpointAsync()
+                    .subscribe(unused -> LOG.debug("Processed one event..."),
+                            error -> LOG.debug("Error when updating Checkpoint: {}", error.getMessage()),
+                            () -> {
+                                LOG.debug("Checkpoint updated.");
+                                processedEvents.set(0);
+                            });
         } else {
             LOG.debug("skip checkpointing offset even if timeout is reached. No events processed");
         }

--- a/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsConsumer.java
+++ b/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsConsumer.java
@@ -174,12 +174,13 @@ public class EventHubsConsumer extends DefaultConsumer {
             var completionCondition = processCheckpoint(exchange);
             if (completionCondition.equals(COMPLETED_BY_SIZE)) {
                 eventContext.updateCheckpointAsync()
-                        .subscribe(unused -> LOG.debug("Processed one event..."), error -> {
-                            LOG.debug("Error when updating Checkpoint: {}", error.getMessage());
-                            exchange.setException(error);
-                        }, () -> LOG.debug("Checkpoint updated."));
+                        .subscribe(unused -> LOG.debug("Processed one event..."),
+                                error -> LOG.debug("Error when updating Checkpoint: {}", error.getMessage()),
+                                () -> {
+                                    processedEvents.set(0);
+                                    LOG.debug("Checkpoint updated.");
+                                });
 
-                processedEvents.set(0);
             } else if (!completionCondition.equals(COMPLETED_BY_TIMEOUT)) {
                 processedEvents.incrementAndGet();
             }

--- a/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsConsumer.java
+++ b/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsConsumer.java
@@ -173,7 +173,12 @@ public class EventHubsConsumer extends DefaultConsumer {
         try {
             var completionCondition = processCheckpoint(exchange);
             if (completionCondition.equals(COMPLETED_BY_SIZE)) {
-                eventContext.updateCheckpoint();
+                eventContext.updateCheckpointAsync()
+                        .subscribe(unused -> LOG.debug("Processed one event..."), error -> {
+                            LOG.debug("Error when updating Checkpoint: {}", error.getMessage());
+                            exchange.setException(error);
+                        }, () -> LOG.debug("Checkpoint updated."));
+
                 processedEvents.set(0);
             } else if (!completionCondition.equals(COMPLETED_BY_TIMEOUT)) {
                 processedEvents.incrementAndGet();

--- a/components/camel-azure/camel-azure-eventhubs/src/test/java/org/apache/camel/component/azure/eventhubs/EventHubsCheckpointUpdaterTimerTaskTest.java
+++ b/components/camel-azure/camel-azure-eventhubs/src/test/java/org/apache/camel/component/azure/eventhubs/EventHubsCheckpointUpdaterTimerTaskTest.java
@@ -1,0 +1,44 @@
+package org.apache.camel.component.azure.eventhubs;
+
+import com.azure.messaging.eventhubs.models.EventContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EventHubsCheckpointUpdaterTimerTaskTest {
+
+    @Test
+    void testProcessedEventsResetWhenCheckpointUpdated() {
+        var processedEvents = new AtomicInteger(1);
+        var eventContext = Mockito.mock(EventContext.class);
+
+        Mockito.when(eventContext.updateCheckpointAsync())
+                .thenReturn(Mono.just("").then());
+
+        var timerTask = new EventHubsCheckpointUpdaterTimerTask(eventContext, processedEvents);
+
+        timerTask.run();
+
+        assertEquals(0, processedEvents.get());
+    }
+
+    @Test
+    void testProcessedEventsNotResetWhenCheckpointUpdateFails() {
+        var processedEvents = new AtomicInteger(1);
+        var eventContext = Mockito.mock(EventContext.class);
+
+        Mockito.when(eventContext.updateCheckpointAsync())
+                .thenReturn(Mono.error(new RuntimeException()));
+
+        var timerTask = new EventHubsCheckpointUpdaterTimerTask(eventContext, processedEvents);
+
+        timerTask.run();
+
+        assertEquals(1, processedEvents.get());
+    }
+
+}

--- a/components/camel-azure/camel-azure-eventhubs/src/test/java/org/apache/camel/component/azure/eventhubs/EventHubsCheckpointUpdaterTimerTaskTest.java
+++ b/components/camel-azure/camel-azure-eventhubs/src/test/java/org/apache/camel/component/azure/eventhubs/EventHubsCheckpointUpdaterTimerTaskTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.azure.eventhubs;
 
 import com.azure.messaging.eventhubs.models.EventContext;

--- a/components/camel-azure/camel-azure-eventhubs/src/test/java/org/apache/camel/component/azure/eventhubs/EventHubsCheckpointUpdaterTimerTaskTest.java
+++ b/components/camel-azure/camel-azure-eventhubs/src/test/java/org/apache/camel/component/azure/eventhubs/EventHubsCheckpointUpdaterTimerTaskTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.camel.component.azure.eventhubs;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import com.azure.messaging.eventhubs.models.EventContext;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import reactor.core.publisher.Mono;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 


### PR DESCRIPTION
Invoke asynchronous methods and subscribe to them instead of calling blocking methods.

https://issues.apache.org/jira/browse/CAMEL-18596


