### PR TITLE
CAMEL-14832: camel-swift - Add the SB name and more details to the doc

### DIFF
--- a/components/camel-swift/src/main/docs/swiftMt-dataformat.adoc
+++ b/components/camel-swift/src/main/docs/swiftMt-dataformat.adoc
@@ -5,10 +5,12 @@
 :description: Encode and decode SWIFT MT messages.
 :since: 3.20
 :supportlevel: Preview
+//Manually maintained attributes
+:camel-spring-boot-name: swift
 
 *Since Camel {since}*
 
-The SWIFT MT data format is used to encode and decode SWIFT MT messages.
+The SWIFT MT data format is used to encode and decode SWIFT MT messages. The data format leverages the library https://github.com/prowide/prowide-core[Prowide Core] to encode and decode SWIFT MT messages.
 
 == Options
 
@@ -77,6 +79,8 @@ In Spring DSL:
 ----
 
 == Unmarshal
+
+The unmarshaller converts the input data into the concrete class of type `com.prowidesoftware.swift.model.mt.AbstractMT` that best matches with the content of the message.
 
 In this example, we unmarshal the content of a file to get SWIFT MT
 objects before processing them with the `newOrder` processor.

--- a/components/camel-swift/src/main/docs/swiftMx-dataformat.adoc
+++ b/components/camel-swift/src/main/docs/swiftMx-dataformat.adoc
@@ -5,10 +5,12 @@
 :description: Encode and decode SWIFT MX messages.
 :since: 3.20
 :supportlevel: Preview
+//Manually maintained attributes
+:camel-spring-boot-name: swift
 
 *Since Camel {since}*
 
-The SWIFT MX data format is used to encode and decode SWIFT MX messages.
+The SWIFT MX data format is used to encode and decode SWIFT MX messages. The data format leverages the library https://github.com/prowide/prowide-iso20022[Prowide ISO 20022] to encode and decode SWIFT MX messages.
 
 == Options
 
@@ -77,6 +79,8 @@ In Spring DSL:
 ----
 
 == Unmarshal
+
+The unmarshaller converts the input data into the concrete class of type `com.prowidesoftware.swift.model.mx.AbstractMX` that best matches with the content of the message.
 
 In this example, we unmarshal the content of a file to get SWIFT MX
 objects before processing them with the `newOrder` processor.


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-14832

## Motivation

The Spring Boot starter is available so the doc can refer to it.

## Modifications

* Add the `camel-spring-boot-name` to the doc files
* Improve the doc to indicate the libs used behind the scenes and the type of object produced by the marshallers.
