### PR TITLE
CAMEL-18607: camel-yaml-dsl - Should continue evaluating the rest of …

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
@@ -298,11 +298,10 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
                             return;
                         }
 
-
                         if (propertyType.startsWith("object:")) {
                             final DotName dn = DotName.createSimple(propertyType.substring(7));
                             if (isBanned(view.getClassByName(dn))) {
-                                return;
+                                continue;
                             }
                         }
 


### PR DESCRIPTION
…the properties

Sorry, I overlooked my previous fix for CAMEL-18607 had an issue, it stops evaluating the properties once banned one is found...
