### PR TITLE
(perf chores) camel-seda: cache queue reference to avoid costly operations in the hot path

### DIFF
--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
@@ -100,6 +100,7 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
     private boolean discardIfNoConsumers;
 
     private BlockingQueueFactory<Exchange> queueFactory;
+    private volatile QueueReference ref;
 
     public SedaEndpoint() {
         queueFactory = new LinkedBlockingQueueFactory<>();
@@ -207,14 +208,22 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
         }
     }
 
+    @Override
+    public void start() {
+        super.start();
+
+        final String key = getComponent().getQueueKey(getEndpointUri());
+        if (ref == null) {
+            ref = getComponent().getQueueReference(key);
+        }
+    }
+
     /**
-     * Get's the {@link QueueReference} for the this endpoint.
+     * Gets the {@link QueueReference} for this endpoint.
      *
      * @return the reference, or <tt>null</tt> if no queue reference exists.
      */
-    public synchronized QueueReference getQueueReference() {
-        String key = getComponent().getQueueKey(getEndpointUri());
-        QueueReference ref = getComponent().getQueueReference(key);
+    public QueueReference getQueueReference() {
         return ref;
     }
 


### PR DESCRIPTION
This one seems to add a very small (but still measurable) throughput improvement for Seda by avoiding a few synchronized calls. It's part of several other perf patches I will be sending 


Compared w/ 4.0.0-M1 (both w/ 4 consumers and 1 producer): 

```
--- Patch
Mean: 484459.8571428573
Geometric mean: 484272.99632561835
Standard deviation: 13570.203212282813

--- 4.0.0-M1
Mean: 480957.58035714296
Geometric mean: 479545.8325907664
Standard deviation: 33212.22104132737
```