### PR TITLE
CAMEL-18766 Fixes bug in camel-support

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/task/BackgroundTask.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/task/BackgroundTask.java
@@ -106,11 +106,6 @@ public class BackgroundTask implements BlockingTask {
     }
 
     @Override
-    public <T> boolean run(Predicate<T> predicate, T payload) {
-        return this.run(() -> predicate.test(payload));
-    }
-
-    @Override
     public boolean run(BooleanSupplier supplier) {
         final CountDownLatch latch = new CountDownLatch(1);
         // we need a wrapper for the actual result that will be defined in the runTaskWrapper method which 

--- a/core/camel-support/src/main/java/org/apache/camel/support/task/BlockingTask.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/task/BlockingTask.java
@@ -37,7 +37,7 @@ public interface BlockingTask extends Task {
      *                   task was interrupted.
      */
     default <T> boolean run(Predicate<T> predicate, T payload) {
-    	return this.run(() -> predicate.test(payload));
+        return this.run(() -> predicate.test(payload));
     }
 
     /**

--- a/core/camel-support/src/main/java/org/apache/camel/support/task/BlockingTask.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/task/BlockingTask.java
@@ -36,7 +36,9 @@ public interface BlockingTask extends Task {
      * @return           true if the task has completed successfully or false if: 1) the budget is exhausted or 2) the
      *                   task was interrupted.
      */
-    <T> boolean run(Predicate<T> predicate, T payload);
+    default <T> boolean run(Predicate<T> predicate, T payload) {
+    	return this.run(() -> predicate.test(payload));
+    }
 
     /**
      * Run the task

--- a/core/camel-support/src/main/java/org/apache/camel/support/task/ForegroundTask.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/task/ForegroundTask.java
@@ -81,36 +81,6 @@ public class ForegroundTask implements BlockingTask {
     }
 
     @Override
-    public <T> boolean run(Predicate<T> predicate, T payload) {
-        boolean completed = false;
-        try {
-            if (budget.initialDelay() > 0) {
-                Thread.sleep(budget.initialDelay());
-            }
-
-            while (budget.next()) {
-                if (predicate.test(payload)) {
-                    LOG.debug("Task {} is complete after {} iterations and it is ready to continue",
-                            name, budget.iteration());
-                    completed = true;
-                    break;
-                }
-
-                if (budget.canContinue()) {
-                    Thread.sleep(budget.interval());
-                }
-            }
-        } catch (InterruptedException e) {
-            LOG.warn("Interrupted {} while waiting for the repeatable task to finish", name);
-            Thread.currentThread().interrupt();
-        } finally {
-            elapsed = budget.elapsed();
-        }
-
-        return completed;
-    }
-
-    @Override
     public boolean run(BooleanSupplier supplier) {
         boolean completed = false;
 

--- a/core/camel-support/src/test/java/org/apache/camel/support/task/BackgroundIterationTimeTaskTest.java
+++ b/core/camel-support/src/test/java/org/apache/camel/support/task/BackgroundIterationTimeTaskTest.java
@@ -42,7 +42,8 @@ public class BackgroundIterationTimeTaskTest extends TaskTestSupport {
                         .withMaxIterations(3)
                         .withInterval(Duration.ofSeconds(1))
                         .withInitialDelay(Duration.ZERO)
-                        .withMaxDuration(Duration.ofSeconds(5))
+                        // use unlimited duration so we're sure that the task is really canceled after maxIterations
+                        .withUnlimitedDuration()
                         .build())
                 .build();
 


### PR DESCRIPTION
- [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [X] Each commit in the pull request should have a meaningful subject line and body.
- [X] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md

The changes in this PR fix a bug in the BackgroundTask class which results in a thread that loops forever doing nothing but log a warning. 

The fix is essentially ending the thread when the budget as been consumed. What that means is dependent on the actual implementation of the Budget instance that is passed to the BackgroundThread. It may mean that the `maxDuration` has been exceeded or that the task has been run for `maxIteration` times.

The new implementation saves the result of the runTaskWrapper method in an wrapper instance so that it can be used as return value of the run method implementation.

This is necessary because the Future, returned by the scheduleAtFixedRate method can't be used for that as the invocation of its `get` method would result in an exception. 