### PR TITLE
CAMEL-19070: camel-elasticsearch - Increase startup timeout

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -144,8 +144,8 @@
         <eddsa-version>0.3.0</eddsa-version>
         <egit-github-core-version>2.1.5</egit-github-core-version>
         <ehcache3-version>3.10.8</ehcache3-version>
-        <elasticsearch-java-client-version>8.5.2</elasticsearch-java-client-version>
-        <elasticsearch-java-client-sniffer-version>8.5.2</elasticsearch-java-client-sniffer-version>
+        <elasticsearch-java-client-version>8.6.2</elasticsearch-java-client-version>
+        <elasticsearch-java-client-sniffer-version>8.6.2</elasticsearch-java-client-sniffer-version>
         <elasticsearch-rest-sniffer-version>7.10.2</elasticsearch-rest-sniffer-version>
         <elasticsearch-rest-version>7.10.2</elasticsearch-rest-version>
         <elytron-web>1.10.2.Final</elytron-web>

--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchTestSupport.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchTestSupport.java
@@ -69,7 +69,7 @@ public class ElasticsearchTestSupport extends CamelTestSupport {
 
     private static ElasticSearchLocalContainerService createElasticSearchService() {
         ElasticSearchLocalContainerService ret
-                = new ElasticSearchLocalContainerService("docker.elastic.co/elasticsearch/elasticsearch:8.4.1") {
+                = new ElasticSearchLocalContainerService("docker.elastic.co/elasticsearch/elasticsearch:8.6.2") {
                     @Override
                     public void registerProperties() {
                         super.registerProperties();

--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchTestSupport.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchTestSupport.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.es.integration;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,6 +45,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.Base58;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -88,7 +90,13 @@ public class ElasticsearchTestSupport extends CamelTestSupport {
         ret.getContainer()
                 .withNetworkAliases("elasticsearch-" + Base58.randomString(6))
                 .withPassword(PASSWORD)
-                .withExposedPorts(ELASTICSEARCH_DEFAULT_PORT, ELASTICSEARCH_DEFAULT_TCP_PORT);
+                .withExposedPorts(ELASTICSEARCH_DEFAULT_PORT, ELASTICSEARCH_DEFAULT_TCP_PORT)
+                // Increase the timeout from 60 seconds to 90 seconds to ensure that it will be long enough
+                // on the build pipeline
+                .setWaitStrategy(
+                        new LogMessageWaitStrategy()
+                                .withRegEx(".*(\"message\":\\s?\"started[\\s?|\"].*|] started\n$)")
+                                .withStartupTimeout(Duration.ofSeconds(90)));
 
         return ret;
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -139,8 +139,8 @@
         <eddsa-version>0.3.0</eddsa-version>
         <egit-github-core-version>2.1.5</egit-github-core-version>
         <ehcache3-version>3.10.8</ehcache3-version>
-        <elasticsearch-java-client-version>8.5.2</elasticsearch-java-client-version>
-        <elasticsearch-java-client-sniffer-version>8.5.2</elasticsearch-java-client-sniffer-version>
+        <elasticsearch-java-client-version>8.6.2</elasticsearch-java-client-version>
+        <elasticsearch-java-client-sniffer-version>8.6.2</elasticsearch-java-client-sniffer-version>
         <elasticsearch-rest-sniffer-version>7.10.2</elasticsearch-rest-sniffer-version>
         <elasticsearch-rest-version>7.10.2</elasticsearch-rest-version>
         <elytron-web>1.10.2.Final</elytron-web>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-19070

## Motivation

The integration tests of the component `camel-elasticsearch` fail on the build pipeline and need to be fixed.

## Modifications:

* Upgrade elasticsearch (server and client) to the latest version
* Increase the startup timeout from 60 seconds to 90 seconds to fit with a slow-build pipeline