### PR TITLE
CAMEL-18988: camel-core - tests failing due to OOM

### DIFF
--- a/core/camel-core/pom.xml
+++ b/core/camel-core/pom.xml
@@ -286,6 +286,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- skip file stress tests as they are intended to run manually -->
+                    <argLine>${camel.surefire.fork.vmargs} -Xmx2G -XX:+HeapDumpOnOutOfMemoryError -XX:OnOutOfMemoryError="jcmd %p Thread.print" -XX:+UnlockDiagnosticVMOptions -XX:+LogVMOutput -XX:LogFile=jvm.log</argLine>
                     <excludes>
                         <exclude>org/apache/camel/component/file/stress/**.java</exclude>
                         <exclude>**/DistributedCompletionIntervalTest.java</exclude>

--- a/core/camel-core/src/test/java/org/apache/camel/builder/ExchangeBuilderTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/builder/ExchangeBuilderTest.java
@@ -21,22 +21,34 @@ import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ExchangeBuilderTest {
-    private static final CamelContext CONTEXT = new DefaultCamelContext();
+    private static CamelContext context;
     private static final String BODY = "Message Body";
     private static final String KEY = "Header key";
     private static final String VALUE = "Header value";
     private static final String PROPERTY_KEY = "Property key";
     private static final String PROPERTY_VALUE = "Property value";
 
+    @BeforeAll
+    public static void init() {
+        context = new DefaultCamelContext();
+    }
+
+    @AfterAll
+    public static void destroy() {
+        context = null;
+    }
+
     @Test
     public void testBuildAnExchangeWithDefaultPattern() {
-        Exchange exchange = new DefaultExchange(CONTEXT);
-        Exchange builtExchange = ExchangeBuilder.anExchange(CONTEXT).build();
+        Exchange exchange = new DefaultExchange(context);
+        Exchange builtExchange = ExchangeBuilder.anExchange(context).build();
 
         assertEquals(exchange.getPattern(), builtExchange.getPattern());
     }
@@ -44,7 +56,7 @@ public class ExchangeBuilderTest {
     @Test
     public void testBuildAnExchangeWithBodyHeaderAndPatternInOnly() throws Exception {
 
-        Exchange exchange = ExchangeBuilder.anExchange(CONTEXT).withBody(BODY).withHeader(KEY, VALUE)
+        Exchange exchange = ExchangeBuilder.anExchange(context).withBody(BODY).withHeader(KEY, VALUE)
                 .withProperty(PROPERTY_KEY, PROPERTY_VALUE).withPattern(ExchangePattern.InOnly)
                 .build();
 
@@ -57,7 +69,7 @@ public class ExchangeBuilderTest {
     @Test
     public void testBuildAnExchangeWithBodyHeaderAndPatternInOut() throws Exception {
 
-        Exchange exchange = ExchangeBuilder.anExchange(CONTEXT).withBody(BODY).withHeader(KEY, VALUE)
+        Exchange exchange = ExchangeBuilder.anExchange(context).withBody(BODY).withHeader(KEY, VALUE)
                 .withProperty(PROPERTY_KEY, PROPERTY_VALUE).withPattern(ExchangePattern.InOut)
                 .build();
 

--- a/core/camel-core/src/test/java/org/apache/camel/catalog/RuntimeCamelCatalogTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/catalog/RuntimeCamelCatalogTest.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import org.apache.camel.catalog.impl.DefaultRuntimeCamelCatalog;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.tooling.model.ComponentModel;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +39,11 @@ public class RuntimeCamelCatalogTest {
     public static void createCamelCatalog() {
         catalog = new DefaultRuntimeCamelCatalog();
         catalog.setCamelContext(new DefaultCamelContext());
+    }
+
+    @AfterAll
+    public static void cleanCamelCatalog() {
+        catalog = null;
     }
 
     @Test

--- a/core/camel-core/src/test/java/org/apache/camel/component/log/LogEndpointTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/log/LogEndpointTest.java
@@ -27,6 +27,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spi.CamelLogger;
 import org.apache.camel.spi.LogListener;
 import org.apache.camel.support.processor.CamelLogProcessor;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,6 +36,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class LogEndpointTest extends ContextTestSupport {
 
     private static Exchange logged;
+
+    @AfterAll
+    public static void clean() {
+        logged = null;
+    }
 
     private static class MyLogger extends CamelLogProcessor {
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/CamelProduceInterfaceEventNotifierTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/CamelProduceInterfaceEventNotifierTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CamelProduceInterfaceEventNotifierTest extends ContextTestSupport {
 
-    private static List<CamelEvent> events = new ArrayList<>();
+    private final List<CamelEvent> events = new ArrayList<>();
 
     private CamelBeanPostProcessor postProcessor;
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/CamelEventsTimestampEnabledTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/CamelEventsTimestampEnabledTest.java
@@ -27,19 +27,11 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spi.CamelEvent;
 import org.apache.camel.support.EventNotifierSupport;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class CamelEventsTimestampEnabledTest extends ContextTestSupport {
 
-    private static List<CamelEvent> events = new ArrayList<>();
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        events.clear();
-        super.setUp();
-    }
+    private final List<CamelEvent> events = new ArrayList<>();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierEventsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierEventsTest.java
@@ -36,14 +36,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class EventNotifierEventsTest {
 
-    private static List<CamelEvent> events = new ArrayList<>();
+    private final List<CamelEvent> events = new ArrayList<>();
 
     private CamelContext context;
     private ProducerTemplate template;
 
     @BeforeEach
     public void setUp() throws Exception {
-        events.clear();
         context = createCamelContext();
         context.addRoutes(createRouteBuilder());
         template = context.createProducerTemplate();

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierExchangeCompletedTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierExchangeCompletedTest.java
@@ -26,21 +26,13 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spi.CamelEvent;
 import org.apache.camel.support.EventNotifierSupport;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class EventNotifierExchangeCompletedTest extends ContextTestSupport {
 
-    private static List<CamelEvent> events = new ArrayList<>();
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        events.clear();
-        super.setUp();
-    }
+    private final List<CamelEvent> events = new ArrayList<>();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierExchangeSentTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierExchangeSentTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EventNotifierExchangeSentTest extends ContextTestSupport {
 
-    protected List<CamelEvent> events = new ArrayList<>();
+    protected final List<CamelEvent> events = new ArrayList<>();
 
     @BeforeEach
     public void clearEvents() throws Exception {

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierFailureHandledEventsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierFailureHandledEventsTest.java
@@ -28,21 +28,13 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.processor.SendProcessor;
 import org.apache.camel.spi.CamelEvent;
 import org.apache.camel.support.EventNotifierSupport;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class EventNotifierFailureHandledEventsTest extends ContextTestSupport {
 
-    private static List<CamelEvent> events = new ArrayList<>();
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        events.clear();
-        super.setUp();
-    }
+    private final List<CamelEvent> events = new ArrayList<>();
 
     @Override
     public boolean isUseRouteBuilder() {

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierIgnoreCamelContextInitEventsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierIgnoreCamelContextInitEventsTest.java
@@ -34,14 +34,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EventNotifierIgnoreCamelContextInitEventsTest {
 
-    private static List<CamelEvent> events = new ArrayList<>();
+    private final List<CamelEvent> events = new ArrayList<>();
 
     private CamelContext context;
     private ProducerTemplate template;
 
     @BeforeEach
     public void setUp() throws Exception {
-        events.clear();
         context = createCamelContext();
         context.addRoutes(createRouteBuilder());
         template = context.createProducerTemplate();

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierRedeliveryEventsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierRedeliveryEventsTest.java
@@ -25,7 +25,6 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spi.CamelEvent;
 import org.apache.camel.support.EventNotifierSupport;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,14 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EventNotifierRedeliveryEventsTest extends ContextTestSupport {
 
-    private static List<CamelEvent> events = new ArrayList<>();
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        events.clear();
-        super.setUp();
-    }
+    private final List<CamelEvent> events = new ArrayList<>();
 
     @Override
     public boolean isUseRouteBuilder() {

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierServiceStoppingFailedEventTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/EventNotifierServiceStoppingFailedEventTest.java
@@ -24,22 +24,14 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Service;
 import org.apache.camel.spi.CamelEvent;
 import org.apache.camel.support.EventNotifierSupport;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EventNotifierServiceStoppingFailedEventTest extends ContextTestSupport {
 
-    private static List<CamelEvent> events = new ArrayList<>();
     private static String stopOrder;
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        events.clear();
-        super.setUp();
-    }
+    private final List<CamelEvent> events = new ArrayList<>();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/MultipleEventNotifierEventsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/MultipleEventNotifierEventsTest.java
@@ -25,7 +25,6 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spi.CamelEvent;
 import org.apache.camel.support.EventNotifierSupport;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,20 +32,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class MultipleEventNotifierEventsTest extends ContextTestSupport {
 
-    private static List<CamelEvent> events = new ArrayList<>();
-    private static List<CamelEvent> events2 = new ArrayList<>();
+    private final List<CamelEvent> events = new ArrayList<>();
+    private final List<CamelEvent> events2 = new ArrayList<>();
 
     @Override
     protected boolean useJmx() {
         return true;
-    }
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        events.clear();
-        events2.clear();
-        super.setUp();
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/impl/event/SimpleEventNotifierEventsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/event/SimpleEventNotifierEventsTest.java
@@ -36,14 +36,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class SimpleEventNotifierEventsTest {
 
-    private static List<CamelEvent> events = new ArrayList<>();
+    private final List<CamelEvent> events = new ArrayList<>();
 
     private CamelContext context;
     private ProducerTemplate template;
 
     @BeforeEach
     public void setUp() throws Exception {
-        events.clear();
         context = createCamelContext();
         context.addRoutes(createRouteBuilder());
         template = context.createProducerTemplate();

--- a/core/camel-core/src/test/java/org/apache/camel/processor/NavigateRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/NavigateRouteTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class NavigateRouteTest extends ContextTestSupport {
 
-    private static List<Processor> processors = new ArrayList<>();
+    private final List<Processor> processors = new ArrayList<>();
 
     @Test
     public void testNavigateRoute() throws Exception {

--- a/core/camel-core/src/test/resources/log4j2.properties
+++ b/core/camel-core/src/test/resources/log4j2.properties
@@ -37,16 +37,16 @@ appender.file2.layout.type = PatternLayout
 appender.file2.layout.pattern = %-5p %c{1} %m%n
 
 logger.customlogger.name = org.apache.camel.customlogger
-logger.customlogger.level = TRACE
+logger.customlogger.level = INFO
 logger.customlogger.appenderRef.file2.ref = file2
 
 logger.file-cluster.name = org.apache.camel.component.file.cluster
-logger.file-cluster.level = DEBUG
+logger.file-cluster.level = INFO
 
-rootLogger.level = DEBUG
+rootLogger.level = INFO
 
 rootLogger.appenderRef.file.ref = file
 #rootLogger.appenderRef.console.ref = console
 
 #logger.camel-core.name = org.apache.camel
-#logger.camel-core.level = TRACE
+#logger.camel-core.level = INFO

--- a/core/camel-support/src/main/java/org/apache/camel/throttling/ThrottlingExceptionRoutePolicy.java
+++ b/core/camel-support/src/main/java/org/apache/camel/throttling/ThrottlingExceptionRoutePolicy.java
@@ -115,6 +115,15 @@ public class ThrottlingExceptionRoutePolicy extends RoutePolicySupport implement
     }
 
     @Override
+    protected void doStop() throws Exception {
+        Timer timer = halfOpenTimer;
+        if (timer != null) {
+            timer.cancel();
+            halfOpenTimer = null;
+        }
+    }
+
+    @Override
     public void onExchangeDone(Route route, Exchange exchange) {
         if (keepOpen.get()) {
             if (state.get() != STATE_OPEN) {


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-18988

## Motivation

Since we upgraded to surefire + failsafe M8, some of our tests have started to fail with `OutOfMemoryException`.

## Modifications

After a deeper analysis using JProfiler, it appears that there is no significant memory leak, only small ones, especially some `DefaultCamelContext` leaks.

* Restore the log level to info
* Fix main `DefaultCamelContext` leaks except for the Simple expression cache and the cache in `DefaultParameterMappingStrategy`.
* Add JVM options to allow future analysis if it happens again