### PR TITLE
CAMEL-19198: 3.x branch version -- Added sorting logic to ensure dynamic router eip component filters are evaluated in order of their priority property

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
@@ -2,516 +2,414 @@
     
   <xs:element name="aggregate" type="tns:aggregateDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Aggregates many messages into a single message
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="any23" type="tns:any23DataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Extract RDF data from HTML documents.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="apiKey" type="tns:apiKeyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest security basic auth definition
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="asn1" type="tns:asn1DataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Encode and decode data structures using Abstract Syntax Notation One (ASN.1).
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="avro" type="tns:avroDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Serialize and deserialize messages using Apache Avro binary data format.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="barcode" type="tns:barcodeDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Transform strings to various 1D/2D barcode bitmap formats and back.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="base64" type="tns:base64DataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Encode and decode data using Base64.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="basicAuth" type="tns:basicAuthDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest security basic auth definition
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="batch-config" type="tns:batchResequencerConfig">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Configures batch-processing resequence eip.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="bean" type="tns:beanDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Calls a Java bean
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="beanPostProcessor" type="tns:camelBeanPostProcessor">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Spring specific DefaultCamelBeanPostProcessor which uses Spring
 BeanPostProcessor to post process beans.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="bearerToken" type="tns:bearerTokenDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest security bearer token authentication definition
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="bindy" type="tns:bindyDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshal and unmarshal Java beans from and to flat payloads (such as CSV,
 delimited, fixed length formats, or FIX messages).
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="blacklistServiceFilter" type="tns:blacklistServiceCallServiceFilterConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="cachingServiceDiscovery" type="tns:cachingServiceCallServiceDiscoveryConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="camelContext" type="tns:camelContextFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 CamelContext using XML configuration.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="cbor" type="tns:cborDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Unmarshal a CBOR payload to POJO and back.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="choice" type="tns:choiceDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Route messages based on a series of predicates
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="circuitBreaker" type="tns:circuitBreakerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Route messages in a fault tolerance way using Circuit Breaker
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="claimCheck" type="tns:claimCheckDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 The Claim Check EIP allows you to replace message content with a claim check (a
 unique key), which can be used to retrieve the message content at a later time.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="combinedServiceDiscovery" type="tns:combinedServiceCallServiceDiscoveryConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="combinedServiceFilter" type="tns:combinedServiceCallServiceFilterConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="constant" type="tns:constantExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A fixed value set only once during the route startup.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="consulServiceDiscovery" type="tns:consulServiceCallServiceDiscoveryConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="consumerTemplate" type="tns:camelConsumerTemplateFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Configures a ConsumerTemplate
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="contextScan" type="tns:contextScanDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Scans for Java org.apache.camel.builder.RouteBuilder instances in the context
 org.apache.camel.spi.Registry .
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="convertBodyTo" type="tns:convertBodyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Converts the message body to another type
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="crypto" type="tns:cryptoDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Encrypt and decrypt messages using Java Cryptography Extension (JCE).
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="csimple" type="tns:cSimpleExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluate a compiled simple expression.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="csv" type="tns:csvDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Handle CSV (Comma Separated Values) payloads.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="custom" type="tns:customDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Delegate to a custom org.apache.camel.spi.DataFormat implementation via Camel
 registry.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="customLoadBalancer" type="tns:customLoadBalancerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To use a custom load balancer implementation.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="customServiceFilter" type="tns:customServiceCallServiceFilterConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="dataFormats" type="tns:dataFormatsDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Configure data formats.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="datasonnet" type="tns:datasonnetExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To use DataSonnet scripts for message transformations.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="deadLetterChannel" type="tns:deadLetterChannelDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Error handler with dead letter queue.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="defaultErrorHandler" type="tns:defaultErrorHandlerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 The default error handler.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="defaultLoadBalancer" type="tns:defaultServiceCallServiceLoadBalancerConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="delay" type="tns:delayDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Delays processing for a specified length of time
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="delete" type="tns:deleteDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest DELETE command
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="description" type="tns:descriptionDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To provide comments about the node.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="dnsServiceDiscovery" type="tns:dnsServiceCallServiceDiscoveryConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="doCatch" type="tns:catchDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Catches exceptions as part of a try, catch, finally block
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="doFinally" type="tns:finallyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Path traversed when a try, catch, finally block exits
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="doTry" type="tns:tryDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marks the beginning of a try, catch, finally block
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="dynamicRouter" type="tns:dynamicRouterDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Route messages based on dynamic rules
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="endpoint" type="tns:camelEndpointFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Camel endpoint configuration
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="enrich" type="tns:enrichDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Enriches a message with data from a secondary resource
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="errorHandler" nillable="true" type="xs:anyType">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
-Camel error handling.
-      ]]>
-      </xs:documentation>
+      <xs:documentation xml:lang="en"><![CDATA[
+Error handler settings
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="exchangeProperty" type="tns:exchangePropertyExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Gets a property from the Exchange.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="expression" type="tns:expressionSubElementDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A useful base class for an expression
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
@@ -519,242 +417,195 @@ A useful base class for an expression
     
   <xs:element name="failover" type="tns:failoverLoadBalancerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 In case of failures the exchange will be tried on the next endpoint.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="faultToleranceConfiguration" type="tns:faultToleranceConfigurationDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 MicroProfile Fault Tolerance Circuit Breaker EIP configuration
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="fhirJson" type="tns:fhirJsonDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshall and unmarshall FHIR objects to/from JSON.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="fhirXml" type="tns:fhirXmlDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshall and unmarshall FHIR objects to/from XML.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="filter" type="tns:filterDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Filter out messages based using a predicate
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="flatpack" type="tns:flatpackDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshal and unmarshal Java lists and maps to/from flat files (such as CSV,
 delimited, or fixed length formats) using Flatpack library.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="fluentTemplate" type="tns:camelFluentProducerTemplateFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Configures a org.apache.camel.FluentProducerTemplate
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="from" type="tns:fromDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Act as a message source as input to a route
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="get" type="tns:getDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest GET command
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="globalOption" type="tns:globalOptionDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Models a string key/value pair for configuring some global options on a Camel
 context such as max debug log length.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="globalOptions" type="tns:globalOptionsDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Models a series of string key/value pairs for configuring some global options on
 a Camel context such as max debug log length.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="grok" type="tns:grokDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Unmarshal unstructured data to objects using Logstash based Grok patterns.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="groovy" type="tns:groovyExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates a Groovy script.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="gzipDeflater" type="tns:gzipDeflaterDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Compress and decompress messages using java.util.zip.GZIPStream.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="head" type="tns:headDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest HEAD command
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="header" type="tns:headerExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Gets a header from the Exchange.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="healthyServiceFilter" type="tns:healthyServiceCallServiceFilterConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="hl7" type="tns:hl7DataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshal and unmarshal HL7 (Health Care) model objects using the HL7 MLLP codec.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="hl7terser" type="tns:hl7TerserExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Get the value of a HL7 message field specified by terse location specification
 syntax.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="ical" type="tns:icalDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshal and unmarshal iCal (.ics) documents to/from model objects.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="idempotentConsumer" type="tns:idempotentConsumerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Filters out duplicate messages
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="inOnly" type="tns:inOnlyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: Marks the exchange pattern for the route to one way
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="inOut" type="tns:inOutDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: Marks the exchange pattern for the route to request/reply
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="inputType" type="tns:inputTypeDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Set the expected data type of the input message. If the actual message type is
 different at runtime, camel look for a required Transformer and apply if exists.
 If validate attribute is true then camel applies Validator as well. Type name
@@ -764,387 +615,311 @@ consists of two parts, 'scheme' and 'name' connected with ':'. For Java type
 it works like a wildcard. If only 'xml' is specified, all the XML message
 matches. It's handy to add only one transformer/validator for all the
 transformation from/to XML.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="intercept" type="tns:interceptDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Intercepts a message at each step in the route
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="interceptFrom" type="tns:interceptFromDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Intercepts incoming messages
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="interceptSendToEndpoint" type="tns:interceptSendToEndpointDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Intercepts messages being sent to an endpoint
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="jacksonXml" type="tns:jacksonXMLDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Unmarshal an XML payloads to POJOs and back using XMLMapper extension of
 Jackson.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="jaxb" type="tns:jaxbDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Unmarshal XML payloads to POJOs and back using JAXB2 XML marshalling standard.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="jmxAgent" type="tns:camelJMXAgentDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 JMX configuration.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="joor" type="tns:joorExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates a jOOR (Java compiled once at runtime) expression.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="jq" type="tns:jqExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates a JQ expression against a JSON message body.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="js" type="tns:javaScriptExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates a JavaScript expression.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="json" type="tns:jsonDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshal POJOs to JSON and back.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="jsonApi" type="tns:jsonApiDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshal and unmarshal JSON:API resources using JSONAPI-Converter library.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="jsonpath" type="tns:jsonPathExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates a JSONPath expression against a JSON message body.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="jtaTransactionErrorHandler" type="tns:jtaTransactionErrorHandlerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 JTA based transactional error handler (requires camel-jta).
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="kamelet" type="tns:kameletDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To call Kamelets in special situations
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="keyStoreParameters" type="tns:keyStoreParametersFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Key store facility for cryptographic keys and certificates
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="kubernetesServiceDiscovery" type="tns:kubernetesServiceCallServiceDiscoveryConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="language" type="tns:languageExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates a custom language.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="loadBalance" type="tns:loadBalanceDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Balances message processing among a number of nodes
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="loadBalancerConfiguration" type="tns:serviceCallServiceLoadBalancerConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="log" type="tns:logDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Logs the defined message to the logger
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="loop" type="tns:loopDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Processes a message multiple times
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="lzf" type="tns:lzfDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Compress and decompress streams using LZF deflate algorithm.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="marshal" type="tns:marshalDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshals data into a specified format for transmission over a transport or
 component
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="method" type="tns:methodCallExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Calls a Java bean method.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="mimeMultipart" type="tns:mimeMultipartDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshal Camel messages with attachments into MIME-Multipart messages and back.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="multicast" type="tns:multicastDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Routes the same message to multiple paths either sequentially or in parallel.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="mutualTLS" type="tns:mutualTLSDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest security mutual TLS authentication definition
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="mvel" type="tns:mvelExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates a MVEL template.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="noErrorHandler" type="tns:noErrorHandlerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To not use an error handler.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="oauth2" type="tns:oAuth2Definition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest security OAuth2 definition
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="ognl" type="tns:ognlExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates an OGNL expression (Apache Commons OGNL).
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="onCompletion" type="tns:onCompletionDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Route to be executed when normal route processing completes
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="onException" type="tns:onExceptionDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Route to be executed when an exception is thrown
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="onFallback" type="tns:onFallbackDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Route to be executed when Circuit Breaker EIP executes fallback
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="openIdConnect" type="tns:openIdConnectDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest security OpenID Connect definition
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="optimisticLockRetryPolicy" type="tns:optimisticLockRetryPolicyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To configure optimistic locking
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="otherwise" type="tns:otherwiseDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Route to be executed when all other choices evaluate to false
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="outputType" type="tns:outputTypeDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Set the expected data type of the output message. If the actual message type is
 different at runtime, camel look for a required Transformer and apply if exists.
 If validate attribute is true then camel applies Validator as well. Type name
@@ -1154,1357 +929,1088 @@ consists of two parts, 'scheme' and 'name' connected with ':'. For Java type
 it works like a wildcard. If only 'xml' is specified, all the XML message
 matches. It's handy to add only one transformer/validator for all the XML-Java
 transformation.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="packageScan" type="tns:packageScanDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Scans for Java org.apache.camel.builder.RouteBuilder classes in java packages
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="param" type="tns:paramDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To specify the rest operation parameters.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="passThroughServiceFilter" type="tns:passThroughServiceCallServiceFilterConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="patch" type="tns:patchDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest PATCH command
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="pausable" type="tns:pausableDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Pausable EIP to support resuming processing from last known offset.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="pgp" type="tns:pgpDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Encrypt and decrypt messages using Java Cryptographic Extension (JCE) and PGP.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="pipeline" type="tns:pipelineDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Routes the message to a sequence of processors.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="policy" type="tns:policyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Defines a policy the route will use
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="pollEnrich" type="tns:pollEnrichDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Enriches messages with data polled from a secondary resource
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="post" type="tns:postDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest POST command
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="process" type="tns:processDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Calls a Camel processor
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="propertiesFunction" type="tns:camelPropertyPlaceholderFunctionDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Function to use with properties placeholder
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="propertiesLocation" type="tns:camelPropertyPlaceholderLocationDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Properties to use with properties placeholder
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="property" type="tns:propertyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A key value pair where the value is a literal value
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="propertyExpression" type="tns:propertyExpressionDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A key value pair where the value is an expression.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="propertyPlaceholder" type="tns:camelPropertyPlaceholderDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Properties placeholder
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="protobuf" type="tns:protobufDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Serialize and deserialize Java objects using Google's Protocol buffers.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="put" type="tns:putDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest PUT command
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="python" type="tns:pythonExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates a Python expression.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="random" type="tns:randomLoadBalancerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 The destination endpoints are selected by random.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="recipientList" type="tns:recipientListDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Route messages to a number of dynamically specified recipients
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="redeliveryPolicy" type="tns:redeliveryPolicyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To configure re-delivery for error handling
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="redeliveryPolicyProfile" type="tns:camelRedeliveryPolicyFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Configuration of redelivery policy.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="ref" type="tns:refExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Uses an existing expression from the registry.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="refErrorHandler" type="tns:refErrorHandlerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 References to an existing or custom error handler.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="removeHeader" type="tns:removeHeaderDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Removes a named header from the message
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="removeHeaders" type="tns:removeHeadersDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Removes message headers whose name matches a specified pattern
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="removeProperties" type="tns:removePropertiesDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Removes message exchange properties whose name matches a specified pattern
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="removeProperty" type="tns:removePropertyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Removes a named property from the message exchange
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="resequence" type="tns:resequenceDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Resequences (re-order) messages based on an expression
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="resilience4jConfiguration" type="tns:resilience4JConfigurationDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Resilience4j Circuit Breaker EIP configuration
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="responseHeader" type="tns:responseHeaderDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To specify the rest operation response headers.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="responseMessage" type="tns:responseMessageDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To specify the rest operation response messages.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="rest" type="tns:restDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Defines a rest service using the rest-dsl
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="restBinding" type="tns:restBindingDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To configure rest binding
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="restConfiguration" type="tns:restConfigurationDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To configure rest
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="restContext" type="tns:camelRestContextFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Configuration of REST services using rest-dsl using XML
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="restContextRef" type="tns:restContextRefDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To refer to an XML file with rest services defined using the rest-dsl
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="restProperty" type="tns:restPropertyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A key value pair
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="rests" type="tns:restsDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A series of rest services defined using the rest-dsl
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="resumable" type="tns:resumableDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Resume EIP to support resuming processing from last known offset.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="rollback" type="tns:rollbackDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Forces a rollback by stopping routing the message
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="roundRobin" type="tns:roundRobinLoadBalancerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 The destination endpoints are selected in a round-robin fashion. This is a well
 known and classic policy, which spreads the load evenly.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="route" type="tns:routeDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A Camel route
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routeBuilder" type="tns:routeBuilderDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To refer to a Java org.apache.camel.builder.RouteBuilder instance to use.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routeConfiguration" type="tns:routeConfigurationDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Reusable configuration for Camel route(s).
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routeConfigurationContext" type="tns:camelRouteConfigurationContextFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Configuration of route configurations using XML
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routeConfigurationContextRef" type="tns:routeConfigurationContextRefDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To refer to an XML file with route configuration defined using the xml-dsl
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routeConfigurations" type="tns:routeConfigurationsDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A series of route configurations
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routeContext" type="tns:camelRouteContextFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Configuration of routes using XML
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routeContextRef" type="tns:routeContextRefDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To refer to an XML file with routes defined using the xml-dsl
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routeController" type="tns:camelRouteControllerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Route controller configuration.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routeTemplate" type="tns:routeTemplateDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Defines a route template (parameterized routes)
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routeTemplateContext" type="tns:camelRouteTemplateContextFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Configuration of route templates using XML
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routeTemplateContextRef" type="tns:routeTemplateContextRefDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To refer to an XML file with route templates defined using the xml-dsl
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routeTemplates" type="tns:routeTemplatesDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A series of route templates
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routes" type="tns:routesDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A series of Camel routes
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="routingSlip" type="tns:routingSlipDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Routes a message through a series of steps that are pre-determined (the slip)
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="rss" type="tns:rssDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Transform from ROME SyndFeed Java Objects to XML and vice-versa.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="saga" type="tns:sagaDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Enables Sagas on the route
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="sample" type="tns:samplingDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Extract a sample of the messages passing through a route
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="script" type="tns:scriptDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Executes a script from a language which does not change the message body.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="secureRandomParameters" type="tns:secureRandomParametersFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Cryptographically strong random number generator
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="security" type="tns:securityDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Rest security definition
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="securityDefinitions" type="tns:restSecuritiesDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To configure rest security definitions.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="serviceCall" type="tns:serviceCallDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: To call remote services
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="serviceCallConfiguration" type="tns:serviceCallConfigurationDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: Remote service call configuration
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="serviceChooserConfiguration" type="tns:serviceCallServiceChooserConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="serviceDiscoveryConfiguration" type="tns:serviceCallServiceDiscoveryConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="serviceExpression" type="tns:serviceCallExpressionConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="serviceFilterConfiguration" type="tns:serviceCallServiceFilterConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="setBody" type="tns:setBodyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Sets the contents of the message body
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="setExchangePattern" type="tns:setExchangePatternDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Sets the exchange pattern on the message exchange
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="setHeader" type="tns:setHeaderDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Sets the value of a message header
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="setProperty" type="tns:setPropertyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Sets a named property on the message exchange
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="simple" type="tns:simpleExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates a Camel simple expression.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="soap" type="tns:soapDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshal Java objects to SOAP messages and back.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="sort" type="tns:sortDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Sorts the contents of the message
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="spel" type="tns:spELExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates a Spring expression (SpEL).
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="split" type="tns:splitDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Splits a single message into many sub-messages.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="springTransactionErrorHandler" type="tns:springTransactionErrorHandlerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Spring based transactional error handler (requires camel-spring).
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="sslContextParameters" type="tns:sslContextParametersFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Secure socket protocol configuration
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="staticServiceDiscovery" type="tns:staticServiceCallServiceDiscoveryConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="step" type="tns:stepDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Routes the message to a sequence of processors which is grouped together as one
 logical name
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="sticky" type="tns:stickyLoadBalancerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Sticky load balancing using an expression to calculate a correlation key to
 perform the sticky load balancing.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="stop" type="tns:stopDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Stops the processing of the current message
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="stream-config" type="tns:streamResequencerConfig">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Configures stream-processing resequence eip.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="streamCaching" type="tns:camelStreamCachingStrategyDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Stream caching configuration.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="swiftMt" type="tns:swiftMtDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Encode and decode SWIFT MT messages.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="swiftMx" type="tns:swiftMxDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Encode and decode SWIFT MX messages.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="syslog" type="tns:syslogDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshall SyslogMessages to RFC3164 and RFC5424 messages and back.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="tarFile" type="tns:tarFileDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Archive files into tarballs or extract files from tarballs.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="template" type="tns:camelProducerTemplateFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Configures a ProducerTemplate
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="templateBean" type="tns:routeTemplateBeanDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A route template bean (local bean)
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="templateParameter" type="tns:routeTemplateParameterDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A route template parameter
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="templatedRoute" type="tns:templatedRouteDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Defines a templated route (a route built from a route template)
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="templatedRouteBean" type="tns:templatedRouteBeanDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A bean as input of a route template (local bean)
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="templatedRouteParameter" type="tns:templatedRouteParameterDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 An input parameter of a route template.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="templatedRoutes" type="tns:templatedRoutesDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A series of templated routes
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="threadPool" type="tns:camelThreadPoolFactoryBean">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Configuration of thread pools
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="threadPoolProfile" type="tns:threadPoolProfileDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To configure thread pools
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="threads" type="tns:threadsDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Specifies that all steps after this node are processed asynchronously
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="thrift" type="tns:thriftDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Serialize and deserialize messages using Apache Thrift binary data format.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="throttle" type="tns:throttleDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Controls the rate at which messages are passed to the next node in the route
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="throwException" type="tns:throwExceptionDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Throws an exception
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="tidyMarkup" type="tns:tidyMarkupDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Parse (potentially invalid) HTML into valid HTML or DOM.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="to" type="tns:toDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Sends the message to a static endpoint
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="toD" type="tns:toDynamicDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Sends the message to a dynamic endpoint
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="tokenize" type="tns:tokenizerExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Tokenize text payloads using delimiter patterns.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="topic" type="tns:topicLoadBalancerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Topic which sends to all destinations.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="transacted" type="tns:transactedDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Enables transaction on the route
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="transform" type="tns:transformDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Transforms the message body based on an expression
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="transformers" type="tns:transformersDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To configure transformers.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="typeFilter" type="tns:yamlTypeFilterDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="univocityCsv" type="tns:uniVocityCsvDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshal and unmarshal Java objects from and to CSV (Comma Separated Values)
 using UniVocity Parsers.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="univocityFixed" type="tns:uniVocityFixedDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshal and unmarshal Java objects from and to fixed length records using
 UniVocity Parsers.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="univocityHeader" type="tns:uniVocityHeader">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To configure headers for UniVocity data formats.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="univocityTsv" type="tns:uniVocityTsvDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshal and unmarshal Java objects from and to TSV (Tab-Separated Values)
 records using UniVocity Parsers.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="unmarshal" type="tns:unmarshalDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Converts the message data received from the wire into a format that Apache Camel
 processors can consume
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="validate" type="tns:validateDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Validates a message based on an expression
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="validators" type="tns:validatorsDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 To configure validators.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="value" type="tns:valueDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 A single value
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="weighted" type="tns:weightedLoadBalancerDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Uses a weighted load distribution ratio for each server with respect to others.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="when" type="tns:whenDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Triggers a route when the expression evaluates to true
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="wireTap" type="tns:wireTapDefinition">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Routes a copy of a message (or creates a new message) to a secondary destination
 while continue routing the original message.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="xmlSecurity" type="tns:xmlSecurityDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Encrypt and decrypt XML payloads using Apache Santuario.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="xpath" type="tns:xPathExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates an XPath expression against an XML payload.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="xquery" type="tns:xQueryExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Evaluates an XQuery expressions against an XML payload.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="xstream" type="tns:xStreamDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: Marshal and unmarshal POJOs to/from XML using XStream library.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="xtokenize" type="tns:xmlTokenizerExpression">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Tokenize XML payloads.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="yaml" type="tns:yamlDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Marshal and unmarshal Java objects to and from YAML.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="zipDeflater" type="tns:zipDeflaterDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Compress and decompress streams using java.util.zip.Deflater and
 java.util.zip.Inflater.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="zipFile" type="tns:zipFileDataFormat">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Compression and decompress streams using java.util.zip.ZipStream.
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
   <xs:element name="zookeeperServiceDiscovery" type="tns:zooKeeperServiceCallServiceDiscoveryConfiguration">
     <xs:annotation>
-      <xs:documentation xml:lang="en">
-        <![CDATA[
+      <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: null
-      ]]>
-      </xs:documentation>
+      ]]></xs:documentation>
     </xs:annotation>
   </xs:element>
     
