### PR TITLE
camel-resilience4j - Upgrade to 2.x

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -451,7 +451,7 @@
         <reactor-version>3.5.1</reactor-version>
         <reactor-netty-version>1.1.1</reactor-netty-version>
         <redisson-version>3.16.7</redisson-version>
-        <resilience4j-version>1.7.1</resilience4j-version>
+        <resilience4j-version>2.0.2</resilience4j-version>
         <rest-assured-version>4.5.1</rest-assured-version>
         <roaster-version>2.26.0.Final</roaster-version>
         <robotframework-version>4.1.2</robotframework-version>

--- a/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceProcessor.java
+++ b/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceProcessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.resilience4j;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -386,7 +387,7 @@ public class ResilienceProcessor extends AsyncProcessorSupport
 
     @ManagedAttribute
     public long getCircuitBreakerWaitDurationInOpenState() {
-        return circuitBreakerConfig.getWaitDurationInOpenState().getSeconds();
+        return Duration.ofMillis(circuitBreakerConfig.getWaitIntervalFunctionInOpenState().apply(1)).getSeconds();
     }
 
     @ManagedAttribute

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -446,7 +446,7 @@
         <reactor-version>3.5.1</reactor-version>
         <reactor-netty-version>1.1.1</reactor-netty-version>
         <redisson-version>3.16.7</redisson-version>
-        <resilience4j-version>1.7.1</resilience4j-version>
+        <resilience4j-version>2.0.2</resilience4j-version>
         <rest-assured-version>4.5.1</rest-assured-version>
         <roaster-version>2.26.0.Final</roaster-version>
         <robotframework-version>4.1.2</robotframework-version>


### PR DESCRIPTION
# Description

camel-resilience4j - Upgrade to 2.x
https://issues.apache.org/jira/browse/CAMEL-18738

They removed a deprecated method, it was doing under : 
```Duration.ofMillis(waitIntervalFunctionInOpenState.apply(1));```

