### PR TITLE
Typo in migration guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_11.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_11.adoc
@@ -94,7 +94,7 @@ mvn camel-karaf:run
 
 Support of deprecated use of named dataSource in the URI has been removed.
 
-You have to use `sql:select * from table where id=# order by name?dataSource=#myDS` instead of `sql:select * from table where id=# order by name?dataSource=myDS`.
+You have to use `sql:select * from table where id=# order by name?dataSource=\#myDS` instead of `sql:select * from table where id=# order by name?dataSource=myDS`.
 
 === Spring Boot Starters
 


### PR DESCRIPTION
Typo: The # char is not correctly escaped in the migration guide. This leads to the # not being displayed but only formating the following word and possibly causing confusion on how to use it.