### PR TITLE
CAMEL-19174: camel-jira - Fix duplicate messages created by Jira consumer

### DIFF
--- a/components/camel-jira/src/main/java/org/apache/camel/component/jira/consumer/NewCommentsConsumer.java
+++ b/components/camel-jira/src/main/java/org/apache/camel/component/jira/consumer/NewCommentsConsumer.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class NewCommentsConsumer extends AbstractJiraConsumer {
 
-    private static final transient Logger LOG = LoggerFactory.getLogger(NewCommentsConsumer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(NewCommentsConsumer.class);
 
     private Long lastCommentId = -1L;
 

--- a/components/camel-jira/src/main/java/org/apache/camel/component/jira/consumer/NewIssuesConsumer.java
+++ b/components/camel-jira/src/main/java/org/apache/camel/component/jira/consumer/NewIssuesConsumer.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class NewIssuesConsumer extends AbstractJiraConsumer {
 
-    private static final transient Logger LOG = LoggerFactory.getLogger(NewIssuesConsumer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(NewIssuesConsumer.class);
 
     private final String jql;
     private long latestIssueId = -1;
@@ -58,13 +58,14 @@ public class NewIssuesConsumer extends AbstractJiraConsumer {
         // grab only the top
         try {
             List<Issue> issues = getIssues(jql, 0, 1, 1);
-            // in case there aren't any issues...
             if (!issues.isEmpty()) {
+                // Issues returned are ordered descendant so this is the newest issue
                 return issues.get(0).getId();
             }
         } catch (Exception e) {
             // ignore
         }
+        // in case there aren't any issues...
         return -1;
     }
 
@@ -72,9 +73,8 @@ public class NewIssuesConsumer extends AbstractJiraConsumer {
         // it may happen the poll() is called while the route is doing the initial load,
         // this way we need to wait for the latestIssueId being associated to the last indexed issue id
         List<Issue> newIssues = getNewIssues();
-        // In the end, we want only *new* issues oldest to newest.
-        for (int i = newIssues.size() - 1; i > -1; i--) {
-            Issue newIssue = newIssues.get(i);
+        // In the end, we want only *new* issues oldest to newest. New issues returned are ordered descendant already.
+        for (Issue newIssue : newIssues) {
             Exchange e = createExchange(true);
             e.getIn().setBody(newIssue);
             getProcessor().process(e);
@@ -113,8 +113,8 @@ public class NewIssuesConsumer extends AbstractJiraConsumer {
 
         if (!issues.isEmpty()) {
             // remember last id we have processed
-            int last = issues.size() - 1;
-            latestIssueId = issues.get(last).getId();
+            // issues are ordered descendant so save the first issue in the list as the newest
+            latestIssueId = issues.get(0).getId();
         }
         return issues;
     }

--- a/components/camel-jira/src/main/java/org/apache/camel/component/jira/consumer/WatchUpdatesConsumer.java
+++ b/components/camel-jira/src/main/java/org/apache/camel/component/jira/consumer/WatchUpdatesConsumer.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 public class WatchUpdatesConsumer extends AbstractJiraConsumer {
 
-    private static final transient Logger LOG = LoggerFactory.getLogger(WatchUpdatesConsumer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(WatchUpdatesConsumer.class);
     HashMap<Long, Issue> watchedIssues;
     List<String> watchedFieldsList;
     String watchedIssuesKeys;

--- a/components/camel-jira/src/test/java/org/apache/camel/component/jira/consumer/NewCommentsConsumerTest.java
+++ b/components/camel-jira/src/test/java/org/apache/camel/component/jira/consumer/NewCommentsConsumerTest.java
@@ -57,7 +57,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class NewCommentsConsumerTest extends CamelTestSupport {
 
-    private static List<Issue> issues = new ArrayList<>();
+    private static final List<Issue> ISSUES = new ArrayList<>();
 
     @Mock
     private JiraRestClient jiraClient;
@@ -81,13 +81,13 @@ public class NewCommentsConsumerTest extends CamelTestSupport {
 
     @BeforeAll
     public static void beforeAll() {
-        issues.add(createIssueWithComments(1L, 1));
-        issues.add(createIssueWithComments(2L, 1));
-        issues.add(createIssueWithComments(3L, 1));
+        ISSUES.add(createIssueWithComments(3L, 1));
+        ISSUES.add(createIssueWithComments(2L, 1));
+        ISSUES.add(createIssueWithComments(1L, 1));
     }
 
     public void setMocks() {
-        SearchResult result = new SearchResult(0, 50, 100, issues);
+        SearchResult result = new SearchResult(0, 50, 100, ISSUES);
         Promise<SearchResult> promiseSearchResult = Promises.promise(result);
         Issue issue = createIssueWithComments(4L, 1);
         Promise<Issue> promiseIssue = Promises.promise(issue);
@@ -159,9 +159,9 @@ public class NewCommentsConsumerTest extends CamelTestSupport {
         Issue issue2 = createIssueWithComments(21L, 3000);
         Issue issue3 = createIssueWithComments(22L, 1000);
         List<Issue> newIssues = new ArrayList<>();
-        newIssues.add(issue1);
-        newIssues.add(issue2);
         newIssues.add(issue3);
+        newIssues.add(issue2);
+        newIssues.add(issue1);
         Issue issueWithNoComments = createIssue(31L);
 
         reset(searchRestClient);

--- a/components/camel-jira/src/test/java/org/apache/camel/component/jira/consumer/WatchUpdatesConsumerTest.java
+++ b/components/camel-jira/src/test/java/org/apache/camel/component/jira/consumer/WatchUpdatesConsumerTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class WatchUpdatesConsumerTest extends CamelTestSupport {
-    private static List<Issue> issues = new ArrayList<>();
+    private static final List<Issue> ISSUES = new ArrayList<>();
 
     @Mock
     private JiraRestClient jiraClient;
@@ -73,14 +73,14 @@ public class WatchUpdatesConsumerTest extends CamelTestSupport {
 
     @BeforeAll
     public static void beforeAll() {
-        issues.clear();
-        issues.add(createIssue(1L));
-        issues.add(createIssue(2L));
-        issues.add(createIssue(3L));
+        ISSUES.clear();
+        ISSUES.add(createIssue(1L));
+        ISSUES.add(createIssue(2L));
+        ISSUES.add(createIssue(3L));
     }
 
     public void setMocks() {
-        SearchResult result = new SearchResult(0, 50, 100, issues);
+        SearchResult result = new SearchResult(0, 50, 100, ISSUES);
         Promise<SearchResult> promiseSearchResult = Promises.promise(result);
 
         when(jiraClient.getSearchClient()).thenReturn(searchRestClient);
@@ -118,17 +118,17 @@ public class WatchUpdatesConsumerTest extends CamelTestSupport {
 
     @Test
     public void singleChangeTest() throws Exception {
-        Issue issue = setPriority(issues.get(0), new Priority(
+        Issue issue = setPriority(ISSUES.get(0), new Priority(
                 null, 4L, "High", null, null, null));
         reset(searchRestClient);
         AtomicBoolean searched = new AtomicBoolean();
         when(searchRestClient.searchJql(any(), any(), any(), any())).then(invocation -> {
 
             if (!searched.get()) {
-                issues.remove(0);
-                issues.add(0, issue);
+                ISSUES.remove(0);
+                ISSUES.add(0, issue);
             }
-            SearchResult result = new SearchResult(0, 50, 100, issues);
+            SearchResult result = new SearchResult(0, 50, 100, ISSUES);
             return Promises.promise(result);
         });
 
@@ -141,23 +141,23 @@ public class WatchUpdatesConsumerTest extends CamelTestSupport {
 
     @Test
     public void multipleChangesWithAddedNewIssueTest() throws Exception {
-        final Issue issue = transitionIssueDone(issues.get(1));
-        final Issue issue2 = setPriority(issues.get(2), new Priority(
+        final Issue issue = transitionIssueDone(ISSUES.get(1));
+        final Issue issue2 = setPriority(ISSUES.get(2), new Priority(
                 null, 4L, "High", null, null, null));
 
         reset(searchRestClient);
         AtomicBoolean searched = new AtomicBoolean();
         when(searchRestClient.searchJql(any(), any(), any(), any())).then(invocation -> {
             if (!searched.get()) {
-                issues.add(createIssue(4L));
-                issues.remove(1);
-                issues.add(1, issue);
-                issues.remove(2);
-                issues.add(2, issue2);
+                ISSUES.add(createIssue(4L));
+                ISSUES.remove(1);
+                ISSUES.add(1, issue);
+                ISSUES.remove(2);
+                ISSUES.add(2, issue2);
                 searched.set(true);
             }
 
-            SearchResult result = new SearchResult(0, 50, 3, issues);
+            SearchResult result = new SearchResult(0, 50, 3, ISSUES);
             return Promises.promise(result);
         });
 


### PR DESCRIPTION
Backport of #9589 to `camel-3.20.x`

- Issues returned are already ordered descendant - do not revert the order of issues a 2nd time
- Make sure to exit polling loop early when no further issues are returned (total # of issues returned is lower than query page size)
- Avoid duplicates in returned issue list
- Adjust query page size according to given max results limitation
- Fix ordering of mocked issue return values in unit tests (mocks should return issues in descendant order)
- Add more unit tests on new issues consumer (testing filter offset, pagination, duplicates)

