### PR TITLE
Convert expression when setting header / property on message / exchange.

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultExchangeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultExchangeTest.java
@@ -29,6 +29,7 @@ import org.apache.camel.Message;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.SafeCopyProperty;
 import org.apache.camel.TypeConversionException;
+import org.apache.camel.builder.Builder;
 import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.support.DefaultMessage;
 import org.apache.camel.support.ExchangeHelper;
@@ -148,6 +149,9 @@ public class DefaultExchangeTest extends ExchangeTestSupport {
         assertEquals("apple", exchange.getProperty("fruit", "banana", String.class));
         assertEquals("banana", exchange.getProperty("beer", "banana"));
         assertEquals("banana", exchange.getProperty("beer", "banana", String.class));
+
+        exchange.setProperty("expression", Builder.constant("constant"));
+        assertEquals("constant", exchange.getProperty("expression"));
     }
 
     @Test

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultMessageHeaderTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultMessageHeaderTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.impl;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Message;
+import org.apache.camel.builder.Builder;
 import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.support.DefaultMessage;
 import org.junit.jupiter.api.BeforeEach;
@@ -122,6 +123,15 @@ public class DefaultMessageHeaderTest {
         assertEquals("bar", msg.getHeader("FOO"));
         assertEquals("bar", msg.getHeader("foo"));
         assertEquals("bar", msg.getHeader("Foo"));
+    }
+
+    @Test
+    public void testSetWithExpression() {
+        Message msg = new DefaultExchange(camelContext).getMessage();
+        assertNull(msg.getHeader("foo"));
+
+        msg.setHeader("foo", Builder.constant("bar"));
+        assertEquals("bar", msg.getHeader("foo"));
     }
 
     @Test

--- a/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
@@ -32,6 +32,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.ExchangePropertyKey;
+import org.apache.camel.Expression;
 import org.apache.camel.ExtendedCamelContext;
 import org.apache.camel.ExtendedExchange;
 import org.apache.camel.Message;
@@ -343,6 +344,9 @@ class AbstractExchange implements ExtendedExchange {
     @Override
     public void setProperty(String name, Object value) {
         ExchangePropertyKey key = ExchangePropertyKey.asExchangePropertyKey(name);
+        if (value instanceof Expression) {
+            value = ((Expression) value).evaluate(this, Object.class);
+        }
         if (key != null) {
             setProperty(key, value);
         } else if (value != null) {

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultMessage.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultMessage.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
+import org.apache.camel.Expression;
 import org.apache.camel.ExtendedCamelContext;
 import org.apache.camel.spi.HeadersMapFactory;
 
@@ -206,6 +207,9 @@ public class DefaultMessage extends MessageSupport {
     public void setHeader(String name, Object value) {
         if (headers == null) {
             headers = createHeaders();
+        }
+        if (value instanceof Expression) {
+            value = ((Expression) value).evaluate(getExchange(), Object.class);
         }
         headers.put(name, value);
     }


### PR DESCRIPTION
# Description

Convert an expression to an object value when it is used on a `setHeader` method on a `Message` or on a `setProperty` on an `Exchange`

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`
  Local build is failing with JAXB generation errors on `camel-spring-xml`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

