### PR TITLE
CAMEL-18749: camel-hdfs: Add Snappy compression support

### DIFF
--- a/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/HdfsCompressionCodec.java
+++ b/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/HdfsCompressionCodec.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.io.compress.BZip2Codec;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.io.compress.GzipCodec;
+import org.apache.hadoop.io.compress.SnappyCodec;
 
 public enum HdfsCompressionCodec {
 
@@ -41,6 +42,13 @@ public enum HdfsCompressionCodec {
         @Override
         public CompressionCodec getCodec() {
             return new BZip2Codec();
+        }
+    },
+
+    SNAPPY {
+        @Override
+        public CompressionCodec getCodec() {
+            return new SnappyCodec();
         }
     };
 


### PR DESCRIPTION
camel-hdfs currently supports gzip and bzip2 compression, but HDFS itself supports some other codecs.
This PR adds snappy compression feature to the producer.

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
