### PR TITLE
CAMEL-18961 change sun-mail to angus-mail

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -272,7 +272,6 @@
         <jakarta-el-expressly-version>5.0.0</jakarta-el-expressly-version>
         <jakarta-activation-version>2.1.1</jakarta-activation-version>
         <jakarta-annotation-api-version>2.1.1</jakarta-annotation-api-version>
-        <jakarta-mail-version>2.0.1</jakarta-mail-version>
         <jakarta-servlet-api-version>6.0.0</jakarta-servlet-api-version>
         <jakarta-enterprise-cdi-api-version>4.0.1</jakarta-enterprise-cdi-api-version>
         <jakarta-api-version>2.1.5</jakarta-api-version>

--- a/components/camel-aws/camel-aws2-ses/pom.xml
+++ b/components/camel-aws/camel-aws2-ses/pom.xml
@@ -51,9 +51,9 @@
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>jakarta.mail</artifactId>
-            <version>${jakarta-mail-version}</version>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>angus-mail</artifactId>
+            <version>${angus-mail-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/components/camel-google/camel-google-mail/pom.xml
+++ b/components/camel-google/camel-google-mail/pom.xml
@@ -98,9 +98,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>jakarta.mail</artifactId>
-            <version>${jakarta-mail-version}</version>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>angus-mail</artifactId>
+            <version>${angus-mail-version}</version>
         </dependency>
 
         <!-- logging -->

--- a/components/camel-mail/pom.xml
+++ b/components/camel-mail/pom.xml
@@ -55,9 +55,9 @@
             <artifactId>camel-attachments</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>jakarta.mail</artifactId>
-            <version>${jakarta-mail-version}</version>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>angus-mail</artifactId>
+            <version>${angus-mail-version}</version>
             <exclusions>
                 <!-- javax activation is part of the JDK now -->
                 <exclusion>
@@ -143,9 +143,9 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>com.sun.mail</groupId>
-                                    <artifactId>jakarta.mail</artifactId>
-                                    <version>${jakarta-mail-version}</version>
+                                    <groupId>org.eclipse.angus</groupId>
+                                    <artifactId>angus-mail</artifactId>
+                                    <version>${angus-mail-version}</version>
                                     <type>jar</type>
                                     <outputDirectory>${project.basedir}/src/generated/resources</outputDirectory>
                                     <includes>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -267,7 +267,6 @@
         <jakarta-el-expressly-version>5.0.0</jakarta-el-expressly-version>
         <jakarta-activation-version>2.1.1</jakarta-activation-version>
         <jakarta-annotation-api-version>2.1.1</jakarta-annotation-api-version>
-        <jakarta-mail-version>2.0.1</jakarta-mail-version>
         <jakarta-servlet-api-version>6.0.0</jakarta-servlet-api-version>
         <jakarta-enterprise-cdi-api-version>4.0.1</jakarta-enterprise-cdi-api-version>
         <jakarta-api-version>2.1.5</jakarta-api-version>

--- a/tests/test-bundles/mock-javamail_1.7/pom.xml
+++ b/tests/test-bundles/mock-javamail_1.7/pom.xml
@@ -55,9 +55,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>jakarta.mail</artifactId>
-            <version>${jakarta-mail-version}</version>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>angus-mail</artifactId>
+            <version>${angus-mail-version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
August 18, 2021 - Jakarta Mail implementation moves to Eclipse Angus
https://eclipse-ee4j.github.io/angus-mail/

We are already importing the last version of **angus-mail** 1.1.0
