### PR TITLE
CAMEL-18608: camel-spark - Fix compatibility issues with JDK 17

### DIFF
--- a/components/camel-spark/pom.xml
+++ b/components/camel-spark/pom.xml
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.12.14</version>
+            <version>2.12.17</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-reflect</artifactId>
-            <version>2.12.14</version>
+            <version>2.12.17</version>
         </dependency>
 
         <!-- guava -->
@@ -299,5 +299,22 @@
         </dependency>
 
     </dependencies>
-
+    <profiles>
+        <profile>
+            <id>jdk17-build</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens java.base/sun.nio.ch=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Motivation

The spark test fails with JDK 17 on Jenkins and should be fixed.

## Modifications

* Add the missing `--add-opens`
* Upgrade to the latest maintenance version of scala `2.12` to have the fix for https://github.com/scala/bug/issues/12419 which makes the test fails 