### PR TITLE
Rethrow exceptions in Azure Service Bus consumer

### DIFF
--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
@@ -144,6 +144,9 @@ public class ServiceBusConsumer extends DefaultConsumer {
         // use default consumer callback
         AsyncCallback cb = defaultConsumerCallback(exchange, true);
         getAsyncProcessor().process(exchange, cb);
+        if (exchange.getException() != null) {
+            throw RuntimeCamelException.wrapRuntimeException(exchange.getException());
+        }
     }
 
     private Exchange createServiceBusExchange(final ServiceBusReceivedMessage receivedMessage) {
@@ -189,6 +192,7 @@ public class ServiceBusConsumer extends DefaultConsumer {
             getExceptionHandler().handleException("Error processing exchange", exchange,
                     exchange.getException());
         }
+        throw RuntimeCamelException.wrapRuntimeException(errorContext);
     }
 
     private Exchange createServiceBusExchange(final Throwable errorContext) {


### PR DESCRIPTION
If an exception occurred during Exchange processing, the exception must be rethrown in the message receive and error handlers to trigger the `ServiceBusReceiverAsyncClient` to abandon the message so that the message is requeued.

Fixes [CAMEL-19155](https://issues.apache.org/jira/browse/CAMEL-19155).