@@ -2518,11 +2024,9 @@ Deprecated: null
                 
         <xs:attribute name="maximumCacheSize" type="xs:int">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a custom maximum cache size to use in the backing cache pools.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -2542,11 +2046,9 @@ Sets a custom maximum cache size to use in the backing cache pools.
                 
         <xs:attribute name="camelContextId" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Id of CamelContext to use if there are multiple CamelContexts in the same JVM.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -2562,11 +2064,9 @@ Id of CamelContext to use if there are multiple CamelContexts in the same JVM.
         
     <xs:attribute name="id" type="xs:ID">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The id of this node.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -2600,12 +2100,10 @@ The id of this node.
                 
         <xs:attribute name="uri" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the URI to use to resolve the endpoint. Notice that additional options can
 be configured using a series of property.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -2621,21 +2119,17 @@ be configured using a series of property.
         
     <xs:attribute name="key" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Property key.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="value" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Property value.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -2651,21 +2145,17 @@ Property value.
                 
         <xs:attribute name="defaultEndpoint" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the default endpoint URI used by default for sending message exchanges.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maximumCacheSize" type="xs:int">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a custom maximum cache size to use in the backing cache pools.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -2685,21 +2175,17 @@ Sets a custom maximum cache size to use in the backing cache pools.
                 
         <xs:attribute name="defaultEndpoint" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the default endpoint URI used by default for sending message exchanges.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maximumCacheSize" type="xs:int">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a custom maximum cache size to use in the backing cache pools.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -2719,260 +2205,212 @@ Sets a custom maximum cache size to use in the backing cache pools.
                 
         <xs:attribute name="maximumRedeliveries" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum number of times a message exchange will be redelivered. Setting
 a negative value will retry forever.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="redeliveryDelay" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum redelivery delay. Use -1 if you wish to have no maximum.
 Default value: 1000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="asyncDelayedRedelivery" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether asynchronous delayed redelivery is allowed. This is disabled by
 default. When enabled it allows Camel to schedule a future task for delayed
 redelivery which prevents current thread from blocking while waiting. Exchange
 which is transacted will however always use synchronous delayed redelivery
 because the transaction must execute in the same thread context. Default value:
 false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="backOffMultiplier" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the multiplier used to increase the delay between redeliveries if
 useExponentialBackOff is enabled. Default value: 2
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useExponentialBackOff" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Enables/disables exponential backoff using the backOffMultiplier to increase the
 time between retries. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="collisionAvoidanceFactor" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the factor used for collision avoidance if enabled via
 useCollisionAvoidance. Default value: 0.15
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useCollisionAvoidance" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Enables/disables collision avoidance which adds some randomization to the
 backoff timings to reduce contention probability. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maximumRedeliveryDelay" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum redelivery delay. Use -1 if you wish to have no maximum.
 Default value: 60000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="retriesExhaustedLogLevel" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the logging level to use for log messages when retries have been exhausted.
 Default value: ERROR
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="retryAttemptedLogLevel" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the logging level to use for log messages when retries are attempted.
 Default value: DEBUG
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="retryAttemptedLogInterval" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the interval for log messages when retries are attempted. Default value: 0
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logRetryAttempted" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether to log retry attempts. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logStackTrace" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether stack traces should be logged or not. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logRetryStackTrace" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether stack traces should be logged or not. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logHandled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether errors should be logged even if its handled. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logNewException" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether errors should be logged when a new exception occurred during
 handling a previous exception. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logContinued" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether errors should be logged even if its continued. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logExhausted" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether exhausted exceptions should be logged or not. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logExhaustedMessageHistory" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether to log exhausted errors including message history. Default value:
 false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logExhaustedMessageBody" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether exhausted message body/headers should be logged with message
 history included. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="disableRedelivery" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Disables redelivery by setting maximum redeliveries to 0. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="delayPattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets an optional delay pattern to use instead of fixed delay.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowRedeliveryWhileStopping" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Controls whether to allow redelivery while stopping/shutting down a route that
 uses error handling. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="exchangeFormatterRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the reference of the instance of org.apache.camel.spi.ExchangeFormatter to
 generate the log message from exchange.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -2992,93 +2430,75 @@ generate the log message from exchange.
                 
         <xs:attribute name="poolSize" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the core pool size (threads to keep minimum in pool).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maxPoolSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum pool size.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="keepAliveTime" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the keep alive time for inactive threads.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeUnit" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the time unit used for keep alive time. Default value: SECONDS
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maxQueueSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum number of tasks in the work queue. Use -1 for an unbounded
 queue.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowCoreThreadTimeOut" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether to allow core threads to timeout. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="rejectedPolicy" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the handler for tasks which cannot be executed by the thread pool. Default
 value: CallerRuns
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="threadName" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom thread name / pattern.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="scheduled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to use a scheduled thread pool. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -3098,150 +2518,122 @@ Whether to use a scheduled thread pool. Default value: false
                 
         <xs:attribute name="disabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Disable JMI (default false). Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="onlyRegisterProcessorWithCustomId" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Only register processor if a custom id was defined for it. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="mbeanServerDefaultDomain" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 MBean server default domain name (default org.apache.camel). Default value:
 org.apache.camel
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="mbeanObjectDomainName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 MBean object domain name (default org.apache.camel). Default value:
 org.apache.camel
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="usePlatformMBeanServer" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A flag that indicates whether the platform mbean server should be used. Default
 value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="registerAlways" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A flag that indicates whether to register mbeans always. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="registerNewRoutes" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A flag that indicates whether to register mbeans when starting new routes.
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="statisticsLevel" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Level of granularity for performance statistics enabled. Default value: Default
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="mbeansLevel" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the mbeans registration level. The default value is Default. Default value:
 Default
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="loadStatisticsEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A flag that indicates whether Load statistics is enabled. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="endpointRuntimeStatisticsEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A flag that indicates whether endpoint runtime statistics is enabled. Default
 value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="includeHostName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A flag that indicates whether to include hostname in JMX MBean names. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useHostIPAddress" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A flag that indicates whether to use hostname or IP Address in the service url.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="mask" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A flag that indicates whether to remove detected sensitive information (such as
 passwords) from MBean names and attributes. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -3267,70 +2659,58 @@ passwords) from MBean names and attributes. Default value: true
                 
         <xs:attribute name="location" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A list of locations to load properties. You can use comma to separate multiple
 locations. This option will override any default locations and only use the
 locations from this option.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="encoding" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Encoding to use when loading properties file from the file system or classpath.
 If no encoding has been set, then the properties files is loaded using
 ISO-8859-1 encoding (latin-1) as documented by
 java.util.Properties#load(java.io.InputStream).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreMissingLocation" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to silently ignore if a location cannot be located, such as a properties
 file not found. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="nestedPlaceholder" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to support nested property placeholders. A nested placeholder, means
 that a placeholder, has also a placeholder, that should be resolved
 (recursively). Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="propertiesParserRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Reference to a custom PropertiesParser to be used.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="defaultFallbackEnabled" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If false, the component does not attempt to find a default for the key by
 looking after the colon separator. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -3350,11 +2730,9 @@ looking after the colon separator. Default value: true
                 
         <xs:attribute name="ref" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Reference to the custom properties function to lookup in the registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -3374,31 +2752,25 @@ Reference to the custom properties function to lookup in the registry.
                 
         <xs:attribute name="resolver" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The resolver to use to locate the location. Default value: classpath
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="path" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Property locations to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="optional" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If the location is optional. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -3418,8 +2790,7 @@ If the location is optional. Default value: false
                 
         <xs:attribute name="supervising" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To enable using supervising route controller which allows Camel to startup and
 then the controller takes care of starting the routes in a safe manner. This can
 be used when you want to startup Camel despite a route may otherwise fail fast
@@ -3427,141 +2798,118 @@ during startup and cause Camel to fail to startup as well. By delegating the
 route startup to the supervising route controller then its manages the startup
 using a background thread. The controller allows to be configured with various
 settings to attempt to restart failing routes. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="includeRoutes" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Pattern for filtering routes to be included as supervised. The pattern is
 matching on route id, and endpoint uri for the route. Multiple patterns can be
 separated by comma. For example to include all kafka routes, you can say kafka:.
 And to include routes with specific route ids myRoute,myOtherRoute. The pattern
 supports wildcards and uses the matcher from
 org.apache.camel.support.PatternHelper#matchPattern.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="excludeRoutes" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Pattern for filtering routes to be excluded as supervised. The pattern is
 matching on route id, and endpoint uri for the route. Multiple patterns can be
 separated by comma. For example to exclude all JMS routes, you can say jms:. And
 to exclude routes with specific route ids mySpecialRoute,myOtherSpecialRoute.
 The pattern supports wildcards and uses the matcher from
 org.apache.camel.support.PatternHelper#matchPattern.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="threadPoolSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The number of threads used by the scheduled thread pool that are used for
 restarting routes. The pool uses 1 thread by default, but you can increase this
 to allow the controller to concurrently attempt to restart multiple routes in
 case more than one route has problems starting. Default value: 1
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="initialDelay" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Initial delay in milli seconds before the route controller starts, after
 CamelContext has been started.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="backOffDelay" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Backoff delay in millis when restarting a route that failed to startup. Default
 value: 2000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="backOffMaxDelay" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Backoff maximum delay in millis when restarting a route that failed to startup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="backOffMaxElapsedTime" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Backoff maximum elapsed time in millis, after which the backoff should be
 considered exhausted and no more attempts should be made.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="backOffMaxAttempts" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Backoff maximum number of attempts to restart a route that failed to startup.
 When this threshold has been exceeded then the controller will give up
 attempting to restart the route, and the route will remain as stopped.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="backOffMultiplier" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Backoff multiplier to use for exponential backoff. This is used to extend the
 delay between restart attempts. Default value: 1.0
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="unhealthyOnExhausted" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to mark the route as unhealthy (down) when all restarting attempts
 (backoff) have failed and the route is not successfully started and the route
 manager is giving up. Setting this to true allows health checks to know about
 this and can report the Camel application as DOWN. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="loggingLevel" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the logging level used for logging route activity (such as starting and
 stopping routes). The default logging level is DEBUG. Default value: DEBUG
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -3581,8 +2929,7 @@ stopping routes). The default logging level is DEBUG. Default value: DEBUG
                 
         <xs:attribute name="enabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether stream caching is enabled or not. While stream types (like
 StreamSource, InputStream and Reader) are commonly used in messaging for
 performance reasons, they also have an important drawback: they can only be read
@@ -3592,138 +2939,115 @@ streamCachingSpoolEnabled=true, then, for large stream messages (over 128 KB by
 default) will be cached in a temporary file instead, and Camel will handle
 deleting the temporary file once the cached stream is no longer necessary.
 Default is true. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="spoolEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To enable stream caching spooling to disk. This means, for large stream messages
 (over 128 KB by default) will be cached in a temporary file instead, and Camel
 will handle deleting the temporary file once the cached stream is no longer
 necessary. Default is false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="spoolDirectory" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the spool (temporary) directory to use for overflow and spooling to disk.
 If no spool directory has been explicit configured, then a temporary directory
 is created in the java.io.tmpdir directory.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="spoolCipher" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a cipher name to use when spooling to disk to write with encryption. By
 default the data is not encrypted.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="spoolThreshold" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Threshold in bytes when overflow to disk is activated. The default threshold is
 org.apache.camel.StreamCache#DEFAULT_SPOOL_THRESHOLD bytes (eg 128kb). Use -1 to
 disable overflow to disk. Default value: 131072
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="spoolUsedHeapMemoryThreshold" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a percentage (1-99) of used heap memory threshold to activate spooling to
 disk.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="spoolUsedHeapMemoryLimit" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets what the upper bounds should be when spoolUsedHeapMemoryThreshold is in
 use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="spoolRules" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Reference to one or more custom
 org.apache.camel.spi.StreamCachingStrategy.SpoolRule to use. Multiple rules can
 be separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="bufferSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the buffer size to use when allocating in-memory buffers used for in-memory
 stream caches. The default size is
 org.apache.camel.util.IOHelper#DEFAULT_BUFFER_SIZE. Default value: 4096
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="removeSpoolDirectoryWhenStopping" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to remove the temporary directory when stopping. This option is default
 true. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="statisticsEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether statistics is enabled. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="anySpoolRules" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether if just any of the
 org.apache.camel.spi.StreamCachingStrategy.SpoolRule rules returns true then
 shouldSpoolCache(long) returns true. If this option is false, then all the
 org.apache.camel.spi.StreamCachingStrategy.SpoolRule must return true. The
 default value is false which means that all the rules must return true. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -3783,44 +3107,36 @@ value: false
                 
         <xs:attribute name="type" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The optional type of the key store to load. See Appendix A in the Java
 Cryptography Architecture Standard Algorithm Name Documentation for more
 information on standard names.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="password" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The optional password for reading/opening/verifying the key store.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="provider" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The optional provider identifier for instantiating the key store.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="resource" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The optional file path, class path resource, or URL of the resource used to load
 the key store.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -3840,26 +3156,22 @@ the key store.
                 
         <xs:attribute name="algorithm" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The Random Number Generator algorithm identifier for the SecureRandom factory
 method used to create the SecureRandom represented by this object's
 configuration. See Appendix A in the Java Cryptography Architecture API
 Specification and Reference guide for information about standard RNG algorithm
 names.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="provider" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The optional provider identifier for the SecureRandom factory method used to
 create the SecureRandom represented by this object's configuration.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -3955,12 +3267,10 @@ create the SecureRandom represented by this object's configuration.
                 
         <xs:attribute name="disabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to disable this EIP from the route during build time. Once an EIP has
 been disabled then it cannot be enabled later at runtime. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
@@ -3984,11 +3294,9 @@ been disabled then it cannot be enabled later at runtime. Default value: false
         
     <xs:attribute name="id" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the id of this node.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -4002,11 +3310,9 @@ Sets the id of this node.
                 
         <xs:attribute name="lang" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Deprecated: Language, such as en for english.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -4026,33 +3332,28 @@ Deprecated: Language, such as en for english.
                     
           <xs:element name="correlationExpression" type="tns:expressionSubElementDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 The expression used to calculate the correlation key to use for aggregation. The
 Exchange which has the same correlation key is aggregated together. If the
 correlation key could not be evaluated an Exception is thrown. You can disable
 this by using the ignoreBadCorrelationKeys option.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element minOccurs="0" name="completionPredicate" type="tns:expressionSubElementDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 A Predicate to indicate when an aggregated exchange is complete. If this is not
 specified and the AggregationStrategy object implements Predicate, the
 aggregationStrategy object will be used as the completionPredicate.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element minOccurs="0" name="completionTimeoutExpression" type="tns:expressionSubElementDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Time in millis that an aggregated exchange should be inactive before its
 complete (timeout). This option can be set as either a fixed value or using an
 Expression which allows you to evaluate a timeout dynamically - will use Long as
@@ -4064,21 +3365,18 @@ option to configure how frequently to run the checker. The timeout is an
 approximation and there is no guarantee that the a timeout is triggered exactly
 after the timeout value. It is not recommended to use very low timeout values or
 checker intervals.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element minOccurs="0" name="completionSizeExpression" type="tns:expressionSubElementDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Number of messages aggregated before the aggregation is complete. This option
 can be set as either a fixed value or using an Expression which allows you to
 evaluate a size dynamically - will use Integer as result. If both are set Camel
 will fallback to use the fixed value if the Expression result was null or 0.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
@@ -4226,147 +3524,124 @@ will fallback to use the fixed value if the Expression result was null or 0.
                 
         <xs:attribute name="parallelProcessing" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When aggregated are completed they are being send out of the aggregator. This
 option indicates whether or not Camel should use a thread pool with multiple
 threads for concurrency. If no custom thread pool has been specified then Camel
 creates a default pool with 10 concurrent threads. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="optimisticLocking" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Turns on using optimistic locking, which requires the aggregationRepository
 being used, is supporting this by implementing
 org.apache.camel.spi.OptimisticLockingAggregationRepository . Default value:
 false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="executorService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If using parallelProcessing you can specify a custom thread pool to be used. In
 fact also if you are not using parallelProcessing this custom thread pool is
 used to send out aggregated exchanges as well.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeoutCheckerExecutorService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If using either of the completionTimeout, completionTimeoutExpression, or
 completionInterval options a background thread is created to check for the
 completion for every aggregator. Set this option to provide a custom thread pool
 to be used rather than creating a new thread for every aggregator.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregateController" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a org.apache.camel.processor.aggregate.AggregateController to allow
 external sources to control this aggregator.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationRepository" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The AggregationRepository to use. Sets the custom aggregate repository to use.
 Will by default use
 org.apache.camel.processor.aggregate.MemoryAggregationRepository.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategy" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The AggregationStrategy to use. For example to lookup a bean with the name foo,
 the value is simply just #bean:foo. Configuring an AggregationStrategy is
 required, and is used to merge the incoming Exchange with the existing already
 merged exchanges. At first call the oldExchange parameter is null. On subsequent
 invocations the oldExchange contains the merged exchanges and newExchange is of
 course the new incoming Exchange.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 This option can be used to explicit declare the method name to use, when using
 beans as the AggregationStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodAllowNull" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If this option is false then the aggregate method is not used for the very first
 aggregation. If this option is true then null values is used as the oldExchange
 (at the very first aggregation), when using beans as the AggregationStrategy.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="completionSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Number of messages aggregated before the aggregation is complete. This option
 can be set as either a fixed value or using an Expression which allows you to
 evaluate a size dynamically - will use Integer as result. If both are set Camel
 will fallback to use the fixed value if the Expression result was null or 0.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="completionInterval" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A repeating period in millis by which the aggregator will complete all current
 aggregated exchanges. Camel has a background task which is triggered every
 period. You cannot use this option together with completionTimeout, only one of
 them can be used.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="completionTimeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Time in millis that an aggregated exchange should be inactive before its
 complete (timeout). This option can be set as either a fixed value or using an
 Expression which allows you to evaluate a timeout dynamically - will use Long as
@@ -4378,128 +3653,108 @@ option to configure how frequently to run the checker. The timeout is an
 approximation and there is no guarantee that the a timeout is triggered exactly
 after the timeout value. It is not recommended to use very low timeout values or
 checker intervals.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="completionTimeoutCheckerInterval" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Interval in millis that is used by the background task that checks for timeouts
 ( org.apache.camel.TimeoutMap ). By default the timeout checker runs every
 second. The timeout is an approximation and there is no guarantee that the a
 timeout is triggered exactly after the timeout value. It is not recommended to
 use very low timeout values or checker intervals. Default value: 1000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="completionFromBatchConsumer" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Enables the batch completion mode where we aggregate from a
 org.apache.camel.BatchConsumer and aggregate the total number of exchanges the
 org.apache.camel.BatchConsumer has reported as total by checking the exchange
 property org.apache.camel.Exchange#BATCH_COMPLETE when its complete. This option
 cannot be used together with discardOnAggregationFailure. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="completionOnNewCorrelationGroup" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Enables completion on all previous groups when a new incoming correlation group.
 This can for example be used to complete groups with same correlation keys when
 they are in consecutive order. Notice when this is enabled then only 1
 correlation group can be in progress as when a new correlation group starts,
 then the previous groups is forced completed. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="eagerCheckCompletion" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Use eager completion checking which means that the completionPredicate will use
 the incoming Exchange. As opposed to without eager completion checking the
 completionPredicate will use the aggregated Exchange. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreInvalidCorrelationKeys" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If a correlation key cannot be successfully evaluated it will be ignored by
 logging a DEBUG and then just ignore the incoming Exchange. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="closeCorrelationKeyOnCompletion" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Closes a correlation key when its complete. Any late received exchanges which
 has a correlation key that has been closed, it will be defined and a
 ClosedCorrelationKeyException is thrown.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="discardOnCompletionTimeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Discards the aggregated message on completion timeout. This means on timeout the
 aggregated message is dropped and not sent out of the aggregator. Default value:
 false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="discardOnAggregationFailure" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Discards the aggregated message when aggregation failed (an exception was thrown
 from AggregationStrategy . This means the partly aggregated message is dropped
 and not sent out of the aggregator. This option cannot be used together with
 completionFromBatchConsumer. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="forceCompletionOnStop" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Indicates to complete all current aggregated exchanges when the context is
 stopped. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="completeAllOnStop" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Indicates to wait to complete all current and partial (pending) aggregated
 exchanges when the context is stopped. This also means that we will wait for all
 pending exchanges which are stored in the aggregation repository to complete so
@@ -4508,8 +3763,7 @@ using the memory based aggregation repository that is memory based only, and do
 not store data on disk. When this option is enabled, then the aggregator is
 waiting to complete all those exchanges before its stopped, when stopping
 CamelContext or the route using it. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -4583,22 +3837,18 @@ CamelContext or the route using it. Default value: false
                 
         <xs:attribute name="id" type="xs:ID">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the id of this node.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="trim" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to trim the value to remove leading and trailing whitespaces and line
 breaks. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -4614,52 +3864,42 @@ breaks. Default value: true
         
     <xs:attribute name="maximumRetries" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum number of retries.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="retryDelay" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the delay in millis between retries. Default value: 50
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="maximumRetryDelay" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the upper value of retry in millis between retries, when using exponential
 or random backoff. Default value: 1000
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="exponentialBackOff" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Enable exponential backoff. Default value: true
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="randomBackOff" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Enables random backoff. Default value: false
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -4675,39 +3915,32 @@ Enables random backoff. Default value: false
                 
         <xs:attribute name="ref" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to an exiting bean to use, which is looked up from the
 registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="method" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the method name on the bean to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="beanType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the class name (fully qualified) of the bean to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="scope" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Scope of bean. When using singleton scope (default) the bean is created or
 looked up only once and reused for the lifetime of the endpoint. The bean should
 be thread-safe in case concurrent threads is calling the bean at the same time.
@@ -4721,8 +3954,7 @@ this is delegated to the bean registry such as Spring or CDI (if in use), which
 depends on their configuration can act as either singleton or prototype scope.
 So when using prototype scope then this depends on the bean registry
 implementation. Default value: Singleton
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -4754,14 +3986,12 @@ implementation. Default value: Singleton
             
       <xs:element minOccurs="0" name="script" type="xs:string">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 The script to execute that creates the bean when using scripting languages. If
 the script use the prefix resource: such as
 resource:classpath:com/foo/myscript.groovy, resource:file:/var/myscript.groovy,
 then its loaded from the external resource.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
           
@@ -4769,37 +3999,31 @@ then its loaded from the external resource.
         
     <xs:attribute name="name" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Bean name.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="type" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 What type to use for creating the bean. Can be one of:
 #class,#type,bean,groovy,joor,language,mvel,ognl. #class or #type then the bean
 is created via the fully qualified classname, such as #class:com.foo.MyBean The
 others are scripting languages that gives more power to create the bean with an
 inlined code in the script section, such as using groovy.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="beanType" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 To set the type (fully qualified class name) of the returned bean created by the
 script. Knowing the type of the bean can be needed when dependency injection by
 type is in use, or when looking in registry via class type.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -4815,23 +4039,19 @@ type is in use, or when looking in registry via class type.
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="exception" type="xs:string">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 The exception(s) to catch.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element minOccurs="0" name="onWhen" type="tns:whenDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Sets an additional predicate that should be true before the onCatch is
 triggered. To be used for fine grained controlling whether a thrown exception
 should be intercepted by this exception type or not.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
@@ -5203,13 +4423,11 @@ should be intercepted by this exception type or not.
                 
         <xs:attribute name="precondition" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Indicates whether this Choice EIP is in precondition mode or not. If so its
 branches (when/otherwise) are evaluated during startup to keep at runtime only
 the branch that matched. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -5527,12 +4745,10 @@ the branch that matched. Default value: false
                 
         <xs:attribute name="configuration" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a circuit breaker configuration (such as resillience4j, or
 microprofile-fault-tolerance) to use for configuring the circuit breaker EIP.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -5582,67 +4798,56 @@ microprofile-fault-tolerance) to use for configuring the circuit breaker EIP.
                 
         <xs:attribute name="circuitBreaker" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to an existing io.github.resilience4j.circuitbreaker.CircuitBreaker
 instance to lookup and use from the registry. When using this, then any other
 circuit breaker options are not in use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="config" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to an existing io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
 instance to lookup and use from the registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="failureRateThreshold" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures the failure rate threshold in percentage. If the failure rate is
 equal or greater than the threshold the CircuitBreaker transitions to open and
 starts short-circuiting calls. The threshold must be greater than 0 and not
 greater than 100. Default value is 50 percentage. Default value: 50
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="permittedNumberOfCallsInHalfOpenState" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures the number of permitted calls when the CircuitBreaker is half open.
 The size must be greater than 0. Default size is 10. Default value: 10
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="throwExceptionWhenHalfOpenOrOpenState" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to throw io.github.resilience4j.circuitbreaker.CallNotPermittedException
 when the call is rejected due circuit breaker is half open or open. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="slidingWindowSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures the size of the sliding window which is used to record the outcome of
 calls when the CircuitBreaker is closed. slidingWindowSize configures the size
 of the sliding window. Sliding window can either be count-based or time-based.
