### PR TITLE
CAMEL-19130: Upgrade to snakeyaml 2.x

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -447,7 +447,7 @@
         <smallrye-config-version>3.1.1</smallrye-config-version>
         <smallrye-health-version>4.0.1</smallrye-health-version>
         <smallrye-fault-tolerance-version>6.1.0</smallrye-fault-tolerance-version>
-        <snakeyaml-version>1.33</snakeyaml-version>
+        <snakeyaml-version>2.0</snakeyaml-version>
         <snakeyaml-engine-version>2.3</snakeyaml-engine-version>
         <snmp4j-version>2.8.15</snmp4j-version>
         <!-- solr version aligned with lucene -->

--- a/components/camel-snakeyaml/src/main/java/org/apache/camel/component/snakeyaml/custom/CustomClassLoaderConstructor.java
+++ b/components/camel-snakeyaml/src/main/java/org/apache/camel/component/snakeyaml/custom/CustomClassLoaderConstructor.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.snakeyaml.custom;
 
+import java.util.Objects;
+
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -24,14 +26,11 @@ import org.yaml.snakeyaml.constructor.Constructor;
  */
 public class CustomClassLoaderConstructor extends Constructor {
 
-    private ClassLoader loader = this.getClass().getClassLoader();
+    private final ClassLoader loader;
 
     public CustomClassLoaderConstructor(ClassLoader theLoader, LoaderOptions options) {
         super(Object.class, options);
-        if (theLoader == null) {
-            throw new NullPointerException("Loader must be provided.");
-        }
-        this.loader = theLoader;
+        this.loader = Objects.requireNonNull(theLoader, "Loader must be provided.");
     }
 
     @Override

--- a/components/camel-snakeyaml/src/test/java/org/apache/camel/component/snakeyaml/SnakeYAMLDoSTest.java
+++ b/components/camel-snakeyaml/src/test/java/org/apache/camel/component/snakeyaml/SnakeYAMLDoSTest.java
@@ -26,6 +26,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -42,14 +43,15 @@ public class SnakeYAMLDoSTest extends CamelTestSupport {
         assertNotNull(mock);
         mock.expectedMessageCount(1);
 
-        InputStream is = this.getClass().getClassLoader().getResourceAsStream("data.yaml");
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("data.yaml")) {
 
-        ProducerTemplate template = context.createProducerTemplate();
-        String result = template.requestBody("direct:back", is, String.class);
-        assertNotNull(result);
-        assertEquals("{name=Colm, location=Dublin}", result.trim());
+            ProducerTemplate template = context.createProducerTemplate();
+            String result = template.requestBody("direct:back", is, String.class);
+            assertNotNull(result);
+            assertEquals("{name=Colm, location=Dublin}", result.trim());
 
-        mock.assertIsSatisfied();
+            mock.assertIsSatisfied();
+        }
     }
 
     @Test
@@ -59,18 +61,19 @@ public class SnakeYAMLDoSTest extends CamelTestSupport {
         assertNotNull(mock);
         mock.expectedMessageCount(0);
 
-        InputStream is = this.getClass().getClassLoader().getResourceAsStream("data-dos.yaml");
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("data-dos.yaml")) {
 
-        ProducerTemplate template = context.createProducerTemplate();
+            ProducerTemplate template = context.createProducerTemplate();
 
-        Exception ex = assertThrows(CamelExecutionException.class,
-                () -> template.requestBody("direct:back", is, String.class),
-                "Failure expected on an alias expansion attack");
+            Exception ex = assertThrows(CamelExecutionException.class,
+                    () -> template.requestBody("direct:back", is, String.class),
+                    "Failure expected on an alias expansion attack");
 
-        Throwable cause = ex.getCause();
-        assertEquals("Number of aliases for non-scalar nodes exceeds the specified max=50", cause.getMessage());
+            Throwable cause = ex.getCause();
+            assertEquals("Number of aliases for non-scalar nodes exceeds the specified max=50", cause.getMessage());
 
-        mock.assertIsSatisfied();
+            mock.assertIsSatisfied();
+        }
     }
 
     @Test
@@ -139,7 +142,7 @@ public class SnakeYAMLDoSTest extends CamelTestSupport {
         f.put(f, "a");
         f.put("g", root);
 
-        Yaml yaml = new Yaml(new SafeConstructor());
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         return yaml.dump(f);
     }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -442,7 +442,7 @@
         <smallrye-config-version>3.1.1</smallrye-config-version>
         <smallrye-health-version>4.0.1</smallrye-health-version>
         <smallrye-fault-tolerance-version>6.1.0</smallrye-fault-tolerance-version>
-        <snakeyaml-version>1.33</snakeyaml-version>
+        <snakeyaml-version>2.0</snakeyaml-version>
         <snakeyaml-engine-version>2.3</snakeyaml-engine-version>
         <snmp4j-version>2.8.15</snmp4j-version>
         <!-- solr version aligned with lucene -->


### PR DESCRIPTION
Fix for  https://issues.apache.org/jira/browse/CAMEL-19130

## Motivation

In order to get the latest improvements and bug fixes, we need to upgrade to snakeyaml 2.

## Modifications:

* Updated the version of snakeyaml
* Upgared `camel-snakeyaml` and `camel-restdsl-openapi-plugin`
* Fixed some violations raised