### PR TITLE
CAMEL-19050: set bind mode to read-only in order to resolve permission error in Docker container

### DIFF
--- a/components/camel-dhis2/camel-dhis2-component/src/main/docs/dhis2-component.adoc
+++ b/components/camel-dhis2/camel-dhis2-component/src/main/docs/dhis2-component.adoc
@@ -11,7 +11,7 @@
 
 *{component-header}*
 
-The Camel DHIS2 component leverages the https://github.com/dhis2/dhis2-java-sdk[DHIS2 Java SDK] to integrate Apache Camel with the https://dhis2.org/[DHIS2]. DHIS2 is a free, open-source software platform for collecting, analyzing, visualizing and sharing data.
+The Camel DHIS2 component leverages the https://github.com/dhis2/dhis2-java-sdk[DHIS2 Java SDK] to integrate Apache Camel with the https://dhis2.org/[DHIS2]. DHIS2 is a free, open-source, fully customizable platform for collecting, analyzing, visualizing, and sharing aggregate and individual-data for district-level, national, regional, and international system and program management in health, education, and other domains.
 
 Maven users will need to add the following dependency to their `+pom.xml+`.
 

--- a/components/camel-dhis2/camel-dhis2-component/src/test/java/org/apache/camel/component/dhis2/Environment.java
+++ b/components/camel-dhis2/camel-dhis2-component/src/test/java/org/apache/camel/component/dhis2/Environment.java
@@ -61,7 +61,7 @@ public final class Environment {
         DHIS2_CONTAINER = new GenericContainer<>(
                 "dhis2/core:2.37.4-tomcat-8.5.34-jre8-alpine")
                 .dependsOn(POSTGRESQL_CONTAINER)
-                .withClasspathResourceMapping("dhis.conf", "/DHIS2_home/dhis.conf", BindMode.READ_WRITE)
+                .withClasspathResourceMapping("dhis.conf", "/DHIS2_home/dhis.conf", BindMode.READ_ONLY)
                 .withNetwork(NETWORK).withExposedPorts(8080)
                 .waitingFor(
                         new HttpWaitStrategy().forStatusCode(200).withStartupTimeout(Duration.ofSeconds(120)))


### PR DESCRIPTION
# Description

Set bind mode to read-only which might resolve the Docker container permission error in the camel-dhis2 component during the Jenkins build.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

