### PR TITLE
[CAMEL-18842] Checks for compression before throwing exception

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/HttpMessageUtils.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/HttpMessageUtils.java
@@ -212,6 +212,10 @@ public final class HttpMessageUtils {
         MimeEntity mimeEntity = multipartSignedEntity.getSignedDataEntity();
         if (mimeEntity instanceof ApplicationEDIEntity) {
             ediEntity = (ApplicationEDIEntity) mimeEntity;
+        } else if (mimeEntity instanceof ApplicationPkcs7MimeCompressedDataEntity) {
+            ApplicationPkcs7MimeCompressedDataEntity compressedDataEntity
+                    = (ApplicationPkcs7MimeCompressedDataEntity) mimeEntity;
+            ediEntity = extractEdiPayloadFromCompressedEntity(compressedDataEntity);
         } else {
             throw new HttpException(
                     "Failed to extract EDI payload: invalid content type '" + mimeEntity.getContentTypeValue()
@@ -244,6 +248,10 @@ public final class HttpMessageUtils {
                 MimeEntity mimeEntity = multipartSignedEntity.getSignedDataEntity();
                 if (mimeEntity instanceof ApplicationEDIEntity) {
                     ediEntity = (ApplicationEDIEntity) mimeEntity;
+                } else if (mimeEntity instanceof ApplicationPkcs7MimeCompressedDataEntity) {
+                    ApplicationPkcs7MimeCompressedDataEntity compressedDataEntity
+                            = (ApplicationPkcs7MimeCompressedDataEntity) mimeEntity;
+                    ediEntity = extractEdiPayloadFromCompressedEntity(compressedDataEntity);
                 } else {
 
                     throw new HttpException(


### PR DESCRIPTION
In order to support different orders of compression and signature, this PR checks if the mimeEntity is a compressed entity before throwing unknown entity exception - both compression before and after signature are allowed according to the RFC https://datatracker.ietf.org/doc/html/rfc5402/#section-3