### PR TITLE
Azure Data Lake - CAMEL-19152 additional file client header field + CAMEL-18636 additional auth options

### DIFF
--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeComponent.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeComponent.java
@@ -96,5 +96,4 @@ public class DataLakeComponent extends DefaultComponent {
 
         }
     }
-
 }

--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeComponent.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeComponent.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.azure.storage.datalake;
 import java.util.Map;
 import java.util.Set;
 
+import com.azure.core.credential.AzureSasCredential;
 import com.azure.identity.ClientSecretCredential;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import org.apache.camel.CamelContext;
@@ -85,15 +86,18 @@ public class DataLakeComponent extends DefaultComponent {
                     = getCamelContext().getRegistry().findByType(StorageSharedKeyCredential.class);
             final Set<ClientSecretCredential> clientSecretCredentials
                     = getCamelContext().getRegistry().findByType(ClientSecretCredential.class);
+            final Set<AzureSasCredential> sasCredentials
+                    = getCamelContext().getRegistry().findByType(AzureSasCredential.class);
 
             if (storageSharedKeyCredentials.size() == 1) {
                 configuration.setSharedKeyCredential(storageSharedKeyCredentials.stream().findFirst().get());
             }
-
             if (clientSecretCredentials.size() == 1) {
                 configuration.setClientSecretCredential(clientSecretCredentials.stream().findFirst().get());
             }
-
+            if (sasCredentials.size() == 1) {
+                configuration.setSasCredential(sasCredentials.stream().findFirst().get());
+            }
         }
     }
 }

--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeConfiguration.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeConfiguration.java
@@ -20,6 +20,7 @@ import java.nio.file.OpenOption;
 import java.time.Duration;
 import java.util.Set;
 
+import com.azure.core.credential.AzureSasCredential;
 import com.azure.identity.ClientSecretCredential;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import com.azure.storage.file.datalake.DataLakeServiceClient;
