### PR TITLE
CAMEL-18839: reverts upgrade to Kafka 3.3.1

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -343,7 +343,7 @@
         <jython-version>2.7.3</jython-version>
         <jython-standalone-version>2.7.3</jython-standalone-version>
         <jzlib-version>1.1.3</jzlib-version>
-        <kafka-version>3.3.1</kafka-version>
+        <kafka-version>3.2.3</kafka-version>
         <kafka-vertx-version>2.8.2</kafka-vertx-version>
         <kotlin-version>1.7.22</kotlin-version>
         <kubernetes-client-version>6.3.1</kubernetes-client-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -338,7 +338,7 @@
         <jython-version>2.7.3</jython-version>
         <jython-standalone-version>2.7.3</jython-standalone-version>
         <jzlib-version>1.1.3</jzlib-version>
-        <kafka-version>3.3.1</kafka-version>
+        <kafka-version>3.2.3</kafka-version>
         <kafka-vertx-version>2.8.2</kafka-vertx-version>
         <kotlin-version>1.7.22</kotlin-version>
         <kubernetes-client-version>6.3.1</kubernetes-client-version>


### PR DESCRIPTION
The upgrade breaks the idempotent repository due to KAFKA-14553.

Ref.: 8738cb71bc387ca1d55ed775726f5b8bcea58a5b