### PR TITLE
Removed a call of Class.getClass().getClass() that is called on the i…

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/generics/GenericsUtil.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/generics/GenericsUtil.java
@@ -74,7 +74,7 @@ public final class GenericsUtil {
         } else if (beanType instanceof WildcardType) {
             return isAssignableFrom(isDelegateOrEvent, (Type) injectionPointType, (WildcardType) beanType);
         } else {
-            throw new IllegalArgumentException("Unsupported type " + injectionPointType.getClass());
+            throw new IllegalArgumentException("Unsupported type " + injectionPointType);
         }
     }
 


### PR DESCRIPTION
Removed a call of Class.getClass().getClass() that is called on the instance of type Class<?> and additional getClass() call that could erase the type

injectionPointType has type Class<?> and calling injectionPointType.getClass() just erases the actual type.

There is a similar block of code.
in the line 61 requiredType has type implementing Type (it's an interface). Hence, requiredType.getClass() gives relevant information.

Previous PR https://github.com/apache/camel/pull/9782
