### PR TITLE
(chores) tests: move utility method to TestSupport

### DIFF
--- a/components/camel-barcode/src/test/java/org/apache/camel/dataformat/barcode/BarcodeDataFormatCamelTest.java
+++ b/components/camel-barcode/src/test/java/org/apache/camel/dataformat/barcode/BarcodeDataFormatCamelTest.java
@@ -23,6 +23,7 @@ import com.google.zxing.BarcodeFormat;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spi.DataFormat;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -131,40 +132,40 @@ public class BarcodeDataFormatCamelTest extends BarcodeTestBase {
 
                 from("direct:code1")
                         .marshal(code1)
-                        .to(fileUri(testDirectory));
+                        .to(TestSupport.fileUri(testDirectory));
 
                 // QR-Code with modified size
                 DataFormat code2 = new BarcodeDataFormat(200, 200);
 
                 from("direct:code2")
                         .marshal(code2)
-                        .to(fileUri(testDirectory));
+                        .to(TestSupport.fileUri(testDirectory));
 
                 // QR-Code with JPEG type
                 DataFormat code3 = new BarcodeDataFormat(BarcodeImageType.JPG);
 
                 from("direct:code3")
                         .marshal(code3)
-                        .to(fileUri(testDirectory));
+                        .to(TestSupport.fileUri(testDirectory));
 
                 // PDF-417 code with modified size and image type
                 DataFormat code4 = new BarcodeDataFormat(200, 200, BarcodeImageType.JPG, BarcodeFormat.PDF_417);
 
                 from("direct:code4")
                         .marshal(code4)
-                        .to(fileUri(testDirectory));
+                        .to(TestSupport.fileUri(testDirectory));
 
                 // AZTEC with modified size and PNG type
                 DataFormat code5 = new BarcodeDataFormat(200, 200, BarcodeImageType.PNG, BarcodeFormat.AZTEC);
 
                 from("direct:code5")
                         .marshal(code5)
-                        .to(fileUri(testDirectory));
+                        .to(TestSupport.fileUri(testDirectory));
 
                 // generic file read --->
                 // 
                 // read file and route it
-                from(fileUri(testDirectory, "?noop=true&initialDelay=0&delay=10"))
+                from(TestSupport.fileUri(testDirectory, "?noop=true&initialDelay=0&delay=10"))
                         .multicast().to("direct:unmarshall", "mock:image");
 
                 // get the message from code

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpTempFileNameIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpTempFileNameIT.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -38,7 +39,8 @@ public class FileToFtpTempFileNameIT extends FtpServerTestSupport {
     public void testFileToFtp() {
         NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
 
-        template.sendBodyAndHeader(fileUri(testDirectory, "in"), "Hello World", Exchange.FILE_NAME, "sub/hello.txt");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory, "in"), "Hello World", Exchange.FILE_NAME,
+                "sub/hello.txt");
 
         assertTrue(notify.matchesWaitTime());
 
@@ -51,7 +53,7 @@ public class FileToFtpTempFileNameIT extends FtpServerTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(fileUri(testDirectory, "in?recursive=true"))
+                from(TestSupport.fileUri(testDirectory, "in?recursive=true"))
                         .to("ftp://admin:admin@localhost:{{ftp.server.port}}"
                             + "/out/?fileName=${file:name}&tempFileName=${file:onlyname}.part&stepwise=false");
             }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFileToFtpDeleteIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFileToFtpDeleteIT.java
@@ -22,6 +22,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -44,7 +45,8 @@ public class FromFileToFtpDeleteIT extends FtpServerTestSupport {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
 
-        template.sendBodyAndHeader(fileUri(testDirectory, "delete"), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory, "delete"), "Hello World", Exchange.FILE_NAME,
+                "hello.txt");
 
         MockEndpoint.assertIsSatisfied(context);
         assertTrue(notify.matchesWaitTime());
