### PR TITLE
Change Mojo for example projects

### DIFF
--- a/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/ExampleModel.java
+++ b/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/ExampleModel.java
@@ -24,6 +24,7 @@ public class ExampleModel {
     protected String description = "";
     protected String readmeFileName = "readme.md";
     protected String deprecated;
+    protected String middleFolder;
 
     public String getFileName() {
         return fileName;
@@ -73,7 +74,19 @@ public class ExampleModel {
         this.deprecated = deprecated;
     }
 
+    public String getMiddleFolder() {
+        return middleFolder;
+    }
+
+    public void setMiddleFolder(String middleFolder) {
+        this.middleFolder = middleFolder;
+    }
+
     public String getDocLink() {
-        return fileName + "/" + readmeFileName;
+        if (middleFolder == null) {
+            return fileName + "/" + readmeFileName;
+        }
+
+        return middleFolder + "/" + fileName + "/" + readmeFileName;
     }
 }

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PrepareExampleMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PrepareExampleMojo.java
@@ -108,15 +108,16 @@ public class PrepareExampleMojo extends AbstractMojo {
                     if (!middleFolders.contains(file.getName())) {
                         File pom = new File(file, "pom.xml");
                         if (pom.exists()) {
-                            processExamples(models, file, pom);
+                            processExamples(models, file, pom, null);
                         }
                     } else {
                         File[] subFiles = file.listFiles();
+                        String middleFolder = file.getName();
                         for (File innerFile : subFiles) {
                             if (innerFile.isDirectory()) {
                                 File pom = new File(innerFile, "pom.xml");
                                 if (pom.exists()) {
-                                    processExamples(models, innerFile, pom);
+                                    processExamples(models, innerFile, pom, middleFolder);
                                 }
                             }
                         }
@@ -153,7 +154,7 @@ public class PrepareExampleMojo extends AbstractMojo {
         }
     }
 
-    private void processExamples(List<ExampleModel> models, File file, File pom) throws IOException {
+    private void processExamples(List<ExampleModel> models, File file, File pom, String middleFolder) throws IOException {
         String existing = FileUtils.readFileToString(pom, Charset.defaultCharset());
 
         ExampleModel model = new ExampleModel();
@@ -180,6 +181,9 @@ public class PrepareExampleMojo extends AbstractMojo {
             model.setDeprecated("true");
         } else {
             model.setDeprecated("false");
+        }
+        if (middleFolder != null) {
+            model.setMiddleFolder(middleFolder);
         }
 
         // readme files is either readme.md or readme.adoc


### PR DESCRIPTION
# Description

The `camel-examples` project's [examples/README.adoc](https://github.com/apache/camel-examples/blob/main/examples/README.adoc) file contains some broken links. This is happening because some examples are grouped in a folder, for example the [aws](https://github.com/apache/camel-examples/tree/main/examples/aws) folder. The change I made provides a way for Mojo to correctly prepare example links when there is a grouping of examples by folder.

Reference: apache/camel-examples#123

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->