### PR TITLE
CAMEL-19173 - Splitting long uris in XML DSLs

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -794,4 +794,17 @@ public final class URISupport {
         return joined.toString();
     }
 
+    public static String removeNoiseFromUri(String uri) {
+        String before = StringHelper.before(uri, "?");
+        String after = StringHelper.after(uri, "?");
+
+        if (before != null && after != null) {
+            String changed = after.replaceAll("&\\s+", "&").trim();
+            if (!after.equals(changed)) {
+                String newAtr = before.trim() + "?" + changed;
+                return newAtr;
+            }
+        }
+        return uri;
+    }
 }

--- a/core/camel-xml-io/src/main/java/org/apache/camel/xml/in/BaseParser.java
+++ b/core/camel-xml-io/src/main/java/org/apache/camel/xml/in/BaseParser.java
@@ -35,7 +35,7 @@ import org.apache.camel.LineNumberAware;
 import org.apache.camel.model.language.ExpressionDefinition;
 import org.apache.camel.spi.NamespaceAware;
 import org.apache.camel.spi.Resource;
-import org.apache.camel.util.StringHelper;
+import org.apache.camel.util.URISupport;
 import org.apache.camel.xml.io.MXParser;
 import org.apache.camel.xml.io.XmlPullParser;
 import org.apache.camel.xml.io.XmlPullParserException;
