### PR TITLE
fixed typo on Getting Started Page under Concepts And Terminology Fun…

### DIFF
--- a/docs/main/modules/getting-started/pages/index.adoc
+++ b/docs/main/modules/getting-started/pages/index.adoc
@@ -309,7 +309,7 @@ You don’t interact directly with the _CamelContext_ in this example, but it is
 [[BookGettingStarted-ConceptsAndTerminologyFundamentalToCamel]]
 == Concepts and terminology fundamental to Camel
 
-In this section, we explain additional of Camel concepts and features.
+In this section, we explain additional Camel concepts and features.
 
 [[BookGettingStarted-CamelContext]]
 === CamelContext


### PR DESCRIPTION
Corrected a typo under section "Concepts and Terminology Fundamental to Camel."

![67EB7D25-D8A2-45BD-9BFA-8D0227A504EB](https://user-images.githubusercontent.com/109642366/221452145-1c9d1e4d-f1bc-42e9-8e06-56fe4caa1f9d.jpeg)
