### PR TITLE
Make AWS test credentials FIPS compliant

### DIFF
--- a/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/common/TestAWSCredentialsProvider.java
+++ b/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/common/TestAWSCredentialsProvider.java
@@ -21,7 +21,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 public class TestAWSCredentialsProvider implements AwsCredentialsProvider {
     public static final TestAWSCredentialsProvider CONTAINER_LOCAL_DEFAULT_PROVIDER
-            = new TestAWSCredentialsProvider("accesskey", "secretkey");
+            = new TestAWSCredentialsProvider("accesskey", "randomatleast16bytes");
 
     private AwsCredentials credentials;
 


### PR DESCRIPTION
Changing the length of the password by at least 16 bytes, allows AWS test executions in FIPS enabled environments
