### PR TITLE
CAMEL-18660: Upgrade LocalStack to 1.3.0 that contains kinesis-mock

### DIFF
--- a/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSContainer.java
+++ b/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSContainer.java
@@ -37,8 +37,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
  */
 public class AWSContainer extends GenericContainer<AWSContainer> {
 
-    // Keep using 1.1.0 as long as https://github.com/localstack/localstack/issues/7103 is not fixed and released.
-    public static final String LOCALSTACK_CONTAINER = "localstack/localstack:1.1.0";
+    public static final String LOCALSTACK_CONTAINER = "localstack/localstack:1.3.0";
 
     private static final Logger LOG = LoggerFactory.getLogger(AWSLocalContainerService.class);
     private static final int SERVICE_PORT = 4566;


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18660

## Motivation

The test `Kinesis2ConsumerHealthCustomClientTest systematically` fails on Jenkins due to a rate limit issue caused by an incomplete docker image of LocalStack.

## Modifications:

* Upgrade the version of the docker image of LocalStack to the most recent version that contains kinesis-mock
