### PR TITLE
CAMEL-18716: camel-jbang - Provide completion for positional file path parameters

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -451,7 +451,7 @@
     <pdfbox-version>2.0.27</pdfbox-version>
     <pgjdbc-driver-version>42.4.1</pgjdbc-driver-version>
     <pgjdbc-ng-driver-version>0.8.9</pgjdbc-ng-driver-version>
-    <picocli-version>4.6.3</picocli-version>
+    <picocli-version>4.7.0</picocli-version>
     <plc4x-version>0.10.0</plc4x-version>
     <powermock-version>2.0.7</powermock-version>
     <properties-maven-plugin-version>1.0-alpha-2</properties-maven-plugin-version>

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Bind.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Bind.java
@@ -19,8 +19,10 @@ package org.apache.camel.dsl.jbang.core.commands;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.Stack;
 
 import org.apache.camel.github.GitHubResourceResolver;
 import org.apache.camel.impl.engine.DefaultResourceResolvers;
@@ -55,7 +57,10 @@ class Bind extends CamelCommand {
                         required = true)
     String sink;
 
-    @CommandLine.Parameters(description = "Name of binding file to be saved", arity = "1")
+    @CommandLine.Parameters(description = "Name of binding file to be saved", arity = "1",
+                            paramLabel = "<file>", parameterConsumer = FileConsumer.class)
+    Path filePath; // Defined only for file path completion; the field never used
+
     String file;
 
     public Bind(CamelJBangMain main) {
@@ -187,6 +192,14 @@ class Bind extends CamelCommand {
         }
 
         return sb.toString();
+    }
+
+    static class FileConsumer extends ParameterConsumer<Bind> {
+        @Override
+        protected void doConsumeParameters(Stack<String> args, Bind cmd) {
+            String arg = args.pop();
+            cmd.file = arg;
+        }
     }
 
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelCommand.java
@@ -17,9 +17,14 @@
 package org.apache.camel.dsl.jbang.core.commands;
 
 import java.io.File;
+import java.util.Stack;
 import java.util.concurrent.Callable;
 
 import picocli.CommandLine;
+import picocli.CommandLine.IParameterConsumer;
+import picocli.CommandLine.Model.ArgSpec;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.ParameterException;
 
 public abstract class CamelCommand implements Callable<Integer> {
 
@@ -61,6 +66,20 @@ public abstract class CamelCommand implements Callable<Integer> {
             camelDir = new File(System.getProperty("user.home"), ".camel");
         }
         return new File(camelDir, pid + "-output.json");
+    }
+
+    protected abstract static class ParameterConsumer<T> implements IParameterConsumer {
+
+        @Override
+        public void consumeParameters(Stack<String> args, ArgSpec argSpec, CommandSpec cmdSpec) {
+            if (args.isEmpty()) {
+                throw new ParameterException(cmdSpec.commandLine(), "Error: missing required parameter");
+            }
+            T cmd = (T) cmdSpec.userObject();
+            doConsumeParameters(args, cmd);
+        }
+
+        protected abstract void doConsumeParameters(Stack<String> args, T cmd);
     }
 
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Init.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Init.java
@@ -19,6 +19,8 @@ package org.apache.camel.dsl.jbang.core.commands;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Stack;
 import java.util.StringJoiner;
 
 import org.apache.camel.CamelContext;
@@ -31,9 +33,9 @@ import org.apache.camel.spi.Resource;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
 import org.apache.commons.io.IOUtils;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 import static org.apache.camel.dsl.jbang.core.common.GistHelper.fetchGistUrls;
 import static org.apache.camel.dsl.jbang.core.common.GitHubHelper.asGithubSingleUrl;
@@ -42,7 +44,10 @@ import static org.apache.camel.dsl.jbang.core.common.GitHubHelper.fetchGithubUrl
 @Command(name = "init", description = "Creates a new Camel integration")
 class Init extends CamelCommand {
 
-    @CommandLine.Parameters(description = "Name of integration file (or a github link)", arity = "1")
+    @Parameters(description = "Name of integration file (or a github link)", arity = "1",
+                paramLabel = "<file>", parameterConsumer = FileConsumer.class)
+    private Path filePath; // Defined only for file path completion; the field never used
+
     private String file;
 
     @Option(names = { "--integration" },
@@ -222,6 +227,14 @@ class Init extends CamelCommand {
         }
 
         return 0;
+    }
+
+    static class FileConsumer extends ParameterConsumer<Init> {
+        @Override
+        protected void doConsumeParameters(Stack<String> args, Init cmd) {
+            String arg = args.pop();
+            cmd.file = arg;
+        }
     }
 
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Pipe.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Pipe.java
@@ -16,12 +16,18 @@
  */
 package org.apache.camel.dsl.jbang.core.commands;
 
+import java.nio.file.Path;
+import java.util.Stack;
+
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "pipe", description = "Run Camel integration in pipe and filters mode for terminal scripting")
 class Pipe extends CamelCommand {
 
-    @CommandLine.Parameters(description = "Name of file", arity = "1")
+    @CommandLine.Parameters(description = "Name of file", arity = "1",
+                            paramLabel = "<file>", parameterConsumer = FileConsumer.class)
+    Path filePath; // Defined only for file path completion; the field never used
+
     String file;
 
     @CommandLine.Option(names = { "--max-messages" }, defaultValue = "0",
@@ -71,6 +77,14 @@ class Pipe extends CamelCommand {
         run.property = property;
         run.propertiesFiles = propertiesFiles;
         return run.runPipe(file);
+    }
+
+    static class FileConsumer extends ParameterConsumer<Pipe> {
+        @Override
+        protected void doConsumeParameters(Stack<String> args, Pipe cmd) {
+            String arg = args.pop();
+            cmd.file = arg;
+        }
     }
 
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -437,7 +437,7 @@
         <pdfbox-version>2.0.27</pdfbox-version>
         <pgjdbc-driver-version>42.4.1</pgjdbc-driver-version>
         <pgjdbc-ng-driver-version>0.8.9</pgjdbc-ng-driver-version>
-        <picocli-version>4.6.3</picocli-version>
+        <picocli-version>4.7.0</picocli-version>
         <plc4x-version>0.10.0</plc4x-version>
         <powermock-version>2.0.7</powermock-version>
         <properties-maven-plugin-version>1.0-alpha-2</properties-maven-plugin-version>


### PR DESCRIPTION
<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
https://issues.apache.org/jira/browse/CAMEL-18716

This implements file path completion for `<file>` argument, not only for commands that refer to exisitng files:
- `camel run`
- `camel pipe`

but also for ones that create a new file:
- `camel init`
- `camel bind`.

It's because even though they create new files users might want to create them under an exisitng directory, or with the same prefix/suffix as the existing ones. In those cases file path completion still helps.