### PR TITLE
CAMEL-18860: java-joor-dsl - Adapt the code for native compilation

### DIFF
--- a/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/ClassRoutesBuilderLoader.java
+++ b/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/ClassRoutesBuilderLoader.java
@@ -31,9 +31,10 @@ import org.apache.camel.spi.CompilePostProcessor;
 import org.apache.camel.spi.Resource;
 import org.apache.camel.spi.ResourceAware;
 import org.apache.camel.spi.annotations.RoutesLoader;
-import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.camel.dsl.java.joor.Helper.asClassName;
 
 @ManagedResource(description = "Managed ClassRoutesBuilderLoader")
 @RoutesLoader(ClassRoutesBuilderLoader.EXTENSION)
@@ -98,18 +99,5 @@ public class ClassRoutesBuilderLoader extends ExtendedRouteBuilderLoaderSupport 
         }
 
         return answer;
-    }
-
-    private static String asClassName(Resource resource) {
-        String className = resource.getLocation();
-        if (className.contains(":")) {
-            // remove scheme such as classpath:foo.class
-            className = StringHelper.after(className, ":");
-        }
-        className = className.replace('/', '.');
-        if (className.endsWith(".class")) {
-            className = className.substring(0, className.length() - 6);
-        }
-        return className;
     }
 }

--- a/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/Helper.java
+++ b/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/Helper.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.java.joor;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.camel.spi.Resource;
+import org.apache.camel.support.ResourceHelper;
+import org.apache.camel.util.FileUtil;
+import org.apache.camel.util.StringHelper;
+
+/**
+ * A helper class allowing to reuse part of the code outside of Camel easily.
+ */
+public final class Helper {
+
+    private static final Pattern PACKAGE_PATTERN = Pattern.compile(
+            "^\\s*package\\s+([a-zA-Z][.\\w]*)\\s*;.*$", Pattern.MULTILINE);
+
+    private Helper() {
+
+    }
+
+    /**
+     * @return the name of the class according to its location.
+     */
+    public static String asClassName(Resource resource) {
+        String className = resource.getLocation();
+        if (className.contains(":")) {
+            // remove scheme such as classpath:foo.class
+            className = StringHelper.after(className, ":");
+        }
+        assert className != null;
+        className = className.replace('/', '.');
+        if (className.endsWith(".class")) {
+            className = className.substring(0, className.length() - 6);
+        }
+        return className;
+    }
+
+    /**
+     * @return the name of the class according to its location and its source code.
+     */
+    public static String determineName(Resource resource, String content) {
+        String loc = resource.getLocation();
+        // strip scheme to compute the name
+        String scheme = ResourceHelper.getScheme(loc);
+        if (scheme != null) {
+            loc = loc.substring(scheme.length());
+        }
+        final String name = FileUtil.onlyName(loc, true);
+        final Matcher matcher = PACKAGE_PATTERN.matcher(content);
+
+        return matcher.find()
+                ? matcher.group(1) + "." + name
+                : name;
+    }
+}

--- a/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/JavaJoorClassLoader.java
+++ b/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/JavaJoorClassLoader.java
@@ -31,13 +31,12 @@ public class JavaJoorClassLoader extends ClassLoader implements CompilePostProce
     }
 
     @Override
