### PR TITLE
CAMEL-18730: camel-report-maven-plugin - Fix import issue

### DIFF
--- a/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
+++ b/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
@@ -22,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -47,7 +48,6 @@ import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import org.apache.camel.maven.model.RouteCoverageNode;
 import org.apache.camel.parser.RouteBuilderParser;
 import org.apache.camel.parser.XmlRouteParser;


### PR DESCRIPTION
Backport of https://issues.apache.org/jira/browse/CAMEL-18730 for 3.14

## Motivation

After generating the route coverage of the tests, if we launch the maven command `mvn camel-report:route-coverage`, the plugin fails due to an import issue.

## Modifications:

* Use `java.util.Collections` instead of `edu.emory.mathcs.backport.java.util.Collections`.
