### PR TITLE
Fix typo in getting started page

### DIFF
--- a/docs/main/modules/getting-started/pages/index.adoc
+++ b/docs/main/modules/getting-started/pages/index.adoc
@@ -287,7 +287,7 @@ Camel supports most of the xref:components:eips:enterprise-integration-patterns.
 [[BookGettingStarted-RoutesAdding]]
 === Adding Routes and Running the Application
 
-Before executing a route, it needs to be to be configured and added to the _CamelContext_.
+Before executing a route, it needs to be configured and added to the _CamelContext_.
 
 The `MainApp.java` file contains the code that performs these steps:
 


### PR DESCRIPTION
While reading the getting started documentation I found a typo. 
I fixed it in this PR.