### PR TITLE
CAMEL-18620: Fix Redpanda integration tests

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepository.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepository.java
@@ -399,6 +399,10 @@ public class KafkaIdempotentRepository extends ServiceSupport implements Idempot
         return topicPoller.isRunning();
     }
 
+    public boolean isCacheReady() {
+        return cacheReadyLatch.getCount() == 0;
+    }
+
     private class TopicPoller implements Runnable {
 
         private final Logger log = LoggerFactory.getLogger(this.getClass());

--- a/components/camel-kafka/src/test/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepositoryPersistenceIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepositoryPersistenceIT.java
@@ -89,6 +89,7 @@ public class KafkaIdempotentRepositoryPersistenceIT extends BaseEmbeddedKafkaTes
     @Test
     @DisplayName("Checks that half of the messages pass and duplicates are blocked")
     public void testFirstPassFiltersAsExpected() {
+        await().until(() -> kafkaIdempotentRepository.isCacheReady());
         int count = 10;
         sendMessages(count);
 

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/RedpandaTransactionsEnabledContainer.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/RedpandaTransactionsEnabledContainer.java
@@ -22,7 +22,7 @@ import org.testcontainers.redpanda.RedpandaContainer;
 
 public class RedpandaTransactionsEnabledContainer extends RedpandaContainer {
 
-    public static final String DEFAULT_REDPANDA_CONTAINER = "docker.redpanda.com/vectorized/redpanda:v22.3.9";
+    public static final String DEFAULT_REDPANDA_CONTAINER = "docker.redpanda.com/vectorized/redpanda:v22.3.10";
     public static final String REDPANDA_CONTAINER
             = System.getProperty("itest.redpanda.container.image", DEFAULT_REDPANDA_CONTAINER);
     public static final int REDPANDA_PORT = 9092;
@@ -33,10 +33,7 @@ public class RedpandaTransactionsEnabledContainer extends RedpandaContainer {
 
     protected void containerIsStarting(InspectContainerResponse containerInfo) {
         super.containerIsStarting(containerInfo);
-
         String command = "#!/bin/bash\n";
-        // enable transactions
-        command += "/usr/bin/rpk redpanda config set redpanda.enable_transactions true\n";
 
         command += "/usr/bin/rpk redpanda start --mode dev-container ";
         command += "--kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092 ";


### PR DESCRIPTION
Updates the Redpanda container image to 22.3.10 which enables transactions by default and sets consumer group init delay to 0 to avoid initial consumption delays seen in tests.

Additionally 22.3.10 includes better broker side coordination when creating topics with autocreate set to true which was causing test races.

More details here: https://github.com/redpanda-data/redpanda/issues/7084

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->
