### PR TITLE
Explicitly complete/abandon Azure Service Bus messages

### DIFF
--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
@@ -145,6 +145,9 @@ public class ServiceBusConsumer extends DefaultConsumer {
         // use default consumer callback
         AsyncCallback cb = defaultConsumerCallback(exchange, true);
         getAsyncProcessor().process(exchange, cb);
+        if (exchange.getException() != null) {
+            throw RuntimeCamelException.wrapRuntimeException(exchange.getException());
+        }
     }
 
     private Exchange createServiceBusExchange(final ServiceBusReceivedMessage receivedMessage) {
@@ -190,6 +193,7 @@ public class ServiceBusConsumer extends DefaultConsumer {
             getExceptionHandler().handleException("Error processing exchange", exchange,
                     exchange.getException());
         }
+        throw RuntimeCamelException.wrapRuntimeException(errorContext);
     }
 
     private Exchange createServiceBusExchange(final Throwable errorContext) {

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
@@ -145,9 +145,6 @@ public class ServiceBusConsumer extends DefaultConsumer {
         // use default consumer callback
         AsyncCallback cb = defaultConsumerCallback(exchange, true);
         getAsyncProcessor().process(exchange, cb);
-        if (exchange.getException() != null) {
-            throw RuntimeCamelException.wrapRuntimeException(exchange.getException());
-        }
     }
 
     private Exchange createServiceBusExchange(final ServiceBusReceivedMessage receivedMessage) {
@@ -193,7 +190,6 @@ public class ServiceBusConsumer extends DefaultConsumer {
             getExceptionHandler().handleException("Error processing exchange", exchange,
                     exchange.getException());
         }
-        throw RuntimeCamelException.wrapRuntimeException(errorContext);
     }
 
     private Exchange createServiceBusExchange(final Throwable errorContext) {

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
@@ -30,14 +30,13 @@ import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.azure.servicebus.client.ServiceBusClientFactory;
 import org.apache.camel.component.azure.servicebus.client.ServiceBusReceiverAsyncClientWrapper;
 import org.apache.camel.component.azure.servicebus.operations.ServiceBusReceiverOperations;
-import org.apache.camel.spi.Synchronization;
 import org.apache.camel.support.DefaultConsumer;
 import org.apache.camel.support.SynchronizationAdapter;
 import org.apache.camel.util.ObjectHelper;
+import reactor.core.scheduler.Schedulers;
 
 public class ServiceBusConsumer extends DefaultConsumer {
 
-    private Synchronization onCompletion;
     private ServiceBusReceiverAsyncClientWrapper clientWrapper;
     private ServiceBusReceiverOperations operations;
 
@@ -55,7 +54,6 @@ public class ServiceBusConsumer extends DefaultConsumer {
     @Override
     protected void doInit() throws Exception {
         super.doInit();
-        onCompletion = new ConsumerOnCompletion();
     }
 
     @Override
@@ -139,7 +137,7 @@ public class ServiceBusConsumer extends DefaultConsumer {
 
     private void onEventListener(final ServiceBusReceivedMessage message) {
         final Exchange exchange = createServiceBusExchange(message);
-
+        final ConsumerOnCompletion onCompletion = new ConsumerOnCompletion(message);
         // add exchange callback
         exchange.adapt(ExtendedExchange.class).addOnCompletion(onCompletion);
         // use default consumer callback
@@ -202,12 +200,28 @@ public class ServiceBusConsumer extends DefaultConsumer {
     }
 
     private class ConsumerOnCompletion extends SynchronizationAdapter {
+        private final ServiceBusReceivedMessage message;
+
+        public ConsumerOnCompletion(ServiceBusReceivedMessage message) {
+            this.message = message;
+        }
+
+        @Override
+        public void onComplete(Exchange exchange) {
+            super.onComplete(exchange);
+            if (!getConfiguration().isDisableAutoComplete()) {
+                clientWrapper.complete(message).subscribeOn(Schedulers.boundedElastic()).subscribe();
+            }
+        }
 
         @Override
         public void onFailure(Exchange exchange) {
             final Exception cause = exchange.getException();
             if (cause != null) {
                 getExceptionHandler().handleException("Error during processing exchange.", exchange, cause);
+            }
+            if (!getConfiguration().isDisableAutoComplete()) {
+                clientWrapper.abandon(message).subscribeOn(Schedulers.boundedElastic()).subscribe();
             }
         }
     }

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/client/ServiceBusClientFactory.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/client/ServiceBusClientFactory.java
@@ -79,6 +79,9 @@ public final class ServiceBusClientFactory {
             final ServiceBusClientBuilder busClientBuilder, final ServiceBusConfiguration configuration) {
         final ServiceBusClientBuilder.ServiceBusReceiverClientBuilder receiverClientBuilder = busClientBuilder.receiver();
 
+        // We handle auto-complete in the producer, since we have no way to propagate errors back to the reactive
+        // pipeline messages are published on so the message would be completed even if an error occurs during Exchange
+        // processing.
         receiverClientBuilder.disableAutoComplete();
 
         if (configuration.getServiceBusType() == ServiceBusType.queue) {

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/client/ServiceBusClientFactory.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/client/ServiceBusClientFactory.java
@@ -79,7 +79,7 @@ public final class ServiceBusClientFactory {
             final ServiceBusClientBuilder busClientBuilder, final ServiceBusConfiguration configuration) {
         final ServiceBusClientBuilder.ServiceBusReceiverClientBuilder receiverClientBuilder = busClientBuilder.receiver();
 
-        // We handle auto-complete in the producer, since we have no way to propagate errors back to the reactive
+        // We handle auto-complete in the consumer, since we have no way to propagate errors back to the reactive
         // pipeline messages are published on so the message would be completed even if an error occurs during Exchange
         // processing.
         receiverClientBuilder.disableAutoComplete();

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/client/ServiceBusClientFactory.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/client/ServiceBusClientFactory.java
@@ -79,9 +79,7 @@ public final class ServiceBusClientFactory {
             final ServiceBusClientBuilder busClientBuilder, final ServiceBusConfiguration configuration) {
         final ServiceBusClientBuilder.ServiceBusReceiverClientBuilder receiverClientBuilder = busClientBuilder.receiver();
 
-        if (configuration.isDisableAutoComplete()) {
-            receiverClientBuilder.disableAutoComplete();
-        }
+        receiverClientBuilder.disableAutoComplete();
 
         if (configuration.getServiceBusType() == ServiceBusType.queue) {
             return receiverClientBuilder.queueName(configuration.getTopicOrQueueName());


### PR DESCRIPTION
If an exception occurred during Exchange processing, the exception must be rethrown in the message receive and error handlers to trigger the `ServiceBusReceiverAsyncClient` to abandon the message so that the message is requeued.

Fixes [CAMEL-19155](https://issues.apache.org/jira/browse/CAMEL-19155).