@@ -60,7 +62,7 @@ public class FromFileToFtpDeleteIT extends FtpServerTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from(fileUri(testDirectory, "delete?delete=true")).to(getFtpUrl()).to("mock:result");
+                from(TestSupport.fileUri(testDirectory, "delete?delete=true")).to(getFtpUrl()).to("mock:result");
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpDirectoryToBinaryFilesIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpDirectoryToBinaryFilesIT.java
@@ -23,6 +23,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.converter.IOConverter;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -92,7 +93,7 @@ public class FromFtpDirectoryToBinaryFilesIT extends FtpServerTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from(getFtpUrl()).to(fileUri(testDirectory, "?noop=true"), "mock:result");
+                from(getFtpUrl()).to(TestSupport.fileUri(testDirectory, "?noop=true"), "mock:result");
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpKeepLastModifiedIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpKeepLastModifiedIT.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -52,7 +53,7 @@ public class FromFtpKeepLastModifiedIT extends FtpServerTestSupport {
         context.addRoutes(new RouteBuilder() {
             @Override
             public void configure() {
-                from(getFtpUrl()).delay(3000).to(fileUri(testDirectory, "?keepLastModified=true"), "mock:result");
+                from(getFtpUrl()).delay(3000).to(TestSupport.fileUri(testDirectory, "?keepLastModified=true"), "mock:result");
             }
         });
         context.start();
@@ -75,7 +76,7 @@ public class FromFtpKeepLastModifiedIT extends FtpServerTestSupport {
         context.addRoutes(new RouteBuilder() {
             @Override
             public void configure() {
-                from(getFtpUrl()).delay(3000).to(fileUri(testDirectory, "?keepLastModified=false"), "mock:result");
+                from(getFtpUrl()).delay(3000).to(TestSupport.fileUri(testDirectory, "?keepLastModified=false"), "mock:result");
             }
         });
         context.start();
@@ -98,7 +99,7 @@ public class FromFtpKeepLastModifiedIT extends FtpServerTestSupport {
         context.addRoutes(new RouteBuilder() {
             @Override
             public void configure() {
-                from(getFtpUrl()).delay(3000).to(fileUri(testDirectory), "mock:result");
+                from(getFtpUrl()).delay(3000).to(TestSupport.fileUri(testDirectory), "mock:result");
             }
         });
         context.start();

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpSetNamesWithMultiDirectoriesIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpSetNamesWithMultiDirectoriesIT.java
@@ -26,6 +26,7 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.converter.IOConverter;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -101,7 +102,7 @@ public class FromFtpSetNamesWithMultiDirectoriesIT extends FtpServerTestSupport 
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from(getFtpUrl()).routeId("foo").noAutoStartup().to(fileUri(testDirectory), "mock:result");
+                from(getFtpUrl()).routeId("foo").noAutoStartup().to(TestSupport.fileUri(testDirectory), "mock:result");
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpToAsciiFileIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpToAsciiFileIT.java
@@ -24,6 +24,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Producer;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -81,7 +82,7 @@ public class FromFtpToAsciiFileIT extends FtpServerTestSupport {
         return new RouteBuilder() {
             public void configure() {
                 from(getFtpUrl()).setHeader(Exchange.FILE_NAME, constant("deleteme.txt")).convertBodyTo(String.class)
-                        .to(fileUri(testDirectory, "?fileExist=Override&noop=true")).to("mock:result");
+                        .to(TestSupport.fileUri(testDirectory, "?fileExist=Override&noop=true")).to("mock:result");
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpToAsciiFileNoBodyConversionIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpToAsciiFileNoBodyConversionIT.java
@@ -23,6 +23,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Producer;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -70,7 +71,7 @@ public class FromFtpToAsciiFileNoBodyConversionIT extends FtpServerTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from(getFtpUrl()).to(fileUri(testDirectory, "?fileExist=Override&noop=true"), "mock:result");
+                from(getFtpUrl()).to(TestSupport.fileUri(testDirectory, "?fileExist=Override&noop=true"), "mock:result");
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpToBinaryFileIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpToBinaryFileIT.java
@@ -25,6 +25,7 @@ import org.apache.camel.Producer;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.converter.IOConverter;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -85,7 +86,7 @@ public class FromFtpToBinaryFileIT extends FtpServerTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                String fileUrl = fileUri(testDirectory, "?noop=true&fileExist=Override");
+                String fileUrl = TestSupport.fileUri(testDirectory, "?noop=true&fileExist=Override");
                 from(getFtpUrl()).setHeader(Exchange.FILE_NAME, constant("deleteme.jpg")).to(fileUrl, "mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpToBinaryFilesIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpToBinaryFilesIT.java
@@ -25,6 +25,7 @@ import org.apache.camel.Producer;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.converter.IOConverter;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -102,7 +103,7 @@ public class FromFtpToBinaryFilesIT extends FtpServerTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from(getFtpUrl()).to(fileUri(testDirectory, "?noop=true"), "mock:result");
+                from(getFtpUrl()).to(TestSupport.fileUri(testDirectory, "?noop=true"), "mock:result");
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpToFileNoFileNameHeaderIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpToFileNoFileNameHeaderIT.java
@@ -23,6 +23,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Producer;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -74,7 +75,7 @@ public class FromFtpToFileNoFileNameHeaderIT extends FtpServerTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                String fileUrl = fileUri(testDirectory, "?fileExist=Override&noop=true");
+                String fileUrl = TestSupport.fileUri(testDirectory, "?fileExist=Override&noop=true");
                 // we do not set any filename in the header property so the
                 // filename should be the one
                 // from the FTP server we downloaded

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpChangedReadLockIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpChangedReadLockIT.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
@@ -82,7 +83,7 @@ public class FtpChangedReadLockIT extends FtpServerTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(getFtpUrl()).to(fileUri(testDirectory, "out"), "mock:result");
+                from(getFtpUrl()).to(TestSupport.fileUri(testDirectory, "out"), "mock:result");
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpChangedRootDirReadLockIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpChangedRootDirReadLockIT.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
@@ -83,7 +84,7 @@ public class FtpChangedRootDirReadLockIT extends FtpServerTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(getFtpUrl()).to(fileUri(testDirectory), "mock:result");
+                from(getFtpUrl()).to(TestSupport.fileUri(testDirectory), "mock:result");
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpChangedZeroLengthReadLockIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpChangedZeroLengthReadLockIT.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -61,7 +62,7 @@ public class FtpChangedZeroLengthReadLockIT extends FtpServerTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(getFtpUrl()).to(fileUri(testDirectory), "mock:result");
+                from(getFtpUrl()).to(TestSupport.fileUri(testDirectory), "mock:result");
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerLocalWorkDirectoryAsAbsolutePathIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerLocalWorkDirectoryAsAbsolutePathIT.java
@@ -26,6 +26,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.Producer;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.apache.camel.util.FileUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -97,7 +98,7 @@ public class FtpConsumerLocalWorkDirectoryAsAbsolutePathIT extends FtpServerTest
                         assertTrue(body.exists(), "Local work file should exists");
                         assertEquals(FileUtil.normalizePath(testDirectory.resolve("hello.txt").toString()), body.getPath());
                     }
-                }).to("mock:result", fileUri(testDirectory, "out"));
+                }).to("mock:result", TestSupport.fileUri(testDirectory, "out"));
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerLocalWorkDirectoryDirectIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerLocalWorkDirectoryDirectIT.java
@@ -23,6 +23,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Producer;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -78,7 +79,7 @@ public class FtpConsumerLocalWorkDirectoryDirectIT extends FtpServerTestSupport 
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from(getFtpUrl()).to(fileUri(testDirectory, "out"));
+                from(getFtpUrl()).to(TestSupport.fileUri(testDirectory, "out"));
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerLocalWorkDirectoryIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerLocalWorkDirectoryIT.java
@@ -26,6 +26,7 @@ import org.apache.camel.Producer;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.apache.camel.util.FileUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -100,7 +101,7 @@ public class FtpConsumerLocalWorkDirectoryIT extends FtpServerTestSupport {
                         assertTrue(body.exists(), "Local work file should exists");
                         assertEquals(FileUtil.normalizePath(testDirectory.resolve("lwd/hello.txt").toString()), body.getPath());
                     }
-                }).to("mock:result", fileUri(testDirectory, "out"));
+                }).to("mock:result", TestSupport.fileUri(testDirectory, "out"));
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerLocalWorkDirectoryWorkOnPayloadIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerLocalWorkDirectoryWorkOnPayloadIT.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.file.remote.integration;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.junit5.TestSupport;
 
 public class FtpConsumerLocalWorkDirectoryWorkOnPayloadIT extends FtpConsumerLocalWorkDirectoryIT {
 
@@ -32,7 +33,7 @@ public class FtpConsumerLocalWorkDirectoryWorkOnPayloadIT extends FtpConsumerLoc
                         exchange.getIn().setBody("Hello World");
 
                     }
