### PR TITLE
fix whatsapp doc, the "since" field to 3.19

### DIFF
--- a/components/camel-whatsapp/src/main/docs/whatsapp-component.adoc
+++ b/components/camel-whatsapp/src/main/docs/whatsapp-component.adoc
@@ -3,7 +3,7 @@
 :shortname: whatsapp
 :artifactid: camel-whatsapp
 :description: Send messages to WhatsApp.
-:since: 3.18
+:since: 3.19
 :supportlevel: Stable
 :component-header: Only producer is supported
 


### PR DESCRIPTION
This component was merged after 3.18
