### PR TITLE
Not setting events for log methods on routes

### DIFF
--- a/components/camel-observation/src/main/java/org/apache/camel/observation/MicrometerObservationSpanAdapter.java
+++ b/components/camel-observation/src/main/java/org/apache/camel/observation/MicrometerObservationSpanAdapter.java
@@ -111,9 +111,9 @@ public class MicrometerObservationSpanAdapter implements SpanAdapter {
             } else {
                 setError(true);
             }
-        } else {
-            observation.event(() -> getMessageNameFromFields(fields));
         }
+        // Making a log in spans / creating counters doesn't make a lot of sense
+        // This is a difference between Observation and OTel versions
     }
 
     @Override
@@ -135,15 +135,6 @@ public class MicrometerObservationSpanAdapter implements SpanAdapter {
     @Override
     public AutoCloseable makeCurrent() {
         return observation.openScope();
-    }
-
-    String getMessageNameFromFields(Map<String, ?> fields) {
-        Object eventValue = fields == null ? null : fields.get("message");
-        if (eventValue != null) {
-            return eventValue.toString();
-        }
-
-        return DEFAULT_EVENT_NAME;
     }
 
     public void setCorrelationContextItem(String key, String value) {

--- a/components/camel-observation/src/test/java/org/apache/camel/observation/ABCRouteTest.java
+++ b/components/camel-observation/src/test/java/org/apache/camel/observation/ABCRouteTest.java
@@ -24,11 +24,11 @@ import org.junit.jupiter.api.Test;
 class ABCRouteTest extends CamelMicrometerObservationTestSupport {
     private static SpanTestData[] testdata = {
             new SpanTestData().setLabel("seda:b server").setUri("seda://b").setOperation("b")
-                    .setParentId(2).addLogMessage("routing at b"),
+                    .setParentId(2),
             new SpanTestData().setLabel("seda:c server").setUri("seda://c").setOperation("c")
-                    .setParentId(2).addLogMessage("Exchange[ExchangePattern: InOut, BodyType: String, Body: Hello]"),
+                    .setParentId(2),
             new SpanTestData().setLabel("seda:a server").setUri("seda://a").setOperation("a")
-                    .setParentId(3).addLogMessage("routing at a").addLogMessage("End of routing"),
+                    .setParentId(3),
             new SpanTestData().setLabel("direct:start server").setUri("direct://start").setOperation("start")
                     .setKind(SpanKind.SERVER)
     };

--- a/components/camel-observation/src/test/java/org/apache/camel/observation/CustomComponentNameRouteTest.java
+++ b/components/camel-observation/src/test/java/org/apache/camel/observation/CustomComponentNameRouteTest.java
@@ -25,11 +25,11 @@ class CustomComponentNameRouteTest extends CamelMicrometerObservationTestSupport
 
     private static SpanTestData[] testdata = {
             new SpanTestData().setLabel("myseda:b server").setUri("myseda://b").setOperation("b")
-                    .setParentId(2).addLogMessage("routing at b"),
+                    .setParentId(2),
             new SpanTestData().setLabel("myseda:c server").setUri("myseda://c").setOperation("c")
-                    .setParentId(2).addLogMessage("Exchange[ExchangePattern: InOut, BodyType: String, Body: Hello]"),
+                    .setParentId(2),
             new SpanTestData().setLabel("myseda:a server").setUri("myseda://a").setOperation("a")
-                    .setParentId(3).addLogMessage("routing at a").addLogMessage("End of routing"),
+                    .setParentId(3),
             new SpanTestData().setLabel("direct:start server").setUri("direct://start").setOperation("start")
                     .setKind(SpanKind.SERVER)
     };

--- a/components/camel-observation/src/test/java/org/apache/camel/observation/MulticastParallelRouteTest.java
+++ b/components/camel-observation/src/test/java/org/apache/camel/observation/MulticastParallelRouteTest.java
@@ -25,11 +25,11 @@ class MulticastParallelRouteTest extends CamelMicrometerObservationTestSupport {
 
     private static SpanTestData[] testdata = {
             new SpanTestData().setLabel("seda:b server").setUri("seda://b").setOperation("b")
-                    .setParentId(2).addLogMessage("routing at b"),
+                    .setParentId(2),
             new SpanTestData().setLabel("seda:c server").setUri("seda://c").setOperation("c")
-                    .setParentId(2).addLogMessage("routing at c"),
+                    .setParentId(2),
             new SpanTestData().setLabel("seda:a server").setUri("seda://a").setOperation("a")
-                    .setParentId(3).addLogMessage("routing at a").addLogMessage("End of routing"),
+                    .setParentId(3),
             new SpanTestData().setLabel("direct:start server").setUri("direct://start").setOperation("start")
                     .setKind(SpanKind.SERVER)
     };

--- a/components/camel-observation/src/test/java/org/apache/camel/observation/SpanProcessorsTest.java
+++ b/components/camel-observation/src/test/java/org/apache/camel/observation/SpanProcessorsTest.java
@@ -29,12 +29,12 @@ class SpanProcessorsTest extends CamelMicrometerObservationTestSupport {
 
     private static final SpanTestData[] TEST_DATA = {
             new SpanTestData().setLabel("seda:b server").setUri("seda://b").setOperation("b")
-                    .setParentId(2).addLogMessage("routing at b")
+                    .setParentId(2)
                     .addTag("b-tag", "request-header-value"),
             new SpanTestData().setLabel("seda:c server").setUri("seda://c").setOperation("c")
-                    .setParentId(2).addLogMessage("Exchange[ExchangePattern: InOut, BodyType: String, Body: Hello]"),
+                    .setParentId(2),
             new SpanTestData().setLabel("seda:a server").setUri("seda://a").setOperation("a")
-                    .setParentId(3).addLogMessage("routing at a").addLogMessage("End of routing"),
+                    .setParentId(3),
             new SpanTestData().setLabel("direct:start server").setUri("direct://start").setOperation("start")
                     .setKind(SpanKind.SERVER)
     };


### PR DESCRIPTION
without this change we are always creating an event when a log happens within a route. That corresponds to a log on a span and a counter on a metrics. The log statement is arbitrary and logs on spans should be meaningful and short in name. Same thing for metric names that should of super low cardinality. Since we can't ensure that the log statement follows these requirements (nor should we) we think that we should not set those entries on spans and create such counters.