-                }).to("mock:result", fileUri(testDirectory, "out"));
+                }).to("mock:result", TestSupport.fileUri(testDirectory, "out"));
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerResumeDownloadIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerResumeDownloadIT.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -82,7 +83,7 @@ public class FtpConsumerResumeDownloadIT extends FtpServerTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from(getFtpUrl()).routeId("myRoute").noAutoStartup().to("mock:result", fileUri(lwd, "out"));
+                from(getFtpUrl()).routeId("myRoute").noAutoStartup().to("mock:result", TestSupport.fileUri(lwd, "out"));
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpSimpleConsumeStreamingStepwiseIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpSimpleConsumeStreamingStepwiseIT.java
@@ -25,6 +25,7 @@ import org.apache.camel.Producer;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.converter.IOConverter;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -80,7 +81,7 @@ public class FtpSimpleConsumeStreamingStepwiseIT extends FtpServerTestSupport {
         return new RouteBuilder() {
             public void configure() {
                 from(getFtpUrl()).setHeader(Exchange.FILE_NAME, constant("deleteme.jpg"))
-                        .to(fileUri(testDirectory), "mock:result");
+                        .to(TestSupport.fileUri(testDirectory), "mock:result");
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/RemoteFileProduceOverruleOnlyOnceIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/RemoteFileProduceOverruleOnlyOnceIT.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -54,7 +55,7 @@ public class RemoteFileProduceOverruleOnlyOnceIT extends FtpServerTestSupport {
             @Override
             public void configure() {
                 from("direct:input").to("ftp://admin:admin@localhost:{{ftp.server.port}}/out/").to(
-                        fileUri(testDirectory, "out"),
+                        TestSupport.fileUri(testDirectory, "out"),
                         "mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/SftpConsumerLocalWorkDirectoryIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/SftpConsumerLocalWorkDirectoryIT.java
@@ -27,6 +27,7 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.file.remote.sftp.integration.SftpServerTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.apache.camel.util.FileUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -101,7 +102,7 @@ public class SftpConsumerLocalWorkDirectoryIT extends SftpServerTestSupport {
                         assertTrue(body.exists(), "Local work file should exists");
                         assertEquals(FileUtil.normalizePath(testDirectory.resolve("lwd/hello.txt").toString()), body.getPath());
                     }
-                }).to("mock:result", fileUri(testDirectory, "out"));
+                }).to("mock:result", TestSupport.fileUri(testDirectory, "out"));
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/manual/FtpConsumerCamelManualTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/manual/FtpConsumerCamelManualTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -41,7 +42,7 @@ public class FtpConsumerCamelManualTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("ftp:localhost/one/two?username=camel&password=camel&noop=true").to(fileUri(testDirectory))
+                from("ftp:localhost/one/two?username=camel&password=camel&noop=true").to(TestSupport.fileUri(testDirectory))
                         .to("mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/manual/FtpConsumerCamelRecursiveManualTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/manual/FtpConsumerCamelRecursiveManualTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -41,7 +42,8 @@ public class FtpConsumerCamelRecursiveManualTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("ftp:localhost/one/two?username=camel&password=camel&recursive=true&noop=true").to(fileUri(testDirectory))
+                from("ftp:localhost/one/two?username=camel&password=camel&recursive=true&noop=true")
+                        .to(TestSupport.fileUri(testDirectory))
                         .to("mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/manual/FtpConsumerNotStepwiseCamelManualTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/manual/FtpConsumerNotStepwiseCamelManualTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -41,7 +42,8 @@ public class FtpConsumerNotStepwiseCamelManualTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("ftp:localhost/one/two?username=camel&password=camel&noop=true&stepwise=false").to(fileUri(testDirectory))
+                from("ftp:localhost/one/two?username=camel&password=camel&noop=true&stepwise=false")
+                        .to(TestSupport.fileUri(testDirectory))
                         .to("mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/manual/FtpConsumerNotStepwiseCamelRecursiveManualTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/manual/FtpConsumerNotStepwiseCamelRecursiveManualTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -42,7 +43,7 @@ public class FtpConsumerNotStepwiseCamelRecursiveManualTest extends CamelTestSup
             @Override
             public void configure() {
                 from("ftp:localhost/one/two?username=camel&password=camel&recursive=true&noop=true&stepwise=false")
-                        .to(fileUri(testDirectory)).to("mock:result");
+                        .to(TestSupport.fileUri(testDirectory)).to("mock:result");
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/manual/FtpConsumerScottManualTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/manual/FtpConsumerScottManualTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -41,7 +42,8 @@ public class FtpConsumerScottManualTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("ftp:localhost?username=scott&password=tiger&noop=true").to(fileUri(testDirectory)).to("mock:result");
+                from("ftp:localhost?username=scott&password=tiger&noop=true").to(TestSupport.fileUri(testDirectory))
+                        .to("mock:result");
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/manual/FtpConsumerScottRecursiveManualTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/manual/FtpConsumerScottRecursiveManualTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -41,7 +42,8 @@ public class FtpConsumerScottRecursiveManualTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("ftp:localhost?username=scott&password=tiger&noop=true&recursive=true").to(fileUri(testDirectory))
+                from("ftp:localhost?username=scott&password=tiger&noop=true&recursive=true")
+                        .to(TestSupport.fileUri(testDirectory))
                         .to("mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChangedReadLockIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChangedReadLockIT.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.io.TempDir;
@@ -83,7 +84,7 @@ public class SftpChangedReadLockIT extends SftpServerTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(getFtpUrl()).routeId("foo").noAutoStartup().to(fileUri(testDirectory, "out"), "mock:result");
+                from(getFtpUrl()).routeId("foo").noAutoStartup().to(TestSupport.fileUri(testDirectory, "out"), "mock:result");
             }
         };
     }

--- a/components/camel-jaxb/src/test/java/org/apache/camel/example/ExplicitEncodingAndXMLCharFilteringTest.java
+++ b/components/camel-jaxb/src/test/java/org/apache/camel/example/ExplicitEncodingAndXMLCharFilteringTest.java
@@ -30,6 +30,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.converter.jaxb.JaxbDataFormat;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -74,7 +75,7 @@ public class ExplicitEncodingAndXMLCharFilteringTest extends CamelTestSupport {
 
                 from("direct:start")
                         .marshal(jaxb)
-                        .to(fileUri(testDirectory, "?fileName=output.xml&charset=iso-8859-1"));
+                        .to(TestSupport.fileUri(testDirectory, "?fileName=output.xml&charset=iso-8859-1"));
             }
         };
     }

--- a/components/camel-jaxb/src/test/java/org/apache/camel/example/ExplicitFileEncodingTest.java
+++ b/components/camel-jaxb/src/test/java/org/apache/camel/example/ExplicitFileEncodingTest.java
@@ -25,6 +25,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.converter.jaxb.JaxbDataFormat;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -65,7 +66,7 @@ public class ExplicitFileEncodingTest extends CamelTestSupport {
 
                 from("direct:start")
                         .marshal(jaxb)
-                        .to(fileUri(testDirectory, "?fileName=output.txt&charset=iso-8859-1"));
+                        .to(TestSupport.fileUri(testDirectory, "?fileName=output.txt&charset=iso-8859-1"));
             }
         };
     }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpToFileTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpToFileTest.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -65,7 +66,7 @@ public class HttpToFileTest extends BaseJettyTest {
 
                 // store the content from the queue as a file
                 from("seda:in").setHeader(Exchange.FILE_NAME, constant("hello.txt")).convertBodyTo(String.class)
-                        .to(fileUri(testDirectory)).to("mock:result");
+                        .to(TestSupport.fileUri(testDirectory)).to("mock:result");
             }
         };
     }

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/file/JettyFileConsumerTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/file/JettyFileConsumerTest.java
@@ -25,6 +25,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jetty.BaseJettyTest;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -74,7 +75,7 @@ public class JettyFileConsumerTest extends BaseJettyTest {
         getMockEndpoint("mock:result").expectedMessageCount(1);
 
         File jpg = new File("src/test/resources/java.jpg");
-        template.sendBodyAndHeader(fileUri(testDirectory, "binary"), jpg, Exchange.FILE_NAME, "java.jpg");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory, "binary"), jpg, Exchange.FILE_NAME, "java.jpg");
 
         MockEndpoint.assertIsSatisfied(context);
 
