### PR TITLE
Adding support to named parameters on queries provided by using the C…

### DIFF
--- a/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlHelper.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlHelper.java
@@ -39,20 +39,26 @@ public final class SqlHelper {
             try (InputStream is = ResourceHelper.resolveMandatoryResourceAsInputStream(camelContext, query)) {
                 answer = camelContext.getTypeConverter().mandatoryConvertTo(String.class, is);
             }
-            if (placeholder != null) {
-                answer = answer.replaceAll(placeholder, "?");
-            }
-            // skip lines with comments
-            StringJoiner sj = new StringJoiner("\n");
-            String[] lines = answer.split("\n");
-            for (String line : lines) {
-                String trim = line.trim();
-                if (!trim.isEmpty() && !trim.startsWith("--")) {
-                    sj.add(line);
-                }
-            }
-            answer = sj.toString();
+            answer = resolvePlaceholders(answer, placeholder);
         }
+        return answer;
+    }
+
+    public static String resolvePlaceholders(String query, String placeholder) {
+        String answer = query;
+        if (placeholder != null) {
+            answer = answer.replaceAll(placeholder, "?");
+        }
+        // skip lines with comments
+        StringJoiner sj = new StringJoiner("\n");
+        String[] lines = answer.split("\n");
+        for (String line : lines) {
+            String trim = line.trim();
+            if (!trim.isEmpty() && !trim.startsWith("--")) {
+                sj.add(line);
+            }
+        }
+        answer = sj.toString();
         return answer;
     }
 }

--- a/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlProducer.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlProducer.java
@@ -98,7 +98,12 @@ public class SqlProducer extends DefaultProducer {
             sql = exchange.getIn().getBody(String.class);
         } else {
             String queryHeader = exchange.getIn().getHeader(SqlConstants.SQL_QUERY, String.class);
-            sql = queryHeader != null ? queryHeader : resolvedQuery;
+            if (queryHeader != null) {
+                String placeholder = getEndpoint().isUsePlaceholder() ? getEndpoint().getPlaceholder() : null;
+                sql = SqlHelper.resolveQuery(getEndpoint().getCamelContext(), queryHeader, placeholder);
+            } else {
+                sql = resolvedQuery;
+            }
         }
         final String preparedQuery
                 = sqlPrepareStatementStrategy.prepareQuery(sql, getEndpoint().isAllowNamedParameters(), exchange);

--- a/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlProducer.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlProducer.java
@@ -100,7 +100,7 @@ public class SqlProducer extends DefaultProducer {
             String queryHeader = exchange.getIn().getHeader(SqlConstants.SQL_QUERY, String.class);
             if (queryHeader != null) {
                 String placeholder = getEndpoint().isUsePlaceholder() ? getEndpoint().getPlaceholder() : null;
-                sql = SqlHelper.resolveQuery(getEndpoint().getCamelContext(), queryHeader, placeholder);
+                sql = SqlHelper.resolvePlaceholders(queryHeader, placeholder);
             } else {
                 sql = resolvedQuery;
             }

--- a/components/camel-sql/src/test/java/org/apache/camel/component/sql/SqlRouteTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/component/sql/SqlRouteTest.java
@@ -88,9 +88,8 @@ public class SqlRouteTest extends CamelTestSupport {
 
         mock.expectedMessageCount(1);
         Exchange exchange = new DefaultExchange(context);
-        exchange.getMessage().setHeader(SqlConstants.SQL_QUERY, "select * from projects where project = :#id order by id");
-        exchange.getMessage().setHeader("id", 3);
-        exchange.getMessage().setBody("Camel");
+        exchange.getMessage().setHeader(SqlConstants.SQL_QUERY, "select * from projects where id = :#id order by id");
+        exchange.getMessage().setHeader("id", 1);
         template.send("direct:simple", exchange);
         mock.assertIsSatisfied();
         received = assertIsInstanceOf(List.class, mock.getReceivedExchanges().get(0).getIn().getBody());

--- a/components/camel-sql/src/test/java/org/apache/camel/component/sql/SqlRouteTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/component/sql/SqlRouteTest.java
@@ -23,9 +23,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,6 +84,20 @@ public class SqlRouteTest extends CamelTestSupport {
         row = assertIsInstanceOf(Map.class, received.get(0));
         assertEquals("Linux", row.get("PROJECT"));
         assertEquals("XXX", row.get("license"));
+        mock.reset();
+
+        mock.expectedMessageCount(1);
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getMessage().setHeader(SqlConstants.SQL_QUERY, "select * from projects where project = :#id order by id");
+        exchange.getMessage().setHeader("id", 3);
+        exchange.getMessage().setBody("Camel");
+        template.send("direct:simple", exchange);
+        mock.assertIsSatisfied();
+        received = assertIsInstanceOf(List.class, mock.getReceivedExchanges().get(0).getIn().getBody());
+        row = assertIsInstanceOf(Map.class, received.get(0));
+        assertEquals(1, row.get("id"));
+        assertEquals("ASF", row.get("license"));
+        mock.reset();
     }
 
     @Test


### PR DESCRIPTION
…amelSqlQuery header

# Description

If a SQL query is provided using the `CamelSqlQuery` header and the query contains named parameters (e.g., :#id), the named parameters are not identified the current `SqlPreparedStatementStrategy`.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

