### PR TITLE
camel-plc4x: Added timeout to future in process() method of Plc4XProducer and fixed deprecated Camel methods

### DIFF
--- a/components/camel-plc4x/src/main/java/org/apache/camel/component/plc4x/Plc4XProducer.java
+++ b/components/camel-plc4x/src/main/java/org/apache/camel/component/plc4x/Plc4XProducer.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.plc4x;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.AsyncCallback;
@@ -69,9 +70,9 @@ public class Plc4XProducer extends DefaultAsyncProducer {
         int currentlyOpenRequests = openRequests.incrementAndGet();
         try {
             log.debug("Currently open requests including {}:{}", exchange, currentlyOpenRequests);
-            Object plcWriteResponse = completableFuture.get();
+            Object plcWriteResponse = completableFuture.get(5000, TimeUnit.MILLISECONDS);
             if (exchange.getPattern().isOutCapable()) {
-                Message out = exchange.getOut();
+                Message out = exchange.getMessage();
                 out.copyFrom(exchange.getIn());
                 out.setBody(plcWriteResponse);
             } else {
@@ -87,10 +88,10 @@ public class Plc4XProducer extends DefaultAsyncProducer {
     public boolean process(Exchange exchange, AsyncCallback callback) {
         try {
             process(exchange);
-            Message out = exchange.getOut();
+            Message out = exchange.getMessage();
             out.copyFrom(exchange.getIn());
         } catch (Exception e) {
-            exchange.setOut(null);
+            exchange.setMessage(null);
             exchange.setException(e);
         }
         callback.done(true);


### PR DESCRIPTION
I do not have a JIRA account yet, so I could not create a JIRA ticket. I will create a ticket as soon as I have an account.

Because the CompletableFuture in the process() method of the Plc4XProducer didn't have a timeout, it sometimes got stuck there. Resulting in no more write requests being processed. I added a timeout of 5000 ms because the first process sometimes takes a couple of seconds to complete.
I also changed some deprecated methods for non-deprecated ones.