### PR TITLE
(chores) camel-aws2-cw: fix test for configuration without options

### DIFF
--- a/components/camel-aws/camel-aws2-cw/src/test/java/org/apache/camel/component/aws2/cw/CwComponentConfigurationTest.java
+++ b/components/camel-aws/camel-aws2-cw/src/test/java/org/apache/camel/component/aws2/cw/CwComponentConfigurationTest.java
@@ -70,7 +70,7 @@ public class CwComponentConfigurationTest extends CamelTestSupport {
     public void createEndpointWithoutSecretKeyAndAccessKeyConfiguration() {
         Cw2Component component = context.getComponent("aws2-cw", Cw2Component.class);
         assertThrows(IllegalArgumentException.class, () -> {
-            component.createEndpoint("aws2-cw://camel.apache.org/test?accessKey=xxx");
+            component.createEndpoint("aws2-cw://camel.apache.org/test");
         });
     }
 


### PR DESCRIPTION
Remove accessKey configuration to make createEndpointWithoutSecretKeyAndAccessKeyConfiguration test correct