### PR TITLE
Execute test sequentially

### DIFF
--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFileToFtpSplitParallelIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFileToFtpSplitParallelIT.java
@@ -26,9 +26,11 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.builder.ThreadPoolProfileBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spi.ThreadPoolProfile;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+@Tag("not-parallel")
 class FromFileToFtpSplitParallelIT extends FtpServerTestSupport {
 
     private static final int SIZE = 5_000;


### PR DESCRIPTION
# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

Fix CI failure
```
Cancelling nested steps due to timeout
Sending interrupt signal to process
```
as you can see from https://ci-builds.apache.org/job/Camel/job/Camel%20JDK17/job/main/554/consoleText the test org.apache.camel.component.file.remote.integration.FromFileToFtpSplitParallelIT started the execution but didn't complete, locally I couldn't reproduce the same issue, but from time to time the test would hang during the shutdown of the route, I didn't notice any hang using the not-parallel tag.