@@ -88,13 +89,14 @@ public class JettyFileConsumerTest extends BaseJettyTest {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from("jetty:http://localhost:{{port}}/myapp/myservice").to(fileUri(testDirectory, "test?fileName=temp.xml"))
+                from("jetty:http://localhost:{{port}}/myapp/myservice")
+                        .to(TestSupport.fileUri(testDirectory, "test?fileName=temp.xml"))
                         .setBody(constant("OK"));
 
                 from("jetty:http://localhost:{{port}}/myapp/myservice2").to("log:foo?showAll=true")
-                        .to(fileUri(testDirectory, "test?fileName=java.jpg")).setBody(constant("OK"));
+                        .to(TestSupport.fileUri(testDirectory, "test?fileName=java.jpg")).setBody(constant("OK"));
 
-                from(fileUri(testDirectory, "binary?noop=true")).to("http://localhost:{{port}}/myapp/myservice2")
+                from(TestSupport.fileUri(testDirectory, "binary?noop=true")).to("http://localhost:{{port}}/myapp/myservice2")
                         .to("mock:result");
             }
         };

--- a/components/camel-quartz/src/test/java/org/apache/camel/pollconsumer/quartz/FileConsumerQuartzSchedulerRestartTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/pollconsumer/quartz/FileConsumerQuartzSchedulerRestartTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -32,7 +33,7 @@ public class FileConsumerQuartzSchedulerRestartTest extends CamelTestSupport {
     @Test
     public void testQuartzSchedulerRestart() throws Exception {
         getMockEndpoint("mock:result").expectedMessageCount(1);
-        template.sendBodyAndHeader(fileUri(testDirectory), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory), "Hello World", Exchange.FILE_NAME, "hello.txt");
         context.getRouteController().startRoute("foo");
         MockEndpoint.assertIsSatisfied(context);
 
@@ -40,7 +41,7 @@ public class FileConsumerQuartzSchedulerRestartTest extends CamelTestSupport {
         MockEndpoint.resetMocks(context);
 
         getMockEndpoint("mock:result").expectedMessageCount(1);
-        template.sendBodyAndHeader(fileUri(testDirectory), "Bye World", Exchange.FILE_NAME, "bye.txt");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory), "Bye World", Exchange.FILE_NAME, "bye.txt");
         context.getRouteController().startRoute("foo");
         MockEndpoint.assertIsSatisfied(context);
     }
