### PR TITLE
SOAP-Fault to Java Exception also lookups by SOAPAction

### DIFF
--- a/components/camel-soap/pom.xml
+++ b/components/camel-soap/pom.xml
@@ -226,6 +226,11 @@
                                         </bindingFile>
                                     </bindingFiles>
                                 </wsdlOption>
+                                <wsdlOption>
+                                    <wsdl>
+                                        ${basedir}/src/test/resources/org/apache/camel/dataformat/soap/TestService.wsdl
+                                    </wsdl>
+                                </wsdlOption>
                             </wsdlOptions>
                         </configuration>
                         <goals>

--- a/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/Soap11DataFormatAdapter.java
+++ b/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/Soap11DataFormatAdapter.java
@@ -174,7 +174,8 @@ public class Soap11DataFormatAdapter implements SoapDataFormatAdapter {
         Object payloadEl = anyElement.get(0);
         Object payload = JAXBIntrospector.getValue(payloadEl);
         if (payload instanceof Fault) {
-            Exception exception = createExceptionFromFault((Fault) payload);
+            String soapAction = exchange.getProperty(Exchange.SOAP_ACTION, String.class);
+            Exception exception = createExceptionFromFault(soapAction, (Fault) payload);
             exchange.setException(exception);
             return null;
         } else {
@@ -190,7 +191,7 @@ public class Soap11DataFormatAdapter implements SoapDataFormatAdapter {
      * @param  fault Soap fault
      * @return       created Exception
      */
-    private Exception createExceptionFromFault(Fault fault) {
+    private Exception createExceptionFromFault(String soapAction, Fault fault) {
         String message = fault.getFaultstring();
 
         Detail faultDetail = fault.getDetail();
@@ -214,7 +215,7 @@ public class Soap11DataFormatAdapter implements SoapDataFormatAdapter {
 
         JAXBElement<?> detailEl = (JAXBElement<?>) detailObj;
         Class<? extends Exception> exceptionClass
-                = getDataFormat().getElementNameStrategy().findExceptionForFaultName(detailEl.getName());
+                = getDataFormat().getElementNameStrategy().findExceptionForSoapActionAndFaultName(soapAction, detailEl.getName());
         Constructor<? extends Exception> messageConstructor;
         Constructor<? extends Exception> constructor;
 

--- a/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/Soap12DataFormatAdapter.java
+++ b/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/Soap12DataFormatAdapter.java
@@ -185,7 +185,8 @@ public class Soap12DataFormatAdapter implements SoapDataFormatAdapter {
         Object payloadEl = anyElement.get(0);
         Object payload = JAXBIntrospector.getValue(payloadEl);
         if (payload instanceof Fault) {
-            Exception exception = createExceptionFromFault((Fault) payload);
+            String soapAction = exchange.getProperty(Exchange.SOAP_ACTION, String.class);
+            Exception exception = createExceptionFromFault(soapAction, (Fault) payload);
             exchange.setException(exception);
             return null;
         } else {
@@ -201,7 +202,7 @@ public class Soap12DataFormatAdapter implements SoapDataFormatAdapter {
      * @param  fault Soap fault
      * @return       created Exception
      */
-    private Exception createExceptionFromFault(Fault fault) {
+    private Exception createExceptionFromFault(String soapAction, Fault fault) {
         StringBuilder sb = new StringBuilder();
         for (Reasontext text : fault.getReason().getText()) {
             sb.append(text.getValue());
@@ -229,7 +230,7 @@ public class Soap12DataFormatAdapter implements SoapDataFormatAdapter {
 
         JAXBElement<?> detailEl = (JAXBElement<?>) detailObj;
         Class<? extends Exception> exceptionClass
-                = getDataFormat().getElementNameStrategy().findExceptionForFaultName(detailEl.getName());
+                = getDataFormat().getElementNameStrategy().findExceptionForSoapActionAndFaultName(soapAction, detailEl.getName());
         Constructor<? extends Exception> messageConstructor;
         Constructor<? extends Exception> constructor;
 

--- a/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/name/ElementNameStrategy.java
+++ b/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/name/ElementNameStrategy.java
@@ -39,4 +39,12 @@ public interface ElementNameStrategy {
      * @return
      */
     Class<? extends Exception> findExceptionForFaultName(QName faultName);
+
+    /**
+     * Determine exception class for given SOAP Action and Fault QName
+     *
+     * @param  faultName
+     * @return
+     */
+    Class<? extends Exception> findExceptionForSoapActionAndFaultName(String soapAction, QName faultName);
 }

--- a/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/name/QNameStrategy.java
+++ b/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/name/QNameStrategy.java
@@ -46,4 +46,9 @@ public class QNameStrategy implements ElementNameStrategy {
         throw new UnsupportedOperationException("Exception lookup is not supported for QNameStrategy");
     }
 
+    @Override
+    public Class<? extends Exception> findExceptionForSoapActionAndFaultName(String soapAction, QName faultName) {
+        throw new UnsupportedOperationException("Exception lookup is not supported for QNameStrategy");
+    }
+
 }

--- a/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/name/TypeNameStrategy.java
+++ b/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/name/TypeNameStrategy.java
@@ -61,4 +61,9 @@ public class TypeNameStrategy implements ElementNameStrategy {
         throw new UnsupportedOperationException("Exception lookup is not supported for TypeNameStrategy");
     }
 
+    @Override
+    public Class<? extends Exception> findExceptionForSoapActionAndFaultName(String soapAction, QName faultName) {
+        throw new UnsupportedOperationException("Exception lookup is not supported for TypeNameStrategy");
+    }
+
 }

--- a/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/name/XmlRootElementPreferringElementNameStrategy.java
+++ b/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/name/XmlRootElementPreferringElementNameStrategy.java
@@ -73,4 +73,9 @@ public class XmlRootElementPreferringElementNameStrategy implements ElementNameS
         throw new UnsupportedOperationException("Exception lookup is not supported");
     }
 
+    @Override
+    public Class<? extends Exception> findExceptionForSoapActionAndFaultName(String soapAction, QName faultName) {
+        throw new UnsupportedOperationException("Exception lookup is not supported");
+    }
+
 }

--- a/components/camel-soap/src/test/java/org/apache/camel/converter/soap/name/ServiceInterfaceStrategyTest.java
+++ b/components/camel-soap/src/test/java/org/apache/camel/converter/soap/name/ServiceInterfaceStrategyTest.java
@@ -22,6 +22,9 @@ import com.example.customerservice.CustomerService;
 import com.example.customerservice.GetCustomersByName;
 import com.example.customerservice.GetCustomersByNameResponse;
 import com.example.customerservice.multipart.MultiPartCustomerService;
+import com.example.duplicateerror.ExceptionA;
+import com.example.duplicateerror.ExceptionB;
+import com.example.duplicateerror.TestService;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dataformat.soap.name.ServiceInterfaceStrategy;
 import org.junit.jupiter.api.Test;
@@ -129,5 +132,20 @@ public class ServiceInterfaceStrategyTest {
 
         assertEquals("http://multipart.customerservice.example.com/", custTypeQName.getNamespaceURI());
         assertEquals("product", custTypeQName.getLocalPart());
+    }
+
+    @Test
+    public void testQNameToException() {
+        ServiceInterfaceStrategy strategy = new ServiceInterfaceStrategy(TestService.class, true);
+        QName soapExceptionMultipleDefined = new QName("http://www.example.com/duplicateerror", "soapException");
+        assertEquals(ExceptionA.class, strategy.findExceptionForSoapActionAndFaultName("throwErrorA", soapExceptionMultipleDefined));
+        assertEquals(ExceptionB.class, strategy.findExceptionForSoapActionAndFaultName("throwErrorB", soapExceptionMultipleDefined));
+
+        // This is implementation dependant (position in HashMap) one of ExceptionA or ExceptionB
+        Class<? extends Exception> multiDefinedException = strategy.findExceptionForFaultName(soapExceptionMultipleDefined);
+
+        if (multiDefinedException != ExceptionA.class && multiDefinedException != ExceptionB.class) {
+            fail("Not one of ExceptionA or ExceptionB");
+        }
     }
 }

--- a/components/camel-soap/src/test/resources/org/apache/camel/dataformat/soap/TestService.wsdl
+++ b/components/camel-soap/src/test/resources/org/apache/camel/dataformat/soap/TestService.wsdl
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestServiceService" targetNamespace="http://www.example.com/duplicateerror" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.example.com/duplicateerror" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
+  <wsdl:types>
+<xs:schema xmlns:tns="http://www.example.com/duplicateerror" xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://www.example.com/duplicateerror" version="1.0">
+  <xs:element name="throwErrorA" type="tns:throwErrorA"/>
+  <xs:element name="throwErrorAResponse" type="tns:throwErrorAResponse"/>
+  <xs:element name="throwErrorB" type="tns:throwErrorB"/>
+  <xs:element name="throwErrorBResponse" type="tns:throwErrorBResponse"/>
+  <xs:complexType name="throwErrorA">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="name" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="throwErrorAResponse">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:complexType name="throwErrorB">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="name" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="throwErrorBResponse">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:element name="soapException" type="tns:soapException"/>
+  <xs:complexType name="soapException">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="message" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="ExceptionB">
+    <wsdl:part name="ExceptionB" element="tns:soapException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="ExceptionA">
+    <wsdl:part name="ExceptionA" element="tns:soapException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="throwErrorA">
+    <wsdl:part name="parameters" element="tns:throwErrorA">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="throwErrorBResponse">
+    <wsdl:part name="parameters" element="tns:throwErrorBResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="throwErrorAResponse">
+    <wsdl:part name="parameters" element="tns:throwErrorAResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="throwErrorB">
+    <wsdl:part name="parameters" element="tns:throwErrorB">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="testService">
+    <wsdl:operation name="throwErrorA">
+      <wsdl:input name="throwErrorA" message="tns:throwErrorA">
+    </wsdl:input>
+      <wsdl:output name="throwErrorAResponse" message="tns:throwErrorAResponse">
+    </wsdl:output>
+      <wsdl:fault name="ExceptionA" message="tns:ExceptionA">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="throwErrorB">
+      <wsdl:input name="throwErrorB" message="tns:throwErrorB">
+    </wsdl:input>
+      <wsdl:output name="throwErrorBResponse" message="tns:throwErrorBResponse">
+    </wsdl:output>
+      <wsdl:fault name="ExceptionB" message="tns:ExceptionB">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="TestServiceServiceSoapBinding" type="tns:testService">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="throwErrorA">
+      <soap:operation soapAction="throwErrorA" style="document"/>
+      <wsdl:input name="throwErrorA">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="throwErrorAResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="ExceptionA">
+        <soap:fault name="ExceptionA" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="throwErrorB">
+      <soap:operation soapAction="throwErrorB" style="document"/>
+      <wsdl:input name="throwErrorB">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="throwErrorBResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="ExceptionB">
+        <soap:fault name="ExceptionB" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="TestServiceService">
+    <wsdl:port name="testServicePort" binding="tns:TestServiceServiceSoapBinding">
+      <soap:address location="http://localhost:9090/testServicePort"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Duplicated SOAP-Exceptions QNames did lead to random selection of corresponding
java exceptions in the unmarshal codepath.
CXF handle this correctly.
With this patch we always lookup by SOAPAction and QName if SOAPAction is available.

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
