### PR TITLE
CAMEL-19214: camel-hdfs - Add ShortWritable support to the HDFS component

### DIFF
--- a/components/camel-hdfs/src/main/docs/hdfs-component.adoc
+++ b/components/camel-hdfs/src/main/docs/hdfs-component.adoc
@@ -75,6 +75,7 @@ include::partial$component-endpoint-headers.adoc[]
 * BYTE for writing a byte, the java Byte class is mapped into a BYTE
 * BYTES for writing a sequence of bytes. It maps the java ByteBuffer
 class
+* SHORT for writing java short
 * INT for writing java integer
 * FLOAT for writing java float
 * LONG for writing java long

--- a/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/DefaultHdfsFile.java
+++ b/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/DefaultHdfsFile.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.io.FloatWritable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.ShortWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 
@@ -93,6 +94,7 @@ abstract class DefaultHdfsFile<T extends Closeable, U extends Closeable> impleme
             writables.put(ByteBuffer.class, new HdfsWritableFactories.HdfsBytesWritableFactory());
             writables.put(Double.class, new HdfsWritableFactories.HdfsDoubleWritableFactory());
             writables.put(Float.class, new HdfsWritableFactories.HdfsFloatWritableFactory());
+            writables.put(Short.class, new HdfsWritableFactories.HdfsShortWritableFactory());
             writables.put(Integer.class, new HdfsWritableFactories.HdfsIntWritableFactory());
             writables.put(Long.class, new HdfsWritableFactories.HdfsLongWritableFactory());
             writables.put(String.class, new HdfsWritableFactories.HdfsTextWritableFactory());
@@ -105,6 +107,7 @@ abstract class DefaultHdfsFile<T extends Closeable, U extends Closeable> impleme
             readables.put(BytesWritable.class, new HdfsWritableFactories.HdfsBytesWritableFactory());
             readables.put(DoubleWritable.class, new HdfsWritableFactories.HdfsDoubleWritableFactory());
             readables.put(FloatWritable.class, new HdfsWritableFactories.HdfsFloatWritableFactory());
+            readables.put(ShortWritable.class, new HdfsWritableFactories.HdfsShortWritableFactory());
             readables.put(IntWritable.class, new HdfsWritableFactories.HdfsIntWritableFactory());
             readables.put(LongWritable.class, new HdfsWritableFactories.HdfsLongWritableFactory());
             readables.put(Text.class, new HdfsWritableFactories.HdfsTextWritableFactory());

--- a/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/HdfsWritableFactories.java
+++ b/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/HdfsWritableFactories.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.ShortWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 
@@ -152,6 +153,25 @@ public class HdfsWritableFactories {
         public Object read(Writable writable, Holder<Integer> size) {
             size.setValue(SIZE);
             return ((FloatWritable) writable).get();
+        }
+    }
+
+    public static final class HdfsShortWritableFactory implements HdfsWritableFactory {
+
+        private static final int SIZE = 2;
+
+        @Override
+        public Writable create(Object value, TypeConverter typeConverter, Holder<Integer> size) {
+            size.setValue(SIZE);
+            ShortWritable writable = new ShortWritable();
+            writable.set(typeConverter.convertTo(Short.class, value));
+            return writable;
+        }
+
+        @Override
+        public Object read(Writable writable, Holder<Integer> size) {
+            size.setValue(SIZE);
+            return ((ShortWritable) writable).get();
         }
     }
 

--- a/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/WritableType.java
+++ b/components/camel-hdfs/src/main/java/org/apache/camel/component/hdfs/WritableType.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.io.FloatWritable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.ShortWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
 
@@ -47,6 +48,13 @@ public enum WritableType {
         @Override
         public Class<ByteWritable> getWritableClass() {
             return ByteWritable.class;
+        }
+    },
+
+    SHORT {
+        @Override
+        public Class<ShortWritable> getWritableClass() {
+            return ShortWritable.class;
         }
     },
 

--- a/components/camel-hdfs/src/test/java/org/apache/camel/component/hdfs/HdfsProducerTest.java
+++ b/components/camel-hdfs/src/test/java/org/apache/camel/component/hdfs/HdfsProducerTest.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.MapFile;
 import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.ShortWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.util.ReflectionUtils;
@@ -131,6 +132,23 @@ public class HdfsProducerTest extends HdfsTestSupport {
         reader.next(key, value);
         byte rByte = ((ByteWritable) value).get();
         assertEquals(rByte, aByte);
+
+        IOHelper.close(reader);
+    }
+
+    @Test
+    public void testWriteShort() throws Exception {
+        short aShort = 32767;
+        template.sendBody("direct:write_short", aShort);
+
+        Configuration conf = new Configuration();
+        Path file1 = new Path("file:///" + TEMP_DIR.toUri() + "/test-camel-short");
+        SequenceFile.Reader reader = new SequenceFile.Reader(conf, SequenceFile.Reader.file(file1));
+        Writable key = (Writable) ReflectionUtils.newInstance(reader.getKeyClass(), conf);
+        Writable value = (Writable) ReflectionUtils.newInstance(reader.getValueClass(), conf);
+        reader.next(key, value);
+        short rShort = ((ShortWritable) value).get();
+        assertEquals(rShort, aShort);
 
         IOHelper.close(reader);
     }
@@ -443,6 +461,9 @@ public class HdfsProducerTest extends HdfsTestSupport {
 
                 from("direct:write_byte").to("hdfs:localhost/" + TEMP_DIR.toUri()
                                              + "/test-camel-byte?fileSystemType=LOCAL&valueType=BYTE&fileType=SEQUENCE_FILE");
+
+                from("direct:write_short").to("hdfs:localhost/" + TEMP_DIR.toUri()
+                                              + "/test-camel-short?fileSystemType=LOCAL&valueType=SHORT&fileType=SEQUENCE_FILE");
 
                 from("direct:write_int").to("hdfs:localhost/" + TEMP_DIR.toUri()
                                             + "/test-camel-int?fileSystemType=LOCAL&valueType=INT&fileType=SEQUENCE_FILE");


### PR DESCRIPTION
# Description

The HDFS component supports most of Hadoop Writables corresponding to Java primary types, but it only doesn't support ShortWritable for some reason. This PR adds that support to the HDFS component.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking

- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`
