### PR TITLE
CAMEL-18608: camel-file - Fix is done file checker

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileEndpoint.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileEndpoint.java
@@ -1715,8 +1715,8 @@ public abstract class GenericFileEndpoint<T> extends ScheduledPollEndpoint imple
         }
 
         // the static part of the pattern, is that a prefix or suffix?
-        // its a prefix if ${ start token is not at the start of the pattern
-        boolean prefix = pattern.contains("${");
+        // it is a prefix if ${ start token is not at the start of the pattern
+        boolean prefix = pattern.indexOf("${") > 0; // NOSONAR
 
         // remove dynamic parts of the pattern so we only got the static part
         // left


### PR DESCRIPTION
## Motivation

The tests `FtpConsumerDoneFileNameStepwiseIT` and `FtpConsumerDoneFileNameIT` are failing systematically on the Jenkins build indicating that there is regression to fix.

## Modifications:

* Restore the previous test to check if it is a prefix to avoid getting true when it starts with `${`.
* Add the `NOSONAR` tag indicating that it is expected and must be ignored by sonar.