@@ -5654,81 +4859,69 @@ greater than 0. If the slidingWindowType is COUNT_BASED, the
 minimumNumberOfCalls cannot be greater than slidingWindowSize . If the
 slidingWindowType is TIME_BASED, you can pick whatever you want. Default
 slidingWindowSize is 100. Default value: 100
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="slidingWindowType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures the type of the sliding window which is used to record the outcome of
 calls when the CircuitBreaker is closed. Sliding window can either be
 count-based or time-based. If slidingWindowType is COUNT_BASED, the last
 slidingWindowSize calls are recorded and aggregated. If slidingWindowType is
 TIME_BASED, the calls of the last slidingWindowSize seconds are recorded and
 aggregated. Default slidingWindowType is COUNT_BASED. Default value: COUNT_BASED
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="minimumNumberOfCalls" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures the minimum number of calls which are required (per sliding window
 period) before the CircuitBreaker can calculate the error rate. For example, if
 minimumNumberOfCalls is 10, then at least 10 calls must be recorded, before the
 failure rate can be calculated. If only 9 calls have been recorded the
 CircuitBreaker will not transition to open even if all 9 calls have failed.
 Default minimumNumberOfCalls is 100. Default value: 100
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="writableStackTraceEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Enables writable stack traces. When set to false, Exception.getStackTrace
 returns a zero length array. This may be used to reduce log spam when the
 circuit breaker is open as the cause of the exceptions is already known (the
 circuit breaker is short-circuiting calls). Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="waitDurationInOpenState" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures the wait duration (in seconds) which specifies how long the
 CircuitBreaker should stay open, before it switches to half open. Default value
 is 60 seconds. Default value: 60
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="automaticTransitionFromOpenToHalfOpenEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Enables automatic transition from OPEN to HALF_OPEN state once the
 waitDurationInOpenState has passed. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="slowCallRateThreshold" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures a threshold in percentage. The CircuitBreaker considers a call as
 slow when the call duration is greater than slowCallDurationThreshold Duration.
 When the percentage of slow calls is equal or greater the threshold, the
@@ -5736,20 +4929,17 @@ CircuitBreaker transitions to open and starts short-circuiting calls. The
 threshold must be greater than 0 and not greater than 100. Default value is 100
 percentage which means that all recorded calls must be slower than
 slowCallDurationThreshold. Default value: 100
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="slowCallDurationThreshold" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures the duration threshold (seconds) above which calls are considered as
 slow and increase the slow calls percentage. Default value is 60 seconds.
 Default value: 60
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -5783,146 +4973,120 @@ Default value: 60
                 
         <xs:attribute name="circuitBreaker" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to an existing
 io.smallrye.faulttolerance.core.circuit.breaker.CircuitBreaker instance to
 lookup and use from the registry. When using this, then any other circuit
 breaker options are not in use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="delay" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Control how long the circuit breaker stays open. The default is 5 seconds.
 Default value: 5000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="successThreshold" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Controls the number of trial calls which are allowed when the circuit breaker is
 half-open. Default value: 1
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="requestVolumeThreshold" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Controls the size of the rolling window used when the circuit breaker is closed.
 Default value: 20
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="failureRatio" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures the failure rate threshold in percentage. If the failure rate is
 equal or greater than the threshold the CircuitBreaker transitions to open and
 starts short-circuiting calls. The threshold must be greater than 0 and not
 greater than 100. Default value is 50 percentage. Default value: 50
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeoutEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether timeout is enabled or not on the circuit breaker. Default is false.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeoutDuration" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures the thread execution timeout. Default value is 1 second. Default
 value: 1000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeoutPoolSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures the pool size of the thread pool when timeout is enabled. Default
 value is 10. Default value: 10
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeoutScheduledExecutorService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 References to a custom thread pool to use when timeout is enabled.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="bulkheadEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether bulkhead is enabled or not on the circuit breaker. Default is false.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="bulkheadMaxConcurrentCalls" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures the max amount of concurrent calls the bulkhead will support. Default
 value: 10
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="bulkheadWaitingTaskQueue" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Configures the task queue size for holding waiting tasks to be processed by the
 bulkhead. Default value: 10
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="bulkheadExecutorService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 References to a custom thread pool to use when bulkhead is enabled.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -5942,34 +5106,29 @@ References to a custom thread pool to use when bulkhead is enabled.
                 
         <xs:attribute name="operation" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The claim check operation to use. The following operations are supported: Get -
 Gets (does not remove) the claim check by the given key. GetAndRemove - Gets and
 removes the claim check by the given key. Set - Sets a new (will override if key
 already exists) claim check with the given key. Push - Sets a new claim check on
 the stack (does not use key). Pop - Gets the latest claim check from the stack
 (does not use key).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="key" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a specific key for claim check id (for dynamic keys use simple language
 syntax as the key).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="filter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Specify a filter to control what data gets merged data back from the claim check
 repository. The following syntax is supported: body - to aggregate the message
 body attachments - to aggregate all the message attachments headers - to
@@ -5985,31 +5144,26 @@ the default mode) - - to exclude (exclude takes precedence over include) -- - to
 remove (remove takes precedence) For example to exclude a header name foo, and
 remove all headers starting with bar, -header:foo,--headers:bar Note you cannot
 have both include and exclude header:pattern at the same time.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategy" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom AggregationStrategy instead of the default implementation.
 Notice you cannot use both custom aggregation strategy and configure data at the
 same time.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 This option can be used to explicit declare the method name to use, when using
 POJOs as the AggregationStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -6031,21 +5185,17 @@ POJOs as the AggregationStrategy.
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="excludes" type="xs:string">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Exclude finding route builder from these java package names.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="includes" type="xs:string">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Include finding route builder from these java package names.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
           
@@ -6053,12 +5203,10 @@ Include finding route builder from these java package names.
         
     <xs:attribute name="includeNonSingletons" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Whether to include non-singleton beans (prototypes) By default only singleton
 beans is included in the context scan. Default value: false
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -6074,34 +5222,28 @@ beans is included in the context scan. Default value: false
                 
         <xs:attribute name="type" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The java type to convert to.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="mandatory" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When mandatory then the conversion must return a value (cannot be null), if this
 is not possible then NoTypeConversionAvailableException is thrown. Setting this
 to false could mean conversion is not possible and the value is null. Default
 value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="charset" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a specific charset when converting.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -6185,33 +5327,27 @@ To use a specific charset when converting.
                 
         <xs:attribute name="asyncDelayed" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Enables asynchronous delay which means the thread will not block while delaying.
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="callerRunsWhenRejected" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not the caller should run the task when it was rejected by the thread
 pool. Is by default true. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="executorService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom Thread Pool if asyncDelay has been enabled.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -6281,29 +5417,24 @@ To use a custom Thread Pool if asyncDelay has been enabled.
                 
         <xs:attribute name="uriDelimiter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the uri delimiter to use. Default value: ,
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreInvalidEndpoints" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Ignore the invalidate endpoint exception when try to create a producer with that
 endpoint. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="cacheSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum size used by the org.apache.camel.spi.ProducerCache which is
 used to cache and reuse producers when using this dynamic router, when uris are
 reused. Beware that when using dynamic endpoints then it affects how well the
@@ -6318,8 +5449,7 @@ size can be set accordingly or rely on the default size (1000). If there is a
 mix of unique and used before dynamic endpoints, then setting a reasonable cache
 size can help reduce memory usage to avoid storing too many non frequent used
 producers.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -6389,71 +5519,60 @@ producers.
                 
         <xs:attribute name="aggregationStrategy" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the AggregationStrategy to be used to merge the reply from the external
 service, into a single outgoing message. By default Camel will use the reply
 from the external service as outgoing message.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 This option can be used to explicit declare the method name to use, when using
 POJOs as the AggregationStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodAllowNull" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If this option is false then the aggregate method is not used if there was no
 data to enrich. If this option is true then null values is used as the
 oldExchange (when no data to enrich), when using POJOs as the
 AggregationStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregateOnException" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If this option is false then the aggregate method is not used if there was an
 exception thrown while trying to retrieve the data to enrich from the resource.
 Setting this option to true allows end users to control what to do if there was
 an exception in the aggregate method. For example to suppress the exception or
 set a custom message body etc. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="shareUnitOfWork" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Shares the org.apache.camel.spi.UnitOfWork with the parent and the resource
 exchange. Enrich will by default not share unit of work between the parent
 exchange and the resource exchange. This means the resource exchange has its own
 individual unit of work. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="cacheSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum size used by the org.apache.camel.spi.ProducerCache which is
 used to cache and reuse producer when uris are reused. Beware that when using
 dynamic endpoints then it affects how well the cache can be utilized. If each
@@ -6467,30 +5586,25 @@ and endpoints and therefore the cache size can be set accordingly or rely on the
 default size (1000). If there is a mix of unique and used before dynamic
 endpoints, then setting a reasonable cache size can help reduce memory usage to
 avoid storing too many non frequent used producers.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreInvalidEndpoint" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Ignore the invalidate endpoint exception when try to create a producer with that
 endpoint. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowOptimisedComponents" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to allow components to optimise enricher if they are
 org.apache.camel.spi.SendDynamicAware . Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -6540,18 +5654,15 @@ org.apache.camel.spi.SendDynamicAware . Default value: true
                 
         <xs:attribute name="deadLetterUri" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The dead letter endpoint uri for the Dead Letter error handler.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="deadLetterHandleNewException" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the dead letter channel should handle (and ignore) any new exception
 that may been thrown during sending the message to the dead letter endpoint. The
 default value is true which means any such kind of exception is handled and
@@ -6563,8 +5674,7 @@ of a new exception being thrown, then by setting this to false the new
 exceptions is propagated back and set on the org.apache.camel.Exchange , which
 allows the transaction to detect the exception, and rollback. Default value:
 true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -6588,39 +5698,32 @@ true
                 
         <xs:attribute name="loggerRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 References to a logger to use as logger for the error handler.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="level" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Logging level to use when using the logging error handler type. Default value:
 ERROR
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of the logger to use for the logging error handler.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useOriginalMessage" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Will use the original input org.apache.camel.Message (original body and headers)
 when an org.apache.camel.Exchange is moved to the dead letter queue. Notice:
 this only applies when all redeliveries attempt have failed and the
@@ -6649,15 +5752,13 @@ the splitted message); however these EIPs have an option named shareUnitOfWork
 which allows to combine with the parent unit of work in regard to error handling
 and therefore use the parent original message. By default this feature is off.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useOriginalBody" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Will use the original input org.apache.camel.Message body (original body only)
 when an org.apache.camel.Exchange is moved to the dead letter queue. Notice:
 this only applies when all redeliveries attempt have failed and the
@@ -6686,76 +5787,63 @@ the splitted message); however these EIPs have an option named shareUnitOfWork
 which allows to combine with the parent unit of work in regard to error handling
 and therefore use the parent original message. By default this feature is off.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="onRedeliveryRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a processor that should be processed before a redelivery
 attempt. Can be used to change the org.apache.camel.Exchange before its being
 redelivered.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="onExceptionOccurredRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a processor that should be processed just after an exception
 occurred. Can be used to perform custom logging about the occurred exception at
 the exact time it happened. Important: Any exception thrown from this processor
 will be ignored.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="onPrepareFailureRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a processor to prepare the org.apache.camel.Exchange before
 handled by the failure processor / dead letter channel. This allows for example
 to enrich the message before sending to a dead letter queue.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="retryWhileRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a retry while predicate. Will continue retrying until the predicate
 evaluates to false.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="redeliveryPolicyRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a RedeliveryPolicy to be used for redelivery settings.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="executorServiceRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a thread pool to be used by the error handler.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -6789,260 +5877,212 @@ Sets a reference to a thread pool to be used by the error handler.
                 
         <xs:attribute name="maximumRedeliveries" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum redeliveries x = redeliver at most x times 0 = no redeliveries
 -1 = redeliver forever.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="redeliveryDelay" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the initial redelivery delay. Default value: 1000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="asyncDelayedRedelivery" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Allow asynchronous delayed redelivery. The route, in particular the consumer's
 component, must support the Asynchronous Routing Engine (e.g. seda). Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="backOffMultiplier" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the back off multiplier. Default value: 2.0
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useExponentialBackOff" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Turn on exponential backk off. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="collisionAvoidanceFactor" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the collision avoidance factor. Default value: 0.15
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useCollisionAvoidance" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Turn on collision avoidance. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maximumRedeliveryDelay" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum delay between redelivery. Default value: 60000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="retriesExhaustedLogLevel" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the logging level to use when retries have been exhausted. Default value:
 ERROR
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="retryAttemptedLogLevel" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the logging level to use for logging retry attempts. Default value: DEBUG
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="retryAttemptedLogInterval" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the interval to use for logging retry attempts. Default value: 1
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logRetryAttempted" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether retry attempts should be logged or not. Can be used to include or
 reduce verbose. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logStackTrace" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether stack traces should be logged. Can be used to include or reduce
 verbose. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logRetryStackTrace" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether stack traces should be logged when an retry attempt failed. Can be
 used to include or reduce verbose. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logHandled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether handled exceptions should be logged or not. Can be used to include
 or reduce verbose. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logNewException" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether new exceptions should be logged or not. Can be used to include or
 reduce verbose. A new exception is an exception that was thrown while handling a
 previous exception. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logContinued" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether continued exceptions should be logged or not. Can be used to
 include or reduce verbose. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logExhausted" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether exhausted exceptions should be logged or not. Can be used to
 include or reduce verbose. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logExhaustedMessageHistory" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether exhausted exceptions should be logged including message history or
 not (supports property placeholders). Can be used to include or reduce verbose.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logExhaustedMessageBody" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether exhausted message body should be logged including message history
 or not (supports property placeholders). Can be used to include or reduce
 verbose. Requires logExhaustedMessageHistory to be enabled. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="disableRedelivery" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Disables redelivery (same as setting maximum redeliveries to 0). Default value:
 false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="delayPattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the delay pattern with delay intervals.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowRedeliveryWhileStopping" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Controls whether to allow redelivery while stopping/shutting down a route that
 uses error handling. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="exchangeFormatterRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the reference of the instance of org.apache.camel.spi.ExchangeFormatter to
 generate the log message from exchange.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -7090,24 +6130,20 @@ generate the log message from exchange.
                 
         <xs:attribute name="transactedPolicyRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The transacted policy to use that is configured for either Spring or JTA based
 transactions. If no policy has been configured then Camel will attempt to
 auto-discover.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="rollbackLoggingLevel" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the logging level to use for logging transactional rollback. This option is
 default WARN. Default value: WARN
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -7333,12 +6369,10 @@ default WARN. Default value: WARN
                 
         <xs:attribute name="statusPropertyName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of exchange property to use for storing the status of the filtering.
 Setting this allows to know if the filter predicate evaluated as true or false.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -7512,11 +6546,9 @@ Setting this allows to know if the filter predicate evaluated as true or false.
                 
         <xs:attribute name="uri" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the URI of the endpoint to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -7532,21 +6564,17 @@ Sets the URI of the endpoint to use.
         
     <xs:attribute name="key" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Global option key.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="value" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Global option value.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -7764,29 +6792,24 @@ Global option value.
                 
         <xs:attribute name="idempotentRepository" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the reference name of the message id repository.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="eager" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether to eagerly add the key to the idempotent repository or wait until
 the exchange is complete. Eager is default enabled. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="completionEager" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether to complete the idempotent consumer eager or when the exchange is
 done. If this option is true to complete eager, then the idempotent consumer
 will trigger its completion when the exchange reached the end of the block of
@@ -7797,32 +6820,27 @@ will complete when the exchange is done being routed. So if the exchange is
 continued routed after the block ends, then whatever happens there also affect
 the state. For example if the exchange failed due to an exception, then the
 state of the idempotent consumer will be a rollback. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="skipDuplicate" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether to skip duplicates or not. The default behavior is to skip
 duplicates. A duplicate message would have the Exchange property
 org.apache.camel.Exchange#DUPLICATE_MESSAGE set to a Boolean#TRUE value. A none
 duplicate message will not have this property set. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="removeOnFailure" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether to remove or keep the key on failure. The default behavior is to
 remove the key on failure. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -7856,11 +6874,9 @@ remove the key on failure. Default value: true
                 
         <xs:attribute name="uri" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the uri of the endpoint to send to.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -7894,21 +6910,17 @@ Sets the uri of the endpoint to send to.
                 
         <xs:attribute name="urn" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The input type URN.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="validate" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether if validation is required for this input type. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -8082,12 +7094,10 @@ Whether if validation is required for this input type. Default value: false
                 
         <xs:attribute name="uri" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Intercept incoming messages from the uri or uri pattern. If this option is not
 configured, then all incoming messages is intercepted.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -8247,33 +7257,27 @@ configured, then all incoming messages is intercepted.
                 
         <xs:attribute name="uri" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Intercept sending to the uri or uri pattern.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="skipSendToOriginalEndpoint" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set to true then the message is not sent to the original endpoint. By default
 (false) the message is both intercepted and then sent to the original endpoint.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="afterUri" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 After sending to the endpoint then send the message to this uri which allows to
 process its result.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -8433,12 +7437,10 @@ process its result.
                 
         <xs:attribute name="name" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of the Kamelet (templateId/routeId) to call. Options for the kamelet can be
 specified using uri syntax, eg mynamecount=4&type=gold.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -8630,11 +7632,9 @@ specified using uri syntax, eg mynamecount=4&type=gold.
                 
         <xs:attribute name="ref" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to the custom load balancer to lookup from the registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -8668,12 +7668,10 @@ Refers to the custom load balancer to lookup from the registry.
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="exception" type="xs:string">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 A list of class names for specific exceptions to monitor. If no exceptions are
 configured then all exceptions are monitored.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                   
@@ -8681,8 +7679,7 @@ configured then all exceptions are monitored.
                 
         <xs:attribute name="roundRobin" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not the failover load balancer should operate in round robin mode or
 not. If not, then it will always start from the first endpoint when a new
 message is to be processed. In other words it restart from the top for every
@@ -8691,15 +7688,13 @@ the next endpoint in a round robin fashion. You can also enable sticky mode
 together with round robin, if so then it will pick the last known good endpoint
 to use when starting the load balancing (instead of using the next when
 starting).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="sticky" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not the failover load balancer should operate in sticky mode or not.
 If not, then it will always start from the first endpoint when a new message is
 to be processed. In other words it restart from the top for every message. If
@@ -8707,22 +7702,19 @@ sticky is enabled, then it keeps state and will continue with the last known
 good endpoint. You can also enable sticky mode together with round robin, if so
 then it will pick the last known good endpoint to use when starting the load
 balancing (instead of using the next when starting).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maximumFailoverAttempts" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A value to indicate after X failover attempts we should exhaust (give up). Use
 -1 to indicate never give up and continuously try to failover. Use 0 to never
 failover. And use e.g. 3 to failover at most 3 times before giving up. his
 option can be used whether or not roundRobin is enabled or not. Default value:
 -1
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -8770,11 +7762,9 @@ option can be used whether or not roundRobin is enabled or not. Default value:
                     
           <xs:element name="correlationExpression" type="tns:expressionSubElementDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 The correlation expression to use to calculate the correlation key.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                   
@@ -8810,35 +7800,29 @@ The correlation expression to use to calculate the correlation key.
                 
         <xs:attribute name="distributionRatio" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The distribution ratio is a delimited String consisting on integer weights
 separated by delimiters for example 2,3,5. The distributionRatio must match the
 number of endpoints and/or processors specified in the load balancer list.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="distributionRatioDelimiter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Delimiter used to specify the distribution ratio. The default value is ,
 (comma). Default value: ,
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="roundRobin" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To enable round robin mode. By default the weighted distribution mode is used.
 The default value is false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -8858,51 +7842,41 @@ The default value is false. Default value: false
                 
         <xs:attribute name="message" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the log message (uses simple language).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="loggingLevel" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the logging level. The default value is INFO. Default value: INFO
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the name of the logger.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="marker" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use slf4j marker.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logger" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To refer to a custom logger instance to lookup from the registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -9114,36 +8088,30 @@ To refer to a custom logger instance to lookup from the registry.
                 
         <xs:attribute name="copy" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If the copy attribute is true, a copy of the input Exchange is used for each
 iteration. That means each iteration will start from a copy of the same message.
 By default loop will loop the same exchange all over, so each iteration may have
 different message content. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="doWhile" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Enables the while loop that loops until the predicate evaluates to false or
 null. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="breakOnShutdown" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If the breakOnShutdown attribute is true, then the loop will not iterate until
 it reaches the end when Camel is shut down. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -9265,25 +8233,21 @@ it reaches the end when Camel is shut down. Default value: false
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="configuration" type="tns:propertyDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Configurations for Apache Any23 as key-value pairs in order to customize the
 extraction process. The list of supported parameters can be found here. If not
 provided, a default configuration is used.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="extractors" type="xs:string">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 List of Any23 extractors to be used in the unmarshal operation. A list of the
 available extractors can be found here here. If not provided, all the available
 extractors are used.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                   
