### PR TITLE
Fixed Camel 18719 : camel-jbang - Adding the dependency of camel-quarkus-core creates two entries in exported POM.xml

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -265,8 +265,8 @@ abstract class ExportBaseCommand extends CamelCommand {
         if (profile != null && profile.exists()) {
             Properties prop = new CamelCaseOrderedProperties();
             RuntimeUtil.loadProperties(prop, profile);
-            String deps = prop.getProperty("camel.jbang.dependencies");
-            if (deps != null) {
+            String deps = RuntimeUtil.getDependencies(prop);
+            if (!deps.isBlank()) {
                 for (String d : deps.split(",")) {
                     answer.add(d.trim());
                 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
@@ -354,6 +354,11 @@ class ExportQuarkus extends Export {
 
         StringBuilder sb = new StringBuilder();
         for (MavenGav gav : gavs) {
+            //Special case, quarkus-pom.tmpl already have them included.
+            if ("camel-quarkus-core".equals(gav.getArtifactId()) || "camel-quarkus-platform-http".equals(gav.getArtifactId())
+                    || "camel-quarkus-microprofile-health".equals(gav.getArtifactId())) {
+                continue;
+            }
             sb.append("        <dependency>\n");
             sb.append("            <groupId>").append(gav.getGroupId()).append("</groupId>\n");
             sb.append("            <artifactId>").append(gav.getArtifactId()).append("</artifactId>\n");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -344,7 +344,7 @@ class Run extends CamelCommand {
         // merge existing dependencies with --deps
         String deps = RuntimeUtil.getDependencies(profileProperties);
         if (deps.isBlank()) {
-            deps = dependencies;
+            deps = dependencies != null ? dependencies : "";
         } else if (dependencies != null && !dependencies.equals(deps)) {
             deps += "," + dependencies;
         }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -342,15 +342,15 @@ class Run extends CamelCommand {
         writeSetting(main, profileProperties, "camel.jbang.console", console ? "true" : "false");
         writeSetting(main, profileProperties, "camel.main.routesCompileDirectory", WORK_DIR);
         // merge existing dependencies with --deps
-        String dep = profileProperties != null ? profileProperties.getProperty("camel.jbang.dependencies") : null;
-        if (dep == null) {
-            dep = dependencies;
-        } else if (dependencies != null && !dependencies.equals(dep)) {
-            dep += "," + dependencies;
+        String deps = RuntimeUtil.getDependencies(profileProperties);
+        if (deps.isBlank()) {
+            deps = dependencies;
+        } else if (dependencies != null && !dependencies.equals(deps)) {
+            deps += "," + dependencies;
         }
-        if (dep != null) {
-            main.addInitialProperty("camel.jbang.dependencies", dep);
-            writeSettings("camel.jbang.dependencies", dep);
+        if (deps != null) {
+            main.addInitialProperty("camel.jbang.dependencies", deps);
+            writeSettings("camel.jbang.dependencies", deps);
         }
 
         // command line arguments

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -348,7 +348,7 @@ class Run extends CamelCommand {
         } else if (dependencies != null && !dependencies.equals(deps)) {
             deps += "," + dependencies;
         }
-        if (deps != null) {
+        if (!deps.isBlank()) {
             main.addInitialProperty("camel.jbang.dependencies", deps);
             writeSettings("camel.jbang.dependencies", deps);
         }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeUtil.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeUtil.java
@@ -83,4 +83,20 @@ public final class RuntimeUtil {
         }
     }
 
+    public static String getDependencies(Properties properties) {
+        String deps = properties.getProperty("camel.jbang.dependencies");
+        if (deps != null) {
+            deps = deps.trim();
+            if (deps.length() > 0 && deps.charAt(0) == ',') {
+                deps = deps.substring(1);
+            }
+            if (deps.length() > 0 && deps.charAt(deps.length() - 1) == ',') {
+                deps = deps.substring(0, deps.lastIndexOf(","));
+            }
+        } else {
+            deps = new String("");
+        }
+        return deps;
+    }
+
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeUtil.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeUtil.java
@@ -94,7 +94,7 @@ public final class RuntimeUtil {
                 deps = deps.substring(0, deps.lastIndexOf(","));
             }
         } else {
-            deps = new String("");
+            deps = "";
         }
         return deps;
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeUtil.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeUtil.java
@@ -84,7 +84,7 @@ public final class RuntimeUtil {
     }
 
     public static String getDependencies(Properties properties) {
-        String deps = properties.getProperty("camel.jbang.dependencies");
+        String deps = properties != null ? properties.getProperty("camel.jbang.dependencies") : null;
         if (deps != null) {
             deps = deps.trim();
             if (deps.length() > 0 && deps.charAt(0) == ',') {


### PR DESCRIPTION
This pull request fixes [CAMEL-18719](https://issues.apache.org/jira/browse/CAMEL-18719)
