### PR TITLE
(chores) camel-ftp: test cleanups

### DIFF
--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/RemoteFileIgnoreDoPollErrorTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/RemoteFileIgnoreDoPollErrorTest.java
@@ -40,7 +40,7 @@ public class RemoteFileIgnoreDoPollErrorTest {
 
     private final CamelContext camelContext = new DefaultCamelContext();
 
-    private final RemoteFileEndpoint<Object> remoteFileEndpoint = new RemoteFileEndpoint<Object>() {
+    private final RemoteFileEndpoint<Object> remoteFileEndpoint = new RemoteFileEndpoint<>() {
         @Override
         protected RemoteFileConsumer<Object> buildConsumer(Processor processor) {
             return null;
@@ -70,14 +70,14 @@ public class RemoteFileIgnoreDoPollErrorTest {
     @Test
     public void testReadDirErrorIsHandled() {
         RemoteFileConsumer<Object> consumer = getRemoteFileConsumer("true", true);
-        boolean result = consumer.doSafePollSubDirectory("anyPath", "adir", new ArrayList<GenericFile<Object>>(), 0);
+        boolean result = consumer.doSafePollSubDirectory("anyPath", "adir", new ArrayList<>(), 0);
         assertTrue(result);
     }
 
     @Test
     public void testReadDirErrorIsHandledWithNoMorePoll() {
         RemoteFileConsumer<Object> consumer = getRemoteFileConsumer("false", true);
-        boolean result = consumer.doSafePollSubDirectory("anyPath", "adir", new ArrayList<GenericFile<Object>>(), 0);
+        boolean result = consumer.doSafePollSubDirectory("anyPath", "adir", new ArrayList<>(), 0);
         assertFalse(result);
     }
 
@@ -108,7 +108,7 @@ public class RemoteFileIgnoreDoPollErrorTest {
 
         remoteFileEndpoint.setCamelContext(camelContext);
 
-        return new RemoteFileConsumer<Object>(remoteFileEndpoint, null, null, null) {
+        return new RemoteFileConsumer<>(remoteFileEndpoint, null, null, null) {
             @Override
             protected boolean doPollDirectory(
                     String absolutePath, String dirName, List<GenericFile<Object>> genericFiles, int depth) {

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/UriConfigurationTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/UriConfigurationTest.java
@@ -21,8 +21,10 @@ import org.apache.camel.test.junit5.TestSupport;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UriConfigurationTest extends CamelTestSupport {
 
@@ -36,7 +38,7 @@ public class UriConfigurationTest extends CamelTestSupport {
         assertEquals(21, config.getPort());
         assertNull(config.getUsername());
         assertNull(config.getPassword());
-        assertEquals(false, config.isBinary());
+        assertFalse(config.isBinary());
         assertEquals(RemoteFileConfiguration.PathSeparator.UNIX, config.getSeparator());
     }
 
@@ -50,7 +52,7 @@ public class UriConfigurationTest extends CamelTestSupport {
         assertEquals(22, config.getPort());
         assertNull(config.getUsername());
         assertNull(config.getPassword());
-        assertEquals(false, config.isBinary());
+        assertFalse(config.isBinary());
         assertEquals(RemoteFileConfiguration.PathSeparator.UNIX, config.getSeparator());
     }
 
@@ -64,8 +66,8 @@ public class UriConfigurationTest extends CamelTestSupport {
         assertEquals(21, config.getPort());
         assertNull(config.getUsername());
         assertNull(config.getPassword());
-        assertEquals(false, config.isBinary());
-        assertEquals(false, config.isImplicit());
+        assertFalse(config.isBinary());
+        assertFalse(config.isImplicit());
         assertEquals("TLSv1.3", config.getSecurityProtocol());
         assertEquals(RemoteFileConfiguration.PathSeparator.UNIX, config.getSeparator());
     }
@@ -80,8 +82,8 @@ public class UriConfigurationTest extends CamelTestSupport {
         assertEquals(990, config.getPort());
         assertNull(config.getUsername());
         assertNull(config.getPassword());
-        assertEquals(false, config.isBinary());
-        assertEquals(true, config.isImplicit());
+        assertFalse(config.isBinary());
+        assertTrue(config.isImplicit());
         assertEquals("TLSv1.3", config.getSecurityProtocol());
     }
 
@@ -96,7 +98,7 @@ public class UriConfigurationTest extends CamelTestSupport {
         assertEquals(1021, config.getPort());
         assertEquals("user", config.getUsername());
         assertEquals("secret", config.getPassword());
-        assertEquals(true, config.isBinary());
+        assertTrue(config.isBinary());
     }
 
     @Test
@@ -110,7 +112,7 @@ public class UriConfigurationTest extends CamelTestSupport {
         assertEquals(1021, config.getPort());
         assertEquals("user", config.getUsername());
         assertEquals("secret", config.getPassword());
-        assertEquals(true, config.isBinary());
+        assertTrue(config.isBinary());
     }
 
     @Test
@@ -125,8 +127,8 @@ public class UriConfigurationTest extends CamelTestSupport {
         assertEquals(1021, config.getPort());
         assertEquals("user", config.getUsername());
         assertEquals("secret", config.getPassword());
-        assertEquals(true, config.isBinary());
-        assertEquals(true, config.isImplicit());
+        assertTrue(config.isBinary());
+        assertTrue(config.isImplicit());
         assertEquals("SSL", config.getSecurityProtocol());
     }
 
@@ -186,7 +188,7 @@ public class UriConfigurationTest extends CamelTestSupport {
         assertEquals(1021, config.getPort());
         assertEquals("user", config.getUsername());
         assertEquals("secret", config.getPassword());
-        assertEquals(true, config.isBinary());
+        assertTrue(config.isBinary());
         assertEquals("/home/janstey/.ssh/known_hosts", config.getKnownHostsFile());
     }
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpFilterIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpFilterIT.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 public class FromFtpFilterIT extends FtpServerTestSupport {
 
     @BindToRegistry("myFilter")
-    private final MyFileFilter filter = new MyFileFilter<>();
+    private final MyFileFilter<Object> filter = new MyFileFilter<>();
 
     protected String getFtpUrl() {
         return "ftp://admin@localhost:{{ftp.server.port}}/filter?password=admin&binary=false&filter=#myFilter";

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpRemoteFileFilterDirectoryIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpRemoteFileFilterDirectoryIT.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.condition.OS;
 public class FromFtpRemoteFileFilterDirectoryIT extends FtpServerTestSupport {
 
     @BindToRegistry("myFilter")
-    private final MyFileFilter filter = new MyFileFilter<>();
+    private final MyFileFilter<Object> filter = new MyFileFilter<>();
 
     private String getFtpUrl() {
         return "ftp://admin@localhost:{{ftp.server.port}}/filefilter?password=admin&recursive=true&filter=#myFilter";

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpRemoteFileFilterIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FromFtpRemoteFileFilterIT.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.condition.OS;
 public class FromFtpRemoteFileFilterIT extends FtpServerTestSupport {
 
     @BindToRegistry("myFilter")
-    private final MyFileFilter filter = new MyFileFilter<>();
+    private final MyFileFilter<Object> filter = new MyFileFilter<>();
 
     private String getFtpUrl() {
         return "ftp://admin@localhost:{{ftp.server.port}}/filefilter?password=admin&filter=#myFilter";

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerProcessStrategyIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerProcessStrategyIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.file.remote.integration;
 
+import java.io.File;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.apache.camel.BindToRegistry;
@@ -33,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class FtpConsumerProcessStrategyIT extends FtpServerTestSupport {
 
     @BindToRegistry("myStrategy")
-    private final MyStrategy myStrategy = new MyStrategy();
+    private final MyStrategy<File> myStrategy = new MyStrategy<>();
 
     private String getFtpUrl() {
         return "ftp://admin@localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
@@ -50,35 +51,36 @@ public class FtpConsumerProcessStrategyIT extends FtpServerTestSupport {
         assertEquals(1, myStrategy.getInvoked(), "Begin should have been invoked 1 times");
     }
 
-    private static class MyStrategy implements GenericFileProcessStrategy {
+    private static class MyStrategy<T extends File> implements GenericFileProcessStrategy<T> {
 
         private final LongAdder invoked = new LongAdder();
 
         @Override
-        public void prepareOnStartup(GenericFileOperations operations, GenericFileEndpoint endpoint) {
+        public void prepareOnStartup(GenericFileOperations<T> operations, GenericFileEndpoint<T> endpoint) {
             // noop
         }
 
         @Override
         public boolean begin(
-                GenericFileOperations operations, GenericFileEndpoint endpoint, Exchange exchange, GenericFile file) {
+                GenericFileOperations<T> operations, GenericFileEndpoint<T> endpoint, Exchange exchange, GenericFile<T> file) {
             return true;
         }
 
         @Override
-        public void abort(GenericFileOperations operations, GenericFileEndpoint endpoint, Exchange exchange, GenericFile file) {
+        public void abort(
+                GenericFileOperations<T> operations, GenericFileEndpoint<T> endpoint, Exchange exchange, GenericFile<T> file) {
             // noop
         }
 
         @Override
         public void commit(
-                GenericFileOperations operations, GenericFileEndpoint endpoint, Exchange exchange, GenericFile file) {
+                GenericFileOperations<T> operations, GenericFileEndpoint<T> endpoint, Exchange exchange, GenericFile<T> file) {
             invoked.increment();
         }
 
         @Override
         public void rollback(
-                GenericFileOperations operations, GenericFileEndpoint endpoint, Exchange exchange, GenericFile file) {
+                GenericFileOperations<T> operations, GenericFileEndpoint<T> endpoint, Exchange exchange, GenericFile<T> file) {
             // noop
         }
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpProducerConcurrentIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpProducerConcurrentIT.java
@@ -53,7 +53,7 @@ public class FtpProducerConcurrentIT extends FtpServerTestSupport {
             getMockEndpoint("mock:result").expectedFileExists(service.ftpFile("concurrent/" + i + ".txt"));
 
             final int index = i;
-            executor.submit(new Callable<Object>() {
+            executor.submit(new Callable<>() {
                 public Object call() {
                     sendFile("direct:start", "Hello World", index + ".txt");
                     return null;

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpProducerDoneFileNameIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpProducerDoneFileNameIT.java
@@ -24,7 +24,6 @@ import org.apache.camel.ExpressionIllegalSyntaxException;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -39,10 +38,10 @@ public class FtpProducerDoneFileNameIT extends FtpServerTestSupport {
         template.sendBodyAndHeader(getFtpUrl() + "&doneFileName=done", "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         File file = service.ftpFile("done/hello.txt").toFile();
-        assertEquals(true, file.exists(), "File should exists");
+        assertTrue(file.exists(), "File should exists");
 
         File done = service.ftpFile("done/done").toFile();
-        assertEquals(true, done.exists(), "Done file should exists");
+        assertTrue(done.exists(), "Done file should exists");
     }
 
     @Test
@@ -51,10 +50,10 @@ public class FtpProducerDoneFileNameIT extends FtpServerTestSupport {
                 "hello.txt");
 
         File file = service.ftpFile("done/hello.txt").toFile();
-        assertEquals(true, file.exists(), "File should exists");
+        assertTrue(file.exists(), "File should exists");
 
         File done = service.ftpFile("done/done-hello.txt").toFile();
-        assertEquals(true, done.exists(), "Done file should exists");
+        assertTrue(done.exists(), "Done file should exists");
     }
 
     @Test
@@ -63,10 +62,10 @@ public class FtpProducerDoneFileNameIT extends FtpServerTestSupport {
                 "hello.txt");
 
         File file = service.ftpFile("done/hello.txt").toFile();
-        assertEquals(true, file.exists(), "File should exists");
+        assertTrue(file.exists(), "File should exists");
 
         File done = service.ftpFile("done/hello.txt.done").toFile();
-        assertEquals(true, done.exists(), "Done file should exists");
+        assertTrue(done.exists(), "Done file should exists");
     }
 
     @Test
@@ -75,10 +74,10 @@ public class FtpProducerDoneFileNameIT extends FtpServerTestSupport {
                 "hello.txt");
 
         File file = service.ftpFile("done/hello.txt").toFile();
-        assertEquals(true, file.exists(), "File should exists");
+        assertTrue(file.exists(), "File should exists");
 
         File done = service.ftpFile("done/hello.done").toFile();
-        assertEquals(true, done.exists(), "Done file should exists");
+        assertTrue(done.exists(), "Done file should exists");
     }
 
     @Test

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpProducerTempFileExistIssueIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpProducerTempFileExistIssueIT.java
@@ -56,7 +56,7 @@ public class FtpProducerTempFileExistIssueIT extends FtpServerTestSupport {
         template.sendBodyAndHeader(getFtpUrl() + "&tempPrefix=foo", "Bye World", Exchange.FILE_NAME, "hello.txt");
 
         File file = service.ftpFile("tempprefix/hello.txt").toFile();
-        await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> assertEquals(true, file.exists()));
+        await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> assertTrue(file.exists()));
         assertEquals("Bye World", context.getTypeConverter().convertTo(String.class, file));
     }
 
@@ -70,7 +70,7 @@ public class FtpProducerTempFileExistIssueIT extends FtpServerTestSupport {
         template.sendBodyAndHeader(getFtpUrl() + "&tempPrefix=foo", "Bye World", Exchange.FILE_NAME, "hello.txt");
 
         File file = service.ftpFile("tempprefix/hello.txt").toFile();
-        await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> assertEquals(true, file.exists()));
+        await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> assertTrue(file.exists()));
         assertEquals("Bye World", context.getTypeConverter().convertTo(String.class, file));
     }
 
@@ -85,7 +85,7 @@ public class FtpProducerTempFileExistIssueIT extends FtpServerTestSupport {
 
         File file = service.ftpFile("tempprefix/hello.txt").toFile();
         await().atMost(500, TimeUnit.MILLISECONDS)
-                .untilAsserted(() -> assertEquals(true, file.exists()));
+                .untilAsserted(() -> assertTrue(file.exists()));
         assertEquals("Bye World", context.getTypeConverter().convertTo(String.class, file));
     }
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpConsumerProcessStrategyIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpConsumerProcessStrategyIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.file.remote.sftp.integration;
 
+import java.io.File;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.apache.camel.BindToRegistry;
@@ -35,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SftpConsumerProcessStrategyIT extends SftpServerTestSupport {
 
     @BindToRegistry("myStrategy")
-    private final MyStrategy myStrategy = new MyStrategy();
+    private final MyStrategy<File> myStrategy = new MyStrategy<>();
 
     @Test
     public void testSftpConsume() {
@@ -51,35 +52,36 @@ public class SftpConsumerProcessStrategyIT extends SftpServerTestSupport {
         assertEquals(1, myStrategy.getInvoked(), "CustomProcessStrategy should have been invoked 1 times");
     }
 
-    private static class MyStrategy implements GenericFileProcessStrategy {
+    private static class MyStrategy<T extends File> implements GenericFileProcessStrategy<T> {
 
         private final LongAdder invoked = new LongAdder();
 
         @Override
-        public void prepareOnStartup(GenericFileOperations operations, GenericFileEndpoint endpoint) {
+        public void prepareOnStartup(GenericFileOperations<T> operations, GenericFileEndpoint<T> endpoint) {
             // noop
         }
 
         @Override
         public boolean begin(
-                GenericFileOperations operations, GenericFileEndpoint endpoint, Exchange exchange, GenericFile file) {
+                GenericFileOperations<T> operations, GenericFileEndpoint<T> endpoint, Exchange exchange, GenericFile<T> file) {
             return true;
         }
 
         @Override
-        public void abort(GenericFileOperations operations, GenericFileEndpoint endpoint, Exchange exchange, GenericFile file) {
+        public void abort(
+                GenericFileOperations<T> operations, GenericFileEndpoint<T> endpoint, Exchange exchange, GenericFile<T> file) {
             // noop
         }
 
         @Override
         public void commit(
-                GenericFileOperations operations, GenericFileEndpoint endpoint, Exchange exchange, GenericFile file) {
+                GenericFileOperations<T> operations, GenericFileEndpoint<T> endpoint, Exchange exchange, GenericFile<T> file) {
             invoked.increment();
         }
 
         @Override
         public void rollback(
-                GenericFileOperations operations, GenericFileEndpoint endpoint, Exchange exchange, GenericFile file) {
+                GenericFileOperations<T> operations, GenericFileEndpoint<T> endpoint, Exchange exchange, GenericFile<T> file) {
             // noop
         }
 


### PR DESCRIPTION
- simplify assertions
- cleanup raw usages of parameterized objects