### PR TITLE
CAMEL-18761 camel-open-api - Warning log when using boolean type

### DIFF
--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestModelConverters.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestModelConverters.java
@@ -225,6 +225,7 @@ public class RestModelConverters {
                         model.enum_ = new ArrayList<String>(schema.getEnum());
                     }
                     break;
+                case "boolean":
                 case "number":
                 case "integer":
                     break;

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/User.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/User.java
@@ -20,13 +20,15 @@ public class User {
 
     private int id;
     private String name;
+    private boolean alive;
 
     public User() {
     }
 
-    public User(int id, String name) {
+    public User(int id, String name, boolean alive) {
         this.id = id;
         this.name = name;
+        this.alive = alive;
     }
 
     public int getId() {
@@ -43,5 +45,13 @@ public class User {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public boolean isAlive() {
+        return alive;
+    }
+
+    public void setAlive(boolean alive) {
+        this.alive = alive;
     }
 }


### PR DESCRIPTION
Trivial change

The generation of the Schema produce a warn log when it should not for the boolean type : 
`WARN  RestModelConverters            - Encountered unexpected type boolean in processing schema.`

The OpenApi spec says : https://swagger.io/docs/specification/data-models/data-types

```
string (this includes dates and files)
number
integer
boolean
array
object
```

Since it just an error log, it's hard to test, so I added a boolean in the User.java, the log is no longer there.