### PR TITLE
CAMEL-18607: camel-yaml-dsl - bannedDefinition partially fails to exc…

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
@@ -298,6 +298,14 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
                             return;
                         }
 
+
+                        if (propertyType.startsWith("object:")) {
+                            final DotName dn = DotName.createSimple(propertyType.substring(7));
+                            if (isBanned(view.getClassByName(dn))) {
+                                return;
+                            }
+                        }
+
                         if (propertyName.startsWith("__")) {
                             // reserved property, add it
                             annotations.add(property);


### PR DESCRIPTION
…lude expression definition

This fix enables to exclude the expression definition also from `org.apache.camel.model.language.ExpressionDefinition` and `org.apache.camel.model.ExpressionSubElementDefinition` properties.

Cc: @lburgazzoli 