### PR TITLE
camel-jbang - Upgrade to Camel 3.18.3

### DIFF
--- a/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
@@ -21,7 +21,7 @@
 //REPOS mavencentral,apache=https://repository.apache.org/snapshots
 //DEPS org.apache.camel:camel-bom:${camel.jbang.version:3.18.3}@pom
 //DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:3.18.3}
-//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:0.9.0}
+//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:0.9.3}
 
 package main;
 

--- a/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
@@ -19,8 +19,8 @@
 
 //JAVA 11+
 //REPOS mavencentral,apache=https://repository.apache.org/snapshots
-//DEPS org.apache.camel:camel-bom:${camel.jbang.version:3.18.2}@pom
-//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:3.18.2}
+//DEPS org.apache.camel:camel-bom:${camel.jbang.version:3.18.3}@pom
+//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:3.18.3}
 //DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:0.9.0}
 
 package main;

--- a/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
@@ -21,7 +21,7 @@
 //REPOS mavencentral,apache=https://repository.apache.org/snapshots
 //DEPS org.apache.camel:camel-bom:${camel.jbang.version:3.18.3}@pom
 //DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:3.18.3}
-//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:0.9.0}
+//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:0.9.3}
 
 package main;
 

--- a/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
@@ -19,8 +19,8 @@
 
 //JAVA 11+
 //REPOS mavencentral,apache=https://repository.apache.org/snapshots
-//DEPS org.apache.camel:camel-bom:${camel.jbang.version:3.18.2}@pom
-//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:3.18.2}
+//DEPS org.apache.camel:camel-bom:${camel.jbang.version:3.18.3}@pom
+//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:3.18.3}
 //DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:0.9.0}
 
 package main;


### PR DESCRIPTION
This will let you install Camel 3.18.3 `camel` cli with this command:
```
jbang app install install camel@apache/camel/camel-3.18.x
```
