### PR TITLE
CAMEL-18582: Remove SocketTimeoutException from non retryable classes

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx3584m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication -Daether.syncContext.named.factory=rwlock-local -Daether.syncContext.named.time=900 -Dmaven.wagon.rto=300000
+-Xmx3584m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication -Daether.syncContext.named.factory=rwlock-local -Daether.syncContext.named.time=900 -Dmaven.wagon.rto=300000 -Dmaven.wagon.http.retryHandler.class=default -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.net.UnknownHostException,java.net.ConnectException,javax.net.ssl.SSLException


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-18582

## Motivation

With the latest fix, we now get errors of type `SocketTimeoutException: Read timed out` indicating that the runner loses regularly the connection with maven central for some period of time but as it can recover it, to workaround it, we need to make sure that it can retry when it faces this kind of error.

## Modifications:

* Use `default` as retry handler instead of `standard` to be able to change the non-retryable classes
* By default, `SocketTimeoutException` as a subclass of `InterruptedIOException` is part of the non-retryable classes which is the reason why no retries are made, so we need to redefine the non-retryable classes without `InterruptedIOException` to make sure that it will retry in case of `Read timed out`
