### PR TITLE
CAMEL-18770: move the blueprint archetype information to Camel Karaf

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-maven-archetypes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-maven-archetypes.adoc
@@ -8,10 +8,6 @@ Camel is distributed with the following archetypes for Maven end users.
 |=======================================================================
 |Archetype |Description
 
-|camel-archetype-blueprint |This archetype is used to
-create a new Maven project for Camel routes to be running in OSGi using
-Blueprint.
-
 |camel-archetype-api-component |This archetype is used for creating a new
 Maven project for Camel xref:components::index.adoc[Components]. Use this if
 there is an API component missing in Camel that you want to create yourself.


### PR DESCRIPTION
The archetype was moved as part of CAMEL-15695 but this part of the
documentation was left behind