### PR TITLE
CAMEL-18816: camel-ahc component crashes when traffic starts too early

### DIFF
--- a/components/camel-ahc/src/main/java/org/apache/camel/component/ahc/AhcProducer.java
+++ b/components/camel-ahc/src/main/java/org/apache/camel/component/ahc/AhcProducer.java
@@ -43,7 +43,7 @@ public class AhcProducer extends DefaultAsyncProducer {
 
     public AhcProducer(AhcEndpoint endpoint) {
         super(endpoint);
-        this.client = endpoint.getClient();
+        this.client = endpoint.getOrCreateClient();
     }
 
     @Override

--- a/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcRecipientListInOnlyWithTryBlockTest.java
+++ b/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcRecipientListInOnlyWithTryBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -45,9 +45,8 @@ public class AhcRecipientListInOnlyWithTryBlockTest extends BaseAhcTest {
                     .end();
 
                 from(getTestServerEndpointUri())
-                    .transform(constant("Hello"));
+                        .transform(constant("Hello"));
             }
         };
     }
 }
-

--- a/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcRecipientListInOnlyWithTryBlockTest.java
+++ b/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcRecipientListInOnlyWithTryBlockTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.ahc;
+
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+public class AhcRecipientListInOnlyWithTryBlockTest extends BaseAhcTest {
+
+    @Test
+    public void testRecipientListCalledBeforeComponentStarted() throws Exception {
+        getMockEndpoint("mock:result").expectedBodiesReceived("Hello");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("timer://foo?delay=-1&?repeatCount=1")
+                    .doTry()
+                        .recipientList(constant(getAhcEndpointUri()))
+                        .to("mock:result")
+                    .endDoTry()
+                    .doCatch(Exception.class)
+                        .log(LoggingLevel.ERROR, "Exception occured ${exception}")
+                        .transform(constant("Exception occured"))
+                    .end();
+
+                from(getTestServerEndpointUri())
+                    .transform(constant("Hello"));
+            }
+        };
+    }
+}
+

--- a/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcRecipientListInOutWithTryBlockTest.java
+++ b/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcRecipientListInOutWithTryBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -37,7 +37,7 @@ public class AhcRecipientListInOutWithTryBlockTest extends BaseAhcTest {
             @Override
             public void configure() throws Exception {
                 from("timer://foo?delay=-1&?repeatCount=1")
-                    .to("direct:start");
+                        .to("direct:start");
 
                 from("direct:start")
                     .doTry()
@@ -49,7 +49,7 @@ public class AhcRecipientListInOutWithTryBlockTest extends BaseAhcTest {
                     .end();
 
                 from(getTestServerEndpointUri())
-                    .transform(constant("Bye"));
+                        .transform(constant("Bye"));
             }
         };
     }

--- a/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcRecipientListInOutWithTryBlockTest.java
+++ b/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcRecipientListInOutWithTryBlockTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.ahc;
+
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AhcRecipientListInOutWithTryBlockTest extends BaseAhcTest {
+
+    @Test
+    public void testRecipientListCalledBeforeComponentStarted() throws Exception {
+        String response = template.requestBody("direct:start", "Hello", String.class);
+
+        assertEquals("Bye", response);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("timer://foo?delay=-1&?repeatCount=1")
+                    .to("direct:start");
+
+                from("direct:start")
+                    .doTry()
+                        .recipientList(constant(getAhcEndpointUri()))
+                    .endDoTry()
+                    .doCatch(Exception.class)
+                        .log(LoggingLevel.ERROR, "Exception occured ${exception}")
+                        .transform(constant("Exception occured"))
+                    .end();
+
+                from(getTestServerEndpointUri())
+                    .transform(constant("Bye"));
+            }
+        };
+    }
+
+}

--- a/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcRecipientListTest.java
+++ b/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcRecipientListTest.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.ahc;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+public class AhcRecipientListTest extends BaseAhcTest {
+
+
+    @Test
+    public void testRecipientListCalledBeforeComponentStarted() throws Exception {
+        getMockEndpoint("mock:result").expectedBodiesReceived("Hello");
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("timer://foo?delay=-1&?repeatCount=1")
+                    .recipientList(constant(getAhcEndpointUri()))
+                    .to("mock:result");
+
+                from(getTestServerEndpointUri())
+                    .transform(constant("Hello"));
+            }
+        };
+    }
+}

--- a/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcRecipientListTest.java
+++ b/components/camel-ahc/src/test/java/org/apache/camel/component/ahc/AhcRecipientListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 
 public class AhcRecipientListTest extends BaseAhcTest {
 
-
     @Test
     public void testRecipientListCalledBeforeComponentStarted() throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceived("Hello");
@@ -35,11 +34,11 @@ public class AhcRecipientListTest extends BaseAhcTest {
             @Override
             public void configure() throws Exception {
                 from("timer://foo?delay=-1&?repeatCount=1")
-                    .recipientList(constant(getAhcEndpointUri()))
-                    .to("mock:result");
+                        .recipientList(constant(getAhcEndpointUri()))
+                        .to("mock:result");
 
                 from(getTestServerEndpointUri())
-                    .transform(constant("Hello"));
+                        .transform(constant("Hello"));
             }
         };
     }


### PR DESCRIPTION
Fix for bug CAMEL-18816.

Problem is caused by the fact that  `createProducer()` method in `AhcEndpoint` class may be executed before `doStart()` method.

This PR contains 3 tests that reproduce a problem and a fix based on solution from HttpEndpoint/HttpDestination.

Creation of `client` field in `AhcEndpoint` has been moved from `doStart()` method to `getOrCreateClient()` method. This `getOrCreateClient()` method is invoked from `AhcProducer(AhcEndpoint endpoint)` constructor.


<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
