### PR TITLE
Fix the camel project export dir option typo

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
@@ -1456,7 +1456,7 @@ To export to another directly (copies the files) you execute:
 
 [source,bash]
 ----
-camel export --runtime=spring-boot --gav=com.foo:acme:1.0-SNAPSHOT --dir=../myproject
+camel export --runtime=spring-boot --gav=com.foo:acme:1.0-SNAPSHOT --directory=../myproject
 ----
 
 When exporting to Spring Boot then the Camel version defined in the `pom.xml` or `build.gradle` is
@@ -1464,7 +1464,7 @@ the same version as Camel JBang uses. However, you can specify the Camel version
 
 [source,bash]
 ----
-camel export --runtime=spring-boot --gav=com.foo:acme:1.0-SNAPSHOT --dir=../myproject --camel-spring-boot-version=3.18.3
+camel export --runtime=spring-boot --gav=com.foo:acme:1.0-SNAPSHOT --directory=../myproject --camel-spring-boot-version=3.18.3
 ----
 
 TIP: See the possible options by running: `camel export --help` for more details.
@@ -1488,7 +1488,7 @@ To export to another directly (copies the files) you execute:
 
 [source,bash]
 ----
-camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --dir=../myproject
+camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --directory=../myproject
 ----
 
 TIP: See the possible options by running: `camel export --help` for more details.
@@ -1512,7 +1512,7 @@ To export to another directly (copies the files) you execute:
 
 [source,bash]
 ----
-camel export --runtime=camel-main --gav=com.foo:acme:1.0-SNAPSHOT -dir=../myproject
+camel export --runtime=camel-main --gav=com.foo:acme:1.0-SNAPSHOT --directory=../myproject
 ----
 
 TIP: See the possible options by running: `camel export --help` for more details.
@@ -1524,7 +1524,7 @@ specify the `--build-tool=gradle` when exporting, such as:
 
 [source,bash]
 ----
-camel export --build-tool=gradle --runtime=spring-boot --gav=com.foo:acme:1.0-SNAPSHOT -dir=../myproject
+camel export --build-tool=gradle --runtime=spring-boot --gav=com.foo:acme:1.0-SNAPSHOT --directory=../myproject
 ----
 
 === Exporting with JMX management included
@@ -1534,7 +1534,7 @@ To include JMX, you need to add `camel:management` in the `--deps` option, as sh
 
 [source,bash]
 ----
-camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --deps=camel:management -dir=../myproject
+camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --deps=camel:management --directory=../myproject
 ----
 
 === Exporting with Camel CLI included
@@ -1544,7 +1544,7 @@ To be able to continue to use Camel CLI (i.e. `camel`), you need to add `camel:c
 
 [source,bash]
 ----
-camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --deps=camel:cli-connector -dir=../myproject
+camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --deps=camel:cli-connector --directory=../myproject
 ----
 
 === Configuring exporting

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
@@ -1512,7 +1512,7 @@ To export to another directly (copies the files) you execute:
 
 [source,bash]
 ----
-camel export --runtime=camel-main --gav=com.foo:acme:1.0-SNAPSHOT --dir=../myproject
+camel export --runtime=camel-main --gav=com.foo:acme:1.0-SNAPSHOT -dir=../myproject
 ----
 
 TIP: See the possible options by running: `camel export --help` for more details.
@@ -1524,7 +1524,7 @@ specify the `--build-tool=gradle` when exporting, such as:
 
 [source,bash]
 ----
-camel export --build-tool=gradle --runtime=spring-boot --gav=com.foo:acme:1.0-SNAPSHOT --dir=../myproject
+camel export --build-tool=gradle --runtime=spring-boot --gav=com.foo:acme:1.0-SNAPSHOT -dir=../myproject
 ----
 
 === Exporting with JMX management included
@@ -1534,7 +1534,7 @@ To include JMX, you need to add `camel:management` in the `--deps` option, as sh
 
 [source,bash]
 ----
-camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --deps=camel:management --dir=../myproject
+camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --deps=camel:management -dir=../myproject
 ----
 
 === Exporting with Camel CLI included
@@ -1544,7 +1544,7 @@ To be able to continue to use Camel CLI (i.e. `camel`), you need to add `camel:c
 
 [source,bash]
 ----
-camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --deps=camel:cli-connector --dir=../myproject
+camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --deps=camel:cli-connector -dir=../myproject
 ----
 
 === Configuring exporting


### PR DESCRIPTION
`camel export` command directory parameter should be `-dir` instead of `--dir`
