### PR TITLE
CAMEL-19219: camel-kudu - add projection and limit support to the scan operation

### DIFF
--- a/components/camel-kudu/src/main/java/org/apache/camel/component/kudu/KuduConstants.java
+++ b/components/camel-kudu/src/main/java/org/apache/camel/component/kudu/KuduConstants.java
@@ -23,8 +23,12 @@ public final class KuduConstants {
     public static final String CAMEL_KUDU_SCHEMA = "CamelKuduSchema";
     @Metadata(description = "The create table options", javaType = "org.apache.kudu.client.CreateTableOptions")
     public static final String CAMEL_KUDU_TABLE_OPTIONS = "CamelKuduTableOptions";
+    @Metadata(description = "The projected column names for scan operation", javaType = "java.util.List<String>")
+    public static final String CAMEL_KUDU_SCAN_COLUMN_NAMES = "CamelKuduScanColumnNames";
     @Metadata(description = "The predicate for scan operation", javaType = "org.apache.kudu.client.KuduPredicate")
     public static final String CAMEL_KUDU_SCAN_PREDICATE = "CamelKuduScanPredicate";
+    @Metadata(description = "The limit on the number of rows for scan operation", javaType = "long")
+    public static final String CAMEL_KUDU_SCAN_LIMIT = "CamelKuduScanLimit";
 
     private KuduConstants() {
     }

--- a/components/camel-kudu/src/main/java/org/apache/camel/component/kudu/KuduProducer.java
+++ b/components/camel-kudu/src/main/java/org/apache/camel/component/kudu/KuduProducer.java
@@ -16,7 +16,9 @@
  */
 package org.apache.camel.component.kudu;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.support.DefaultProducer;
@@ -176,7 +178,9 @@ public class KuduProducer extends DefaultProducer {
     }
 
     private void doScan(Exchange exchange, String tableName) throws KuduException {
+        List<String> columnNames = (List<String>) exchange.getIn().getHeader(KuduConstants.CAMEL_KUDU_SCAN_COLUMN_NAMES);
         KuduPredicate predicate = (KuduPredicate) exchange.getIn().getHeader(KuduConstants.CAMEL_KUDU_SCAN_PREDICATE);
-        exchange.getIn().setBody(KuduUtils.doScan(tableName, endpoint.getKuduClient(), predicate));
+        long limit = Optional.ofNullable((Long) exchange.getIn().getHeader(KuduConstants.CAMEL_KUDU_SCAN_LIMIT)).orElse(-1L);
+        exchange.getIn().setBody(KuduUtils.doScan(tableName, endpoint.getKuduClient(), columnNames, predicate, limit));
     }
 }

--- a/components/camel-kudu/src/main/java/org/apache/camel/component/kudu/KuduUtils.java
+++ b/components/camel-kudu/src/main/java/org/apache/camel/component/kudu/KuduUtils.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.kudu.ColumnSchema;
 import org.apache.kudu.client.KuduClient;
@@ -42,14 +44,14 @@ public final class KuduUtils {
     /**
      * Convert results to a more Java friendly type
      */
-    public static List<Map<String, Object>> scannerToList(KuduTable table, KuduScanner scanner) {
+    public static List<Map<String, Object>> scannerToList(KuduScanner scanner) {
         KuduScannerIterator it = scanner.iterator();
         List<Map<String, Object>> res = new ArrayList<Map<String, Object>>();
         while (it.hasNext()) {
             RowResult row = it.next();
             Map<String, Object> r = new HashMap<String, Object>();
             res.add(r);
-            for (ColumnSchema columnSchema : table.getSchema().getColumns()) {
+            for (ColumnSchema columnSchema : scanner.getProjectionSchema().getColumns()) {
                 final String name = columnSchema.getName();
                 r.put(name, row.getObject(name));
             }
@@ -58,25 +60,26 @@ public final class KuduUtils {
     }
 
     public static List<Map<String, Object>> doScan(String tableName, KuduClient connection) throws KuduException {
-        return doScan(tableName, connection, null);
+        return doScan(tableName, connection, null, null, -1);
     }
 
-    public static List<Map<String, Object>> doScan(String tableName, KuduClient connection, KuduPredicate predicate)
+    public static List<Map<String, Object>> doScan(
+            String tableName, KuduClient connection, List<String> columnNames,
+            KuduPredicate predicate, long limit)
             throws KuduException {
         LOG.trace("Scanning table {}", tableName);
         KuduTable table = connection.openTable(tableName);
-
-        List<String> projectColumns = new ArrayList<>(1);
-
-        for (ColumnSchema columnSchema : table.getSchema().getColumns()) {
-            projectColumns.add(columnSchema.getName());
-        }
 
         KuduScanner.KuduScannerBuilder builder = connection.newScannerBuilder(table);
         if (predicate != null) {
             builder.addPredicate(predicate);
         }
+        if (-1 < limit) {
+            builder.limit(limit);
+        }
+        List<String> projectColumns = Optional.ofNullable(columnNames).orElse(
+                table.getSchema().getColumns().stream().map(ColumnSchema::getName).collect(Collectors.toList()));
         KuduScanner scanner = builder.setProjectedColumnNames(projectColumns).build();
-        return KuduUtils.scannerToList(table, scanner);
+        return KuduUtils.scannerToList(scanner);
     }
 }


### PR DESCRIPTION
# Description

In addition to CAMEL-19216, this PR adds the following functionalities to the scan operation of the Kudu producer for more efficient scanning:

* filter columns
* limit the number of results

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`
