### PR TITLE
Fix version property in DHIS2 component

### DIFF
--- a/components/camel-dhis2/camel-dhis2-component/pom.xml
+++ b/components/camel-dhis2/camel-dhis2-component/pom.xml
@@ -151,7 +151,7 @@
             <plugin>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-api-component-maven-plugin</artifactId>
-                <version>${camelVersion}</version>
+                <version>${project.version}</version>
                 <configuration>
                     <scheme>${schemeName}</scheme>
                     <componentName>${componentName}</componentName>


### PR DESCRIPTION
An invalid version is specified in the DHIS2 component `pom.xml`:

```
<groupId>org.apache.camel</groupId>
<artifactId>camel-api-component-maven-plugin</artifactId>
<version>${camelVersion}</version>
```