### PR TITLE
CAMEL-19171: camel-http - Prevent duplicating slashes in generated URI

### DIFF
--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpHelper.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpHelper.java
@@ -209,13 +209,17 @@ public final class HttpHelper {
                 // if there are no query params
                 if (idx == -1) {
                     // make sure that there is exactly one "/" between HTTP_URI and HTTP_PATH
-                    uri = uri.endsWith("/") || path.startsWith("/") ? uri : uri + "/";
-                    uri = uri.concat(path);
+                    if (uri.endsWith("/") && path.startsWith("/")) {
+                        uri = uri.concat(path.substring(1));
+                    } else {
+                        uri = uri.endsWith("/") || path.startsWith("/") ? uri : uri + "/";
+                        uri = uri.concat(path);
+                    }
                 } else {
                     // there are query params, so inject the relative path in the right place
                     String base = uri.substring(0, idx);
                     base = base.endsWith("/") ? base : base + "/";
-                    base = base.concat(path);
+                    base = base.concat(path.startsWith("/") ? path.substring(1) : path);
                     uri = base.concat(uri.substring(idx));
                 }
             }

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/helper/HttpHelperTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/helper/HttpHelperTest.java
@@ -88,6 +88,44 @@ public class HttpHelperTest {
     }
 
     @Test
+    public void createURLShouldReturnTheEndpointURIIfBridgeEndpointWithOneSlashOnly() throws URISyntaxException {
+        String url = HttpHelper.createURL(
+                createExchangeWithOptionalCamelHttpUriHeader("http://apache.org", "/"),
+                createHttpEndpoint(true, "http://camel.apache.org/"));
+
+        assertEquals("http://camel.apache.org/", url);
+    }
+
+    @Test
+    public void createURLShouldReturnTheEndpointURIIfBridgeEndpointWithSubPathAndOneSlashOnly() throws URISyntaxException {
+        String url = HttpHelper.createURL(
+                createExchangeWithOptionalCamelHttpUriHeader("http://apache.org", "/somePath/"),
+                createHttpEndpoint(true, "http://camel.apache.org/"));
+
+        assertEquals("http://camel.apache.org/somePath/", url);
+    }
+
+    @Test
+    public void createURLShouldReturnTheEndpointURIIfBridgeEndpointWithQueryParameterSubPathAndOneSlashOnly()
+            throws URISyntaxException {
+        String url = HttpHelper.createURL(
+                createExchangeWithOptionalCamelHttpUriHeader("http://apache.org", "/"),
+                createHttpEndpoint(true, "http://camel.apache.org/?foo=bar"));
+
+        assertEquals("http://camel.apache.org/?foo=bar", url);
+    }
+
+    @Test
+    public void createURLShouldReturnTheEndpointURIIfBridgeEndpointWithQueryParameterAndOneSlashOnly()
+            throws URISyntaxException {
+        String url = HttpHelper.createURL(
+                createExchangeWithOptionalCamelHttpUriHeader("http://apache.org", "/somePath/"),
+                createHttpEndpoint(true, "http://camel.apache.org/?foo=bar"));
+
+        assertEquals("http://camel.apache.org/somePath/?foo=bar", url);
+    }
+
+    @Test
     public void createURLShouldReturnTheEndpointURIIfNotBridgeEndpoint() throws URISyntaxException {
         String url = HttpHelper.createURL(
                 createExchangeWithOptionalCamelHttpUriHeader(null, null),


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-19171

## Motivation

When the endpoint URI has a trailing slash and the path starts with a slash, the generated URI contains 2 slashes instead of only one which was accepted by HttpComponents v4 but it is rejected by HttpComponents v5.

## Modifications:

* Skip one slash one, when the endpoint URI has a trailing slash and the path to append starts with a slash
* Add a unit test to cover the use case