### PR TITLE
CAMEL-19058: fix a type check scability issue for Message types

### DIFF
--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessage.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessage.java
@@ -25,6 +25,7 @@ import jakarta.jms.Message;
 import jakarta.jms.Queue;
 import jakarta.jms.Session;
 import jakarta.jms.Topic;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.support.DefaultMessage;
@@ -48,8 +49,18 @@ public class JmsMessage extends DefaultMessage {
             this.jmsMessage = message;
         }
 
-        public boolean isTransactedRedelivered() {
-            return JmsMessageHelper.getJMSRedelivered(jmsMessage.jmsMessage);
+        public TransactedRedeliveryState transactedRedeliveredState() {
+            final Boolean jmsRedelivered = JmsMessageHelper.getJMSRedelivered(jmsMessage.jmsMessage);
+
+            if (jmsRedelivered == null) {
+                return TransactedRedeliveryState.UNDEFINED;
+            } else {
+                if (jmsRedelivered) {
+                    return TransactedRedeliveryState.IS_REDELIVERY;
+                }
+            }
+
+            return TransactedRedeliveryState.NON_REDELIVERY;
         }
     }
 

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessage.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessage.java
@@ -270,12 +270,13 @@ public class JmsMessage extends DefaultMessage {
     }
 
     @Override
