### PR TITLE
[camel-resilience4j] Increase test coverage making a context pooled

### DIFF
--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResiliencePooledRouteOkTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResiliencePooledRouteOkTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.resilience4j;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.engine.PooledExchangeFactory;
+import org.apache.camel.spi.BeanIntrospection;
+import org.apache.camel.spi.CircuitBreakerConstants;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ResiliencePooledRouteOkTest extends CamelTestSupport {
+
+    private BeanIntrospection bi;
+
+    @Override
+    protected boolean useJmx() {
+        return false;
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        context.adapt(ExtendedCamelContext.class).setExchangeFactory(new PooledExchangeFactory());
+
+        bi = context.adapt(ExtendedCamelContext.class).getBeanIntrospection();
+        bi.setLoggingLevel(LoggingLevel.INFO);
+        bi.resetCounters();
+
+        return context;
+    }
+
+    @Test
+    public void testResilience() throws Exception {
+        test("direct:start");
+    }
+
+    @Test
+    public void testResilienceWithTimeOut() throws Exception {
+        test("direct:start.with.timeout.enabled");
+    }
+
+    private void test(String endPointUri) throws Exception {
+        assertEquals(0, bi.getInvokedCounter());
+
+        getMockEndpoint("mock:result").expectedBodiesReceived("Bye World");
+        getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_SUCCESSFUL_EXECUTION, true);
+        getMockEndpoint("mock:result").expectedPropertyReceived(CircuitBreakerConstants.RESPONSE_FROM_FALLBACK, false);
+
+        template.sendBody(endPointUri, "Hello World");
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        assertEquals(0, bi.getInvokedCounter());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").circuitBreaker().to("direct:foo").to("log:foo").onFallback().transform()
+                        .constant("Fallback message").end().to("log:result").to("mock:result");
+
+                from("direct:start.with.timeout.enabled").circuitBreaker().resilience4jConfiguration()
+                        .timeoutEnabled(true).timeoutDuration(2000).end()
+                        .to("direct:foo").to("log:foo").onFallback().transform()
+                        .constant("Fallback message").end().to("log:result").to("mock:result");
+
+                from("direct:foo").transform().constant("Bye World");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md

I have created a new test class called ResiliencePooledRouteOkTest where the context is pooled to increase code coverage.
Specifically, doBuild() method in ResilienceProcessor class got increased coverage for if (pooled) statement.

You can compare the original coverage and its analysis with the improved one on the screenshots. 

Original:
<img width="1718" alt="Original_code_coverage" src="https://user-images.githubusercontent.com/49488040/204785770-86d7eabd-e16e-4863-9e8a-cf3a719a5e95.png">

Improved:
<img width="1716" alt="Improved_code_coverage" src="https://user-images.githubusercontent.com/49488040/204785838-c8470543-e330-468c-a28d-b2f246512792.png">
