### PR TITLE
camel-plc4x: Fixed inconsistently passing/failing unit test (CAMEL-18861)

### DIFF
--- a/components/camel-plc4x/src/main/java/org/apache/camel/component/plc4x/Plc4XEndpoint.java
+++ b/components/camel-plc4x/src/main/java/org/apache/camel/component/plc4x/Plc4XEndpoint.java
@@ -145,6 +145,11 @@ public class Plc4XEndpoint extends DefaultEndpoint {
             LOGGER.debug("Successfully reconnected");
         } else if (autoReconnect && !connection.isConnected()) {
             connection.connect();
+            // If reconnection fails without Exception, reset connection
+            if (!connection.isConnected()) {
+                LOGGER.debug("No connection established after connect, resetting connection");
+                connection = plcDriverManager.getConnection(uri);
+            }
             LOGGER.debug("Successfully reconnected");
         } else {
             LOGGER.warn("Connection lost and auto-reconnect is turned off, shutting down Plc4XEndpoint");

--- a/components/camel-plc4x/src/test/java/org/apache/camel/component/plc4x/Plc4XComponentTest.java
+++ b/components/camel-plc4x/src/test/java/org/apache/camel/component/plc4x/Plc4XComponentTest.java
@@ -45,6 +45,7 @@ public class Plc4XComponentTest extends CamelTestSupport {
                 tags.put("Test1", "%TestQuery");
                 Plc4XEndpoint producer = getContext().getEndpoint("plc4x:mock:10.10.10.1/1/1", Plc4XEndpoint.class);
                 producer.setTags(tags);
+                producer.setAutoReconnect(true);
                 from("direct:plc4x")
                         .setBody(constant(Collections.singletonMap("test", Collections.singletonMap("testAddress", false))))
                         .to("plc4x:mock:10.10.10.1/1/1")


### PR DESCRIPTION
After [this comment](https://github.com/apache/camel/pull/9254#issuecomment-1410312534) by @davsclaus I looked further into the Plc4XComponentTest which was inconsistently passing/failing. These changes should fix it.