@@ -50,7 +51,7 @@ public class FileConsumerQuartzSchedulerRestartTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(fileUri(testDirectory,
+                from(TestSupport.fileUri(testDirectory,
                         "?scheduler=quartz&scheduler.cron=0/2+*+*+*+*+?&scheduler.triggerGroup=myGroup&scheduler.triggerId=myId"))
                                 .routeId("foo").noAutoStartup()
                                 .to("mock:result");

--- a/components/camel-quartz/src/test/java/org/apache/camel/pollconsumer/quartz/FileConsumerQuartzSchedulerTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/pollconsumer/quartz/FileConsumerQuartzSchedulerTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -33,7 +34,7 @@ public class FileConsumerQuartzSchedulerTest extends CamelTestSupport {
     public void testQuartzScheduler() throws Exception {
         getMockEndpoint("mock:result").expectedMessageCount(1);
 
-        template.sendBodyAndHeader(fileUri(testDirectory), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory), "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         context.getRouteController().startRoute("foo");
 
@@ -45,7 +46,8 @@ public class FileConsumerQuartzSchedulerTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(fileUri(testDirectory, "?scheduler=quartz&scheduler.cron=0/2+*+*+*+*+?")).routeId("foo").noAutoStartup()
+                from(TestSupport.fileUri(testDirectory, "?scheduler=quartz&scheduler.cron=0/2+*+*+*+*+?")).routeId("foo")
+                        .noAutoStartup()
                         .to("mock:result");
             }
         };

--- a/components/camel-saxon/src/test/java/org/apache/camel/builder/saxon/XPathSplitChoicePerformanceTest.java
+++ b/components/camel-saxon/src/test/java/org/apache/camel/builder/saxon/XPathSplitChoicePerformanceTest.java
@@ -27,6 +27,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.TimeUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -88,7 +89,7 @@ public class XPathSplitChoicePerformanceTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(fileUri(testDirectory, "?noop=true"))
+                from(TestSupport.fileUri(testDirectory, "?noop=true"))
                         .process(new Processor() {
                             public void process(Exchange exchange) {
                                 log.info("Starting to process file");

--- a/components/camel-saxon/src/test/java/org/apache/camel/component/xquery/XQueryFromFileExceptionTest.java
+++ b/components/camel-saxon/src/test/java/org/apache/camel/component/xquery/XQueryFromFileExceptionTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -42,7 +43,7 @@ public class XQueryFromFileExceptionTest extends CamelTestSupport {
 
         String body = "<person user='James'><firstName>James</firstName>"
                       + "<lastName>Strachan</lastName><city>London</city></person>";
-        template.sendBodyAndHeader(fileUri(testDirectory), body, Exchange.FILE_NAME, "hello.xml");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory), body, Exchange.FILE_NAME, "hello.xml");
 
         MockEndpoint.assertIsSatisfied(context);
 
@@ -60,7 +61,7 @@ public class XQueryFromFileExceptionTest extends CamelTestSupport {
         // the last tag is not ended properly
         String body = "<person user='James'><firstName>James</firstName>"
                       + "<lastName>Strachan</lastName><city>London</city></person";
-        template.sendBodyAndHeader(fileUri(testDirectory), body, Exchange.FILE_NAME, "hello2.xml");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory), body, Exchange.FILE_NAME, "hello2.xml");
 
         MockEndpoint.assertIsSatisfied(context);
 

--- a/components/camel-saxon/src/test/java/org/apache/camel/component/xquery/XQueryFromFileTest.java
+++ b/components/camel-saxon/src/test/java/org/apache/camel/component/xquery/XQueryFromFileTest.java
@@ -23,6 +23,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -41,7 +42,8 @@ public class XQueryFromFileTest extends CamelTestSupport {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
 
-        template.sendBodyAndHeader(fileUri(testDirectory), "<mail><subject>Hey</subject><body>Hello world!</body></mail>",
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory),
+                "<mail><subject>Hey</subject><body>Hello world!</body></mail>",
                 Exchange.FILE_NAME, "body.xml");
 
         MockEndpoint.assertIsSatisfied(context);
@@ -60,7 +62,7 @@ public class XQueryFromFileTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(fileUri(testDirectory))
+                from(TestSupport.fileUri(testDirectory))
                         .to("xquery:org/apache/camel/component/xquery/transform.xquery")
                         .to("mock:result");
             }

--- a/components/camel-saxon/src/test/java/org/apache/camel/component/xquery/XQueryLanguageFromFileTest.java
+++ b/components/camel-saxon/src/test/java/org/apache/camel/component/xquery/XQueryLanguageFromFileTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -42,11 +43,11 @@ public class XQueryLanguageFromFileTest extends CamelTestSupport {
         other.expectedMessageCount(1);
         other.message(0).body(String.class).contains("Bye World");
 
-        template.sendBodyAndHeader(fileUri(testDirectory),
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory),
                 "<mail from=\"davsclaus@apache.org\"><subject>Hey</subject><body>Hello World!</body></mail>",
                 Exchange.FILE_NAME, "claus.xml");
 
-        template.sendBodyAndHeader(fileUri(testDirectory),
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory),
                 "<mail from=\"janstey@apache.org\"><subject>Hey</subject><body>Bye World!</body></mail>",
                 Exchange.FILE_NAME, "janstey.xml");
 
@@ -58,7 +59,7 @@ public class XQueryLanguageFromFileTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(fileUri(testDirectory))
+                from(TestSupport.fileUri(testDirectory))
                         .choice()
                         .when().xquery("/mail/@from = 'davsclaus@apache.org'")
                         .convertBodyTo(String.class)

--- a/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/SplitGroupMultiXmlTokenTest.java
+++ b/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/SplitGroupMultiXmlTokenTest.java
@@ -23,6 +23,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.support.builder.Namespaces;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -43,7 +44,7 @@ public class SplitGroupMultiXmlTokenTest extends CamelTestSupport {
         mock.message(2).body().isEqualTo("<group><order id=\"5\" xmlns=\"http:acme.com\">Groovy in Action</order></group>");
 
         String body = createBody();
-        template.sendBodyAndHeader(fileUri(testDirectory), body, Exchange.FILE_NAME, "orders.xml");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory), body, Exchange.FILE_NAME, "orders.xml");
 
         MockEndpoint.assertIsSatisfied(context);
     }
