### PR TITLE
CAMEL-19049 - fix for 3.18.x

### DIFF
--- a/components/camel-bean/pom.xml
+++ b/components/camel-bean/pom.xml
@@ -52,5 +52,30 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.aries.proxy</groupId>
+            <artifactId>org.apache.aries.proxy</artifactId>
+            <version>1.1.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>9.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+            <version>9.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+            <version>7.0.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -63,7 +63,9 @@ public class BeanInfo {
     private static final Logger LOG = LoggerFactory.getLogger(BeanInfo.class);
     private static final String CGLIB_CLASS_SEPARATOR = "$$";
     private static final String CGLIB_METHOD_MARKER = "CGLIB$";
+    private static final String BYTE_BUDDY_CLASS_SEPARATOR = "$ByteBuddy$";
     private static final String BYTE_BUDDY_METHOD_MARKER = "$accessor$";
+    private static final String ARIES_PROXY_CLASS_PREFIX = "Proxy";
     private static final String CLIENT_PROXY_SUFFIX = "_ClientProxy";
     private static final String SUBCLASS_SUFFIX = "_Subclass";
     private static final String[] EXCLUDED_METHOD_NAMES = new String[] {
@@ -1147,7 +1149,9 @@ public class BeanInfo {
     private static Class<?> getTargetClass(Class<?> clazz) {
         if (clazz != null
                 && (clazz.getName().contains(CGLIB_CLASS_SEPARATOR) || clazz.getName().endsWith(CLIENT_PROXY_SUFFIX)
-                        || clazz.getName().endsWith(SUBCLASS_SUFFIX))) {
+                        || clazz.getName().endsWith(SUBCLASS_SUFFIX)
+                        || clazz.getName().contains(BYTE_BUDDY_CLASS_SEPARATOR)
+                        || clazz.getName().startsWith(ARIES_PROXY_CLASS_PREFIX))) {
             Class<?> superClass = clazz.getSuperclass();
             if (superClass != null && !Object.class.equals(superClass)) {
                 return superClass;

--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -69,14 +70,14 @@ public class BeanInfo {
     private static final String CGLIB_METHOD_MARKER = "CGLIB$";
     private static final String BYTE_BUDDY_CLASS_SEPARATOR = "$ByteBuddy$";
     private static final String BYTE_BUDDY_METHOD_MARKER = "$accessor$";
-    private static final String ARIES_PROXY_CLASS_PREFIX = "Proxy";
     private static final String CLIENT_PROXY_SUFFIX = "_ClientProxy";
     private static final String SUBCLASS_SUFFIX = "_Subclass";
     private static final String[] EXCLUDED_METHOD_NAMES = new String[] {
             "equals", "finalize", "getClass", "hashCode", "notify", "notifyAll", "wait", // java.lang.Object
             "getInvocationHandler", "getProxyClass", "isProxyClass", "newProxyInstance" // java.lang.Proxy
     };
-
+    private static final Pattern ARIES_PROXY_CLASS_PATTERN
+            = Pattern.compile("^Proxy[0-9a-fA-F]{8}_[0-9a-fA-F]{4}_[0-9a-fA-F]{4}_[0-9a-fA-F]{4}_[0-9a-fA-F]{12}$");
     private static final Set<String> KNOWN_PROXY_INTERFACES = Collections.unmodifiableSet(Stream.of(
             "org.apache.aries.proxy.weaving.WovenProxy").collect(Collectors.toSet()));
 
@@ -1159,7 +1160,7 @@ public class BeanInfo {
                 && (clazz.getName().contains(CGLIB_CLASS_SEPARATOR) || clazz.getName().endsWith(CLIENT_PROXY_SUFFIX)
                         || clazz.getName().endsWith(SUBCLASS_SUFFIX)
                         || clazz.getName().contains(BYTE_BUDDY_CLASS_SEPARATOR)
-                        || clazz.getName().startsWith(ARIES_PROXY_CLASS_PREFIX))) {
+                        || ARIES_PROXY_CLASS_PATTERN.matcher(clazz.getName()).matches())) {
             Class<?> superClass = clazz.getSuperclass();
             if (superClass != null && !Object.class.equals(superClass)) {
                 return superClass;

--- a/components/camel-bean/src/test/java/org/apache/camel/component/bean/BeanInfoTest.java
+++ b/components/camel-bean/src/test/java/org/apache/camel/component/bean/BeanInfoTest.java
@@ -24,6 +24,8 @@ import net.bytebuddy.description.modifier.SyntheticState;
 import net.bytebuddy.description.modifier.Visibility;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
+import org.apache.aries.proxy.UnableToProxyException;
+import org.apache.aries.proxy.impl.AsmProxyManager;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Handler;
@@ -78,8 +80,24 @@ public class BeanInfoTest {
     }
 
     @Test
+    public void testHandlerOnSyntheticProxyWithInterface() {
+        Object proxy = buildProxyObject(MyHandlerInterface.class);
+
+        BeanInfo info = new BeanInfo(context, proxy.getClass());
+        assertTrue(info.hasAnyMethodHandlerAnnotation());
+    }
+
+    @Test
     public void testInvocationOnSyntheticProxy() {
         Object proxy = buildProxyObject(MyDerivedClass.class);
+
+        BeanInfo info = new BeanInfo(context, proxy.getClass());
+        info.createInvocation(info, createMockExchange());
+    }
+
+    @Test
+    public void testInvocationOnSyntheticProxyWithInterface() throws UnableToProxyException {
+        Object proxy = new AsmProxyManager().createNewProxy(null, Collections.singleton(MyInterface.class), () -> null, null);
 
         BeanInfo info = new BeanInfo(context, proxy.getClass());
         info.createInvocation(info, createMockExchange());
@@ -175,6 +193,12 @@ public class BeanInfoTest {
     public interface MyHandlerInterface {
         @Handler
         String myMethod();
+    }
+
+    public interface MyInterface {
+
+        void myMethod();
+
     }
 
 }


### PR DESCRIPTION
Fix of CAMEL-19049 based on #9359


Fixes problem introduced in [CAMEL-18411](https://issues.apache.org/jira/browse/CAMEL-18411) in BeanInfo class, in 3.14.x, where methods from synthetic classes are no longer considered as overriding the original methods (via a change in the #findMostSpecificOverride method).

This causes ambiguity when trying to invoke them. I'm mainly concerned about usage in Karaf, where the proxy class is created via aries-proxy. For simplicity, test case added uses bytebuddy.