### PR TITLE
CAMEL-18255: Address memory leak caused by scheduling MDC.afterProces…

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/CamelInternalProcessor.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/CamelInternalProcessor.java
@@ -400,14 +400,7 @@ public class CamelInternalProcessor extends DelegateAsyncProcessor implements In
             // CAMEL END USER - DEBUG ME HERE +++ END +++
             // ----------------------------------------------------------
 
-            // optimize to only do after uow processing if really needed
-            if (beforeAndAfter) {
-                // use the same callback as with beforeProcess
-                final CamelInternalTask afterCallback = afterTask;
-                reactiveExecutor.schedule(() -> {
-                    uow.afterProcess(processor, exchange, afterCallback, sync);
-                });
-            }
+            // CAMEL-18255: move uow.afterProcess handling to the callback
 
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Exchange processed and is continued routed {} for exchangeId: {} -> {}",

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultUnitOfWork.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultUnitOfWork.java
@@ -356,8 +356,8 @@ public class DefaultUnitOfWork implements UnitOfWork {
 
     @Override
     public AsyncCallback beforeProcess(Processor processor, Exchange exchange, AsyncCallback callback) {
-        // no wrapping needed
-        return callback;
+        // CAMEL-18255: support running afterProcess from the async callback
+        return isBeforeAfterProcess() ? new UnitOfWorkCallback(callback, processor) : callback;
     }
 
     @Override
@@ -376,5 +376,27 @@ public class DefaultUnitOfWork implements UnitOfWork {
     @Override
     public String toString() {
         return "DefaultUnitOfWork";
+    }
+
+    private final class UnitOfWorkCallback implements AsyncCallback {
+
+        private final AsyncCallback delegate;
+        private final Processor processor;
+
+        private UnitOfWorkCallback(AsyncCallback delegate, Processor processor) {
+            this.delegate = delegate;
+            this.processor = processor;
+        }
+
+        @Override
+        public void done(boolean doneSync) {
+            delegate.done(doneSync);
+            afterProcess(processor, exchange, delegate, doneSync);
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
     }
 }

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/MDCUnitOfWork.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/MDCUnitOfWork.java
@@ -85,6 +85,10 @@ public class MDCUnitOfWork extends DefaultUnitOfWork implements Service {
         if (breadcrumbId != null) {
             MDC.put(MDC_BREADCRUMB_ID, breadcrumbId);
         }
+        Route current = getRoute();
+        if (current != null) {
+            MDC.put(MDC_ROUTE_ID, current.getRouteId());
+        }
     }
 
     @Override
@@ -145,7 +149,8 @@ public class MDCUnitOfWork extends DefaultUnitOfWork implements Service {
             MDC.put(MDC_STEP_ID, stepId);
         }
         // return callback with after processing work
-        return new MDCCallback(callback, pattern);
+        final AsyncCallback uowCallback = super.beforeProcess(processor, exchange, callback);
+        return new MDCCallback(uowCallback, pattern);
     }
 
     @Override


### PR DESCRIPTION
Backport of c36e6e7305f47b9048e3a64313782fa0bc6c7ad1 fixing CAMEL-18255 for 3.14.x LTS

* CAMEL-18255: Address memory leak caused by scheduling MDC.afterProcess. Call the afterProcess from the MDCcallback instead of scheduling it separately. Reset current routeId on MDC from startProcess.