@@ -68,7 +69,7 @@ public class SplitGroupMultiXmlTokenTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 // START SNIPPET: e1
-                from(fileUri(testDirectory, "?initialDelay=0&delay=10"))
+                from(TestSupport.fileUri(testDirectory, "?initialDelay=0&delay=10"))
                         // split the order child tags, and inherit namespaces from
                         // the orders root tag
                         .split().xtokenize("//order", 'i', ns, 2).to("log:split").to("mock:split");

--- a/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/SplitGroupWrappedMultiXmlTokenTest.java
+++ b/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/SplitGroupWrappedMultiXmlTokenTest.java
@@ -23,6 +23,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.support.builder.Namespaces;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -44,7 +45,7 @@ public class SplitGroupWrappedMultiXmlTokenTest extends CamelTestSupport {
                 "<?xml version=\"1.0\"?>\n<orders xmlns=\"http:acme.com\">\n  <order id=\"5\">Groovy in Action</order></orders>");
 
         String body = createBody();
-        template.sendBodyAndHeader(fileUri(testDirectory), body, Exchange.FILE_NAME, "orders.xml");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory), body, Exchange.FILE_NAME, "orders.xml");
 
         MockEndpoint.assertIsSatisfied(context);
     }
@@ -69,7 +70,7 @@ public class SplitGroupWrappedMultiXmlTokenTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 // START SNIPPET: e1
-                from(fileUri(testDirectory, "?initialDelay=0&delay=10"))
+                from(TestSupport.fileUri(testDirectory, "?initialDelay=0&delay=10"))
                         // split the order child tags, and inherit namespaces from
                         // the orders root tag
                         .split().xtokenize("//order", 'w', ns, 2).to("log:split").to("mock:split");

