### PR TITLE
CAMEL-18730: camel-report-maven-plugin - Fix import issue

### DIFF
--- a/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
+++ b/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
@@ -47,7 +47,6 @@ import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import org.apache.camel.maven.model.RouteCoverageNode;
 import org.apache.camel.parser.RouteBuilderParser;
 import org.apache.camel.parser.XmlRouteParser;
@@ -249,7 +248,7 @@ public class RouteCoverageMojo extends AbstractExecMojo {
                     getLog().warn("No route coverage data found for route: " + routeId
                         + ". Make sure to enable route coverage in your unit tests and assign unique route ids to your routes. Also remember to run unit tests first.");
                 } else {
-                    List<RouteCoverageNode> coverage = gatherRouteCoverageSummary(Collections.singletonList(t), coverageData);
+                    List<RouteCoverageNode> coverage = gatherRouteCoverageSummary(List.of(t), coverageData);
                     totalNumberOfNodes += coverage.size();
                     String out = templateCoverageData(fileName, routeId, coverage, notCovered, coveredNodes);
                     getLog().info("Route coverage summary:\n\n" + out);


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-18730

## Motivation

After generating the route coverage of the tests, if we launch the maven command `mvn camel-report:route-coverage`, the plugin fails due to an import issue.

## Modifications:

* Remove the bad import and replace it with `List.of`.

## Result

Tested against the example `main`:

```
$ mvn camel-report:route-coverage
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------< org.apache.camel.example:camel-example-main >-------------
[INFO] Building Camel :: Example :: Main 3.20.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- camel-report-maven-plugin:3.20.0-SNAPSHOT:route-coverage (default-cli) @ camel-example-main ---
[INFO] Discovered 1 routes
[INFO] Route coverage summary:

Class:	org.apache.camel.example.MyRouteBuilder
Route:	foo

  Line #       Count    Route
  ------       -----    -----
      25           2    from
      26           2      bean
      27           2      log

Coverage: 3 out of 3 (100.0% / threshold 100.0%)
Status: Success


[INFO] 
[INFO] Overall coverage summary:

Coverage: 3 out of 3 (100.0% / threshold 0.0%)
Status: Success
```