### PR TITLE
CAMEL-18780: Prevent blocking sqs consumer when using message extend

### DIFF
--- a/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/SqsConsumerExtendMessageVisibilityTest.java
+++ b/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/SqsConsumerExtendMessageVisibilityTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.sqs;
+
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SqsConsumerExtendMessageVisibilityTest extends CamelTestSupport {
+
+    private static final int TIMEOUT = 2; // 2 seconds.
+    private static final String RECEIPT_HANDLE = "0NNAq8PwvXsyZkR6yu4nQ07FGxNmOBWi5";
+
+    @EndpointInject("mock:result")
+    private MockEndpoint mock;
+
+    @BindToRegistry("amazonSQSClient")
+    private AmazonSQSClientMock client = new AmazonSQSClientMock();
+
+    @Test
+    public void extendVisiblityForLongTask() throws Exception {
+        this.mock.expectedMessageCount(1);
+        this.mock.whenAnyExchangeReceived(new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                // Simulate message that takes a while to receive.
+                Thread.sleep(TIMEOUT * 1500L); // 150% of TIMEOUT.
+            }
+        });
+
+        Message.Builder message = Message.builder();
+        message.body("Message 1");
+        message.md5OfBody("6a1559560f67c5e7a7d5d838bf0272ee");
+        message.messageId("f6fb6f99-5eb2-4be4-9b15-144774141458");
+        message.receiptHandle(RECEIPT_HANDLE);
+        this.client.messages.add(message.build());
+
+        // Wait for message to arrive.
+        MockEndpoint.assertIsSatisfied(context);
+
+        assertTrue(this.client.changeMessageVisibilityRequests.size() >= 1);
+        assertTrue(this.client.changeMessageVisibilityRequests.size() <= 3);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("aws2-sqs://MyQueue?amazonSQSClient=#amazonSQSClient&visibilityTimeout=" + TIMEOUT
+                     + "&extendMessageVisibility=true").to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
# Description
When using message extending feature together with Threads EIP, it was possible to completely block the consumer (deadlock) if the message extend executor task queue would be filled up.

This could be triggered by the default threads profile where the message queue size is set to 1000 tasks.

On default settings, the consumer would consume: `max queue size`+`max threads`+`consumer thread` = 1000+20+1 concurrent tasks. The extender queue size however is only 1000. The `consumer thread` is due to `CallerRuns` policy.

There is no way to register that the consumer is called from a route which uses threads EIP, and thus we have two options for preventing this blocking behavior. Either increase the maxQueue size to something very high - or make it unbound.

I went with the latter as I believe it to be safe as the queue will be constrained by the thread profile of the route at all times and thus cannot grow unbounded, except if the outer profile is configured without a limit.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

