### PR TITLE
provide a way to define global groovy variables

### DIFF
--- a/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyExpression.java
+++ b/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyExpression.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.language.groovy;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -61,7 +62,7 @@ public class GroovyExpression extends ExpressionSupport {
         Set<GroovyShellFactory> shellFactories = exchange.getContext().getRegistry().findByType(GroovyShellFactory.class);
         GroovyShellFactory shellFactory = null;
         String fileName = null;
-        Map<String, Object> variables = null;
+        Map<String, Object> variables = Collections.emptyMap();
         if (shellFactories.size() == 1) {
             shellFactory = shellFactories.iterator().next();
             fileName = shellFactory.getFileName(exchange);
@@ -79,12 +80,11 @@ public class GroovyExpression extends ExpressionSupport {
         }
         // New instance of the script
         Script script = ObjectHelper.newInstance(scriptClass, Script.class);
-        if (null != variables) {
-            Binding binding = script.getBinding();
-            for (Map.Entry<String, Object> variableEntry : variables.entrySet()) {
-                binding.setVariable(variableEntry.getKey(), variableEntry.getValue());
-            }
+        Binding binding = script.getBinding();
+        for (Map.Entry<String, Object> variableEntry : variables.entrySet()) {
+            binding.setVariable(variableEntry.getKey(), variableEntry.getValue());
         }
+
         return script;
     }
 

--- a/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyExpression.java
+++ b/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyExpression.java
@@ -48,7 +48,7 @@ public class GroovyExpression extends ExpressionSupport {
     @Override
     public <T> T evaluate(Exchange exchange, Class<T> type) {
         Script script = instantiateScript(exchange);
-        script.setBinding(createBinding(exchange));
+        populateBinding(script.getBinding(), exchange);
         Object value = script.run();
 
         return exchange.getContext().getTypeConverter().convertTo(type, value);
@@ -61,9 +61,11 @@ public class GroovyExpression extends ExpressionSupport {
         Set<GroovyShellFactory> shellFactories = exchange.getContext().getRegistry().findByType(GroovyShellFactory.class);
         GroovyShellFactory shellFactory = null;
         String fileName = null;
+        Map<String, Object> variables = null;
         if (shellFactories.size() == 1) {
             shellFactory = shellFactories.iterator().next();
             fileName = shellFactory.getFileName(exchange);
+            variables = shellFactory.getVariables(exchange);
         }
         final String key = fileName != null ? fileName + text : text;
         Class<Script> scriptClass = language.getScriptFromCache(key);
@@ -75,14 +77,22 @@ public class GroovyExpression extends ExpressionSupport {
                     ? shell.getClassLoader().parseClass(text, fileName) : shell.getClassLoader().parseClass(text);
             language.addScriptToCache(key, scriptClass);
         }
-
         // New instance of the script
-        return ObjectHelper.newInstance(scriptClass, Script.class);
+        Script script = ObjectHelper.newInstance(scriptClass, Script.class);
+        if (null != variables) {
+            Binding binding = script.getBinding();
+            for (Map.Entry<String, Object> variableEntry : variables.entrySet()) {
+                binding.setVariable(variableEntry.getKey(), variableEntry.getValue());
+            }
+        }
+        return script;
     }
 
-    private Binding createBinding(Exchange exchange) {
+    private void populateBinding(Binding binding, Exchange exchange) {
         Map<String, Object> variables = new HashMap<>();
         ExchangeHelper.populateVariableMap(exchange, variables, true);
-        return new Binding(variables);
+        for (Map.Entry<String, Object> variableEntry : variables.entrySet()) {
+            binding.setVariable(variableEntry.getKey(), variableEntry.getValue());
+        }
     }
 }

--- a/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyShellFactory.java
+++ b/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyShellFactory.java
@@ -19,11 +19,17 @@ package org.apache.camel.language.groovy;
 import groovy.lang.GroovyShell;
 import org.apache.camel.Exchange;
 
+import java.util.Map;
+
 public interface GroovyShellFactory {
 
     GroovyShell createGroovyShell(Exchange exchange);
 
     default String getFileName(Exchange exchange) {
+        return null;
+    }
+
+    default Map<String, Object> getVariables(Exchange exchange) {
         return null;
     }
 

--- a/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyShellFactory.java
+++ b/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyShellFactory.java
@@ -29,6 +29,12 @@ public interface GroovyShellFactory {
         return null;
     }
 
+    /**
+     * This method provide a way to define some global variables that will be applied to all the groovy script context.
+     *
+     * @param exchange the camel exchange in process.
+     * @return the global variables that will be applied to all the groovy script context.
+     */
     default Map<String, Object> getVariables(Exchange exchange) {
         return null;
     }

--- a/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyShellFactory.java
+++ b/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyShellFactory.java
@@ -16,10 +16,11 @@
  */
 package org.apache.camel.language.groovy;
 
+import java.util.Collections;
+import java.util.Map;
+
 import groovy.lang.GroovyShell;
 import org.apache.camel.Exchange;
-
-import java.util.Map;
 
 public interface GroovyShellFactory {
 
@@ -36,7 +37,6 @@ public interface GroovyShellFactory {
      * @return the global variables that will be applied to all the groovy script context.
      */
     default Map<String, Object> getVariables(Exchange exchange) {
-        return null;
+        return Collections.emptyMap();
     }
-
 }


### PR DESCRIPTION
# Description
When using groovy script, we sometime need to config some global variables without pollute the camelContext and exchange,  that say,  in every script we want to use not only the request, response, context, but also some other global variables, and don't want to put them in the header etc.
So we need a interface method to meet this request.
# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)




