### PR TITLE
CAMEL-18977: camel-joor - Make the code more flexible for native mode

### DIFF
--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorCompiler.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorCompiler.java
@@ -116,7 +116,7 @@ public class JoorCompiler extends ServiceSupport implements StaticService {
         return answer;
     }
 
-    private String evalCode(CamelContext camelContext, String fqn, String script, boolean singleQuotes) {
+    public String evalCode(CamelContext camelContext, String fqn, String script, boolean singleQuotes) {
         String qn = fqn.substring(0, fqn.lastIndexOf('.'));
         String name = fqn.substring(fqn.lastIndexOf('.') + 1);
 

--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorLanguage.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorLanguage.java
@@ -41,14 +41,31 @@ public class JoorLanguage extends TypedLanguageSupport implements ScriptingLangu
     private static final Logger LOG = LoggerFactory.getLogger(JoorLanguage.class);
 
     private static Boolean java8;
-    private final JoorCompiler compiler = new JoorCompiler();
-    private final JoorScriptingCompiler scriptingCompiler = new JoorScriptingCompiler();
+    private final JoorCompiler compiler;
+    private final JoorScriptingCompiler scriptingCompiler;
     private final Set<String> imports = new TreeSet<>();
     private final Map<String, String> aliases = new HashMap<>();
 
     private String configResource = "classpath:camel-joor.properties?optional=true";
     private boolean preCompile = true;
     private boolean singleQuotes = true;
+
+    public JoorLanguage() {
+        this(new JoorCompiler(), new JoorScriptingCompiler());
+    }
+
+    public JoorLanguage(JoorCompiler compiler, JoorScriptingCompiler scriptingCompiler) {
+        this.compiler = compiler;
+        this.scriptingCompiler = scriptingCompiler;
+    }
+
+    public JoorCompiler getCompiler() {
+        return compiler;
+    }
+
+    public JoorScriptingCompiler getScriptingCompiler() {
+        return scriptingCompiler;
+    }
 
     public String getConfigResource() {
         return configResource;


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18977

## Motivation

With the current code base, it is hard to change the behavior of the jOOR language in order to move most of the logic at build time and/or at static initialization time, without having to use ugly hacks like reflection. The goal of this task is to make the code more flexible to avoid using hacks. 

## Modifications:

* Add a constructor to the class `JoorLanguage` to be able to inject specific jOOR compiler and jOOR script compiler
* Add getters for the jOOR compiler and jOOR script compiler
* Make the method `evalCode` public to give access to the generated code.