### PR TITLE
CAMEL-19110: Update with Spring Boot 3.0.4 dependencies

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -362,7 +362,7 @@
         <maven-surefire-report-plugin-version>3.0.0-M8</maven-surefire-report-plugin-version>
         <maven-wagon-version>3.5.2</maven-wagon-version>
         <maven-war-plugin-version>3.3.1</maven-war-plugin-version>
-        <metrics-version>4.2.15</metrics-version>
+        <metrics-version>4.2.17</metrics-version>
         <micrometer-version>1.10.4</micrometer-version>
         <microprofile-config-version>3.0.2</microprofile-config-version>
         <microprofile-fault-tolerance-version>4.0.2</microprofile-fault-tolerance-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -357,7 +357,7 @@
         <maven-surefire-report-plugin-version>3.0.0-M8</maven-surefire-report-plugin-version>
         <maven-wagon-version>3.5.2</maven-wagon-version>
         <maven-war-plugin-version>3.3.1</maven-war-plugin-version>
-        <metrics-version>4.2.15</metrics-version>
+        <metrics-version>4.2.17</metrics-version>
         <micrometer-version>1.10.4</micrometer-version>
         <microprofile-config-version>3.0.2</microprofile-config-version>
         <microprofile-fault-tolerance-version>4.0.2</microprofile-fault-tolerance-version>


### PR DESCRIPTION
Update dependencies for the Spring Boot update to version 3.0.4.

Spring Boot 3.0.4 dependency updates are listed in https://github.com/spring-projects/spring-boot/releases/tag/v3.0.4.

Also see: https://github.com/apache/camel-spring-boot/pull/771