### PR TITLE
[CXF-8762] CXF client sends the SOAPAction header without quotes

### DIFF
--- a/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/DefaultCxfBindingTest.java
+++ b/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/DefaultCxfBindingTest.java
@@ -180,9 +180,9 @@ public class DefaultCxfBindingTest {
         assertNotNull(headers);
         assertEquals(3, headers.size());
 
-        verifyHeader(headers, "soapaction", "urn:hello:world");
-        verifyHeader(headers, "SoapAction", "urn:hello:world");
-        verifyHeader(headers, "SOAPAction", "urn:hello:world");
+        verifyHeader(headers, "soapaction", "\"urn:hello:world\"");
+        verifyHeader(headers, "SoapAction", "\"urn:hello:world\"");
+        verifyHeader(headers, "SOAPAction", "\"urn:hello:world\"");
         verifyHeader(headers, "myfruitheader", "peach");
         verifyHeader(headers, "myFruitHeader", "peach");
         verifyHeader(headers, "MYFRUITHEADER", "peach");
@@ -319,9 +319,9 @@ public class DefaultCxfBindingTest {
         assertNotNull(headers);
         assertEquals(2, headers.size());
 
-        verifyHeader(headers, "soapaction", "urn:hello:world");
-        verifyHeader(headers, "SoapAction", "urn:hello:world");
-        verifyHeader(headers, "SOAPAction", "urn:hello:world");
+        verifyHeader(headers, "soapaction", "\"urn:hello:world\"");
+        verifyHeader(headers, "SoapAction", "\"urn:hello:world\"");
+        verifyHeader(headers, "SOAPAction", "\"urn:hello:world\"");
         verifyHeader(headers, "myfruitheader", "peach");
         verifyHeader(headers, "myFruitHeader", "peach");
         verifyHeader(headers, "MYFRUITHEADER", "peach");
@@ -345,7 +345,7 @@ public class DefaultCxfBindingTest {
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         headers.put("content-type", Arrays.asList("text/xml;charset=UTF-8"));
         headers.put("Content-Length", Arrays.asList("241"));
-        headers.put("soapAction", Arrays.asList("urn:hello:world"));
+        headers.put("soapAction", Arrays.asList("\"urn:hello:world\""));
         headers.put("myfruitheader", Arrays.asList("peach"));
         headers.put("mybrewheader", Arrays.asList("cappuccino", "espresso"));
         cxfMessage.put(org.apache.cxf.message.Message.PROTOCOL_HEADERS, headers);


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CXF-8762

Actually, there are two SOAPAction headers.
1. SOAPAction Camel header (stored top-level in the context)
2. SOAPAction Protocol header (stored in the context inside PROTOCOL_HEADERS)

The value inside PROTOCOL_HEADERS is used in CXF when creating a HTTP request. It should be quoted as stated in this specification. http://www.ws-i.org/Profiles/BasicProfile-1.1.html#SOAPAction_HTTP_Header

I believe we should leave the value stored top-level in the context unquoted, since it has nothing to do with the HTTP protocol. Because of that, I'm removing the quotes inside _propagateHeadersFromCxfToCamel_.

Any comment are welcome.