### PR TITLE
CAMEL-18739 fix by handing over the completion to the original exchange

### DIFF
--- a/components/camel-zipfile/pom.xml
+++ b/components/camel-zipfile/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategySplitTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategySplitTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.aggregate.zipfile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.processor.aggregate.GroupedMessageAggregationStrategy;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.util.IOHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ZipAggregationStrategySplitTest extends CamelTestSupport {
+
+    private static final int EXPECTED_NO_FILES = 3;
+    private static final String TEST_DIR = "target/out_ZipAggregationStrategyTest";
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        deleteDirectory(TEST_DIR);
+        super.setUp();
+    }
+
+    @Test
+    public void testSplitter() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:aggregateToZipEntry");
+        mock.expectedMessageCount(1);
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        String tempFile = mock.getExchanges().get(0).getIn().getHeader("tempFile", String.class);
+
+        File[] files = new File(TEST_DIR).listFiles();
+        assertNotNull(files);
+        assertTrue(files.length > 0, "Should be a file in " + TEST_DIR + " directory");
+
+        File resultFile = files[0];
+
+        ZipInputStream zin = new ZipInputStream(new FileInputStream(resultFile));
+        try {
+            int fileCount = 0;
+            for (ZipEntry ze = zin.getNextEntry(); ze != null; ze = zin.getNextEntry()) {
+                fileCount++;
+            }
+            assertEquals(ZipAggregationStrategySplitTest.EXPECTED_NO_FILES, fileCount,
+                "Zip file should contains " + ZipAggregationStrategySplitTest.EXPECTED_NO_FILES + " files");
+        } finally {
+            IOHelper.close(zin);
+        }
+
+        // Temp file needs to be deleted now
+        assertFalse(new File(tempFile).exists());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                // Unzip file and Split it according to FileEntry
+                from("file:src/test/resources/org/apache/camel/aggregate/zipfile/data?delay=1000&noop=true")
+                    .aggregate(new GroupedMessageAggregationStrategy())
+                    .constant(true)
+                    .completionFromBatchConsumer()
+                    .eagerCheckCompletion()
+                    .split(body(), new ZipAggregationStrategy(true, true))
+                    .streaming()
+                    .process(exchange -> { /* NOOP - Do nothing */ })
+                    .end()
+                    .setHeader("tempFile", header("CamelFileAbsolutePath"))
+                    .to("file:" + TEST_DIR)
+                    .to("mock:aggregateToZipEntry")
+                    .log("Done processing zip file: ${header.CamelFileName}");
+            }
+        };
+
+    }
+}

--- a/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategySplitTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategySplitTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.processor.aggregate.zipfile;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -26,6 +27,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.processor.aggregate.GroupedMessageAggregationStrategy;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.util.IOHelper;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +53,7 @@ public class ZipAggregationStrategySplitTest extends CamelTestSupport {
 
         MockEndpoint.assertIsSatisfied(context);
 
-        String tempFile = mock.getExchanges().get(0).getIn().getHeader("tempFile", String.class);
+        String tempFileLocation = mock.getExchanges().get(0).getIn().getHeader("tempFile", String.class);
 
         File[] files = new File(TEST_DIR).listFiles();
         assertNotNull(files);
@@ -66,13 +68,14 @@ public class ZipAggregationStrategySplitTest extends CamelTestSupport {
                 fileCount++;
             }
             assertEquals(ZipAggregationStrategySplitTest.EXPECTED_NO_FILES, fileCount,
-                "Zip file should contains " + ZipAggregationStrategySplitTest.EXPECTED_NO_FILES + " files");
+                    "Zip file should contains " + ZipAggregationStrategySplitTest.EXPECTED_NO_FILES + " files");
         } finally {
             IOHelper.close(zin);
         }
 
         // Temp file needs to be deleted now
-        assertFalse(new File(tempFile).exists());
+        File tempFile = new File(tempFileLocation);
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).alias("Tempfile is deleted").until(() -> !tempFile.exists());
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
@@ -802,6 +802,7 @@ public class MulticastProcessor extends AsyncProcessorSupport
             } else {
                 // copy the current result to original so it will contain this result of this eip
                 ExchangeHelper.copyResults(original, subExchange);
+                subExchange.adapt(ExtendedExchange.class).handoverCompletions(original);
             }
         }
 


### PR DESCRIPTION
Handing over the completions in the MultiCastProcessor solves an issue, where temporary files were not cleaned up after using a route with a "Split Definition"

Detaisl can be found in CAMEL-18739