### PR TITLE
Fix File flaky test

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerAbsolutePathTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerAbsolutePathTest.java
@@ -41,7 +41,7 @@ public class FileConsumerAbsolutePathTest extends ContextTestSupport {
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
             public void configure() throws Exception {
-                from(fileUri("?initialDelay=0&delay=10&delete=true")).convertBodyTo(String.class).to("mock:report");
+                from(fileUri("?initialDelay=0&delay=100&delete=true")).convertBodyTo(String.class).to("mock:report");
             }
         };
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistAppendNoFileBeforeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistAppendNoFileBeforeTest.java
@@ -40,7 +40,7 @@ public class FileProducerFileExistAppendNoFileBeforeTest extends ContextTestSupp
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from(fileUri("?noop=true&initialDelay=0&delay=10")).convertBodyTo(String.class).to("mock:result");
+                from(fileUri("?noop=true&initialDelay=100&delay=10")).convertBodyTo(String.class).to("mock:result");
             }
         };
     }


### PR DESCRIPTION
# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

[FileConsumerAbsolutePathTest.java](https://github.com/apache/camel/compare/main...Croway:core-fix-flaky-test?expand=1#diff-8074c392d0272d82ae27b8a04b0c8982e66c3304bc106b17e9e2bab0ffd3b584) was failing on CI, while [FileProducerFileExistAppendNoFileBeforeTest.java](https://github.com/apache/camel/compare/main...Croway:core-fix-flaky-test?expand=1#diff-9aea9351eb88d2e13c3d4804927b954a48c6ee0df428069ca1da164281af3c81) was failing locally when executing all file test in sequence.