@@ -9291,24 +8255,20 @@ extractors are used.
                 
         <xs:attribute name="outputFormat" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 What RDF syntax to unmarshal as, can be: NTRIPLES, TURTLE, NQUADS, RDFXML,
 JSONLD, RDFJSON, RDF4JMODEL. It is by default: RDF4JMODEL. Default value:
 RDF4JMODEL
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="baseUri" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The URI to use as base for building RDF entities if only relative paths are
 provided.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -9328,23 +8288,19 @@ provided.
                 
         <xs:attribute name="unmarshalType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Class to use when unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="usingIterator" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If the asn1 file has more than one entry, the setting this option to true,
 allows working with the splitter EIP, to split the data using an iterator in a
 streaming mode. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -9364,228 +8320,188 @@ streaming mode. Default value: false
                 
         <xs:attribute name="instanceClassName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Class name to use for marshal and unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="library" type="tns:avroLibrary">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Which Avro library to use. Default value: ApacheAvro
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="objectMapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Lookup and use the existing ObjectMapper with the given id when using Jackson.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useDefaultObjectMapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to lookup and use default Jackson ObjectMapper from the registry.
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="unmarshalType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Class name of the java type to use when unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="jsonView" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When marshalling a POJO to JSON you might want to exclude certain fields from
 the JSON output. With Jackson you can use JSON views to accomplish this. This
 option is to refer to the class which has JsonView annotations.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="include" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If you want to marshal a pojo to JSON, and the pojo has some fields with null
 values. And you want to skip these null values, you can set this option to
 NON_NULL.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowJmsType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Used for JMS users to allow the JMSType header from the JMS spec to specify a
 FQN classname to use to unmarshal to. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="collectionType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a custom collection type to lookup in the registry to use. This option
 should rarely be used, but allows to use different collection types than
 java.util.Collection based as default.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useList" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To unmarshal to a List of Map or a List of Pojo. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="moduleClassNames" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use custom Jackson modules com.fasterxml.jackson.databind.Module specified as
 a String with FQN class names. Multiple classes can be separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="moduleRefs" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use custom Jackson modules referred from the Camel registry. Multiple modules
 can be separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="enableFeatures" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set of features to enable on the Jackson
 com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that
 matches a enum from com.fasterxml.jackson.databind.SerializationFeature,
 com.fasterxml.jackson.databind.DeserializationFeature, or
 com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated
 by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="disableFeatures" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set of features to disable on the Jackson
 com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that
 matches a enum from com.fasterxml.jackson.databind.SerializationFeature,
 com.fasterxml.jackson.databind.DeserializationFeature, or
 com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated
 by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowUnmarshallType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then Jackson is allowed to attempt to use the
 CamelJacksonUnmarshalType header during the unmarshalling. This should only be
 enabled when desired to be used. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timezone" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set then Jackson will use the Timezone when marshalling/unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="autoDiscoverObjectMapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set to true then Jackson will lookup for an objectMapper into the registry.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="contentTypeHeader" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the data format should set the Content-Type header with the type from
 the data format. For example application/xml for data formats marshalling to
 XML, or application/json for data formats marshalling to JSON. Default value:
 true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="schemaResolver" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Optional schema resolver used to lookup schemas for the data in transit.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="autoDiscoverSchemaResolver" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When not disabled, the SchemaResolver will be looked up into the registry.
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -9605,41 +8521,33 @@ Default value: true
                 
         <xs:attribute name="barcodeFormat" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Barcode format such as QR-Code.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="imageType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Image type of the barcode such as png.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="width" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Width of the barcode.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="height" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Height of the barcode.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -9659,34 +8567,28 @@ Height of the barcode.
                 
         <xs:attribute name="lineLength" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To specific a maximum line length for the encoded data. By default 76 is used.
 Default value: 76
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="lineSeparator" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The line separators to use. Uses new line characters (CRLF) by default.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="urlSafe" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Instead of emitting '' and '/' we emit '-' and '_' respectively. urlSafe is only
 applied to encode operations. Decoding seamlessly handles both modes. Is by
 default false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -9706,54 +8608,44 @@ default false. Default value: false
                 
         <xs:attribute name="type" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to use Csv, Fixed, or KeyValue.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="classType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of model class to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowEmptyStream" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to allow empty streams in the unmarshal process. If true, no exception
 will be thrown when a body without records is provided. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="unwrapSingleInstance" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When unmarshalling should a single instance be unwrapped and returned instead of
 wrapped in a java.util.List. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="locale" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To configure a default locale to use, such as us for united states. To use the
 JVM platform default locale then use the name default.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -9773,119 +8665,99 @@ JVM platform default locale then use the name default.
                 
         <xs:attribute name="objectMapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Lookup and use the existing CBOR ObjectMapper with the given id when using
 Jackson.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useDefaultObjectMapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to lookup and use default Jackson CBOR ObjectMapper from the registry.
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="unmarshalType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Class name of the java type to use when unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="collectionType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a custom collection type to lookup in the registry to use. This option
 should rarely be used, but allows to use different collection types than
 java.util.Collection based as default.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useList" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To unmarshal to a List of Map or a List of Pojo. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowUnmarshallType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then Jackson CBOR is allowed to attempt to use the
 CamelCBORUnmarshalType header during the unmarshalling. This should only be
 enabled when desired to be used. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="prettyPrint" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To enable pretty printing output nicely formatted. Is by default false. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowJmsType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Used for JMS users to allow the JMSType header from the JMS spec to specify a
 FQN classname to use to unmarshal to. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="enableFeatures" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set of features to enable on the Jackson
 com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that
 matches a enum from com.fasterxml.jackson.databind.SerializationFeature,
 com.fasterxml.jackson.databind.DeserializationFeature, or
 com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated
 by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="disableFeatures" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set of features to disable on the Jackson
 com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that
 matches a enum from com.fasterxml.jackson.databind.SerializationFeature,
 com.fasterxml.jackson.databind.DeserializationFeature, or
 com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated
 by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -9905,96 +8777,78 @@ by comma.
                 
         <xs:attribute name="algorithm" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The JCE algorithm name indicating the cryptographic algorithm that will be used.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="keyRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to the secret key to lookup from the register to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="cryptoProvider" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The name of the JCE Security Provider that should be used.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="initVectorRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a byte array containing the Initialization Vector that will be used to
 initialize the Cipher.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="algorithmParameterRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A JCE AlgorithmParameterSpec used to initialize the Cipher. Will lookup the type
 using the given name as a java.security.spec.AlgorithmParameterSpec type.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="bufferSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The size of the buffer used in the signature process. Default value: 4096
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="macAlgorithm" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The JCE algorithm name indicating the Message Authentication algorithm. Default
 value: HmacSHA1
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="shouldAppendHMAC" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Flag indicating that a Message Authentication Code should be calculated and
 appended to the encrypted data. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="inline" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Flag indicating that the configured IV should be inlined into the encrypted data
 stream. Is by default false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -10014,11 +8868,9 @@ stream. Is by default false. Default value: false
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="header" type="xs:string">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 To configure the CSV headers.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                   
@@ -10026,293 +8878,237 @@ To configure the CSV headers.
                 
         <xs:attribute name="formatRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The reference format to use, it will be updated with the other format options,
 the default value is CSVFormat.DEFAULT.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="formatName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The name of the format to use, the default value is CSVFormat.DEFAULT. Default
 value: DEFAULT
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="commentMarkerDisabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Disables the comment marker of the reference format. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="commentMarker" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the comment marker of the reference format.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="delimiter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the delimiter to use. The default value is , (comma).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="escapeDisabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Use for disabling using escape character. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="escape" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the escape character to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="headerDisabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Use for disabling headers. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowMissingColumnNames" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to allow missing column names. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreEmptyLines" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to ignore empty lines. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreSurroundingSpaces" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to ignore surrounding spaces. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="nullStringDisabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Used to disable null strings. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="nullString" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the null string.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="quoteDisabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Used to disable quotes. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="quote" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the quote which by default is.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="recordSeparatorDisabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Used for disabling record separator.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="recordSeparator" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the record separator (aka new line) which by default is new line characters
 (CRLF).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="skipHeaderRecord" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to skip the header record in the output. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="quoteMode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the quote mode.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreHeaderCase" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether or not to ignore case when accessing header names. Default value:
 false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="trim" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether or not to trim leading and trailing blanks. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="trailingDelimiter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether or not to add a trailing delimiter. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="marshallerFactoryRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the implementation of the CsvMarshallerFactory interface which is able to
 customize marshalling/unmarshalling behavior by extending CsvMarshaller or
 creating it from scratch.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="lazyLoad" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the unmarshalling should produce an iterator that reads the lines on the
 fly or if all the lines must be read at one. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useMaps" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the unmarshalling should produce maps (HashMap)for the lines values
 instead of lists. It requires to have header (either defined or collected).
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useOrderedMaps" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the unmarshalling should produce ordered maps (LinkedHashMap) for the
 lines values instead of lists. It requires to have header (either defined or
 collected). Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="recordConverterRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a custom CsvRecordConverter to lookup from the registry to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="captureHeaderRecord" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the unmarshalling should capture the header record and store it in the
 message header. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -10332,12 +9128,10 @@ message header. Default value: false
                 
         <xs:attribute name="ref" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Reference to the custom org.apache.camel.spi.DataFormat to lookup from the Camel
 registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -10371,130 +9165,109 @@ registry.
                 
         <xs:attribute name="fhirVersion" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The version of FHIR to use. Possible values are:
 DSTU2,DSTU2_HL7ORG,DSTU2_1,DSTU3,R4,R5. Default value: R4
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="fhirContext" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom fhir context. Reference to object of type
 ca.uhn.fhir.context.FhirContext.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="prettyPrint" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the pretty print flag, meaning that the parser will encode resources with
 human-readable spacing and newlines between elements instead of condensing
 output as much as possible. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="parserErrorHandler" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Registers an error handler which will be invoked when any parse errors are
 found. Reference to object of type ca.uhn.fhir.parser.IParserErrorHandler.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="parserOptions" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the parser options object which will be used to supply default options to
 newly created parsers. Reference to object of type
 ca.uhn.fhir.context.ParserOptions.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="preferTypes" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set (FQN class names), when parsing resources the parser will try to use the
 given types when possible, in the order that they are provided (from highest to
 lowest priority). For example, if a custom type which declares to implement the
 Patient resource is passed in here, and the parser is parsing a Bundle
 containing a Patient resource, the parser will use the given custom type.
 Multiple class names can be separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="forceResourceId" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When encoding, force this resource ID to be encoded as the resource ID.
 Reference to object of type org.hl7.fhir.instance.model.api.IIdType.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="serverBaseUrl" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the server's base URL used by this parser. If a value is set, resource
 references will be turned into relative references if they are provided as
 absolute URLs but have a base matching the given base.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="omitResourceId" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set to true (default is false) the ID of any resources being encoded will not
 be included in the output. Note that this does not apply to contained resources,
 only to root resources. In other words, if this is set to true, contained
 resources will still have local IDs but the outer/containing ID will not have an
 ID. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="encodeElementsAppliesToChildResourcesOnly" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set to true (default is false), the values supplied to setEncodeElements(Set)
 will not be applied to the root resource (typically a Bundle), but will be
 applied to any sub-resources contained within it (i.e. search result resources
 in that bundle). Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="encodeElements" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If provided, specifies the elements which should be encoded, to the exclusion of
 all others. Multiple elements can be separated by comma when using String
 parameter. Valid values for this field would include: Patient - Encode patient
@@ -10503,15 +9276,13 @@ Patient.name.family - Encode only the patient's family name .text - Encode the
 text element on any resource (only the very first position may contain a
 wildcard) .(mandatory) - This is a special case which causes any mandatory
 fields (min 0) to be encoded.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="dontEncodeElements" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If provided, specifies the elements which should NOT be encoded. Multiple
 elements can be separated by comma when using String parameter. Valid values for
 this field would include: Patient - Don't encode patient and all its children
@@ -10521,15 +9292,13 @@ resource (only the very first position may contain a wildcard) DSTU2 note: Note
 that values including meta, such as Patient.meta will work for DSTU2 parsers,
 but values with subelements on meta such as Patient.meta.lastUpdated will only
 work in DSTU3 mode.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="stripVersionsFromReferences" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set to true (which is the default), resource references containing a version
 will have the version removed when the resource is encoded. This is generally
 good behaviour because in most situations, references from one resource to
@@ -10538,52 +9307,44 @@ though, it may be desirable to preserve the version in resource links. In that
 case, this value should be set to false. This method provides the ability to
 globally disable reference encoding. If finer-grained control is needed, use
 setDontStripVersionsFromReferencesAtPaths(List). Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="overrideResourceIdWithBundleEntryFullUrl" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set to true (which is the default), the Bundle.entry.fullUrl will override
 the Bundle.entry.resource's resource id if the fullUrl is defined. This behavior
 happens when parsing the source data into a Bundle object. Set this to false if
 this is not the desired behavior (e.g. the client code wishes to perform
 additional validation checks between the fullUrl and the resource id). Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="summaryMode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set to true (default is false) only elements marked by the FHIR specification
 as being summary elements will be included. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="suppressNarratives" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set to true (default is false), narratives will not be included in the
 encoded values. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="dontStripVersionsFromReferencesAtPaths" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If supplied value(s), any resource references at the specified paths will have
 their resource versions encoded instead of being automatically stripped during
 the encoding process. This setting has no effect on the parsing process.
@@ -10592,21 +9353,18 @@ method provides a finer-grained level of control than
 setStripVersionsFromReferences(String) and any paths specified by this method
 will be encoded even if setStripVersionsFromReferences(String) has been set to
 true (which is the default).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="contentTypeHeader" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the data format should set the Content-Type header with the type from
 the data format. For example application/xml for data formats marshalling to
 XML, or application/json for data formats marshalling to JSON. Default value:
 true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -10640,85 +9398,69 @@ true
                 
         <xs:attribute name="definition" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The flatpack pzmap configuration file. Can be omitted in simpler situations, but
 its preferred to use the pzmap.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="fixed" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Delimited or fixed. Is by default false = delimited. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="delimiter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The delimiter char (could be ; , or similar). Default value: ,
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreFirstRecord" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the first line is ignored for delimited files (for the column headers).
 Is by default true. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowShortLines" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Allows for lines to be shorter than expected and ignores the extra characters.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreExtraColumns" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Allows for lines to be longer than expected and ignores the extra characters.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="textQualifier" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If the text is qualified with a character. Uses quote character by default.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="parserFactoryRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 References to a custom parser factory to lookup in the registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -10738,45 +9480,37 @@ References to a custom parser factory to lookup in the registry.
                 
         <xs:attribute name="pattern" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The grok pattern to match lines of input.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="flattened" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Turns on flattened mode. In flattened mode the exception is thrown when there
 are multiple pattern matches with same key. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowMultipleMatchesPerLine" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If false, every line of input is matched for pattern only once. Otherwise the
 line can be scanned multiple times when non-terminal pattern is used. Default
 value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="namedOnly" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to capture named expressions only or not (i.e. %{IP:ip} but not ${IP}).
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -10810,11 +9544,9 @@ Default value: false
                 
         <xs:attribute name="validate" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to validate the HL7 message Is by default true. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -10834,11 +9566,9 @@ Whether to validate the HL7 message Is by default true. Default value: true
                 
         <xs:attribute name="validating" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to validate. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -10858,187 +9588,155 @@ Whether to validate. Default value: false
                 
         <xs:attribute name="xmlMapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Lookup and use the existing XmlMapper with the given id.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="prettyPrint" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To enable pretty printing output nicely formatted. Is by default false. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="unmarshalType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Class name of the java type to use when unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowUnmarshallType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then Jackson is allowed to attempt to use the
 CamelJacksonUnmarshalType header during the unmarshalling. This should only be
 enabled when desired to be used. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="jsonView" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When marshalling a POJO to JSON you might want to exclude certain fields from
 the JSON output. With Jackson you can use JSON views to accomplish this. This
 option is to refer to the class which has JsonView annotations.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="include" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If you want to marshal a pojo to JSON, and the pojo has some fields with null
 values. And you want to skip these null values, you can set this option to
 NON_NULL.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowJmsType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Used for JMS users to allow the JMSType header from the JMS spec to specify a
 FQN classname to use to unmarshal to. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="collectionType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a custom collection type to lookup in the registry to use. This option
 should rarely be used, but allows to use different collection types than
 java.util.Collection based as default.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useList" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To unmarshal to a List of Map or a List of Pojo. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timezone" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set then Jackson will use the Timezone when marshalling/unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="enableJaxbAnnotationModule" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to enable the JAXB annotations module when using jackson. When enabled
 then JAXB annotations can be used by Jackson. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="moduleClassNames" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use custom Jackson modules com.fasterxml.jackson.databind.Module specified as
 a String with FQN class names. Multiple classes can be separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="moduleRefs" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use custom Jackson modules referred from the Camel registry. Multiple modules
 can be separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="enableFeatures" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set of features to enable on the Jackson
 com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that
 matches a enum from com.fasterxml.jackson.databind.SerializationFeature,
 com.fasterxml.jackson.databind.DeserializationFeature, or
 com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated
 by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="disableFeatures" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set of features to disable on the Jackson
 com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that
 matches a enum from com.fasterxml.jackson.databind.SerializationFeature,
 com.fasterxml.jackson.databind.DeserializationFeature, or
 com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated
 by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="contentTypeHeader" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the data format should set the Content-Type header with the type from
 the data format. For example application/xml for data formats marshalling to
 XML, or application/json for data formats marshalling to JSON. Default value:
 true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -11058,122 +9756,101 @@ true
                 
         <xs:attribute name="contextPath" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Package name where your JAXB classes are located.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="contextPathIsClassName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 This can be set to true to mark that the contextPath is referring to a classname
 and not a package name. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="schema" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To validate against an existing schema. Your can use the prefix classpath:,
 file: or http: to specify how the resource should be resolved. You can separate
 multiple schema files by using the ',' character.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="schemaSeverityLevel" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the schema severity level to use when validating against a schema. This
 level determines the minimum severity error that triggers JAXB to stop continue
 parsing. The default value of 0 (warning) means that any error (warning, error
 or fatal error) will trigger JAXB to stop. There are the following three levels:
 0=warning, 1=error, 2=fatal error. Default value: 0
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="prettyPrint" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To enable pretty printing output nicely formatted. Is by default false. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="objectFactory" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to allow using ObjectFactory classes to create the POJO classes during
 marshalling. This only applies to POJO classes that has not been annotated with
 JAXB and providing jaxb.index descriptor files. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreJAXBElement" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to ignore JAXBElement elements - only needed to be set to false in very
 special use-cases. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="mustBeJAXBElement" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether marhsalling must be java objects with JAXB annotations. And if not then
 it fails. This option can be set to false to relax that, such as when the data
 is already in XML format. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="filterNonXmlChars" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To ignore non xml characheters and replace them with an empty space. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="encoding" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To overrule and use a specific encoding.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="fragment" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To turn on marshalling XML fragment trees. By default JAXB looks for
 XmlRootElement annotation on given class to operate on whole XML tree. This is
 useful but not always - sometimes generated code does not have XmlRootElement
@@ -11181,111 +9858,92 @@ annotation, sometimes you need unmarshall only part of tree. In that case you
 can use partial unmarshalling. To enable this behaviours you need set property
 partClass. Camel will pass this class to JAXB's unmarshaler. Default value:
 false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="partClass" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of class used for fragment parsing. See more details at the fragment
 option.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="partNamespace" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 XML namespace to use for fragment parsing. See more details at the fragment
 option.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="namespacePrefixRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When marshalling using JAXB or SOAP then the JAXB implementation will automatic
 assign namespace prefixes, such as ns2, ns3, ns4 etc. To control this mapping,
 Camel allows you to refer to a map which contains the desired mapping.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="xmlStreamWriterWrapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom xml stream writer.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="schemaLocation" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To define the location of the schema.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="noNamespaceSchemaLocation" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To define the location of the namespaceless schema.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="jaxbProviderProperties" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a custom java.util.Map to lookup in the registry containing custom
 JAXB provider properties to be used with the JAXB marshaller.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="contentTypeHeader" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the data format should set the Content-Type header with the type from
 the data format. For example application/xml for data formats marshalling to
 XML, or application/json for data formats marshalling to JSON. Default value:
 true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="accessExternalSchemaProtocols" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Only in use if schema validation has been enabled. Restrict access to the
 protocols specified for external reference set by the schemaLocation attribute,
 Import and Include element. Examples of protocols are file, http, jar:file.
 false or none to deny all access to external references; a specific protocol,
 such as file, to give permission to only the protocol; the keyword all to grant
 permission to all protocols. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -11305,180 +9963,149 @@ permission to all protocols. Default value: false
                 
         <xs:attribute name="objectMapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Lookup and use the existing ObjectMapper with the given id when using Jackson.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useDefaultObjectMapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to lookup and use default Jackson ObjectMapper from the registry.
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="autoDiscoverObjectMapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set to true then Jackson will look for an objectMapper to use from the
 registry. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="prettyPrint" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To enable pretty printing output nicely formatted. Is by default false. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="library" type="tns:jsonLibrary">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Which json library to use. Default value: Jackson
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="unmarshalType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Class name of the java type to use when unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="jsonView" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When marshalling a POJO to JSON you might want to exclude certain fields from
 the JSON output. With Jackson you can use JSON views to accomplish this. This
 option is to refer to the class which has JsonView annotations.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="include" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If you want to marshal a pojo to JSON, and the pojo has some fields with null
 values. And you want to skip these null values, you can set this option to
 NON_NULL.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowJmsType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Used for JMS users to allow the JMSType header from the JMS spec to specify a
 FQN classname to use to unmarshal to. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="collectionType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a custom collection type to lookup in the registry to use. This option
 should rarely be used, but allows using different collection types than
 java.util.Collection based as default.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useList" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To unmarshal to a List of Map or a List of Pojo. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="moduleClassNames" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use custom Jackson modules com.fasterxml.jackson.databind.Module specified as
 a String with FQN class names. Multiple classes can be separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="moduleRefs" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use custom Jackson modules referred from the Camel registry. Multiple modules
 can be separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="enableFeatures" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set of features to enable on the Jackson
 com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that
 matches a enum from com.fasterxml.jackson.databind.SerializationFeature,
 com.fasterxml.jackson.databind.DeserializationFeature, or
 com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated
 by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="disableFeatures" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set of features to disable on the Jackson
 com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that
 matches a enum from com.fasterxml.jackson.databind.SerializationFeature,
 com.fasterxml.jackson.databind.DeserializationFeature, or
 com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated
 by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="permissions" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Adds permissions that controls which Java packages and classes XStream is
 allowed to use during unmarshal from xml/json to Java beans. A permission must
 be configured either here or globally using a JVM system property. The
