### PR TITLE
Fix Flaky Tests Caused by JSON permutations

### DIFF
--- a/components/camel-gson/src/test/java/org/apache/camel/component/gson/GsonFieldNamePolicyTest.java
+++ b/components/camel-gson/src/test/java/org/apache/camel/component/gson/GsonFieldNamePolicyTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GsonFieldNamePolicyTest extends CamelTestSupport {
 
@@ -44,9 +45,10 @@ public class GsonFieldNamePolicyTest extends CamelTestSupport {
         pojo.setFirstName("Donald");
         pojo.setLastName("Duck");
 
-        String expected = "{\"id\":123,\"first_name\":\"Donald\",\"last_name\":\"Duck\"}";
         String json = template.requestBody("direct:inPojo", pojo, String.class);
-        assertEquals(expected, json);
+        assertTrue(json.contains("\"id\":123"));
+        assertTrue(json.contains("\"first_name\":\"Donald\""));
+        assertTrue(json.contains("\"last_name\":\"Duck\""));
     }
 
     @Override

--- a/components/camel-gson/src/test/java/org/apache/camel/component/gson/GsonMarshalExclusionTest.java
+++ b/components/camel-gson/src/test/java/org/apache/camel/component/gson/GsonMarshalExclusionTest.java
@@ -27,7 +27,6 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/components/camel-gson/src/test/java/org/apache/camel/component/gson/GsonMarshalExclusionTest.java
+++ b/components/camel-gson/src/test/java/org/apache/camel/component/gson/GsonMarshalExclusionTest.java
@@ -28,6 +28,8 @@ import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GsonMarshalExclusionTest extends CamelTestSupport {
 
@@ -43,7 +45,9 @@ public class GsonMarshalExclusionTest extends CamelTestSupport {
 
         Object marshalled = template.requestBody("direct:inPojoExcludeWeight", in);
         String marshalledAsString = context.getTypeConverter().convertTo(String.class, marshalled);
-        assertEquals("{\"age\":30,\"height\":190}", marshalledAsString);
+        assertTrue(marshalledAsString.contains("\"height\":190"));
+        assertTrue(marshalledAsString.contains("\"age\":30"));
+		assertFalse(marshalledAsString.contains("\"weight\":70"));
 
         template.sendBody("direct:backPojoExcludeWeight", marshalled);
 
@@ -62,7 +66,9 @@ public class GsonMarshalExclusionTest extends CamelTestSupport {
 
         Object marshalled = template.requestBody("direct:inPojoExcludeAge", in);
         String marshalledAsString = context.getTypeConverter().convertTo(String.class, marshalled);
-        assertEquals("{\"height\":190,\"weight\":70}", marshalledAsString);
+        assertTrue(marshalledAsString.contains("\"height\":190"));
+        assertTrue(marshalledAsString.contains("\"weight\":70"));
+        assertFalse(marshalledAsString.contains("\"age\":30"));
 
         template.sendBody("direct:backPojoExcludeAge", marshalled);
 

--- a/components/camel-gson/src/test/java/org/apache/camel/component/gson/GsonMarshalExclusionTest.java
+++ b/components/camel-gson/src/test/java/org/apache/camel/component/gson/GsonMarshalExclusionTest.java
@@ -46,7 +46,7 @@ public class GsonMarshalExclusionTest extends CamelTestSupport {
         String marshalledAsString = context.getTypeConverter().convertTo(String.class, marshalled);
         assertTrue(marshalledAsString.contains("\"height\":190"));
         assertTrue(marshalledAsString.contains("\"age\":30"));
-		assertFalse(marshalledAsString.contains("\"weight\":70"));
+        assertFalse(marshalledAsString.contains("\"weight\":70"));
 
         template.sendBody("direct:backPojoExcludeWeight", marshalled);
 

--- a/components/camel-gson/src/test/java/org/apache/camel/component/gson/SpringGsonFieldNamePolicyTest.java
+++ b/components/camel-gson/src/test/java/org/apache/camel/component/gson/SpringGsonFieldNamePolicyTest.java
@@ -23,6 +23,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SpringGsonFieldNamePolicyTest extends CamelSpringTestSupport {
 
@@ -49,8 +50,9 @@ public class SpringGsonFieldNamePolicyTest extends CamelSpringTestSupport {
         pojo.setFirstName("Donald");
         pojo.setLastName("Duck");
 
-        String expected = "{\"id\":123,\"first_name\":\"Donald\",\"last_name\":\"Duck\"}";
         String json = template.requestBody("direct:inPojo", pojo, String.class);
-        assertEquals(expected, json);
+        assertTrue(json.contains("\"id\":123"));
+        assertTrue(json.contains("\"first_name\":\"Donald\""));
+        assertTrue(json.contains("\"last_name\":\"Duck\""));
     }
 }


### PR DESCRIPTION
### Description
Flaky Tests found using [NonDex](https://github.com/TestingResearchIllinois/NonDex) by running the commands -
`
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.camel.component.gson.GsonFieldNamePolicyTest#testMarshalPojo
`

`
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.camel.component.gson.GsonMarshalExclusionTest#testMarshalAndUnmarshalPojoWithAnotherExclusion
`

`
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.camel.component.gson.GsonMarshalExclusionTest#testMarshalAndUnmarshalPojoWithExclusion
`

`
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.camel.component.gson.SpringGsonFieldNamePolicyTest#testMarshalPojo
`
The logged failures were-
```
[ERROR] org.apache.camel.component.gson.GsonFieldNamePolicyTest.testMarshalPojo
[ERROR]   Run 1: GsonFieldNamePolicyTest.testMarshalPojo:49 expected: <{"id":123,"first_name":"Donald","last_name":"Duck"}> but was: <{"first_name":"Donald","last_name":"Duck","id":123}>
[ERROR]   Run 2: GsonFieldNamePolicyTest.testMarshalPojo:49 expected: <{"id":123,"first_name":"Donald","last_name":"Duck"}> but was: <{"last_name":"Duck","first_name":"Donald","id":123}>
[ERROR]   Run 3: GsonFieldNamePolicyTest.testMarshalPojo:49 expected: <{"id":123,"first_name":"Donald","last_name":"Duck"}> but was: <{"id":123,"last_name":"Duck","first_name":"Donald"}>
```
```
[ERROR] [WARNING] Flakes: 
[WARNING] org.apache.camel.component.gson.GsonMarshalExclusionTest.testMarshalAndUnmarshalPojoWithAnotherExclusion
[ERROR]   Run 1: GsonMarshalExclusionTest.testMarshalAndUnmarshalPojoWithAnotherExclusion:65 expected: <{"height":190,"weight":70}> but was: <{"weight":70,"height":190}>
[INFO]   Run 2: PASS
```
```
[WARNING] Flakes: 
[WARNING] org.apache.camel.component.gson.GsonMarshalExclusionTest.testMarshalAndUnmarshalPojoWithExclusion
[ERROR]   Run 1: GsonMarshalExclusionTest.testMarshalAndUnmarshalPojoWithExclusion:46 expected: <{"age":30,"height":190}> but was: <{"height":190,"age":30}>
[INFO]   Run 2: PASS
```
```
[ERROR] org.apache.camel.component.gson.SpringGsonFieldNamePolicyTest.testMarshalPojo
[ERROR]   Run 1: SpringGsonFieldNamePolicyTest.testMarshalPojo:54 expected: <{"id":123,"first_name":"Donald","last_name":"Duck"}> but was: <{"last_name":"Duck","id":123,"first_name":"Donald"}>
[ERROR]   Run 2: SpringGsonFieldNamePolicyTest.testMarshalPojo:54 expected: <{"id":123,"first_name":"Donald","last_name":"Duck"}> but was: <{"id":123,"last_name":"Duck","first_name":"Donald"}>
[ERROR]   Run 3: SpringGsonFieldNamePolicyTest.testMarshalPojo:54 expected: <{"id":123,"first_name":"Donald","last_name":"Duck"}> but was: <{"id":123,"last_name":"Duck","first_name":"Donald"}>
```
### Investigation
The tests  fail with a comparison error while comparing an expected JSON String and the result from the value returned by the funtion template.requestBody(...). The function of the that converts given Pojo Object to String does not guarantee the order of the fields in the Pojos. This makes the test outcome non-deterministic, and the test fails whenever the function returns a mismatch in order of the elements in the JSON String. To fix this, the expected and actual keys should be checked in a more deterministic way so that the assertions do not fail.

### Fix
Expected and actual arrays can be compared without making assumptions about the order of the keys in these JSON Strings. Instead of using assertEquals for the complete JSON String, using contains for every subpart of the expected String makes the test more deterministic and ensures that the flakiness from the test is removed.

The PR does not introduce a breaking change.