### PR TITLE
Fix asserts in swagger tests

### DIFF
--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/ParameterAssert.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/ParameterAssert.java
@@ -79,7 +79,7 @@ public final class ParameterAssert extends ObjectAssert<Parameter> {
         Assertions.assertThat(items).isNotNull();
         final String actualArrayType = items.getType();
         Assertions.assertThat(actualArrayType).as("Parameter array should be of %s type, but it's of %s", type,
-                actualArrayType);
+                actualArrayType).isEqualTo(type);
 
         return this;
     }
@@ -89,7 +89,8 @@ public final class ParameterAssert extends ObjectAssert<Parameter> {
 
         final SerializableParameter serializableParameter = (SerializableParameter) actual;
         final String actualType = serializableParameter.getType();
-        Assertions.assertThat(actualType).as("Parameter should be of %s type, but it's of %s", type, actualType);
+        Assertions.assertThat(actualType).as("Parameter should be of %s type, but it's of %s", type, actualType)
+                .isEqualTo(type);
 
         return this;
     }

--- a/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerArrayEnumTest.java
+++ b/components/camel-swagger-java/src/test/java/org/apache/camel/swagger/RestSwaggerArrayEnumTest.java
@@ -72,20 +72,20 @@ public class RestSwaggerArrayEnumTest extends CamelTestSupport {
         ParameterAssert.assertThat(parameters.get(0)).hasName("pathParam").isGivenIn("path").isOfType("string")
                 .hasEnumSpecifiedWith("a", "b", "c");
 
-        ParameterAssert.assertThat(parameters.get(1)).hasName("queryParam").isGivenIn("query").isOfType("string")
+        ParameterAssert.assertThat(parameters.get(1)).hasName("queryParam").isGivenIn("query").isOfType("int")
                 .hasEnumSpecifiedWith("1", "2", "3");
 
-        ParameterAssert.assertThat(parameters.get(2)).hasName("headerParam").isGivenIn("header").isOfType("string")
+        ParameterAssert.assertThat(parameters.get(2)).hasName("headerParam").isGivenIn("header").isOfType("float")
                 .hasEnumSpecifiedWith("1.1", "2.2", "3.3");
 
         ParameterAssert.assertThat(parameters.get(3)).hasName("pathArrayParam").isGivenIn("path").isOfType("array")
                 .isOfArrayType("string").hasArrayEnumSpecifiedWith("a", "b", "c");
 
         ParameterAssert.assertThat(parameters.get(4)).hasName("queryArrayParam").isGivenIn("query").isOfType("array")
-                .isOfArrayType("int").hasArrayEnumSpecifiedWith(1, 2, 3);
+                .isOfArrayType("integer").hasArrayEnumSpecifiedWith(1, 2, 3);
 
         ParameterAssert.assertThat(parameters.get(5)).hasName("headerArrayParam").isGivenIn("header").isOfType("array")
-                .isOfArrayType("float").hasArrayEnumSpecifiedWith(1.1f, 2.2f, 3.3f);
+                .isOfArrayType("number").hasArrayEnumSpecifiedWith(1.1f, 2.2f, 3.3f);
     }
 
 }

--- a/tooling/swagger-rest-dsl-generator/src/test/java/org/apache/camel/generator/swagger/RestDslXmlGeneratorTest.java
+++ b/tooling/swagger-rest-dsl-generator/src/test/java/org/apache/camel/generator/swagger/RestDslXmlGeneratorTest.java
@@ -47,7 +47,7 @@ public class RestDslXmlGeneratorTest {
 
         final String xml = RestDslGenerator.toXml(swagger).withBlueprint().generate(context);
         assertThat(xml).isNotEmpty();
-        assertThat(xml.contains("http://camel.apache.org/schema/blueprint"));
+        assertThat(xml).contains("http://camel.apache.org/schema/blueprint");
     }
 
     @Test
@@ -56,7 +56,7 @@ public class RestDslXmlGeneratorTest {
 
         final String xml = RestDslGenerator.toXml(swagger).generate(context);
         assertThat(xml).isNotEmpty();
-        assertThat(xml.contains("http://camel.apache.org/schema/spring"));
+        assertThat(xml).contains("http://camel.apache.org/schema/spring");
     }
 
     @Test


### PR DESCRIPTION
It fixes bug in usage of `asserThat` in swagger tests which missed evaluation of condition.