### PR TITLE
camel-jbang - Upgrade to Camel 3.20.0 (3.20.x)

### DIFF
--- a/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
@@ -19,8 +19,8 @@
 
 //JAVA 11+
 //REPOS mavencentral,apache-snapshot=http://repository.apache.org/content/groups/snapshots/
-//DEPS org.apache.camel:camel-bom:${camel.jbang.version:3.19.0}@pom
-//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:3.19.0}
+//DEPS org.apache.camel:camel-bom:${camel.jbang.version:3.20.0}@pom
+//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:3.20.0}
 //DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:0.10.0}
 
 package main;

--- a/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
@@ -19,8 +19,8 @@
 
 //JAVA 11+
 //REPOS mavencentral,apache-snapshot=http://repository.apache.org/content/groups/snapshots/
-//DEPS org.apache.camel:camel-bom:${camel.jbang.version:3.19.0}@pom
-//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:3.19.0}
+//DEPS org.apache.camel:camel-bom:${camel.jbang.version:3.20.0}@pom
+//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:3.20.0}
 //DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:0.10.0}
 
 package main;


### PR DESCRIPTION
Backport #8914 to 3.20.x branch. With this now users can do:
```
jbang app install camel@apache/camel/camel-3.20.x
```
to install the latest 3.20.x version of Camel JBang.
