### PR TITLE
CAMEL-19019: camel-kafka - Upgrade to Kafka 3.4.x

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -318,9 +318,8 @@
         <jython-version>2.7.3</jython-version>
         <jython-standalone-version>2.7.3</jython-standalone-version>
         <jzlib-version>1.1.3</jzlib-version>
-	<kafka-version>3.2.3</kafka-version>
-	<kafka-debezium-version>3.3.1</kafka-debezium-version>
-        <kafka-vertx-version>2.8.2</kafka-vertx-version>
+        <kafka-version>3.4.0</kafka-version>
+        <kafka-debezium-version>3.3.1</kafka-debezium-version>
         <kotlin-version>1.8.0</kotlin-version>
         <kubernetes-client-version>6.4.1</kubernetes-client-version>
         <kubernetes-model-version>6.4.1</kubernetes-model-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -313,9 +313,8 @@
         <jython-version>2.7.3</jython-version>
         <jython-standalone-version>2.7.3</jython-standalone-version>
         <jzlib-version>1.1.3</jzlib-version>
-	<kafka-version>3.2.3</kafka-version>
-	<kafka-debezium-version>3.3.1</kafka-debezium-version>
-        <kafka-vertx-version>2.8.2</kafka-vertx-version>
+        <kafka-version>3.4.0</kafka-version>
+        <kafka-debezium-version>3.3.1</kafka-debezium-version>
         <kotlin-version>1.8.0</kotlin-version>
         <kubernetes-client-version>6.4.1</kubernetes-client-version>
         <kubernetes-model-version>6.4.1</kubernetes-model-version>

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
@@ -25,7 +25,7 @@ import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class ContainerLocalKafkaService implements KafkaService, ContainerService<KafkaContainer> {
-    public static final String KAFKA3_IMAGE_NAME = "confluentinc/cp-kafka:7.3.1";
+    public static final String KAFKA3_IMAGE_NAME = "confluentinc/cp-kafka:7.3.2";
 
     private static final Logger LOG = LoggerFactory.getLogger(ContainerLocalKafkaService.class);
     private final KafkaContainer kafka;
@@ -39,7 +39,7 @@ public class ContainerLocalKafkaService implements KafkaService, ContainerServic
     }
 
     protected KafkaContainer initContainer() {
-        return new KafkaContainer().withEmbeddedZookeeper();
+        return new KafkaContainer(DockerImageName.parse(KAFKA3_IMAGE_NAME)).withEmbeddedZookeeper();
     }
 
     public String getBootstrapServers() {

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/RedpandaTransactionsEnabledContainer.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/RedpandaTransactionsEnabledContainer.java
@@ -22,7 +22,7 @@ import org.testcontainers.redpanda.RedpandaContainer;
 
 public class RedpandaTransactionsEnabledContainer extends RedpandaContainer {
 
-    public static final String DEFAULT_REDPANDA_CONTAINER = "docker.redpanda.com/vectorized/redpanda:v22.3.10";
+    public static final String DEFAULT_REDPANDA_CONTAINER = "docker.redpanda.com/vectorized/redpanda:v23.1.1";
     public static final String REDPANDA_CONTAINER
             = System.getProperty("itest.redpanda.container.image", DEFAULT_REDPANDA_CONTAINER);
     public static final int REDPANDA_PORT = 9092;

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/StrimziContainer.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/StrimziContainer.java
@@ -23,7 +23,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 public class StrimziContainer extends GenericContainer<StrimziContainer> {
-    public static final String DEFAULT_STRIMZI_CONTAINER = "quay.io/strimzi/kafka:latest-kafka-3.3.1";
+    public static final String DEFAULT_STRIMZI_CONTAINER = "quay.io/strimzi/kafka:latest-kafka-3.4.0";
     private static final String STRIMZI_CONTAINER
             = System.getProperty("itest.strimzi.container.image", DEFAULT_STRIMZI_CONTAINER);
     private static final int KAFKA_PORT = 9092;


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-19019

## Description

In order to get the latest improvements and bug fixes, we need to upgrade to Kafka 3.4.

## Modifications:

* Change the version of Kafka to `3.4.0`
* Remove the version of Kafka vert.x as it is no more used
* Update the version of the Docker images used to the latest version
* Force the image name to the `KafkaContainer` to avoid using the default tag which `5.4.3`