### PR TITLE
Rewrite JdbcOrphanLockAwareIdempotentRepository::insert to not rely on exception

### DIFF
--- a/components/camel-sql/src/main/java/org/apache/camel/processor/idempotent/jdbc/JdbcMessageIdRepository.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/processor/idempotent/jdbc/JdbcMessageIdRepository.java
@@ -22,8 +22,6 @@ import javax.sql.DataSource;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
 /**
@@ -78,34 +76,28 @@ public class JdbcMessageIdRepository extends AbstractJdbcMessageIdRepository {
     protected void doStart() throws Exception {
         super.doStart();
 
-        transactionTemplate.execute(new TransactionCallback<Boolean>() {
-            @Override
-            public Boolean doInTransaction(TransactionStatus status) {
+        try {
+            // we will receive an exception if the table doesn't exists or we cannot access it
+            jdbcTemplate.execute(getTableExistsString());
+            log.debug("Expected table for JdbcMessageIdRepository exist");
+        } catch (DataAccessException e) {
+            if (createTableIfNotExists) {
                 try {
-                    // we will receive an exception if the table doesn't exists or we cannot access it
-                    jdbcTemplate.execute(getTableExistsString());
-                    log.debug("Expected table for JdbcMessageIdRepository exist");
-                } catch (DataAccessException e) {
-                    if (createTableIfNotExists) {
-                        try {
-                            log.debug("creating table for JdbcMessageIdRepository because it doesn't exist...");
-                            jdbcTemplate.execute(getCreateString());
-                            log.info("table created with query '{}'", getCreateString());
-                        } catch (DataAccessException dae) {
-                            // we will fail if we cannot create it
-                            log.error(
-                                    "Can't create table for JdbcMessageIdRepository with query '{}' because of: {}. This may be a permissions problem. Please create this table and try again.",
-                                    getCreateString(), dae.getMessage());
-                            throw dae;
-                        }
-                    } else {
-                        throw e;
-                    }
-
+                    log.debug("creating table for JdbcMessageIdRepository because it doesn't exist...");
+                    jdbcTemplate.execute(getCreateString());
+                    log.info("table created with query '{}'", getCreateString());
+                } catch (DataAccessException dae) {
+                    // we will fail if we cannot create it
+                    log.error(
+                            "Can't create table for JdbcMessageIdRepository with query '{}' because of: {}. This may be a permissions problem. Please create this table and try again.",
+                            getCreateString(), dae.getMessage());
+                    throw dae;
                 }
-                return Boolean.TRUE;
+            } else {
+                throw e;
             }
-        });
+
+        }
     }
 
     @Override

--- a/components/camel-sql/src/main/java/org/apache/camel/processor/idempotent/jdbc/JdbcOrphanLockAwareIdempotentRepository.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/processor/idempotent/jdbc/JdbcOrphanLockAwareIdempotentRepository.java
@@ -119,14 +119,13 @@ public class JdbcOrphanLockAwareIdempotentRepository extends JdbcMessageIdReposi
         long stamp = sl.writeLock();
         try {
             if (jdbcTemplate.queryForObject(getQueryString(), Integer.class, processorName, key) == 0) {
-                int result =
-                    jdbcTemplate.update(getInsertString(), processorName, key, currentTimestamp);
+                int result = jdbcTemplate.update(getInsertString(), processorName, key, currentTimestamp);
                 processorNameMessageIdSet.add(new ProcessorNameAndMessageId(processorName, key));
                 return result;
             } else {
                 //Update in case of orphan lock where a process dies without releasing exist lock
                 return jdbcTemplate.update(getUpdateTimestampQuery(), currentTimestamp,
-                    processorName, key);
+                        processorName, key);
             }
         } finally {
             sl.unlockWrite(stamp);

--- a/components/camel-sql/src/main/java/org/apache/camel/processor/idempotent/jdbc/JdbcOrphanLockAwareIdempotentRepository.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/processor/idempotent/jdbc/JdbcOrphanLockAwareIdempotentRepository.java
@@ -31,7 +31,6 @@ import javax.sql.DataSource;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ShutdownableService;
 import org.apache.camel.spi.ExecutorServiceManager;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -119,12 +118,16 @@ public class JdbcOrphanLockAwareIdempotentRepository extends JdbcMessageIdReposi
         Timestamp currentTimestamp = new Timestamp(System.currentTimeMillis());
         long stamp = sl.writeLock();
         try {
-            int result = jdbcTemplate.update(getInsertString(), processorName, key, currentTimestamp);
-            processorNameMessageIdSet.add(new ProcessorNameAndMessageId(processorName, key));
-            return result;
-        } catch (DuplicateKeyException e) {
-            //Update in case of orphan lock where a process dies without releasing exist lock
-            return jdbcTemplate.update(getUpdateTimestampQuery(), currentTimestamp, processorName, key);
+            if (jdbcTemplate.queryForObject(getQueryString(), Integer.class, processorName, key) == 0) {
+                int result =
+                    jdbcTemplate.update(getInsertString(), processorName, key, currentTimestamp);
+                processorNameMessageIdSet.add(new ProcessorNameAndMessageId(processorName, key));
+                return result;
+            } else {
+                //Update in case of orphan lock where a process dies without releasing exist lock
+                return jdbcTemplate.update(getUpdateTimestampQuery(), currentTimestamp,
+                    processorName, key);
+            }
         } finally {
             sl.unlockWrite(stamp);
         }

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/idempotent/jdbc/JdbcMessageIdRepositoryTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/idempotent/jdbc/JdbcMessageIdRepositoryTest.java
@@ -45,7 +45,6 @@ public class JdbcMessageIdRepositoryTest extends CamelSpringTestSupport {
     protected static final String PROCESSOR_NAME = "myProcessorName";
 
     protected JdbcTemplate jdbcTemplate;
-    protected DataSource dataSource;
 
     @EndpointInject("mock:result")
     protected MockEndpoint resultEndpoint;
@@ -58,7 +57,7 @@ public class JdbcMessageIdRepositoryTest extends CamelSpringTestSupport {
     public void setUp() throws Exception {
         super.setUp();
 
-        dataSource = context.getRegistry().lookupByNameAndType("dataSource", DataSource.class);
+        DataSource dataSource = context.getRegistry().lookupByNameAndType("dataSource", DataSource.class);
         jdbcTemplate = new JdbcTemplate(dataSource);
         jdbcTemplate.afterPropertiesSet();
     }


### PR DESCRIPTION
Rewrote `JdbcOrphanLockAwareIdempotentRepository::insert` to not rely on an exception. The exception caused problems with postgresql databases if `autosave=always` was not set.