-    protected Class<?> findClass(String name) throws ClassNotFoundException {
+    protected Class<?> findClass(String name) {
         return classes.get(name);
     }
 
     @Override
-    public void postCompile(CamelContext camelContext, String name, Class<?> clazz, byte[] byteCode, Object instance)
-            throws Exception {
+    public void postCompile(CamelContext camelContext, String name, Class<?> clazz, byte[] byteCode, Object instance) {
         if (name != null && clazz != null) {
             classes.put(name, clazz);
         }

--- a/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/JavaRoutesBuilderLoader.java
+++ b/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/JavaRoutesBuilderLoader.java
@@ -27,8 +27,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
@@ -45,19 +43,18 @@ import org.apache.camel.spi.ResourceAware;
 import org.apache.camel.spi.annotations.RoutesLoader;
 import org.apache.camel.support.ResourceHelper;
 import org.apache.camel.support.RouteWatcherReloadStrategy;
-import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.camel.dsl.java.joor.Helper.determineName;
 
 @ManagedResource(description = "Managed JavaRoutesBuilderLoader")
 @RoutesLoader(JavaRoutesBuilderLoader.EXTENSION)
 public class JavaRoutesBuilderLoader extends ExtendedRouteBuilderLoaderSupport {
 
     public static final String EXTENSION = "java";
-    public static final Pattern PACKAGE_PATTERN = Pattern.compile(
-            "^\\s*package\\s+([a-zA-Z][\\.\\w]*)\\s*;.*$", Pattern.MULTILINE);
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaRoutesBuilderLoader.class);
 
@@ -69,7 +66,7 @@ public class JavaRoutesBuilderLoader extends ExtendedRouteBuilderLoaderSupport {
     protected void doBuild() throws Exception {
         super.doBuild();
 
-        // register joor classloader to camel so we are able to load classes we have compiled
+        // register jOOR classloader to camel, so we are able to load classes we have compiled
         CamelContext context = getCamelContext();
         if (context != null) {
             JavaJoorClassLoader cl = new JavaJoorClassLoader();
@@ -220,21 +217,6 @@ public class JavaRoutesBuilderLoader extends ExtendedRouteBuilderLoaderSupport {
                 LOG.warn("Error saving compiled class: {} as bytecode to file: {} due to {}", name, target, e.getMessage());
             }
         }
-    }
-
-    private static String determineName(Resource resource, String content) {
-        String loc = resource.getLocation();
-        // strip scheme to compute the name
-        String scheme = ResourceHelper.getScheme(loc);
-        if (scheme != null) {
-            loc = loc.substring(scheme.length());
-        }
-        final String name = FileUtil.onlyName(loc, true);
-        final Matcher matcher = PACKAGE_PATTERN.matcher(content);
-
-        return matcher.find()
-                ? matcher.group(1) + "." + name
-                : name;
     }
 
 }

--- a/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/MultiCompile.java
+++ b/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/MultiCompile.java
@@ -72,6 +72,17 @@ public final class MultiCompile {
      * @return      the compilation result
      */
     public static CompilationUnit.Result compileUnit(CompilationUnit unit) {
+        return compileUnit(unit, new ArrayList<>());
+    }
+
+    /**
+     * Compiles multiple files as one unit
+     *
+     * @param  unit    the files to compile in the same unit
+     * @param  options the compilation options to use
+     * @return         the compilation result
+     */
+    public static CompilationUnit.Result compileUnit(CompilationUnit unit, List<String> options) {
         CompilationUnit.Result result = CompilationUnit.result();
 
         // some classes may already be compiled so try to load them first
@@ -91,10 +102,6 @@ public final class MultiCompile {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
         try {
-            ClassFileManager fileManager = new ClassFileManager(compiler.getStandardFileManager(null, null, null));
-            StringWriter out = new StringWriter();
-
-            List<String> options = new ArrayList<>();
             if (!options.contains("-classpath")) {
                 StringBuilder classpath = new StringBuilder();
                 String separator = System.getProperty("path.separator");
@@ -121,16 +128,18 @@ public final class MultiCompile {
                 }
 
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Java JooR Compile -classpath: {}", classpath);
+                    LOG.debug("Java jOOR Compile -classpath: {}", classpath);
                 }
                 options.addAll(Arrays.asList("-classpath", classpath.toString()));
             }
 
             DiagnosticCollector<javax.tools.JavaFileObject> dc = new DiagnosticCollector<>();
+            ClassFileManager fileManager = new ClassFileManager(compiler.getStandardFileManager(null, null, null));
+            StringWriter out = new StringWriter();
             CompilationTask task = compiler.getTask(out, fileManager, dc, options, null, files);
 
             boolean success = task.call();
-            // after compilation then we need to cleanup some unexpected output
+            // after compilation then we need to clean up some unexpected output
             cleanupWaste();
 
             if (!success || fileManager.isEmpty()) {


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-18860

## Motivation

To ease the native compilation of routes written using the Java DSL, we need to adapt the code to be able to reuse some parts of the existing code.

## Modifications

* Move the reusable methods `asClassName` and `determineName` to a helper class
* Allow providing compilation options when compiling to give the ability to set the classpath
* Fix some violations
