### PR TITLE
[CAMEL-19101] Features for Camel-Micrometer

### DIFF
--- a/components/camel-micrometer/src/main/docs/micrometer-component.adoc
+++ b/components/camel-micrometer/src/main/docs/micrometer-component.adoc
@@ -403,6 +403,24 @@ following options:
 |prettyPrint |false |Whether to use pretty print when outputting statistics in json format
 |meterRegistry |  |Allow to use a shared `MeterRegistry`. If none is provided then Camel will create a shared instance used by the this CamelContext.
 |durationUnit |TimeUnit.MILLISECONDS |The unit to use for duration in when dumping the statistics as json.
+|configuration | see below |MicrometerRoutePolicyConfiguration.class
+|=======================================================================
+
+The `MicrometerRoutePolicyConfiguration` supports the
+following options:
+
+[width="100%",options="header"]
+|=======================================================================
+|Name |Default |Description
+|additionalCounters | true | activates all additional counters
+|exchangesSucceeded | true | activates counter for succeeded exchanges
+|exchangesFailed | true | activates counter for failed exchanges
+|exchangesTotal | true | activates counter for total count of exchanges
+|externalRedeliveries | true | activates counter for redeliveries of exchanges
+|failuresHandled | true | activates counter for handled failures
+|longTask | false | activates long task timer (current processing time for micrometer)
+|timerInitiator |  null | Consumer<Timer.Builder> for custom initialize Timer
+|longTaskInitiator |  null | Consumer<LongTaskTimer.Builder> for custom initialize LongTaskTimer
 |=======================================================================
 
 If JMX is enabled in the CamelContext, the MBean is registered in the `type=services` tree

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/DistributionStatisticConfigFilter.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/DistributionStatisticConfigFilter.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.micrometer;
 
 import java.time.Duration;
 import java.util.function.Predicate;
