### PR TITLE
CAMEL-19058: adjust producer caching to reduce impacts of false sharing

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/cache/DefaultProducerCache.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/cache/DefaultProducerCache.java
@@ -58,6 +58,9 @@ public class DefaultProducerCache extends ServiceSupport implements ProducerCach
     private boolean extendedStatistics;
     private int maxCacheSize;
 
+    private Endpoint lastUsedEndpoint;
+    private AsyncProducer lastUsedProducer;
+
     public DefaultProducerCache(Object source, CamelContext camelContext, int cacheSize) {
         this.source = source;
         this.camelContext = camelContext;
@@ -119,11 +122,20 @@ public class DefaultProducerCache extends ServiceSupport implements ProducerCach
 
     @Override
     public AsyncProducer acquireProducer(Endpoint endpoint) {
+        // Try to favor thread locality as some data in the producer's cache may be shared among threads,
+        // triggering cases of false sharing
+        if (endpoint == lastUsedEndpoint) {
+            return lastUsedProducer;
+        }
+
         try {
             AsyncProducer producer = producers.acquire(endpoint);
             if (statistics != null) {
                 statistics.onHit(endpoint.getEndpointUri());
             }
+            lastUsedEndpoint = endpoint;
+            lastUsedProducer = producer;
+
             return producer;
         } catch (Throwable e) {
             throw new FailedToCreateProducerException(endpoint, e);


### PR DESCRIPTION
With this one, we get another nice performance improvement:

```
--- 4.0.0-SNAPSHOT (w/ single shot initialization check + local cache)
Minimum: 652933.0
Maximum: 763599.0
Mean: 720940.8750000001
Geometric mean: 720782.7857395237
Standard deviation: 14897.378438658043

-- 4.0.0-SNAPSHOT (w/ single shot initialization check) 
Minimum: 604363.0
Maximum: 738706.0
Mean: 690079.2589285716
Geometric mean: 689914.539795926
Standard deviation: 14777.32031672733

-- 4.0.0-SNAPSHOT (w/ current patches)
Minimum: 666288.0
Maximum: 736833.0
Mean: 682849.5803571424
Geometric mean: 682692.0184731855
Standard deviation: 14906.813491217838

-- 4.0.0-M1
Minimum: 314709.0
Maximum: 504790.0
Mean: 437547.0535714286
Geometric mean: 436218.60520058003
Standard deviation: 32919.50500783796
```
