### PR TITLE
CAMEL-17505: camel-core - Propose primitive types in builder methods

### DIFF
--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ASN1DataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ASN1DataFormat.java
@@ -125,6 +125,15 @@ public class ASN1DataFormat extends DataFormatDefinition {
         }
 
         /**
+         * If the asn1 file has more than one entry, the setting this option to true, allows working with the splitter
+         * EIP, to split the data using an iterator in a streaming mode.
+         */
+        public Builder usingIterator(boolean usingIterator) {
+            this.usingIterator = Boolean.toString(usingIterator);
+            return this;
+        }
+
+        /**
          * Class to use when unmarshalling.
          */
         public Builder unmarshalTypeName(String unmarshalTypeName) {

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/Any23DataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/Any23DataFormat.java
@@ -169,7 +169,7 @@ public class Any23DataFormat extends DataFormatDefinition {
     @XmlTransient
     public static class Builder implements DataFormatBuilder<Any23DataFormat> {
 
-        private String outputFormat = "RDF4JMODEL";
+        private String outputFormat;
         private String baseUri;
         private List<PropertyDefinition> configuration;
         private Map<String, String> configurations;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/AvroDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/AvroDataFormat.java
@@ -578,6 +578,11 @@ public class AvroDataFormat extends DataFormatDefinition {
             return this;
         }
 
+        public Builder contentTypeHeader(boolean contentTypeHeader) {
+            this.contentTypeHeader = Boolean.toString(contentTypeHeader);
+            return this;
+        }
+
         /**
          * Lookup and use the existing ObjectMapper with the given id when using Jackson.
          */
@@ -591,6 +596,14 @@ public class AvroDataFormat extends DataFormatDefinition {
          */
         public Builder useDefaultObjectMapper(String useDefaultObjectMapper) {
             this.useDefaultObjectMapper = useDefaultObjectMapper;
+            return this;
+        }
+
+        /**
+         * Whether to lookup and use default Jackson ObjectMapper from the registry.
+         */
+        public Builder useDefaultObjectMapper(boolean useDefaultObjectMapper) {
+            this.useDefaultObjectMapper = Boolean.toString(useDefaultObjectMapper);
             return this;
         }
 
@@ -649,6 +662,15 @@ public class AvroDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Used for JMS users to allow the JMSType header from the JMS spec to specify a FQN classname to use to
+         * unmarshal to.
+         */
+        public Builder allowJmsType(boolean allowJmsType) {
+            this.allowJmsType = Boolean.toString(allowJmsType);
+            return this;
+        }
+
+        /**
          * Refers to a custom collection type to lookup in the registry to use. This option should rarely be used, but
          * allows to use different collection types than java.util.Collection based as default.
          */
@@ -667,6 +689,14 @@ public class AvroDataFormat extends DataFormatDefinition {
          */
         public Builder useList(String useList) {
             this.useList = useList;
+            return this;
+        }
+
+        /**
+         * To unmarshal to a List of Map or a List of Pojo.
+         */
+        public Builder useList(boolean useList) {
+            this.useList = Boolean.toString(useList);
             return this;
         }
 
@@ -729,6 +759,17 @@ public class AvroDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * If enabled then Jackson is allowed to attempt to use the CamelJacksonUnmarshalType header during the
+         * unmarshalling.
+         * <p/>
+         * This should only be enabled when desired to be used.
+         */
+        public Builder allowUnmarshallType(boolean allowUnmarshallType) {
+            this.allowUnmarshallType = Boolean.toString(allowUnmarshallType);
+            return this;
+        }
+
+        /**
          * If set then Jackson will use the Timezone when marshalling/unmarshalling.
          */
         public Builder timezone(String timezone) {
@@ -745,6 +786,14 @@ public class AvroDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * If set to true then Jackson will lookup for an objectMapper into the registry
+         */
+        public Builder autoDiscoverObjectMapper(boolean autoDiscoverObjectMapper) {
+            this.autoDiscoverObjectMapper = Boolean.toString(autoDiscoverObjectMapper);
+            return this;
+        }
+
+        /**
          * Optional schema resolver used to lookup schemas for the data in transit.
          */
         public Builder schemaResolver(String schemaResolver) {
@@ -757,6 +806,14 @@ public class AvroDataFormat extends DataFormatDefinition {
          */
         public Builder autoDiscoverSchemaResolver(String autoDiscoverSchemaResolver) {
             this.autoDiscoverSchemaResolver = autoDiscoverSchemaResolver;
+            return this;
+        }
+
+        /**
+         * When not disabled, the SchemaResolver will be looked up into the registry
+         */
+        public Builder autoDiscoverSchemaResolver(boolean autoDiscoverSchemaResolver) {
+            this.autoDiscoverSchemaResolver = Boolean.toString(autoDiscoverSchemaResolver);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/AvroDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/AvroDataFormat.java
@@ -534,7 +534,7 @@ public class AvroDataFormat extends DataFormatDefinition {
         private String instanceClassName;
         private AvroLibrary library = AvroLibrary.ApacheAvro;
         private String objectMapper;
-        private String useDefaultObjectMapper = "true";
+        private String useDefaultObjectMapper;
         private String unmarshalTypeName;
         private String jsonViewTypeName;
         private String include;
@@ -548,9 +548,9 @@ public class AvroDataFormat extends DataFormatDefinition {
         private String allowUnmarshallType;
         private String timezone;
         private String autoDiscoverObjectMapper;
-        private String contentTypeHeader = "true";
+        private String contentTypeHeader;
         private String schemaResolver;
-        private String autoDiscoverSchemaResolver = "true";
+        private String autoDiscoverSchemaResolver;
 
         /**
          * Class name to use for marshal and unmarshalling

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/BarcodeDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/BarcodeDataFormat.java
@@ -121,10 +121,26 @@ public class BarcodeDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Width of the barcode
+         */
+        public Builder width(int width) {
+            this.width = Integer.toString(width);
+            return this;
+        }
+
+        /**
          * Height of the barcode
          */
         public Builder height(String height) {
             this.height = height;
+            return this;
+        }
+
+        /**
+         * Height of the barcode
+         */
+        public Builder height(int height) {
+            this.height = Integer.toString(height);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/Base64DataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/Base64DataFormat.java
@@ -99,7 +99,7 @@ public class Base64DataFormat extends DataFormatDefinition {
     @XmlTransient
     public static class Builder implements DataFormatBuilder<Base64DataFormat> {
 
-        private String lineLength = "76";
+        private String lineLength;
         private String lineSeparator;
         private String urlSafe;
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/Base64DataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/Base64DataFormat.java
@@ -114,6 +114,16 @@ public class Base64DataFormat extends DataFormatDefinition {
         }
 
         /**
+         * To specific a maximum line length for the encoded data.
+         * <p/>
+         * By default 76 is used.
+         */
+        public Builder lineLength(int lineLength) {
+            this.lineLength = Integer.toString(lineLength);
+            return this;
+        }
+
+        /**
          * The line separators to use.
          * <p/>
          * Uses new line characters (CRLF) by default.
@@ -129,6 +139,15 @@ public class Base64DataFormat extends DataFormatDefinition {
          */
         public Builder urlSafe(String urlSafe) {
             this.urlSafe = urlSafe;
+            return this;
+        }
+
+        /**
+         * Instead of emitting '+' and '/' we emit '-' and '_' respectively. urlSafe is only applied to encode
+         * operations. Decoding seamlessly handles both modes. Is by default false.
+         */
+        public Builder urlSafe(boolean urlSafe) {
+            this.urlSafe = Boolean.toString(urlSafe);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/BindyDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/BindyDataFormat.java
@@ -229,8 +229,8 @@ public class BindyDataFormat extends DataFormatDefinition {
         private Class<?> clazz;
         private String type;
         private String classType;
-        private String allowEmptyStream = "false";
-        private String unwrapSingleInstance = "true";
+        private String allowEmptyStream;
+        private String unwrapSingleInstance;
         private String locale;
 
         /**

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/BindyDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/BindyDataFormat.java
@@ -281,11 +281,29 @@ public class BindyDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * When unmarshalling should a single instance be unwrapped and returned instead of wrapped in a
+         * <tt>java.util.List</tt>.
+         */
+        public Builder unwrapSingleInstance(boolean unwrapSingleInstance) {
+            this.unwrapSingleInstance = Boolean.toString(unwrapSingleInstance);
+            return this;
+        }
+
+        /**
          * Whether to allow empty streams in the unmarshal process. If true, no exception will be thrown when a body
          * without records is provided.
          */
         public Builder allowEmptyStream(String allowEmptyStream) {
             this.allowEmptyStream = allowEmptyStream;
+            return this;
+        }
+
+        /**
+         * Whether to allow empty streams in the unmarshal process. If true, no exception will be thrown when a body
+         * without records is provided.
+         */
+        public Builder allowEmptyStream(boolean allowEmptyStream) {
+            this.allowEmptyStream = Boolean.toString(allowEmptyStream);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/CBORDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/CBORDataFormat.java
@@ -246,13 +246,13 @@ public class CBORDataFormat extends DataFormatDefinition {
         private Class<?> collectionType;
         private Class<?> unmarshalType;
         private String objectMapper;
-        private String useDefaultObjectMapper = "true";
+        private String useDefaultObjectMapper;
         private String unmarshalTypeName;
         private String collectionTypeName;
-        private String useList = "false";
-        private String allowUnmarshallType = "false";
-        private String prettyPrint = "false";
-        private String allowJmsType = "false";
+        private String useList;
+        private String allowUnmarshallType;
+        private String prettyPrint;
+        private String allowJmsType;
         private String enableFeatures;
         private String disableFeatures;
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/CBORDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/CBORDataFormat.java
@@ -273,6 +273,14 @@ public class CBORDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Whether to lookup and use default Jackson CBOR ObjectMapper from the registry.
+         */
+        public Builder useDefaultObjectMapper(boolean useDefaultObjectMapper) {
+            this.useDefaultObjectMapper = Boolean.toString(useDefaultObjectMapper);
+            return this;
+        }
+
+        /**
          * Class name of the java type to use when unmarshalling
          */
         public Builder unmarshalTypeName(String unmarshalTypeName) {
@@ -291,11 +299,30 @@ public class CBORDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * To enable pretty printing output nicely formatted.
+         * <p/>
+         * Is by default false.
+         */
+        public Builder prettyPrint(boolean prettyPrint) {
+            this.prettyPrint = Boolean.toString(prettyPrint);
+            return this;
+        }
+
+        /**
          * Used for JMS users to allow the JMSType header from the JMS spec to specify a FQN classname to use to
          * unmarshal to.
          */
         public Builder allowJmsType(String allowJmsType) {
             this.allowJmsType = allowJmsType;
+            return this;
+        }
+
+        /**
+         * Used for JMS users to allow the JMSType header from the JMS spec to specify a FQN classname to use to
+         * unmarshal to.
+         */
+        public Builder allowJmsType(boolean allowJmsType) {
+            this.allowJmsType = Boolean.toString(allowJmsType);
             return this;
         }
 
@@ -330,6 +357,14 @@ public class CBORDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * To unmarshal to a List of Map or a List of Pojo.
+         */
+        public Builder useList(boolean useList) {
+            this.useList = Boolean.toString(useList);
+            return this;
+        }
+
+        /**
          * If enabled then Jackson CBOR is allowed to attempt to use the CamelCBORUnmarshalType header during the
          * unmarshalling.
          * <p/>
@@ -337,6 +372,17 @@ public class CBORDataFormat extends DataFormatDefinition {
          */
         public Builder allowUnmarshallType(String allowUnmarshallType) {
             this.allowUnmarshallType = allowUnmarshallType;
+            return this;
+        }
+
+        /**
+         * If enabled then Jackson CBOR is allowed to attempt to use the CamelCBORUnmarshalType header during the
+         * unmarshalling.
+         * <p/>
+         * This should only be enabled when desired to be used.
+         */
+        public Builder allowUnmarshallType(boolean allowUnmarshallType) {
+            this.allowUnmarshallType = Boolean.toString(allowUnmarshallType);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/CryptoDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/CryptoDataFormat.java
@@ -191,10 +191,10 @@ public class CryptoDataFormat extends DataFormatDefinition {
         private String cryptoProvider;
         private String initVectorRef;
         private String algorithmParameterRef;
-        private String bufferSize = "4096";
+        private String bufferSize;
         private String macAlgorithm = "HmacSHA1";
-        private String shouldAppendHMAC = "true";
-        private String inline = "false";
+        private String shouldAppendHMAC;
+        private String inline;
 
         /**
          * The JCE algorithm name indicating the cryptographic algorithm that will be used.

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/CryptoDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/CryptoDataFormat.java
@@ -247,6 +247,14 @@ public class CryptoDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * The size of the buffer used in the signature process.
+         */
+        public Builder bufferSize(int bufferSize) {
+            this.bufferSize = Integer.toString(bufferSize);
+            return this;
+        }
+
+        /**
          * The JCE algorithm name indicating the Message Authentication algorithm.
          */
         public Builder macAlgorithm(String macAlgorithm) {
@@ -263,12 +271,30 @@ public class CryptoDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Flag indicating that a Message Authentication Code should be calculated and appended to the encrypted data.
+         */
+        public Builder shouldAppendHMAC(boolean shouldAppendHMAC) {
+            this.shouldAppendHMAC = Boolean.toString(shouldAppendHMAC);
+            return this;
+        }
+
+        /**
          * Flag indicating that the configured IV should be inlined into the encrypted data stream.
          * <p/>
          * Is by default false.
          */
         public Builder inline(String inline) {
             this.inline = inline;
+            return this;
+        }
+
+        /**
+         * Flag indicating that the configured IV should be inlined into the encrypted data stream.
+         * <p/>
+         * Is by default false.
+         */
+        public Builder inline(boolean inline) {
+            this.inline = Boolean.toString(inline);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/CsvDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/CsvDataFormat.java
@@ -510,7 +510,7 @@ public class CsvDataFormat extends DataFormatDefinition {
     @XmlTransient
     public static class Builder implements DataFormatBuilder<CsvDataFormat> {
         private String formatRef;
-        private String formatName = "DEFAULT";
+        private String formatName;
         private String commentMarkerDisabled;
         private String commentMarker;
         private String delimiter;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/CsvDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/CsvDataFormat.java
@@ -576,6 +576,14 @@ public class CsvDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Disables the comment marker of the reference format.
+         */
+        public Builder commentMarkerDisabled(boolean commentMarkerDisabled) {
+            this.commentMarkerDisabled = Boolean.toString(commentMarkerDisabled);
+            return this;
+        }
+
+        /**
          * Sets the comment marker of the reference format.
          */
         public Builder commentMarker(String commentMarker) {
@@ -602,6 +610,14 @@ public class CsvDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Use for disabling using escape character
+         */
+        public Builder escapeDisabled(boolean escapeDisabled) {
+            this.escapeDisabled = Boolean.toString(escapeDisabled);
+            return this;
+        }
+
+        /**
          * Sets the escape character to use
          */
         public Builder escape(String escape) {
@@ -611,6 +627,11 @@ public class CsvDataFormat extends DataFormatDefinition {
 
         public Builder headerDisabled(String headerDisabled) {
             this.headerDisabled = headerDisabled;
+            return this;
+        }
+
+        public Builder headerDisabled(boolean headerDisabled) {
+            this.headerDisabled = Boolean.toString(headerDisabled);
             return this;
         }
 
@@ -631,10 +652,26 @@ public class CsvDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Whether to allow missing column names.
+         */
+        public Builder allowMissingColumnNames(boolean allowMissingColumnNames) {
+            this.allowMissingColumnNames = Boolean.toString(allowMissingColumnNames);
+            return this;
+        }
+
+        /**
          * Whether to ignore empty lines.
          */
         public Builder ignoreEmptyLines(String ignoreEmptyLines) {
             this.ignoreEmptyLines = ignoreEmptyLines;
+            return this;
+        }
+
+        /**
+         * Whether to ignore empty lines.
+         */
+        public Builder ignoreEmptyLines(boolean ignoreEmptyLines) {
+            this.ignoreEmptyLines = Boolean.toString(ignoreEmptyLines);
             return this;
         }
 
@@ -647,10 +684,26 @@ public class CsvDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Whether to ignore surrounding spaces
+         */
+        public Builder ignoreSurroundingSpaces(boolean ignoreSurroundingSpaces) {
+            this.ignoreSurroundingSpaces = Boolean.toString(ignoreSurroundingSpaces);
+            return this;
+        }
+
+        /**
          * Used to disable null strings
          */
         public Builder nullStringDisabled(String nullStringDisabled) {
             this.nullStringDisabled = nullStringDisabled;
+            return this;
+        }
+
+        /**
+         * Used to disable null strings
+         */
+        public Builder nullStringDisabled(boolean nullStringDisabled) {
+            this.nullStringDisabled = Boolean.toString(nullStringDisabled);
             return this;
         }
 
@@ -667,6 +720,14 @@ public class CsvDataFormat extends DataFormatDefinition {
          */
         public Builder quoteDisabled(String quoteDisabled) {
             this.quoteDisabled = quoteDisabled;
+            return this;
+        }
+
+        /**
+         * Used to disable quotes
+         */
+        public Builder quoteDisabled(boolean quoteDisabled) {
+            this.quoteDisabled = Boolean.toString(quoteDisabled);
             return this;
         }
 
@@ -703,6 +764,14 @@ public class CsvDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Whether to skip the header record in the output
+         */
+        public Builder skipHeaderRecord(boolean skipHeaderRecord) {
+            this.skipHeaderRecord = Boolean.toString(skipHeaderRecord);
+            return this;
+        }
+
+        /**
          * Sets the quote mode
          */
         public Builder quoteMode(String quoteMode) {
@@ -720,6 +789,15 @@ public class CsvDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Whether the unmarshalling should produce an iterator that reads the lines on the fly or if all the lines must
+         * be read at one.
+         */
+        public Builder lazyLoad(boolean lazyLoad) {
+            this.lazyLoad = Boolean.toString(lazyLoad);
+            return this;
+        }
+
+        /**
          * Whether the unmarshalling should produce maps (HashMap)for the lines values instead of lists. It requires to
          * have header (either defined or collected).
          */
@@ -729,11 +807,29 @@ public class CsvDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Whether the unmarshalling should produce maps (HashMap)for the lines values instead of lists. It requires to
+         * have header (either defined or collected).
+         */
+        public Builder useMaps(boolean useMaps) {
+            this.useMaps = Boolean.toString(useMaps);
+            return this;
+        }
+
+        /**
          * Whether the unmarshalling should produce ordered maps (LinkedHashMap) for the lines values instead of lists.
          * It requires to have header (either defined or collected).
          */
         public Builder useOrderedMaps(String useOrderedMaps) {
             this.useOrderedMaps = useOrderedMaps;
+            return this;
+        }
+
+        /**
+         * Whether the unmarshalling should produce ordered maps (LinkedHashMap) for the lines values instead of lists.
+         * It requires to have header (either defined or collected).
+         */
+        public Builder useOrderedMaps(boolean useOrderedMaps) {
+            this.useOrderedMaps = Boolean.toString(useOrderedMaps);
             return this;
         }
 
@@ -754,10 +850,26 @@ public class CsvDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Sets whether or not to trim leading and trailing blanks.
+         */
+        public Builder trim(boolean trim) {
+            this.trim = Boolean.toString(trim);
+            return this;
+        }
+
+        /**
          * Sets whether or not to ignore case when accessing header names.
          */
         public Builder ignoreHeaderCase(String ignoreHeaderCase) {
             this.ignoreHeaderCase = ignoreHeaderCase;
+            return this;
+        }
+
+        /**
+         * Sets whether or not to ignore case when accessing header names.
+         */
+        public Builder ignoreHeaderCase(boolean ignoreHeaderCase) {
+            this.ignoreHeaderCase = Boolean.toString(ignoreHeaderCase);
             return this;
         }
 
@@ -770,10 +882,26 @@ public class CsvDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Sets whether or not to add a trailing delimiter.
+         */
+        public Builder trailingDelimiter(boolean trailingDelimiter) {
+            this.trailingDelimiter = Boolean.toString(trailingDelimiter);
+            return this;
+        }
+
+        /**
          * Whether the unmarshalling should capture the header record and store it in the message header
          */
         public Builder captureHeaderRecord(String captureHeaderRecord) {
             this.captureHeaderRecord = captureHeaderRecord;
+            return this;
+        }
+
+        /**
+         * Whether the unmarshalling should capture the header record and store it in the message header
+         */
+        public Builder captureHeaderRecord(boolean captureHeaderRecord) {
+            this.captureHeaderRecord = Boolean.toString(captureHeaderRecord);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/FhirDataformat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/FhirDataformat.java
@@ -446,6 +446,17 @@ public abstract class FhirDataformat extends DataFormatDefinition implements Con
         }
 
         /**
+         * Sets the "pretty print" flag, meaning that the parser will encode resources with human-readable spacing and
+         * newlines between elements instead of condensing output as much as possible.
+         *
+         * @param prettyPrint The flag
+         */
+        public T prettyPrint(boolean prettyPrint) {
+            this.prettyPrint = Boolean.toString(prettyPrint);
+            return (T) this;
+        }
+
+        /**
          * Registers an error handler which will be invoked when any parse errors are found
          *
          * @param parserErrorHandler The error handler to set. Must not be null.
@@ -511,12 +522,35 @@ public abstract class FhirDataformat extends DataFormatDefinition implements Con
         }
 
         /**
+         * If set to <code>true</code> (default is <code>false</code>) the ID of any resources being encoded will not be
+         * included in the output. Note that this does not apply to contained resources, only to root resources. In
+         * other words, if this is set to <code>true</code>, contained resources will still have local IDs but the
+         * outer/containing ID will not have an ID.
+         *
+         * @param omitResourceId Should resource IDs be omitted
+         */
+        public T omitResourceId(boolean omitResourceId) {
+            this.omitResourceId = Boolean.toString(omitResourceId);
+            return (T) this;
+        }
+
+        /**
          * If set to <code>true</code> (default is false), the values supplied to {@link #setEncodeElements(Set)} will
          * not be applied to the root resource (typically a Bundle), but will be applied to any sub-resources contained
          * within it (i.e. search result resources in that bundle)
          */
         public T encodeElementsAppliesToChildResourcesOnly(String encodeElementsAppliesToChildResourcesOnly) {
             this.encodeElementsAppliesToChildResourcesOnly = encodeElementsAppliesToChildResourcesOnly;
+            return (T) this;
+        }
+
+        /**
+         * If set to <code>true</code> (default is false), the values supplied to {@link #setEncodeElements(Set)} will
+         * not be applied to the root resource (typically a Bundle), but will be applied to any sub-resources contained
+         * within it (i.e. search result resources in that bundle)
+         */
+        public T encodeElementsAppliesToChildResourcesOnly(boolean encodeElementsAppliesToChildResourcesOnly) {
+            this.encodeElementsAppliesToChildResourcesOnly = Boolean.toString(encodeElementsAppliesToChildResourcesOnly);
             return (T) this;
         }
 
@@ -587,6 +621,28 @@ public abstract class FhirDataformat extends DataFormatDefinition implements Con
         }
 
         /**
+         * If set to <code>true<code> (which is the default), resource references containing a version
+         * will have the version removed when the resource is encoded. This is generally good behaviour because
+         * in most situations, references from one resource to another should be to the resource by ID, not
+         * by ID and version. In some cases though, it may be desirable to preserve the version in resource
+         * links. In that case, this value should be set to <code>false</code>.
+         * <p>
+         * This method provides the ability to globally disable reference encoding. If finer-grained control is needed,
+         * use {@link #setDontStripVersionsFromReferencesAtPaths(List)}
+         * </p>
+         *
+         * @param stripVersionsFromReferences Set this to
+         *                                    <code>false<code> to prevent the parser from removing resource versions
+         *                                    from references (or <code>null</code> to apply the default setting from
+         *                                    the {@link #setParserOptions(Object)}
+         * @see                               #setDontStripVersionsFromReferencesAtPaths(List)
+         */
+        public T stripVersionsFromReferences(boolean stripVersionsFromReferences) {
+            this.stripVersionsFromReferences = Boolean.toString(stripVersionsFromReferences);
+            return (T) this;
+        }
+
+        /**
          * If set to <code>true</code> (which is the default), the Bundle.entry.fullUrl will override the
          * Bundle.entry.resource's resource id if the fullUrl is defined. This behavior happens when parsing the source
          * data into a Bundle object. Set this to <code>false</code> if this is not the desired behavior (e.g. the
@@ -603,6 +659,22 @@ public abstract class FhirDataformat extends DataFormatDefinition implements Con
         }
 
         /**
+         * If set to <code>true</code> (which is the default), the Bundle.entry.fullUrl will override the
+         * Bundle.entry.resource's resource id if the fullUrl is defined. This behavior happens when parsing the source
+         * data into a Bundle object. Set this to <code>false</code> if this is not the desired behavior (e.g. the
+         * client code wishes to perform additional validation checks between the fullUrl and the resource id).
+         *
+         * @param overrideResourceIdWithBundleEntryFullUrl Set this to <code>false</code> to prevent the parser from
+         *                                                 overriding resource ids with the Bundle.entry.fullUrl (or
+         *                                                 <code>null</code> to apply the default setting from the
+         *                                                 {@link #setParserOptions(Object)})
+         */
+        public T overrideResourceIdWithBundleEntryFullUrl(boolean overrideResourceIdWithBundleEntryFullUrl) {
+            this.overrideResourceIdWithBundleEntryFullUrl = Boolean.toString(overrideResourceIdWithBundleEntryFullUrl);
+            return (T) this;
+        }
+
+        /**
          * If set to <code>true</code> (default is <code>false</code>) only elements marked by the FHIR specification as
          * being "summary elements" will be included.
          */
@@ -612,11 +684,29 @@ public abstract class FhirDataformat extends DataFormatDefinition implements Con
         }
 
         /**
+         * If set to <code>true</code> (default is <code>false</code>) only elements marked by the FHIR specification as
+         * being "summary elements" will be included.
+         */
+        public T summaryMode(boolean summaryMode) {
+            this.summaryMode = Boolean.toString(summaryMode);
+            return (T) this;
+        }
+
+        /**
          * If set to <code>true</code> (default is <code>false</code>), narratives will not be included in the encoded
          * values.
          */
         public T suppressNarratives(String suppressNarratives) {
             this.suppressNarratives = suppressNarratives;
+            return (T) this;
+        }
+
+        /**
+         * If set to <code>true</code> (default is <code>false</code>), narratives will not be included in the encoded
+         * values.
+         */
+        public T suppressNarratives(boolean suppressNarratives) {
+            this.suppressNarratives = Boolean.toString(suppressNarratives);
             return (T) this;
         }
 
@@ -647,6 +737,11 @@ public abstract class FhirDataformat extends DataFormatDefinition implements Con
 
         public T contentTypeHeader(String contentTypeHeader) {
             this.contentTypeHeader = contentTypeHeader;
+            return (T) this;
+        }
+
+        public T contentTypeHeader(boolean contentTypeHeader) {
+            this.contentTypeHeader = Boolean.toString(contentTypeHeader);
             return (T) this;
         }
     }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/FhirDataformat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/FhirDataformat.java
@@ -403,7 +403,7 @@ public abstract class FhirDataformat extends DataFormatDefinition implements Con
             implements DataFormatBuilder<F> {
 
         private Object fhirContext;
-        private String fhirVersion = "R4";
+        private String fhirVersion;
         private String prettyPrint;
         private Object parserErrorHandler;
         private Object parserOptions;
@@ -419,7 +419,7 @@ public abstract class FhirDataformat extends DataFormatDefinition implements Con
         private String summaryMode;
         private String suppressNarratives;
         private List<String> dontStripVersionsFromReferencesAtPaths;
-        private String contentTypeHeader = "true";
+        private String contentTypeHeader;
 
         public T fhirContext(Object fhirContext) {
             this.fhirContext = fhirContext;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/FlatpackDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/FlatpackDataFormat.java
@@ -200,12 +200,30 @@ public class FlatpackDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Delimited or fixed. Is by default false = delimited
+         */
+        public Builder fixed(boolean fixed) {
+            this.fixed = Boolean.toString(fixed);
+            return this;
+        }
+
+        /**
          * Whether the first line is ignored for delimited files (for the column headers).
          * <p/>
          * Is by default true.
          */
         public Builder ignoreFirstRecord(String ignoreFirstRecord) {
             this.ignoreFirstRecord = ignoreFirstRecord;
+            return this;
+        }
+
+        /**
+         * Whether the first line is ignored for delimited files (for the column headers).
+         * <p/>
+         * Is by default true.
+         */
+        public Builder ignoreFirstRecord(boolean ignoreFirstRecord) {
+            this.ignoreFirstRecord = Boolean.toString(ignoreFirstRecord);
             return this;
         }
 
@@ -236,10 +254,26 @@ public class FlatpackDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Allows for lines to be shorter than expected and ignores the extra characters
+         */
+        public Builder allowShortLines(boolean allowShortLines) {
+            this.allowShortLines = Boolean.toString(allowShortLines);
+            return this;
+        }
+
+        /**
          * Allows for lines to be longer than expected and ignores the extra characters.
          */
         public Builder ignoreExtraColumns(String ignoreExtraColumns) {
             this.ignoreExtraColumns = ignoreExtraColumns;
+            return this;
+        }
+
+        /**
+         * Allows for lines to be longer than expected and ignores the extra characters.
+         */
+        public Builder ignoreExtraColumns(boolean ignoreExtraColumns) {
+            this.ignoreExtraColumns = Boolean.toString(ignoreExtraColumns);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/FlatpackDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/FlatpackDataFormat.java
@@ -175,8 +175,8 @@ public class FlatpackDataFormat extends DataFormatDefinition {
 
         private String definition;
         private String fixed;
-        private String delimiter = ",";
-        private String ignoreFirstRecord = "true";
+        private String delimiter;
+        private String ignoreFirstRecord;
         private String allowShortLines;
         private String ignoreExtraColumns;
         private String textQualifier;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/GrokDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/GrokDataFormat.java
@@ -118,7 +118,7 @@ public class GrokDataFormat extends DataFormatDefinition {
 
         private String pattern;
         private String flattened;
-        private String allowMultipleMatchesPerLine = "true";
+        private String allowMultipleMatchesPerLine;
         private String namedOnly;
 
         /**

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/GrokDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/GrokDataFormat.java
@@ -139,6 +139,15 @@ public class GrokDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Turns on flattened mode. In flattened mode the exception is thrown when there are multiple pattern matches
+         * with same key.
+         */
+        public Builder flattened(boolean flattened) {
+            this.flattened = Boolean.toString(flattened);
+            return this;
+        }
+
+        /**
          * If false, every line of input is matched for pattern only once. Otherwise the line can be scanned multiple
          * times when non-terminal pattern is used.
          */
@@ -148,10 +157,27 @@ public class GrokDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * If false, every line of input is matched for pattern only once. Otherwise the line can be scanned multiple
+         * times when non-terminal pattern is used.
+         */
+        public Builder allowMultipleMatchesPerLine(boolean allowMultipleMatchesPerLine) {
+            this.allowMultipleMatchesPerLine = Boolean.toString(allowMultipleMatchesPerLine);
+            return this;
+        }
+
+        /**
          * Whether to capture named expressions only or not (i.e. %{IP:ip} but not ${IP})
          */
         public Builder namedOnly(String namedOnly) {
             this.namedOnly = namedOnly;
+            return this;
+        }
+
+        /**
+         * Whether to capture named expressions only or not (i.e. %{IP:ip} but not ${IP})
+         */
+        public Builder namedOnly(boolean namedOnly) {
+            this.namedOnly = Boolean.toString(namedOnly);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/HL7DataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/HL7DataFormat.java
@@ -83,7 +83,7 @@ public class HL7DataFormat extends DataFormatDefinition {
     public static class Builder implements DataFormatBuilder<HL7DataFormat> {
 
         private Object parser;
-        private String validate = "true";
+        private String validate;
 
         /**
          * Whether to validate the HL7 message

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/HL7DataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/HL7DataFormat.java
@@ -96,6 +96,16 @@ public class HL7DataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Whether to validate the HL7 message
+         * <p/>
+         * Is by default true.
+         */
+        public Builder validate(boolean validate) {
+            this.validate = Boolean.toString(validate);
+            return this;
+        }
+
+        /**
          * To use a custom HL7 parser
          */
         public Builder parser(Object parser) {

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/IcalDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/IcalDataFormat.java
@@ -74,6 +74,14 @@ public class IcalDataFormat extends DataFormatDefinition {
             return this;
         }
 
+        /**
+         * Whether to validate.
+         */
+        public Builder validating(boolean validating) {
+            this.validating = Boolean.toString(validating);
+            return this;
+        }
+
         @Override
         public IcalDataFormat end() {
             return new IcalDataFormat(this);

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JacksonXMLDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JacksonXMLDataFormat.java
@@ -388,6 +388,16 @@ public class JacksonXMLDataFormat extends DataFormatDefinition implements Conten
         }
 
         /**
+         * To enable pretty printing output nicely formatted.
+         * <p/>
+         * Is by default false.
+         */
+        public Builder prettyPrint(boolean prettyPrint) {
+            this.prettyPrint = Boolean.toString(prettyPrint);
+            return this;
+        }
+
+        /**
          * Class name of the java type to use when unmarshalling
          */
         public Builder unmarshalTypeName(String unmarshalTypeName) {
@@ -442,6 +452,15 @@ public class JacksonXMLDataFormat extends DataFormatDefinition implements Conten
         }
 
         /**
+         * Used for JMS users to allow the JMSType header from the JMS spec to specify a FQN classname to use to
+         * unmarshal to.
+         */
+        public Builder allowJmsType(boolean allowJmsType) {
+            this.allowJmsType = Boolean.toString(allowJmsType);
+            return this;
+        }
+
+        /**
          * Refers to a custom collection type to lookup in the registry to use. This option should rarely be used, but
          * allows to use different collection types than java.util.Collection based as default.
          */
@@ -464,11 +483,28 @@ public class JacksonXMLDataFormat extends DataFormatDefinition implements Conten
         }
 
         /**
+         * To unmarshal to a List of Map or a List of Pojo.
+         */
+        public Builder useList(boolean useList) {
+            this.useList = Boolean.toString(useList);
+            return this;
+        }
+
+        /**
          * Whether to enable the JAXB annotations module when using jackson. When enabled then JAXB annotations can be
          * used by Jackson.
          */
         public Builder enableJaxbAnnotationModule(String enableJaxbAnnotationModule) {
             this.enableJaxbAnnotationModule = enableJaxbAnnotationModule;
+            return this;
+        }
+
+        /**
+         * Whether to enable the JAXB annotations module when using jackson. When enabled then JAXB annotations can be
+         * used by Jackson.
+         */
+        public Builder enableJaxbAnnotationModule(boolean enableJaxbAnnotationModule) {
+            this.enableJaxbAnnotationModule = Boolean.toString(enableJaxbAnnotationModule);
             return this;
         }
 
@@ -530,8 +566,24 @@ public class JacksonXMLDataFormat extends DataFormatDefinition implements Conten
             return this;
         }
 
+        /**
+         * If enabled then Jackson is allowed to attempt to use the CamelJacksonUnmarshalType header during the
+         * unmarshalling.
+         * <p/>
+         * This should only be enabled when desired to be used.
+         */
+        public Builder allowUnmarshallType(boolean allowUnmarshallType) {
+            this.allowUnmarshallType = Boolean.toString(allowUnmarshallType);
+            return this;
+        }
+
         public Builder contentTypeHeader(String contentTypeHeader) {
             this.contentTypeHeader = contentTypeHeader;
+            return this;
+        }
+
+        public Builder contentTypeHeader(boolean contentTypeHeader) {
+            this.contentTypeHeader = Boolean.toString(contentTypeHeader);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JacksonXMLDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JacksonXMLDataFormat.java
@@ -367,7 +367,7 @@ public class JacksonXMLDataFormat extends DataFormatDefinition implements Conten
         private String moduleRefs;
         private String enableFeatures;
         private String disableFeatures;
-        private String contentTypeHeader = "true";
+        private String contentTypeHeader;
 
         /**
          * Lookup and use the existing XmlMapper with the given id.

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JaxbDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JaxbDataFormat.java
@@ -356,7 +356,7 @@ public class JaxbDataFormat extends DataFormatDefinition implements ContentTypeH
         private String contextPath;
         private String contextPathIsClassName;
         private String schema;
-        private String schemaSeverityLevel = "0";
+        private String schemaSeverityLevel;
         private String prettyPrint;
         private String objectFactory;
         private String ignoreJAXBElement;
@@ -371,7 +371,7 @@ public class JaxbDataFormat extends DataFormatDefinition implements ContentTypeH
         private String schemaLocation;
         private String noNamespaceSchemaLocation;
         private String jaxbProviderProperties;
-        private String contentTypeHeader = "true";
+        private String contentTypeHeader;
 
         /**
          * Package name where your JAXB classes are located.

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JaxbDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JaxbDataFormat.java
@@ -390,6 +390,14 @@ public class JaxbDataFormat extends DataFormatDefinition implements ContentTypeH
         }
 
         /**
+         * This can be set to true to mark that the contextPath is referring to a classname and not a package name.
+         */
+        public Builder contextPathIsClassName(boolean contextPathIsClassName) {
+            this.contextPathIsClassName = Boolean.toString(contextPathIsClassName);
+            return this;
+        }
+
+        /**
          * To validate against an existing schema. Your can use the prefix classpath:, file:* or *http: to specify how
          * the resource should be resolved. You can separate multiple schema files by using the ',' character.
          */
@@ -410,12 +418,33 @@ public class JaxbDataFormat extends DataFormatDefinition implements ContentTypeH
         }
 
         /**
+         * Sets the schema severity level to use when validating against a schema. This level determines the minimum
+         * severity error that triggers JAXB to stop continue parsing. The default value of 0 (warning) means that any
+         * error (warning, error or fatal error) will trigger JAXB to stop. There are the following three levels:
+         * 0=warning, 1=error, 2=fatal error.
+         */
+        public Builder schemaSeverityLevel(int schemaSeverityLevel) {
+            this.schemaSeverityLevel = Integer.toString(schemaSeverityLevel);
+            return this;
+        }
+
+        /**
          * To enable pretty printing output nicely formatted.
          * <p/>
          * Is by default false.
          */
         public Builder prettyPrint(String prettyPrint) {
             this.prettyPrint = prettyPrint;
+            return this;
+        }
+
+        /**
+         * To enable pretty printing output nicely formatted.
+         * <p/>
+         * Is by default false.
+         */
+        public Builder prettyPrint(boolean prettyPrint) {
+            this.prettyPrint = Boolean.toString(prettyPrint);
             return this;
         }
 
@@ -429,10 +458,27 @@ public class JaxbDataFormat extends DataFormatDefinition implements ContentTypeH
         }
 
         /**
+         * Whether to allow using ObjectFactory classes to create the POJO classes during marshalling. This only applies
+         * to POJO classes that has not been annotated with JAXB and providing jaxb.index descriptor files.
+         */
+        public Builder objectFactory(boolean objectFactory) {
+            this.objectFactory = Boolean.toString(objectFactory);
+            return this;
+        }
+
+        /**
          * Whether to ignore JAXBElement elements - only needed to be set to false in very special use-cases.
          */
         public Builder ignoreJAXBElement(String ignoreJAXBElement) {
             this.ignoreJAXBElement = ignoreJAXBElement;
+            return this;
+        }
+
+        /**
+         * Whether to ignore JAXBElement elements - only needed to be set to false in very special use-cases.
+         */
+        public Builder ignoreJAXBElement(boolean ignoreJAXBElement) {
+            this.ignoreJAXBElement = Boolean.toString(ignoreJAXBElement);
             return this;
         }
 
@@ -442,6 +488,15 @@ public class JaxbDataFormat extends DataFormatDefinition implements ContentTypeH
          */
         public Builder mustBeJAXBElement(String mustBeJAXBElement) {
             this.mustBeJAXBElement = mustBeJAXBElement;
+            return this;
+        }
+
+        /**
+         * Whether marhsalling must be java objects with JAXB annotations. And if not then it fails. This option can be
+         * set to false to relax that, such as when the data is already in XML format.
+         */
+        public Builder mustBeJAXBElement(boolean mustBeJAXBElement) {
+            this.mustBeJAXBElement = Boolean.toString(mustBeJAXBElement);
             return this;
         }
 
@@ -458,10 +513,30 @@ public class JaxbDataFormat extends DataFormatDefinition implements ContentTypeH
         }
 
         /**
+         * To turn on marshalling XML fragment trees. By default JAXB looks for @XmlRootElement annotation on given
+         * class to operate on whole XML tree. This is useful but not always - sometimes generated code does not
+         * have @XmlRootElement annotation, sometimes you need unmarshall only part of tree. In that case you can use
+         * partial unmarshalling. To enable this behaviours you need set property partClass. Camel will pass this class
+         * to JAXB's unmarshaler.
+         */
+        public Builder fragment(boolean fragment) {
+            this.fragment = Boolean.toString(fragment);
+            return this;
+        }
+
+        /**
          * To ignore non xml characters and replace them with an empty space.
          */
         public Builder filterNonXmlChars(String filterNonXmlChars) {
             this.filterNonXmlChars = filterNonXmlChars;
+            return this;
+        }
+
+        /**
+         * To ignore non xml characters and replace them with an empty space.
+         */
+        public Builder filterNonXmlChars(boolean filterNonXmlChars) {
+            this.filterNonXmlChars = Boolean.toString(filterNonXmlChars);
             return this;
         }
 
@@ -538,6 +613,11 @@ public class JaxbDataFormat extends DataFormatDefinition implements ContentTypeH
 
         public Builder contentTypeHeader(String contentTypeHeader) {
             this.contentTypeHeader = contentTypeHeader;
+            return this;
+        }
+
+        public Builder contentTypeHeader(boolean contentTypeHeader) {
+            this.contentTypeHeader = Boolean.toString(contentTypeHeader);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JsonDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JsonDataFormat.java
@@ -674,6 +674,11 @@ public class JsonDataFormat extends DataFormatDefinition implements ContentTypeH
             return this;
         }
 
+        public Builder contentTypeHeader(boolean contentTypeHeader) {
+            this.contentTypeHeader = Boolean.toString(contentTypeHeader);
+            return this;
+        }
+
         /**
          * Lookup and use the existing ObjectMapper with the given id when using Jackson.
          */
@@ -691,12 +696,30 @@ public class JsonDataFormat extends DataFormatDefinition implements ContentTypeH
         }
 
         /**
+         * Whether to lookup and use default Jackson ObjectMapper from the registry.
+         */
+        public Builder useDefaultObjectMapper(boolean useDefaultObjectMapper) {
+            this.useDefaultObjectMapper = Boolean.toString(useDefaultObjectMapper);
+            return this;
+        }
+
+        /**
          * To enable pretty printing output nicely formatted.
          * <p/>
          * Is by default false.
          */
         public Builder prettyPrint(String prettyPrint) {
             this.prettyPrint = prettyPrint;
+            return this;
+        }
+
+        /**
+         * To enable pretty printing output nicely formatted.
+         * <p/>
+         * Is by default false.
+         */
+        public Builder prettyPrint(boolean prettyPrint) {
+            this.prettyPrint = Boolean.toString(prettyPrint);
             return this;
         }
 
@@ -763,6 +786,15 @@ public class JsonDataFormat extends DataFormatDefinition implements ContentTypeH
         }
 
         /**
+         * Used for JMS users to allow the JMSType header from the JMS spec to specify a FQN classname to use to
+         * unmarshal to.
+         */
+        public Builder allowJmsType(boolean allowJmsType) {
+            this.allowJmsType = Boolean.toString(allowJmsType);
+            return this;
+        }
+
+        /**
          * Refers to a custom collection type to lookup in the registry to use. This option should rarely be used, but
          * allows using different collection types than java.util.Collection based as default.
          */
@@ -781,6 +813,14 @@ public class JsonDataFormat extends DataFormatDefinition implements ContentTypeH
          */
         public Builder useList(String useList) {
             this.useList = useList;
+            return this;
+        }
+
+        /**
+         * To unmarshal to a List of Map or a List of Pojo.
+         */
+        public Builder useList(boolean useList) {
+            this.useList = Boolean.toString(useList);
             return this;
         }
 
@@ -870,6 +910,17 @@ public class JsonDataFormat extends DataFormatDefinition implements ContentTypeH
         }
 
         /**
+         * If enabled then Jackson is allowed to attempt to use the CamelJacksonUnmarshalType header during the
+         * unmarshalling.
+         * <p/>
+         * This should only be enabled when desired to be used.
+         */
+        public Builder allowUnmarshallType(boolean allowUnmarshallType) {
+            this.allowUnmarshallType = Boolean.toString(allowUnmarshallType);
+            return this;
+        }
+
+        /**
          * If set then Jackson will use the Timezone when marshalling/unmarshalling. This option will have no effect on
          * the others Json DataFormat, like gson, fastjson and xstream.
          */
@@ -887,12 +938,30 @@ public class JsonDataFormat extends DataFormatDefinition implements ContentTypeH
         }
 
         /**
+         * If set to true then Jackson will look for an objectMapper to use from the registry
+         */
+        public Builder autoDiscoverObjectMapper(boolean autoDiscoverObjectMapper) {
+            this.autoDiscoverObjectMapper = Boolean.toString(autoDiscoverObjectMapper);
+            return this;
+        }
+
+        /**
          * Whether XStream will drop the root node in the generated JSon. You may want to enable this when using POJOs;
          * as then the written object will include the class name as root node, which is often not intended to be
          * written in the JSON output.
          */
         public Builder dropRootNode(String dropRootNode) {
             this.dropRootNode = dropRootNode;
+            return this;
+        }
+
+        /**
+         * Whether XStream will drop the root node in the generated JSon. You may want to enable this when using POJOs;
+         * as then the written object will include the class name as root node, which is often not intended to be
+         * written in the JSON output.
+         */
+        public Builder dropRootNode(boolean dropRootNode) {
+            this.dropRootNode = Boolean.toString(dropRootNode);
             return this;
         }
 
@@ -909,6 +978,14 @@ public class JsonDataFormat extends DataFormatDefinition implements ContentTypeH
          */
         public Builder autoDiscoverSchemaResolver(String autoDiscoverSchemaResolver) {
             this.autoDiscoverSchemaResolver = autoDiscoverSchemaResolver;
+            return this;
+        }
+
+        /**
+         * When not disabled, the SchemaResolver will be looked up into the registry
+         */
+        public Builder autoDiscoverSchemaResolver(boolean autoDiscoverSchemaResolver) {
+            this.autoDiscoverSchemaResolver = Boolean.toString(autoDiscoverSchemaResolver);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JsonDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/JsonDataFormat.java
@@ -643,8 +643,8 @@ public class JsonDataFormat extends DataFormatDefinition implements ContentTypeH
     public static class Builder implements DataFormatBuilder<JsonDataFormat> {
 
         private String objectMapper;
-        private String useDefaultObjectMapper = "true";
-        private String autoDiscoverObjectMapper = "false";
+        private String useDefaultObjectMapper;
+        private String autoDiscoverObjectMapper;
         private String prettyPrint;
         private JsonLibrary library = JsonLibrary.Jackson;
         private String unmarshalTypeName;
@@ -663,11 +663,11 @@ public class JsonDataFormat extends DataFormatDefinition implements ContentTypeH
         private String permissions;
         private String allowUnmarshallType;
         private String timezone;
-        private String dropRootNode = "false";
+        private String dropRootNode;
         private String schemaResolver;
-        private String autoDiscoverSchemaResolver = "true";
+        private String autoDiscoverSchemaResolver;
         private String namingStrategy;
-        private String contentTypeHeader = "true";
+        private String contentTypeHeader;
 
         public Builder contentTypeHeader(String contentTypeHeader) {
             this.contentTypeHeader = contentTypeHeader;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/LZFDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/LZFDataFormat.java
@@ -74,6 +74,14 @@ public class LZFDataFormat extends DataFormatDefinition {
             return this;
         }
 
+        /**
+         * Enable encoding (compress) using multiple processing cores.
+         */
+        public Builder usingParallelCompression(boolean usingParallelCompression) {
+            this.usingParallelCompression = Boolean.toString(usingParallelCompression);
+            return this;
+        }
+
         @Override
         public LZFDataFormat end() {
             return new LZFDataFormat(this);

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/MimeMultipartDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/MimeMultipartDataFormat.java
@@ -163,6 +163,17 @@ public class MimeMultipartDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Defines whether a message without attachment is also marshaled into a MIME Multipart (with only one body
+         * part).
+         * <p>
+         * Default is false.
+         */
+        public Builder multipartWithoutAttachment(boolean multipartWithoutAttachment) {
+            this.multipartWithoutAttachment = Boolean.toString(multipartWithoutAttachment);
+            return this;
+        }
+
+        /**
          * Defines whether the MIME-Multipart headers are part of the message body (true) or are set as Camel headers
          * (false).
          * <p>
@@ -170,6 +181,17 @@ public class MimeMultipartDataFormat extends DataFormatDefinition {
          */
         public Builder headersInline(String headersInline) {
             this.headersInline = headersInline;
+            return this;
+        }
+
+        /**
+         * Defines whether the MIME-Multipart headers are part of the message body (true) or are set as Camel headers
+         * (false).
+         * <p>
+         * Default is false.
+         */
+        public Builder headersInline(boolean headersInline) {
+            this.headersInline = Boolean.toString(headersInline);
             return this;
         }
 
@@ -191,6 +213,16 @@ public class MimeMultipartDataFormat extends DataFormatDefinition {
          */
         public Builder binaryContent(String binaryContent) {
             this.binaryContent = binaryContent;
+            return this;
+        }
+
+        /**
+         * Defines whether the content of binary parts in the MIME multipart is binary (true) or Base-64 encoded (false)
+         * <p>
+         * Default is false.
+         */
+        public Builder binaryContent(boolean binaryContent) {
+            this.binaryContent = Boolean.toString(binaryContent);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/PGPDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/PGPDataFormat.java
@@ -280,8 +280,8 @@ public class PGPDataFormat extends DataFormatDefinition {
         private String keyFileName;
         private String signatureKeyFileName;
         private String signatureKeyRing;
-        private String armored = "false";
-        private String integrity = "true";
+        private String armored;
+        private String integrity;
         private String provider;
         private String algorithm;
         private String compressionAlgorithm;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/PGPDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/PGPDataFormat.java
@@ -338,10 +338,27 @@ public class PGPDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Signature hash algorithm; possible values are defined in org.bouncycastle.bcpg.HashAlgorithmTags; for example
+         * 2 (= SHA1), 8 (= SHA256), 9 (= SHA384), 10 (= SHA512), 11 (=SHA224). Only relevant for signing.
+         */
+        public Builder hashAlgorithm(int hashAlgorithm) {
+            this.hashAlgorithm = Integer.toString(hashAlgorithm);
+            return this;
+        }
+
+        /**
          * This option will cause PGP to base64 encode the encrypted text, making it available for copy/paste, etc.
          */
         public Builder armored(String armored) {
             this.armored = armored;
+            return this;
+        }
+
+        /**
+         * This option will cause PGP to base64 encode the encrypted text, making it available for copy/paste, etc.
+         */
+        public Builder armored(boolean armored) {
+            this.armored = Boolean.toString(armored);
             return this;
         }
 
@@ -352,6 +369,16 @@ public class PGPDataFormat extends DataFormatDefinition {
          */
         public Builder integrity(String integrity) {
             this.integrity = integrity;
+            return this;
+        }
+
+        /**
+         * Adds an integrity check/sign into the encryption file.
+         * <p/>
+         * The default value is true.
+         */
+        public Builder integrity(boolean integrity) {
+            this.integrity = Boolean.toString(integrity);
             return this;
         }
 
@@ -385,11 +412,30 @@ public class PGPDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Symmetric key encryption algorithm; possible values are defined in
+         * org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags; for example 2 (= TRIPLE DES), 3 (= CAST5), 4 (= BLOWFISH), 6
+         * (= DES), 7 (= AES_128). Only relevant for encrypting.
+         */
+        public Builder algorithm(int algorithm) {
+            this.algorithm = Integer.toString(algorithm);
+            return this;
+        }
+
+        /**
          * Compression algorithm; possible values are defined in org.bouncycastle.bcpg.CompressionAlgorithmTags; for
          * example 0 (= UNCOMPRESSED), 1 (= ZIP), 2 (= ZLIB), 3 (= BZIP2). Only relevant for encrypting.
          */
         public Builder compressionAlgorithm(String compressionAlgorithm) {
             this.compressionAlgorithm = compressionAlgorithm;
+            return this;
+        }
+
+        /**
+         * Compression algorithm; possible values are defined in org.bouncycastle.bcpg.CompressionAlgorithmTags; for
+         * example 0 (= UNCOMPRESSED), 1 (= ZIP), 2 (= ZLIB), 3 (= BZIP2). Only relevant for encrypting.
+         */
+        public Builder compressionAlgorithm(int compressionAlgorithm) {
+            this.compressionAlgorithm = Integer.toString(compressionAlgorithm);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ProtobufDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ProtobufDataFormat.java
@@ -551,8 +551,8 @@ public class ProtobufDataFormat extends DataFormatDefinition implements ContentT
         private Object defaultInstance;
         private String instanceClass;
         private String objectMapper;
-        private String useDefaultObjectMapper = "true";
-        private String autoDiscoverObjectMapper = "false";
+        private String useDefaultObjectMapper;
+        private String autoDiscoverObjectMapper;
         private ProtobufLibrary library = ProtobufLibrary.GoogleProtobuf;
         private String unmarshalTypeName;
         private Class<?> unmarshalType;
@@ -570,9 +570,9 @@ public class ProtobufDataFormat extends DataFormatDefinition implements ContentT
         private String allowUnmarshallType;
         private String timezone;
         private String schemaResolver;
-        private String autoDiscoverSchemaResolver = "true";
-        private String contentTypeFormat = "native";
-        private String contentTypeHeader = "true";
+        private String autoDiscoverSchemaResolver;
+        private String contentTypeFormat;
+        private String contentTypeHeader;
 
         /**
          * Name of class to use when unmarshalling

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ProtobufDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ProtobufDataFormat.java
@@ -597,6 +597,11 @@ public class ProtobufDataFormat extends DataFormatDefinition implements ContentT
             return this;
         }
 
+        public Builder contentTypeHeader(boolean contentTypeHeader) {
+            this.contentTypeHeader = Boolean.toString(contentTypeHeader);
+            return this;
+        }
+
         public Builder defaultInstance(Object defaultInstance) {
             this.defaultInstance = defaultInstance;
             return this;
@@ -623,6 +628,14 @@ public class ProtobufDataFormat extends DataFormatDefinition implements ContentT
          */
         public Builder useDefaultObjectMapper(String useDefaultObjectMapper) {
             this.useDefaultObjectMapper = useDefaultObjectMapper;
+            return this;
+        }
+
+        /**
+         * Whether to lookup and use default Jackson ObjectMapper from the registry.
+         */
+        public Builder useDefaultObjectMapper(boolean useDefaultObjectMapper) {
+            this.useDefaultObjectMapper = Boolean.toString(useDefaultObjectMapper);
             return this;
         }
 
@@ -681,6 +694,15 @@ public class ProtobufDataFormat extends DataFormatDefinition implements ContentT
         }
 
         /**
+         * Used for JMS users to allow the JMSType header from the JMS spec to specify a FQN classname to use to
+         * unmarshal to.
+         */
+        public Builder allowJmsType(boolean allowJmsType) {
+            this.allowJmsType = Boolean.toString(allowJmsType);
+            return this;
+        }
+
+        /**
          * Refers to a custom collection type to lookup in the registry to use. This option should rarely be used, but
          * allows to use different collection types than java.util.Collection based as default.
          */
@@ -699,6 +721,14 @@ public class ProtobufDataFormat extends DataFormatDefinition implements ContentT
          */
         public Builder useList(String useList) {
             this.useList = useList;
+            return this;
+        }
+
+        /**
+         * To unmarshal to a List of Map or a List of Pojo.
+         */
+        public Builder useList(boolean useList) {
+            this.useList = Boolean.toString(useList);
             return this;
         }
 
@@ -761,6 +791,17 @@ public class ProtobufDataFormat extends DataFormatDefinition implements ContentT
         }
 
         /**
+         * If enabled then Jackson is allowed to attempt to use the CamelJacksonUnmarshalType header during the
+         * unmarshalling.
+         * <p/>
+         * This should only be enabled when desired to be used.
+         */
+        public Builder allowUnmarshallType(boolean allowUnmarshallType) {
+            this.allowUnmarshallType = Boolean.toString(allowUnmarshallType);
+            return this;
+        }
+
+        /**
          * If set then Jackson will use the Timezone when marshalling/unmarshalling.
          */
         public Builder timezone(String timezone) {
@@ -777,6 +818,14 @@ public class ProtobufDataFormat extends DataFormatDefinition implements ContentT
         }
 
         /**
+         * If set to true then Jackson will lookup for an objectMapper into the registry
+         */
+        public Builder autoDiscoverObjectMapper(boolean autoDiscoverObjectMapper) {
+            this.autoDiscoverObjectMapper = Boolean.toString(autoDiscoverObjectMapper);
+            return this;
+        }
+
+        /**
          * Optional schema resolver used to lookup schemas for the data in transit.
          */
         public Builder schemaResolver(String schemaResolver) {
@@ -789,6 +838,14 @@ public class ProtobufDataFormat extends DataFormatDefinition implements ContentT
          */
         public Builder autoDiscoverSchemaResolver(String autoDiscoverSchemaResolver) {
             this.autoDiscoverSchemaResolver = autoDiscoverSchemaResolver;
+            return this;
+        }
+
+        /**
+         * When not disabled, the SchemaResolver will be looked up into the registry
+         */
+        public Builder autoDiscoverSchemaResolver(boolean autoDiscoverSchemaResolver) {
+            this.autoDiscoverSchemaResolver = Boolean.toString(autoDiscoverSchemaResolver);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/SoapDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/SoapDataFormat.java
@@ -208,7 +208,7 @@ public class SoapDataFormat extends DataFormatDefinition {
         private String encoding;
         private String elementNameStrategyRef;
         private Object elementNameStrategy;
-        private String version = "1.1";
+        private String version;
         private String namespacePrefixRef;
         private String schema;
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/TarFileDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/TarFileDataFormat.java
@@ -130,11 +130,29 @@ public class TarFileDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * If the tar file has more than one entry, the setting this option to true, allows working with the splitter
+         * EIP, to split the data using an iterator in a streaming mode.
+         */
+        public Builder usingIterator(boolean usingIterator) {
+            this.usingIterator = Boolean.toString(usingIterator);
+            return this;
+        }
+
+        /**
          * If the tar file has more than one entry, setting this option to true, allows to get the iterator even if the
          * directory is empty
          */
         public Builder allowEmptyDirectory(String allowEmptyDirectory) {
             this.allowEmptyDirectory = allowEmptyDirectory;
+            return this;
+        }
+
+        /**
+         * If the tar file has more than one entry, setting this option to true, allows to get the iterator even if the
+         * directory is empty
+         */
+        public Builder allowEmptyDirectory(boolean allowEmptyDirectory) {
+            this.allowEmptyDirectory = Boolean.toString(allowEmptyDirectory);
             return this;
         }
 
@@ -148,6 +166,15 @@ public class TarFileDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * If the file name contains path elements, setting this option to true, allows the path to be maintained in the
+         * tar file.
+         */
+        public Builder preservePathElements(boolean preservePathElements) {
+            this.preservePathElements = Boolean.toString(preservePathElements);
+            return this;
+        }
+
+        /**
          * Set the maximum decompressed size of a tar file (in bytes). The default value if not specified corresponds to
          * 1 gigabyte. An IOException will be thrown if the decompressed size exceeds this amount. Set to -1 to disable
          * setting a maximum decompressed size.
@@ -156,6 +183,18 @@ public class TarFileDataFormat extends DataFormatDefinition {
          */
         public Builder maxDecompressedSize(String maxDecompressedSize) {
             this.maxDecompressedSize = maxDecompressedSize;
+            return this;
+        }
+
+        /**
+         * Set the maximum decompressed size of a tar file (in bytes). The default value if not specified corresponds to
+         * 1 gigabyte. An IOException will be thrown if the decompressed size exceeds this amount. Set to -1 to disable
+         * setting a maximum decompressed size.
+         *
+         * @param maxDecompressedSize the maximum decompressed size of a tar file (in bytes)
+         */
+        public Builder maxDecompressedSize(long maxDecompressedSize) {
+            this.maxDecompressedSize = Long.toString(maxDecompressedSize);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/TarFileDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/TarFileDataFormat.java
@@ -118,7 +118,7 @@ public class TarFileDataFormat extends DataFormatDefinition {
         private String usingIterator;
         private String allowEmptyDirectory;
         private String preservePathElements;
-        private String maxDecompressedSize = "1073741824";
+        private String maxDecompressedSize;
 
         /**
          * If the tar file has more than one entry, the setting this option to true, allows working with the splitter

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ThriftDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ThriftDataFormat.java
@@ -145,6 +145,11 @@ public class ThriftDataFormat extends DataFormatDefinition implements ContentTyp
             return this;
         }
 
+        public Builder contentTypeHeader(boolean contentTypeHeader) {
+            this.contentTypeHeader = Boolean.toString(contentTypeHeader);
+            return this;
+        }
+
         public Builder defaultInstance(Object defaultInstance) {
             this.defaultInstance = defaultInstance;
             return this;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ThriftDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ThriftDataFormat.java
@@ -119,8 +119,8 @@ public class ThriftDataFormat extends DataFormatDefinition implements ContentTyp
 
         private Object defaultInstance;
         private String instanceClass;
-        private String contentTypeFormat = "binary";
-        private String contentTypeHeader = "true";
+        private String contentTypeFormat;
+        private String contentTypeHeader;
 
         /**
          * Name of class to use when unmarshalling

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/TidyMarkupDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/TidyMarkupDataFormat.java
@@ -111,7 +111,7 @@ public class TidyMarkupDataFormat extends DataFormatDefinition {
     public static class Builder implements DataFormatBuilder<TidyMarkupDataFormat> {
 
         private Class<?> dataObjectType;
-        private String dataObjectTypeName = "org.w3c.dom.Node";
+        private String dataObjectTypeName;
         private String omitXmlDeclaration;
 
         /**

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/TidyMarkupDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/TidyMarkupDataFormat.java
@@ -142,6 +142,14 @@ public class TidyMarkupDataFormat extends DataFormatDefinition {
             return this;
         }
 
+        /**
+         * When returning a String, do we omit the XML declaration in the top.
+         */
+        public Builder omitXmlDeclaration(boolean omitXmlDeclaration) {
+            this.omitXmlDeclaration = Boolean.toString(omitXmlDeclaration);
+            return this;
+        }
+
         @Override
         public TidyMarkupDataFormat end() {
             return new TidyMarkupDataFormat(this);

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/UniVocityAbstractDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/UniVocityAbstractDataFormat.java
@@ -291,17 +291,17 @@ public abstract class UniVocityAbstractDataFormat extends DataFormatDefinition {
             implements DataFormatBuilder<F> {
 
         private String nullValue;
-        private String skipEmptyLines = "true";
-        private String ignoreTrailingWhitespaces = "true";
-        private String ignoreLeadingWhitespaces = "true";
+        private String skipEmptyLines;
+        private String ignoreTrailingWhitespaces;
+        private String ignoreLeadingWhitespaces;
         private String headersDisabled;
         private List<UniVocityHeader> headers;
         private String headerExtractionEnabled;
         private String numberOfRecordsToRead;
         private String emptyValue;
         private String lineSeparator;
-        private String normalizedLineSeparator = "\\n";
-        private String comment = "#";
+        private String normalizedLineSeparator;
+        private String comment;
         private String lazyLoad;
         private String asMap;
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/UniVocityAbstractDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/UniVocityAbstractDataFormat.java
@@ -326,12 +326,32 @@ public abstract class UniVocityAbstractDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Whether or not the empty lines must be ignored.
+         * <p/>
+         * The default value is true
+         */
+        public T skipEmptyLines(boolean skipEmptyLines) {
+            this.skipEmptyLines = Boolean.toString(skipEmptyLines);
+            return (T) this;
+        }
+
+        /**
          * Whether or not the trailing white spaces must be ignored.
          * <p/>
          * The default value is true
          */
         public T ignoreTrailingWhitespaces(String ignoreTrailingWhitespaces) {
             this.ignoreTrailingWhitespaces = ignoreTrailingWhitespaces;
+            return (T) this;
+        }
+
+        /**
+         * Whether or not the trailing white spaces must be ignored.
+         * <p/>
+         * The default value is true
+         */
+        public T ignoreTrailingWhitespaces(boolean ignoreTrailingWhitespaces) {
+            this.ignoreTrailingWhitespaces = Boolean.toString(ignoreTrailingWhitespaces);
             return (T) this;
         }
 
@@ -346,6 +366,16 @@ public abstract class UniVocityAbstractDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Whether or not the leading white spaces must be ignored.
+         * <p/>
+         * The default value is true
+         */
+        public T ignoreLeadingWhitespaces(boolean ignoreLeadingWhitespaces) {
+            this.ignoreLeadingWhitespaces = Boolean.toString(ignoreLeadingWhitespaces);
+            return (T) this;
+        }
+
+        /**
          * Whether or not the headers are disabled. When defined, this option explicitly sets the headers as null which
          * indicates that there is no header.
          * <p/>
@@ -353,6 +383,17 @@ public abstract class UniVocityAbstractDataFormat extends DataFormatDefinition {
          */
         public T headersDisabled(String headersDisabled) {
             this.headersDisabled = headersDisabled;
+            return (T) this;
+        }
+
+        /**
+         * Whether or not the headers are disabled. When defined, this option explicitly sets the headers as null which
+         * indicates that there is no header.
+         * <p/>
+         * The default value is false
+         */
+        public T headersDisabled(boolean headersDisabled) {
+            this.headersDisabled = Boolean.toString(headersDisabled);
             return (T) this;
         }
 
@@ -375,10 +416,28 @@ public abstract class UniVocityAbstractDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Whether or not the header must be read in the first line of the test document
+         * <p/>
+         * The default value is false
+         */
+        public T headerExtractionEnabled(boolean headerExtractionEnabled) {
+            this.headerExtractionEnabled = Boolean.toString(headerExtractionEnabled);
+            return (T) this;
+        }
+
+        /**
          * The maximum number of record to read.
          */
         public T numberOfRecordsToRead(String numberOfRecordsToRead) {
             this.numberOfRecordsToRead = numberOfRecordsToRead;
+            return (T) this;
+        }
+
+        /**
+         * The maximum number of record to read.
+         */
+        public T numberOfRecordsToRead(int numberOfRecordsToRead) {
+            this.numberOfRecordsToRead = Integer.toString(numberOfRecordsToRead);
             return (T) this;
         }
 
@@ -432,6 +491,17 @@ public abstract class UniVocityAbstractDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Whether the unmarshalling should produce an iterator that reads the lines on the fly or if all the lines must
+         * be read at one.
+         * <p/>
+         * The default value is false
+         */
+        public T lazyLoad(boolean lazyLoad) {
+            this.lazyLoad = Boolean.toString(lazyLoad);
+            return (T) this;
+        }
+
+        /**
          * Whether the unmarshalling should produce maps for the lines values instead of lists. It requires to have
          * header (either defined or collected).
          * <p/>
@@ -439,6 +509,17 @@ public abstract class UniVocityAbstractDataFormat extends DataFormatDefinition {
          */
         public T asMap(String asMap) {
             this.asMap = asMap;
+            return (T) this;
+        }
+
+        /**
+         * Whether the unmarshalling should produce maps for the lines values instead of lists. It requires to have
+         * header (either defined or collected).
+         * <p/>
+         * The default value is false
+         */
+        public T asMap(boolean asMap) {
+            this.asMap = Boolean.toString(asMap);
             return (T) this;
         }
     }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/UniVocityCsvDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/UniVocityCsvDataFormat.java
@@ -121,6 +121,14 @@ public class UniVocityCsvDataFormat extends UniVocityAbstractDataFormat {
         }
 
         /**
+         * Whether or not all values must be quoted when writing them.
+         */
+        public Builder quoteAllFields(boolean quoteAllFields) {
+            this.quoteAllFields = Boolean.toString(quoteAllFields);
+            return this;
+        }
+
+        /**
          * The quote symbol.
          */
         public Builder quote(String quote) {

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/UniVocityCsvDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/UniVocityCsvDataFormat.java
@@ -107,10 +107,10 @@ public class UniVocityCsvDataFormat extends UniVocityAbstractDataFormat {
     @XmlTransient
     public static class Builder extends AbstractBuilder<Builder, UniVocityCsvDataFormat> {
 
-        private String delimiter = ",";
+        private String delimiter;
         private String quoteAllFields;
-        private String quote = "\"";
-        private String quoteEscape = "\"";
+        private String quote;
+        private String quoteEscape;
 
         /**
          * Whether or not all values must be quoted when writing them.

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/UniVocityFixedDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/UniVocityFixedDataFormat.java
@@ -112,12 +112,32 @@ public class UniVocityFixedDataFormat extends UniVocityAbstractDataFormat {
         }
 
         /**
+         * Whether or not the trailing characters until new line must be ignored.
+         * <p/>
+         * The default value is false
+         */
+        public Builder skipTrailingCharsUntilNewline(boolean skipTrailingCharsUntilNewline) {
+            this.skipTrailingCharsUntilNewline = Boolean.toString(skipTrailingCharsUntilNewline);
+            return this;
+        }
+
+        /**
          * Whether or not the record ends on new line.
          * <p/>
          * The default value is false
          */
         public Builder recordEndsOnNewline(String recordEndsOnNewline) {
             this.recordEndsOnNewline = recordEndsOnNewline;
+            return this;
+        }
+
+        /**
+         * Whether or not the record ends on new line.
+         * <p/>
+         * The default value is false
+         */
+        public Builder recordEndsOnNewline(boolean recordEndsOnNewline) {
+            this.recordEndsOnNewline = Boolean.toString(recordEndsOnNewline);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/UniVocityTsvDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/UniVocityTsvDataFormat.java
@@ -62,7 +62,7 @@ public class UniVocityTsvDataFormat extends UniVocityAbstractDataFormat {
     @XmlTransient
     public static class Builder extends AbstractBuilder<Builder, UniVocityTsvDataFormat> {
 
-        private String escapeChar = "\\";
+        private String escapeChar;
 
         /**
          * The escape character.

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/XMLSecurityDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/XMLSecurityDataFormat.java
@@ -379,6 +379,15 @@ public class XMLSecurityDataFormat extends DataFormatDefinition implements Names
         }
 
         /**
+         * A boolean value to specify whether the XML Element is to be encrypted or the contents of the XML Element.
+         * false = Element Level. true = Element Content Level.
+         */
+        public Builder secureTagContents(boolean secureTagContents) {
+            this.secureTagContents = Boolean.toString(secureTagContents);
+            return this;
+        }
+
+        /**
          * The cipher algorithm to be used for encryption/decryption of the asymmetric key. The available choices are:
          * <ul>
          * <li>XMLCipher.RSA_v1dot5</li>
@@ -462,6 +471,15 @@ public class XMLSecurityDataFormat extends DataFormatDefinition implements Names
          */
         public Builder addKeyValueForEncryptedKey(String addKeyValueForEncryptedKey) {
             this.addKeyValueForEncryptedKey = addKeyValueForEncryptedKey;
+            return this;
+        }
+
+        /**
+         * Whether to add the public key used to encrypt the session key as a KeyValue in the EncryptedKey structure or
+         * not.
+         */
+        public Builder addKeyValueForEncryptedKey(boolean addKeyValueForEncryptedKey) {
+            this.addKeyValueForEncryptedKey = Boolean.toString(addKeyValueForEncryptedKey);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/XMLSecurityDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/XMLSecurityDataFormat.java
@@ -302,18 +302,18 @@ public class XMLSecurityDataFormat extends DataFormatDefinition implements Names
     @XmlTransient
     public static class Builder implements DataFormatBuilder<XMLSecurityDataFormat> {
 
-        private String xmlCipherAlgorithm = "AES-256-GCM";
+        private String xmlCipherAlgorithm;
         private String passPhrase;
         private byte[] passPhraseByte;
         private String secureTag;
         private String secureTagContents;
-        private String keyCipherAlgorithm = "RSA_OAEP";
+        private String keyCipherAlgorithm;
         private String recipientKeyAlias;
         private String keyOrTrustStoreParametersRef;
         private String keyPassword;
-        private String digestAlgorithm = "SHA1";
-        private String mgfAlgorithm = "MGF1_SHA1";
-        private String addKeyValueForEncryptedKey = "true";
+        private String digestAlgorithm;
+        private String mgfAlgorithm;
+        private String addKeyValueForEncryptedKey;
         private KeyStoreParameters keyOrTrustStoreParameters;
         private Map<String, String> namespaces;
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/XStreamDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/XStreamDataFormat.java
@@ -441,6 +441,11 @@ public class XStreamDataFormat extends DataFormatDefinition implements ContentTy
             return this;
         }
 
+        public Builder contentTypeHeader(boolean contentTypeHeader) {
+            this.contentTypeHeader = Boolean.toString(contentTypeHeader);
+            return this;
+        }
+
         @Override
         public XStreamDataFormat end() {
             return new XStreamDataFormat(this);

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/XStreamDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/XStreamDataFormat.java
@@ -322,7 +322,7 @@ public class XStreamDataFormat extends DataFormatDefinition implements ContentTy
         private String driver;
         private String driverRef;
         private String mode;
-        private String contentTypeHeader = "true";
+        private String contentTypeHeader;
         private List<PropertyDefinition> converters;
         private List<PropertyDefinition> aliases;
         private List<PropertyDefinition> omitFields;
@@ -381,6 +381,18 @@ public class XStreamDataFormat extends DataFormatDefinition implements ContentTy
 
         public Builder converters(Map<String, String> converters) {
             return converters(XStreamDataFormat.toList(converters));
+        }
+
+        /**
+         * Alias a Class to a shorter name to be used in XML elements.
+         */
+        public Builder aliases(List<PropertyDefinition> aliases) {
+            this.aliases = aliases;
+            return this;
+        }
+
+        public Builder aliases(Map<String, String> aliases) {
+            return aliases(toList(aliases));
         }
 
         /**

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/YAMLDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/YAMLDataFormat.java
@@ -44,7 +44,7 @@ public class YAMLDataFormat extends DataFormatDefinition {
 
     @XmlAttribute
     @Metadata(defaultValue = "SnakeYAML")
-    private YAMLLibrary library = YAMLLibrary.SnakeYAML;
+    private YAMLLibrary library;
     @XmlAttribute(name = "unmarshalType")
     private String unmarshalTypeName;
     @XmlAttribute
@@ -288,11 +288,11 @@ public class YAMLDataFormat extends DataFormatDefinition {
         private String representer;
         private String dumperOptions;
         private String resolver;
-        private String useApplicationContextClassLoader = "true";
+        private String useApplicationContextClassLoader;
         private String prettyFlow;
         private String allowAnyType;
         private List<YAMLTypeFilterDefinition> typeFilters;
-        private String maxAliasesForCollections = "50";
+        private String maxAliasesForCollections;
         private String allowRecursiveKeys;
 
         /**

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/YAMLDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/YAMLDataFormat.java
@@ -371,6 +371,14 @@ public class YAMLDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Use ApplicationContextClassLoader as custom ClassLoader
+         */
+        public Builder useApplicationContextClassLoader(boolean useApplicationContextClassLoader) {
+            this.useApplicationContextClassLoader = Boolean.toString(useApplicationContextClassLoader);
+            return this;
+        }
+
+        /**
          * Force the emitter to produce a pretty YAML document when using the flow style.
          */
         public Builder prettyFlow(String prettyFlow) {
@@ -379,10 +387,26 @@ public class YAMLDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Force the emitter to produce a pretty YAML document when using the flow style.
+         */
+        public Builder prettyFlow(boolean prettyFlow) {
+            this.prettyFlow = Boolean.toString(prettyFlow);
+            return this;
+        }
+
+        /**
          * Allow any class to be un-marshaled
          */
         public Builder allowAnyType(String allowAnyType) {
             this.allowAnyType = allowAnyType;
+            return this;
+        }
+
+        /**
+         * Allow any class to be un-marshaled
+         */
+        public Builder allowAnyType(boolean allowAnyType) {
+            this.allowAnyType = Boolean.toString(allowAnyType);
             return this;
         }
 
@@ -403,10 +427,26 @@ public class YAMLDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * Set the maximum amount of aliases allowed for collections.
+         */
+        public Builder maxAliasesForCollections(int maxAliasesForCollections) {
+            this.maxAliasesForCollections = Integer.toString(maxAliasesForCollections);
+            return this;
+        }
+
+        /**
          * Set whether recursive keys are allowed.
          */
         public Builder allowRecursiveKeys(String allowRecursiveKeys) {
             this.allowRecursiveKeys = allowRecursiveKeys;
+            return this;
+        }
+
+        /**
+         * Set whether recursive keys are allowed.
+         */
+        public Builder allowRecursiveKeys(boolean allowRecursiveKeys) {
+            this.allowRecursiveKeys = Boolean.toString(allowRecursiveKeys);
             return this;
         }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ZipDeflaterDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ZipDeflaterDataFormat.java
@@ -65,7 +65,7 @@ public class ZipDeflaterDataFormat extends DataFormatDefinition {
     @XmlTransient
     public static class Builder implements DataFormatBuilder<ZipDeflaterDataFormat> {
 
-        private String compressionLevel = "-1";
+        private String compressionLevel;
 
         /**
          * To specify a specific compression between 0-9. -1 is default compression, 0 is no compression, and 9 is the

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ZipDeflaterDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ZipDeflaterDataFormat.java
@@ -76,6 +76,15 @@ public class ZipDeflaterDataFormat extends DataFormatDefinition {
             return this;
         }
 
+        /**
+         * To specify a specific compression between 0-9. -1 is default compression, 0 is no compression, and 9 is the
+         * best compression.
+         */
+        public Builder compressionLevel(int compressionLevel) {
+            this.compressionLevel = Integer.toString(compressionLevel);
+            return this;
+        }
+
         @Override
         public ZipDeflaterDataFormat end() {
             return new ZipDeflaterDataFormat(this);

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ZipFileDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ZipFileDataFormat.java
@@ -119,7 +119,7 @@ public class ZipFileDataFormat extends DataFormatDefinition {
         private String usingIterator;
         private String allowEmptyDirectory;
         private String preservePathElements;
-        private String maxDecompressedSize = "1073741824";
+        private String maxDecompressedSize;
 
         /**
          * If the zip file has more than one entry, the setting this option to true, allows working with the splitter

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ZipFileDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ZipFileDataFormat.java
@@ -131,11 +131,29 @@ public class ZipFileDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * If the zip file has more than one entry, the setting this option to true, allows working with the splitter
+         * EIP, to split the data using an iterator in a streaming mode.
+         */
+        public Builder usingIterator(boolean usingIterator) {
+            this.usingIterator = Boolean.toString(usingIterator);
+            return this;
+        }
+
+        /**
          * If the zip file has more than one entry, setting this option to true, allows to get the iterator even if the
          * directory is empty
          */
         public Builder allowEmptyDirectory(String allowEmptyDirectory) {
             this.allowEmptyDirectory = allowEmptyDirectory;
+            return this;
+        }
+
+        /**
+         * If the zip file has more than one entry, setting this option to true, allows to get the iterator even if the
+         * directory is empty
+         */
+        public Builder allowEmptyDirectory(boolean allowEmptyDirectory) {
+            this.allowEmptyDirectory = Boolean.toString(allowEmptyDirectory);
             return this;
         }
 
@@ -149,6 +167,15 @@ public class ZipFileDataFormat extends DataFormatDefinition {
         }
 
         /**
+         * If the file name contains path elements, setting this option to true, allows the path to be maintained in the
+         * zip file.
+         */
+        public Builder preservePathElements(boolean preservePathElements) {
+            this.preservePathElements = Boolean.toString(preservePathElements);
+            return this;
+        }
+
+        /**
          * Set the maximum decompressed size of a zip file (in bytes). The default value if not specified corresponds to
          * 1 gigabyte. An IOException will be thrown if the decompressed size exceeds this amount. Set to -1 to disable
          * setting a maximum decompressed size.
@@ -157,6 +184,18 @@ public class ZipFileDataFormat extends DataFormatDefinition {
          */
         public Builder maxDecompressedSize(String maxDecompressedSize) {
             this.maxDecompressedSize = maxDecompressedSize;
+            return this;
+        }
+
+        /**
+         * Set the maximum decompressed size of a zip file (in bytes). The default value if not specified corresponds to
+         * 1 gigabyte. An IOException will be thrown if the decompressed size exceeds this amount. Set to -1 to disable
+         * setting a maximum decompressed size.
+         *
+         * @param maxDecompressedSize the maximum decompressed size of a zip file (in bytes)
+         */
+        public Builder maxDecompressedSize(long maxDecompressedSize) {
+            this.maxDecompressedSize = Long.toString(maxDecompressedSize);
             return this;
         }
 


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-17505

## Motivation

For primitive types like int, boolean and long, the builders propose only methods that accept a `String` as parameter, we need to overload those methods to propose more appropriate types in case of primitive types.

## Modifications:

* Add a method with a more convenient parameter type for each parameter of a primitive type
* Avoid setting unnecessary default values to keep the code easy to read and maintain
* Add the missing method `aliases` to `XStreamDataFormat`