### PR TITLE
CAMEL-18988: camel-core - tests failing due to OOM (part 2)

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -41,7 +41,7 @@
         <compiler.fork>true</compiler.fork>
         <cxf.codegenplugin.forkmode>true</cxf.codegenplugin.forkmode>
         <cxf.codegen.jvmArgs/>
-        <camel.surefire.fork.vmargs>-XX:+ExitOnOutOfMemoryError</camel.surefire.fork.vmargs>
+        <camel.surefire.fork.vmargs>-XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError</camel.surefire.fork.vmargs>
         <camel.surefire.forkCount>1</camel.surefire.forkCount>
         <camel.surefire.forkTimeout>600</camel.surefire.forkTimeout>
         <camel.surefire.reuseForks>true</camel.surefire.reuseForks>

--- a/components/camel-aws/camel-aws-secrets-manager/pom.xml
+++ b/components/camel-aws/camel-aws-secrets-manager/pom.xml
@@ -98,7 +98,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>${camel.surefire.fork.vmargs} -XX:+ExitOnOutOfMemoryError -Xmx2G</argLine>
+                    <argLine>${camel.surefire.fork.vmargs} -Xmx2G</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/components/camel-aws/camel-aws2-kms/pom.xml
+++ b/components/camel-aws/camel-aws2-kms/pom.xml
@@ -81,7 +81,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                <argLine>${camel.surefire.fork.vmargs} -XX:+ExitOnOutOfMemoryError -Xmx2G</argLine>
+                <argLine>${camel.surefire.fork.vmargs} -Xmx2G</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/components/camel-aws/camel-aws2-lambda/pom.xml
+++ b/components/camel-aws/camel-aws2-lambda/pom.xml
@@ -85,7 +85,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>${camel.surefire.fork.vmargs} -XX:+ExitOnOutOfMemoryError -Xmx2G</argLine>
+                    <argLine>${camel.surefire.fork.vmargs} -Xmx2G</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/components/camel-aws/camel-aws2-sns/pom.xml
+++ b/components/camel-aws/camel-aws2-sns/pom.xml
@@ -109,7 +109,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>${camel.surefire.fork.vmargs} -XX:+ExitOnOutOfMemoryError -Xmx2G</argLine>
+                    <argLine>${camel.surefire.fork.vmargs} -Xmx2G</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/components/camel-bindy/pom.xml
+++ b/components/camel-bindy/pom.xml
@@ -32,7 +32,7 @@
     <description>Camel Bindy data format support</description>
 
     <properties>
-        <camel.surefire.fork.vmargs>-XX:+ExitOnOutOfMemoryError -Duser.language=en -Duser.region=GB</camel.surefire.fork.vmargs>
+        <camel.surefire.fork.vmargs>-XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.region=GB</camel.surefire.fork.vmargs>
         <camel.surefire.parallel>true</camel.surefire.parallel>
     </properties>
 

--- a/core/camel-core/pom.xml
+++ b/core/camel-core/pom.xml
@@ -286,7 +286,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- skip file stress tests as they are intended to run manually -->
-                    <argLine>${camel.surefire.fork.vmargs} -Xmx2G -XX:+HeapDumpOnOutOfMemoryError -XX:OnOutOfMemoryError="jcmd %p Thread.print" -XX:+UnlockDiagnosticVMOptions -XX:+LogVMOutput -XX:LogFile=jvm.log</argLine>
+                    <argLine>${camel.surefire.fork.vmargs} -Xmx2G</argLine>
                     <excludes>
                         <exclude>org/apache/camel/component/file/stress/**.java</exclude>
                         <exclude>**/DistributedCompletionIntervalTest.java</exclude>

--- a/core/camel-core/src/test/resources/junit-platform.properties
+++ b/core/camel-core/src/test/resources/junit-platform.properties
@@ -20,5 +20,5 @@ junit.jupiter.execution.parallel.mode.default = same_thread
 junit.jupiter.execution.parallel.mode.classes.default = concurrent
 junit.jupiter.execution.parallel.config.strategy = custom
 junit.jupiter.execution.parallel.config.custom.parallelism = 4
-junit.jupiter.execution.parallel.config.custom.maxPoolSize = 1024
+junit.jupiter.execution.parallel.config.custom.maxPoolSize = 512
 junit.jupiter.execution.parallel.config.custom.class=org.apache.camel.CamelParallelExecutionStrategy

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -36,7 +36,7 @@
         <compiler.fork>true</compiler.fork>
         <cxf.codegenplugin.forkmode>true</cxf.codegenplugin.forkmode>
         <cxf.codegen.jvmArgs/>
-        <camel.surefire.fork.vmargs>-XX:+ExitOnOutOfMemoryError</camel.surefire.fork.vmargs>
+        <camel.surefire.fork.vmargs>-XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError</camel.surefire.fork.vmargs>
         <camel.surefire.forkCount>1</camel.surefire.forkCount>
         <camel.surefire.forkTimeout>600</camel.surefire.forkTimeout>
         <camel.surefire.reuseForks>true</camel.surefire.reuseForks>


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-18988 (part 2)

## Motivation

Since we upgraded to surefire + failsafe M8, some of our tests have started to fail with `OnOutOfMemoryError`.

## Modifications

In practice, only the JVM option `-XX:+HeapDumpOnOutOfMemoryError` is needed as a thread dump can be extracted from an `hprof` file.

* Ensure that an `hprof` file is always generated on OOME
* Remove duplicated JVM options
* Reduce the max pool size of the thread pool used to launch the tests to limit the impact on memory since there is no real memory leak so the OOMEs are likely due to an excessive amount of threads 

## Result

The heap size doesn't exceed 1 Go during the tests whereas it could reach 1.5 Go before the change.