--- a/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/SpringXMLTokenSplitTest.java
+++ b/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/SpringXMLTokenSplitTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Paths;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.TestSupport;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractApplicationContext;
@@ -38,7 +39,7 @@ public class SpringXMLTokenSplitTest extends CamelSpringTestSupport {
         mock.message(2).body().isEqualTo("<order id=\"3\" xmlns=\"http:acme.com\">DSL in Action</order>");
 
         String body = createBody();
-        template.sendBodyAndHeader(fileUri(testDirectory, "xtokenizer"), body, Exchange.FILE_NAME, "orders.xml");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory, "xtokenizer"), body, Exchange.FILE_NAME, "orders.xml");
 
         MockEndpoint.assertIsSatisfied(context);
     }

--- a/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/XMLTokenSplitTest.java
+++ b/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/XMLTokenSplitTest.java
@@ -23,6 +23,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.support.builder.Namespaces;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -39,7 +40,7 @@ public class XMLTokenSplitTest extends CamelTestSupport {
         mock.message(2).body().isEqualTo("<order id=\"3\" xmlns=\"http:acme.com\">DSL in Action</order>");
 
         String body = createBody();
-        template.sendBodyAndHeader(fileUri(testDirectory, "xtokenizer"), body, Exchange.FILE_NAME, "orders.xml");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory, "xtokenizer"), body, Exchange.FILE_NAME, "orders.xml");
 
         MockEndpoint.assertIsSatisfied(context);
     }