@@ -93,6 +94,12 @@ public class DataLakeConfiguration implements Cloneable {
     private String umask;
     @UriParam(description = "set open options for creating file")
     private Set<OpenOption> openOptions;
+    @UriParam(description = "SAS token signature")
+    private String sasSignature;
+    @UriParam(description = "SAS token credential")
+    private AzureSasCredential sasCredential;
+    @UriParam(description = "Use default identity")
+    private Boolean useDefaultIdentity = false;
 
     @UriParam(label = "producer", enums = "listFileSystem, listFiles", defaultValue = "listFileSystem",
               description = "operation to be performed")
@@ -344,6 +351,30 @@ public class DataLakeConfiguration implements Cloneable {
 
     public void setOpenOptions(Set<OpenOption> openOptions) {
         this.openOptions = openOptions;
+    }
+
+    public String getSasSignature() {
+        return sasSignature;
+    }
+
+    public void setSasSignature(String sasSignature) {
+        this.sasSignature = sasSignature;
+    }
+
+    public AzureSasCredential getSasCredential() {
+        return sasCredential;
+    }
+
+    public void setSasCredential(AzureSasCredential sasCredential) {
+        this.sasCredential = sasCredential;
+    }
+
+    public Boolean getUseDefaultIdentity() {
+        return useDefaultIdentity;
+    }
+
+    public void setUseDefaultIdentity(Boolean useDefaultIdentity) {
+        this.useDefaultIdentity = useDefaultIdentity;
     }
 
     public DataLakeConfiguration copy() {

--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeConfiguration.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeConfiguration.java
@@ -43,16 +43,16 @@ public class DataLakeConfiguration implements Cloneable {
     private String directoryName;
     @UriParam(description = "name of file to be handled in component")
     private String fileName;
-    @UriParam(description = "client secret credential for authentication")
+    @UriParam(label = "security", secret = true, description = "client secret credential for authentication")
     private ClientSecretCredential clientSecretCredential;
     @UriParam(description = "datalake service client for azure storage datalake")
     @Metadata(autowired = true)
     private DataLakeServiceClient serviceClient;
-    @UriParam(description = "account key for authentication")
+    @UriParam(label = "security", secret = true, description = "account key for authentication")
     private String accountKey;
     @UriParam(description = "client id for azure account")
     private String clientId;
-    @UriParam(description = "client secret for azure account")
+    @UriParam(label = "security", secret = true, description = "client secret for azure account")
     private String clientSecret;
     @UriParam(description = "tenant id for azure account")
     private String tenantId;
@@ -94,11 +94,11 @@ public class DataLakeConfiguration implements Cloneable {
     private String umask;
     @UriParam(description = "set open options for creating file")
     private Set<OpenOption> openOptions;
-    @UriParam(description = "SAS token signature")
+    @UriParam(label = "security", secret = true, description = "SAS token signature")
     private String sasSignature;
-    @UriParam(description = "SAS token credential")
+    @UriParam(label = "security", secret = true, description = "SAS token credential")
     private AzureSasCredential sasCredential;
-    @UriParam(description = "Use default identity")
+    @UriParam(label = "security", secret = false, description = "Use default identity")
     private Boolean useDefaultIdentity = false;
 
     @UriParam(label = "producer", enums = "listFileSystem, listFiles", defaultValue = "listFileSystem",

--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeConfigurationOptionsProxy.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeConfigurationOptionsProxy.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.azure.storage.common.ParallelTransferOptions;
+import com.azure.storage.file.datalake.DataLakeFileClient;
 import com.azure.storage.file.datalake.models.AccessTier;
 import com.azure.storage.file.datalake.models.DataLakeRequestConditions;
 import com.azure.storage.file.datalake.models.FileQueryError;
@@ -115,6 +116,10 @@ public class DataLakeConfigurationOptionsProxy {
 
     public String getLeaseId(final Exchange exchange) {
         return getOption(DataLakeExchangeHeaders::getLeaseIdFromHeaders, () -> null, exchange);
+    }
+
+    public Boolean getFlush(final Exchange exchange) {
+        return getOption(DataLakeExchangeHeaders::getFlushFromHeaders, () -> Boolean.FALSE, exchange);
     }
 
     public Boolean retainUnCommitedData(final Exchange exchange) {
@@ -234,6 +239,10 @@ public class DataLakeConfigurationOptionsProxy {
 
     public PathHttpHeaders getPathHttpHeaders(final Exchange exchange) {
         return DataLakeExchangeHeaders.getPathHttpHeadersFromHeaders(exchange);
+    }
+
+    public DataLakeFileClient getFileClient(final Exchange exchange) {
+        return DataLakeExchangeHeaders.getFileClientFromHeaders(exchange);
     }
 
     public int getMaxRetryRequests() {

--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeConstants.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeConstants.java
@@ -204,6 +204,10 @@ public final class DataLakeConstants {
     public static final String PERMISSION = HEADER_PREFIX + "Permission";
     @Metadata(label = "from user", description = "Sets the umask for file.", javaType = "String")
     public static final String UMASK = HEADER_PREFIX + "Umask";
+    @Metadata(label = "from user", description = "Sets the file client to use", javaType = "DataLakeFileClient")
+    public static final String FILE_CLIENT = HEADER_PREFIX + "FileClient";
+    @Metadata(label = "from user", description = "Sets whether to flush on append", javaType = "Boolean")
+    public static final String FLUSH = HEADER_PREFIX + "Flush";
 
     private DataLakeConstants() {
     }

--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeExchangeHeaders.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeExchangeHeaders.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 
 import com.azure.core.http.HttpHeaders;
 import com.azure.storage.common.ParallelTransferOptions;
+import com.azure.storage.file.datalake.DataLakeFileClient;
 import com.azure.storage.file.datalake.models.AccessTier;
 import com.azure.storage.file.datalake.models.ArchiveStatus;
 import com.azure.storage.file.datalake.models.CopyStatusType;
@@ -258,6 +259,14 @@ public class DataLakeExchangeHeaders {
         return getObjectFromHeaders(exchange, DataLakeConstants.UMASK, String.class);
     }
 
+    public static DataLakeFileClient getFileClientFromHeaders(final Exchange exchange) {
+        return getObjectFromHeaders(exchange, DataLakeConstants.FILE_CLIENT, DataLakeFileClient.class);
+    }
+
+    public static Boolean getFlushFromHeaders(final Exchange exchange) {
+        return getObjectFromHeaders(exchange, DataLakeConstants.FLUSH, Boolean.class);
+    }
+
     private static <T> T getObjectFromHeaders(final Exchange exchange, final String headerName, final Class<T> classType) {
         return ObjectHelper.isEmpty(exchange) ? null : exchange.getIn().getHeader(headerName, classType);
     }
@@ -415,4 +424,8 @@ public class DataLakeExchangeHeaders {
         return this;
     }
 
+    public DataLakeExchangeHeaders fileClient(final DataLakeFileClient fileClient) {
+        headers.put(DataLakeConstants.FILE_CLIENT, fileClient);
+        return this;
+    }
 }

--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/client/DataLakeFileClientWrapper.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/client/DataLakeFileClientWrapper.java
@@ -34,6 +34,7 @@ import com.azure.storage.file.datalake.models.FileReadResponse;
 import com.azure.storage.file.datalake.models.PathHttpHeaders;
 import com.azure.storage.file.datalake.models.PathInfo;
 import com.azure.storage.file.datalake.models.PathProperties;
+import com.azure.storage.file.datalake.options.DataLakeFileAppendOptions;
 import com.azure.storage.file.datalake.options.FileParallelUploadOptions;
 import com.azure.storage.file.datalake.options.FileQueryOptions;
 import com.azure.storage.file.datalake.sas.DataLakeServiceSasSignatureValues;
@@ -104,8 +105,8 @@ public class DataLakeFileClientWrapper {
 
     public Response<Void> appendWithResponse(
             final InputStream stream, final Long fileOffset, final Long length,
-            final byte[] contentMd5, final String leaseId, final Duration timeout) {
-        return client.appendWithResponse(stream, fileOffset, length, contentMd5, leaseId, timeout, Context.NONE);
+            final Duration timeout, final DataLakeFileAppendOptions options) {
+        return client.appendWithResponse(stream, fileOffset, length, options, timeout, Context.NONE);
     }
 
     public Response<PathInfo> uploadWithResponse(final FileParallelUploadOptions uploadOptions, final Duration timeout) {

--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/operations/DataLakeDirectoryOperations.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/operations/DataLakeDirectoryOperations.java
@@ -51,8 +51,10 @@ public class DataLakeDirectoryOperations {
 
         final Response<DataLakeFileClient> response = client.createFileWithResponse(fileName, permission, umask,
                 httpHeaders, metadata, requestConditions, timeout);
-        DataLakeExchangeHeaders exchangeHeaders = DataLakeExchangeHeaders.create().httpHeaders(response.getHeaders());
-        return new DataLakeOperationResponse(response.getValue(), exchangeHeaders.toMap());
+        final DataLakeFileClient fileClient = response.getValue();
+        final DataLakeExchangeHeaders exchangeHeaders
+                = DataLakeExchangeHeaders.create().httpHeaders(response.getHeaders()).fileClient(fileClient);
+        return new DataLakeOperationResponse(fileClient, exchangeHeaders.toMap());
     }
 
     public DataLakeOperationResponse deleteDirectory(final Exchange exchange) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionList.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionList.java
@@ -100,7 +100,7 @@ public class VersionList extends CamelCommand {
         }
 
         CamelCatalog catalog = new DefaultCamelCatalog();
-        List<ReleaseModel> releases = runtime.equals("quarkus") ? catalog.camelQuarkusReleases() : catalog.camelReleases();
+        List<ReleaseModel> releases = "quarkus".equals(runtime) ? catalog.camelQuarkusReleases() : catalog.camelReleases();
 
         List<Row> rows = new ArrayList<>();
         for (String[] v : versions) {
@@ -110,7 +110,7 @@ public class VersionList extends CamelCommand {
             row.runtimeVersion = v[1];
 
             // enrich with details from catalog (if we can find any)
-            String catalogVersion = runtime.equals("quarkus") ? v[1] : v[0];
+            String catalogVersion = "quarkus".equals(runtime) ? v[1] : v[0];
             ReleaseModel rm = releases.stream().filter(r -> catalogVersion.equals(r.getVersion())).findFirst().orElse(null);
             if (rm != null) {
                 row.releaseDate = rm.getDate();


### PR DESCRIPTION
# Description

- see CAMEL-19152 for a detailed description
- patched validateConfiguration() method in the component to accept string based configuration of auth parameters in addition to Java objects
- Added SAS token-based authentication as well as the usage of the default identity if enabled (disabled by default, prioritised if enabled)

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

