### PR TITLE
CAMEL-15520: replace deprecated maven property maven.test.skip.exec

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -3369,7 +3369,7 @@
                 </property>
             </activation>
             <properties>
-                <maven.test.skip.exec>true</maven.test.skip.exec>
+                <skipTests>true</skipTests>
                 <archetype.test.skip>true</archetype.test.skip>
                 <assembly.skipAssembly>true</assembly.skipAssembly>
                 <fastinstall>true</fastinstall>

--- a/pom.xml
+++ b/pom.xml
@@ -469,7 +469,7 @@
               files for modules -->
             <properties>
                 <eclipse.workspace.dir>${basedir}/../workspace</eclipse.workspace.dir>
-                <maven.test.skip.exec>true</maven.test.skip.exec>
+                <skipTests>true</skipTests>
             </properties>
             <build>
                 <defaultGoal>package</defaultGoal>


### PR DESCRIPTION
Replaced a deprecated Maven property (ref: https://maven.apache.org/surefire-archives/surefire-2.22.1/maven-failsafe-plugin/verify-mojo.html#skipExec)