### PR TITLE
Fix Infinispan tests depending on JTA

### DIFF
--- a/components/camel-infinispan/camel-infinispan-embedded/pom.xml
+++ b/components/camel-infinispan/camel-infinispan-embedded/pom.xml
@@ -87,7 +87,7 @@
         <!-- testing - infinispan -->
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-core</artifactId>
+            <artifactId>infinispan-core-jakarta</artifactId>
             <version>${infinispan-version}</version>
             <type>test-jar</type>
             <scope>test</scope>
@@ -95,6 +95,12 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-commons-test</artifactId>
+            <version>${infinispan-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-spring6-embedded</artifactId>
             <version>${infinispan-version}</version>
             <scope>test</scope>
         </dependency>

--- a/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/InfinispanEmbeddedClusteredConsumerTest.java
+++ b/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/InfinispanEmbeddedClusteredConsumerTest.java
@@ -25,12 +25,10 @@ import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.distribution.MagicKey;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@Disabled("Jakarta Transactions are not yet supported by Infinispan")
 public class InfinispanEmbeddedClusteredConsumerTest extends InfinispanEmbeddedClusteredTestSupport {
 
     private static final long WAIT_TIMEOUT = 5000;

--- a/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/spring/SpringInfinispanEmbeddedIdempotentRepositorySpringTest.java
+++ b/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/spring/SpringInfinispanEmbeddedIdempotentRepositorySpringTest.java
@@ -16,12 +16,10 @@
  */
 package org.apache.camel.component.infinispan.embedded.spring;
 
-import org.junit.jupiter.api.Disabled;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 
-@Disabled("Jakarta Transactions are not yet supported by Infinispan")
 @DirtiesContext
 public class SpringInfinispanEmbeddedIdempotentRepositorySpringTest
         extends SpringInfinispanEmbeddedIdempotentRepositoryTestSupport {


### PR DESCRIPTION
## Motivation

Some Infinispan tests have been disabled due to a JTA issue and need to be fixed

## Modifications:

* Use the Jakarta version of the `test-jar` of `infinispan-core` to get a Jakarta-compatible version of the test classes
* Add explicitly `infinispan-spring6-embedded` to the dependencies to get the right version of the class `SpringEmbeddedCacheManagerFactoryBean`