### PR TITLE
CAMEL-19250: Classes generated by camel-restdsl-openapi-plugin are no…

### DIFF
--- a/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/GenerateMojo.java
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/GenerateMojo.java
@@ -147,6 +147,14 @@ public class GenerateMojo extends AbstractGenerateMojo {
             throw new MojoExecutionException(
                     "Unable to generate REST DSL OpenApi sources from specification: " + specificationUri, e);
         }
+
+        // Add the generated classes to the maven build path
+        if (ObjectHelper.isNotEmpty(modelOutput)) {
+            project.addCompileSourceRoot(modelOutput);
+        }
+        if (ObjectHelper.isNotEmpty(outputDirectory)) {
+            project.addCompileSourceRoot(outputDirectory);
+        }
     }
 
 }


### PR DESCRIPTION
…t added to jar

