### PR TITLE
Upgrade kafka-clients versions

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -364,7 +364,7 @@
     <jython-version>2.7.3</jython-version>
     <jzlib-version>1.1.3</jzlib-version>
     <kafka-version>3.2.3</kafka-version>
-    <kafka-vertx-version>2.8.1</kafka-vertx-version>
+    <kafka-vertx-version>2.8.2</kafka-vertx-version>
     <kotlin-version>1.7.20</kotlin-version>
     <kubernetes-client-version>6.2.0</kubernetes-client-version>
     <kubernetes-model-version>6.2.0</kubernetes-model-version>

--- a/components/camel-debezium/camel-debezium-common/camel-debezium-common-component/pom.xml
+++ b/components/camel-debezium/camel-debezium-common/camel-debezium-common-component/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.2</version>
         </dependency>
 
         <!-- test -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -347,7 +347,7 @@
         <jython-standalone-version>2.7.3</jython-standalone-version>
         <jzlib-version>1.1.3</jzlib-version>
         <kafka-version>3.2.3</kafka-version>
-        <kafka-vertx-version>2.8.1</kafka-vertx-version>
+        <kafka-vertx-version>2.8.2</kafka-vertx-version>
         <kotlin-version>1.7.20</kotlin-version>
         <kubernetes-client-version>6.2.0</kubernetes-client-version>
         <kubernetes-model-version>6.2.0</kubernetes-model-version>


### PR DESCRIPTION
Upgrade kafka-clients versions in two places ...

- camel-debezium kafka-clients 3.0.0->3.0.2
- camel-vertx-kafka kafka-clients 2.8.1->2.8.2

Ran tests on camel-debezium, camel-kafka, camel-vertx, passed.