+import java.util.stream.LongStream;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.MeterFilter;
@@ -55,9 +56,9 @@ public class DistributionStatisticConfigFilter implements MeterFilter {
                     .percentilesHistogram(publishPercentileHistogram)
                     .percentiles(percentiles)
                     .percentilePrecision(percentilePrecision)
-                    .maximumExpectedValue(maximumExpectedValue)
-                    .minimumExpectedValue(minimumExpectedValue)
-                    .sla(slas)
+                    .maximumExpectedValue((double) maximumExpectedValue)
+                    .minimumExpectedValue((double) minimumExpectedValue)
+                    .serviceLevelObjectives(LongStream.of(slas).asDoubleStream().toArray())
                     .bufferLength(bufferLength)
                     .expiry(expiry)
                     .build()

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/MicrometerConstants.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/MicrometerConstants.java
@@ -49,6 +49,7 @@ public final class MicrometerConstants {
     public static final String DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_EXTERNAL_REDELIVERIES_METER_NAME
             = "CamelExchangesExternalRedeliveries";
     public static final String DEFAULT_CAMEL_ROUTE_POLICY_METER_NAME = "CamelRoutePolicy";
+    public static final String DEFAULT_CAMEL_ROUTE_POLICY_LONGMETER_NAME = "CamelRoutePolicyLongTask";
     public static final String DEFAULT_CAMEL_EXCHANGE_EVENT_METER_NAME = "CamelExchangeEventNotifier";
     public static final String DEFAULT_CAMEL_ROUTES_ADDED = "CamelRoutesAdded";
     public static final String DEFAULT_CAMEL_ROUTES_RUNNING = "CamelRoutesRunning";

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicy.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicy.java
@@ -16,12 +16,12 @@
  */
 package org.apache.camel.component.micrometer.routepolicy;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.*;
 import org.apache.camel.Exchange;
 import org.apache.camel.NonManagedService;
 import org.apache.camel.Route;
@@ -46,61 +46,103 @@ public class MicrometerRoutePolicy extends RoutePolicySupport implements NonMana
     private MeterRegistry meterRegistry;
     private boolean prettyPrint;
     private TimeUnit durationUnit = TimeUnit.MILLISECONDS;
-    private MetricsStatistics statistics;
     private MicrometerRoutePolicyNamingStrategy namingStrategy = MicrometerRoutePolicyNamingStrategy.DEFAULT;
+    private MicrometerRoutePolicyConfiguration configuration = MicrometerRoutePolicyConfiguration.DEFAULT;
+
+    Map<Route, MetricsStatistics> statisticsMap = new HashMap<>();
 
     private static final class MetricsStatistics {
         private final MeterRegistry meterRegistry;
         private final Route route;
         private final MicrometerRoutePolicyNamingStrategy namingStrategy;
-        private final Counter exchangesSucceeded;
-        private final Counter exchangesFailed;
-        private final Counter exchangesTotal;
-        private final Counter externalRedeliveries;
-        private final Counter failuresHandled;
+        private final MicrometerRoutePolicyConfiguration configuration;
+        private Counter exchangesSucceeded;
+        private Counter exchangesFailed;
+        private Counter exchangesTotal;
+        private Counter externalRedeliveries;
+        private Counter failuresHandled;
+        private Timer timer;
+        private LongTaskTimer longTaskTimer;
 
         private MetricsStatistics(MeterRegistry meterRegistry, Route route,
-                                  MicrometerRoutePolicyNamingStrategy namingStrategy) {
+                                  MicrometerRoutePolicyNamingStrategy namingStrategy,
+                                  MicrometerRoutePolicyConfiguration configuration) {
+            this.configuration = ObjectHelper.notNull(configuration, "MicrometerRoutePolicyConfiguration", this);
             this.meterRegistry = ObjectHelper.notNull(meterRegistry, "MeterRegistry", this);
             this.namingStrategy = ObjectHelper.notNull(namingStrategy, "MicrometerRoutePolicyNamingStrategy", this);
             this.route = route;
-            this.exchangesSucceeded = createCounter(namingStrategy.getExchangesSucceededName(route),
-                    "Number of successfully completed exchanges");
-            this.exchangesFailed = createCounter(namingStrategy.getExchangesFailedName(route), "Number of failed exchanges");
-            this.exchangesTotal
-                    = createCounter(namingStrategy.getExchangesTotalName(route), "Total number of processed exchanges");
-            this.externalRedeliveries = createCounter(namingStrategy.getExternalRedeliveriesName(route),
-                    "Number of external initiated redeliveries (such as from JMS broker)");
-            this.failuresHandled = createCounter(namingStrategy.getFailuresHandledName(route), "Number of failures handled");
+            if (configuration.isAdditionalCounters()) initAdditionalCounters();
+        }
+
+        private void initAdditionalCounters() {
+            if (configuration.isExchangesSucceeded()) {
+                this.exchangesSucceeded = createCounter(namingStrategy.getExchangesSucceededName(route),
+                        "Number of successfully completed exchanges");
+            }
+            if (configuration.isExchangesFailed()) {
+                this.exchangesFailed = createCounter(namingStrategy.getExchangesFailedName(route), "Number of failed exchanges");
+            }
+            if (configuration.isExchangesTotal()) {
+                this.exchangesTotal
+                        = createCounter(namingStrategy.getExchangesTotalName(route), "Total number of processed exchanges");
+            }
+            if (configuration.isExternalRedeliveries()) {
+                this.externalRedeliveries = createCounter(namingStrategy.getExternalRedeliveriesName(route),
+                        "Number of external initiated redeliveries (such as from JMS broker)");
+            }
+            if (configuration.isFailuresHandled()) {
+                this.failuresHandled = createCounter(namingStrategy.getFailuresHandledName(route), "Number of failures handled");
+            }
+            if (configuration.isLongTask()) {
+                LongTaskTimer.Builder builder = LongTaskTimer.builder(namingStrategy.getLongTaskName(route))
+                        .tags(namingStrategy.getTags(route))
+                        .description("Route long task metric");
+                if (configuration.getLongTaskInitiator() != null) {
+                    configuration.getLongTaskInitiator().accept(builder);
+                }
+                longTaskTimer = builder.register(meterRegistry);
+            }
         }
 
         public void onExchangeBegin(Exchange exchange) {
             Timer.Sample sample = Timer.start(meterRegistry);
             exchange.setProperty(propertyName(exchange), sample);
+            if (longTaskTimer != null) {
+                exchange.setProperty(propertyName(exchange) + "_long_task", longTaskTimer.start());
+            }
         }
 
         public void onExchangeDone(Exchange exchange) {
             Timer.Sample sample = (Timer.Sample) exchange.removeProperty(propertyName(exchange));
             if (sample != null) {
-                Timer timer = Timer.builder(namingStrategy.getName(route))
-                        .tags(namingStrategy.getTags(route))
-                        .description("Route performance metrics")
-                        .register(meterRegistry);
+                if (timer == null) {
+                    Timer.Builder builder = Timer.builder(namingStrategy.getName(route))
+                            .tags(namingStrategy.getTags(route))
+                            .description("Route performance metrics");
+                    if (configuration.getTimerInitiator() != null) {
+                        configuration.getTimerInitiator().accept(builder);
+                    }
+                    timer = builder.register(meterRegistry);
+                }
                 sample.stop(timer);
             }
+            LongTaskTimer.Sample ltSampler = (LongTaskTimer.Sample) exchange.removeProperty(propertyName(exchange) + "_long_task");
+            if (ltSampler != null) ltSampler.stop();
+            if (configuration.isAdditionalCounters()) {
+                updateAdditionalCounters(exchange);
+            }
+        }
 
-            exchangesTotal.increment();
-
+        private void updateAdditionalCounters(Exchange exchange) {
+            if (exchangesTotal != null) exchangesTotal.increment();
             if (exchange.isFailed()) {
-                exchangesFailed.increment();
+                if (exchangesFailed != null) exchangesFailed.increment();
             } else {
-                exchangesSucceeded.increment();
-
-                if (ExchangeHelper.isFailureHandled(exchange)) {
+                if (exchangesSucceeded != null) exchangesSucceeded.increment();
+                if (failuresHandled != null && ExchangeHelper.isFailureHandled(exchange)) {
                     failuresHandled.increment();
                 }
-
-                if (exchange.isExternalRedelivered()) {
+                if (externalRedeliveries != null && exchange.isExternalRedelivered()) {
                     externalRedeliveries.increment();
                 }
             }
@@ -150,6 +192,14 @@ public class MicrometerRoutePolicy extends RoutePolicySupport implements NonMana
         this.namingStrategy = namingStrategy;
     }
 
+    public MicrometerRoutePolicyConfiguration getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(MicrometerRoutePolicyConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
     @Override
     public void onInit(Route route) {
         super.onInit(route);
@@ -176,21 +226,19 @@ public class MicrometerRoutePolicy extends RoutePolicySupport implements NonMana
         // create statistics holder
         // for now we record only all the timings of a complete exchange (responses)
         // we have in-flight / total statistics already from camel-core
-        statistics = new MetricsStatistics(getMeterRegistry(), route, getNamingStrategy());
+        statisticsMap.computeIfAbsent(route, it -> new MetricsStatistics(getMeterRegistry(), it, getNamingStrategy(), configuration));
     }
 
     @Override
     public void onExchangeBegin(Route route, Exchange exchange) {
-        if (statistics != null) {
-            statistics.onExchangeBegin(exchange);
-        }
+        Optional.ofNullable(statisticsMap.get(route))
+                .ifPresent(statistics -> statistics.onExchangeBegin(exchange));
     }
 
     @Override
     public void onExchangeDone(Route route, Exchange exchange) {
-        if (statistics != null) {
-            statistics.onExchangeDone(exchange);
-        }
+        Optional.ofNullable(statisticsMap.get(route))
+                .ifPresent(statistics -> statistics.onExchangeDone(exchange));
     }
 
 }

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyConfiguration.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyConfiguration.java
@@ -1,0 +1,91 @@
+package org.apache.camel.component.micrometer.routepolicy;
+
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Timer;
+
+import java.util.function.Consumer;
+
+public class MicrometerRoutePolicyConfiguration {
+    public static final MicrometerRoutePolicyConfiguration DEFAULT = new MicrometerRoutePolicyConfiguration();
+    private boolean additionalCounters = true;
+    private boolean exchangesSucceeded = true;
+    private boolean exchangesFailed = true;
+    private boolean exchangesTotal = true;
+    private boolean externalRedeliveries = true;
+    private boolean failuresHandled = true;
+    private boolean longTask = false;
+    private Consumer<Timer.Builder> timerInitiator;
+    private Consumer<LongTaskTimer.Builder> longTaskInitiator;
+
+    public boolean isAdditionalCounters() {
+        return additionalCounters;
+    }
+
+    public void setAdditionalCounters(boolean additionalCounters) {
+        this.additionalCounters = additionalCounters;
+    }
+
+    public boolean isExchangesSucceeded() {
+        return exchangesSucceeded;
+    }
+
+    public void setExchangesSucceeded(boolean exchangesSucceeded) {
+        this.exchangesSucceeded = exchangesSucceeded;
+    }
+
+    public boolean isExchangesFailed() {
+        return exchangesFailed;
+    }
+
+    public void setExchangesFailed(boolean exchangesFailed) {
+        this.exchangesFailed = exchangesFailed;
+    }
+
+    public boolean isExchangesTotal() {
+        return exchangesTotal;
+    }
+
+    public void setExchangesTotal(boolean exchangesTotal) {
+        this.exchangesTotal = exchangesTotal;
+    }
+
+    public boolean isExternalRedeliveries() {
+        return externalRedeliveries;
+    }
+
+    public void setExternalRedeliveries(boolean externalRedeliveries) {
+        this.externalRedeliveries = externalRedeliveries;
+    }
+
+    public boolean isFailuresHandled() {
+        return failuresHandled;
+    }
+
+    public void setFailuresHandled(boolean failuresHandled) {
+        this.failuresHandled = failuresHandled;
+    }
+
+    public boolean isLongTask() {
+        return longTask;
+    }
+
+    public void setLongTask(boolean longTask) {
+        this.longTask = longTask;
+    }
+
+    public Consumer<Timer.Builder> getTimerInitiator() {
+        return timerInitiator;
+    }
+
+    public void setTimerInitiator(Consumer<Timer.Builder> timerInitiator) {
+        this.timerInitiator = timerInitiator;
+    }
+
+    public Consumer<LongTaskTimer.Builder> getLongTaskInitiator() {
+        return longTaskInitiator;
+    }
+
+    public void setLongTaskInitiator(Consumer<LongTaskTimer.Builder> longTaskInitiator) {
+        this.longTaskInitiator = longTaskInitiator;
+    }
+}

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyConfiguration.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyConfiguration.java
@@ -1,9 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.micrometer.routepolicy;
+
+import java.util.function.Consumer;
 
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Timer;
-
-import java.util.function.Consumer;
 
 public class MicrometerRoutePolicyConfiguration {
     public static final MicrometerRoutePolicyConfiguration DEFAULT = new MicrometerRoutePolicyConfiguration();
@@ -13,7 +29,7 @@ public class MicrometerRoutePolicyConfiguration {
     private boolean exchangesTotal = true;
     private boolean externalRedeliveries = true;
     private boolean failuresHandled = true;
-    private boolean longTask = false;
+    private boolean longTask;
     private Consumer<Timer.Builder> timerInitiator;
     private Consumer<LongTaskTimer.Builder> longTaskInitiator;
 

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyFactory.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyFactory.java
@@ -34,6 +34,7 @@ public class MicrometerRoutePolicyFactory implements RoutePolicyFactory {
     private boolean prettyPrint = true;
     private TimeUnit durationUnit = TimeUnit.MILLISECONDS;
     private MicrometerRoutePolicyNamingStrategy namingStrategy = MicrometerRoutePolicyNamingStrategy.DEFAULT;
+    private MicrometerRoutePolicyConfiguration policyConfiguration = MicrometerRoutePolicyConfiguration.DEFAULT;
 
     /**
      * To use a specific {@link io.micrometer.core.instrument.MeterRegistry} instance.
@@ -81,6 +82,14 @@ public class MicrometerRoutePolicyFactory implements RoutePolicyFactory {
         this.namingStrategy = namingStrategy;
     }
 
+    public MicrometerRoutePolicyConfiguration getPolicyConfiguration() {
+        return policyConfiguration;
+    }
+
+    public void setPolicyConfiguration(MicrometerRoutePolicyConfiguration policyConfiguration) {
+        this.policyConfiguration = policyConfiguration;
+    }
+
     @Override
     public RoutePolicy createRoutePolicy(CamelContext camelContext, String routeId, NamedNode routeDefinition) {
         MicrometerRoutePolicy answer = new MicrometerRoutePolicy();
@@ -88,6 +97,7 @@ public class MicrometerRoutePolicyFactory implements RoutePolicyFactory {
         answer.setPrettyPrint(isPrettyPrint());
         answer.setDurationUnit(getDurationUnit());
         answer.setNamingStrategy(getNamingStrategy());
+        answer.setConfiguration(getPolicyConfiguration());
         return answer;
     }
 

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyNamingStrategy.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyNamingStrategy.java
@@ -22,15 +22,7 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tags;
 import org.apache.camel.Route;
 
-import static org.apache.camel.component.micrometer.MicrometerConstants.CAMEL_CONTEXT_TAG;
-import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_EXTERNAL_REDELIVERIES_METER_NAME;
-import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_FAILED_METER_NAME;
-import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_FAILURES_HANDLED_METER_NAME;
-import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_SUCCEEDED_METER_NAME;
-import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_TOTAL_METER_NAME;
-import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_ROUTE_POLICY_METER_NAME;
-import static org.apache.camel.component.micrometer.MicrometerConstants.ROUTE_ID_TAG;
-import static org.apache.camel.component.micrometer.MicrometerConstants.SERVICE_NAME;
+import static org.apache.camel.component.micrometer.MicrometerConstants.*;
 
 /**
  * Provides a strategy to derive a meter name and tags
@@ -62,6 +54,10 @@ public interface MicrometerRoutePolicyNamingStrategy {
 
     default String getExternalRedeliveriesName(Route route) {
         return DEFAULT_CAMEL_ROUTE_POLICY_EXCHANGES_EXTERNAL_REDELIVERIES_METER_NAME;
+    }
+
+    default String getLongTaskName(Route route) {
+        return DEFAULT_CAMEL_ROUTE_POLICY_LONGMETER_NAME;
     }
 
     default Tags getTags(Route route) {

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/messagehistory/ManagedMessageHistoryTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/messagehistory/ManagedMessageHistoryTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+
 public class ManagedMessageHistoryTest extends CamelTestSupport {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
@@ -75,8 +76,20 @@ public class ManagedMessageHistoryTest extends CamelTestSupport {
         return context;
     }
 
+    private void cleanMbeanServer() throws Exception {
+        //Deleting data from other tests
+        for (ObjectName it : timerNames()) {
+            getMBeanServer().unregisterMBean(it);
+        }
+    }
+
+    private Set<ObjectName> timerNames() throws Exception {
+        return getMBeanServer().queryNames(new ObjectName("org.apache.camel.micrometer:type=timers,name=*"), null);
+    }
+
     @Test
     public void testMessageHistory() throws Exception {
+        cleanMbeanServer();
         int count = 10;
 
         getMockEndpoint("mock:foo").expectedMessageCount(count / 2);
@@ -97,8 +110,7 @@ public class ManagedMessageHistoryTest extends CamelTestSupport {
         assertEquals(3, meterRegistry.getMeters().size());
 
         // there should be 3 mbeans
-        Set<ObjectName> set
-                = getMBeanServer().queryNames(new ObjectName("org.apache.camel.micrometer:type=timers,name=*"), null);
+        Set<ObjectName> set = timerNames();
         assertEquals(3, set.size());
 
         ObjectName fooMBean = set.stream().filter(on -> on.getCanonicalName().contains("foo")).findFirst()

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/messagehistory/ManagedMessageHistoryTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/messagehistory/ManagedMessageHistoryTest.java
@@ -41,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
 public class ManagedMessageHistoryTest extends CamelTestSupport {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/AbstractMicrometerRoutePolicyTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/AbstractMicrometerRoutePolicyTest.java
@@ -47,13 +47,16 @@ public abstract class AbstractMicrometerRoutePolicyTest extends CamelTestSupport
         return meterRegistry;
     }
 
+    protected MicrometerRoutePolicyFactory createMicrometerRoutePolicyFactory() {
+        return new MicrometerRoutePolicyFactory();
+    }
+
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext context = super.createCamelContext();
-        MicrometerRoutePolicyFactory factory = new MicrometerRoutePolicyFactory();
+        MicrometerRoutePolicyFactory factory = createMicrometerRoutePolicyFactory();
         factory.setMeterRegistry(meterRegistry);
         context.addRoutePolicyFactory(factory);
-
         return context;
     }
 

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyConfigrationTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyConfigrationTest.java
@@ -1,12 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.micrometer.routepolicy;
+
+import java.util.List;
 
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Timer;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -21,10 +37,8 @@ public class MicrometerRoutePolicyConfigrationTest extends AbstractMicrometerRou
         policyConfiguration.setExchangesTotal(false);
         policyConfiguration.setExternalRedeliveries(false);
         policyConfiguration.setFailuresHandled(false);
-        policyConfiguration.setTimerInitiator(builder ->
-            builder.tags("firstTag", "hello", "secondTag", "world")
-                    .description("Test Description")
-        );
+        policyConfiguration.setTimerInitiator(builder -> builder.tags("firstTag", "hello", "secondTag", "world")
+                .description("Test Description"));
         policyConfiguration.setLongTask(true);
         policyConfiguration.setLongTaskInitiator(builder -> builder.description("Test long task"));
         factory.setPolicyConfiguration(policyConfiguration);
@@ -43,11 +57,12 @@ public class MicrometerRoutePolicyConfigrationTest extends AbstractMicrometerRou
 
     @Test
     public void testConfigurationPolicy() throws Exception {
-        template.request("direct:foo", x -> {});
+        template.request("direct:foo", x -> {
+        });
         List<Meter> meters = meterRegistry.getMeters();
         assertEquals(2, meters.size(), "additional counters does not disable");
         Timer timer = (Timer) meters.stream().filter(it -> it instanceof Timer)
-                        .findFirst().orElse(null);
+                .findFirst().orElse(null);
 
         assertNotNull(timer, "timer is null");
         Meter.Id id = timer.getId();

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyConfigrationTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/MicrometerRoutePolicyConfigrationTest.java
@@ -1,0 +1,65 @@
+package org.apache.camel.component.micrometer.routepolicy;
+
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Timer;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MicrometerRoutePolicyConfigrationTest extends AbstractMicrometerRoutePolicyTest {
+
+    @Override
+    protected MicrometerRoutePolicyFactory createMicrometerRoutePolicyFactory() {
+        MicrometerRoutePolicyFactory factory = new MicrometerRoutePolicyFactory();
+        MicrometerRoutePolicyConfiguration policyConfiguration = new MicrometerRoutePolicyConfiguration();
+        policyConfiguration.setExchangesSucceeded(false);
+        policyConfiguration.setExchangesFailed(false);
+        policyConfiguration.setExchangesTotal(false);
+        policyConfiguration.setExternalRedeliveries(false);
+        policyConfiguration.setFailuresHandled(false);
+        policyConfiguration.setTimerInitiator(builder ->
+            builder.tags("firstTag", "hello", "secondTag", "world")
+                    .description("Test Description")
+        );
+        policyConfiguration.setLongTask(true);
+        policyConfiguration.setLongTaskInitiator(builder -> builder.description("Test long task"));
+        factory.setPolicyConfiguration(policyConfiguration);
+        return factory;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:foo").routeId("foo").delay(1);
+            }
+        };
+    }
+
+    @Test
+    public void testConfigurationPolicy() throws Exception {
+        template.request("direct:foo", x -> {});
+        List<Meter> meters = meterRegistry.getMeters();
+        assertEquals(2, meters.size(), "additional counters does not disable");
+        Timer timer = (Timer) meters.stream().filter(it -> it instanceof Timer)
+                        .findFirst().orElse(null);
+
+        assertNotNull(timer, "timer is null");
+        Meter.Id id = timer.getId();
+        assertEquals("Test Description", id.getDescription(), "incorrect description");
+        assertEquals("hello", id.getTag("firstTag"), "firstTag not setted");
+        assertEquals("world", id.getTag("secondTag"), "secondTag not setted");
+
+        LongTaskTimer longTaskTimer = (LongTaskTimer) meters.stream().filter(it -> it instanceof LongTaskTimer)
+                .findFirst().orElse(null);
+        assertNotNull(longTaskTimer, "LongTaskTimer is null");
+        id = longTaskTimer.getId();
+        assertEquals("Test long task", id.getDescription(), "incorrect long task description");
+    }
+
+}

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/SharedMicrometerRoutePolicyTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/SharedMicrometerRoutePolicyTest.java
@@ -1,4 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.micrometer.routepolicy;
+
+import java.util.List;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -10,8 +28,6 @@ import org.apache.camel.component.micrometer.MicrometerConstants;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SharedMicrometerRoutePolicyTest extends CamelTestSupport {
@@ -22,8 +38,10 @@ public class SharedMicrometerRoutePolicyTest extends CamelTestSupport {
 
     @Test
     public void testSharedPolicy() throws Exception {
-        template.request("direct:foo", x -> {});
-        template.request("direct:bar", x -> {});
+        template.request("direct:foo", x -> {
+        });
+        template.request("direct:bar", x -> {
+        });
         List<Meter> meters = meterRegistry.getMeters();
         long timers = meters.stream()
                 .filter(it -> it instanceof Timer)

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/SharedMicrometerRoutePolicyTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/routepolicy/SharedMicrometerRoutePolicyTest.java
@@ -1,0 +1,52 @@
+package org.apache.camel.component.micrometer.routepolicy;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.micrometer.MicrometerConstants;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SharedMicrometerRoutePolicyTest extends CamelTestSupport {
+
+    protected MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+    protected MicrometerRoutePolicy singletonPolicy = new MicrometerRoutePolicy();
+
+    @Test
+    public void testSharedPolicy() throws Exception {
+        template.request("direct:foo", x -> {});
+        template.request("direct:bar", x -> {});
+        List<Meter> meters = meterRegistry.getMeters();
+        long timers = meters.stream()
+                .filter(it -> it instanceof Timer)
+                .count();
+        assertEquals(2L, timers, "timers count incorrect");
+    }
+
+    @BindToRegistry(MicrometerConstants.METRICS_REGISTRY_NAME)
+    public MeterRegistry addRegistry() {
+        return meterRegistry;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:foo").routeId("foo").routePolicy(singletonPolicy)
+                        .to("mock:result");
+
+                from("direct:bar").routeId("bar").routePolicy(singletonPolicy)
+                        .to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
# Description

Features for MicrometerRoutePolicy

Repair test
Allow users to use one MicrometerRoutePolicy instance for multiple routes. This is especially useful when using OSGI XML
Allow users to disable additional counters
Allow users to set up timers with advanced micrometer API settings
Written for all this tests
