### PR TITLE
CAMEL-19216: camel-kudu - add predicate support to the scan operation

### DIFF
--- a/components/camel-kudu/src/main/java/org/apache/camel/component/kudu/KuduConstants.java
+++ b/components/camel-kudu/src/main/java/org/apache/camel/component/kudu/KuduConstants.java
@@ -23,6 +23,8 @@ public final class KuduConstants {
     public static final String CAMEL_KUDU_SCHEMA = "CamelKuduSchema";
     @Metadata(description = "The create table options", javaType = "org.apache.kudu.client.CreateTableOptions")
     public static final String CAMEL_KUDU_TABLE_OPTIONS = "CamelKuduTableOptions";
+    @Metadata(description = "The predicate for scan operation", javaType = "org.apache.kudu.client.KuduPredicate")
+    public static final String CAMEL_KUDU_SCAN_PREDICATE = "CamelKuduScanPredicate";
 
     private KuduConstants() {
     }

--- a/components/camel-kudu/src/main/java/org/apache/camel/component/kudu/KuduProducer.java
+++ b/components/camel-kudu/src/main/java/org/apache/camel/component/kudu/KuduProducer.java
@@ -27,6 +27,7 @@ import org.apache.kudu.client.Delete;
 import org.apache.kudu.client.Insert;
 import org.apache.kudu.client.KuduClient;
 import org.apache.kudu.client.KuduException;
+import org.apache.kudu.client.KuduPredicate;
 import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.PartialRow;
 import org.apache.kudu.client.Update;
@@ -175,6 +176,7 @@ public class KuduProducer extends DefaultProducer {
     }
 
     private void doScan(Exchange exchange, String tableName) throws KuduException {
-        exchange.getIn().setBody(KuduUtils.doScan(tableName, endpoint.getKuduClient()));
+        KuduPredicate predicate = (KuduPredicate) exchange.getIn().getHeader(KuduConstants.CAMEL_KUDU_SCAN_PREDICATE);
+        exchange.getIn().setBody(KuduUtils.doScan(tableName, endpoint.getKuduClient(), predicate));
     }
 }

--- a/components/camel-kudu/src/test/java/org/apache/camel/component/kudu/KuduScanTest.java
+++ b/components/camel-kudu/src/test/java/org/apache/camel/component/kudu/KuduScanTest.java
@@ -122,8 +122,7 @@ public class KuduScanTest extends AbstractKuduTest {
         sendBody("direct:scan", null, headers);
         List<Map<String, Object>> results = (List<Map<String, Object>>) successEndpoint.getReceivedExchanges()
                 .get(0).getIn().getBody(List.class);
-        // two records with id=1 and id=2 are expected to be returned
-        assertEquals(2, results.size());
+        assertEquals(2, results.size(), "two records with id=1 and id=2 are expected to be returned");
 
         // with predicate
         ColumnSchema schema = new ColumnSchema.ColumnSchemaBuilder("id", Type.INT32).build();
@@ -132,8 +131,7 @@ public class KuduScanTest extends AbstractKuduTest {
         sendBody("direct:scan", null, headers);
         results = (List<Map<String, Object>>) successEndpoint.getReceivedExchanges()
                 .get(1).getIn().getBody(List.class);
-        // only one record with id=2 is expected to be returned
-        assertEquals(1, results.size());
+        assertEquals(1, results.size(), "only one record with id=2 is expected to be returned");
 
         errorEndpoint.assertIsSatisfied();
         successEndpoint.assertIsSatisfied();


### PR DESCRIPTION
# Description

Currently, the scan operation of the Kudu producer scans entire table and sets the whole results to the message body, but it's inefficient or not practical if the table is large. This PR adds predicate support to the scan operation so that users can filter the results.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`
