### PR TITLE
Remove unnecessary property due to deprecating the Spark component

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -452,7 +452,6 @@
         <!-- solr version aligned with lucene -->
         <solr-version>8.11.2</solr-version>
         <solr-zookeeper-version>3.6.2</solr-zookeeper-version>
-        <spark-version>3.3.1</spark-version>
         <splunk-version>1.9.0_1</splunk-version>
         <spock-version>2.3-groovy-4.0</spock-version>
         <spring-batch-version>4.3.8</spring-batch-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -447,7 +447,6 @@
         <!-- solr version aligned with lucene -->
         <solr-version>8.11.2</solr-version>
         <solr-zookeeper-version>3.6.2</solr-zookeeper-version>
-        <spark-version>3.3.1</spark-version>
         <splunk-version>1.9.0_1</splunk-version>
         <spock-version>2.3-groovy-4.0</spock-version>
         <spring-batch-version>4.3.8</spring-batch-version>


### PR DESCRIPTION
# Description

This PR removes unnecessary property from parent/pom.xml in accordance with the deprecation of the Spark component. It is tested by the following command:

```
$ ./mvnw clean install -Pfastinstall
```

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

This PR doesn't require the corresponding JIRA issue since it's just a single property removal.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

