### PR TITLE
Split init of contextPropagators to separate method.

### DIFF
--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetryTracer.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetryTracer.java
@@ -19,7 +19,6 @@ package org.apache.camel.opentelemetry;
 import java.util.Set;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
@@ -89,14 +88,13 @@ public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
         }
 
         if (tracer == null) {
+            // GlobalOpenTelemetry.get() is always NotNull, falls back to OpenTelemetry.noop()
             tracer = GlobalOpenTelemetry.get().getTracer(instrumentationName);
         }
+    }
 
-        if (tracer == null) {
-            // No tracer is available, so setup NoopTracer
-            tracer = OpenTelemetry.noop().getTracer(instrumentationName);
-        }
-
+    @Override
+    protected void initContextPropagators() {
         if (contextPropagators == null) {
             Set<ContextPropagators> contextPropagatorsSet
                     = getCamelContext().getRegistry().findByType(ContextPropagators.class);
@@ -106,12 +104,8 @@ public class OpenTelemetryTracer extends org.apache.camel.tracing.Tracer {
         }
 
         if (contextPropagators == null) {
+            // GlobalOpenTelemetry.get() is always NotNull, falls back to OpenTelemetry.noop()
             contextPropagators = GlobalOpenTelemetry.get().getPropagators();
-        }
-
-        if (contextPropagators == null) {
-            // No contextPropagators is available, so setup NoopTracer
-            contextPropagators = OpenTelemetry.noop().getPropagators();
         }
     }
 

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/Tracer.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/Tracer.java
@@ -78,6 +78,8 @@ public abstract class Tracer extends ServiceSupport implements RoutePolicyFactor
 
     protected abstract void initTracer();
 
+    protected abstract void initContextPropagators();
+
     protected abstract SpanAdapter startSendingEventSpan(String operationName, SpanKind kind, SpanAdapter parent);
 
     protected abstract SpanAdapter startExchangeBeginSpan(
@@ -179,6 +181,7 @@ public abstract class Tracer extends ServiceSupport implements RoutePolicyFactor
             camelContext.adapt(ExtendedCamelContext.class).addInterceptStrategy(tracingStrategy);
         }
         initTracer();
+        initContextPropagators();
         ServiceHelper.startService(eventNotifier);
     }
 


### PR DESCRIPTION
# Description

Here we improve on the first [PR-9341](https://github.com/apache/camel/pull/9341)

- init of ContextPropagators is moved to it's own init method
- unnecessary code for init if **GlobalOpenTelemetry.get()** should fail is removed

GlobalOpenTelemetry.get() always falls itself back to **OpenTelemetry.noop()** so no need for us to try that ourselves.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

