### PR TITLE
Simplify creation of SSL context for WireMock Jetty server.

### DIFF
--- a/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/HttpsTest.java
+++ b/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/HttpsTest.java
@@ -67,7 +67,7 @@ public abstract class HttpsTest extends CamelTestSupport {
     protected static WireMockServer petstore = new WireMockServer(
             wireMockConfig().httpServerFactory(new WireMockJettyServerFactory()).containerThreads(13).dynamicPort()
                     .dynamicHttpsPort().keystorePath(Resources.getResource("localhost.p12").toString()).keystoreType("PKCS12")
-                    .keystorePassword("changeit"));
+                    .keystorePassword("changeit").keyManagerPassword("changeit"));
 
     static final Object NO_BODY = null;
 

--- a/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/HttpsV3Test.java
+++ b/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/HttpsV3Test.java
@@ -67,7 +67,7 @@ public abstract class HttpsV3Test extends CamelTestSupport {
     public static WireMockServer petstore = new WireMockServer(
             wireMockConfig().httpServerFactory(new WireMockJettyServerFactory()).containerThreads(13).dynamicPort()
                     .dynamicHttpsPort().keystorePath(Resources.getResource("localhost.p12").toString()).keystoreType("PKCS12")
-                    .keystorePassword("changeit"));
+                    .keystorePassword("changeit").keyManagerPassword("changeit"));
 
     static final Object NO_BODY = null;
 

--- a/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/WireMockJettyServerFactory.java
+++ b/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/WireMockJettyServerFactory.java
@@ -16,21 +16,12 @@
  */
 package org.apache.camel.component.rest.openapi;
 
-import com.github.tomakehurst.wiremock.common.HttpsSettings;
-import com.github.tomakehurst.wiremock.common.JettySettings;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
 import com.github.tomakehurst.wiremock.http.HttpServer;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.github.tomakehurst.wiremock.jetty.JettyHttpServer;
 import com.github.tomakehurst.wiremock.jetty.JettyHttpServerFactory;
-import org.eclipse.jetty.io.NetworkTrafficListener;
-import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.server.HttpConnectionFactory;
-import org.eclipse.jetty.server.SecureRequestCustomizer;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 /**
@@ -44,32 +35,11 @@ public final class WireMockJettyServerFactory extends JettyHttpServerFactory {
 
         return new JettyHttpServer(options, adminRequestHandler, stubRequestHandler) {
             @Override
-            protected ServerConnector createHttpsConnector(
-                    Server server,
-                    final String bindAddress, final HttpsSettings httpsSettings,
-                    final JettySettings jettySettings, final NetworkTrafficListener listener) {
-                final SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
-
-                sslContextFactory.setKeyStorePath(httpsSettings.keyStorePath());
-                sslContextFactory.setKeyManagerPassword(httpsSettings.keyStorePassword());
-                sslContextFactory.setKeyStorePassword(httpsSettings.keyStorePassword());
-                sslContextFactory.setKeyStoreType(httpsSettings.keyStoreType());
-                if (httpsSettings.hasTrustStore()) {
-                    sslContextFactory.setTrustStorePath(httpsSettings.trustStorePath());
-                    sslContextFactory.setTrustStorePassword(httpsSettings.trustStorePassword());
-                    sslContextFactory.setTrustStoreType(httpsSettings.trustStoreType());
-                }
-                sslContextFactory.setNeedClientAuth(httpsSettings.needClientAuth());
+            protected SslContextFactory.Server buildSslContextFactory() {
+                SslContextFactory.Server sslContextFactory = super.buildSslContextFactory();
                 sslContextFactory.setIncludeCipherSuites("TLS_DHE_RSA_WITH_AES_128_GCM_SHA256");
                 sslContextFactory.setProtocol("TLSv1.3");
-
-                final HttpConfiguration httpConfig = createHttpConfig(jettySettings);
-                httpConfig.addCustomizer(new SecureRequestCustomizer());
-
-                final int port = httpsSettings.port();
-
-                return createServerConnector(bindAddress, jettySettings, port, listener,
-                        new SslConnectionFactory(sslContextFactory, "http/1.1"), new HttpConnectionFactory(httpConfig));
+                return sslContextFactory;
             }
         };
     }


### PR DESCRIPTION
Use the method JettyHttpServer.buildSslContextFactory in the new WireMock version to avoid having to override createHttpConnector.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