@@ -11489,102 +10116,85 @@ configured separated by comma, such as com.foo.,-com.foo.bar.MySecretBean. The
 following default permission is always included: -,java.lang.,java.util. unless
 its overridden by specifying a JVM system property with they key
 org.apache.camel.xstream.permissions.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowUnmarshallType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then Jackson is allowed to attempt to use the
 CamelJacksonUnmarshalType header during the unmarshalling. This should only be
 enabled when desired to be used. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timezone" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set then Jackson will use the Timezone when marshalling/unmarshalling. This
 option will have no effect on the others Json DataFormat, like gson, fastjson
 and xstream.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="dropRootNode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether XStream will drop the root node in the generated JSon. You may want to
 enable this when using POJOs; as then the written object will include the class
 name as root node, which is often not intended to be written in the JSON output.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="schemaResolver" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Optional schema resolver used to lookup schemas for the data in transit.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="autoDiscoverSchemaResolver" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When not disabled, the SchemaResolver will be looked up into the registry.
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="namingStrategy" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set then Jackson will use the the defined Property Naming Strategy.Possible
 values are: LOWER_CAMEL_CASE, LOWER_DOT_CASE, LOWER_CASE, KEBAB_CASE, SNAKE_CASE
 and UPPER_CAMEL_CASE.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="contentTypeHeader" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the data format should set the Content-Type header with the type from
 the data format. For example application/xml for data formats marshalling to
 XML, or application/json for data formats marshalling to JSON. Default value:
 true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="dateFormatPattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To configure the date format while marshall or unmarshall Date fields in JSON
 using Gson.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -11604,22 +10214,18 @@ using Gson.
                 
         <xs:attribute name="dataFormatTypes" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The classes to take into account for the marshalling. Multiple classes can be
 separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="mainFormatType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The class to take into account while unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -11639,11 +10245,9 @@ The class to take into account while unmarshalling.
                 
         <xs:attribute name="usingParallelCompression" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Enable encoding (compress) using multiple processing cores. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -11663,57 +10267,47 @@ Enable encoding (compress) using multiple processing cores. Default value: false
                 
         <xs:attribute name="multipartSubType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Specify the subtype of the MIME Multipart. Default is mixed. Default value:
 mixed
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="multipartWithoutAttachment" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Defines whether a message without attachment is also marshaled into a MIME
 Multipart (with only one body part). Default is false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="headersInline" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Defines whether the MIME-Multipart headers are part of the message body (true)
 or are set as Camel headers (false). Default is false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="includeHeaders" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A regex that defines which Camel headers are also included as MIME headers into
 the MIME multipart. This will only work if headersInline is set to true. Default
 is to include no headers.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="binaryContent" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Defines whether the content of binary parts in the MIME multipart is binary
 (true) or Base-64 encoded (false) Default is false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -11733,241 +10327,199 @@ Defines whether the content of binary parts in the MIME multipart is binary
                 
         <xs:attribute name="instanceClass" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of class to use when unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="objectMapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Lookup and use the existing ObjectMapper with the given id when using Jackson.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useDefaultObjectMapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to lookup and use default Jackson ObjectMapper from the registry.
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="autoDiscoverObjectMapper" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set to true then Jackson will lookup for an objectMapper into the registry.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="library" type="tns:protobufLibrary">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Which Protobuf library to use. Default value: GoogleProtobuf
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="unmarshalType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Class name of the java type to use when unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="jsonView" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When marshalling a POJO to JSON you might want to exclude certain fields from
 the JSON output. With Jackson you can use JSON views to accomplish this. This
 option is to refer to the class which has JsonView annotations.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="include" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If you want to marshal a pojo to JSON, and the pojo has some fields with null
 values. And you want to skip these null values, you can set this option to
 NON_NULL.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowJmsType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Used for JMS users to allow the JMSType header from the JMS spec to specify a
 FQN classname to use to unmarshal to. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="collectionType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a custom collection type to lookup in the registry to use. This option
 should rarely be used, but allows to use different collection types than
 java.util.Collection based as default.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useList" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To unmarshal to a List of Map or a List of Pojo. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="moduleClassNames" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use custom Jackson modules com.fasterxml.jackson.databind.Module specified as
 a String with FQN class names. Multiple classes can be separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="moduleRefs" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use custom Jackson modules referred from the Camel registry. Multiple modules
 can be separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="enableFeatures" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set of features to enable on the Jackson
 com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that
 matches a enum from com.fasterxml.jackson.databind.SerializationFeature,
 com.fasterxml.jackson.databind.DeserializationFeature, or
 com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated
 by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="disableFeatures" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set of features to disable on the Jackson
 com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that
 matches a enum from com.fasterxml.jackson.databind.SerializationFeature,
 com.fasterxml.jackson.databind.DeserializationFeature, or
 com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated
 by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowUnmarshallType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then Jackson is allowed to attempt to use the
 CamelJacksonUnmarshalType header during the unmarshalling. This should only be
 enabled when desired to be used. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timezone" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If set then Jackson will use the Timezone when marshalling/unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="schemaResolver" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Optional schema resolver used to lookup schemas for the data in transit.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="autoDiscoverSchemaResolver" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When not disabled, the SchemaResolver will be looked up into the registry.
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="contentTypeFormat" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Defines a content type format in which protobuf message will be
 serialized/deserialized from(to) the Java been. The format can either be native
 or json for either native protobuf or json fields representation. The default
 value is native. Default value: native
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="contentTypeHeader" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the data format should set the Content-Type header with the type from
 the data format. For example application/xml for data formats marshalling to
 XML, or application/json for data formats marshalling to JSON. Default value:
 true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12001,28 +10553,23 @@ true
                 
         <xs:attribute name="contextPath" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Package name where your JAXB classes are located.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="encoding" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To overrule and use a specific encoding.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="elementNameStrategyRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to an element strategy to lookup from the registry. An element name
 strategy is used for two purposes. The first is to find a xml element name for a
 given object and soap action when marshaling the object into a SOAP message. The
@@ -12038,42 +10585,35 @@ org.apache.camel.dataformat.soap.name If you have generated the web service stub
 code with cxf-codegen or a similar tool then you probably will want to use the
 ServiceInterfaceStrategy. In the case you have no annotated service interface
 you should use QNameStrategy or TypeNameStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="version" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 SOAP version should either be 1.1 or 1.2. Is by default 1.1. Default value: 1.1
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="namespacePrefixRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When marshalling using JAXB or SOAP then the JAXB implementation will automatic
 assign namespace prefixes, such as ns2, ns3, ns4 etc. To control this mapping,
 Camel allows you to refer to a map which contains the desired mapping.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="schema" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To validate against an existing schema. Your can use the prefix classpath:,
 file: or http: to specify how the resource should be resolved. You can separate
 multiple schema files by using the ',' character.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12093,12 +10633,10 @@ multiple schema files by using the ',' character.
                 
         <xs:attribute name="writeInJson" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The flag indicating that messages must be marshalled in a JSON format. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12118,45 +10656,37 @@ value: false
                 
         <xs:attribute name="writeConfigRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a specific configuration to use when marshalling a message to lookup
 from the registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="writeInJson" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The flag indicating that messages must be marshalled in a JSON format. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="readMessageId" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The type of MX message to produce when unmarshalling an input stream. If not
 set, it will be automatically detected from the namespace used.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="readConfigRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a specific configuration to use when unmarshalling an input stream to
 lookup from the registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12190,48 +10720,40 @@ lookup from the registry.
                 
         <xs:attribute name="usingIterator" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If the tar file has more than one entry, the setting this option to true, allows
 working with the splitter EIP, to split the data using an iterator in a
 streaming mode. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowEmptyDirectory" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If the tar file has more than one entry, setting this option to true, allows to
 get the iterator even if the directory is empty. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="preservePathElements" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If the file name contains path elements, setting this option to true, allows the
 path to be maintained in the tar file. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maxDecompressedSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set the maximum decompressed size of a tar file (in bytes). The default value if
 not specified corresponds to 1 gigabyte. An IOException will be thrown if the
 decompressed size exceeds this amount. Set to -1 to disable setting a maximum
 decompressed size. Default value: 1073741824
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12251,37 +10773,31 @@ decompressed size. Default value: 1073741824
                 
         <xs:attribute name="instanceClass" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of class to use when unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="contentTypeFormat" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Defines a content type format in which thrift message will be
 serialized/deserialized from(to) the Java been. The format can either be native
 or json for either native binary thrift, json or simple json fields
 representation. The default value is binary. Default value: binary
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="contentTypeHeader" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the data format should set the Content-Type header with the type from
 the data format. For example application/xml for data formats marshalling to
 XML, or application/json for data formats marshalling to JSON. Default value:
 true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12301,24 +10817,20 @@ true
                 
         <xs:attribute name="dataObjectType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 What data type to unmarshal as, can either be org.w3c.dom.Node or
 java.lang.String. Is by default org.w3c.dom.Node. Default value:
 org.w3c.dom.Node
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="omitXmlDeclaration" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When returning a String, do we omit the XML declaration in the top. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12338,41 +10850,33 @@ value: false
                 
         <xs:attribute name="delimiter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The delimiter of values. Default value: ,
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="quoteAllFields" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not all values must be quoted when writing them. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="quote" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The quote symbol. Default value: "
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="quoteEscape" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The quote escape symbol. Default value: "
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12396,143 +10900,117 @@ The quote escape symbol. Default value: "
                 
         <xs:attribute name="nullValue" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The string representation of a null value. The default value is null.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="skipEmptyLines" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not the empty lines must be ignored. The default value is true.
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreTrailingWhitespaces" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not the trailing white spaces must be ignored. The default value is
 true. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreLeadingWhitespaces" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not the leading white spaces must be ignored. The default value is
 true. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="headersDisabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not the headers are disabled. When defined, this option explicitly
 sets the headers as null which indicates that there is no header. The default
 value is false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="headerExtractionEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not the header must be read in the first line of the test document
 The default value is false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="numberOfRecordsToRead" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The maximum number of record to read.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="emptyValue" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The String representation of an empty value.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="lineSeparator" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The line separator of the files The default value is to use the JVM platform
 line separator.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="normalizedLineSeparator" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The normalized line separator of the files The default value is a new line
 character. Default value: \n
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="comment" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The comment symbol. The default value is #. Default value: #
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="lazyLoad" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the unmarshalling should produce an iterator that reads the lines on the
 fly or if all the lines must be read at one. The default value is false. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="asMap" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the unmarshalling should produce maps for the lines values instead of
 lists. It requires to have header (either defined or collected). The default
 value is false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12550,11 +11028,9 @@ value is false. Default value: false
                 
         <xs:attribute name="length" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Header length.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12574,33 +11050,27 @@ Header length.
                 
         <xs:attribute name="padding" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The padding character. The default value is a space.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="skipTrailingCharsUntilNewline" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not the trailing characters until new line must be ignored. The
 default value is false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="recordEndsOnNewline" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not the record ends on new line. The default value is false. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12620,11 +11090,9 @@ value: false
                 
         <xs:attribute name="escapeChar" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The escape character. Default value: \
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12644,148 +11112,124 @@ The escape character. Default value: \
                 
         <xs:attribute name="xmlCipherAlgorithm" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The cipher algorithm to be used for encryption/decryption of the XML message
 content. The available choices are: XMLCipher.TRIPLEDES XMLCipher.AES_128
 XMLCipher.AES_128_GCM XMLCipher.AES_192 XMLCipher.AES_192_GCM XMLCipher.AES_256
 XMLCipher.AES_256_GCM XMLCipher.SEED_128 XMLCipher.CAMELLIA_128
 XMLCipher.CAMELLIA_192 XMLCipher.CAMELLIA_256 The default value is
 XMLCipher.AES_256_GCM. Default value: AES-256-GCM
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="passPhrase" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A String used as passPhrase to encrypt/decrypt content. The passPhrase has to be
 provided. The passPhrase needs to be put together in conjunction with the
 appropriate encryption algorithm. For example using TRIPLEDES the passPhase can
 be a Only another 24 Byte key.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="passPhraseByte" type="xs:base64Binary">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A byte used as passPhrase to encrypt/decrypt content. The passPhrase has to be
 provided. The passPhrase needs to be put together in conjunction with the
 appropriate encryption algorithm. For example using TRIPLEDES the passPhase can
 be a Only another 24 Byte key.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="secureTag" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The XPath reference to the XML Element selected for encryption/decryption. If no
 tag is specified, the entire payload is encrypted/decrypted.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="secureTagContents" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A boolean value to specify whether the XML Element is to be encrypted or the
 contents of the XML Element. false = Element Level. true = Element Content
 Level. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="keyCipherAlgorithm" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The cipher algorithm to be used for encryption/decryption of the asymmetric key.
 The available choices are: XMLCipher.RSA_v1dot5 XMLCipher.RSA_OAEP
 XMLCipher.RSA_OAEP_11 The default value is XMLCipher.RSA_OAEP. Default value:
 RSA_OAEP
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="recipientKeyAlias" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The key alias to be used when retrieving the recipient's public or private key
 from a KeyStore when performing asymmetric key encryption or decryption.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="keyOrTrustStoreParametersRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a KeyStore instance to lookup in the registry, which is used for
 configuration options for creating and loading a KeyStore instance that
 represents the sender's trustStore or recipient's keyStore.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="keyPassword" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The password to be used for retrieving the private key from the KeyStore. This
 key is used for asymmetric decryption.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="digestAlgorithm" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The digest algorithm to use with the RSA OAEP algorithm. The available choices
 are: XMLCipher.SHA1 XMLCipher.SHA256 XMLCipher.SHA512 The default value is
 XMLCipher.SHA1. Default value: SHA1
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="mgfAlgorithm" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The MGF Algorithm to use with the RSA OAEP algorithm. The available choices are:
 EncryptionConstants.MGF1_SHA1 EncryptionConstants.MGF1_SHA256
 EncryptionConstants.MGF1_SHA512 The default value is
 EncryptionConstants.MGF1_SHA1. Default value: MGF1_SHA1
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="addKeyValueForEncryptedKey" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to add the public key used to encrypt the session key as a KeyValue in
 the EncryptedKey structure or not. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12805,45 +11249,37 @@ the EncryptedKey structure or not. Default value: true
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="converters" type="tns:propertyDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 List of class names for using custom XStream converters. The classes must be of
 type com.thoughtworks.xstream.converters.Converter.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="aliases" type="tns:propertyDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Alias a Class to a shorter name to be used in XML elements.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="omitFields" type="tns:propertyDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Prevents a field from being serialized. To omit a field you must always provide
 the declaring type and not necessarily the type that is converted. Multiple
 values can be separated by comma.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="implicitCollections" type="tns:propertyDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Adds a default implicit collection which is used for any unmapped XML tag.
 Multiple values can be separated by comma.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                   
@@ -12851,8 +11287,7 @@ Multiple values can be separated by comma.
                 
         <xs:attribute name="permissions" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Adds permissions that controls which Java packages and classes XStream is
 allowed to use during unmarshal from xml/json to Java beans. A permission must
 be configured either here or globally using a JVM system property. The
@@ -12863,65 +11298,54 @@ configured separated by comma, such as com.foo.,-com.foo.bar.MySecretBean. The
 following default permission is always included: -,java.lang.,java.util. unless
 its overridden by specifying a JVM system property with they key
 org.apache.camel.xstream.permissions.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="encoding" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the encoding to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="driver" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom XStream driver. The instance must be of type
 com.thoughtworks.xstream.io.HierarchicalStreamDriver.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="driverRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To refer to a custom XStream driver to lookup in the registry. The instance must
 be of type com.thoughtworks.xstream.io.HierarchicalStreamDriver.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="mode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Mode for dealing with duplicate references The possible values are:
 NO_REFERENCES ID_REFERENCES XPATH_RELATIVE_REFERENCES XPATH_ABSOLUTE_REFERENCES
 SINGLE_NODE_XPATH_RELATIVE_REFERENCES SINGLE_NODE_XPATH_ABSOLUTE_REFERENCES.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="contentTypeHeader" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the data format should set the Content-Type header with the type from
 the data format. For example application/xml for data formats marshalling to
 XML, or application/json for data formats marshalling to JSON. Default value:
 true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -12941,20 +11365,17 @@ true
                 
         <xs:attribute name="keyUserid" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The user ID of the key in the PGP keyring used during encryption. Can also be
 only a part of a user ID. For example, if the user ID is Test User then you can
 use the part Test User or to address the user ID.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="signatureKeyUserid" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 User ID of the key in the PGP keyring used for signing (during encryption) or
 signature verification (during decryption). During the signature verification
 process the specified User ID restricts the public keys from the public keyring
@@ -12962,141 +11383,117 @@ which can be used for the verification. If no User ID is specified for the
 signature verficiation then any public key in the public keyring can be used for
 the verification. Can also be only a part of a user ID. For example, if the user
 ID is Test User then you can use the part Test User or to address the User ID.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="password" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Password used when opening the private key (not used for encryption).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="signaturePassword" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Password used when opening the private key used for signing (during encryption).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="keyFileName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Filename of the keyring; must be accessible as a classpath resource (but you can
 specify a location in the file system by using the file: prefix).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="signatureKeyFileName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Filename of the keyring to use for signing (during encryption) or for signature
 verification (during decryption); must be accessible as a classpath resource
 (but you can specify a location in the file system by using the file: prefix).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="signatureKeyRing" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Keyring used for signing/verifying as byte array. You can not set the
 signatureKeyFileName and signatureKeyRing at the same time.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="armored" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 This option will cause PGP to base64 encode the encrypted text, making it
 available for copy/paste, etc. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="integrity" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Adds an integrity check/sign into the encryption file. The default value is
 true. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="provider" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Java Cryptography Extension (JCE) provider, default is Bouncy Castle (BC).
 Alternatively you can use, for example, the IAIK JCE provider; in this case the
 provider must be registered beforehand and the Bouncy Castle provider must not
 be registered beforehand. The Sun JCE provider does not work.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="algorithm" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Symmetric key encryption algorithm; possible values are defined in
 org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags; for example 2 (= TRIPLE DES), 3
 (= CAST5), 4 (= BLOWFISH), 6 (= DES), 7 (= AES_128). Only relevant for
 encrypting.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="compressionAlgorithm" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Compression algorithm; possible values are defined in
 org.bouncycastle.bcpg.CompressionAlgorithmTags; for example 0 (= UNCOMPRESSED),
 1 (= ZIP), 2 (= ZLIB), 3 (= BZIP2). Only relevant for encrypting.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="hashAlgorithm" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Signature hash algorithm; possible values are defined in
 org.bouncycastle.bcpg.HashAlgorithmTags; for example 2 (= SHA1), 8 (= SHA256), 9
 (= SHA384), 10 (= SHA512), 11 (=SHA224). Only relevant for signing.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="signatureVerificationOption" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Controls the behavior for verifying the signature during unmarshaling. There are
 4 values possible: optional: The PGP message may or may not contain signatures;
 if it does contain signatures, then a signature verification is executed.
@@ -13105,8 +11502,7 @@ the case an exception (PGPException) is thrown. A signature verification is
 executed. ignore: Contained signatures in the PGP message are ignored; no
 signature verification is executed. no_signature_allowed: The PGP message must
 not contain a signature; otherwise an exception (PGPException) is thrown.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -13130,112 +11526,90 @@ not contain a signature; otherwise an exception (PGPException) is thrown.
                 
         <xs:attribute name="library" type="tns:yamlLibrary">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Which yaml library to use. By default it is SnakeYAML. Default value: SnakeYAML
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="unmarshalType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Class name of the java type to use when unmarshalling.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="constructor" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 BaseConstructor to construct incoming documents.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="representer" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Representer to emit outgoing objects.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="dumperOptions" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 DumperOptions to configure outgoing objects.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="resolver" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Resolver to detect implicit type.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useApplicationContextClassLoader" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Use ApplicationContextClassLoader as custom ClassLoader. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="prettyFlow" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Force the emitter to produce a pretty YAML document when using the flow style.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowAnyType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Allow any class to be un-marshaled. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maxAliasesForCollections" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set the maximum amount of aliases allowed for collections. Default value: 50
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowRecursiveKeys" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set whether recursive keys are allowed. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -13251,21 +11625,17 @@ Set whether recursive keys are allowed. Default value: false
         
     <xs:attribute name="value" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Value of type such as class name or regular expression.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="type" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Whether to filter by class type or regular expression.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -13281,12 +11651,10 @@ Whether to filter by class type or regular expression.
                 
         <xs:attribute name="compressionLevel" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To specify a specific compression between 0-9. -1 is default compression, 0 is
 no compression, and 9 is the best compression. Default value: -1
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -13306,48 +11674,40 @@ no compression, and 9 is the best compression. Default value: -1
                 
         <xs:attribute name="usingIterator" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If the zip file has more than one entry, the setting this option to true, allows
 working with the splitter EIP, to split the data using an iterator in a
 streaming mode. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowEmptyDirectory" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If the zip file has more than one entry, setting this option to true, allows to
 get the iterator even if the directory is empty. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="preservePathElements" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If the file name contains path elements, setting this option to true, allows the
 path to be maintained in the zip file. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maxDecompressedSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set the maximum decompressed size of a zip file (in bytes). The default value if
 not specified corresponds to 1 gigabyte. An IOException will be thrown if the
 decompressed size exceeds this amount. Set to -1 to disable setting a maximum
 decompressed size. Default value: 1073741824
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -13513,85 +11873,72 @@ decompressed size. Default value: 1073741824
                 
         <xs:attribute name="aggregationStrategy" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to an AggregationStrategy to be used to assemble the replies from the
 multicasts, into a single outgoing message from the Multicast. By default Camel
 will use the last reply as the outgoing message. You can also use a POJO as the
 AggregationStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 This option can be used to explicit declare the method name to use, when using
 POJOs as the AggregationStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodAllowNull" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If this option is false then the aggregate method is not used if there was no
 data to enrich. If this option is true then null values is used as the
 oldExchange (when no data to enrich), when using POJOs as the
 AggregationStrategy. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="parallelAggregate" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then the aggregate method on AggregationStrategy can be called
 concurrently. Notice that this would require the implementation of
 AggregationStrategy to be implemented as thread-safe. By default this is false
 meaning that Camel synchronizes the call to the aggregate method. Though in some
 use-cases this can be used to archive higher performance when the
 AggregationStrategy is implemented as thread-safe. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="parallelProcessing" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then sending messages to the multicasts occurs concurrently. Note the
 caller thread will still wait until all messages has been fully processed,
 before it continues. Its only the sending and processing the replies from the
 multicasts which happens concurrently. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="streaming" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then Camel will process replies out-of-order, eg in the order they
 come back. If disabled, Camel will process replies in the same order as defined
 by the multicast. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="stopOnException" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Will now stop further processing if an exception or failure occurred during
 processing of an org.apache.camel.Exchange and the caused exception will be
 thrown. Will also stop if processing the exchange failed (has a fault message)
@@ -13600,15 +11947,13 @@ onException). In all situations the multicast will stop further processing. This
 is the same behavior as in pipeline, which is used by the routing engine. The
 default behavior is to not stop but continue processing till the end. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a total timeout specified in millis, when using parallel processing. If the
 Multicast hasn't been able to send and process all replies within the given
 timeframe, then the timeout triggers and the Multicast breaks out and continues.
