### PR TITLE
(backport) Github CI fixes

### DIFF
--- a/.github/actions/quick-test/quick-test.sh
+++ b/.github/actions/quick-test/quick-test.sh
@@ -93,12 +93,24 @@ function componentTest() {
   fi
 }
 
+function coreTest() {
+  cd "core"
+  runTest "core" "1" "1"
+}
+
 function main() {
   local current=0
   local startCommit=${1:-""}
   local endCommit=${2:-""}
 
   mkdir -p "${logDir}"
+
+  echo "Searching for camel core changes"
+  local core=$(git diff "${startCommit}..${endCommit}" --name-only --pretty=format:"" | grep -e '^core' | grep -v -e '^$' | cut -d / -f 1 | uniq | sort)
+  if [[ ! -z "${core}" ]] ; then
+    coreTest
+  fi
+
 
   echo "Searching for modified components"
   local components=$(git diff "${startCommit}..${endCommit}" --name-only --pretty=format:"" | grep -e '^components' | grep -v -e '^$' | cut -d / -f 1-2 | uniq | sort)

--- a/.github/actions/quick-test/quick-test.sh
+++ b/.github/actions/quick-test/quick-test.sh
@@ -27,7 +27,7 @@ MVN_OPTS=${MVN_OPTS:-$MVN_DEFAULT_OPTS}
 
 # Script variables
 failures=0
-maxNumberOfTestableComponents=15
+maxNumberOfTestableComponents=20
 basedir=$(pwd)
 testDate=$(date '+%Y-%m-%d-%H%M%S')
 logDir=${basedir}/automated-build-log

--- a/.github/actions/quick-test/quick-test.sh
+++ b/.github/actions/quick-test/quick-test.sh
@@ -101,6 +101,7 @@ function coreTest() {
 
   cd "core"
   runTest "core" "1" "1"
+  find . -iname '*test*.log' -exec mv {} "${logDir}"/ \;
 }
 
 function main() {

--- a/.github/actions/quick-test/quick-test.sh
+++ b/.github/actions/quick-test/quick-test.sh
@@ -27,6 +27,7 @@ MVN_OPTS=${MVN_OPTS:-$MVN_DEFAULT_OPTS}
 
 # Script variables
 failures=0
+successes=0
 maxNumberOfTestableComponents=20
 basedir=$(pwd)
 testDate=$(date '+%Y-%m-%d-%H%M%S')
@@ -67,6 +68,7 @@ function runTest() {
     ((failures++))
     notifyError "${component} test" "${total}" "${current}" "${failures}"
   else
+    ((successes++))
     notifySuccess "${component}" "${total}" "${current}" "${failures}"
   fi
 
@@ -111,7 +113,6 @@ function main() {
     coreTest
   fi
 
-
   echo "Searching for modified components"
   local components=$(git diff "${startCommit}..${endCommit}" --name-only --pretty=format:"" | grep -e '^components' | grep -v -e '^$' | cut -d / -f 1-2 | uniq | sort)
   local total=$(echo "${components}" | grep -v -e '^$' | wc -l)
@@ -120,11 +121,13 @@ function main() {
   if [[ ${total} -eq 0 ]]; then
     echo "0" > "${logDir}/tested"
     echo "0" > "${logDir}/failures"
+    echo "0" > "${logDir}/successes"
     exit 0
   else
     if [[ ${total} -gt ${maxNumberOfTestableComponents} ]]; then
       echo "0" > "${logDir}/tested"
       echo "0" > "${logDir}/failures"
+      echo "0" > "${logDir}/successes"
       exit 0
     fi
   fi
@@ -142,6 +145,7 @@ function main() {
 
   echo "${total}" > "${logDir}/tested"
   echo "${failures}" > "${logDir}/failures"
+  echo "${successes}" > "${logDir}/successes"
   exit "${failures}"
 }
 

--- a/.github/actions/quick-test/quick-test.sh
+++ b/.github/actions/quick-test/quick-test.sh
@@ -39,6 +39,7 @@ function notifySuccess() {
   local current=$3
 
   echo "${component} test completed successfully: ${current} verified / ${failures} failed"
+  echo "| ${component} | :white_check_mark: pass" >> $GITHUB_STEP_SUMMARY
 }
 
 function notifyError() {
@@ -47,6 +48,7 @@ function notifyError() {
   local current=$3
 
   echo "Failed ${component} test: ${current} verified / ${failures} failed"
+  echo "| ${component} | :x: fail" >> $GITHUB_STEP_SUMMARY
 }
 
 function runTest() {
@@ -60,6 +62,9 @@ function runTest() {
   echo ""
 
   echo "Logging test to ${logDir}/${component/\//-}.log"
+  echo "| Component | Result |" >> $GITHUB_STEP_SUMMARY
+  echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+
   mvn -Psourcecheck ${MVN_OPTS} verify 2>&1 >> "${logDir}/${component/\//-}.log"
   if [[ $? -ne 0 ]]; then
     ((failures++))

--- a/.github/actions/quick-test/quick-test.sh
+++ b/.github/actions/quick-test/quick-test.sh
@@ -96,6 +96,9 @@ function componentTest() {
 }
 
 function coreTest() {
+  echo "| Core | Result |" >> $GITHUB_STEP_SUMMARY
+  echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+
   cd "core"
   runTest "core" "1" "1"
 }
@@ -135,6 +138,7 @@ function main() {
   echo "It will test the following ${total} components:"
   echo "${components}"
 
+  echo "" >> $GITHUB_STEP_SUMMARY
   echo "| Component | Result |" >> $GITHUB_STEP_SUMMARY
   echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
   current=0

--- a/.github/actions/quick-test/quick-test.sh
+++ b/.github/actions/quick-test/quick-test.sh
@@ -62,9 +62,6 @@ function runTest() {
   echo ""
 
   echo "Logging test to ${logDir}/${component/\//-}.log"
-  echo "| Component | Result |" >> $GITHUB_STEP_SUMMARY
-  echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
-
   mvn -Psourcecheck ${MVN_OPTS} verify 2>&1 >> "${logDir}/${component/\//-}.log"
   if [[ $? -ne 0 ]]; then
     ((failures++))
@@ -123,6 +120,8 @@ function main() {
   echo "It will test the following ${total} components:"
   echo "${components}"
 
+  echo "| Component | Result |" >> $GITHUB_STEP_SUMMARY
+  echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
   current=0
   for component in $(echo $components); do
     ((current++))

--- a/.github/actions/quick-test/quick-test.sh
+++ b/.github/actions/quick-test/quick-test.sh
@@ -63,7 +63,7 @@ function runTest() {
   echo ""
 
   echo "Logging test to ${logDir}/${component/\//-}.log"
-  mvn -Psourcecheck ${MVN_OPTS} verify 2>&1 >> "${logDir}/${component/\//-}.log"
+  mvn -l "${logDir}/${component/\//-}.log" -Psourcecheck ${MVN_OPTS} verify
   if [[ $? -ne 0 ]]; then
     ((failures++))
     notifyError "${component} test" "${total}" "${current}" "${failures}"

--- a/.github/workflows/component-pr.yaml
+++ b/.github/workflows/component-pr.yaml
@@ -55,7 +55,7 @@ jobs:
             If necessary Apache Camel Committers may access logs and test results in the job summaries!`
             })
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6
         if: |
           github.event_name == 'workflow_run'
         with:

--- a/.github/workflows/component-pr.yaml
+++ b/.github/workflows/component-pr.yaml
@@ -55,7 +55,7 @@ jobs:
             If necessary Apache Camel Committers may access logs and test results in the job summaries!`
             })
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.1
+        uses: actions/github-script@v6
         if: |
           github.event_name == 'workflow_run'
         with:
@@ -63,7 +63,7 @@ jobs:
 # - https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 # - https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -71,7 +71,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "test-logs"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,

--- a/.github/workflows/component-pr.yaml
+++ b/.github/workflows/component-pr.yaml
@@ -55,7 +55,7 @@ jobs:
             If necessary Apache Camel Committers may access logs and test results in the job summaries!`
             })
       - name: 'Download artifact'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v3.1.1
         if: |
           github.event_name == 'workflow_run'
         with:

--- a/.github/workflows/component-pr.yaml
+++ b/.github/workflows/component-pr.yaml
@@ -47,7 +47,11 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `:warning: This PR changes Camel components and will be tested automatically.`
+              body: `:star2: Thanks for your contribution to the Apache Camel project! :star2: 
+            
+            :warning: Please note that the changes on this PR may be **tested automatically**. 
+            
+            If necessary Apache Camel Committers may access logs and test results in the job summaries!`
             })
       - name: 'Download artifact'
         uses: actions/github-script@v3.1.0
@@ -96,7 +100,7 @@ jobs:
                 message = ":no_entry_sign: There are (likely) no components to be tested in this PR"
               } else {
                 if (total > 20) {
-                  message = `:leftwards_arrow_with_hook: There are too many components to be tested in this PR, components were removed or the code needs a rebase: (${total} likely to be tested)`
+                  message = `:leftwards_arrow_with_hook: There are either **too many** changes to be tested in this PR or the code **needs be rebased**: (${total} components likely to be affected)`
                 }
               }
             } else {

--- a/.github/workflows/component-pr.yaml
+++ b/.github/workflows/component-pr.yaml
@@ -96,7 +96,7 @@ jobs:
                 message = ":no_entry_sign: There are (likely) no components to be tested in this PR"
               } else {
                 if (total > 20) {
-                  message = `There are too many components to be tested in this PR, components were removed or the code needs a rebase: (${total} likely to be tested)`
+                  message = `:leftwards_arrow_with_hook: There are too many components to be tested in this PR, components were removed or the code needs a rebase: (${total} likely to be tested)`
                 }
               }
             } else {

--- a/.github/workflows/component-pr.yaml
+++ b/.github/workflows/component-pr.yaml
@@ -47,7 +47,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `:star2: Thanks for your contribution to the Apache Camel project! :star2: 
+              body: `:star2: Thank you for your contribution to the Apache Camel project! :star2: 
             
             :warning: Please note that the changes on this PR may be **tested automatically**. 
             
@@ -92,7 +92,8 @@ jobs:
             let total = Number(fs.readFileSync('./total'));
             let tested = Number(fs.readFileSync('./tested'));
             let failures = Number(fs.readFileSync('./failures'));
-
+            let successes = Number(fs.readFileSync('./successes'));
+                                
             var message = ""
 
             if (tested === 0) {
@@ -104,11 +105,11 @@ jobs:
                 }
               }
             } else {
-              if (failures === 0) {
-                message = `:heavy_check_mark: Finished component verification: ${failures} component(s) test failed out of **${tested} component(s) tested**`
-              } else {
-                message = `:x: Finished component verification: **${failures} component(s) test failed** out of ${tested} component(s) tested`
-              }
+              message = `### Components tested: 
+                    | Total | Tested | Failed :x: | Passed :white_check_mark: | 
+                    | --- | --- | --- |  --- |
+                    | ${total} | ${tested} | ${failures} | ${successes} | 
+                    `
             }
 
             await github.rest.issues.createComment({

--- a/.github/workflows/component-pr.yaml
+++ b/.github/workflows/component-pr.yaml
@@ -23,6 +23,7 @@ on:
       - opened
       - reopened
     paths:
+      - 'core/**'
       - 'components/**'
   workflow_run:
     workflows: [ "main pr build" ]

--- a/.github/workflows/component-pr.yaml
+++ b/.github/workflows/component-pr.yaml
@@ -95,7 +95,7 @@ jobs:
               if (total === 0) {
                 message = ":no_entry_sign: There are (likely) no components to be tested in this PR"
               } else {
-                if (total > 10) {
+                if (total > 20) {
                   message = `There are too many components to be tested in this PR, components were removed or the code needs a rebase: (${total} likely to be tested)`
                 }
               }

--- a/.github/workflows/component-pr.yaml
+++ b/.github/workflows/component-pr.yaml
@@ -106,11 +106,11 @@ jobs:
                 }
               }
             } else {
-              message = `### Components tested: 
-                    | Total | Tested | Failed :x: | Passed :white_check_mark: | 
-                    | --- | --- | --- |  --- |
-                    | ${total} | ${tested} | ${failures} | ${successes} | 
-                    `
+              message = `### Components tested:
+            
+            | Total | Tested | Failed :x: | Passed :white_check_mark: | 
+            | --- | --- | --- |  --- |
+            | ${total} | ${tested} | ${failures} | ${successes} |`
             }
 
             await github.rest.issues.createComment({

--- a/.github/workflows/generic-pr/label-config.yml
+++ b/.github/workflows/generic-pr/label-config.yml
@@ -27,6 +27,11 @@ core-build-and-dependencies:
   - camel-dependencies/**
   - parent/**
 
+core-build-tooling:
+  - buildingtools/**/*
+  - etc/**/*
+  - init/**/*
+
 catalog:
   - catalog/**/*
 
@@ -62,7 +67,6 @@ tests:
 
 tooling:
   - tooling/**/*
-  - buildingtools/**/*
 
 tooling-maven:
   - archetypes/**/*

--- a/.github/workflows/generic-pr/label-config.yml
+++ b/.github/workflows/generic-pr/label-config.yml
@@ -22,6 +22,11 @@ ci:
 core:
   - core/**/*
 
+core-build-and-dependencies:
+  - apache-camel/**
+  - camel-dependencies/**
+  - parent/**
+
 catalog:
   - catalog/**/*
 

--- a/.github/workflows/generic-pr/label-config.yml
+++ b/.github/workflows/generic-pr/label-config.yml
@@ -57,6 +57,7 @@ tests:
 
 tooling:
   - tooling/**/*
+  - buildingtools/**/*
 
 tooling-maven:
   - archetypes/**/*

--- a/.github/workflows/main-checkstyle-build.yml
+++ b/.github/workflows/main-checkstyle-build.yml
@@ -51,3 +51,13 @@ jobs:
         with:
           name: checkstyle.log
           path: checkstyle.log
+      - name: Generate failure checkstyle summary
+        if: failure()
+        run: |
+          echo ":x: Checkstyle failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+      - name: Generate successful checkstyle summary
+        if: failure()
+        run: |
+          echo ":white_check_mark: Checkstyle passed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/main-checkstyle-build.yml
+++ b/.github/workflows/main-checkstyle-build.yml
@@ -51,13 +51,3 @@ jobs:
         with:
           name: checkstyle.log
           path: checkstyle.log
-      - name: Generate failure checkstyle summary
-        if: failure()
-        run: |
-          echo ":x: Checkstyle failed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-      - name: Generate successful checkstyle summary
-        if: failure()
-        run: |
-          echo ":white_check_mark: Checkstyle passed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -54,6 +54,16 @@ jobs:
       with:
         name: checkstyle.log
         path: checkstyle.log
+    - name: Generate failure checkstyle summary
+      if: failure()
+      run: |
+        echo ":x: Checkstyle failed" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+    - name: Generate successful checkstyle summary
+      if: failure()
+      run: |
+        echo ":white_check_mark: Checkstyle passed" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
   build:
     if: github.repository == 'apache/camel'
     permissions:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -60,7 +60,7 @@ jobs:
         echo ":x: Checkstyle failed" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
     - name: Generate successful checkstyle summary
-      if: failure()
+      if: success()
       run: |
         echo ":white_check_mark: Checkstyle passed" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
We have to backport the set of Github CI fixes from last week because the feature is going to be deprecated. As such, our PR testing on this branch could work. 

This brings all of the fixes, GH cleanups and related changes I implemented last week. 


Note: there's 3 commits on core + components that are here with the intention of testing the patch set. 