### PR TITLE
CAMEL-18608: camel-box - Fix the regression with shared connection

### DIFF
--- a/components/camel-box/camel-box-component/src/main/java/org/apache/camel/component/box/BoxConfiguration.java
+++ b/components/camel-box/camel-box-component/src/main/java/org/apache/camel/component/box/BoxConfiguration.java
@@ -467,11 +467,8 @@ public class BoxConfiguration {
             return true;
         }
 
-        if (o == null) {
-            return false;
-        }
-
-        if (this.getClass() != o.getClass()) {
+        // Don't check that the classes are equal intentionally to support subclasses
+        if (!(o instanceof BoxConfiguration)) {
             return false;
         }
 


### PR DESCRIPTION
## Motivation

The test `org.apache.camel.component.box.BoxSharedConnectionTest.testEndpointUsesSharedConnection` fails continuously on Jenkins indicating that there is a regression so it needs to be fixed.

## Modifications:

* Modify the implementation of the `equals` of the class `BoxConfiguration` to support subclasses like `org.apache.camel.component.box.BoxFilesManagerEndpointConfiguration`
* Cleanup the code of the test class (not related to the regression)

