### PR TITLE
CAMEL-19233: changed code generation for <component>ApiCollection

### DIFF
--- a/tooling/maven/camel-api-component-maven-plugin/src/main/resources/api-collection.vm
+++ b/tooling/maven/camel-api-component-maven-plugin/src/main/resources/api-collection.vm
@@ -37,10 +37,10 @@
 package $packageName;
 
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 
 #set( $componentConfig = "${componentName}Configuration" )
 import ${componentPackage}.${componentConfig};
@@ -60,8 +60,8 @@ public final class $collectionName extends ApiCollection<${apiNameEnum}, ${compo
     private static $collectionName collection;
 
     private ${collectionName}() {
-        final Map<String, String> aliases = new HashMap<String, String>();
-        final Map<${apiNameEnum}, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new HashMap<>();
+        final Map<String, String> aliases = new HashMap<>();
+        final Map<${apiNameEnum}, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(${apiNameEnum}.class);
         final Map<Class<? extends ApiMethod>, ${apiNameEnum}> apiMethods = new HashMap<>();
 
         List<String> nullableArgs;
@@ -74,7 +74,7 @@ public final class $collectionName extends ApiCollection<${apiNameEnum}, ${compo
 #set( $apiMethod = ${helper.getApiMethod($api.ProxyClass, $api.ClassPrefix)} )
 #set( $apiName = "${apiNameEnum}.${helper.getEnumConstant($api.ApiName)}" )
         nullableArgs = Arrays.asList(${helper.getNullableOptionValues($api.NullableOptions)});
-        apiHelpers.put($apiName, new ApiMethodHelper<$apiMethod>(${apiMethod}.class, aliases, nullableArgs));
+        apiHelpers.put($apiName, new ApiMethodHelper<>(${apiMethod}.class, aliases, nullableArgs));
         apiMethods.put(${apiMethod}.class, ${apiName});
 #end
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-19233

Removed explicit generic types, fixed duplicated import, made use of EnumMap instead of HashMap.

Tested on my beloved AS2.  I rebuilt the plugin and changed the file as2.json. That triggered the regeneration of the sources in the build of AS2. New AS2ApiCollection file is OK.

Please note that the regeneration of the sources for collections must be forced.