### PR TITLE
CAMEL-18730: camel-report-maven-plugin - Fix import issue

### DIFF
--- a/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
+++ b/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
@@ -47,7 +47,6 @@ import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import org.apache.camel.maven.model.RouteCoverageNode;
 import org.apache.camel.parser.RouteBuilderParser;
 import org.apache.camel.parser.XmlRouteParser;
@@ -250,7 +249,7 @@ public class RouteCoverageMojo extends AbstractExecMojo {
                     getLog().warn("No route coverage data found for route: " + routeId
                         + ". Make sure to enable route coverage in your unit tests and assign unique route ids to your routes. Also remember to run unit tests first.");
                 } else {
-                    List<RouteCoverageNode> coverage = gatherRouteCoverageSummary(Collections.singletonList(t), coverageData);
+                    List<RouteCoverageNode> coverage = gatherRouteCoverageSummary(List.of(t), coverageData);
                     totalNumberOfNodes += coverage.size();
                     String out = templateCoverageData(fileName, routeId, coverage, notCovered, coveredNodes);
                     getLog().info("Route coverage summary:\n\n" + out);


### PR DESCRIPTION
Backport of https://issues.apache.org/jira/browse/CAMEL-18730 for 3.18

## Motivation

After generating the route coverage of the tests, if we launch the maven command `mvn camel-report:route-coverage`, the plugin fails due to an import issue.

## Modifications:

* Remove the bad import and replace it with `List.of`.