@@ -53,7 +54,7 @@ public class XMLTokenSplitTest extends CamelTestSupport {
         mock.message(2).body().isEqualTo("<order id=\"3\" xmlns=\"http:acme.com\">DSL in Action</order>");
 
         String body = createBody();
-        template.sendBodyAndHeader(fileUri(testDirectory, "xtokenizer2"), body, Exchange.FILE_NAME, "orders.xml");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory, "xtokenizer2"), body, Exchange.FILE_NAME, "orders.xml");
 
         MockEndpoint.assertIsSatisfied(context);
     }
@@ -77,13 +78,13 @@ public class XMLTokenSplitTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 // START SNIPPET: e1
-                from(fileUri(testDirectory, "xtokenizer?initialDelay=0&delay=10"))
+                from(TestSupport.fileUri(testDirectory, "xtokenizer?initialDelay=0&delay=10"))
                         // split the order child tags, and inherit namespaces from
                         // the orders root tag
                         .split().xtokenize("//orders/order", ns).to("mock:split");
                 // END SNIPPET: e1
 
-                from(fileUri(testDirectory, "xtokenizer2?initialDelay=0&delay=10"))
+                from(TestSupport.fileUri(testDirectory, "xtokenizer2?initialDelay=0&delay=10"))
                         // split the order child tags, and inherit namespaces from
                         // the orders root tag
                         .split(body().xtokenize("//orders/order", ns)).to("mock:split");

--- a/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/XMLTokenizeLanguageStreamingFileTest.java
+++ b/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/XMLTokenizeLanguageStreamingFileTest.java
@@ -23,6 +23,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.support.builder.Namespaces;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -44,7 +45,7 @@ public class XMLTokenizeLanguageStreamingFileTest extends CamelTestSupport {
                   + "<c:child some_attr='b' anotherAttr='b'></c:child>" + "<c:child some_attr='c' anotherAttr='c'></c:child>"
                   + "<c:child some_attr='d' anotherAttr='d'></c:child>" + "</c:parent>";
 
-        template.sendBodyAndHeader(fileUri(testDirectory), body, Exchange.FILE_NAME, "myxml.xml");
+        template.sendBodyAndHeader(TestSupport.fileUri(testDirectory), body, Exchange.FILE_NAME, "myxml.xml");
 
         MockEndpoint.assertIsSatisfied(context);
     }
@@ -55,7 +56,7 @@ public class XMLTokenizeLanguageStreamingFileTest extends CamelTestSupport {
             Namespaces ns = new Namespaces("C", "urn:c");
 
             public void configure() {
-                from(fileUri(testDirectory, "?initialDelay=0&delay=10")).split().xtokenize("//C:child", ns).streaming()
+                from(TestSupport.fileUri(testDirectory, "?initialDelay=0&delay=10")).split().xtokenize("//C:child", ns).streaming()
                         .to("mock:result").end();
             }
         };

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -17,7 +17,6 @@
 package org.apache.camel.test.junit5;
 
 import java.lang.annotation.Annotation;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -1049,13 +1048,4 @@ public abstract class CamelTestSupport
         }
     }
 
-    @Deprecated
-    protected static String fileUri(Path testDirectory) {
-        return "file:" + testDirectory;
-    }
-
-    @Deprecated
-    protected static String fileUri(Path testDirectory, String query) {
-        return "file:" + testDirectory + (query.startsWith("?") ? "" : "/") + query;
-    }
 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/TestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/TestSupport.java
@@ -596,4 +596,12 @@ public final class TestSupport {
                 .getResource(String.format("%s%s", FactoryFinder.DEFAULT_PATH, Debugger.FACTORY))
                != null;
     }
+
+    public static String fileUri(Path testDirectory) {
+        return "file:" + testDirectory;
+    }
+
+    public static String fileUri(Path testDirectory, String query) {
+        return "file:" + testDirectory + (query.startsWith("?") ? "" : "/") + query;
+    }
 }


### PR DESCRIPTION
This is a leftover from CAMEL-18575 and moves a generic utility method out of CamelTestSupport.