### PR TITLE
Tracing: fix flaky test and add scope checks before closing

### DIFF
--- a/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/CamelOpenTelemetryTestSupport.java
+++ b/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/CamelOpenTelemetryTestSupport.java
@@ -194,6 +194,7 @@ class CamelOpenTelemetryTestSupport extends CamelTestSupport {
 
     private static class LoggingSpanProcessor implements SpanProcessor {
         private static final Logger LOG = LoggerFactory.getLogger(LoggingSpanProcessor.class);
+
         @Override
         public void onStart(Context context, ReadWriteSpan readWriteSpan) {
             LOG.debug("Span started: name - '{}', kind - '{}', id - '{}-{}", readWriteSpan.getName(), readWriteSpan.getKind(),
@@ -207,7 +208,7 @@ class CamelOpenTelemetryTestSupport extends CamelTestSupport {
 
         @Override
         public void onEnd(ReadableSpan readableSpan) {
-            LOG.debug("Span ended: name - '{}', kind - '{}', id - '{}-{}",  readableSpan.getName(), readableSpan.getKind(),
+            LOG.debug("Span ended: name - '{}', kind - '{}', id - '{}-{}", readableSpan.getName(), readableSpan.getKind(),
                     readableSpan.getSpanContext().getTraceId(), readableSpan.getSpanContext().getSpanId());
         }
 

--- a/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/CamelOpenTelemetryTestSupport.java
+++ b/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/CamelOpenTelemetryTestSupport.java
@@ -28,13 +28,19 @@ import java.util.stream.Collectors;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.apache.camel.CamelContext;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.tracing.SpanDecorator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -63,6 +69,7 @@ class CamelOpenTelemetryTestSupport extends CamelTestSupport {
         ottracer = new OpenTelemetryTracer();
 
         tracerFactory = SdkTracerProvider.builder()
+                .addSpanProcessor(new LoggingSpanProcessor())
                 .addSpanProcessor(SimpleSpanProcessor.create(inMemorySpanExporter)).build();
 
         tracer = tracerFactory.get("tracerTest");
@@ -185,4 +192,28 @@ class CamelOpenTelemetryTestSupport extends CamelTestSupport {
         assertEquals(1, inMemorySpanExporter.getFinishedSpanItems().stream().map(s -> s.getTraceId()).distinct().count());
     }
 
+    private static class LoggingSpanProcessor implements SpanProcessor {
+        private static final Logger LOG = LoggerFactory.getLogger(LoggingSpanProcessor.class);
+        @Override
+        public void onStart(Context context, ReadWriteSpan readWriteSpan) {
+            LOG.debug("Span started: name - '{}', kind - '{}', id - '{}-{}", readWriteSpan.getName(), readWriteSpan.getKind(),
+                    readWriteSpan.getSpanContext().getTraceId(), readWriteSpan.getSpanContext().getSpanId());
+        }
+
+        @Override
+        public boolean isStartRequired() {
+            return true;
+        }
+
+        @Override
+        public void onEnd(ReadableSpan readableSpan) {
+            LOG.debug("Span ended: name - '{}', kind - '{}', id - '{}-{}",  readableSpan.getName(), readableSpan.getKind(),
+                    readableSpan.getSpanContext().getTraceId(), readableSpan.getSpanContext().getSpanId());
+        }
+
+        @Override
+        public boolean isEndRequired() {
+            return true;
+        }
+    }
 }

--- a/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/CurrentSpanTest.java
+++ b/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/CurrentSpanTest.java
@@ -58,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CurrentSpanTest extends CamelOpenTelemetryTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(CurrentSpanTest.class);
+
     CurrentSpanTest() {
         super(new SpanTestData[0]);
     }
@@ -247,10 +248,12 @@ class CurrentSpanTest extends CamelOpenTelemetryTestSupport {
         String errorMessage = null;
         if (Span.current() instanceof ReadableSpan) {
             ReadableSpan readable = (ReadableSpan) Span.current();
-            errorMessage = String.format("Current span: name - '%s', kind - '%s', ended - `%s', id - '%s-%s', exchange id - '%s', thread - '%s'\n",
+            errorMessage = String.format(
+                    "Current span: name - '%s', kind - '%s', ended - `%s', id - '%s-%s', exchange id - '%s', thread - '%s'\n",
                     readable.getName(), readable.getKind(), readable.hasEnded(),
                     readable.getSpanContext().getTraceId(), readable.getSpanContext().getSpanId(),
-                    ActiveSpanManager.getSpan(exc).traceId(), ActiveSpanManager.getSpan(exc).spanId(), Thread.currentThread().getName());
+                    ActiveSpanManager.getSpan(exc).traceId(), ActiveSpanManager.getSpan(exc).spanId(),
+                    Thread.currentThread().getName());
 
         }
 

--- a/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/CurrentSpanTest.java
+++ b/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/CurrentSpanTest.java
@@ -47,8 +47,6 @@ import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.tracing.ActiveSpanManager;
 import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/CurrentSpanTest.java
+++ b/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/CurrentSpanTest.java
@@ -56,9 +56,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CurrentSpanTest extends CamelOpenTelemetryTestSupport {
-
-    private static final Logger LOG = LoggerFactory.getLogger(CurrentSpanTest.class);
-
     CurrentSpanTest() {
         super(new SpanTestData[0]);
     }
@@ -249,7 +246,7 @@ class CurrentSpanTest extends CamelOpenTelemetryTestSupport {
         if (Span.current() instanceof ReadableSpan) {
             ReadableSpan readable = (ReadableSpan) Span.current();
             errorMessage = String.format(
-                    "Current span: name - '%s', kind - '%s', ended - `%s', id - '%s-%s', exchange id - '%s', thread - '%s'\n",
+                    "Current span: name - '%s', kind - '%s', ended - `%s', id - '%s-%s', exchange id - '%s-%s', thread - '%s'\n",
                     readable.getName(), readable.getKind(), readable.hasEnded(),
                     readable.getSpanContext().getTraceId(), readable.getSpanContext().getSpanId(),
                     ActiveSpanManager.getSpan(exc).traceId(), ActiveSpanManager.getSpan(exc).spanId(),

--- a/components/camel-opentelemetry/src/test/resources/log4j2.properties
+++ b/components/camel-opentelemetry/src/test/resources/log4j2.properties
@@ -24,6 +24,6 @@ appender.out.name=out
 appender.out.layout.type=PatternLayout
 appender.out.layout.pattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
 logger.opentelemetry.name=org.apache.camel.opentelemetry
-logger.opentelemetry.level=INFO
+logger.opentelemetry.level=DEBUG
 rootLogger.level=INFO
 rootLogger.appenderRef.file.ref=file

--- a/components/camel-opentelemetry/src/test/resources/log4j2.properties
+++ b/components/camel-opentelemetry/src/test/resources/log4j2.properties
@@ -24,6 +24,6 @@ appender.out.name=out
 appender.out.layout.type=PatternLayout
 appender.out.layout.pattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
 logger.opentelemetry.name=org.apache.camel.opentelemetry
-logger.opentelemetry.level=DEBUG
+logger.opentelemetry.level=INFO
 rootLogger.level=INFO
 rootLogger.appenderRef.file.ref=file

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/ActiveSpanManager.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/ActiveSpanManager.java
@@ -143,18 +143,19 @@ public final class ActiveSpanManager {
     }
 
     /**
-     * Makes closing scopes idempotent and prevents restoring scope on the wrong thread:
-     * maybe removed if https://github.com/open-telemetry/opentelemetry-java/issues/5055
-     * is fixed.
+     * Makes closing scopes idempotent and prevents restoring scope on the wrong thread: Should be removed if
+     * https://github.com/open-telemetry/opentelemetry-java/issues/5055 is fixed.
      */
     private static class ScopeWrapper implements AutoCloseable {
         private final long startThreadId;
         private final AutoCloseable inner;
         private boolean closed;
+
         public ScopeWrapper(AutoCloseable inner, long startThreadId) {
             this.startThreadId = startThreadId;
             this.inner = inner;
         }
+
         @Override
         public void close() throws Exception {
             if (!closed && Thread.currentThread().getId() == startThreadId) {
@@ -162,7 +163,7 @@ public final class ActiveSpanManager {
                 inner.close();
             } else {
                 LOG.debug("not closing scope, closed - {}, started on thread - '{}', current thread - '{}'",
-                        closed, startThreadId, Thread.currentThread().getName());
+                        closed, startThreadId, Thread.currentThread().getId());
             }
         }
     }

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/ActiveSpanManager.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/ActiveSpanManager.java
@@ -57,7 +57,7 @@ public final class ActiveSpanManager {
      */
     public static void activate(Exchange exchange, SpanAdapter span) {
         exchange.setProperty(ACTIVE_SPAN_PROPERTY,
-                new Holder((Holder) exchange.getProperty(ACTIVE_SPAN_PROPERTY), span, span.makeCurrent()));
+                new Holder((Holder) exchange.getProperty(ACTIVE_SPAN_PROPERTY), span));
         if (exchange.getContext().isUseMDCLogging()) {
             MDC.put(MDC_TRACE_ID, "" + span.traceId());
             MDC.put(MDC_SPAN_ID, "" + span.spanId());
@@ -116,10 +116,10 @@ public final class ActiveSpanManager {
         private SpanAdapter span;
         private AutoCloseable scope;
 
-        public Holder(Holder parent, SpanAdapter span, AutoCloseable scope) {
+        public Holder(Holder parent, SpanAdapter span) {
             this.parent = parent;
             this.span = span;
-            this.scope = scope;
+            this.scope = new ScopeWrapper(span.makeCurrent(), Thread.currentThread().getId());
         }
 
         public Holder getParent() {
@@ -138,6 +138,31 @@ public final class ActiveSpanManager {
                     LOG.debug("Failed to close span scope", e);
                 }
                 this.scope = null;
+            }
+        }
+    }
+
+    /**
+     * Makes closing scopes idempotent and prevents restoring scope on the wrong thread:
+     * maybe removed if https://github.com/open-telemetry/opentelemetry-java/issues/5055
+     * is fixed.
+     */
+    private static class ScopeWrapper implements AutoCloseable {
+        private final long startThreadId;
+        private final AutoCloseable inner;
+        private boolean closed;
+        public ScopeWrapper(AutoCloseable inner, long startThreadId) {
+            this.startThreadId = startThreadId;
+            this.inner = inner;
+        }
+        @Override
+        public void close() throws Exception {
+            if (!closed && Thread.currentThread().getId() == startThreadId) {
+                closed = true;
+                inner.close();
+            } else {
+                LOG.debug("not closing scope, closed - {}, started on thread - '{}', current thread - '{}'",
+                        closed, startThreadId, Thread.currentThread().getName());
             }
         }
     }

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/Tracer.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/Tracer.java
@@ -264,8 +264,8 @@ public abstract class Tracer extends ServiceSupport implements RoutePolicyFactor
                             LOG.trace("Tracing: start client span={}", span);
                         }
                         sd.post(span, ese.getExchange(), ese.getEndpoint());
-                        finishSpan(span);
                         ActiveSpanManager.deactivate(ese.getExchange());
+                        finishSpan(span);
                     } else {
                         LOG.warn("Tracing: could not find managed span for exchange={}", ese.getExchange());
                     }


### PR DESCRIPTION
Follow up for #8713 and #8911.

Fixes flaky `CurrentSpanTest.testContextDoesNotLeak` test.
I was able to repro failures locally and with this change, they are no longer reproducible (tried on 1000 iterations).

 There are several problems:
1. We can't guarantee that `ExchangeAsyncProcessingStartedEvent` is fired once and only if a span was created previously
2. We can't guarantee that span ends on the same thread it was started, i.e. scope is closed on the same thread
3. Due to concurrency in async scenarios we can call close on scope two times

As a result, we're closing scopes multiple times and from the wrong threads. Changing these on Camel side, AFAIK would be quite difficult.

Unfortunately, OTel scope closing works differently than I thought - https://github.com/open-telemetry/opentelemetry-java/issues/5055. If called multiple times and on a different thread than the scope was started, it restores the wrong context on the other thread.

While the solution on OTel side is evaluated, I suggest guarding scope closing with thread check and making it idempotent.

This PR also adds logging in case there is more flakiness. 