### PR TITLE
Disable Infinispan tests depending on JTA

### DIFF
--- a/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/InfinispanEmbeddedClusteredConsumerTest.java
+++ b/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/InfinispanEmbeddedClusteredConsumerTest.java
@@ -25,10 +25,12 @@ import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.distribution.MagicKey;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@Disabled("Jakarta Transactions are not yet supported by Infinispan")
 public class InfinispanEmbeddedClusteredConsumerTest extends InfinispanEmbeddedClusteredTestSupport {
 
     private static final long WAIT_TIMEOUT = 5000;

--- a/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/spring/SpringInfinispanEmbeddedIdempotentRepositorySpringTest.java
+++ b/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/spring/SpringInfinispanEmbeddedIdempotentRepositorySpringTest.java
@@ -16,10 +16,12 @@
  */
 package org.apache.camel.component.infinispan.embedded.spring;
 
+import org.junit.jupiter.api.Disabled;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 
+@Disabled("Jakarta Transactions are not yet supported by Infinispan")
 @DirtiesContext
 public class SpringInfinispanEmbeddedIdempotentRepositorySpringTest
         extends SpringInfinispanEmbeddedIdempotentRepositoryTestSupport {


### PR DESCRIPTION
## Motivation

[Some tests](https://ci-builds.apache.org/job/Camel/job/Camel%20JDK17/job/main/692/testReport/) are failing on Jenkins because Infinispan doesn't support Jakarta Transactions

## Modifications:

* Disable the tests that depend on JTA