### PR TITLE
Problem when parameter type of bean method is String.

### DIFF
--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/MethodInfo.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/MethodInfo.java
@@ -577,7 +577,7 @@ public class MethodInfo {
             if (methodParameters != null) {
                 // split the parameters safely separated by comma, but beware that we can have
                 // quoted parameters which contains comma as well, so do a safe quote split
-                String[] parameters = StringQuoteHelper.splitSafeQuote(methodParameters, ',', true);
+                String[] parameters = StringQuoteHelper.splitSafeQuote(methodParameters, ',', true, true);
                 it = ObjectHelper.createIterator(parameters, ",", true);
             }
 

--- a/components/camel-bean/src/test/java/org/apache/camel/component/bean/BeanInfoTest.java
+++ b/components/camel-bean/src/test/java/org/apache/camel/component/bean/BeanInfoTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.bean;
 
 import java.util.Collections;
+import java.util.Iterator;
 
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.modifier.Ownership;
@@ -27,6 +28,8 @@ import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Handler;
 import org.apache.camel.spi.Registry;
+import org.apache.camel.support.ObjectHelper;
+import org.apache.camel.util.StringQuoteHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -106,6 +109,28 @@ public class BeanInfoTest {
 
         BeanInfo info = new BeanInfo(context, mhi.getClass());
         assertTrue(info.hasAnyMethodHandlerAnnotation());
+    }
+
+    @Test
+    public void testSplitSafeQuotesUnremoveQuoteAfterValidParameterTypeCheck() {
+        String[] out = StringQuoteHelper.splitSafeQuote("'Hello,Camel','Bye,World'", ',', true, true);
+        Iterator<?> it = ObjectHelper.createIterator(out, ",", true);
+        Object parameterValue = it != null && it.hasNext() ? it.next() : null;
+        while (parameterValue != null) {
+            assertTrue(BeanHelper.isValidParameterValue(parameterValue.toString()));
+            parameterValue = it != null && it.hasNext() ? it.next() : null;
+        }
+    }
+
+    @Test
+    public void testSplitSafeQuoteRemoveQuoteAfterValidParameterTypeCheck() {
+        String[] out = StringQuoteHelper.splitSafeQuote("'\"Hello,Camel\"','\"Bye,World\"'", ',');
+        Iterator<?> it = ObjectHelper.createIterator(out, ",", true);
+        Object parameterValue = it != null && it.hasNext() ? it.next() : null;
+        while (parameterValue != null) {
+            assertTrue(BeanHelper.isValidParameterValue(parameterValue.toString()));
+            parameterValue = it != null && it.hasNext() ? it.next() : null;
+        }
     }
 
     private Object buildProxyObject() {

--- a/core/camel-util/src/main/java/org/apache/camel/util/StringQuoteHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringQuoteHelper.java
@@ -66,7 +66,23 @@ public final class StringQuoteHelper {
      * @return           the input split, or <tt>null</tt> if the input is null.
      */
     public static String[] splitSafeQuote(String input, char separator) {
-        return splitSafeQuote(input, separator, true);
+        return splitSafeQuote(input, separator, true, false);
+    }
+
+    /**
+     * Splits the input safely honoring if values is enclosed in quotes.
+     * <p/>
+     * Though this method does not support double quoting values. A quoted value must start with the same start and
+     * ending quote, which is either a single quote or double quote value.
+     * <p/>
+     *
+     * @param  input     the input
+     * @param  separator the separator char to split the input, for example a comma.
+     * @param  trim      whether to trim each split value
+     * @return           the input split, or <tt>null</tt> if the input is null.
+     */
+    public static String[] splitSafeQuote(String input, char separator, boolean trim) {
+        return splitSafeQuote(input, separator, trim, false);
     }
 
     /**
@@ -78,9 +94,10 @@ public final class StringQuoteHelper {
      * @param  input     the input
      * @param  separator the separator char to split the input, for example a comma.
      * @param  trim      whether to trim each split value
+     * @param  startEndQuoteUnRemove True : Don't remove start and ending quotes
      * @return           the input split, or <tt>null</tt> if the input is null.
      */
-    public static String[] splitSafeQuote(String input, char separator, boolean trim) {
+    public static String[] splitSafeQuote(String input, char separator, boolean trim, boolean startEndQuoteUnRemove) {
         if (input == null) {
             return null;
         }
@@ -108,7 +125,8 @@ public final class StringQuoteHelper {
                     answer.add("");
                 }
                 // special logic needed if this quote is the end
-                if (i == input.length() - 1) {
+                int inputLength = startEndQuoteUnRemove ? input.length() : input.length() - 1;
+                if (i == inputLength) {
                     if (singleQuoted && sb.length() > 0) {
                         String text = sb.toString();
                         // do not trim a quoted string
@@ -117,14 +135,17 @@ public final class StringQuoteHelper {
                     }
                 }
                 singleQuoted = !singleQuoted;
-                continue;
+                if (!startEndQuoteUnRemove) {
+                    continue;
+                }
             } else if (!singleQuoted && ch == '"') {
                 if (doubleQuoted && prev == ch && sb.length() == 0) {
                     // its an empty quote so add empty text
                     answer.add("");
                 }
                 // special logic needed if this quote is the end
-                if (i == input.length() - 1) {
+                int inputLength = startEndQuoteUnRemove ? input.length() : input.length() - 1;
+                if (i == inputLength) {
                     if (doubleQuoted && sb.length() > 0) {
                         String text = sb.toString();
                         // do not trim a quoted string
@@ -133,7 +154,9 @@ public final class StringQuoteHelper {
                     }
                 }
                 doubleQuoted = !doubleQuoted;
-                continue;
+                if (!startEndQuoteUnRemove) {
+                    continue;
+                }
             } else if (!isQuoting && separator != ' ' && ch == ' ') {
                 if (skipLeadingWhitespace) {
                     continue;


### PR DESCRIPTION
[camel-bean] 
Problem when parameter type of bean method is String.
Problems with more than 2 parameters.

Expression to evaluate the bean parameter parameters and provide the correct values when the method is invoked.

There are several problems:
1. There is a problem with quotes being removed in the splitSafeQuote method used inside the evaluate method.
   splitSafeQuote("'Camel', 'Test'", ",", true)  -> ["Camel","Test"]   
2. The quote is removed and false is returned from the isValidParameterValue method. 
   isValidParameterValue("Camel") -> return false
3. When “ClassLoader” is working which make thread blocked it caused by Disk I/O.
   So it behavior make that performance deteriorates.

This PR also adds TestCase.



