### PR TITLE
CAMEL-19066: Do not copy correlationId after Enricher

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/enricher/EnricherCorrelationIdTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/enricher/EnricherCorrelationIdTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.enricher;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.Exchange.CORRELATION_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EnricherCorrelationIdTest extends ContextTestSupport {
+
+    @Test
+    void testCorrelationIdIsNotOverwrittenByEnricher() {
+        String originalCorrelationId = "SOME_ID";
+        Exchange exchange = template.request("direct:start", e -> e.setProperty(CORRELATION_ID, originalCorrelationId));
+
+        assertEquals(originalCorrelationId, exchange.getProperty(CORRELATION_ID));
+    }
+
+    @Test
+    void testCorrelationIdIsNotOverwrittenByEnricherfailedResource() {
+        String originalCorrelationId = "SOME_ID";
+        Exchange exchange
+                = template.request("direct:failed-resource", e -> e.setProperty(CORRELATION_ID, originalCorrelationId));
+
+        assertEquals(originalCorrelationId, exchange.getProperty(CORRELATION_ID));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").enrich("direct:enrich");
+                from("direct:enrich").setBody(constant("enrichment"));
+
+                from("direct:failed-resource").enrich("direct:failure");
+                from("direct:failure").throwException(new RuntimeException("Fail"));
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
# Description

Do not copy correlationId to the result exchange after Enricher EIP.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

