### PR TITLE
Outdated reference to CompletionAwareAggregationStrategy in aggregate-eip.adoc

### DIFF
--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/aggregate-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/aggregate-eip.adoc
@@ -290,10 +290,9 @@ completions
 * any other completion are not used (such as by size, from batch consumer etc)
 * _eagerCheckCompletion_ is implied as `true`, but the option has no effect
 
-=== CompletionAwareAggregationStrategy
+=== onCompletion
 
-If your aggregation strategy implements
-`CompletionAwareAggregationStrategy`, then Camel will invoke the
+Camel will invoke the
 `onComplete` method when the aggregated `Exchange` is completed. This
 allows you to do any last minute custom logic such as to clean up some
 resources, or additional work on the exchange as it's now completed.


### PR DESCRIPTION
# Description

Chapter CompletionAwareAggregationStrategy is not up-to-date, because CompletionAwareAggregationStrategy interface was removed in Camel 3.x and onCompletion method is now part of AggregationStrategy interface. See commit e441457951b7d7cb6ede65a62fd8460a6485e322.

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

