### PR TITLE
CAMEL-19049 - unwrap aries proxy & bytebuddy proxy classes when introspecting

### DIFF
--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -63,7 +63,9 @@ public class BeanInfo {
     private static final Logger LOG = LoggerFactory.getLogger(BeanInfo.class);
     private static final String CGLIB_CLASS_SEPARATOR = "$$";
     private static final String CGLIB_METHOD_MARKER = "CGLIB$";
+    private static final String BYTE_BUDDY_CLASS_SEPARATOR = "$ByteBuddy$";
     private static final String BYTE_BUDDY_METHOD_MARKER = "$accessor$";
+    private static final String ARIES_PROXY_CLASS_PREFIX = "Proxy";
     private static final String[] EXCLUDED_METHOD_NAMES = new String[] {
             "clone", "equals", "finalize", "getClass", "hashCode", "notify", "notifyAll", "wait", // java.lang.Object
             "getInvocationHandler", "getProxyClass", "isProxyClass", "newProxyInstance" // java.lang.Proxy
@@ -1138,7 +1140,10 @@ public class BeanInfo {
     }
 
     private static Class<?> getTargetClass(Class<?> clazz) {
-        if (clazz != null && clazz.getName().contains(CGLIB_CLASS_SEPARATOR)) {
+        if (clazz != null
+                && (clazz.getName().contains(CGLIB_CLASS_SEPARATOR)
+                        || clazz.getName().contains(BYTE_BUDDY_CLASS_SEPARATOR)
+                        || clazz.getName().startsWith(ARIES_PROXY_CLASS_PREFIX))) {
             Class<?> superClass = clazz.getSuperclass();
             if (superClass != null && !Object.class.equals(superClass)) {
                 return superClass;


### PR DESCRIPTION
Fixes problem introduced in CAMEL-18411 in `BeanInfo` class, in 3.14.x, where methods from synthetic classes are no longer considered as overriding the original methods (via a change in the `#findMostSpecificOverride` method). 

This causes ambiguity when trying to invoke them. I'm mainly concerned about usage in Karaf, where the proxy class is created via aries-proxy. For simplicity, test case added uses bytebuddy.
