### PR TITLE
CAMEL-19066: Do not copy correlationId after multicast

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
@@ -800,7 +800,9 @@ public class MulticastProcessor extends AsyncProcessorSupport
                 original.setException(subExchange.getException());
             } else {
                 // copy the current result to original, so it will contain this result of this eip
+                Object correlationId = subExchange.removeProperty(ExchangePropertyKey.CORRELATION_ID);
                 ExchangeHelper.copyResults(original, subExchange);
+                subExchange.setProperty(ExchangePropertyKey.CORRELATION_ID, correlationId);
             }
         }
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/MulticastCorrelationIdTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/MulticastCorrelationIdTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MulticastCorrelationIdTest extends ContextTestSupport {
+
+    @Test
+    void testCorrelationIdIsNotOverwrittenByMulticast() {
+        String originalCorrelationId = "SOME_ID";
+        Exchange exchange
+                = template.request("direct:start", e -> e.setProperty(Exchange.CORRELATION_ID, originalCorrelationId));
+
+        assertEquals(originalCorrelationId, exchange.getProperty(Exchange.CORRELATION_ID));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").multicast().to("direct:a", "direct:b");
+                from("direct:a").log("Route a");
+                from("direct:b").log("Route b");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
# Description

Remove the correlationId from `subExchange` before copying the multicast result to the original Exchange. This seemed preferable to removing the id after it has been copied. This way an already present id will remain on the original exchange.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

If this is fine I can also provide a PR for 3.x .

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

