### PR TITLE
CAMEL-18932: fixed camel-pulsar tests due to sl4fj upgrade

### DIFF
--- a/components/camel-pulsar/pom.xml
+++ b/components/camel-pulsar/pom.xml
@@ -72,7 +72,14 @@
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
-        </dependency>
+    	</dependency>
+
+    	<dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2-version}</version>
+            <scope>test</scope>
+    	</dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This fixes the pulsar errors caused by the upgrade to SL4F 2.

*Note*: there's a few failures that have been [caused by the upgrade to Pulsar 2.11.0](https://ci-builds.apache.org/job/Camel/job/Camel%20JDK17/job/main/521/) and still need to be fixed.