### PR TITLE
Fixed concatenations with empty string

### DIFF
--- a/catalog/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaParserHelper.java
+++ b/catalog/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaParserHelper.java
@@ -606,7 +606,7 @@ public final class CamelJavaParserHelper {
         if (expression instanceof StringLiteral) {
             return ((StringLiteral) expression).getLiteralValue();
         } else if (expression instanceof BooleanLiteral) {
-            return "" + ((BooleanLiteral) expression).booleanValue();
+            return String.valueOf(((BooleanLiteral) expression).booleanValue());
         } else if (expression instanceof NumberLiteral) {
             return ((NumberLiteral) expression).getToken();
         }

--- a/catalog/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaRestDslParserHelper.java
+++ b/catalog/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaRestDslParserHelper.java
@@ -509,7 +509,7 @@ public final class CamelJavaRestDslParserHelper {
         if (expression instanceof StringLiteral) {
             return ((StringLiteral) expression).getLiteralValue();
         } else if (expression instanceof BooleanLiteral) {
-            return "" + ((BooleanLiteral) expression).booleanValue();
+            return String.valueOf(((BooleanLiteral) expression).booleanValue());
         } else if (expression instanceof NumberLiteral) {
             return ((NumberLiteral) expression).getToken();
         }

--- a/catalog/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaTreeParserHelper.java
+++ b/catalog/camel-route-parser/src/main/java/org/apache/camel/parser/helper/CamelJavaTreeParserHelper.java
@@ -349,7 +349,7 @@ public final class CamelJavaTreeParserHelper {
         if (expression instanceof StringLiteral) {
             return ((StringLiteral) expression).getLiteralValue();
         } else if (expression instanceof BooleanLiteral) {
-            return "" + ((BooleanLiteral) expression).booleanValue();
+            return String.valueOf(((BooleanLiteral) expression).booleanValue());
         } else if (expression instanceof NumberLiteral) {
             return ((NumberLiteral) expression).getToken();
         }

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/InvalidAS2NameException.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/InvalidAS2NameException.java
@@ -44,7 +44,7 @@ public class InvalidAS2NameException extends Exception {
     @Override
     public String getMessage() {
         char character = name.charAt(index);
-        String invalidChar = "" + character;
+        String invalidChar = String.valueOf(character);
         if (Character.isISOControl(character)) {
             invalidChar = String.format("\\u%04x", (int) character);
         }

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsProducer.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsProducer.java
@@ -316,7 +316,7 @@ public class JmsProducer extends DefaultAsyncProducer {
             // prefer to use destination over destination name
             destinationName = null;
         }
-        final String to = destinationName != null ? destinationName : "" + destination;
+        final String to = destinationName != null ? destinationName : String.valueOf(destination);
         MessageSentCallback messageSentCallback = getEndpoint().getConfiguration().isIncludeSentJMSMessageID()
                 ? new InOnlyMessageSentCallback(exchange) : null;
 

--- a/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/easypredicate/EasyPredicateOperators.java
+++ b/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/easypredicate/EasyPredicateOperators.java
@@ -46,7 +46,7 @@ public final class EasyPredicateOperators {
      */
     static boolean hasOperator(String exp) {
         // need to have space around operator to not match eg in used in some other word
-        return Arrays.stream(OPS).anyMatch(o -> exp.contains(" " + o + ""));
+        return Arrays.stream(OPS).anyMatch(o -> exp.contains(" " + o));
     }
 
     /**
@@ -60,7 +60,7 @@ public final class EasyPredicateOperators {
      * Gets the operator (with single space around)
      */
     static String getOperatorAtStart(String exp) {
-        return Arrays.stream(OPS).filter(o -> exp.startsWith(" " + o + "")).findFirst().orElse(null);
+        return Arrays.stream(OPS).filter(o -> exp.startsWith(" " + o)).findFirst().orElse(null);
     }
 
 }

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
@@ -157,7 +157,7 @@ public class KafkaConsumer extends DefaultConsumer
         BridgeExceptionHandlerToErrorHandler bridge = new BridgeExceptionHandlerToErrorHandler(this);
         for (int i = 0; i < endpoint.getConfiguration().getConsumersCount(); i++) {
             KafkaFetchRecords task = new KafkaFetchRecords(
-                    this, bridge, topic, pattern, i + "", getProps(), consumerListener);
+                    this, bridge, topic, pattern, Integer.toString(i), getProps(), consumerListener);
 
             executor.submit(task);
 

--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConfiguration.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConfiguration.java
@@ -272,7 +272,7 @@ public class MailConfiguration implements Cloneable {
         properties.put("mail." + protocol + ".connectiontimeout", connectionTimeout);
         properties.put("mail." + protocol + ".timeout", connectionTimeout);
         properties.put("mail." + protocol + ".host", host);
-        properties.put("mail." + protocol + ".port", "" + port);
+        properties.put("mail." + protocol + ".port", Integer.toString(port));
         String pUserName = getPasswordAuthentication().getUserName();
         if (pUserName != null) {
             properties.put("mail." + protocol + ".user", pUserName);
@@ -293,11 +293,11 @@ public class MailConfiguration implements Cloneable {
         if (sslContextParameters != null && isSecureProtocol()) {
             properties.put("mail." + protocol + ".socketFactory", createSSLContext(context).getSocketFactory());
             properties.put("mail." + protocol + ".socketFactory.fallback", "false");
-            properties.put("mail." + protocol + ".socketFactory.port", "" + port);
+            properties.put("mail." + protocol + ".socketFactory.port", Integer.toString(port));
         }
         if (sslContextParameters != null && isStartTlsEnabled()) {
             properties.put("mail." + protocol + ".ssl.socketFactory", createSSLContext(context).getSocketFactory());
-            properties.put("mail." + protocol + ".ssl.socketFactory.port", "" + port);
+            properties.put("mail." + protocol + ".ssl.socketFactory.port", Integer.toString(port));
         }
 
         return properties;

--- a/components/camel-mock/src/main/java/org/apache/camel/component/mock/MockValueBuilder.java
+++ b/components/camel-mock/src/main/java/org/apache/camel/component/mock/MockValueBuilder.java
@@ -221,7 +221,7 @@ public class MockValueBuilder implements Expression, Predicate {
     }
 
     public MockValueBuilder tokenize(String token, int group, boolean skipFirst) {
-        return tokenize(token, "" + group, skipFirst);
+        return tokenize(token, Integer.toString(group), skipFirst);
     }
 
     public MockValueBuilder tokenize(String token, String group, boolean skipFirst) {

--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiSupport.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiSupport.java
@@ -413,7 +413,7 @@ public class RestOpenApiSupport {
                 Object dump = io.apicurio.datamodels.Library.writeNode(openApi);
                 byte[] bytes = mapper.writeValueAsBytes(dump);
                 int len = bytes.length;
-                response.setHeader(Exchange.CONTENT_LENGTH, "" + len);
+                response.setHeader(Exchange.CONTENT_LENGTH, Integer.toString(len));
 
                 response.writeBytes(bytes);
             } else {
@@ -439,7 +439,7 @@ public class RestOpenApiSupport {
                 byte[] bytes = new YAMLMapper().writeValueAsString(node).getBytes();
 
                 int len = bytes.length;
-                response.setHeader(Exchange.CONTENT_LENGTH, "" + len);
+                response.setHeader(Exchange.CONTENT_LENGTH, Integer.toString(len));
 
                 response.writeBytes(bytes);
             }

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/ActiveSpanManager.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/ActiveSpanManager.java
@@ -59,8 +59,8 @@ public final class ActiveSpanManager {
         exchange.setProperty(ACTIVE_SPAN_PROPERTY,
                 new Holder((Holder) exchange.getProperty(ACTIVE_SPAN_PROPERTY), span));
         if (exchange.getContext().isUseMDCLogging()) {
-            MDC.put(MDC_TRACE_ID, "" + span.traceId());
-            MDC.put(MDC_SPAN_ID, "" + span.spanId());
+            MDC.put(MDC_TRACE_ID, span.traceId());
+            MDC.put(MDC_SPAN_ID, span.spanId());
         }
     }
 
@@ -81,8 +81,8 @@ public final class ActiveSpanManager {
                 Holder parent = holder.getParent();
                 if (parent != null) {
                     SpanAdapter span = holder.getParent().getSpan();
-                    MDC.put(MDC_TRACE_ID, "" + span.traceId());
-                    MDC.put(MDC_SPAN_ID, "" + span.spanId());
+                    MDC.put(MDC_TRACE_ID, span.traceId());
+                    MDC.put(MDC_SPAN_ID, span.spanId());
                 } else {
                     MDC.remove(MDC_TRACE_ID);
                     MDC.remove(MDC_SPAN_ID);

--- a/components/camel-weather/src/main/java/org/apache/camel/component/weather/WeatherConfiguration.java
+++ b/components/camel-weather/src/main/java/org/apache/camel/component/weather/WeatherConfiguration.java
@@ -106,7 +106,7 @@ public class WeatherConfiguration {
             // ignore and fallback the period to be an empty string
         }
         if (result != 0) {
-            this.period = "" + result;
+            this.period = Integer.toString(result);
         }
     }
 

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultManagementNameStrategy.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultManagementNameStrategy.java
@@ -118,7 +118,7 @@ public class DefaultManagementNameStrategy implements ManagementNameStrategy {
         String answer = pattern;
         if (pattern.contains("#counter#")) {
             // only increment the counter on-demand
-            answer = pattern.replace("#counter#", "" + nextNameCounter());
+            answer = pattern.replace("#counter#", Long.toString(nextNameCounter()));
         }
         // camelId and name is the same tokens
         answer = answer.replace("#camelId#", name);

--- a/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/DefaultServiceCallExpression.java
+++ b/core/camel-cloud/src/main/java/org/apache/camel/impl/cloud/DefaultServiceCallExpression.java
@@ -55,7 +55,7 @@ public class DefaultServiceCallExpression extends ServiceCallExpressionSupport {
                 answer = answer.replaceFirst(name + "\\.host", host);
             }
             if (answer.contains(name + ".port") && port != null) {
-                answer = answer.replaceFirst(name + "\\.port", "" + port);
+                answer = answer.replaceFirst(name + "\\.port", Integer.toString(port));
             }
             if (answer.contains(name) && port != null) {
                 answer = answer.replaceFirst(name, host + ":" + port);

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/csimple/CSimpleHelper.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/csimple/CSimpleHelper.java
@@ -80,7 +80,7 @@ public final class CSimpleHelper {
     }
 
     public static <T> T bodyAsIndex(Message message, Class<T> type, int key) {
-        return bodyAsIndex(message, type, "" + key);
+        return bodyAsIndex(message, type, Integer.toString(key));
     }
 
     public static <T> T bodyAsIndex(Message message, Class<T> type, String key) {
@@ -102,7 +102,7 @@ public final class CSimpleHelper {
     }
 
     public static <T> T mandatoryBodyAsIndex(Message message, Class<T> type, int key) throws InvalidPayloadException {
-        T out = bodyAsIndex(message, type, "" + key);
+        T out = bodyAsIndex(message, type, Integer.toString(key));
         if (out == null) {
             throw new InvalidPayloadException(message.getExchange(), type, message);
         }

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleExpressionBuilder.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleExpressionBuilder.java
@@ -144,7 +144,7 @@ public final class SimpleExpressionBuilder {
                 // first use simple then create the group expression
                 exp = context.resolveLanguage("simple").createExpression(expression);
                 exp.init(context);
-                exp = ExpressionBuilder.groupIteratorExpression(exp, null, "" + group, false);
+                exp = ExpressionBuilder.groupIteratorExpression(exp, null, Integer.toString(group), false);
                 exp.init(context);
             }
 

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleTokenizer.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleTokenizer.java
@@ -228,7 +228,7 @@ public final class SimpleTokenizer {
 
         // fallback and create a character token
         char ch = expression.charAt(index);
-        SimpleToken token = new SimpleToken(new SimpleTokenType(TokenType.character, "" + ch), index);
+        SimpleToken token = new SimpleToken(new SimpleTokenType(TokenType.character, String.valueOf(ch)), index);
         return token;
     }
 

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/BooleanExpression.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/BooleanExpression.java
@@ -47,7 +47,7 @@ public class BooleanExpression extends BaseSimpleNode {
 
             @Override
             public String toString() {
-                return "" + value;
+                return String.valueOf(value);
             }
         };
     }

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/NumericExpression.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/NumericExpression.java
@@ -66,7 +66,7 @@ public class NumericExpression extends BaseSimpleNode {
 
             @Override
             public String toString() {
-                return "" + number;
+                return String.valueOf(number);
             }
         };
     }

--- a/core/camel-core-model/src/main/java/org/apache/camel/builder/ExpressionClause.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/builder/ExpressionClause.java
@@ -785,7 +785,7 @@ public class ExpressionClause<T> implements Expression, Predicate {
      * @return           the builder to continue processing the DSL
      */
     public T tokenize(String token, boolean regex, int group, String groupDelimiter, boolean skipFirst) {
-        return delegate.tokenize(token, null, regex, "" + group, groupDelimiter, skipFirst);
+        return delegate.tokenize(token, null, regex, Integer.toString(group), groupDelimiter, skipFirst);
     }
 
     /**

--- a/core/camel-core-model/src/main/java/org/apache/camel/builder/ExpressionClauseSupport.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/builder/ExpressionClauseSupport.java
@@ -967,7 +967,7 @@ public class ExpressionClauseSupport<T> implements ExpressionFactoryAware, Predi
      * @return            the builder to continue processing the DSL
      */
     public T tokenize(String token, String headerName, boolean regex, int group, boolean skipFirst) {
-        return tokenize(token, headerName, regex, "" + group, skipFirst);
+        return tokenize(token, headerName, regex, Integer.toString(group), skipFirst);
     }
 
     /**
@@ -1033,7 +1033,7 @@ public class ExpressionClauseSupport<T> implements ExpressionFactoryAware, Predi
      * @return                         the builder to continue processing the DSL
      */
     public T tokenizeXMLPair(String tagName, String inheritNamespaceTagName, int group) {
-        return tokenizeXMLPair(tagName, inheritNamespaceTagName, "" + group);
+        return tokenizeXMLPair(tagName, inheritNamespaceTagName, Integer.toString(group));
     }
 
     /**

--- a/core/camel-core-model/src/main/java/org/apache/camel/builder/NotifyBuilder.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/builder/NotifyBuilder.java
@@ -962,9 +962,9 @@ public class NotifyBuilder {
             @Override
             public String toString() {
                 if (received) {
-                    return "" + (exact ? "whenExactBodiesReceived(" : "whenBodiesReceived(") + bodies + ")";
+                    return (exact ? "whenExactBodiesReceived(" : "whenBodiesReceived(") + bodies + ")";
                 } else {
-                    return "" + (exact ? "whenExactBodiesDone(" : "whenBodiesDone(") + bodies + ")";
+                    return (exact ? "whenExactBodiesDone(" : "whenBodiesDone(") + bodies + ")";
                 }
             }
         });

--- a/core/camel-main/src/main/java/org/apache/camel/main/DefaultConfigurationConfigurer.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/DefaultConfigurationConfigurer.java
@@ -182,7 +182,8 @@ public final class DefaultConfigurationConfigurer {
         camelContext.getInflightRepository().setInflightBrowseEnabled(config.isInflightRepositoryBrowseEnabled());
 
         if (config.getLogDebugMaxChars() != 0) {
-            camelContext.getGlobalOptions().put(Exchange.LOG_DEBUG_BODY_MAX_CHARS, Integer.toString(config.getLogDebugMaxChars()));
+            camelContext.getGlobalOptions().put(Exchange.LOG_DEBUG_BODY_MAX_CHARS,
+                    Integer.toString(config.getLogDebugMaxChars()));
         }
 
         // stream caching

--- a/core/camel-main/src/main/java/org/apache/camel/main/DefaultConfigurationConfigurer.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/DefaultConfigurationConfigurer.java
@@ -182,7 +182,7 @@ public final class DefaultConfigurationConfigurer {
         camelContext.getInflightRepository().setInflightBrowseEnabled(config.isInflightRepositoryBrowseEnabled());
 
         if (config.getLogDebugMaxChars() != 0) {
-            camelContext.getGlobalOptions().put(Exchange.LOG_DEBUG_BODY_MAX_CHARS, "" + config.getLogDebugMaxChars());
+            camelContext.getGlobalOptions().put(Exchange.LOG_DEBUG_BODY_MAX_CHARS, Integer.toString(config.getLogDebugMaxChars()));
         }
 
         // stream caching

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/LoadThroughput.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/LoadThroughput.java
@@ -64,7 +64,7 @@ public final class LoadThroughput {
 
     @Override
     public String toString() {
-        return "" + thp;
+        return Double.toString(thp);
     }
 
 }

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedAsyncProcessorAwaitManager.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedAsyncProcessorAwaitManager.java
@@ -70,12 +70,12 @@ public class ManagedAsyncProcessorAwaitManager extends ManagedService implements
             Collection<AsyncProcessorAwaitManager.AwaitThread> threads = manager.browse();
             for (AsyncProcessorAwaitManager.AwaitThread entry : threads) {
                 CompositeType ct = CamelOpenMBeanTypes.listAwaitThreadsCompositeType();
-                String id = "" + entry.getBlockedThread().getId();
+                String id = Long.toString(entry.getBlockedThread().getId());
                 String name = entry.getBlockedThread().getName();
                 String exchangeId = entry.getExchange().getExchangeId();
                 String routeId = entry.getRouteId();
                 String nodeId = entry.getNodeId();
-                String duration = "" + entry.getWaitDuration();
+                String duration = Long.toString(entry.getWaitDuration());
 
                 CompositeData data = new CompositeDataSupport(
                         ct,

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedInflightRepository.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedInflightRepository.java
@@ -86,8 +86,8 @@ public class ManagedInflightRepository extends ManagedService implements Managed
                 String fromRouteId = entry.getFromRouteId();
                 String atRouteId = entry.getAtRouteId();
                 String nodeId = entry.getNodeId();
-                String elapsed = "" + entry.getElapsed();
-                String duration = "" + entry.getDuration();
+                String elapsed = Long.toString(entry.getElapsed());
+                String duration = Long.toString(entry.getDuration());
 
                 CompositeData data = new CompositeDataSupport(
                         ct,

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/RouteCoverageXmlParser.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/RouteCoverageXmlParser.java
@@ -117,9 +117,9 @@ public final class RouteCoverageXmlParser {
                                     .getContextPlugin(ManagedCamelContext.class).getManagedRoute(id);
                             if (route != null) {
                                 long total = route.getExchangesTotal();
-                                el.setAttribute("exchangesTotal", "" + total);
+                                el.setAttribute("exchangesTotal", Long.toString(total));
                                 long totalTime = route.getTotalProcessingTime();
-                                el.setAttribute("totalProcessingTime", "" + totalTime);
+                                el.setAttribute("totalProcessingTime", Long.toString(totalTime));
                             }
                         } else if ("from".equals(qName)) {
                             // grab statistics from the parent route as from would be the same
@@ -131,9 +131,9 @@ public final class RouteCoverageXmlParser {
                                                 .getManagedRoute(routeId);
                                 if (route != null) {
                                     long total = route.getExchangesTotal();
-                                    el.setAttribute("exchangesTotal", "" + total);
+                                    el.setAttribute("exchangesTotal", Long.toString(total));
                                     long totalTime = route.getTotalProcessingTime();
-                                    el.setAttribute("totalProcessingTime", "" + totalTime);
+                                    el.setAttribute("totalProcessingTime", Long.toString(totalTime));
                                     // from is index-0
                                     el.setAttribute("index", "0");
                                 }
@@ -144,11 +144,11 @@ public final class RouteCoverageXmlParser {
                                             .getManagedProcessor(id);
                             if (processor != null) {
                                 long total = processor.getExchangesTotal();
-                                el.setAttribute("exchangesTotal", "" + total);
+                                el.setAttribute("exchangesTotal", Long.toString(total));
                                 long totalTime = processor.getTotalProcessingTime();
-                                el.setAttribute("totalProcessingTime", "" + totalTime);
+                                el.setAttribute("totalProcessingTime", Long.toString(totalTime));
                                 int index = processor.getIndex();
-                                el.setAttribute("index", "" + index);
+                                el.setAttribute("index", Integer.toString(index));
                             }
                         }
                     } catch (Exception e) {

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/StatisticCounter.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/StatisticCounter.java
@@ -34,7 +34,7 @@ public class StatisticCounter extends Statistic {
 
     @Override
     public String toString() {
-        return "" + value.get();
+        return Long.toString(value.get());
     }
 
     @Override

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/StatisticDelta.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/StatisticDelta.java
@@ -36,7 +36,7 @@ public class StatisticDelta extends Statistic {
 
     @Override
     public String toString() {
-        return "" + value.get();
+        return Long.toString(value.get());
     }
 
     @Override

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/StatisticMaximum.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/StatisticMaximum.java
@@ -46,7 +46,7 @@ public class StatisticMaximum extends Statistic {
 
     @Override
     public String toString() {
-        return "" + value.get();
+        return Long.toString(value.get());
     }
 
     @Override

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/StatisticMinimum.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/StatisticMinimum.java
@@ -46,7 +46,7 @@ public class StatisticMinimum extends Statistic {
 
     @Override
     public String toString() {
-        return "" + value.get();
+        return Long.toString(value.get());
     }
 
     @Override

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/StatisticValue.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/StatisticValue.java
@@ -34,7 +34,7 @@ public class StatisticValue extends Statistic {
 
     @Override
     public String toString() {
-        return "" + value.get();
+        return Long.toString(value.get());
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/builder/ExpressionBuilder.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/builder/ExpressionBuilder.java
@@ -734,7 +734,7 @@ public class ExpressionBuilder {
 
             @Override
             public String toString() {
-                return "" + value;
+                return String.valueOf(value);
             }
         };
     }
@@ -1238,7 +1238,7 @@ public class ExpressionBuilder {
 
             @Override
             public String toString() {
-                return "" + expression;
+                return String.valueOf(expression);
             }
         };
     }
@@ -1267,7 +1267,7 @@ public class ExpressionBuilder {
 
             @Override
             public String toString() {
-                return "" + expression;
+                return String.valueOf(expression);
             }
         };
     }

--- a/core/camel-support/src/main/java/org/apache/camel/support/builder/PredicateBuilder.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/builder/PredicateBuilder.java
@@ -574,7 +574,7 @@ public class PredicateBuilder {
 
             @Override
             public String toString() {
-                return "" + answer;
+                return String.valueOf(answer);
             }
         };
     }

--- a/core/camel-support/src/main/java/org/apache/camel/support/builder/ValueBuilder.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/builder/ValueBuilder.java
@@ -186,7 +186,7 @@ public class ValueBuilder implements Expression, Predicate {
     }
 
     public ValueBuilder tokenize(String token, int group, boolean skipFirst) {
-        return tokenize(token, "" + group, skipFirst);
+        return tokenize(token, Integer.toString(group), skipFirst);
     }
 
     public ValueBuilder tokenize(String token, String group, boolean skipFirst) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/FileUtil.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/FileUtil.java
@@ -270,7 +270,7 @@ public final class FileUtil {
      * {@link java.io.File#separator}).
      */
     public static String compactPath(String path) {
-        return compactPath(path, "" + File.separatorChar);
+        return compactPath(path, String.valueOf(File.separatorChar));
     }
 
     /**
@@ -278,7 +278,7 @@ public final class FileUtil {
      *
      */
     public static String compactPath(String path, char separator) {
-        return compactPath(path, "" + separator);
+        return compactPath(path, String.valueOf(separator));
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
@@ -924,7 +924,7 @@ public final class StringHelper {
             return bytes + " B";
         }
         int exp = (int) (Math.log(bytes) / Math.log(unit));
-        String pre = "KMGTPE".charAt(exp - 1) + "";
+        String pre = String.valueOf("KMGTPE".charAt(exp - 1));
         return String.format(locale, "%.1f %sB", bytes / Math.pow(unit, exp), pre);
     }
 

--- a/core/camel-util/src/main/java/org/apache/camel/util/UnitUtils.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/UnitUtils.java
@@ -43,7 +43,7 @@ public final class UnitUtils {
             return bytes + " B";
         }
         int exp = (int) (Math.log(bytes) / Math.log(unit));
-        String pre = "" + "kMGTPE".charAt(exp - 1);
+        String pre = String.valueOf("kMGTPE".charAt(exp - 1));
         return String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre);
     }
 
@@ -75,7 +75,7 @@ public final class UnitUtils {
             return bytes + " B";
         }
         int exp = (int) (Math.log(bytes) / Math.log(unit));
-        String pre = "" + "kMGTPE".charAt(exp - 1);
+        String pre = String.valueOf("kMGTPE".charAt(exp - 1));
         String answer = String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre);
 
         char sep = DecimalFormatSymbols.getInstance().getDecimalSeparator();

--- a/core/camel-xml-io/src/main/java/org/apache/camel/xml/io/MXParser.java
+++ b/core/camel-xml-io/src/main/java/org/apache/camel/xml/io/MXParser.java
@@ -3093,7 +3093,7 @@ public class MXParser implements XmlPullParser {
         if (ch > 127 || ch < 32) {
             return "\\u" + Integer.toHexString((int)ch);
         }
-        return "" + ch;
+        return String.valueOf(ch);
     }
 
     protected String printable(String s) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelLogAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelLogAction.java
@@ -190,7 +190,7 @@ public class CamelLogAction extends ActionBaseCommand {
                     JsonObject root = loadStatus(ph.pid());
                     if (root != null) {
                         Row row = new Row();
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         JsonObject context = (JsonObject) root.get("context");
                         if (context == null) {
                             return;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelThreadDump.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelThreadDump.java
@@ -166,7 +166,7 @@ public class CamelThreadDump extends ActionWatchCommand {
 
     protected void singleTable(List<Row> rows) {
         System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
-                new Column().header("ID").headerAlign(HorizontalAlign.CENTER).with(r -> "" + r.id),
+                new Column().header("ID").headerAlign(HorizontalAlign.CENTER).with(r -> Long.toString(r.id)),
                 new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(60, OverflowBehaviour.ELLIPSIS_RIGHT)
                         .with(r -> r.name),
                 new Column().header("STATE").headerAlign(HorizontalAlign.RIGHT).with(r -> r.state),
@@ -179,7 +179,7 @@ public class CamelThreadDump extends ActionWatchCommand {
     protected void tableAndStackTrace(List<Row> rows) {
         for (Row row : rows) {
             System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, List.of(row), Arrays.asList(
-                    new Column().header("ID").headerAlign(HorizontalAlign.CENTER).with(r -> "" + r.id),
+                    new Column().header("ID").headerAlign(HorizontalAlign.CENTER).with(r -> Long.toString(r.id)),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(60, OverflowBehaviour.ELLIPSIS_RIGHT)
                             .with(r -> r.name),
                     new Column().header("STATE").headerAlign(HorizontalAlign.RIGHT).with(r -> r.state),
@@ -235,7 +235,7 @@ public class CamelThreadDump extends ActionWatchCommand {
         if (r.blockedTime > 0) {
             return r.blocked + "(" + r.blockedTime + "ms)";
         } else {
-            return "" + r.blocked;
+            return Long.toString(r.blocked);
         }
     }
 
@@ -243,7 +243,7 @@ public class CamelThreadDump extends ActionWatchCommand {
         if (r.waitedTime > 0) {
             return r.waited + "(" + r.waitedTime + "ms)";
         } else {
-            return "" + r.waited;
+            return Long.toString(r.waited);
         }
     }
 
@@ -251,7 +251,7 @@ public class CamelThreadDump extends ActionWatchCommand {
         if (r.stackTrace == null || r.stackTrace.isEmpty()) {
             return "";
         }
-        return "" + r.stackTrace.get(0);
+        return r.stackTrace.get(0);
     }
 
     private static class Row {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelTraceAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelTraceAction.java
@@ -302,7 +302,7 @@ public class CamelTraceAction extends ActionBaseCommand {
                     JsonObject root = loadStatus(ph.pid());
                     if (root != null) {
                         Pid row = new Pid();
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         JsonObject context = (JsonObject) root.get("context");
                         if (context == null) {
                             return;
@@ -853,7 +853,7 @@ public class CamelTraceAction extends ActionBaseCommand {
         } else if (r.last) {
             return "*<--";
         } else {
-            return "" + r.nodeId;
+            return r.nodeId;
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/LoggerAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/LoggerAction.java
@@ -101,7 +101,7 @@ public class LoggerAction extends ActionBaseCommand {
                     JsonObject root = loadStatus(ph.pid());
                     if (root != null) {
                         Row row = new Row();
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         row.uptime = extractSince(ph);
                         row.ago = TimeUtils.printSince(row.uptime);
                         JsonObject context = (JsonObject) root.get("context");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/RouteControllerAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/RouteControllerAction.java
@@ -271,7 +271,7 @@ public class RouteControllerAction extends ActionWatchCommand {
 
     protected String getAttempts(Row r) {
         if (r.supervising != null) {
-            return "" + r.attempts;
+            return Long.toString(r.attempts);
         }
         return "";
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelContextStatus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelContextStatus.java
@@ -69,7 +69,7 @@ public class CamelContextStatus extends ProcessWatchCommand {
                         if ("CamelJBang".equals(row.name)) {
                             row.name = ProcessHelper.extractName(root, ph);
                         }
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         row.uptime = extractSince(ph);
                         row.age = TimeUtils.printSince(row.uptime);
                         JsonObject runtime = (JsonObject) root.get("runtime");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelContextTop.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelContextTop.java
@@ -81,7 +81,7 @@ public class CamelContextTop extends ProcessWatchCommand {
                         if ("CamelJBang".equals(row.name)) {
                             row.name = ProcessHelper.extractName(root, ph);
                         }
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         row.uptime = extractSince(ph);
                         row.ago = TimeUtils.printSince(row.uptime);
                         JsonObject runtime = (JsonObject) root.get("runtime");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelCount.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelCount.java
@@ -76,7 +76,7 @@ public class CamelCount extends ProcessWatchCommand {
                         if ("CamelJBang".equals(row.name)) {
                             row.name = ProcessHelper.extractName(root, ph);
                         }
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         row.age = TimeUtils.printSince(extractSince(ph));
                         Map<String, ?> stats = context.getMap("statistics");
                         if (stats != null) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelProcessorStatus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelProcessorStatus.java
@@ -95,7 +95,7 @@ public class CamelProcessorStatus extends ProcessWatchCommand {
                             if ("CamelJBang".equals(row.name)) {
                                 row.name = ProcessHelper.extractName(root, ph);
                             }
-                            row.pid = "" + ph.pid();
+                            row.pid = Long.toString(ph.pid());
                             row.routeId = o.getString("routeId");
                             row.processor = o.getString("from");
                             row.source = o.getString("source");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelRouteStatus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelRouteStatus.java
@@ -86,7 +86,7 @@ public class CamelRouteStatus extends ProcessWatchCommand {
                             if ("CamelJBang".equals(row.name)) {
                                 row.name = ProcessHelper.extractName(root, ph);
                             }
-                            row.pid = "" + ph.pid();
+                            row.pid = Long.toString(ph.pid());
                             row.routeId = o.getString("routeId");
                             row.from = o.getString("from");
                             row.source = o.getString("source");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/Hawtio.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/Hawtio.java
@@ -85,7 +85,7 @@ public class Hawtio extends CamelCommand {
 
     protected void disconnectJolokia() throws Exception {
         Jolokia jolokia = new Jolokia(getMain());
-        jolokia.name = "" + pid;
+        jolokia.name = Long.toString(pid);
         jolokia.stop = true;
         jolokia.call();
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/Jolokia.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/Jolokia.java
@@ -58,11 +58,11 @@ public class Jolokia extends ProcessBaseCommand {
         try {
             OptionsAndArgs options;
             if (stop) {
-                options = new OptionsAndArgs(null, "stop", "" + pid);
+                options = new OptionsAndArgs(null, "stop", Long.toString(pid));
             } else {
                 // find a new free port to use when starting a new connection
                 long port = AvailablePortFinder.getNextAvailable(8778, 10000);
-                options = new OptionsAndArgs(null, "--port", "" + port, "start", "" + pid);
+                options = new OptionsAndArgs(null, "--port", Long.toString(port), "start", Long.toString(pid));
             }
             VirtualMachineHandlerOperations vmHandler = PlatformUtils.createVMAccess(options);
             CommandDispatcher dispatcher = new CommandDispatcher(options);

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListBlocked.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListBlocked.java
@@ -68,7 +68,7 @@ public class ListBlocked extends ProcessWatchCommand {
                         if ("CamelJBang".equals(row.name)) {
                             row.name = ProcessHelper.extractName(root, ph);
                         }
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         row.uptime = extractSince(ph);
                         row.age = TimeUtils.printSince(row.uptime);
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListCircuitBreaker.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListCircuitBreaker.java
@@ -68,7 +68,7 @@ public class ListCircuitBreaker extends ProcessWatchCommand {
                         if ("CamelJBang".equals(row.name)) {
                             row.name = ProcessHelper.extractName(root, ph);
                         }
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         row.uptime = extractSince(ph);
                         row.age = TimeUtils.printSince(row.uptime);
                         Row baseRow = row.copy();
@@ -161,27 +161,27 @@ public class ListCircuitBreaker extends ProcessWatchCommand {
         } else if (r.failureRate > 0) {
             return +r.failedCalls + " (" + String.format("%.0f", r.failureRate) + "%)";
         } else {
-            return "" + r.failedCalls;
+            return Integer.toString(r.failedCalls);
         }
     }
 
     private String getPending(Row r) {
         if ("resilience4j".equals(r.component)) {
-            return "" + r.bufferedCalls;
+            return Integer.toString(r.bufferedCalls);
         }
         return "";
     }
 
     private String getSuccess(Row r) {
         if ("resilience4j".equals(r.component)) {
-            return "" + r.successfulCalls;
+            return Integer.toString(r.successfulCalls);
         }
         return "";
     }
 
     private String getReject(Row r) {
         if ("resilience4j".equals(r.component)) {
-            return "" + r.notPermittedCalls;
+            return Long.toString(r.notPermittedCalls);
         }
         return "";
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListEndpoint.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListEndpoint.java
@@ -106,7 +106,7 @@ public class ListEndpoint extends ProcessWatchCommand {
                                 if ("CamelJBang".equals(row.name)) {
                                     row.name = ProcessHelper.extractName(root, ph);
                                 }
-                                row.pid = "" + ph.pid();
+                                row.pid = Long.toString(ph.pid());
                                 row.endpoint = o.getString("uri");
                                 row.direction = o.getString("direction");
                                 row.total = o.getString("hits");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListEvent.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListEvent.java
@@ -72,7 +72,7 @@ public class ListEvent extends ProcessWatchCommand {
                         if ("CamelJBang".equals(row.name)) {
                             row.name = ProcessHelper.extractName(root, ph);
                         }
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
 
                         if (filter == null || filter.contains("context")) {
                             fetchEvents(root, row, "events", rows);

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListHealth.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListHealth.java
@@ -102,7 +102,7 @@ public class ListHealth extends ProcessWatchCommand {
                         for (int i = 0; i < array.size(); i++) {
                             JsonObject o = (JsonObject) array.get(i);
                             Row row = new Row();
-                            row.pid = "" + ph.pid();
+                            row.pid = Long.toString(ph.pid());
                             row.uptime = extractSince(ph);
                             row.ago = TimeUtils.printSince(row.uptime);
                             row.name = context.getString("name");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListInflight.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListInflight.java
@@ -68,7 +68,7 @@ public class ListInflight extends ProcessWatchCommand {
                         if ("CamelJBang".equals(row.name)) {
                             row.name = ProcessHelper.extractName(root, ph);
                         }
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         row.uptime = extractSince(ph);
                         row.age = TimeUtils.printSince(row.uptime);
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListMetric.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListMetric.java
@@ -80,7 +80,7 @@ public class ListMetric extends ProcessWatchCommand {
                         if ("CamelJBang".equals(row.name)) {
                             row.name = ProcessHelper.extractName(root, ph);
                         }
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         row.uptime = extractSince(ph);
                         row.age = TimeUtils.printSince(row.uptime);
                         Row baseRow = row.copy();
@@ -244,7 +244,7 @@ public class ListMetric extends ProcessWatchCommand {
     }
 
     private String getNumber(double d) {
-        String s = "" + d;
+        String s = Double.toString(d);
         if (s.equals("0.0") || s.equals("0,0")) {
             return "";
         } else if (s.endsWith(".0") || s.endsWith(",0")) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListProcess.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListProcess.java
@@ -57,7 +57,7 @@ public class ListProcess extends ProcessWatchCommand {
                     JsonObject root = loadStatus(ph.pid());
                     if (root != null) {
                         Row row = new Row();
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         row.uptime = extractSince(ph);
                         row.ago = TimeUtils.printSince(row.uptime);
                         JsonObject context = (JsonObject) root.get("context");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListService.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListService.java
@@ -68,7 +68,7 @@ public class ListService extends ProcessWatchCommand {
                         if ("CamelJBang".equals(row.name)) {
                             row.name = ProcessHelper.extractName(root, ph);
                         }
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         row.uptime = extractSince(ph);
                         row.age = TimeUtils.printSince(row.uptime);
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListVault.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListVault.java
@@ -68,7 +68,7 @@ public class ListVault extends ProcessWatchCommand {
                     JsonObject root = loadStatus(ph.pid());
                     if (root != null) {
                         Row row = new Row();
-                        row.pid = "" + ph.pid();
+                        row.pid = Long.toString(ph.pid());
                         JsonObject context = (JsonObject) root.get("context");
                         if (context == null) {
                             return;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/StopProcess.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/StopProcess.java
@@ -56,7 +56,7 @@ public class StopProcess extends ProcessBaseCommand {
         // stop by deleting the pid file
         for (Long pid : pids) {
             File dir = new File(System.getProperty("user.home"), ".camel");
-            File pidFile = new File(dir, "" + pid);
+            File pidFile = new File(dir, Long.toString(pid));
             if (pidFile.exists()) {
                 System.out.println("Shutting down Camel integration (PID: " + pid + ")");
                 FileUtil.deleteFile(pidFile);

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeUtil.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeUtil.java
@@ -36,7 +36,7 @@ public final class RuntimeUtil {
             String level, boolean color, boolean json, boolean pipe, boolean export) {
         if (INIT_DONE.compareAndSet(false, true)) {
             long pid = ProcessHandle.current().pid();
-            System.setProperty("pid", "" + pid);
+            System.setProperty("pid", Long.toString(pid));
 
             if (export) {
                 Configurator.initialize("CamelJBang", "log4j2-export.properties");

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/http/VertxHttpServer.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/http/VertxHttpServer.java
@@ -92,7 +92,7 @@ public final class VertxHttpServer {
 
     private static void doRegisterServer(CamelContext camelContext, int port, boolean stub) {
         // need to capture we use http-server
-        CamelJBangSettingsHelper.writeSettings("camel.jbang.platform-http.port", "" + port);
+        CamelJBangSettingsHelper.writeSettings("camel.jbang.platform-http.port", Integer.toString(port));
 
         if (stub) {
             return;


### PR DESCRIPTION
Fixed concatenations with empty string - substituted with <Type>.toString() or String.valueOf()

Concatenation with an empty string provides for 'plus' operation string context. It means, that numeric types are interpreted as strings by calling String.valueOf(). If you take a look at String.valueOf(int), String.valueOf(long) or String.valueOf(double), you can see it's redirected to Integer.toString(), Long.toString() and Double.toString(). So, sometimes I save a stack frame avoiding a call.
Another aspect. 
"" + long1 
most likely will be translated to
new StringBuilder().append(String.valueOf(long1)); 
or
new StringBuilder().append(mew Long(long1).toString()); 
Hence, I can avoid creation of this temporal StringBuilder and probably of Long.