@@ -107,15 +107,7 @@ public class BaseParser {
             String ns = parser.getAttributeNamespace(i);
             String val = parser.getAttributeValue(i);
             if (name.equals("uri") || name.endsWith("Uri")) {
-                String before = StringHelper.before(val, "?");
-                String after = StringHelper.after(val, "?");
-                if (before != null && after != null) {
-                    String changed = after.replaceAll("&\\s+", "&").trim();
-                    if (!after.equals(changed)) {
-                        String newAtr = before.trim() + "?" + changed;
-                        val = newAtr;
-                    }
-                }
+                val = URISupport.removeNoiseFromUri(val);
             }
             if (Objects.equals(ns, "") || Objects.equals(ns, namespace)) {
                 if (attributeHandler == null || !attributeHandler.accept(definition, name, val)) {

--- a/core/camel-xml-io/src/main/java/org/apache/camel/xml/in/BaseParser.java
+++ b/core/camel-xml-io/src/main/java/org/apache/camel/xml/in/BaseParser.java
@@ -35,6 +35,7 @@ import org.apache.camel.LineNumberAware;
 import org.apache.camel.model.language.ExpressionDefinition;
 import org.apache.camel.spi.NamespaceAware;
 import org.apache.camel.spi.Resource;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.xml.io.MXParser;
 import org.apache.camel.xml.io.XmlPullParser;
 import org.apache.camel.xml.io.XmlPullParserException;
@@ -105,6 +106,18 @@ public class BaseParser {
             String name = parser.getAttributeName(i);
             String ns = parser.getAttributeNamespace(i);
             String val = parser.getAttributeValue(i);
+            if (name.equals("uri") || name.endsWith("Uri")) {
+                String before = StringHelper.before(val, "?");
+                String after = StringHelper.after(val, "?");
+                if (before != null && after != null) {
+                    // remove all double spaces in the uri parameters
+                    String changed = after.replaceAll("\\s{2,}", "");
+                    if (!after.equals(changed)) {
+                        String newAtr = before.trim() + "?" + changed.trim();
+                        val = newAtr;
+                    }
+                }
+            }
             if (Objects.equals(ns, "") || Objects.equals(ns, namespace)) {
                 if (attributeHandler == null || !attributeHandler.accept(definition, name, val)) {
                     handleUnexpectedAttribute(namespace, name);

--- a/core/camel-xml-io/src/main/java/org/apache/camel/xml/in/BaseParser.java
+++ b/core/camel-xml-io/src/main/java/org/apache/camel/xml/in/BaseParser.java
@@ -110,10 +110,9 @@ public class BaseParser {
                 String before = StringHelper.before(val, "?");
                 String after = StringHelper.after(val, "?");
                 if (before != null && after != null) {
-                    // remove all double spaces in the uri parameters
-                    String changed = after.replaceAll("\\s{2,}", "");
+                    String changed = after.replaceAll("&\\s+", "&").trim();
                     if (!after.equals(changed)) {
-                        String newAtr = before.trim() + "?" + changed.trim();
+                        String newAtr = before.trim() + "?" + changed;
                         val = newAtr;
                     }
                 }

--- a/core/camel-xml-io/src/test/java/org/apache/camel/xml/in/ModelParserTest.java
+++ b/core/camel-xml-io/src/test/java/org/apache/camel/xml/in/ModelParserTest.java
@@ -28,12 +28,14 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.camel.model.FromDefinition;
 import org.apache.camel.model.PropertyDefinition;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.RouteTemplatesDefinition;
 import org.apache.camel.model.RoutesDefinition;
 import org.apache.camel.model.SetBodyDefinition;
 import org.apache.camel.model.TemplatedRoutesDefinition;
+import org.apache.camel.model.ToDefinition;
 import org.apache.camel.model.language.XPathExpression;
 import org.apache.camel.model.rest.ParamDefinition;
 import org.apache.camel.model.rest.RestDefinition;
@@ -197,6 +199,34 @@ public class ModelParserTest {
         Assertions.assertEquals(1, verb.getParams().size());
         ParamDefinition param = verb.getParams().get(0);
         Assertions.assertEquals(4, param.getAllowableValues().size());
+    }
+
+    @Test
+    public void testUriLineBreak() throws Exception {
+        final String fromFrag1 = "seda:a?concurrentConsumers=2&amp;";
+        final String fromFrag2 = "defaultPollTimeout=500";
+        final String toFrag1 = "seda:b?";
+        final String toFrag2 = "lazyStartProducer=true&amp;";
+        final String toFrag3 = "defaultBlockWhenFull=true";
+        final String routesXml = "<routes xmlns=\"" + NAMESPACE + "\">\n"
+                                 + "  <route>\n"
+                                 + "    <from uri=\"" + fromFrag1 + "\n"
+                                 + "        " + fromFrag2 + "\n"
+                                 + "        \"/>\n"
+                                 + "    <to uri=\"" + toFrag1 + "\n"
+                                 + "        " + toFrag2 + "\n"
+                                 + "        " + toFrag3 + "\"/>\n"
+                                 + "  </route>\n"
+                                 + "</routes>";
+        final RoutesDefinition routes
+                = new ModelParser(new StringReader(routesXml), NAMESPACE).parseRoutesDefinition().orElse(null);
+        final RouteDefinition route = routes.getRoutes().get(0);
+        final FromDefinition from = route.getInput();
+        final ToDefinition to = (ToDefinition) route.getOutputs().get(0);
+        final String fromUri = (fromFrag1 + fromFrag2).replace("&amp;", "&");
+        final String toUri = (toFrag1 + toFrag2 + toFrag3).replace("&amp;", "&");
+        Assertions.assertEquals(fromUri, from.getEndpointUri());
+        Assertions.assertEquals(toUri, to.getEndpointUri());
     }
 
     private Path getResourceFolder() {

--- a/core/camel-xml-io/src/test/java/org/apache/camel/xml/in/ModelParserTest.java
+++ b/core/camel-xml-io/src/test/java/org/apache/camel/xml/in/ModelParserTest.java
@@ -205,6 +205,9 @@ public class ModelParserTest {
     public void testUriLineBreak() throws Exception {
         final String fromFrag1 = "seda:a?concurrentConsumers=2&amp;";
         final String fromFrag2 = "defaultPollTimeout=500";
+        final String jpaFrag1 = "jpa:SomeClass?query=update Object o";
+        final String jpaSpaces = "        ";
+        final String jpaFrag2 = "set o.status = 0";
         final String toFrag1 = "seda:b?";
         final String toFrag2 = "lazyStartProducer=true&amp;";
         final String toFrag3 = "defaultBlockWhenFull=true";
@@ -213,6 +216,8 @@ public class ModelParserTest {
                                  + "    <from uri=\"" + fromFrag1 + "\n"
                                  + "        " + fromFrag2 + "\n"
                                  + "        \"/>\n"
+                                 + "    <to uri=\"" + jpaFrag1 + "\n"
+                                 + jpaSpaces + jpaFrag2 + "\"/>\n"
                                  + "    <to uri=\"" + toFrag1 + "\n"
                                  + "        " + toFrag2 + "\n"
                                  + "        " + toFrag3 + "\"/>\n"
@@ -222,10 +227,16 @@ public class ModelParserTest {
                 = new ModelParser(new StringReader(routesXml), NAMESPACE).parseRoutesDefinition().orElse(null);
         final RouteDefinition route = routes.getRoutes().get(0);
         final FromDefinition from = route.getInput();
-        final ToDefinition to = (ToDefinition) route.getOutputs().get(0);
+
+        final ToDefinition jpa = (ToDefinition) route.getOutputs().get(0);
+        final ToDefinition to = (ToDefinition) route.getOutputs().get(1);
+
         final String fromUri = (fromFrag1 + fromFrag2).replace("&amp;", "&");
+        final String jpaUri = jpaFrag1 + " " + jpaSpaces + jpaFrag2; // \n is changed to a single space
         final String toUri = (toFrag1 + toFrag2 + toFrag3).replace("&amp;", "&");
+
         Assertions.assertEquals(fromUri, from.getEndpointUri());
+        Assertions.assertEquals(jpaUri, jpa.getEndpointUri());
         Assertions.assertEquals(toUri, to.getEndpointUri());
     }
 

--- a/core/camel-xml-jaxb/src/main/java/org/apache/camel/xml/jaxb/JaxbHelper.java
+++ b/core/camel-xml-jaxb/src/main/java/org/apache/camel/xml/jaxb/JaxbHelper.java
@@ -331,7 +331,7 @@ public final class JaxbHelper {
 
     /**
      * Un-marshals the content of the input stream to an instance of {@link TemplatedRoutesDefinition}.
-     * 
+     *
      * @param  context     the Camel context from which the JAXBContext is extracted
      * @param  inputStream the input stream to unmarshal
      * @return             the content unmarshalled as a {@link TemplatedRoutesDefinition}.
@@ -448,10 +448,9 @@ public final class JaxbHelper {
         String after = StringHelper.after(uri, "?");
 
         if (before != null && after != null) {
-            // remove all double spaces in the uri parameters
-            String changed = after.replaceAll("\\s{2,}", "");
+            String changed = after.replaceAll("&\\s+", "&").trim();
             if (!after.equals(changed)) {
-                String newAtr = before.trim() + "?" + changed.trim();
+                String newAtr = before.trim() + "?" + changed;
                 return newAtr;
             }
         }

--- a/core/camel-xml-jaxb/src/main/java/org/apache/camel/xml/jaxb/JaxbHelper.java
+++ b/core/camel-xml-jaxb/src/main/java/org/apache/camel/xml/jaxb/JaxbHelper.java
@@ -57,7 +57,7 @@ import org.apache.camel.model.rest.RestDefinition;
 import org.apache.camel.model.rest.RestsDefinition;
 import org.apache.camel.spi.NamespaceAware;
 import org.apache.camel.util.KeyValueHolder;
-import org.apache.camel.util.StringHelper;
+import org.apache.camel.util.URISupport;
 
 import static org.apache.camel.model.ProcessorDefinitionHelper.filterTypeInOutputs;
 
@@ -428,7 +428,7 @@ public final class JaxbHelper {
             final String attName = attr.getName();
 
             if (attName.equals("uri") || attName.endsWith("Uri")) {
-                attr.setValue(removeNoiseFromUri(attr.getValue()));
+                attr.setValue(URISupport.removeNoiseFromUri(attr.getValue()));
             }
         }
 
@@ -443,17 +443,4 @@ public final class JaxbHelper {
         }
     }
 
-    private static String removeNoiseFromUri(String uri) {
-        String before = StringHelper.before(uri, "?");
-        String after = StringHelper.after(uri, "?");
-
-        if (before != null && after != null) {
-            String changed = after.replaceAll("&\\s+", "&").trim();
-            if (!after.equals(changed)) {
-                String newAtr = before.trim() + "?" + changed;
-                return newAtr;
-            }
-        }
-        return uri;
-    }
 }


### PR DESCRIPTION
# Description

CAMEL-19173.

In new XML DSLs removes spaces before parameter names, so long URIs can be split into lines, similar to https://camel.apache.org/manual/faq/how-do-i-configure-endpoints.html#HowdoIconfigureendpoints-Configuringlongurisusingnewlines 

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

