### PR TITLE
[CAMEL-15111] Fixes bug in camel-as2 via not forcing ascii charset when not specified

### DIFF
--- a/components/camel-as2/camel-as2-api/pom.xml
+++ b/components/camel-as2/camel-as2-api/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.helger.as2</groupId>
             <artifactId>as2-lib</artifactId>
-            <version>4.11.0</version>
+            <version>${as2-lib-version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-as2/camel-as2-api/pom.xml
+++ b/components/camel-as2/camel-as2-api/pom.xml
@@ -96,6 +96,13 @@
             <artifactId>camel-test-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- added for binary content transfer encoding test because Camel AS2 client doesn't support binary currently -->
+        <dependency>
+            <groupId>com.helger.as2</groupId>
+            <artifactId>as2-lib</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/io/AS2SessionInputBuffer.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/io/AS2SessionInputBuffer.java
@@ -52,6 +52,7 @@ public class AS2SessionInputBuffer implements SessionInputBuffer, BufferInfo {
     private int bufferlen;
     private CharBuffer cbuf;
 
+    private boolean lastLineReadEnrichedByCarriageReturn;
     private boolean lastLineReadTerminatedByLineFeed;
 
     public AS2SessionInputBuffer(final HttpTransportMetricsImpl metrics,
@@ -190,6 +191,7 @@ public class AS2SessionInputBuffer implements SessionInputBuffer, BufferInfo {
         final int maxLineLen = this.constraints.getMaxLineLength();
         int noRead = 0;
         boolean retry = true;
+        this.lastLineReadEnrichedByCarriageReturn = false;
         this.lastLineReadTerminatedByLineFeed = false;
         while (retry) {
             // attempt to find end of line (LF)
@@ -198,6 +200,9 @@ public class AS2SessionInputBuffer implements SessionInputBuffer, BufferInfo {
                 if (this.buffer[i] == HTTP.LF) {
                     pos = i;
                     this.lastLineReadTerminatedByLineFeed = true;
+                    if (i > 0 && this.buffer[i - 1] == HTTP.CR) {
+                        this.lastLineReadEnrichedByCarriageReturn = true;
+                    }
                     break;
                 }
             }
@@ -250,6 +255,10 @@ public class AS2SessionInputBuffer implements SessionInputBuffer, BufferInfo {
 
     public boolean isLastLineReadTerminatedByLineFeed() {
         return lastLineReadTerminatedByLineFeed;
+    }
+
+    public boolean isLastLineReadEnrichedByCarriageReturn() {
+        return lastLineReadEnrichedByCarriageReturn;
     }
 
     @Override

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTest.java
@@ -162,9 +162,9 @@ public class AS2MessageTest {
 
     private static File keystoreFile;
 
-    private AS2SignedDataGenerator gen;
-
     private static ApplicationEDIEntity ediEntity;
+
+    private AS2SignedDataGenerator gen;
 
     @BeforeAll
     public static void setUpOnce() throws Exception {
@@ -352,8 +352,9 @@ public class AS2MessageTest {
         final AS2ClientResponse aResponse = new AS2Client().sendSynchronous(aSettings, aRequest);
 
         // Assertions
-        if (aResponse.hasException())
+        if (aResponse.hasException()) {
             fail(aResponse.getException());
+        }
         assertEquals(EDI_MESSAGE, ediEntity.getEdiMessage().replaceAll("\r", ""));
     }
 

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTest.java
@@ -193,8 +193,8 @@ public class AS2MessageTest {
         //
         KeyStore ks = KeyStore.getInstance(EKeyStoreType.PKCS12.getID());
         ks.load(null, "test".toCharArray());
-        ks.setKeyEntry("openas2a_alias", issueKP.getPrivate(), "test".toCharArray(), new X509Certificate[]{issueCert});
-        ks.setKeyEntry("openas2b_alias", signingKP.getPrivate(), "test".toCharArray(), new X509Certificate[]{signingCert});
+        ks.setKeyEntry("openas2a_alias", issueKP.getPrivate(), "test".toCharArray(), new X509Certificate[] { issueCert });
+        ks.setKeyEntry("openas2b_alias", signingKP.getPrivate(), "test".toCharArray(), new X509Certificate[] { signingCert });
         keystoreFile = File.createTempFile("camel-as2", "keystore-p12");
         keystoreFile.deleteOnExit();
         ks.store(new FileOutputStream(keystoreFile), "test".toCharArray());
@@ -314,8 +314,9 @@ public class AS2MessageTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"false,false,false", "false,false,true", "false,true,false", "false,true,true"
-            , "true,false,false", "true,false,true", "true,true,false", "true,true,true"})
+    @CsvSource({
+            "false,false,false", "false,false,true", "false,true,false", "false,true,true", "true,false,false",
+            "true,false,true", "true,true,false", "true,true,true" })
     void binaryContentTransferEncodingTest(boolean encrypt, boolean sign, boolean compress) {
         // test with as2-lib because Camel AS2 client doesn't support binary content transfer encoding at the moment
         // inspired from https://github.com/phax/as2-lib/wiki/Submodule-as2%E2%80%90lib#as2-client

--- a/components/camel-as2/pom.xml
+++ b/components/camel-as2/pom.xml
@@ -29,6 +29,10 @@
     <artifactId>camel-as2-parent</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <as2-lib-version>4.11.0</as2-lib-version>
+    </properties>
+
     <name>Camel :: AS2 :: Parent</name>
     <description>Camel AS2 parent</description>
 


### PR DESCRIPTION
... otherwise you will get `java.nio.charset.MalformedInputException: Input length = 1` when content transfer encoding is binary. This PR mainly does AS2SessionInputBuffer.setCharsetDecoder(null) instead when charset is not specified so it doesn't reach MalformedInputException. Then it convert returned result back to byte[] from String when charset is not specified. String were required to find multipart boundaries. Generally this PR keeps previous behavior otherwise, i.e. when charset is specified. It also tests all 8 different situations for encrypt, sign and compress via a parameterized test. as2-lib third-party library is used for these tests as at the moment, binary content transfer encoding is not supported by Camel AS2 client.

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
