### PR TITLE
Align all Pulsar versions to 2.11.0

### DIFF
--- a/test-infra/camel-test-infra-pulsar/src/test/java/org/apache/camel/test/infra/pulsar/services/PulsarLocalContainerService.java
+++ b/test-infra/camel-test-infra-pulsar/src/test/java/org/apache/camel/test/infra/pulsar/services/PulsarLocalContainerService.java
@@ -26,7 +26,7 @@ import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class PulsarLocalContainerService implements PulsarService, ContainerService<PulsarContainer> {
-    public static final String CONTAINER_IMAGE = "apachepulsar/pulsar:2.10.3";
+    public static final String CONTAINER_IMAGE = "apachepulsar/pulsar:2.11.0";
 
     private static final Logger LOG = LoggerFactory.getLogger(PulsarLocalContainerService.class);
 


### PR DESCRIPTION
# Description

This PR aligns the Pulsar container version used in the integration test with the dependency version. It's tested by the following commands:

```
$ ./mvnw clean install -f test-infra/camel-test-infra-pulsar/pom.xml
$ ./mvnw clean verify -f components/camel-pulsar/pom.xml
```

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

This PR doesn't require the corresponding JIRA issue since it's just a container version upgrade.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