@@ -13617,45 +11962,38 @@ is invoked before breaking out. If the timeout is reached with running tasks
 still remaining, certain tasks for which it is difficult for Camel to shut down
 in a graceful manner may continue to run. So use this option with a bit of care.
 Default value: 0
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="executorService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a custom Thread Pool to be used for parallel processing. Notice if you
 set this option, then parallel processing is automatic implied, and you do not
 have to enable that option as well.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="onPrepare" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Uses the Processor when preparing the org.apache.camel.Exchange to be send. This
 can be used to deep-clone messages that should be send, or any custom logic
 needed before the exchange is send.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="shareUnitOfWork" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Shares the org.apache.camel.spi.UnitOfWork with the parent and each of the sub
 messages. Multicast will by default not share unit of work between the parent
 exchange and each multicasted exchange. This means each sub exchange has its own
 individual unit of work. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -13675,13 +12013,11 @@ individual unit of work. Default value: false
                     
           <xs:element minOccurs="0" name="onWhen" type="tns:whenDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Sets an additional predicate that should be true before the onCompletion is
 triggered. To be used for fine grained controlling whether a completion callback
 should be invoked or not.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
@@ -13827,70 +12163,58 @@ should be invoked or not.
                 
         <xs:attribute name="mode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the on completion mode. The default value is AfterConsumer. Default value:
 AfterConsumer
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="onCompleteOnly" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Will only synchronize when the org.apache.camel.Exchange completed successfully
 (no errors). Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="onFailureOnly" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Will only synchronize when the org.apache.camel.Exchange ended with failure
 (exception or FAULT message). Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="parallelProcessing" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then the on completion process will run asynchronously by a separate
 thread from a thread pool. By default this is false, meaning the on completion
 process will run synchronously using the same caller thread as from the route.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="executorService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom Thread Pool to be used for parallel processing. Notice if you
 set this option, then parallel processing is automatic implied, and you do not
 have to enable that option as well.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useOriginalMessage" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Will use the original input message body when an org.apache.camel.Exchange for
 this on completion. By default this feature is off. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -13910,34 +12234,28 @@ this on completion. By default this feature is off. Default value: false
                     
           <xs:element maxOccurs="unbounded" name="exception" type="xs:string">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 A set of exceptions to react upon.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element minOccurs="0" name="onWhen" type="tns:whenDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Sets an additional predicate that should be true before the onException is
 triggered. To be used for fine grained controlling whether a thrown exception
 should be intercepted by this exception type or not.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element minOccurs="0" name="retryWhile" type="tns:expressionSubElementDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Sets the retry while predicate. Will continue retrying until predicate returns
 false.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
@@ -13945,22 +12263,18 @@ false.
                     
           <xs:element minOccurs="0" name="handled" type="tns:expressionSubElementDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Sets whether the exchange should be marked as handled or not.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element minOccurs="0" name="continued" type="tns:expressionSubElementDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Sets whether the exchange should handle and continue routing from the point of
 failure. If this option is enabled then its considered handled as well.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
@@ -14106,44 +12420,37 @@ failure. If this option is enabled then its considered handled as well.
                 
         <xs:attribute name="redeliveryPolicyRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a redelivery policy to lookup in the
 org.apache.camel.spi.Registry to be used.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="onRedeliveryRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a processor that should be processed before a redelivery
 attempt. Can be used to change the org.apache.camel.Exchange before its being
 redelivered.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="onExceptionOccurredRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a processor that should be processed just after an exception
 occurred. Can be used to perform custom logging about the occurred exception at
 the exact time it happened. Important: Any exception thrown from this processor
 will be ignored.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useOriginalMessage" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Will use the original input org.apache.camel.Message (original body and headers)
 when an org.apache.camel.Exchange is moved to the dead letter queue. Notice:
 this only applies when all redeliveries attempt have failed and the
@@ -14172,15 +12479,13 @@ the split message); however these EIPs have an option named shareUnitOfWork
 which allows to combine with the parent unit of work in regard to error handling
 and therefore use the parent original message. By default this feature is off.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useOriginalBody" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Will use the original input org.apache.camel.Message body (original body only)
 when an org.apache.camel.Exchange is moved to the dead letter queue. Notice:
 this only applies when all redeliveries attempt have failed and the
@@ -14209,8 +12514,7 @@ the split message); however these EIPs have an option named shareUnitOfWork
 which allows to combine with the parent unit of work in regard to error handling
 and therefore use the parent original message. By default this feature is off.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -14370,15 +12674,13 @@ Default value: false
                 
         <xs:attribute name="fallbackViaNetwork" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the fallback goes over the network. If the fallback will go over the
 network it is another possible point of failure. It is important to execute the
 fallback command on a separate thread-pool, otherwise if the main command were
 to become latent and fill the thread-pool this would prevent the fallback from
 running if the two commands share the same pool. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -14398,21 +12700,17 @@ running if the two commands share the same pool. Default value: false
                 
         <xs:attribute name="urn" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set output type URN.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="validate" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether if validation is required for this output type. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -14428,31 +12726,25 @@ Whether if validation is required for this output type. Default value: false
             
       <xs:element maxOccurs="unbounded" name="package" type="xs:string">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Sets the java package names to use for scanning for route builder classes.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="excludes" type="xs:string">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Exclude finding route builder from these java package names.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="includes" type="xs:string">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Include finding route builder from these java package names.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
           
@@ -14470,18 +12762,15 @@ Include finding route builder from these java package names.
                 
         <xs:attribute name="consumerListener" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the consumer listener to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="untilCheck" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 References to a java.util.function.Predicate to use for until checks. The
 predicate is responsible for evaluating whether the processing can resume or
 not. Such predicate should return true if the consumption can resume, or false
@@ -14489,8 +12778,7 @@ otherwise. The exact point of when the predicate is called is dependent on the
 component, and it may be called on either one of the available events.
 Implementations should not assume the predicate to be called at any specific
 point.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -14804,11 +13092,9 @@ point.
                 
         <xs:attribute name="ref" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to use for lookup the policy in the registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -14878,58 +13164,49 @@ Sets a reference to use for lookup the policy in the registry.
                 
         <xs:attribute name="aggregationStrategy" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the AggregationStrategy to be used to merge the reply from the external
 service, into a single outgoing message. By default Camel will use the reply
 from the external service as outgoing message.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 This option can be used to explicit declare the method name to use, when using
 POJOs as the AggregationStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodAllowNull" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If this option is false then the aggregate method is not used if there was no
 data to enrich. If this option is true then null values is used as the
 oldExchange (when no data to enrich), when using POJOs as the
 AggregationStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregateOnException" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If this option is false then the aggregate method is not used if there was an
 exception thrown while trying to retrieve the data to enrich from the resource.
 Setting this option to true allows end users to control what to do if there was
 an exception in the aggregate method. For example to suppress the exception or
 set a custom message body etc. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Timeout in millis when polling from the external service. The timeout has
 influence about the poll enrich behavior. It basically operations in three
 different modes: negative value - Waits until a message is available and then
@@ -14940,15 +13217,13 @@ value - Attempts to receive a message exchange, waiting up to the given timeout
 to expire if a message is not yet available. Returns null if timed out The
 default value is -1 and therefore the method could block indefinitely, and
 therefore its recommended to use a timeout value. Default value: -1
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="cacheSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum size used by the org.apache.camel.spi.ConsumerCache which is
 used to cache and reuse consumers when uris are reused. Beware that when using
 dynamic endpoints then it affects how well the cache can be utilized. If each
@@ -14962,19 +13237,16 @@ and endpoints and therefore the cache size can be set accordingly or rely on the
 default size (1000). If there is a mix of unique and used before dynamic
 endpoints, then setting a reasonable cache size can help reduce memory usage to
 avoid storing too many non frequent used producers.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreInvalidEndpoint" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Ignore the invalidate endpoint exception when try to create a producer with that
 endpoint. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -14994,15 +13266,13 @@ endpoint. Default value: false
                 
         <xs:attribute name="ref" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Reference to the Processor to lookup in the registry to use. Can also be used
 for creating new beans by their class name by prefixing with #class, eg
 #class:com.foo.MyClassType. And it is also possible to refer to singleton beans
 by their type in the registry by prefixing with #type: syntax, eg
 #type:com.foo.MyClassType.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -15078,11 +13348,9 @@ by their type in the registry by prefixing with #type: syntax, eg
         
     <xs:attribute name="key" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Property key.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -15148,84 +13416,71 @@ Property key.
                 
         <xs:attribute name="delimiter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Delimiter used if the Expression returned multiple endpoints. Can be turned off
 using the value false. The default value is ,. Default value: ,
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategy" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the AggregationStrategy to be used to assemble the replies from the
 recipients, into a single outgoing message from the RecipientList. By default
 Camel will use the last reply as the outgoing message. You can also use a POJO
 as the AggregationStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 This option can be used to explicit declare the method name to use, when using
 POJOs as the AggregationStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodAllowNull" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If this option is false then the aggregate method is not used if there was no
 data to enrich. If this option is true then null values is used as the
 oldExchange (when no data to enrich), when using POJOs as the
 AggregationStrategy. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="parallelAggregate" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then the aggregate method on AggregationStrategy can be called
 concurrently. Notice that this would require the implementation of
 AggregationStrategy to be implemented as thread-safe. By default this is false
 meaning that Camel synchronizes the call to the aggregate method. Though in some
 use-cases this can be used to archive higher performance when the
 AggregationStrategy is implemented as thread-safe. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="parallelProcessing" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then sending messages to the recipients occurs concurrently. Note the
 caller thread will still wait until all messages has been fully processed,
 before it continues. Its only the sending and processing the replies from the
 recipients which happens concurrently. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a total timeout specified in millis, when using parallel processing. If the
 Recipient List hasn't been able to send and process all replies within the given
 timeframe, then the timeout triggers and the Recipient List breaks out and
@@ -15234,27 +13489,23 @@ timeout method is invoked before breaking out. If the timeout is reached with
 running tasks still remaining, certain tasks for which it is difficult for Camel
 to shut down in a graceful manner may continue to run. So use this option with a
 bit of care. Default value: 0
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="executorService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom Thread Pool to be used for parallel processing. Notice if you
 set this option, then parallel processing is automatic implied, and you do not
 have to enable that option as well.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="stopOnException" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Will now stop further processing if an exception or failure occurred during
 processing of an org.apache.camel.Exchange and the caused exception will be
 thrown. Will also stop if processing the exchange failed (has a fault message)
@@ -15263,50 +13514,42 @@ onException). In all situations the recipient list will stop further processing.
 This is the same behavior as in pipeline, which is used by the routing engine.
 The default behavior is to not stop but continue processing till the end.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreInvalidEndpoints" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Ignore the invalidate endpoint exception when try to create a producer with that
 endpoint. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="streaming" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then Camel will process replies out-of-order, eg in the order they
 come back. If disabled, Camel will process replies in the same order as defined
 by the recipient list. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="onPrepare" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Uses the Processor when preparing the org.apache.camel.Exchange to be used send.
 This can be used to deep-clone messages that should be send, or any custom logic
 needed before the exchange is send.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="cacheSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum size used by the org.apache.camel.spi.ProducerCache which is
 used to cache and reuse producers when using this recipient list, when uris are
 reused. Beware that when using dynamic endpoints then it affects how well the
@@ -15321,21 +13564,18 @@ size can be set accordingly or rely on the default size (1000). If there is a
 mix of unique and used before dynamic endpoints, then setting a reasonable cache
 size can help reduce memory usage to avoid storing too many non frequent used
 producers.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="shareUnitOfWork" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Shares the org.apache.camel.spi.UnitOfWork with the parent and each of the sub
 messages. Recipient List will by default not share unit of work between the
 parent exchange and each recipient exchange. This means each sub exchange has
 its own individual unit of work. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -15355,11 +13595,9 @@ its own individual unit of work. Default value: false
                 
         <xs:attribute name="name" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of header to remove.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -15379,25 +13617,21 @@ Name of header to remove.
                 
         <xs:attribute name="pattern" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name or pattern of headers to remove. The pattern is matched in the following
 order: 1 = exact match 2 = wildcard (pattern ends with a and the name starts
 with the pattern) 3 = regular expression (all of above is case in-sensitive).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="excludePattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name or patter of headers to not remove. The pattern is matched in the following
 order: 1 = exact match 2 = wildcard (pattern ends with a and the name starts
 with the pattern) 3 = regular expression (all of above is case in-sensitive).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -15417,26 +13651,22 @@ with the pattern) 3 = regular expression (all of above is case in-sensitive).
                 
         <xs:attribute name="pattern" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name or pattern of properties to remove. The pattern is matched in the following
 order: 1 = exact match 2 = wildcard (pattern ends with a and the name starts
 with the pattern) 3 = regular expression (all of above is case in-sensitive).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="excludePattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name or pattern of properties to not remove. The pattern is matched in the
 following order: 1 = exact match 2 = wildcard (pattern ends with a and the name
 starts with the pattern) 3 = regular expression (all of above is case
 in-sensitive).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -15456,11 +13686,9 @@ in-sensitive).
                 
         <xs:attribute name="name" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of property to remove.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -15694,53 +13922,43 @@ Name of property to remove.
                 
         <xs:attribute name="batchSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the size of the batch to be re-ordered. The default size is 100. Default
 value: 100
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="batchTimeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the timeout for collecting elements to be re-ordered. The default timeout
 is 1000 msec. Default value: 1000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowDuplicates" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to allow duplicates. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="reverse" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to reverse the ordering. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreInvalidExchanges" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to ignore invalid exchanges. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -15766,65 +13984,53 @@ Whether to ignore invalid exchanges. Default value: false
                 
         <xs:attribute name="capacity" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the capacity of the resequencer inbound queue. Default value: 1000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets minimum time (milliseconds) to wait for missing elements (messages).
 Default value: 1000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="deliveryAttemptInterval" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the interval in milliseconds the stream resequencer will at most wait while
 waiting for condition of being able to deliver. Default value: 1000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreInvalidExchanges" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to ignore invalid exchanges. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="rejectOld" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If true, throws an exception when messages older than the last delivered message
 are processed. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="comparator" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom comparator as a
 org.apache.camel.processor.resequencer.ExpressionResultComparator type.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -15840,11 +14046,9 @@ org.apache.camel.processor.resequencer.ExpressionResultComparator type.
         
     <xs:attribute name="ref" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Reference to the rest-dsl.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -15864,22 +14068,18 @@ Reference to the rest-dsl.
                 
         <xs:attribute name="resumeStrategy" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the resume strategy to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="intermittent" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether the offsets will be intermittently present or whether they must be
 present in every exchange. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -15899,33 +14099,27 @@ present in every exchange. Default value: false
                 
         <xs:attribute name="message" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Message to use in rollback exception.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="markRollbackOnly" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Mark the transaction for rollback only (cannot be overruled to commit). Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="markRollbackOnlyLast" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Mark only last sub transaction for rollback only. When using sub transactions
 (if the transaction manager support this). Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -15945,11 +14139,9 @@ Mark only last sub transaction for rollback only. When using sub transactions
                 
         <xs:attribute name="ref" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Reference to the route builder instance.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -15965,11 +14157,9 @@ Reference to the route builder instance.
         
     <xs:attribute name="ref" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Reference to the route templates in the xml dsl.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -15999,12 +14189,10 @@ Reference to the route templates in the xml dsl.
                 
         <xs:attribute name="precondition" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The predicate of the precondition in simple language to evaluate in order to
 determine if this route configuration should be included or not.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -16030,11 +14218,9 @@ determine if this route configuration should be included or not.
         
     <xs:attribute name="ref" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Reference to the routes in the xml dsl.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -16198,83 +14384,67 @@ Reference to the routes in the xml dsl.
                 
         <xs:attribute name="autoStartup" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to auto start this route. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="delayer" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to slow down processing messages by a given delay in msec.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="errorHandlerRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the bean ref name of the error handler builder to use on this route.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="group" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The group that this route belongs to; could be the name of the RouteBuilder
 class or be explicitly configured in the XML. May be null.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logMask" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether security mask for Logging is enabled on this route. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="messageHistory" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether message history is enabled on this route.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="nodePrefixId" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a prefix to use for all node ids (not route id).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="precondition" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The predicate of the precondition in simple language to evaluate in order to
 determine if this route should be included or not.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
@@ -16282,63 +14452,51 @@ determine if this route should be included or not.
                 
         <xs:attribute name="routeConfigurationId" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The route configuration id or pattern this route should use for configuration.
 Multiple id/pattern can be separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="routePolicyRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Reference to custom org.apache.camel.spi.RoutePolicy to use by the route.
 Multiple policies can be configured by separating values using comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="shutdownRoute" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To control how to shutdown the route.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="shutdownRunningTask" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To control how to shutdown the route.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="startupOrder" type="xs:int">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To configure the ordering of the routes being started.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="streamCache" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether stream caching is enabled on this route.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
@@ -16346,11 +14504,9 @@ Whether stream caching is enabled on this route.
                 
         <xs:attribute name="trace" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether tracing is enabled on this route.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -16380,11 +14536,9 @@ Whether tracing is enabled on this route.
         
     <xs:attribute name="ref" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Reference to the route templates in the xml dsl.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -16418,44 +14572,36 @@ Reference to the route templates in the xml dsl.
         
     <xs:attribute name="name" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The name of the parameter.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="required" type="xs:boolean">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Whether the parameter is required or not. A parameter is required unless this
 option is set to false or a default value has been configured. Default value:
 false
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="defaultValue" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Default value of the parameter. If a default value is provided then the
 parameter is implied not to be required.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="description" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Description of the parameter.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -16557,29 +14703,24 @@ Description of the parameter.
                 
         <xs:attribute name="uriDelimiter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the uri delimiter to use. Default value: ,
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreInvalidEndpoints" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Ignore the invalidate endpoint exception when try to create a producer with that
 endpoint. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="cacheSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum size used by the org.apache.camel.spi.ProducerCache which is
 used to cache and reuse producers when using this routing slip, when uris are
 reused. Beware that when using dynamic endpoints then it affects how well the
@@ -16594,8 +14735,7 @@ size can be set accordingly or rely on the default size (1000). If there is a
 mix of unique and used before dynamic endpoints, then setting a reasonable cache
 size can help reduce memory usage to avoid storing too many non frequent used
 producers.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -16629,41 +14769,35 @@ producers.
                     
           <xs:element minOccurs="0" name="compensation" type="tns:sagaActionUriDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 The compensation endpoint URI that must be called to compensate all changes done
 in the route. The route corresponding to the compensation URI must perform
 compensation and complete without error. If errors occur during compensation,
 the saga service may call again the compensation URI to retry.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element minOccurs="0" name="completion" type="tns:sagaActionUriDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 The completion endpoint URI that will be called when the Saga is completed
 successfully. The route corresponding to the completion URI must perform
 completion tasks and terminate without error. If errors occur during completion,
 the saga service may call again the completion URI to retry.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="option" type="tns:propertyExpressionDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Allows to save properties of the current exchange in order to re-use them in a
 compensation/completion callback route. Options are usually helpful e.g. to
 store and retrieve identifiers of objects that should be deleted in compensating
 actions. Option values will be transformed into input headers of the
 compensation/completion exchange.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
@@ -16809,49 +14943,41 @@ compensation/completion exchange.
                 
         <xs:attribute name="sagaService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to the id to lookup in the registry for the specific CamelSagaService to
 use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="propagation" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set the Saga propagation mode (REQUIRED, REQUIRES_NEW, MANDATORY, SUPPORTS,
 NOT_SUPPORTED, NEVER). Default value: REQUIRED
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="completionMode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Determine how the saga should be considered complete. When set to AUTO, the saga
 is completed when the exchange that initiates the saga is processed
 successfully, or compensated when it completes exceptionally. When set to
 MANUAL, the user must complete or compensate the saga using the saga:complete or
 saga:compensate endpoints. Default value: AUTO
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set the maximum amount of time for the Saga. After the timeout is expired, the
 saga will be compensated automatically (unless a different decision has been
 taken in the meantime).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -16871,23 +14997,19 @@ taken in the meantime).
                 
         <xs:attribute name="samplePeriod" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the sample period during which only a single Exchange will pass through.
 Default value: 1000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="messageFrequency" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the sample message count which only a single Exchange will pass through
 after this many received.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -17035,12 +15157,10 @@ after this many received.
                 
         <xs:attribute name="pattern" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the new exchange pattern of the Exchange to be used from this point
 forward.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -17110,13 +15230,11 @@ forward.
                 
         <xs:attribute name="name" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of message header to set a new value The simple language can be used to
 define a dynamic evaluated header name to be used. Otherwise a constant name
 will be used.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -17186,13 +15304,11 @@ will be used.
                 
         <xs:attribute name="name" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of exchange property to set a new value. The simple language can be used to
 define a dynamic evaluated exchange property name to be used. Otherwise a
 constant name will be used.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -17262,11 +15378,9 @@ constant name will be used.
                 
         <xs:attribute name="comparator" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the comparator to use for sorting.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -17478,84 +15592,71 @@ Sets the comparator to use for sorting.
                 
         <xs:attribute name="delimiter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Delimiter used in splitting messages. Can be turned off using the value false.
 The default value is ,. Default value: ,
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategy" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to the AggregationStrategy to be used to assemble the replies
 from the split messages, into a single outgoing message from the Splitter. By
 default Camel will use the original incoming message to the splitter (leave it
 unchanged). You can also use a POJO as the AggregationStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 This option can be used to explicit declare the method name to use, when using
 POJOs as the AggregationStrategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aggregationStrategyMethodAllowNull" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If this option is false then the aggregate method is not used if there was no
 data to enrich. If this option is true then null values is used as the
 oldExchange (when no data to enrich), when using POJOs as the
 AggregationStrategy. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="parallelAggregate" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then the aggregate method on AggregationStrategy can be called
 concurrently. Notice that this would require the implementation of
 AggregationStrategy to be implemented as thread-safe. By default this is false
 meaning that Camel synchronizes the call to the aggregate method. Though in some
 use-cases this can be used to archive higher performance when the
 AggregationStrategy is implemented as thread-safe. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="parallelProcessing" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If enabled then processing each split messages occurs concurrently. Note the
 caller thread will still wait until all messages has been fully processed,
 before it continues. It's only processing the sub messages from the splitter
 which happens concurrently. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="streaming" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 When in streaming mode, then the splitter splits the original message on-demand,
 and each split message is processed one by one. This reduces memory usage as the
 splitter do not split all the messages first, but then we do not know the total
@@ -17568,15 +15669,13 @@ streaming mode also affects the aggregation behavior. If enabled then Camel will
 process replies out-of-order, e.g. in the order they come back. If disabled,
 Camel will process replies in the same order as the messages was split. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="stopOnException" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Will now stop further processing if an exception or failure occurred during
 processing of an org.apache.camel.Exchange and the caused exception will be
 thrown. Will also stop if processing the exchange failed (has a fault message)
@@ -17585,15 +15684,13 @@ onException). In all situations the splitter will stop further processing. This
 is the same behavior as in pipeline, which is used by the routing engine. The
 default behavior is to not stop but continue processing till the end. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a total timeout specified in millis, when using parallel processing. If the
 Splitter hasn't been able to split and process all the sub messages within the
 given timeframe, then the timeout triggers and the Splitter breaks out and
