### PR TITLE
[CAMEL-19075] camel-bean. Incorrect choice of overloaded method with several arguments, if one of them has brackets.

### DIFF
--- a/components/camel-bean/pom.xml
+++ b/components/camel-bean/pom.xml
@@ -51,11 +51,5 @@
             <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 </project>

--- a/components/camel-bean/pom.xml
+++ b/components/camel-bean/pom.xml
@@ -51,6 +51,11 @@
             <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 </project>

--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -1088,7 +1088,7 @@ public class BeanInfo {
         }
 
         // match qualifier types which is used to select among overloaded methods
-        String types = StringHelper.between(methodName, "(", ")");
+        String types = StringHelper.betweenOuterPair(methodName, '(', ')');
         if (org.apache.camel.util.ObjectHelper.isNotEmpty(types)) {
             // we must qualify based on types to match method
             String[] parameters = StringQuoteHelper.splitSafeQuote(types, ',');

--- a/components/camel-bean/src/test/java/org/apache/camel/component/bean/BeanProcessorOverloadedMethodsWithBracketsTest.java
+++ b/components/camel-bean/src/test/java/org/apache/camel/component/bean/BeanProcessorOverloadedMethodsWithBracketsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.bean;
 
 import org.apache.camel.builder.RouteBuilder;

--- a/components/camel-bean/src/test/java/org/apache/camel/component/bean/BeanProcessorOverloadedMethodsWithBracketsTest.java
+++ b/components/camel-bean/src/test/java/org/apache/camel/component/bean/BeanProcessorOverloadedMethodsWithBracketsTest.java
@@ -1,0 +1,49 @@
+package org.apache.camel.component.bean;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class BeanProcessorOverloadedMethodsWithBracketsTest extends CamelTestSupport {
+
+    private final String strArgWithBrackets = ")(string_with_brackets()))())";
+
+    @Test
+    public void testOverloadedMethodWithBracketsParams() throws InterruptedException {
+        template.sendBody("direct:start", null);
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        String receivedExchangeBody = mock.getExchanges().get(0).getMessage().getBody(String.class);
+        assertEquals(new MyOverloadedClass().myMethod(strArgWithBrackets, strArgWithBrackets), receivedExchangeBody);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:start")
+                        .bean(MyOverloadedClass.class, "myMethod('" + strArgWithBrackets + "', '" + strArgWithBrackets + "')")
+                        .to("mock:result");
+            }
+        };
+    }
+
+    public static class MyOverloadedClass {
+        public String myMethod() {
+            return "";
+        }
+
+        public String myMethod(String str) {
+            return str;
+        }
+
+        public String myMethod(String str1, String str2) {
+            return str1 + str2;
+        }
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/processor/BeanProcessorOverloadedMethodsWithBracketsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/BeanProcessorOverloadedMethodsWithBracketsTest.java
@@ -14,24 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.component.bean;
+package org.apache.camel.processor;
 
+import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(MockitoExtension.class)
-public class BeanProcessorOverloadedMethodsWithBracketsTest extends CamelTestSupport {
+public class BeanProcessorOverloadedMethodsWithBracketsTest extends ContextTestSupport {
 
     private final String strArgWithBrackets = ")(string_with_brackets()))())";
 
     @Test
-    public void testOverloadedMethodWithBracketsParams() throws InterruptedException {
+    public void testOverloadedMethodWithBracketsParams() {
         template.sendBody("direct:start", null);
         MockEndpoint mock = getMockEndpoint("mock:result");
         String receivedExchangeBody = mock.getExchanges().get(0).getMessage().getBody(String.class);


### PR DESCRIPTION
# Description

BeanInfo.java should use StringHelper.betweenOuterPair instead of StringHelper.between while choosing overloaded method.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

