### PR TITLE
Solving TODO in AS2 component

### DIFF
--- a/components/camel-as2/camel-as2-component/src/main/java/org/apache/camel/component/as2/AS2Consumer.java
+++ b/components/camel-as2/camel-as2-component/src/main/java/org/apache/camel/component/as2/AS2Consumer.java
@@ -43,6 +43,8 @@ import org.apache.http.protocol.HttpRequestHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.util.Optional.ofNullable;
+
 /**
  * The AS2 consumer.
  *
@@ -115,9 +117,8 @@ public class AS2Consumer extends AbstractApiConsumer<AS2ApiName, AS2Configuratio
         try {
             if (request instanceof HttpEntityEnclosingRequest) {
                 EntityParser.parseAS2MessageEntity(request);
-                // TODO derive last to parameters from configuration.
-                apiProxy.handleMDNResponse(context, "MDN Response",
-                        "Camel AS2 Server Endpoint");
+                apiProxy.handleMDNResponse(context, getEndpoint().getSubject(),
+                        ofNullable(getEndpoint().getFrom()).orElse(getEndpoint().getConfiguration().getServer()));
             }
 
             ApplicationEDIEntity ediEntity

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ServerManagerIT.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ServerManagerIT.java
@@ -207,7 +207,7 @@ public class AS2ServerManagerIT extends AbstractAS2ITSupport {
         assertEquals(EDI_MESSAGE.replaceAll("[\n\r]", ""), rcvdMessageFromBody.replaceAll("[\n\r]", ""),
                 "EDI message does not match");
     }
-
+    
     @Test
     public void receiveMultipartSignedMessageTest() throws Exception {
 
@@ -378,6 +378,30 @@ public class AS2ServerManagerIT extends AbstractAS2ITSupport {
         String errorMessage = new String(Streams.readAll(responseEntity.getContent()));
         assertEquals(EXPECTED_EXCEPTION_MSG, errorMessage, "");
     }
+    
+    @Test
+    public void checkMDNTest() throws Exception {
+        AS2ClientConnection clientConnection
+                = new AS2ClientConnection(AS2_VERSION, USER_AGENT, CLIENT_FQDN, TARGET_HOST, TARGET_PORT);
+        AS2ClientManager clientManager = new AS2ClientManager(clientConnection);
+        
+        //Testing MDN parameter defaults
+        HttpCoreContext response=clientManager.send(EDI_MESSAGE, REQUEST_URI, SUBJECT, FROM, AS2_NAME, AS2_NAME, AS2MessageStructure.PLAIN,
+                ContentType.create(AS2MediaType.APPLICATION_EDIFACT, StandardCharsets.US_ASCII), null, null, null, null,
+                null, DISPOSITION_NOTIFICATION_TO, SIGNED_RECEIPT_MIC_ALGORITHMS, null, null, null);
+        
+        assertEquals(new AS2Configuration().getServer(), response.getResponse().getFirstHeader(AS2Header.FROM).getValue(), "Default value for From header not set");
+        assertEquals("MDN Response To:" + SUBJECT, response.getResponse().getFirstHeader(AS2Header.SUBJECT).getValue(), "Default value for Subject header not set");
+        
+        //Testing MDN parameter overwrites
+         response=clientManager.send(EDI_MESSAGE, REQUEST_URI+"mdnTest", SUBJECT, FROM, AS2_NAME, AS2_NAME, AS2MessageStructure.PLAIN,
+                ContentType.create(AS2MediaType.APPLICATION_EDIFACT, StandardCharsets.US_ASCII), null, null, null, null,
+                null, DISPOSITION_NOTIFICATION_TO, SIGNED_RECEIPT_MIC_ALGORITHMS, null, null, null);
+        
+        assertEquals("MdnTestFrom", response.getResponse().getFirstHeader(AS2Header.FROM).getValue(), "Configured value for From header not set");
+        assertEquals("MdnTestSubjectPrefix" + SUBJECT, response.getResponse().getFirstHeader(AS2Header.SUBJECT).getValue(), "Configured value for Subject header not set");
+    }
+
 
     private static void setupSigningGenerator() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
@@ -462,6 +486,9 @@ public class AS2ServerManagerIT extends AbstractAS2ITSupport {
                         .process(failingProcessor)
                         .to("mock:as2RcvMsgs");
 
+                // test route for listen with custom MDN parameters
+                from("as2://" + PATH_PREFIX + "/listen?requestUriPattern=/mdnTest&from=MdnTestFrom&subject=MdnTestSubjectPrefix")
+                        .to("mock:as2RcvMsgs");
             }
         };
     }


### PR DESCRIPTION
I found that the MDN that is sent from the AS2 server component has fixed header values for From and the Subject-prefix.
Looking in the code for AS2Consumer, I saw a TODO to read this values from configuration.

# Description

I've solved the TODO by reading the "From" value from the configuration field "from" with a fallback to the configuration field "server". So if nothing is configured for the endpoint, the value is nearly the same as before.
For the Subject-prefix I'm reading the "subject" from the configuration. If not configured on the endpoint, null is taken as value. This should be OK because the class ResponseMDN already has a fallback for generating the subject when the prefix is null.

Also I've added a unit test in AS2ServerManagerIT to test the default values and overrides from the endpoint configuration.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`


