### PR TITLE
CAMEL-15105: make the CLI ConnectorFactory a plugin of the context

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/ExtendedCamelContext.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExtendedCamelContext.java
@@ -32,7 +32,6 @@ import org.apache.camel.spi.BeanProxyFactory;
 import org.apache.camel.spi.BootstrapCloseable;
 import org.apache.camel.spi.CamelBeanPostProcessor;
 import org.apache.camel.spi.CamelDependencyInjectionAnnotationFactory;
-import org.apache.camel.spi.CliConnectorFactory;
 import org.apache.camel.spi.ComponentNameResolver;
 import org.apache.camel.spi.ComponentResolver;
 import org.apache.camel.spi.ConfigurerResolver;
@@ -795,16 +794,6 @@ public interface ExtendedCamelContext {
      * Sets the {@link StartupStepRecorder} to use.
      */
     void setStartupStepRecorder(StartupStepRecorder startupStepRecorder);
-
-    /**
-     * Gets the {@link CliConnectorFactory} (optional).
-     */
-    CliConnectorFactory getCliConnectorFactory();
-
-    /**
-     * Sets the {@link CliConnectorFactory} to use.
-     */
-    void setCliConnectorFactory(CliConnectorFactory cliConnectorFactory);
 
     /**
      * Internal API for adding routes. Do not use this as end user.

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
@@ -225,7 +225,6 @@ public abstract class AbstractCamelContext extends BaseService
     volatile ManagementStrategy managementStrategy;
     volatile ManagementMBeanAssembler managementMBeanAssembler;
     volatile HeadersMapFactory headersMapFactory;
-    volatile CliConnectorFactory cliConnectorFactory;
     volatile BeanProxyFactory beanProxyFactory;
     volatile BeanProcessorFactory beanProcessorFactory;
     volatile RoutesLoader routesLoader;
@@ -2285,7 +2284,7 @@ public abstract class AbstractCamelContext extends BaseService
 
         // setup cli-connector if not already done
         if (hasService(CliConnector.class) == null) {
-            CliConnectorFactory ccf = camelContextExtension.getCliConnectorFactory();
+            CliConnectorFactory ccf = getCamelContextExtension().getContextPlugin(CliConnectorFactory.class);
             if (ccf != null && ccf.isEnabled()) {
                 CliConnector connector = ccf.createConnector();
                 addService(connector, true);
@@ -4086,8 +4085,6 @@ public abstract class AbstractCamelContext extends BaseService
 
     protected abstract HeadersMapFactory createHeadersMapFactory();
 
-    protected abstract CliConnectorFactory createCliConnectorFactory();
-
     protected abstract BeanProxyFactory createBeanProxyFactory();
 
     protected abstract AnnotationBasedProcessorFactory createAnnotationBasedProcessorFactory();
@@ -4258,10 +4255,6 @@ public abstract class AbstractCamelContext extends BaseService
 
     public void setStartupStepRecorder(StartupStepRecorder startupStepRecorder) {
         camelContextExtension.setStartupStepRecorder(startupStepRecorder);
-    }
-
-    public CliConnectorFactory getCliConnectorFactory() {
-        return camelContextExtension.getCliConnectorFactory();
     }
 
     public void addRoute(Route route) {

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultCamelContextExtension.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultCamelContextExtension.java
@@ -46,7 +46,6 @@ import org.apache.camel.spi.BeanProxyFactory;
 import org.apache.camel.spi.BootstrapCloseable;
 import org.apache.camel.spi.CamelBeanPostProcessor;
 import org.apache.camel.spi.CamelDependencyInjectionAnnotationFactory;
-import org.apache.camel.spi.CliConnectorFactory;
 import org.apache.camel.spi.ComponentNameResolver;
 import org.apache.camel.spi.ComponentResolver;
 import org.apache.camel.spi.ConfigurerResolver;
@@ -1112,23 +1111,6 @@ class DefaultCamelContextExtension implements ExtendedCamelContext {
     @Override
     public void setStartupStepRecorder(StartupStepRecorder startupStepRecorder) {
         camelContext.startupStepRecorder = startupStepRecorder;
-    }
-
-    @Override
-    public CliConnectorFactory getCliConnectorFactory() {
-        if (camelContext.cliConnectorFactory == null) {
-            synchronized (camelContext.lock) {
-                if (camelContext.cliConnectorFactory == null) {
-                    setCliConnectorFactory(camelContext.createCliConnectorFactory());
-                }
-            }
-        }
-        return camelContext.cliConnectorFactory;
-    }
-
-    @Override
-    public void setCliConnectorFactory(CliConnectorFactory cliConnectorFactory) {
-        camelContext.cliConnectorFactory = cliConnectorFactory;
     }
 
     @Override

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/SimpleCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/SimpleCamelContext.java
@@ -128,6 +128,13 @@ public class SimpleCamelContext extends AbstractCamelContext {
     }
 
     @Override
+    public void doBuild() throws Exception {
+        super.doBuild();
+
+        getCamelContextExtension().addContextPlugin(CliConnectorFactory.class, createCliConnectorFactory());
+    }
+
+    @Override
     protected HealthCheckRegistry createHealthCheckRegistry() {
         Optional<HealthCheckRegistry> result = ResolverHelper.resolveService(
                 getCamelContextReference(),
@@ -424,8 +431,7 @@ public class SimpleCamelContext extends AbstractCamelContext {
         return result.orElseGet(DefaultHeadersMapFactory::new);
     }
 
-    @Override
-    protected CliConnectorFactory createCliConnectorFactory() {
+    private CliConnectorFactory createCliConnectorFactory() {
         // lookup in registry first
         CliConnectorFactory ccf = getCamelContextReference().getRegistry().findSingleByType(CliConnectorFactory.class);
         if (ccf != null) {

--- a/core/camel-core-engine/src/generated/java/org/apache/camel/impl/ExtendedCamelContextConfigurer.java
+++ b/core/camel-core-engine/src/generated/java/org/apache/camel/impl/ExtendedCamelContextConfigurer.java
@@ -35,8 +35,6 @@ public class ExtendedCamelContextConfigurer extends org.apache.camel.support.com
         case "BootstrapConfigurerResolver": target.setBootstrapConfigurerResolver(property(camelContext, org.apache.camel.spi.ConfigurerResolver.class, value)); return true;
         case "bootstrapfactoryfinder":
         case "BootstrapFactoryFinder": target.setBootstrapFactoryFinder(property(camelContext, org.apache.camel.spi.FactoryFinder.class, value)); return true;
-        case "cliconnectorfactory":
-        case "CliConnectorFactory": target.setCliConnectorFactory(property(camelContext, org.apache.camel.spi.CliConnectorFactory.class, value)); return true;
         case "componentnameresolver":
         case "ComponentNameResolver": target.setComponentNameResolver(property(camelContext, org.apache.camel.spi.ComponentNameResolver.class, value)); return true;
         case "componentresolver":
@@ -138,8 +136,6 @@ public class ExtendedCamelContextConfigurer extends org.apache.camel.support.com
         case "BootstrapConfigurerResolver": return org.apache.camel.spi.ConfigurerResolver.class;
         case "bootstrapfactoryfinder":
         case "BootstrapFactoryFinder": return org.apache.camel.spi.FactoryFinder.class;
-        case "cliconnectorfactory":
-        case "CliConnectorFactory": return org.apache.camel.spi.CliConnectorFactory.class;
         case "componentnameresolver":
         case "ComponentNameResolver": return org.apache.camel.spi.ComponentNameResolver.class;
         case "componentresolver":
@@ -242,8 +238,6 @@ public class ExtendedCamelContextConfigurer extends org.apache.camel.support.com
         case "BootstrapConfigurerResolver": return target.getBootstrapConfigurerResolver();
         case "bootstrapfactoryfinder":
         case "BootstrapFactoryFinder": return target.getBootstrapFactoryFinder();
-        case "cliconnectorfactory":
-        case "CliConnectorFactory": return target.getCliConnectorFactory();
         case "componentnameresolver":
         case "ComponentNameResolver": return target.getComponentNameResolver();
         case "componentresolver":

--- a/core/camel-core-engine/src/main/java/org/apache/camel/impl/lw/LightweightCamelContextExtension.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/impl/lw/LightweightCamelContextExtension.java
@@ -47,7 +47,6 @@ import org.apache.camel.spi.BeanProxyFactory;
 import org.apache.camel.spi.BootstrapCloseable;
 import org.apache.camel.spi.CamelBeanPostProcessor;
 import org.apache.camel.spi.CamelDependencyInjectionAnnotationFactory;
-import org.apache.camel.spi.CliConnectorFactory;
 import org.apache.camel.spi.ComponentNameResolver;
 import org.apache.camel.spi.ComponentResolver;
 import org.apache.camel.spi.ConfigurerResolver;
@@ -524,16 +523,6 @@ class LightweightCamelContextExtension implements ExtendedCamelContext {
 
     @Override
     public void setHeadersMapFactory(HeadersMapFactory factory) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public CliConnectorFactory getCliConnectorFactory() {
-        return camelContext.getCamelContextExtension().getCliConnectorFactory();
-    }
-
-    @Override
-    public void setCliConnectorFactory(CliConnectorFactory cliConnectorFactory) {
         throw new UnsupportedOperationException();
     }
 

--- a/core/camel-main/src/main/java/org/apache/camel/main/DefaultConfigurationConfigurer.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/DefaultConfigurationConfigurer.java
@@ -366,7 +366,7 @@ public final class DefaultConfigurationConfigurer {
         }
         CliConnectorFactory ccf = getSingleBeanOfType(registry, CliConnectorFactory.class);
         if (ccf != null) {
-            ecc.getCamelContextExtension().setCliConnectorFactory(ccf);
+            ecc.getCamelContextExtension().addContextPlugin(CliConnectorFactory.class, ccf);
         }
         PropertiesComponent pc = getSingleBeanOfType(registry, PropertiesComponent.class);
         if (pc != null) {

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/KameletMain.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/KameletMain.java
@@ -356,7 +356,7 @@ public class KameletMain extends MainCommandLineSupport {
         if (!stub) {
             // setup cli-connector if not already done
             if (answer.hasService(CliConnector.class) == null) {
-                CliConnectorFactory ccf = answer.getCliConnectorFactory();
+                CliConnectorFactory ccf = answer.getCamelContextExtension().getContextPlugin(CliConnectorFactory.class);
                 if (ccf != null && ccf.isEnabled()) {
                     CliConnector connector = ccf.createConnector();
                     try {


### PR DESCRIPTION
This is a proposed way to make the access to the ExtendedExchange plugins uniform. At first, this only implements this for the CliConnectorFactory. If accepted, I'll implement the same pattern for the others.