### PR TITLE
Update dependencies for Spring Boot 2.7.8 update

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -196,7 +196,7 @@
     <flink-version>1.15.0</flink-version>
     <fop-version>2.7</fop-version>
     <formatter-maven-plugin-version>2.17.1</formatter-maven-plugin-version>
-    <freemarker-version>2.3.31</freemarker-version>
+    <freemarker-version>2.3.32</freemarker-version>
     <ftpserver-version>1.1.2</ftpserver-version>
     <geronimo-annotation-1.0-spec-version>1.1.1</geronimo-annotation-1.0-spec-version>
     <geronimo-annotation-1.2-spec-version>1.0</geronimo-annotation-1.2-spec-version>
@@ -403,7 +403,7 @@
     <maven-shade-plugin-version>3.2.3</maven-shade-plugin-version>
     <maven-surefire-report-plugin-version>3.0.0-M4</maven-surefire-report-plugin-version>
     <maven-war-plugin-version>3.3.1</maven-war-plugin-version>
-    <metrics-version>4.2.13</metrics-version>
+    <metrics-version>4.2.15</metrics-version>
     <micrometer-version>1.10.2</micrometer-version>
     <microprofile-config-version>2.0.1</microprofile-config-version>
     <microprofile-fault-tolerance-version>3.0</microprofile-fault-tolerance-version>
@@ -428,7 +428,7 @@
     <nessus-ipfs-version>1.0.0.Beta4</nessus-ipfs-version>
     <nessus-weka-version>1.0.1</nessus-weka-version>
     <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
-    <netty-version>4.1.85.Final</netty-version>
+    <netty-version>4.1.87.Final</netty-version>
     <networknt-json-schema-validator-version>1.0.69</networknt-json-schema-validator-version>
     <nimbus-jose-jwt>9.22</nimbus-jose-jwt>
     <nitrite-version>3.4.4</nitrite-version>
@@ -557,7 +557,7 @@
     <xml-resolver-version>1.2</xml-resolver-version>
     <xmlgraphics-batik-version>1.14</xmlgraphics-batik-version>
     <xmlsec-version>2.2.3</xmlsec-version>
-    <xmlunit-version>2.9.0</xmlunit-version>
+    <xmlunit-version>2.9.1</xmlunit-version>
     <xpp3-version>1.1.4c</xpp3-version>
     <xstream-version>1.4.20</xstream-version>
     <yetus-audience-annotations-version>0.13.0</yetus-audience-annotations-version>


### PR DESCRIPTION
The change updates the dependencies to support the Spring Boot 2.7.8 update: https://github.com/apache/camel-spring-boot/pull/711.