### PR TITLE
[CAMEL-4616] camel-jms: test not loosing messages in async TX sends

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/AsyncJmsProducerExceptionInTXTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/AsyncJmsProducerExceptionInTXTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jms.issues;
+
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
+import org.apache.xbean.spring.context.ClassPathXmlApplicationContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.transaction.TransactionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @see <a href="https://issues.apache.org/jira/browse/CAMEL-4616">CAMEL-4616</a>
+ * @see <a href="https://activemq.apache.org/producer-flow-control.html">ActiveMQ flow control</a>
+ */
+class AsyncJmsProducerExceptionInTXTest extends CamelSpringTestSupport {
+
+    @BeforeAll
+    static void setSystemProperties() {
+        // configure classpath:org/apache/camel/component/jms/issues/broker.xml
+        System.setProperty("producer-flow-control", "true");
+        System.setProperty("send-fail-if-no-space", "true");
+    }
+
+    @Override
+    protected AbstractApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext(
+                new String[] {
+                        "classpath:org/apache/camel/component/jms/issues/broker.xml",
+                        "classpath:org/apache/camel/component/jms/issues/camelBrokerClient.xml" });
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:transacted_start")
+                        .transacted()
+                        // send first 251 kb - need to exceed 500 kb in at least two steps as ActiveMQ doesn't fail in one step
+                        .setBody(constant("X".repeat(251 * 1024)))
+                        .to("direct:jmsProducerEndpoint")
+                        // send second 251 kb to exceed 500 kb and so to trigger ResourceAllocationException
+                        .setBody(constant("Y".repeat(251 * 1024)))
+                        .to("direct:jmsProducerEndpoint");
+
+                from("direct:jmsProducerEndpoint")
+                        // deliveryMode=1 (NON_PERSISTENT) to use Async Sends - generally speaking, producers of non-persistent messages
+                        .to("activemq:queue:AsyncJmsProducerExceptionInTXTest?deliveryMode=1");
+
+                from("direct:non_transacted_start")
+                        .setBody(constant("X".repeat(251 * 1024)))
+                        .to("direct:jmsProducerEndpoint")
+                        .setBody(constant("Y".repeat(251 * 1024)))
+                        .to("direct:jmsProducerEndpoint");
+            }
+        };
+    }
+
+    @Test
+    void testAsyncEndpointException() {
+        try {
+            template.sendBody("direct:transacted_start", null);
+            fail("transaction should fail, otherwise looks like CAMEL-4616 has been emerged!");
+        } catch (CamelExecutionException e) {
+            Throwable cause = e.getCause();
+            assertTrue(cause instanceof TransactionException);
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            assertEquals(
+                    "Usage Manager Memory Limit reached on queue://AsyncJmsProducerExceptionInTXTest. See http://activemq.apache.org/producer-flow-control.html for more info",
+                    cause.getMessage());
+        }
+
+        // non-transacted not fail assertion
+        template.sendBody("direct:non_transacted_start", null);
+    }
+}

--- a/components/camel-jms/src/test/resources/org/apache/camel/component/jms/issues/broker.xml
+++ b/components/camel-jms/src/test/resources/org/apache/camel/component/jms/issues/broker.xml
@@ -27,6 +27,8 @@
 			http://activemq.apache.org/schema/core/activemq-core.xsd
 	">
 
+    <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer" />
+
     <amq:broker brokerName="myBroker"
                 id="broker"
                 useJmx="false"
@@ -41,9 +43,10 @@
                                      minimumMessageSize="1"
                                      optimizedDispatch="true"
                                      lazyDispatch="false"
-                                     producerFlowControl="false"
+                                     producerFlowControl="${producer-flow-control:false}"
                                      memoryLimit="500 kb"
-                                     strictOrderDispatch="true">
+                                     strictOrderDispatch="true"
+                                     sendFailIfNoSpace="${send-fail-if-no-space:false}">
                         <amq:dispatchPolicy>
                             <amq:strictOrderDispatchPolicy/>
                         </amq:dispatchPolicy>

--- a/components/camel-jms/src/test/resources/org/apache/camel/component/jms/issues/camelBrokerClient.xml
+++ b/components/camel-jms/src/test/resources/org/apache/camel/component/jms/issues/camelBrokerClient.xml
@@ -28,12 +28,16 @@ http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/came
         <template id="template"/>
     </camelContext>
 
-    <bean id="activemq" class="org.apache.camel.component.jms.JmsComponent">
-     <property name="connectionFactory">
-       <bean class="org.apache.activemq.ActiveMQConnectionFactory">
+    <bean class="org.apache.activemq.ActiveMQConnectionFactory" id="activeMQConnectionFactory">
         <property name="brokerURL" value="vm://myBroker"/>
-       </bean>
-     </property>
     </bean>
 
+    <bean id="activemq" class="org.apache.camel.component.jms.JmsComponent">
+        <property name="connectionFactory" ref="activeMQConnectionFactory" />
+    </bean>
+
+    <!-- setup spring jms TX manager -->
+    <bean id="jmsTransactionManager" class="org.springframework.jms.connection.JmsTransactionManager">
+        <property name="connectionFactory" ref="activeMQConnectionFactory"/>
+    </bean>
 </beans>


### PR DESCRIPTION
Invalidates CAMEL-4616.

I think that the test provided by this PR proves that camel JMS doesn't loose messages in transaction when AtiveMQ uses `async send` internally and also asynchronously fails. See the test comments to understand what the pull request does, how, and why.