### PR TITLE
added try with resources for ArangoCursor

### DIFF
--- a/components/camel-arangodb/src/main/java/org/apache/camel/component/arangodb/ArangoDbProducer.java
+++ b/components/camel-arangodb/src/main/java/org/apache/camel/component/arangodb/ArangoDbProducer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.arangodb;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
@@ -322,8 +323,11 @@ public class ArangoDbProducer extends DefaultProducer {
                 resultClassType = resultClassType != null ? resultClassType : BaseDocument.class;
 
                 // perform query and return Collection
-                ArangoCursor<?> cursor = database.query(query, bindParameters, queryOptions, resultClassType);
-                return cursor == null ? null : cursor.asListRemaining();
+                try (ArangoCursor<?> cursor = database.query(query, bindParameters, queryOptions, resultClassType)) {
+                    return cursor == null ? null : cursor.asListRemaining();
+                } catch (IOException e) {
+                    throw new RuntimeCamelException("failed to close instance of ArangoCursor", e);
+                }
             } catch (InvalidPayloadException e) {
                 throw new RuntimeCamelException("Invalid payload for command", e);
             }


### PR DESCRIPTION
Added try with resources for ArangoCursor.
Why do I think it's needed? For a typical DB Connection, Statement we have logic: when a Connection gets closed, it closes all its Statements. 
ArangoDatabase doen't implement Closeable/AutoCloseable. Hence it can't close implicitly its Cursors on closing.