@@ -17602,45 +15699,38 @@ timeout method is invoked before breaking out. If the timeout is reached with
 running tasks still remaining, certain tasks for which it is difficult for Camel
 to shut down in a graceful manner may continue to run. So use this option with a
 bit of care. Default value: 0
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="executorService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom Thread Pool to be used for parallel processing. Notice if you
 set this option, then parallel processing is automatically implied, and you do
 not have to enable that option as well.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="onPrepare" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Uses the Processor when preparing the org.apache.camel.Exchange to be sent. This
 can be used to deep-clone messages that should be sent, or any custom logic
 needed before the exchange is sent.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="shareUnitOfWork" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Shares the org.apache.camel.spi.UnitOfWork with the parent and each of the sub
 messages. Splitter will by default not share unit of work between the parent
 exchange and each split exchange. This means each split exchange has its own
 individual unit of work. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -17838,21 +15928,17 @@ individual unit of work. Default value: false
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="parameter" type="tns:templatedRouteParameterDefinition">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Adds an input parameter of the template to build the route.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="bean" type="tns:templatedRouteBeanDefinition">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Adds a local bean as input of the template to build the route.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
           
@@ -17860,31 +15946,25 @@ Adds a local bean as input of the template to build the route.
         
     <xs:attribute name="routeTemplateRef" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the id of the route template to use to build the route.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="routeId" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the id of the route built from the route template.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="prefixId" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets a prefix to use for all node ids (not route id).
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -17896,21 +15976,17 @@ Sets a prefix to use for all node ids (not route id).
         
     <xs:attribute name="name" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The name of the parameter.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="value" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The value of the parameter.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -17944,83 +16020,67 @@ The value of the parameter.
                 
         <xs:attribute name="defaultProfile" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether this profile is the default thread pool profile. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="poolSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the core pool size.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maxPoolSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum pool size.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="keepAliveTime" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the keep alive time for idle threads in the pool.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeUnit" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the time unit to use for keep alive time By default SECONDS is used.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maxQueueSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum number of tasks in the work queue. Use -1 or Integer.MAX_VALUE
 for an unbounded queue.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowCoreThreadTimeOut" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether idle core threads is allowed to timeout and therefore can shrink the
 pool size below the core pool size Is by default true. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="rejectedPolicy" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the handler for tasks which cannot be executed by the thread pool.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -18040,106 +16100,86 @@ Sets the handler for tasks which cannot be executed by the thread pool.
                 
         <xs:attribute name="executorService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom thread pool.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="poolSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the core pool size.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maxPoolSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum pool size.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="keepAliveTime" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the keep alive time for idle threads.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timeUnit" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the keep alive time unit. By default SECONDS is used.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="maxQueueSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum number of tasks in the work queue. Use -1 or Integer.MAX_VALUE
 for an unbounded queue.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowCoreThreadTimeOut" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether idle core threads are allowed to timeout and therefore can shrink the
 pool size below the core pool size Is by default false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="threadName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the thread name to use. Default value: Threads
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="rejectedPolicy" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the handler for tasks which cannot be executed by the thread pool.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="callerRunsWhenRejected" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not to use as caller runs as fallback when a task is rejected being
 added to the thread pool (when its full). This is only used as fallback if no
 rejectedPolicy has been configured, or the thread pool has no configured
 rejection handler. Is by default true. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -18211,12 +16251,10 @@ rejection handler. Is by default true. Default value: true
                     
           <xs:element minOccurs="0" name="correlationExpression" type="tns:expressionSubElementDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 The expression used to calculate the correlation key to use for throttle
 grouping. The Exchange which has the same correlation key is throttled together.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                   
@@ -18224,55 +16262,45 @@ grouping. The Exchange which has the same correlation key is throttled together.
                 
         <xs:attribute name="executorService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom thread pool (ScheduledExecutorService) by the throttler.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="timePeriodMillis" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the time period during which the maximum request count is valid for.
 Default value: 1000
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="asyncDelayed" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Enables asynchronous delay which means the thread will not block while delaying.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="callerRunsWhenRejected" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not the caller should run the task when it was rejected by the thread
 pool. Is by default true. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="rejectExecution" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether or not throttler throws the ThrottlerRejectedExecutionException when the
 exchange exceeds the request limit Is by default false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -18292,32 +16320,26 @@ exchange exceeds the request limit Is by default false. Default value: false
                 
         <xs:attribute name="message" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To create a new exception instance and use the given message as caused message
 (supports simple language).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="exceptionType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The class of the exception to create using the message.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ref" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Reference to the exception instance to lookup from the registry to throw.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -18337,11 +16359,9 @@ Reference to the exception instance to lookup from the registry to throw.
                 
         <xs:attribute name="pattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the optional ExchangePattern used to invoke this endpoint.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -18361,29 +16381,24 @@ Sets the optional ExchangePattern used to invoke this endpoint.
                 
         <xs:attribute name="uri" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The uri of the endpoint to send to. The uri can be dynamic computed using the
 org.apache.camel.language.simple.SimpleLanguage expression.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="pattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the optional ExchangePattern used to invoke this endpoint.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="cacheSize" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the maximum size used by the org.apache.camel.spi.ProducerCache which is
 used to cache and reuse producers when using this recipient list, when uris are
 reused. Beware that when using dynamic endpoints then it affects how well the
@@ -18398,40 +16413,33 @@ size can be set accordingly or rely on the default size (1000). If there is a
 mix of unique and used before dynamic endpoints, then setting a reasonable cache
 size can help reduce memory usage to avoid storing too many non frequent used
 producers.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="ignoreInvalidEndpoint" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to ignore invalid endpoint URIs and skip sending the message. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowOptimisedComponents" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to allow components to optimise toD if they are
 org.apache.camel.spi.SendDynamicAware . Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="autoStartComponents" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to auto startup components when toD is starting up. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -18591,11 +16599,9 @@ Whether to auto startup components when toD is starting up. Default value: true
                 
         <xs:attribute name="ref" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to use for lookup the policy in the registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -18921,12 +16927,10 @@ Sets a reference to use for lookup the policy in the registry.
                 
         <xs:attribute name="allowNullBody" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Indicates whether null is allowed as value of a body to unmarshall. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -18996,14 +17000,12 @@ value: false
                 
         <xs:attribute name="predicateExceptionFactory" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The bean id of custom PredicateExceptionFactory to use for creating the
 exception when the validation fails. By default, Camel will throw
 PredicateValidationException. By using a custom factory you can control which
 exception to throw instead.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -19029,47 +17031,39 @@ exception to throw instead.
                 
         <xs:attribute name="copy" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Uses a copy of the original exchange. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="dynamicUri" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the uri is dynamic or static. If the uri is dynamic then the simple
 language is used to evaluate a dynamic uri to use as the wire-tap destination,
 for each incoming message. This works similar to how the toD EIP pattern works.
 If static then the uri is used as-is as the wire-tap destination. Default value:
 true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="onPrepare" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Uses the Processor when preparing the org.apache.camel.Exchange to be sent. This
 can be used to deep-clone messages that should be sent, or any custom logic
 needed before the exchange is sent.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="executorService" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Uses a custom thread pool.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -19089,12 +17083,10 @@ Uses a custom thread pool.
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="servers" type="xs:string">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Sets the server blacklist. Each entry can be a list of servers separated by
 comma in the format: servicehost:port,servicehost2:port,servicehost3:port.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                   
@@ -19130,13 +17122,11 @@ comma in the format: servicehost:port,servicehost2:port,servicehost3:port.
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" type="tns:propertyDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Set client properties to use. These properties are specific to what service call
 implementation are in use. For example if using a different one, then the client
 properties are defined according to the specific service in use.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                   
@@ -19174,21 +17164,17 @@ properties are defined according to the specific service in use.
                 
         <xs:attribute name="timeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set the time the services will be retained. Default value: 60
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="units" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set the time unit for the timeout. Default value: SECONDS
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -19222,91 +17208,73 @@ Set the time unit for the timeout. Default value: SECONDS
                 
         <xs:attribute name="url" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The Consul agent URL.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="datacenter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The data center.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="aclToken" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the ACL token to be used with Consul.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="userName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the username to be used for basic authentication.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="password" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the password to be used for basic authentication.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="connectTimeoutMillis" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Connect timeout for OkHttpClient.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="readTimeoutMillis" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Read timeout for OkHttpClient.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="writeTimeoutMillis" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Write timeout for OkHttpClient.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="blockSeconds" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The seconds to wait for a watch event, default 10 seconds. Default value: 10
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -19326,21 +17294,17 @@ The seconds to wait for a watch event, default 10 seconds. Default value: 10
                 
         <xs:attribute name="proto" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The transport protocol of the desired service. Default value: _tcp
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="domain" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The domain name;.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -19360,8 +17324,7 @@ The domain name;.
                 
         <xs:attribute name="lookup" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 How to perform service lookup. Possible values: client, dns, environment. When
 using client, then the client queries the kubernetes master to obtain a list of
 active pods that provides the service, and then random (or round robin) select a
@@ -19370,194 +17333,157 @@ name.namespace.svc.dnsDomain. When using dnssrv the service name is resolved
 with SRV query for _._...svc... When using environment then environment
 variables are used to lookup the service. By default environment is used.
 Default value: environment
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="dnsDomain" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the DNS domain to use for DNS lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="portName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the Port Name to use for DNS/DNSSRV lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="portProtocol" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the Port Protocol to use for DNS/DNSSRV lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="namespace" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the namespace to use. Will by default use namespace from the ENV variable
 KUBERNETES_MASTER.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="apiVersion" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the API version when using client lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="masterUrl" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the URL to the master when using client lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="username" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the username for authentication when using client lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="password" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the password for authentication when using client lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="oauthToken" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the OAUTH token for authentication (instead of username/password) when
 using client lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="caCertData" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the Certificate Authority data when using client lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="caCertFile" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the Certificate Authority data that are loaded from the file when using
 client lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="clientCertData" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the Client Certificate data when using client lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="clientCertFile" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the Client Certificate data that are loaded from the file when using client
 lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="clientKeyAlgo" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the Client Keystore algorithm, such as RSA when using client lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="clientKeyData" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the Client Keystore data when using client lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="clientKeyFile" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the Client Keystore data that are loaded from the file when using client
 lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="clientKeyPassphrase" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the Client Keystore passphrase when using client lookup.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="trustCerts" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether to turn on trust certificate check when using client lookup.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -19607,12 +17533,10 @@ Default value: false
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="servers" type="xs:string">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Sets the server list. Each entry can be a list of servers separated by comma in
 the format: servicehost:port,servicehost2:port,servicehost3:port.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                   
@@ -19662,11 +17586,9 @@ the format: servicehost:port,servicehost2:port,servicehost3:port.
                 
         <xs:attribute name="ref" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Reference of a ServiceFilter.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -19776,11 +17698,9 @@ Reference of a ServiceFilter.
                     
           <xs:element minOccurs="0" name="expression" type="tns:serviceCallExpressionConfiguration">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Configures the Expression using the given configuration.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                   
@@ -19788,82 +17708,66 @@ Configures the Expression using the given configuration.
                 
         <xs:attribute name="uri" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The uri of the endpoint to send to. The uri can be dynamic computed using the
 simple language expression.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="component" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The component to use. Default value: http
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="pattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the optional ExchangePattern used to invoke this endpoint.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="serviceDiscoveryRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a custom ServiceDiscovery to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="serviceFilterRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a custom ServiceFilter to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="serviceChooserRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a custom ServiceChooser to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="loadBalancerRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a custom ServiceLoadBalancer to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="expressionRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set a reference to a custom Expression to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -19883,83 +17787,67 @@ Set a reference to a custom Expression to use.
                 
         <xs:attribute name="nodes" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A comma separate list of servers to connect to in the form host:port.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="namespace" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 As ZooKeeper is a shared space, users of a given cluster should stay within a
 pre-defined namespace. If a namespace is set here, all paths will get pre-pended
 with the namespace.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="reconnectBaseSleepTime" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Initial amount of time to wait between retries.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="reconnectMaxSleepTime" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Max time in ms to sleep on each retry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="reconnectMaxRetries" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Max number of times to retry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="sessionTimeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Session timeout.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="connectionTimeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Connection timeout.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="basePath" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set the base path to store in ZK.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20033,23 +17921,19 @@ Set the base path to store in ZK.
                 
         <xs:attribute name="hostHeader" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The header that holds the service host information, default
 ServiceCallConstants.SERVICE_HOST. Default value: CamelServiceCallServiceHost
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="portHeader" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The header that holds the service port information, default
 ServiceCallConstants.SERVICE_PORT. Default value: CamelServiceCallServicePort
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20103,11 +17987,9 @@ ServiceCallConstants.SERVICE_PORT. Default value: CamelServiceCallServicePort
                     
           <xs:element minOccurs="0" name="expression" type="tns:serviceCallExpressionConfiguration">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Configures the Expression using the given configuration.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                   
@@ -20115,102 +17997,82 @@ Configures the Expression using the given configuration.
                 
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the name of the service to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="uri" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The uri of the endpoint to send to. The uri can be dynamic computed using the
 org.apache.camel.language.simple.SimpleLanguage expression.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="component" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The component to use. Default value: http
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="pattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the optional ExchangePattern used to invoke this endpoint.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="configurationRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Refers to a ServiceCall configuration to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="serviceDiscoveryRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a custom ServiceDiscovery to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="serviceFilterRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a custom ServiceFilter to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="serviceChooserRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a custom ServiceChooser to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="loadBalancerRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a reference to a custom ServiceLoadBalancer to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="expressionRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set a reference to a custom Expression to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20344,11 +18206,9 @@ Set a reference to a custom Expression to use.
                 
         <xs:attribute name="ref" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 References to an existing or custom error handler.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20376,11 +18236,9 @@ References to an existing or custom error handler.
                 
         <xs:attribute name="resultType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the class of the result type (type from output).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20408,21 +18266,17 @@ Sets the class of the result type (type from output).
                 
         <xs:attribute name="bodyMediaType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The String representation of the message's body MediaType.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="outputMediaType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The String representation of the MediaType to output.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20480,23 +18334,19 @@ The String representation of the MediaType to output.
                 
         <xs:attribute name="headerName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of header to use as input, instead of the message body It has as higher
 precedent than the propertyName if both are set.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="propertyName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of property to use as input, instead of the message body. It has a lower
 precedent than the headerName if both are set.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20524,25 +18374,21 @@ precedent than the headerName if both are set.
                 
         <xs:attribute name="preCompile" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the expression should be pre compiled once during initialization phase.
 If this is turned off, then the expression is reloaded and compiled on each
 evaluation. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="singleQuotes" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether single quotes can be used as replacement for double quotes. This is
 convenient when you need to work with strings inside strings. Default value:
 true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20570,67 +18416,55 @@ true
                 
         <xs:attribute name="suppressExceptions" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to suppress exceptions such as PathNotFoundException. Default value:
 false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowSimple" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to allow in inlined Simple exceptions in the JSONPath expression.
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowEasyPredicate" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to allow using the easy predicate parser to pre-parse predicates.
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="writeAsString" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to write the output of each row/element as a JSON String value instead
 of a Map/POJO value. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="unpackArray" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to unpack a single element json-array into an object. Default value:
 false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="option" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To configure additional options on JSONPath. Multiple values can be separated by
 comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20648,11 +18482,9 @@ comma.
                 
         <xs:attribute name="language" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The name of the language to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20670,40 +18502,33 @@ The name of the language to use.
                 
         <xs:attribute name="ref" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Reference to an existing bean (bean id) to lookup in the registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="method" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of method to call.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="beanType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Class name (fully qualified) of the bean to use Will lookup in registry and if
 there is a single instance of the same type, then the existing bean is used,
 otherwise a new bean is created (requires a default no-arg constructor).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="scope" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Scope of bean. When using singleton scope (default) the bean is created or
 looked up only once and reused for the lifetime of the endpoint. The bean should
 be thread-safe in case concurrent threads is calling the bean at the same time.
@@ -20717,8 +18542,7 @@ this is delegated to the bean registry such as Spring or CDI (if in use), which
 depends on their configuration can act as either singleton or prototype scope.
 So when using prototype scope then this depends on the bean registry
 implementation. Default value: Singleton
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20756,23 +18580,19 @@ implementation. Default value: Singleton
                 
         <xs:attribute name="headerName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of header to use as input, instead of the message body It has as higher
 precedent than the propertyName if both are set.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="propertyName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of property to use as input, instead of the message body. It has a lower
 precedent than the headerName if both are set.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20840,100 +18660,82 @@ precedent than the headerName if both are set.
                 
         <xs:attribute name="token" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The (start) token to use as tokenizer, for example you can use the new line
 token. You can use simple language as the token to support dynamic tokens.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="endToken" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The end token to use as tokenizer if using start/end token pairs. You can use
 simple language as the token to support dynamic tokens.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="inheritNamespaceTagName" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To inherit namespaces from a root/parent tag name when using XML You can use
 simple language as the tag name to support dynamic names.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="regex" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If the token is a regular expression pattern. The default value is false.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="xml" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether the input is XML messages. This option must be set to true if working
 with XML payloads. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="includeTokens" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to include the tokens in the parts when using pairs. When including
 tokens then the endToken property must also be configured (to use pair mode).
 The default value is false. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="group" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To group N parts together, for example to split big files into chunks of 1000
 lines. You can use simple language as the group to support dynamic group sizes.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="groupDelimiter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the delimiter to use when grouping. If this has not been set then token
 will be used as the delimiter.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="skipFirst" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To skip the very first element. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20951,25 +18753,21 @@ To skip the very first element. Default value: false
                 
         <xs:attribute name="mode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The extraction mode. The available extraction modes are: i - injecting the
 contextual namespace bindings into the extracted token (default) w - wrapping
 the extracted token in its ancestor context u - unwrapping the extracted token
 to its child content t - extracting the text content of the specified element.
 Default value: i
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="group" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To group N parts together.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -20987,70 +18785,57 @@ To group N parts together.
                 
         <xs:attribute name="documentType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Name of class for document type The default value is org.w3c.dom.Document.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="resultType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the class name of the result type (type from output) The default result
 type is NodeSet. Default value: NODESET
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="saxon" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to use Saxon. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="factoryRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 References to a custom XPathFactory to lookup in the registry.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="objectModel" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The XPath object model to use.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logNamespaces" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to log namespaces which can assist during troubleshooting. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="threadSafety" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to enable thread-safety for the returned result of the xpath expression.
 This applies to when using NODESET as the result type, and the returned set has
 multiple elements. In this situation there can be thread-safety issues if you
@@ -21059,23 +18844,20 @@ processing mode. This option prevents concurrency issues by doing defensive
 copies of the nodes. It is recommended to turn this option on if you are using
 camel-saxon or Saxon in your application. Saxon has thread-safety issues which
 can be prevented by turning this option on. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="preCompile" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to enable pre-compiling the xpath expression during initialization
 phase. pre-compile is enabled by default. This can be used to turn off, for
 example in cases the compilation phase is desired at the starting phase, such as
 if the application is ahead of time compiled (for example with camel-quarkus)
 which would then load the xpath factory of the built operating system, and not a
 JVM runtime. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -21093,34 +18875,28 @@ JVM runtime. Default value: true
                 
         <xs:attribute name="resultType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the class of the result type (type from output).
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="type" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the class name of the result type (type from output) The default result
 type is NodeSet.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="configurationRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Reference to a saxon configuration instance in the registry to use for xquery
 (requires camel-saxon). This may be needed to add custom functions to a saxon
 configuration, so these custom functions can be used in xquery expressions.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -21140,41 +18916,33 @@ configuration, so these custom functions can be used in xquery expressions.
                 
         <xs:attribute name="name" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The name of the header or query parameter to be used.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="inHeader" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use header as the location of the API key. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="inQuery" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use query parameter as the location of the API key. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="inCookie" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a cookie as the location of the API key. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -21190,21 +18958,17 @@ To use a cookie as the location of the API key. Default value: false
         
     <xs:attribute name="key" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Key used to refer to this security definition.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="description" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 A short description for security scheme.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -21234,11 +18998,9 @@ A short description for security scheme.
                 
         <xs:attribute name="format" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 A hint to the client to identify how the bearer token is formatted.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -21282,104 +19044,87 @@ A hint to the client to identify how the bearer token is formatted.
                 
         <xs:attribute name="path" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The path mapping URIs of this REST operation such as /{id}.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="consumes" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To define the content type what the REST service consumes (accept as input),
 such as application/xml or application/json. This option will override what may
 be configured on a parent level.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="produces" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To define the content type what the REST service produces (uses for output),
 such as application/xml or application/json This option will override what may
 be configured on a parent level.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="disabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to disable this REST service from the route during build time. Once an
 REST service has been disabled then it cannot be enabled later at runtime.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="type" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the class name to use for binding from input to POJO for the incoming data
 This option will override what may be configured on a parent level. The name of
 the class of the input data. Append a to the end of the name if you want the
 input to be an array type.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="outType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the class name to use for binding from POJO to output for the outgoing data
 This option will override what may be configured on a parent level The name of
 the class of the input data. Append a to the end of the name if you want the
 input to be an array type.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="bindingMode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the binding mode to use. This option will override what may be configured
 on a parent level The default value is off. Default value: off
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="skipBindingOnErrorCode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to skip binding on output if there is a custom HTTP error code header.
 This allows to build custom error messages that do not bind to json / xml etc,
 as success messages otherwise will do. This option will override what may be
 configured on a parent level. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="clientRequestValidation" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to enable validation of the client request to check: 1) Content-Type
 header matches what the Rest DSL consumes; returns HTTP Status 415 if validation
 error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status
@@ -21387,52 +19132,43 @@ error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status
 headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of
 the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP
 Status 400 if validation error. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="enableCORS" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to enable CORS headers in the HTTP response. This option will override
 what may be configured on a parent level The default value is false. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="apiDocs" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to include or exclude this rest operation in API documentation. The
 default value is true. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="deprecated" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Marks this rest operation as deprecated in OpenApi documentation. Default value:
 false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="routeId" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the id of the route.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -21448,11 +19184,9 @@ Sets the id of the route.
             
       <xs:element minOccurs="0" name="allowableValues">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter list of allowable values (enum).
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
                 
         <xs:complexType>
@@ -21469,11 +19203,9 @@ Sets the parameter list of allowable values (enum).
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="examples" type="tns:restPropertyDefinition">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter examples.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
           
@@ -21481,92 +19213,74 @@ Sets the parameter examples.
         
     <xs:attribute name="name" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter name.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="type" type="tns:restParamType" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter type. Default value: path
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="description" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter description.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="defaultValue" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter default value.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="required" type="xs:boolean">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter required flag. Default value: true
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="collectionFormat" type="tns:collectionFormat">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter collection format. Default value: csv
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="arrayType" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter array type. Required if data type is array. Describes the
 type of items in the array. Default value: string
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="dataType" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter data type. Default value: string
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="dataFormat" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter data format.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -21578,21 +19292,17 @@ Sets the parameter data format.
         
     <xs:attribute name="key" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Property key.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="value" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Property value.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -21604,21 +19314,17 @@ Property value.
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="header" type="tns:responseHeaderDefinition">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Adds a response header.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="examples" type="tns:restPropertyDefinition">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Examples of response messages.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
           
@@ -21626,31 +19332,25 @@ Examples of response messages.
         
     <xs:attribute name="code" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The response code such as a HTTP status code. Default value: 200
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="message" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The response message (description).
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="responseModel" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The response model.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -21662,11 +19362,9 @@ The response model.
             
       <xs:element minOccurs="0" name="allowableValues">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter list of allowable values.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
                 
         <xs:complexType>
