### PR TITLE
3.14.x: Bump Jettison to version 1.5.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -312,7 +312,7 @@
         <jetty-version>${jetty9-version}</jetty-version>
         <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
         <jetty-runner-groupId>org.eclipse.jetty</jetty-runner-groupId>
-        <jettison-version>1.4.1</jettison-version>
+        <jettison-version>1.5.1</jettison-version>
         <jgit-version>5.13.0.202109080827-r</jgit-version>
         <jgroups-version>4.2.17.Final</jgroups-version>
         <jgroups-raft-version>0.5.3.Final</jgroups-raft-version>


### PR DESCRIPTION
Cherry-picked commit to bump Jettison from version `1.4.1` to `1.5.1`