-    protected Boolean isTransactedRedelivered() {
-        if (jmsMessage != null) {
-            return JmsMessageHelper.getJMSRedelivered(jmsMessage);
-        } else {
-            return null;
-        }
+    public MessageTrait getMessageTraits() {
+        return new MessageTrait() {
+            @Override
+            public boolean isTransactedRedelivered() {
+                return JmsMessageHelper.getJMSRedelivered(jmsMessage);
+            }
+        };
     }
 
     private String getDestinationAsString(Destination destination) throws JMSException {

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsMessage.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsMessage.java
@@ -288,12 +288,13 @@ public class SjmsMessage extends DefaultMessage {
     }
 
     @Override
-    protected Boolean isTransactedRedelivered() {
-        if (jmsMessage != null) {
-            return JmsMessageHelper.getJMSRedelivered(jmsMessage);
-        } else {
-            return null;
-        }
+    public MessageTrait getMessageTraits() {
+        return new MessageTrait() {
+            @Override
+            public boolean isTransactedRedelivered() {
+                return JmsMessageHelper.getJMSRedelivered(jmsMessage);
+            }
+        };
     }
 
     private String getDestinationAsString(Destination destination) throws JMSException {

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsMessage.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsMessage.java
@@ -51,8 +51,17 @@ public class SjmsMessage extends DefaultMessage {
             this.sJmsMessage = message;
         }
 
-        public boolean isTransactedRedelivered() {
-            return JmsMessageHelper.getJMSRedelivered(sJmsMessage.jmsMessage);
+        public TransactedRedeliveryState transactedRedeliveredState() {
+            final Boolean jmsRedelivered = JmsMessageHelper.getJMSRedelivered(sJmsMessage.jmsMessage);
+            if (jmsRedelivered == null) {
+                return TransactedRedeliveryState.UNDEFINED;
+            } else {
+                if (jmsRedelivered) {
+                    return TransactedRedeliveryState.IS_REDELIVERY;
+                }
+            }
+
+            return TransactedRedeliveryState.NON_REDELIVERY;
         }
     }
 

--- a/core/camel-api/src/main/java/org/apache/camel/Message.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Message.java
@@ -32,6 +32,19 @@ import org.apache.camel.spi.HeadersMapFactory;
  */
 public interface Message {
 
+    interface MessageTrait {
+        /**
+         * A strategy for component-specific messages to determine whether the message is redelivered or not.
+         * <p/>
+         * <b>Important: </b> It is not always possible to determine if the transacted is a redelivery or not, and therefore
+         * <tt>null</tt> is returned. Such an example would be a JDBC message. However, JMS brokers provide details if a
+         * transacted message is redelivered.
+         *
+         * @return <tt>true</tt> if redelivered otherwise returns <tt>false</tt>
+         */
+        boolean isTransactedRedelivered();
+    }
+
     /**
      * Clears the message from user data, so the message can be reused.
      * <p/>
@@ -318,5 +331,14 @@ public interface Message {
      * @param newBody the new body to use
      */
     void copyFromWithNewBody(Message message, Object newBody);
+
+    default MessageTrait getMessageTraits() {
+        return new MessageTrait() {
+            @Override
+            public boolean isTransactedRedelivered() {
+                return false;
+            }
+        };
+    }
 
 }

--- a/core/camel-api/src/main/java/org/apache/camel/Message.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Message.java
@@ -34,6 +34,12 @@ import org.apache.camel.spi.HeadersMapFactory;
 public interface Message {
 
     interface MessageTrait {
+        enum TransactedRedeliveryState {
+            UNDEFINED,
+            NON_REDELIVERY,
+            IS_REDELIVERY
+        }
+
         /**
          * A strategy for component-specific messages to determine whether the message is redelivered or not.
          * <p/>
@@ -43,7 +49,7 @@ public interface Message {
          *
          * @return <tt>true</tt> if redelivered otherwise returns <tt>false</tt>
          */
-        boolean isTransactedRedelivered();
+        TransactedRedeliveryState transactedRedeliveredState();
 
         /**
          * Whether the message can store a data type. Check {@link org.apache.camel.spi.DataTypeAware}.
@@ -356,8 +362,8 @@ public interface Message {
     default MessageTrait getMessageTraits() {
         return new MessageTrait() {
             @Override
-            public boolean isTransactedRedelivered() {
-                return false;
+            public TransactedRedeliveryState transactedRedeliveredState() {
+                return TransactedRedeliveryState.UNDEFINED;
             }
 
             @Override

--- a/core/camel-api/src/main/java/org/apache/camel/Message.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Message.java
@@ -19,6 +19,7 @@ package org.apache.camel;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import org.apache.camel.spi.DataType;
 import org.apache.camel.spi.HeadersMapFactory;
 
 /**
@@ -43,6 +44,26 @@ public interface Message {
          * @return <tt>true</tt> if redelivered otherwise returns <tt>false</tt>
          */
         boolean isTransactedRedelivered();
+
+        /**
+         * Whether the message can store a data type. Check {@link org.apache.camel.spi.DataTypeAware}.
+         * @return
+         */
+        boolean isDataAware();
+
+        /**
+         * Whether any data type has been configured
+         */
+        boolean hasDataType();
+
+
+        /**
+         * Sets the data type
+         * @param dataType
+         */
+        void setDataType(DataType dataType);
+
+        DataType getDataType();
     }
 
     /**
@@ -337,6 +358,26 @@ public interface Message {
             @Override
             public boolean isTransactedRedelivered() {
                 return false;
+            }
+
+            @Override
+            public boolean isDataAware() {
+                return false;
+            }
+
+            @Override
+            public boolean hasDataType() {
+                return false;
+            }
+
+            @Override
+            public void setDataType(DataType dataType) {
+                // NO-OP
+            }
+
+            @Override
+            public DataType getDataType() {
+                return null;
             }
         };
     }

--- a/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
@@ -71,7 +71,6 @@ class AbstractExchange implements Exchange {
     Endpoint fromEndpoint;
     String fromRouteId;
     List<Synchronization> onCompletions;
-    Boolean externalRedelivered;
     String historyNodeId;
     String historyNodeLabel;
     String historyNodeSource;
@@ -653,20 +652,8 @@ class AbstractExchange implements Exchange {
 
     @Override
     public boolean isExternalRedelivered() {
-        if (externalRedelivered == null) {
-            // lets avoid adding methods to the Message API, so we use the
-            // DefaultMessage to allow component specific messages to extend
-            // and implement the isExternalRedelivered method.
-            Message msg = getIn();
-            if (msg instanceof DefaultMessage) {
-                externalRedelivered = ((DefaultMessage) msg).isTransactedRedelivered();
-            }
-            // not from a transactional resource so mark it as false by default
-            if (externalRedelivered == null) {
-                externalRedelivered = false;
-            }
-        }
-        return externalRedelivered;
+        Message message = getIn();
+        return message.getMessageTraits().isTransactedRedelivered();
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
@@ -71,6 +71,7 @@ class AbstractExchange implements Exchange {
     Endpoint fromEndpoint;
     String fromRouteId;
     List<Synchronization> onCompletions;
+    Message.MessageTrait.TransactedRedeliveryState externalRedelivered = Message.MessageTrait.TransactedRedeliveryState.UNDEFINED;
     String historyNodeId;
     String historyNodeLabel;
     String historyNodeSource;
@@ -652,8 +653,19 @@ class AbstractExchange implements Exchange {
 
     @Override
     public boolean isExternalRedelivered() {
-        Message message = getIn();
-        return message.getMessageTraits().isTransactedRedelivered();
+        if (externalRedelivered == Message.MessageTrait.TransactedRedeliveryState.UNDEFINED) {
+            Message message = getIn();
+
+            externalRedelivered = message.getMessageTraits().transactedRedeliveredState();
+
+            if (externalRedelivered == Message.MessageTrait.TransactedRedeliveryState.IS_REDELIVERY) {
+                return true;
+            }
+
+            externalRedelivered = Message.MessageTrait.TransactedRedeliveryState.NON_REDELIVERY;
+        }
+
+        return false;
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultMessage.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultMessage.java
@@ -37,6 +37,12 @@ import org.apache.camel.spi.HeadersMapFactory;
  */
 public class DefaultMessage extends MessageSupport {
     private Map<String, Object> headers;
+    private static final MessageTrait DEFAULT_MESSAGE_TRAIT = new MessageTrait() {
+        @Override
+        public boolean isTransactedRedelivered() {
+            return false;
+        }
+    };
 
     public DefaultMessage(Exchange exchange) {
         setExchange(exchange);
@@ -341,24 +347,14 @@ public class DefaultMessage extends MessageSupport {
     }
 
     /**
-     * A strategy for component specific messages to determine whether the message is redelivered or not.
-     * <p/>
-     * <b>Important: </b> It is not always possible to determine if the transacted is a redelivery or not, and therefore
-     * <tt>null</tt> is returned. Such an example would be a JDBC message. However JMS brokers provides details if a
-     * transacted message is redelivered.
-     *
-     * @return <tt>true</tt> if redelivered, <tt>false</tt> if not, <tt>null</tt> if not able to determine
-     */
-    protected Boolean isTransactedRedelivered() {
-        // return null by default
-        return null;
-    }
-
-    /**
      * Returns true if the headers have been mutated in some way
      */
     protected boolean hasPopulatedHeaders() {
         return headers != null;
     }
 
+    @Override
+    public MessageTrait getMessageTraits() {
+        return DEFAULT_MESSAGE_TRAIT;
+    }
 }

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultMessage.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultMessage.java
@@ -45,8 +45,8 @@ public class DefaultMessage extends MessageSupport {
         }
 
         @Override
-        public boolean isTransactedRedelivered() {
-            return false;
+        public TransactedRedeliveryState transactedRedeliveredState() {
+            return TransactedRedeliveryState.UNDEFINED;
         }
 
         @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultPooledExchange.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultPooledExchange.java
@@ -109,7 +109,6 @@ public final class DefaultPooledExchange extends AbstractExchange implements Poo
                 this.onCompletions.clear();
             }
             // do not reset endpoint/fromRouteId as it would be the same consumer/endpoint again
-            this.externalRedelivered = null;
             this.historyNodeId = null;
             this.historyNodeLabel = null;
             this.transacted = false;

--- a/core/camel-support/src/main/java/org/apache/camel/support/MessageHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/MessageHelper.java
@@ -617,14 +617,12 @@ public final class MessageHelper {
      */
     public static void copyBody(Message source, Message target) {
         // Preserve the DataType if both messages are DataTypeAware
-        if (source instanceof DataTypeAware && target instanceof DataTypeAware) {
-            final DataTypeAware dataTypeAwareSource = (DataTypeAware) source;
-            if (dataTypeAwareSource.hasDataType()) {
-                final DataTypeAware dataTypeAwareTarget = (DataTypeAware) target;
-                dataTypeAwareTarget.setBody(source.getBody(), dataTypeAwareSource.getDataType());
-                return;
+        if (source.getMessageTraits().isDataAware() && target.getMessageTraits().isDataAware()) {
+            if (source.getMessageTraits().hasDataType()) {
+                target.getMessageTraits().setDataType(source.getMessageTraits().getDataType());
             }
         }
+
         target.setBody(source.getBody());
     }
 

--- a/core/camel-support/src/main/java/org/apache/camel/support/MessageSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/MessageSupport.java
@@ -187,10 +187,9 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
 
         copyFromWithNewBody(that, that.getBody());
         // Preserve the DataType
-        if (that instanceof DataTypeAware) {
-            final DataTypeAware dataTypeAware = (DataTypeAware) that;
-            if (dataTypeAware.hasDataType()) {
-                setDataType(dataTypeAware.getDataType());
+        if (that.getMessageTraits().isDataAware()) {
+            if (that.getMessageTraits().hasDataType()) {
+                setDataType(that.getMessageTraits().getDataType());
             }
         }
     }


### PR DESCRIPTION
Using the type check agent, we can see that the Message type is hit pretty hard by the type check scalability issue and reports quite a lot of occurrences for these types: 

```
--------------------------
3:	org.apache.camel.support.DefaultMessage
Count:	197370941
Types:
	org.apache.camel.spi.DataTypeAware
	org.apache.camel.CamelContextAware
Traces:
	org.apache.camel.support.MessageSupport.copyFrom(MessageSupport.java:199)
		class: org.apache.camel.spi.DataTypeAware
		count: 98685471
	org.apache.camel.CamelContextAware.trySetCamelContext(CamelContextAware.java:28)
		class: org.apache.camel.CamelContextAware
		count: 98685470
```

This resolves most of them. 