@@ -21685,72 +19383,58 @@ Sets the parameter list of allowable values.
         
     <xs:attribute name="name" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Name of the parameter. This option is mandatory.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="description" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Description of the parameter.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="collectionFormat" type="tns:collectionFormat">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter collection format. Default value: csv
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="arrayType" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter array type. Required if data type is array. Describes the
 type of items in the array. Default value: string
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="dataType" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the header data type. Default value: string
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="dataFormat" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the parameter data format.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="example" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the example.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -21762,21 +19446,17 @@ Sets the example.
         
     <xs:attribute name="key" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Key used to refer to this security definition.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="scopes" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The scopes to allow (separate multiple scopes by comma).
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -21834,11 +19514,9 @@ The scopes to allow (separate multiple scopes by comma).
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="scopes" type="tns:restPropertyDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 The available scopes for an OAuth2 security scheme.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                   
@@ -21846,45 +19524,37 @@ The available scopes for an OAuth2 security scheme.
                 
         <xs:attribute name="authorizationUrl" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The authorization URL to be used for this flow. This SHOULD be in the form of a
 URL. Required for implicit and access code flows.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="tokenUrl" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The token URL to be used for this flow. This SHOULD be in the form of a URL.
 Required for password, application, and access code flows.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="refreshUrl" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The URL to be used for obtaining refresh tokens. This MUST be in the form of a
 URL.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="flow" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The flow used by the OAuth2 security scheme. Valid values are implicit,
 password, application or accessCode.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -21904,11 +19574,9 @@ password, application or accessCode.
                 
         <xs:attribute name="url" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 OpenId Connect URL to discover OAuth2 configuration values.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -21970,76 +19638,63 @@ OpenId Connect URL to discover OAuth2 configuration values.
                 
         <xs:attribute name="consumes" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To define the content type what the REST service consumes (accept as input),
 such as application/xml or application/json.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="produces" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To define the content type what the REST service produces (uses for output),
 such as application/xml or application/json.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="bindingMode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the binding mode to use. The default value is off. Default value: off
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="type" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the class name to use for binding from input to POJO for the incoming data
 The name of the class of the input data. Append a to the end of the name if you
 want the input to be an array type.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="outType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the class name to use for binding from POJO to output for the outgoing data
 The name of the class of the input data. Append a to the end of the name if you
 want the input to be an array type.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="skipBindingOnErrorCode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to skip binding on output if there is a custom HTTP error code header.
 This allows to build custom error messages that do not bind to json / xml etc,
 as success messages otherwise will do. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="clientRequestValidation" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to enable validation of the client request to check: 1) Content-Type
 header matches what the Rest DSL consumes; returns HTTP Status 415 if validation
 error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status
@@ -22047,29 +19702,24 @@ error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status
 headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of
 the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP
 Status 400 if validation error. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="enableCORS" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to enable CORS headers in the HTTP response. The default value is false.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="component" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the component name that this definition will apply to.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -22085,38 +19735,31 @@ Sets the component name that this definition will apply to.
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="componentProperty" type="tns:restPropertyDefinition">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Allows to configure as many additional properties for the rest component in use.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="endpointProperty" type="tns:restPropertyDefinition">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Allows to configure as many additional properties for the rest endpoint in use.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="consumerProperty" type="tns:restPropertyDefinition">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Allows to configure as many additional properties for the rest consumer in use.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="dataFormatProperty" type="tns:restPropertyDefinition">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Allows to configure as many additional properties for the data formats in use.
 For example set property prettyPrint to true to have json outputted in pretty
 mode. The properties can be prefixed to denote the option is only for either
@@ -22124,29 +19767,24 @@ JSON or XML and for either the IN or the OUT. The prefixes are: json.in.
 json.out. xml.in. xml.out. For example a key with value
 xml.out.mustBeJAXBElement is only for the XML data format for the outgoing. A
 key without a prefix is a common key for all situations.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="apiProperty" type="tns:restPropertyDefinition">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Allows to configure as many additional properties for the api documentation. For
 example set property api.title to my cool stuff.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="corsHeaders" type="tns:restPropertyDefinition">
         <xs:annotation>
-          <xs:documentation xml:lang="en">
-            <![CDATA[
+          <xs:documentation xml:lang="en"><![CDATA[
 Allows to configure custom CORS headers.
-          ]]>
-          </xs:documentation>
+          ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
           
@@ -22154,67 +19792,56 @@ Allows to configure custom CORS headers.
         
     <xs:attribute name="component" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The Camel Rest component to use for the REST transport (consumer), such as
 netty-http, jetty, servlet, undertow. If no component has been explicit
 configured, then Camel will lookup if there is a Camel component that integrates
 with the Rest DSL, or if a org.apache.camel.spi.RestConsumerFactory is
 registered in the registry. If either one is found, then that is being used.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="apiComponent" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The name of the Camel component to use as the REST API. If no API Component has
 been explicit configured, then Camel will lookup if there is a Camel component
 responsible for servicing and generating the REST API documentation, or if a
 org.apache.camel.spi.RestApiProcessorFactory is registered in the registry. If
 either one is found, then that is being used.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="producerComponent" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the name of the Camel component to use as the REST producer.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="scheme" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The scheme to use for exposing the REST service. Usually http or https is
 supported. The default value is http.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="host" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The hostname to use for exposing the REST service.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="port" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 The port number to use for exposing the REST service. Notice if you use servlet
 component then the port number configured here does not apply, as the port
 number in use is the actual port number the servlet component is using. eg if
@@ -22223,133 +19850,111 @@ service in Karaf that uses port 8181 by default etc. Though in those situations
 setting the port number here, allows tooling and JMX to know the port number, so
 its recommended to set the port number to the number that the servlet engine
 uses.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="apiHost" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 To use a specific hostname for the API documentation (such as swagger or
 openapi) This can be used to override the generated host with this configured
 hostname.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="useXForwardHeaders" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Whether to use X-Forward headers for Host and related setting. The default value
 is true. Default value: true
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="producerApiDoc" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the location of the api document the REST producer will use to validate the
 REST uri and query parameters are valid accordingly to the api document. The
 location of the api document is loaded from classpath by default, but you can
 use file: or http: to refer to resources to load from file or http url.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="contextPath" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets a leading context-path the REST services will be using. This can be used
 when using components such as camel-servlet where the deployed web application
 is deployed using a context-path. Or for components such as camel-jetty or
 camel-netty-http that includes a HTTP server.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="apiContextPath" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets a leading API context-path the REST API services will be using. This can be
 used when using components such as camel-servlet where the deployed web
 application is deployed using a context-path.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="apiContextRouteId" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the route id to use for the route that services the REST API. The route
 will by default use an auto assigned route id.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="apiVendorExtension" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Whether vendor extension is enabled in the Rest APIs. If enabled then Camel will
 include additional information as vendor extension (eg keys starting with x-)
 such as route ids, class names etc. Not all 3rd party API gateways and tools
 supports vendor-extensions when importing your API docs. Default value: false
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="hostNameResolver" type="tns:restHostNameResolver">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 If no hostname has been explicit configured, then this resolver is used to
 compute the hostname the REST service will be using. Default value: allLocalIp
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="bindingMode" type="tns:restBindingMode">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Sets the binding mode to use. The default value is off. Default value: off
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="skipBindingOnErrorCode" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Whether to skip binding on output if there is a custom HTTP error code header.
 This allows to build custom error messages that do not bind to json / xml etc,
 as success messages otherwise will do. Default value: false
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="clientRequestValidation" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Whether to enable validation of the client request to check: 1) Content-Type
 header matches what the Rest DSL consumes; returns HTTP Status 415 if validation
 error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status
@@ -22357,58 +19962,49 @@ error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status
 headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of
 the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP
 Status 400 if validation error. Default value: false
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="enableCORS" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Whether to enable CORS headers in the HTTP response. The default value is false.
 Default value: false
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="inlineRoutes" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Inline routes in rest-dsl which are linked using direct endpoints. By default,
 each service in Rest DSL is an individual route, meaning that you would have at
 least two routes per service (rest-dsl, and the route linked from rest-dsl).
 Enabling this allows Camel to optimize and inline this as a single route,
 however this requires to use direct endpoints, which must be unique per service.
 This option is default false. Default value: false
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="jsonDataFormat" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Name of specific json data format to use. By default jackson will be used.
 Important: This option is only for setting a custom name of the data format, not
 to refer to an existing data format instance.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
         
     <xs:attribute name="xmlDataFormat" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">
-          <![CDATA[
+        <xs:documentation xml:lang="en"><![CDATA[
 Name of specific XML data format to use. By default jaxb will be used.
 Important: This option is only for setting a custom name of the data format, not
 to refer to an existing data format instance.
-        ]]>
-        </xs:documentation>
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
       
@@ -22426,11 +20022,9 @@ to refer to an existing data format instance.
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="securityRequirements" type="tns:securityDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Sets the security requirement(s) for all endpoints.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
@@ -22454,78 +20048,65 @@ Sets the security requirement(s) for all endpoints.
                 
         <xs:attribute name="path" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Path of the rest service, such as /foo.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="consumes" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To define the content type what the REST service consumes (accept as input),
 such as application/xml or application/json. This option will override what may
 be configured on a parent level.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="produces" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To define the content type what the REST service produces (uses for output),
 such as application/xml or application/json This option will override what may
 be configured on a parent level.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="disabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to disable this REST service from the route during build time. Once an
 REST service has been disabled then it cannot be enabled later at runtime.
 Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="bindingMode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the binding mode to use. This option will override what may be configured
 on a parent level The default value is auto. Default value: off
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="skipBindingOnErrorCode" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to skip binding on output if there is a custom HTTP error code header.
 This allows to build custom error messages that do not bind to json / xml etc,
 as success messages otherwise will do. This option will override what may be
 configured on a parent level. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="clientRequestValidation" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to enable validation of the client request to check: 1) Content-Type
 header matches what the Rest DSL consumes; returns HTTP Status 415 if validation
 error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status
@@ -22533,42 +20114,35 @@ error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status
 headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of
 the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP
 Status 400 if validation error. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="enableCORS" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to enable CORS headers in the HTTP response. This option will override
 what may be configured on a parent level The default value is false. Default
 value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="apiDocs" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to include or exclude this rest operation in API documentation. This
 option will override what may be configured on a parent level. The default value
 is true. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="tag" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To configure a special tag for the operations within this rest definition.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -22948,15 +20522,13 @@ To configure a special tag for the operations within this rest definition.
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="package" type="xs:string">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Sets the package names to be recursively searched for Java classes which extend
 org.apache.camel.builder.RouteBuilder to be auto-wired up to the CamelContext as
 a route. Note that classes are excluded if they are specifically configured in
 the spring.xml A more advanced configuration can be done using
 setPackageScan(org.apache.camel.model.PackageScanDefinition).
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
@@ -22984,11 +20556,9 @@ setPackageScan(org.apache.camel.model.PackageScanDefinition).
                     
           <xs:element minOccurs="0" name="defaultServiceCallConfiguration" type="tns:serviceCallConfigurationDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 ServiceCall EIP default configuration.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
@@ -22996,11 +20566,9 @@ ServiceCall EIP default configuration.
                     
           <xs:element minOccurs="0" name="defaultResilience4jConfiguration" type="tns:resilience4JConfigurationDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 Resilience4j EIP default configuration.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
@@ -23008,21 +20576,17 @@ Resilience4j EIP default configuration.
                     
           <xs:element minOccurs="0" name="defaultFaultToleranceConfiguration" type="tns:faultToleranceConfigurationDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 MicroProfile Fault Tolerance EIP default configuration.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
           <xs:element maxOccurs="unbounded" minOccurs="0" name="faultToleranceConfiguration" type="tns:resilience4JConfigurationDefinition">
             <xs:annotation>
-              <xs:documentation xml:lang="en">
-                <![CDATA[
+              <xs:documentation xml:lang="en"><![CDATA[
 MicroProfile Circuit Breaker EIP configurations.
-              ]]>
-              </xs:documentation>
+              ]]></xs:documentation>
             </xs:annotation>
           </xs:element>
                     
@@ -23076,163 +20640,134 @@ MicroProfile Circuit Breaker EIP configurations.
                 
         <xs:attribute name="depends-on" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 List of other bean id's this CamelContext depends up. Multiple bean id's can be
 separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="startupSummaryLevel" type="tns:startupSummaryLevel">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Controls the level of information logged during startup (and shutdown) of
 CamelContext. Default value: Default
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="trace" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether tracing is enabled or not. To use tracing then this must be enabled
 on startup to be installed in the CamelContext.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="backlogTrace" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether backlog tracing is enabled or not. To use backlog tracing then this
 must be enabled on startup to be installed in the CamelContext.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="tracePattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Tracing pattern to match which node EIPs to trace. For example to match all To
 EIP nodes, use to. The pattern matches by node and route id's Multiple patterns
 can be separated by comma.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="traceLoggingFormat" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 To use a custom tracing logging format. The default format (arrow, routeId,
 label) is: %-4.4s %-12.12s %-33.33s.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="debug" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether debugging is enabled or not. To use debugging then this must be
 enabled on startup to be installed in the CamelContext.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="messageHistory" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether message history is enabled or not. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="sourceLocationEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to capture precise source location:line-number for all EIPs in Camel
 routes. Enabling this will impact parsing Java based routes (also Groovy,
 Kotlin, etc.) on startup as this uses JDK StackTraceElement to calculate the
 location from the Camel route, which comes with a performance cost. This only
 impact startup, not the performance of the routes at runtime. Default value:
 false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logMask" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether security mask for Logging is enabled or not. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="logExhaustedMessageBody" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether to log exhausted message body with message history.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="streamCache" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether stream caching is enabled or not.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="delayer" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets a delay value in millis that a message is delayed at every step it takes in
 the route path, slowing the process down to better observe what is occurring.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="errorHandlerRef" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the name of the error handler object used to default the error handling
 strategy.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="autoStartup" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether the object should automatically start when Camel starts. Important:
 Currently only routes can be disabled, as CamelContext s are always started.
 Note: When setting auto startup false on CamelContext then that takes precedence
@@ -23240,27 +20775,23 @@ and no routes is started. You would need to start CamelContext explicit using
 the org.apache.camel.CamelContext#start() method, to start the context, and then
 you would need to start the routes manually using
 org.apache.camel.spi.RouteController#startRoute(String) . Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="shutdownEager" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to shutdown CamelContext eager when Spring is shutting down. This ensure
 a cleaner shutdown of Camel, as dependent bean's are not shutdown at this
 moment. The bean's will then be shutdown after camelContext. Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="dumpRoutes" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 If dumping is enabled then Camel will during startup dump all loaded routes
 (incl rests and route templates) represented as XML DSL into the log. This is
 intended for trouble shooting or to assist during development. Sensitive
@@ -23268,25 +20799,21 @@ information that may be configured in the route endpoints could potentially be
 included in the dump output and is therefore not recommended to be used for
 production usage. This requires to have camel-xml-jaxb on the classpath to be
 able to dump the routes as XML. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useMDCLogging" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set whether MDC is enabled.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="mdcLoggingKeysPattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the pattern used for determine which custom MDC keys to propagate during
 message routing when the routing engine continues routing asynchronously for the
 given message. Setting this pattern to will propagate all custom keys. Or
@@ -23296,38 +20823,32 @@ starts with camel. as key name. The match rules are applied in this order (case
 insensitive): 1. exact match, returns true 2. wildcard match (pattern ends with
 a and the name starts with the pattern), returns true 3. regular expression
 match, returns true 4. otherwise returns false.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useDataType" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to enable using data type on Camel messages. Data type are automatic
 turned on if: one ore more routes has been explicit configured with input and
 output types when using rest-dsl with binding turned on Otherwise data type is
 default off.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="useBreadcrumb" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Set whether breadcrumb is enabled.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="beanPostProcessorEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Can be used to turn off bean post processing. Be careful to turn this off, as
 this means that beans that use Camel annotations such as
 org.apache.camel.EndpointInject , org.apache.camel.ProducerTemplate ,
@@ -23336,28 +20857,24 @@ in use. Turning this off should only be done if you are sure you do not use any
 of these Camel features. Not all runtimes allow turning this off (such as
 camel-blueprint or camel-cdi with XML). The default value is true (enabled).
 Default value: true
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="allowUseOriginalMessage" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether to allow access to the original message from Camel's error handler,
 or from org.apache.camel.spi.UnitOfWork#getOriginalInMessage() . Turning this
 off can optimize performance, as defensive copy of the original message is not
 needed.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="caseInsensitiveHeaders" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to use case sensitive or insensitive headers. Important: When using case
 sensitive (this is set to false). Then the map is case sensitive which means
 headers such as content-type and Content-Type are two different keys which can
@@ -23365,99 +20882,83 @@ be a problem for some protocols such as HTTP based, which rely on case
 insensitive headers. However case sensitive implementations can yield faster
 performance. Therefore use case sensitive implementation with care. Default is
 true.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="autowiredEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether autowiring is enabled. This is used for automatic autowiring options
 (the option must be marked as autowired) by looking up in the registry to find
 if there is a single instance of matching type, which then gets configured on
 the component. This can be used for automatic configuring JDBC data sources, JMS
 connection factories, AWS Clients, etc. Default is true.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="runtimeEndpointRegistryEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether org.apache.camel.spi.RuntimeEndpointRegistry is enabled.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="managementNamePattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The naming pattern for creating the CamelContext management name. Default value:
 #name#
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="threadNamePattern" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the thread name pattern used for creating the full thread name. The default
 pattern is: Camel (#camelId#) thread ##counter# - #name# Where #camelId# is the
 name of the org.apache.camel.CamelContext and #counter# is a unique incrementing
 counter. and #name# is the regular thread name. You can also use #longName# is
 the long thread name which can includes endpoint parameters etc. Default value:
 Camel (#camelId#) thread ##counter# - #name#
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="shutdownRoute" type="tns:shutdownRoute">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the ShutdownRoute option for routes. Default value: Default
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="shutdownRunningTask" type="tns:shutdownRunningTask">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets the ShutdownRunningTask option to use when shutting down a route. Default
 value: CompleteCurrentTaskOnly
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="loadTypeConverters" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to load custom type converters by scanning classpath. This is used for
 backwards compatibility with Camel 2.x. Its recommended to migrate to use fast
 type converter loading by setting Converter(loader = true) on your custom type
 converter classes. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="typeConverterStatisticsEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether or not type converter statistics is enabled. By default the type
 converter utilization statistics is disabled. Notice: If enabled then there is a
 slight performance impact under very heavy load. You can enable/disable the
@@ -23465,53 +20966,44 @@ statistics at runtime using the
 org.apache.camel.spi.TypeConverterRegistry#getStatistics()#setTypeConverterStatisticsEnabled(Boolean)
 method, or from JMX on the
 org.apache.camel.api.management.mbean.ManagedTypeConverterRegistryMBean mbean.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="loadHealthChecks" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Whether to load custom health checks by scanning classpath. Default value: false
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="inflightRepositoryBrowseEnabled" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 Sets whether the inflight repository should allow browsing each inflight
 exchange. This is by default disabled as there is a very slight performance
 overhead when enabled.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="typeConverterExists" type="tns:typeConverterExists">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 What should happen when attempting to add a duplicate type converter. The
 default behavior is to ignore the duplicate. Default value: Ignore
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="typeConverterExistsLoggingLevel" type="tns:loggingLevel">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The logging level to use when logging that a type converter already exists when
 attempting to add a duplicate type converter. The default logging level is
 DEBUG. Default value: DEBUG
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               
@@ -23803,46 +21295,38 @@ DEBUG. Default value: DEBUG
                 
         <xs:attribute name="sessionTimeout" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The optional SSLSessionContext timeout time for javax.net.ssl.SSLSession in
 seconds.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="provider" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The optional provider identifier for the JSSE implementation to use when
 constructing an SSLContext.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="secureSocketProtocol" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 The optional protocol for the secure sockets created by the SSLContext
 represented by this instance's configuration. See Appendix A in the Java Secure
 Socket Extension Reference Guide for information about standard protocol names.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
                 
         <xs:attribute name="certAlias" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">
-              <![CDATA[
+            <xs:documentation xml:lang="en"><![CDATA[
 An optional certificate alias to use. This is useful when the keystore has
 multiple certificates.
-            ]]>
-            </xs:documentation>
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
               

--- a/components/camel-dynamic-router/src/main/java/org/apache/camel/component/dynamicrouter/DynamicRouterProcessor.java
+++ b/components/camel-dynamic-router/src/main/java/org/apache/camel/component/dynamicrouter/DynamicRouterProcessor.java
@@ -237,6 +237,7 @@ public class DynamicRouterProcessor extends AsyncProcessorSupport implements Tra
     List<PrioritizedFilterProcessor> matchFilters(final Exchange exchange) {
         return Optional.of(
                 filterMap.values().stream()
+                        .sorted()
                         .filter(f -> f.matches(exchange))
                         .limit(MODE_FIRST_MATCH.equals(recipientMode) ? 1 : Integer.MAX_VALUE)
                         .collect(Collectors.toList()))

--- a/components/camel-dynamic-router/src/test/java/org/apache/camel/component/dynamicrouter/support/DynamicRouterTestSupport.java
+++ b/components/camel-dynamic-router/src/test/java/org/apache/camel/component/dynamicrouter/support/DynamicRouterTestSupport.java
@@ -113,7 +113,10 @@ public class DynamicRouterTestSupport extends CamelTestSupport {
     protected DynamicRouterControlProducer controlProducer;
 
     @Mock
-    protected PrioritizedFilterProcessor filterProcessor;
+    protected PrioritizedFilterProcessor filterProcessorLowPriority;
+
+    @Mock
+    protected PrioritizedFilterProcessor filterProcessorLowestPriority;
 
     @Mock
     protected DynamicRouterControlMessage controlMessage;
@@ -183,8 +186,10 @@ public class DynamicRouterTestSupport extends CamelTestSupport {
 
         lenient().when(simpleLanguage.createPredicate(anyString())).thenReturn(predicate);
 
-        lenient().when(filterProcessor.getId()).thenReturn(TEST_ID);
-        lenient().when(filterProcessor.getPriority()).thenReturn(Integer.MAX_VALUE);
+        lenient().when(filterProcessorLowPriority.getId()).thenReturn(TEST_ID);
+        lenient().when(filterProcessorLowPriority.getPriority()).thenReturn(Integer.MAX_VALUE - 1000);
+
+        lenient().when(filterProcessorLowestPriority.getPriority()).thenReturn(Integer.MAX_VALUE);
 
         lenient().doNothing().when(asyncCallback).done(anyBoolean());
 
@@ -249,7 +254,7 @@ public class DynamicRouterTestSupport extends CamelTestSupport {
             @Override
             public PrioritizedFilterProcessor getInstance(
                     String id, int priority, CamelContext context, Predicate predicate, Processor processor) {
-                return filterProcessor;
+                return filterProcessorLowPriority;
             }
         };
     }


### PR DESCRIPTION
CAMEL-19198: Added sorting logic to ensure dynamic router eip component filters are evaluated in order of their priority property

# Description

When filters are evaluated, the filters are now sorted by priority before being evaluated. 

# Target

- [x ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`
