### PR TITLE
CAMEL-19062: openapi-rest-dsl-generator - Add jackson databind

### DIFF
--- a/tooling/openapi-rest-dsl-generator/pom.xml
+++ b/tooling/openapi-rest-dsl-generator/pom.xml
@@ -52,6 +52,12 @@
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-data-models</artifactId>
             <version>${apicurio-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -59,6 +65,11 @@
             <version>${commons-lang3-version}</version>
         </dependency>
         <!-- yaml dsl (via xml) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson2-version}</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>


### PR DESCRIPTION
## Motivation

There are some failing tests that seem to be related to the pom cleanup https://ci-builds.apache.org/job/Camel/job/Camel%20JDK17/job/main/688/testReport/org.apache.camel.generator.openapi/

## Modifications

* Add `jackson-databind`
* Exclude `jackson-core` from `apicurio-data-models` to prevent version conflicts

