### PR TITLE
(chores) camel-jms: avoid sharing unsafe resources

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionErrorHandlerTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionErrorHandlerTest.java
@@ -47,7 +47,7 @@ public class JMSTransactionErrorHandlerTest extends AbstractSpringJMSTestSupport
         // and not JMS doing the redelivery
         mock.message(0).header("JMSRedelivered").isEqualTo(false);
 
-        template.sendBody("activemq:queue:okay", "Hello World");
+        template.sendBody("activemq:queue:okay.JMSTransactionErrorHandlerTest", "Hello World");
 
         mock.assertIsSatisfied();
     }

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionIsTransactedRedeliveredTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionIsTransactedRedeliveredTest.java
@@ -77,7 +77,7 @@ public class JMSTransactionIsTransactedRedeliveredTest extends AbstractSpringJMS
         // success at 3rd attempt
         mock.message(0).header("count").isEqualTo(3);
 
-        template.sendBody("activemq:queue:okay", "Hello World");
+        template.sendBody("activemq:queue:okay.JMSTransactionIsTransactedRedeliveredTest", "Hello World");
 
         mock.assertIsSatisfied();
         error.assertIsSatisfied();

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionRollbackTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionRollbackTest.java
@@ -39,7 +39,7 @@ public class JMSTransactionRollbackTest extends AbstractSpringJMSTestSupport {
         getMockEndpoint("mock:before").expectedMessageCount(6);
         getMockEndpoint("mock:result").expectedMessageCount(0);
 
-        template.sendBody("activemq:queue:okay", "Hello World");
+        template.sendBody("activemq:queue:okay.JMSTransactionRollbackTest", "Hello World");
 
         MockEndpoint.assertIsSatisfied(context);
     }

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionalClientTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionalClientTest.java
@@ -43,7 +43,7 @@ public class JMSTransactionalClientTest extends AbstractSpringJMSTestSupport {
         // success at 3rd attempt
         mock.message(0).header("count").isEqualTo(3);
 
-        template.sendBody("activemq:queue:okay", "Hello World");
+        template.sendBody("activemq:queue:okay.JMSTransactionalClientTest", "Hello World");
 
         mock.assertIsSatisfied();
         // END SNIPPET: e1

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionalClientWithRollbackTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionalClientWithRollbackTest.java
@@ -42,7 +42,7 @@ public class JMSTransactionalClientWithRollbackTest extends AbstractSpringJMSTes
         // success at 3rd attempt
         mock.message(0).header("count").isEqualTo(3);
 
-        template.sendBody("activemq:queue:okay", "Hello World");
+        template.sendBody("activemq:queue:okay.JMSTransactionalClientWithRollbackTest", "Hello World");
 
         mock.assertIsSatisfied();
     }

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionErrorHandlerBuilderAsSpringBeanTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionErrorHandlerBuilderAsSpringBeanTest.java
@@ -42,7 +42,7 @@ public class TransactionErrorHandlerBuilderAsSpringBeanTest extends AbstractSpri
         // success at 3rd attempt
         mock.message(0).header("count").isEqualTo(3);
 
-        template.sendBody("activemq:queue:okay", "Hello World");
+        template.sendBody("activemq:queue:okay.TransactionErrorHandlerBuilderAsSpringBeanTest", "Hello World");
 
         mock.assertIsSatisfied();
     }

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionErrorHandlerCustomerSpringParserTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionErrorHandlerCustomerSpringParserTest.java
@@ -42,7 +42,7 @@ public class TransactionErrorHandlerCustomerSpringParserTest extends AbstractSpr
         // success at 3rd attempt
         mock.message(0).header("count").isEqualTo(3);
 
-        template.sendBody("activemq:queue:okay", "Hello World");
+        template.sendBody("activemq:queue:okay.TransactionErrorHandlerCustomerSpringParserTest", "Hello World");
 
         mock.assertIsSatisfied();
     }

--- a/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/JMSTransactionErrorHandlerTest.xml
+++ b/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/JMSTransactionErrorHandlerTest.xml
@@ -71,7 +71,7 @@
         <jmxAgent id="agent" disabled="true"/>
         <route errorHandlerRef="myErrorHandler">
             <!-- 1: from the jms queue -->
