### PR TITLE
Bump curator version

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -126,7 +126,7 @@
         <cobertura-maven-plugin-version>2.7</cobertura-maven-plugin-version>
         <corda-version>4.10</corda-version>
         <couchbase-client-version>3.4.2</couchbase-client-version>
-        <curator-version>4.3.0</curator-version>
+        <curator-version>5.4.0</curator-version>
         <cxf-version>4.0.0</cxf-version>
         <cxf-codegen-plugin-version>4.0.0</cxf-codegen-plugin-version>
         <!-- cxf-xjc is not released as often -->

--- a/components/camel-zookeeper-master/src/main/java/org/apache/camel/component/zookeepermaster/group/internal/ZooKeeperGroup.java
+++ b/components/camel-zookeeper-master/src/main/java/org/apache/camel/component/zookeepermaster/group/internal/ZooKeeperGroup.java
@@ -48,7 +48,7 @@ import org.apache.camel.component.zookeepermaster.group.Group;
 import org.apache.camel.component.zookeepermaster.group.GroupListener;
 import org.apache.camel.component.zookeepermaster.group.NodeState;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.listen.ListenerContainer;
+import org.apache.curator.framework.listen.StandardListenerManager;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.utils.EnsurePath;
@@ -85,7 +85,7 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
     private final ExecutorService executorService;
     private final EnsurePath ensurePath;
     private final BlockingQueue<Operation> operations = new LinkedBlockingQueue<>();
-    private final ListenerContainer<GroupListener<T>> listeners = new ListenerContainer<>();
+    private final StandardListenerManager<GroupListener<T>> listeners = StandardListenerManager.standard();
     private final ConcurrentMap<String, ChildData<T>> currentData = new ConcurrentHashMap<>();
     private final AtomicBoolean started = new AtomicBoolean();
     private final AtomicBoolean connected = new AtomicBoolean();
@@ -396,7 +396,7 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
      *
      * @return listenable
      */
-    public ListenerContainer<GroupListener<T>> getListenable() {
+    public StandardListenerManager<GroupListener<T>> getListenable() {
         return listeners;
     }
 
@@ -491,7 +491,6 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
             } catch (Exception e) {
                 handleException(e);
             }
-            return null;
         });
     }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -121,7 +121,7 @@
         <cobertura-maven-plugin-version>2.7</cobertura-maven-plugin-version>
         <corda-version>4.10</corda-version>
         <couchbase-client-version>3.4.2</couchbase-client-version>
-        <curator-version>4.3.0</curator-version>
+        <curator-version>5.4.0</curator-version>
         <cxf-version>4.0.0</cxf-version>
         <cxf-codegen-plugin-version>4.0.0</cxf-codegen-plugin-version>
         <!-- cxf-xjc is not released as often -->


### PR DESCRIPTION
One test in camel spring boot failed due to the curator version used, zookeeper:3.8.1 used in camel is not compatible with curator:4.3.0.

Updating the curator version solves issues on camel-spring-boot and tests on camel-zookeeper and camel-zookeeper-master are successful. ListenerContainer was deprecated in 4.x  and removed in 5.x.