-            <from uri="activemq:queue:okay"/>
+            <from uri="activemq:queue:okay.JMSTransactionErrorHandlerTest"/>
             <!-- 2: mark this route as transacted -->
             <transacted/>
             <!-- 3: call our business logic that is myProcessor -->

--- a/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/JMSTransactionIsTransactedRedeliveredTest.xml
+++ b/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/JMSTransactionIsTransactedRedeliveredTest.xml
@@ -60,7 +60,7 @@
       </errorHandler>
 
         <route id="myRoute" errorHandlerRef="txEH">
-            <from uri="activemq:queue:okay"/>
+            <from uri="activemq:queue:okay.JMSTransactionIsTransactedRedeliveredTest"/>
             <transacted/>
             <to uri="mock:before"/>
             <process ref="myProcessor"/>

--- a/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/JMSTransactionRollbackTest.xml
+++ b/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/JMSTransactionRollbackTest.xml
@@ -56,7 +56,7 @@
       </errorHandler>
 
         <route errorHandlerRef="txEH">
-            <from uri="activemq:queue:okay"/>
+            <from uri="activemq:queue:okay.JMSTransactionRollbackTest"/>
             <transacted/>
             <to uri="mock:before"/>
             <process ref="myProcessor"/>

--- a/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/JMSTransactionalClientTest.xml
+++ b/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/JMSTransactionalClientTest.xml
@@ -30,7 +30,7 @@
         <!-- and now our route using the XML syntax -->
         <camel:route errorHandlerRef="errorHandler">
             <!-- 1: from the jms queue -->
-            <camel:from uri="activemq:queue:okay"/>
+            <camel:from uri="activemq:queue:okay.JMSTransactionalClientTest"/>
             <!-- 2: setup the transactional boundaries to require a transaction -->
             <camel:transacted ref="PROPAGATION_REQUIRED"/>
             <!-- 3: call our business logic that is myProcessor -->

--- a/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/JMSTransactionalClientWithRollbackTest.xml
+++ b/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/JMSTransactionalClientWithRollbackTest.xml
@@ -32,7 +32,7 @@
         <!-- and now our route using the XML syntax -->
         <route errorHandlerRef="errorHandler">
             <!-- 1: from the jms queue -->
-            <from uri="activemq:queue:okay"/>
+            <from uri="activemq:queue:okay.JMSTransactionalClientWithRollbackTest"/>
             <!-- 2: setup the transactional boundaries to require a transaction -->
             <transacted ref="PROPAGATION_REQUIRED"/>
             <!-- 3: call our business logic that is myProcessor -->

--- a/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/TransactionErrorHandlerBuilderAsSpringBeanTest.xml
+++ b/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/TransactionErrorHandlerBuilderAsSpringBeanTest.xml
@@ -33,7 +33,7 @@
         <!-- in this route the transactionErrorHandler is used -->
         <camel:route errorHandlerRef="transactionErrorHandler">
             <!-- 1: from the jms queue -->
-            <camel:from uri="activemq:queue:okay"/>
+            <camel:from uri="activemq:queue:okay.TransactionErrorHandlerBuilderAsSpringBeanTest"/>
             <!-- 2: setup the transactional boundaries to require a transaction -->
             <camel:transacted ref="required"/>
             <!-- 3: call our business logic that is myProcessor -->

--- a/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/TransactionErrorHandlerCustomerSpringParserTest.xml
+++ b/components/camel-jms/src/test/resources/org/apache/camel/component/jms/tx/TransactionErrorHandlerCustomerSpringParserTest.xml
@@ -33,7 +33,7 @@
         <!-- in this route the transactionErrorHandler is used -->
         <camel:route errorHandlerRef="transactionErrorHandler">
             <!-- 1: from the jms queue -->
-            <camel:from uri="activemq:queue:okay"/>
+            <camel:from uri="activemq:queue:okay.TransactionErrorHandlerCustomerSpringParserTest"/>
             <!-- 2: setup the transactional boundaries to require a transaction -->
             <camel:transacted ref="required"/>
             <!-- 3: call our business logic that is myProcessor -->


### PR DESCRIPTION
Do not reuse queues and topic names to avoid concurrent tests from disturbing each other