### PR TITLE
fixed results of inspection "Single char arg in startsWith() and endsWith() can be substituted with charAt()"

### DIFF
--- a/components/camel-azure/camel-azure-cosmosdb/src/main/java/org/apache/camel/component/azure/cosmosdb/operations/CosmosDbDatabaseOperations.java
+++ b/components/camel-azure/camel-azure-cosmosdb/src/main/java/org/apache/camel/component/azure/cosmosdb/operations/CosmosDbDatabaseOperations.java
@@ -28,6 +28,7 @@ import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.ThroughputProperties;
 import com.azure.cosmos.models.ThroughputResponse;
 import org.apache.camel.component.azure.cosmosdb.CosmosDbUtils;
+import org.apache.camel.util.StringHelper;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -55,7 +56,7 @@ public class CosmosDbDatabaseOperations {
 
         // containerPartitionKeyPath it needs to start with /
         final String enhancedContainerPartitionKeyPath;
-        if (!containerPartitionKeyPath.startsWith("/")) {
+        if (!StringHelper.startsWith(containerPartitionKeyPath, '/')) {
             enhancedContainerPartitionKeyPath = "/" + containerPartitionKeyPath;
         } else {
             enhancedContainerPartitionKeyPath = containerPartitionKeyPath;

--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanHelper.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanHelper.java
@@ -44,12 +44,12 @@ public final class BeanHelper {
         value = value.trim();
 
         // single quoted is valid
-        if (value.startsWith("'") && value.endsWith("'")) {
+        if (StringHelper.startsWith(value, '\'') && StringHelper.endsWith(value, '\'')) {
             return String.class;
         }
 
         // double quoted is valid
-        if (value.startsWith("\"") && value.endsWith("\"")) {
+        if (StringHelper.startsWith(value, '\"') && StringHelper.endsWith(value, '\"')) {
             return String.class;
         }
 

--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -180,7 +180,7 @@ public class BeanInfo {
             if (methodName.contains("(")) {
                 name = StringHelper.before(methodName, "(");
                 // the must be a ending parenthesis
-                if (!methodName.endsWith(")")) {
+                if (!StringHelper.endsWith(methodName, ')')) {
                     throw new IllegalArgumentException("Method should end with parenthesis, was " + methodName);
                 }
                 // and there must be an even number of parenthesis in the syntax
@@ -1066,7 +1066,7 @@ public class BeanInfo {
             return true;
         }
 
-        if (methodName.contains("(") && !methodName.endsWith(")")) {
+        if (methodName.contains("(") && !StringHelper.endsWith(methodName, ')')) {
             throw new IllegalArgumentException("Name must have both starting and ending parenthesis, was: " + methodName);
         }
 

--- a/components/camel-chunk/src/main/java/org/apache/camel/component/chunk/ChunkEndpoint.java
+++ b/components/camel-chunk/src/main/java/org/apache/camel/component/chunk/ChunkEndpoint.java
@@ -33,6 +33,7 @@ import org.apache.camel.component.ResourceEndpoint;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.support.ExchangeHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.commons.io.IOUtils;
 
 import static org.apache.camel.component.chunk.ChunkConstants.CHUNK_ENDPOINT_URI_PREFIX;
@@ -194,7 +195,7 @@ public class ChunkEndpoint extends ResourceEndpoint {
     @Override
     public String getResourceUri() {
         String uri = super.getResourceUri();
-        if (uri != null && (uri.startsWith("/") || uri.startsWith("\\"))) {
+        if (uri != null && (StringHelper.startsWith(uri, '/') || StringHelper.startsWith(uri, '\\'))) {
             return uri.substring(1);
         } else {
             return uri;

--- a/components/camel-coap/src/main/java/org/apache/camel/coap/CamelCoapResource.java
+++ b/components/camel-coap/src/main/java/org/apache/camel/coap/CamelCoapResource.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.camel.Message;
+import org.apache.camel.util.StringHelper;
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
@@ -67,7 +68,8 @@ final class CamelCoapResource extends CoapResource {
         if (child == null) {
             final List<CamelCoapResource> possibles = new LinkedList<>();
             for (Resource r : getChildren()) {
-                if (r.getName().startsWith("{") && r.getName().endsWith("}")) {
+                String resourceName = r.getName();
+                if (StringHelper.startsWith(resourceName, '{') && StringHelper.endsWith(resourceName, '}')) {
                     possibles.add((CamelCoapResource) r);
                 }
             }

--- a/components/camel-coap/src/main/java/org/apache/camel/coap/CoAPComponent.java
+++ b/components/camel-coap/src/main/java/org/apache/camel/coap/CoAPComponent.java
@@ -38,6 +38,7 @@ import org.apache.camel.support.DefaultComponent;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.HostUtils;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.URISupport;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.network.CoapEndpoint;
@@ -130,7 +131,7 @@ public class CoAPComponent extends DefaultComponent implements RestConsumerFacto
         String path = basePath;
         if (uriTemplate != null) {
             // make sure to avoid double slashes
-            if (uriTemplate.startsWith("/")) {
+            if (StringHelper.startsWith(uriTemplate, '/')) {
                 path = path + uriTemplate;
             } else {
                 path = path + "/" + uriTemplate;

--- a/components/camel-coap/src/main/java/org/apache/camel/coap/CoAPConsumer.java
+++ b/components/camel-coap/src/main/java/org/apache/camel/coap/CoAPConsumer.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.camel.Processor;
 import org.apache.camel.support.DefaultConsumer;
+import org.apache.camel.util.StringHelper;
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.server.resources.Resource;
 
@@ -45,7 +46,7 @@ public class CoAPConsumer extends DefaultConsumer {
         super.doStart();
 
         String path = endpoint.getUri().getPath();
-        if (path.startsWith("/")) {
+        if (StringHelper.startsWith(path, '/')) {
             path = path.substring(1);
         }
         Resource cr = endpoint.getCoapServer().getRoot();

--- a/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/DefaultCxfBinding.java
+++ b/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/DefaultCxfBinding.java
@@ -844,7 +844,7 @@ public class DefaultCxfBinding implements CxfBinding, HeaderFilterStrategyAware 
             List<String> soapActionList = transportHeaders.get(SoapBindingConstants.SOAP_ACTION);
             if (soapActionList != null && soapActionList.size() == 1) {
                 String soapAction = soapActionList.get(0);
-                if (!soapAction.isEmpty() && !soapAction.startsWith("\"")) {
+                if (!soapAction.isEmpty() && soapAction.charAt(0) != '\"') {
                     //Per RFC, the SOAPAction HTTP header should be quoted if not empty
                     transportHeaders.put(SoapBindingConstants.SOAP_ACTION, Collections.singletonList("\"" + soapAction + "\""));
                 }

--- a/components/camel-cxf/camel-cxf-spring-common/src/main/java/org/apache/camel/component/cxf/spring/AbstractCxfBeanDefinitionParser.java
+++ b/components/camel-cxf/camel-cxf-spring-common/src/main/java/org/apache/camel/component/cxf/spring/AbstractCxfBeanDefinitionParser.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.cxf.spring;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.camel.util.StringHelper;
 import org.w3c.dom.Element;
 
 import org.apache.cxf.common.util.StringUtils;
@@ -43,7 +44,7 @@ public abstract class AbstractCxfBeanDefinitionParser extends AbstractBeanDefini
         }
 
         if (org.springframework.util.StringUtils.hasText(val)) {
-            if (val.startsWith("#")) {
+            if (StringHelper.startsWith(val, '#')) {
                 Map<String, Object> map = getPropertyMap(bean, true);
                 map.put(propertyName, val);
             } else {

--- a/components/camel-cxf/camel-cxf-spring-common/src/main/java/org/apache/camel/component/cxf/spring/AbstractCxfBeanDefinitionParser.java
+++ b/components/camel-cxf/camel-cxf-spring-common/src/main/java/org/apache/camel/component/cxf/spring/AbstractCxfBeanDefinitionParser.java
@@ -19,9 +19,9 @@ package org.apache.camel.component.cxf.spring;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.camel.util.StringHelper;
 import org.w3c.dom.Element;
 
+import org.apache.camel.util.StringHelper;
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.configuration.spring.AbstractBeanDefinitionParser;
 import org.springframework.beans.PropertyValue;

--- a/components/camel-debug/src/main/java/org/apache/camel/component/debug/JmxConnectorService.java
+++ b/components/camel-debug/src/main/java/org/apache/camel/component/debug/JmxConnectorService.java
@@ -119,7 +119,7 @@ public class JmxConnectorService extends ServiceSupport implements CamelContextA
         }
 
         // must start with leading slash
-        String path = StringHelper.startsWith(serviceUrlPath ,'/') ? serviceUrlPath : "/" + serviceUrlPath;
+        String path = StringHelper.startsWith(serviceUrlPath, '/') ? serviceUrlPath : "/" + serviceUrlPath;
         // Create an RMI connector and start it
         final JMXServiceURL url;
         if (connectorPort > 0) {

--- a/components/camel-debug/src/main/java/org/apache/camel/component/debug/JmxConnectorService.java
+++ b/components/camel-debug/src/main/java/org/apache/camel/component/debug/JmxConnectorService.java
@@ -32,6 +32,7 @@ import javax.management.remote.JMXServiceURL;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
 import org.apache.camel.support.service.ServiceSupport;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,7 +119,7 @@ public class JmxConnectorService extends ServiceSupport implements CamelContextA
         }
 
         // must start with leading slash
-        String path = serviceUrlPath.startsWith("/") ? serviceUrlPath : "/" + serviceUrlPath;
+        String path = StringHelper.startsWith(serviceUrlPath ,'/') ? serviceUrlPath : "/" + serviceUrlPath;
         // Create an RMI connector and start it
         final JMXServiceURL url;
         if (connectorPort > 0) {

--- a/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/core/DropboxAPIFacade.java
+++ b/components/camel-dropbox/src/main/java/org/apache/camel/component/dropbox/core/DropboxAPIFacade.java
@@ -48,6 +48,7 @@ import org.apache.camel.component.dropbox.util.DropboxException;
 import org.apache.camel.component.dropbox.util.DropboxResultCode;
 import org.apache.camel.component.dropbox.util.DropboxUploadMode;
 import org.apache.camel.support.builder.OutputStreamBuilder;
+import org.apache.camel.util.StringHelper;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -150,7 +151,7 @@ public final class DropboxAPIFacade {
             for (File file : listFiles) {
                 String absPath = file.getAbsolutePath();
                 int indexRemainingPath = localPath.length();
-                if (!localPath.endsWith("/")) {
+                if (!StringHelper.endsWith(localPath, '/')) {
                     indexRemainingPath += 1;
                 }
                 String remainingPath = absPath.substring(indexRemainingPath);

--- a/components/camel-etcd3/src/main/java/org/apache/camel/component/etcd3/Etcd3Component.java
+++ b/components/camel-etcd3/src/main/java/org/apache/camel/component/etcd3/Etcd3Component.java
@@ -24,6 +24,7 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 
 @Component("etcd3")
 public class Etcd3Component extends DefaultComponent {
@@ -46,7 +47,7 @@ public class Etcd3Component extends DefaultComponent {
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
         // path must start with leading slash
         String path = ObjectHelper.isEmpty(remaining) ? "/" : remaining;
-        if (!path.startsWith("/")) {
+        if (!StringHelper.startsWith(path, '/')) {
             path = String.format("/%s", path);
         }
 

--- a/components/camel-etcd3/src/main/java/org/apache/camel/component/etcd3/Etcd3Helper.java
+++ b/components/camel-etcd3/src/main/java/org/apache/camel/component/etcd3/Etcd3Helper.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.etcd3;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.util.StringHelper;
 
 /**
  * The helper class for the etcd component.
@@ -44,7 +45,7 @@ public final class Etcd3Helper {
      * @return      the given path if it ends with slash, the given path with an appended slash otherwise.
      */
     public static String toPathPrefix(String path) {
-        if (path.endsWith("/")) {
+        if (StringHelper.endsWith(path, '/')) {
             return path;
         }
         return String.format("%s/", path);

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileConsumer.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileConsumer.java
@@ -641,7 +641,7 @@ public abstract class GenericFileConsumer<T> extends ScheduledBatchPollingConsum
 
         // folders/names starting with dot is always skipped (eg. ".", ".camel",
         // ".camelLock")
-        if (name.startsWith(".")) {
+        if (StringHelper.startsWith(name, '.')) {
             return false;
         }
 

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
@@ -356,7 +356,7 @@ public class GenericFileProducer<T> extends DefaultProducer {
             // If the path isn't empty, we need to add a trailing / if it isn't
             // already there
             baseDir = endpointPath;
-            boolean trailingSlash = endpointPath.endsWith("/") || endpointPath.endsWith("\\");
+            boolean trailingSlash = StringHelper.endsWith(endpointPath, '/') || StringHelper.endsWith(endpointPath, '\\');
             if (!trailingSlash) {
                 baseDir += getFileSeparator();
             }

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/MoveExistingFileStrategyUtils.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/MoveExistingFileStrategyUtils.java
@@ -20,6 +20,7 @@ import java.io.File;
 
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 
 public final class MoveExistingFileStrategyUtils {
 
@@ -45,7 +46,7 @@ public final class MoveExistingFileStrategyUtils {
      */
     public static String completePartialRelativePath(String destinationPath, String fileOnlyName, String directoryName) {
 
-        if (destinationPath.length() > 1 && destinationPath.endsWith("/")) {
+        if (destinationPath.length() > 1 && StringHelper.endsWith(destinationPath, '/')) {
             destinationPath = destinationPath + fileOnlyName;
         }
 

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/MarkerFileExclusiveReadLockStrategy.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/MarkerFileExclusiveReadLockStrategy.java
@@ -179,7 +179,7 @@ public class MarkerFileExclusiveReadLockStrategy implements GenericFileExclusive
 
         for (File file : files) {
 
-            if (file.getName().startsWith(".")) {
+            if (StringHelper.startsWith(file.getName(), '.')) {
                 // files starting with dot should be skipped
                 continue;
             }

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpUtils.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpUtils.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 
 import org.apache.camel.Component;
 import org.apache.camel.util.FileUtil;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ public final class FtpUtils {
     public static String extractDirNameFromAbsolutePath(String path) {
         // default is unix so try with '/'
         // otherwise force File.separator
-        if (path.endsWith("/") || path.endsWith("\\")) {
+        if (StringHelper.endsWith(path, '/') || StringHelper.endsWith(path, '\\')) {
             path = path.substring(0, path.length() - 1);
         }
         return FileUtil.stripPath(path);
@@ -64,10 +65,10 @@ public final class FtpUtils {
         }
 
         // preserve ending slash if given in input path
-        boolean endsWithSlash = path.endsWith("/") || path.endsWith("\\");
+        boolean endsWithSlash = StringHelper.endsWith(path, '/') || StringHelper.endsWith(path, '\\');
 
         // preserve starting slash if given in input path
-        boolean startsWithSlash = path.startsWith("/") || path.startsWith("\\");
+        boolean startsWithSlash = StringHelper.startsWith(path, '/') || StringHelper.startsWith(path, '\\');
 
         Deque<String> stack = new ArrayDeque<>();
 
@@ -115,7 +116,7 @@ public final class FtpUtils {
             boolean secondSlash = sb.charAt(1) == '/' || sb.charAt(1) == '\\';
             if (firstSlash && secondSlash) {
                 // remove 2nd clash
-                sb = sb.replace(1, 2, "");
+                sb.replace(1, 2, "");
             }
         }
 

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileEndpoint.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileEndpoint.java
@@ -240,7 +240,7 @@ public abstract class RemoteFileEndpoint<T> extends GenericFileEndpoint<T> {
 
     @Override
     public boolean isAbsolute(String name) {
-        return name.startsWith("/");
+        return StringHelper.startsWith(name, '/');
     }
 
     public int getMaximumReconnectAttempts() {

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
@@ -61,6 +61,7 @@ import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StopWatch;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -665,7 +666,7 @@ public class SftpOperations implements RemoteFileOperations<SftpRemoteFile> {
         if (getCurrentDirectory().startsWith(path)) {
             // extract the path segment relative to the target path and make
             // sure it keeps the preceding '/' for the regex op
-            String p = getCurrentDirectory().substring(path.length() - (path.endsWith("/") ? 1 : 0));
+            String p = getCurrentDirectory().substring(path.length() - (StringHelper.endsWith(path, '/') ? 1 : 0));
             if (p.length() == 0) {
                 return;
             }
@@ -725,7 +726,7 @@ public class SftpOperations implements RemoteFileOperations<SftpRemoteFile> {
 
         String parent = FileUtil.compactPath(current + "/..");
         // must start with absolute
-        if (!parent.startsWith("/")) {
+        if (!StringHelper.startsWith(parent, '/')) {
             parent = "/" + parent;
         }
 

--- a/components/camel-geocoder/src/main/java/org/apache/camel/component/geocoder/GeoCoderNominatimProducer.java
+++ b/components/camel-geocoder/src/main/java/org/apache/camel/component/geocoder/GeoCoderNominatimProducer.java
@@ -108,7 +108,7 @@ public class GeoCoderNominatimProducer extends DefaultProducer {
 
     private String queryForString(String operation, Map<String, String> params) throws IOException {
         String url = endpoint.getServerUrl();
-        if (!url.endsWith("/")) {
+        if (!StringHelper.endsWith(url, '/')) {
             url += "/";
         }
         url += operation;
@@ -133,7 +133,7 @@ public class GeoCoderNominatimProducer extends DefaultProducer {
         }
         exchange.getIn().setHeader(GeoCoderConstants.STATUS, GeocoderStatus.OK);
 
-        if (place.startsWith("[") && place.endsWith("]")) {
+        if (StringHelper.startsWith(place, '[') && StringHelper.endsWith(place, ']')) {
             place = place.substring(1, place.length() - 1);
         }
 

--- a/components/camel-google/camel-google-storage/src/main/java/org/apache/camel/component/google/storage/GoogleCloudStorageConsumer.java
+++ b/components/camel-google/camel-google-storage/src/main/java/org/apache/camel/component/google/storage/GoogleCloudStorageConsumer.java
@@ -45,6 +45,7 @@ import org.apache.camel.support.ScheduledBatchPollingConsumer;
 import org.apache.camel.support.builder.OutputStreamBuilder;
 import org.apache.camel.util.CastUtils;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -171,7 +172,7 @@ public class GoogleCloudStorageConsumer extends ScheduledBatchPollingConsumer {
      */
     protected boolean includeObject(Blob blob) {
         // is the blog a folder
-        boolean folder = blob.getName().endsWith("/");
+        boolean folder = StringHelper.endsWith(blob.getName(), '/');
 
         if (folder && !getConfiguration().isIncludeFolders()) {
             // we should not include folders

--- a/components/camel-hl7/src/main/java/org/apache/camel/component/hl7/AckExpression.java
+++ b/components/camel-hl7/src/main/java/org/apache/camel/component/hl7/AckExpression.java
@@ -81,7 +81,7 @@ public class AckExpression extends ExpressionAdapter {
     }
 
     private boolean isSuccess(AcknowledgmentCode code) {
-        return StringHelper.endsWith(code.name(),'A');
+        return StringHelper.endsWith(code.name(), 'A');
     }
 
 }

--- a/components/camel-hl7/src/main/java/org/apache/camel/component/hl7/AckExpression.java
+++ b/components/camel-hl7/src/main/java/org/apache/camel/component/hl7/AckExpression.java
@@ -24,6 +24,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePropertyKey;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.support.ExpressionAdapter;
+import org.apache.camel.util.StringHelper;
 
 public class AckExpression extends ExpressionAdapter {
 
@@ -80,7 +81,7 @@ public class AckExpression extends ExpressionAdapter {
     }
 
     private boolean isSuccess(AcknowledgmentCode code) {
-        return code.name().endsWith("A");
+        return StringHelper.endsWith(code.name(),'A');
     }
 
 }

--- a/components/camel-huawei/camel-huaweicloud-obs/src/main/java/org/apache/camel/component/huaweicloud/obs/OBSConsumer.java
+++ b/components/camel-huawei/camel-huaweicloud-obs/src/main/java/org/apache/camel/component/huaweicloud/obs/OBSConsumer.java
@@ -37,6 +37,7 @@ import org.apache.camel.spi.Synchronization;
 import org.apache.camel.support.ScheduledBatchPollingConsumer;
 import org.apache.camel.util.CastUtils;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -218,7 +219,7 @@ public class OBSConsumer extends ScheduledBatchPollingConsumer {
      * @param obsObject
      */
     private boolean includeObsObject(ObsObject obsObject) {
-        return endpoint.isIncludeFolders() || !obsObject.getObjectKey().endsWith("/");
+        return endpoint.isIncludeFolders() || !StringHelper.endsWith(obsObject.getObjectKey(), '/');
     }
 
     /**

--- a/components/camel-huawei/camel-huaweicloud-obs/src/main/java/org/apache/camel/component/huaweicloud/obs/OBSUtils.java
+++ b/components/camel-huawei/camel-huaweicloud-obs/src/main/java/org/apache/camel/component/huaweicloud/obs/OBSUtils.java
@@ -27,6 +27,7 @@ import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.huaweicloud.obs.constants.OBSConstants;
 import org.apache.camel.component.huaweicloud.obs.constants.OBSHeaders;
 import org.apache.camel.util.IOHelper;
+import org.apache.camel.util.StringHelper;
 
 public final class OBSUtils {
     private OBSUtils() {
@@ -72,7 +73,7 @@ public final class OBSUtils {
 
         message.setHeader(OBSHeaders.FILE_NAME, obsObject.getObjectKey());
 
-        if (obsObject.getObjectKey().endsWith("/")) {
+        if (StringHelper.endsWith(obsObject.getObjectKey(), '/')) {
             message.setHeader(OBSHeaders.OBJECT_TYPE, OBSConstants.FOLDER);
         } else {
             message.setHeader(OBSHeaders.OBJECT_TYPE, OBSConstants.FILE);

--- a/components/camel-hyperledger-aries/src/main/java/org/apache/camel/component/aries/HyperledgerAriesProducer.java
+++ b/components/camel-hyperledger-aries/src/main/java/org/apache/camel/component/aries/HyperledgerAriesProducer.java
@@ -31,6 +31,7 @@ import org.apache.camel.component.aries.handler.RevocationServiceHandler;
 import org.apache.camel.component.aries.handler.SchemasServiceHandler;
 import org.apache.camel.component.aries.handler.WalletServiceHandler;
 import org.apache.camel.support.DefaultProducer;
+import org.apache.camel.util.StringHelper;
 
 import static org.apache.camel.component.aries.Constants.HEADER_SERVICE;
 
@@ -104,7 +105,7 @@ public class HyperledgerAriesProducer extends DefaultProducer {
             service = getEndpoint().getConfiguration().getService();
         }
         AssertState.notNull(service, "Cannot obtain API service");
-        if (!service.startsWith("/")) {
+        if (!StringHelper.startsWith(service, '/')) {
             service = "/" + service;
         }
         return service;

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcChannel.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcChannel.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.irc;
 
+import org.apache.camel.util.StringHelper;
+
 public final class IrcChannel {
     private String name;
     private String key;
@@ -32,7 +34,7 @@ public final class IrcChannel {
         if (name == null || name.isEmpty()) {
             name = "";
         }
-        this.name = name.startsWith("#") || name.startsWith("&") ? name : "#" + name;
+        this.name = StringHelper.startsWith(name, '#') || StringHelper.startsWith(name, '&') ? name : "#" + name;
     }
 
     public String getName() {

--- a/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConfiguration.java
+++ b/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConfiguration.java
@@ -303,7 +303,7 @@ public class IrcConfiguration implements Cloneable {
         for (int i = 0; i < count; i++) {
             String channel = chs[i].trim();
             String key = ks != null && ks.length > i ? ks[i].trim() : null;
-            if (channel.startsWith("#") && !channel.startsWith("##")) {
+            if (StringHelper.startsWith(channel, '#') && !channel.startsWith("##")) {
                 channel = channel.substring(1);
             }
             if (key != null && !key.isEmpty()) {

--- a/components/camel-jackson/src/main/java/org/apache/camel/component/jackson/AbstractJacksonDataFormat.java
+++ b/components/camel-jackson/src/main/java/org/apache/camel/component/jackson/AbstractJacksonDataFormat.java
@@ -47,6 +47,7 @@ import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.ObjectHelper;
 import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.CastUtils;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -643,7 +644,7 @@ public abstract class AbstractJacksonDataFormat extends ServiceSupport
                 Iterable<?> it = ObjectHelper.createIterable(moduleRefs);
                 for (Object o : it) {
                     String name = o.toString();
-                    if (name.startsWith("#")) {
+                    if (StringHelper.startsWith(name, '#')) {
                         name = name.substring(1);
                     }
                     Module module = CamelContextHelper.mandatoryLookup(camelContext, name, Module.class);

--- a/components/camel-jacksonxml/src/main/java/org/apache/camel/component/jacksonxml/JacksonXMLDataFormat.java
+++ b/components/camel-jacksonxml/src/main/java/org/apache/camel/component/jacksonxml/JacksonXMLDataFormat.java
@@ -46,6 +46,7 @@ import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.ObjectHelper;
 import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.CastUtils;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -622,7 +623,7 @@ public class JacksonXMLDataFormat extends ServiceSupport
             Iterable<?> it = ObjectHelper.createIterable(moduleRefs);
             for (Object o : it) {
                 String name = o.toString();
-                if (name.startsWith("#")) {
+                if (StringHelper.startsWith(name, '#')) {
                     name = name.substring(1);
                 }
                 Module module = CamelContextHelper.mandatoryLookup(camelContext, name, Module.class);

--- a/components/camel-jcr/src/main/java/org/apache/camel/component/jcr/JcrConsumer.java
+++ b/components/camel-jcr/src/main/java/org/apache/camel/component/jcr/JcrConsumer.java
@@ -28,6 +28,7 @@ import javax.jcr.observation.EventListener;
 import org.apache.camel.Processor;
 import org.apache.camel.support.DefaultConsumer;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +80,7 @@ public class JcrConsumer extends DefaultConsumer {
 
         if (absPath == null) {
             absPath = "/";
-        } else if (!absPath.startsWith("/")) {
+        } else if (!StringHelper.startsWith(absPath, '/')) {
             absPath = "/" + absPath;
         }
 

--- a/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
+++ b/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
@@ -413,7 +413,7 @@ public abstract class JettyHttpComponent extends HttpCommonComponent
                 pathSpec = "/";
             }
             if (endpoint.isMatchOnUriPrefix()) {
-                pathSpec = pathSpec.endsWith("/") ? pathSpec + "*" : pathSpec + "/*";
+                pathSpec = StringHelper.endsWith(pathSpec, '/') ? pathSpec + "*" : pathSpec + "/*";
             }
             addFilter(context, filterHolder, pathSpec);
         }
@@ -449,7 +449,7 @@ public abstract class JettyHttpComponent extends HttpCommonComponent
             pathSpec = "/";
         }
         if (endpoint.isMatchOnUriPrefix()) {
-            pathSpec = pathSpec.endsWith("/") ? pathSpec + "*" : pathSpec + "/*";
+            pathSpec = StringHelper.endsWith(pathSpec, '/') ? pathSpec + "*" : pathSpec + "/*";
         }
         addFilter(context, filterHolder, pathSpec);
         LOG.debug("using multipart filter implementation {} for path {}", filter.getClass().getName(), pathSpec);
@@ -1052,7 +1052,7 @@ public abstract class JettyHttpComponent extends HttpCommonComponent
         String path = basePath;
         if (uriTemplate != null) {
             // make sure to avoid double slashes
-            if (uriTemplate.startsWith("/")) {
+            if (StringHelper.startsWith(uriTemplate, '/')) {
                 path = path + uriTemplate;
             } else {
                 path = path + "/" + uriTemplate;

--- a/components/camel-jmx/src/main/java/org/apache/camel/component/jmx/JMXUriBuilder.java
+++ b/components/camel-jmx/src/main/java/org/apache/camel/component/jmx/JMXUriBuilder.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.jmx;
 
+import org.apache.camel.util.StringHelper;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -171,7 +173,7 @@ public class JMXUriBuilder {
      * it's not present.
      */
     public JMXUriBuilder withObjectPropertiesReference(String aReferenceToHashtable) {
-        if (aReferenceToHashtable.startsWith("#")) {
+        if (StringHelper.startsWith(aReferenceToHashtable, '#')) {
             addProperty("objectProperties", aReferenceToHashtable);
         } else {
             addProperty("objectProperties", "#" + aReferenceToHashtable);

--- a/components/camel-jmx/src/main/java/org/apache/camel/component/jmx/JMXUriBuilder.java
+++ b/components/camel-jmx/src/main/java/org/apache/camel/component/jmx/JMXUriBuilder.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.component.jmx;
 
-import org.apache.camel.util.StringHelper;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+
+import org.apache.camel.util.StringHelper;
 
 /**
  * Builder for JMX endpoint URI's. Saves you from having to do the string concat'ing and messing up the param names

--- a/components/camel-jsch/src/main/java/org/apache/camel/component/scp/ScpOperations.java
+++ b/components/camel-jsch/src/main/java/org/apache/camel/component/scp/ScpOperations.java
@@ -42,6 +42,7 @@ import org.apache.camel.component.file.remote.RemoteFileOperations;
 import org.apache.camel.support.ResourceHelper;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -446,7 +447,7 @@ public class ScpOperations implements RemoteFileOperations<ScpFile> {
 
     private static String getRemoteFile(String name, ScpConfiguration config) {
         String dir = config.getDirectory();
-        dir = dir.endsWith("/") ? dir : dir + "/";
+        dir = StringHelper.endsWith(dir, '/') ? dir : dir + "/";
         return name.startsWith(dir) ? name.substring(dir.length()) : name;
     }
 

--- a/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/easypredicate/EasyPredicateParser.java
+++ b/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/easypredicate/EasyPredicateParser.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.jsonpath.easypredicate;
 
-import org.apache.camel.util.StringHelper;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.camel.util.StringHelper;
 
 import static org.apache.camel.jsonpath.easypredicate.EasyPredicateOperators.hasOperator;
 import static org.apache.camel.jsonpath.easypredicate.EasyPredicateOperators.isOperator;

--- a/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/easypredicate/EasyPredicateParser.java
+++ b/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/easypredicate/EasyPredicateParser.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.jsonpath.easypredicate;
 
+import org.apache.camel.util.StringHelper;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,7 +40,7 @@ public class EasyPredicateParser {
      */
     public String parse(String predicate) {
 
-        if (predicate.startsWith("$")) {
+        if (StringHelper.startsWith(predicate, '$')) {
             // regular json path so skip
             return predicate;
         }
@@ -70,7 +72,7 @@ public class EasyPredicateParser {
                     after = prev.substring(pos + 1);
                 }
                 sb.append("$");
-                if (!before.startsWith(".")) {
+                if (!StringHelper.startsWith(before, '.')) {
                     sb.append(".");
                 }
                 sb.append(before);

--- a/components/camel-kafka/src/main/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepository.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepository.java
@@ -83,7 +83,7 @@ public class KafkaIdempotentRepository extends ServiceSupport implements Idempot
     private String topic;
     private String bootstrapServers;
 
-    private String groupId = null;
+    private String groupId;
     private Properties producerConfig;
     private Properties consumerConfig;
     private int maxCacheSize = DEFAULT_MAXIMUM_CACHE_SIZE;

--- a/components/camel-knative/camel-knative-http/src/main/java/org/apache/camel/component/knative/http/KnativeHttpProducer.java
+++ b/components/camel-knative/camel-knative-http/src/main/java/org/apache/camel/component/knative/http/KnativeHttpProducer.java
@@ -39,6 +39,7 @@ import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.support.DefaultAsyncProducer;
 import org.apache.camel.support.MessageHelper;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.URISupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -182,7 +183,7 @@ public class KnativeHttpProducer extends DefaultAsyncProducer {
             if (path.charAt(0) != '/') {
                 path = "/" + path;
             }
-            if (url.endsWith("/")) {
+            if (StringHelper.endsWith(url, '/')) {
                 url = url.substring(0, url.length() - 1);
             }
 

--- a/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRAUrlBuilder.java
+++ b/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRAUrlBuilder.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.apache.camel.Endpoint;
+import org.apache.camel.util.StringHelper;
 
 import static org.apache.camel.service.lra.LRAConstants.URL_COMPENSATION_KEY;
 import static org.apache.camel.service.lra.LRAConstants.URL_COMPLETION_KEY;
@@ -116,10 +117,10 @@ public class LRAUrlBuilder {
     private String joinPath(String first, String second) {
         first = toNonnullString(first);
         second = toNonnullString(second);
-        while (first.endsWith("/")) {
+        while (StringHelper.endsWith(first, '/')) {
             first = first.substring(0, first.length() - 1);
         }
-        while (second.startsWith("/")) {
+        while (StringHelper.startsWith(second, '/')) {
             second = second.substring(1);
         }
         return first + "/" + second;

--- a/components/camel-mail/src/main/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormat.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormat.java
@@ -55,6 +55,7 @@ import org.apache.camel.support.DefaultDataFormat;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.MessageHelper;
 import org.apache.camel.util.IOHelper;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -305,7 +306,7 @@ public class MimeMultipartDataFormat extends DefaultDataFormat {
         // if there is no file name we use the Content-ID header
         if (key == null && bp instanceof MimeBodyPart) {
             key = ((MimeBodyPart) bp).getContentID();
-            if (key != null && key.startsWith("<") && key.length() > 2) {
+            if (key != null && StringHelper.startsWith(key, '<') && key.length() > 2) {
                 // strip <>
                 key = key.substring(1, key.length() - 1);
             }

--- a/components/camel-mustache/src/main/java/org/apache/camel/component/mustache/MustacheEndpoint.java
+++ b/components/camel-mustache/src/main/java/org/apache/camel/component/mustache/MustacheEndpoint.java
@@ -34,6 +34,7 @@ import org.apache.camel.component.ResourceEndpoint;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.support.ExchangeHelper;
+import org.apache.camel.util.StringHelper;
 
 import static org.apache.camel.component.mustache.MustacheConstants.MUSTACHE_ENDPOINT_URI_PREFIX;
 import static org.apache.camel.component.mustache.MustacheConstants.MUSTACHE_RESOURCE_URI;
@@ -157,7 +158,7 @@ public class MustacheEndpoint extends ResourceEndpoint {
     public String getResourceUri() {
         // do not have leading slash as mustache cannot find the resource, as that entails classpath root
         String uri = super.getResourceUri();
-        if (uri != null && (uri.startsWith("/") || uri.startsWith("\\"))) {
+        if (uri != null && (StringHelper.startsWith(uri, '/') || StringHelper.startsWith(uri, '\\'))) {
             return uri.substring(1);
         } else {
             return uri;

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpComponent.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpComponent.java
@@ -48,6 +48,7 @@ import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.PropertiesHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.URISupport;
 import org.apache.camel.util.UnsafeUriCharactersEncoder;
 import org.slf4j.Logger;
@@ -377,7 +378,7 @@ public class NettyHttpComponent extends NettyComponent
         String path = basePath;
         if (uriTemplate != null) {
             // make sure to avoid double slashes
-            if (uriTemplate.startsWith("/")) {
+            if (StringHelper.startsWith(uriTemplate, '/')) {
                 path = path + uriTemplate;
             } else {
                 path = path + "/" + uriTemplate;

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpHelper.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpHelper.java
@@ -204,7 +204,7 @@ public final class NettyHttpHelper {
         String path = exchange.getIn().getHeader(NettyHttpConstants.HTTP_PATH, String.class);
         // NOW the HTTP_PATH is just related path, we don't need to trim it
         if (path != null && !path.isEmpty()) {
-            if (path.startsWith("/")) {
+            if (StringHelper.startsWith(path, '/')) {
                 path = path.substring(1);
             }
 
@@ -214,12 +214,12 @@ public final class NettyHttpHelper {
             // if there are no query params
             if (idx == -1) {
                 // make sure that there is exactly one "/" between HTTP_URI and HTTP_PATH
-                uri = uri.endsWith("/") ? uri : uri + "/";
+                uri = StringHelper.endsWith(uri, '/') ? uri : uri + "/";
                 uri = uri.concat(path);
             } else {
                 // there are query params, so inject the relative path in the right place
                 String base = uri.substring(0, idx);
-                base = base.endsWith("/") ? base : base + "/";
+                base = StringHelper.endsWith(base, '/') ? base : base + "/";
                 base = base.concat(path);
                 uri = base.concat(uri.substring(idx));
             }

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/RestContextPathMatcher.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/RestContextPathMatcher.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.component.netty.http;
 
-import org.apache.camel.util.StringHelper;
-
 import java.util.Locale;
+
+import org.apache.camel.util.StringHelper;
 
 /**
  * A {@link org.apache.camel.component.netty.http.ContextPathMatcher} that supports the Rest DSL.

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/RestContextPathMatcher.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/RestContextPathMatcher.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.netty.http;
 
+import org.apache.camel.util.StringHelper;
+
 import java.util.Locale;
 
 /**
@@ -60,17 +62,17 @@ public class RestContextPathMatcher extends DefaultContextPathMatcher {
      */
     public boolean matchRestPath(String requestPath, String consumerPath, boolean wildcard) {
         // remove starting/ending slashes
-        if (requestPath.startsWith("/")) {
+        if (StringHelper.startsWith(requestPath, '/')) {
             requestPath = requestPath.substring(1);
         }
-        if (requestPath.endsWith("/")) {
+        if (StringHelper.endsWith(requestPath, '/')) {
             requestPath = requestPath.substring(0, requestPath.length() - 1);
         }
         // remove starting/ending slashes
-        if (consumerPath.startsWith("/")) {
+        if (StringHelper.startsWith(consumerPath, '/')) {
             consumerPath = consumerPath.substring(1);
         }
-        if (consumerPath.endsWith("/")) {
+        if (StringHelper.endsWith(consumerPath, '/')) {
             consumerPath = consumerPath.substring(0, consumerPath.length() - 1);
         }
 
@@ -91,7 +93,7 @@ public class RestContextPathMatcher extends DefaultContextPathMatcher {
             String p1 = requestPaths[i];
             String p2 = consumerPaths[i];
 
-            if (wildcard && p2.startsWith("{") && p2.endsWith("}")) {
+            if (wildcard && StringHelper.startsWith(p2, '{') && StringHelper.endsWith(p2, '}')) {
                 // always matches
                 continue;
             }

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/cloud/NettyHttpServiceExpression.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/cloud/NettyHttpServiceExpression.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.netty.http.cloud;
 
 import org.apache.camel.impl.cloud.DefaultServiceCallExpression;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 
 public final class NettyHttpServiceExpression extends DefaultServiceCallExpression {
     public NettyHttpServiceExpression() {
@@ -39,7 +40,7 @@ public final class NettyHttpServiceExpression extends DefaultServiceCallExpressi
         }
 
         if (contextPath != null) {
-            if (!contextPath.startsWith("/")) {
+            if (!StringHelper.startsWith(contextPath, '/')) {
                 contextPath = "/" + contextPath;
             }
 

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/handlers/HttpServerMultiplexChannelHandler.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/handlers/HttpServerMultiplexChannelHandler.java
@@ -42,6 +42,7 @@ import org.apache.camel.component.netty.http.NettyHttpConfiguration;
 import org.apache.camel.component.netty.http.NettyHttpConstants;
 import org.apache.camel.component.netty.http.NettyHttpConsumer;
 import org.apache.camel.support.RestConsumerContextPathMatcher;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.UnsafeUriCharactersEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -288,7 +289,7 @@ public class HttpServerMultiplexChannelHandler extends SimpleChannelInboundHandl
         }
 
         // strip of ending /
-        if (path.endsWith("/")) {
+        if (StringHelper.endsWith(path, '/')) {
             path = path.substring(0, path.length() - 1);
         }
 

--- a/components/camel-netty/src/main/java/org/apache/camel/component/netty/NettyHelper.java
+++ b/components/camel-netty/src/main/java/org/apache/camel/component/netty/NettyHelper.java
@@ -29,6 +29,7 @@ import io.netty.util.concurrent.EventExecutorGroup;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.NoTypeConversionAvailableException;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.concurrent.CamelThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,13 +64,13 @@ public final class NettyHelper {
         if (autoAppendDelimiter) {
             if (TextLineDelimiter.LINE.equals(delimiter)) {
                 // line delimiter so ensure it ends with newline
-                if (!s.endsWith("\n")) {
+                if (!StringHelper.endsWith(s, '\n')) {
                     LOG.trace("Auto appending missing newline delimiter to body");
                     s = s + "\n";
                 }
             } else {
                 // null delimiter so ensure it ends with null
-                if (!s.endsWith("\u0000")) {
+                if (!StringHelper.endsWith(s, '\u0000')) {
                     LOG.trace("Auto appending missing null delimiter to body");
                     s = s + "\u0000";
                 }

--- a/components/camel-olingo2/camel-olingo2-api/pom.xml
+++ b/components/camel-olingo2/camel-olingo2-api/pom.xml
@@ -66,6 +66,10 @@
             <artifactId>camel-test-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-util</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/camel-olingo2/camel-olingo2-api/src/main/java/org/apache/camel/component/olingo2/api/impl/Olingo2AppImpl.java
+++ b/components/camel-olingo2/camel-olingo2-api/src/main/java/org/apache/camel/component/olingo2/api/impl/Olingo2AppImpl.java
@@ -45,6 +45,7 @@ import org.apache.camel.component.olingo2.api.batch.Olingo2BatchQueryRequest;
 import org.apache.camel.component.olingo2.api.batch.Olingo2BatchRequest;
 import org.apache.camel.component.olingo2.api.batch.Olingo2BatchResponse;
 import org.apache.camel.component.olingo2.api.batch.Operation;
+import org.apache.camel.util.StringHelper;
 import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
@@ -920,7 +921,7 @@ public final class Olingo2AppImpl implements Olingo2App {
         // build body string
         String resourcePath = batchRequest.getResourcePath();
         // is it a referenced entity?
-        if (resourcePath.startsWith("$")) {
+        if (StringHelper.startsWith(resourcePath, '$')) {
             resourcePath = replaceContentId(edm, resourcePath, contentIdMap);
         }
 
@@ -1076,7 +1077,7 @@ public final class Olingo2AppImpl implements Olingo2App {
         // resolve resource path and query params and parse batch part uri
         final String resourcePath = request.getResourcePath();
         final String resolvedResourcePath;
-        if (resourcePath.startsWith("$") && !(METADATA.equals(resourcePath) || BATCH.equals(resourcePath))) {
+        if (StringHelper.startsWith(resourcePath, '$') && !(METADATA.equals(resourcePath) || BATCH.equals(resourcePath))) {
             resolvedResourcePath = findLocation(resourcePath, contentIdLocationMap);
         } else {
             final String resourceLocation = response.getHeader(HttpHeaders.LOCATION);

--- a/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Endpoint.java
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Endpoint.java
@@ -40,6 +40,7 @@ import org.apache.camel.support.PropertyBindingSupport;
 import org.apache.camel.support.component.AbstractApiEndpoint;
 import org.apache.camel.support.component.ApiMethod;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
+import org.apache.camel.util.StringHelper;
 
 /**
  * Communicate with OData 2.0 services using Apache Olingo.
@@ -117,7 +118,7 @@ public class Olingo2Endpoint extends AbstractApiEndpoint<Olingo2ApiName, Olingo2
         Map<String, Object> query = new LinkedHashMap<>();
         Map<String, Object> known = new LinkedHashMap<>();
         options.forEach((k, v) -> {
-            if (StringHelper.startsWith(Olingo2Endpoint.java, '$')) {
+            if (StringHelper.startsWith(k, '$')) {
                 query.put(k, v);
             } else {
                 known.put(k, v);

--- a/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Endpoint.java
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Endpoint.java
@@ -117,7 +117,7 @@ public class Olingo2Endpoint extends AbstractApiEndpoint<Olingo2ApiName, Olingo2
         Map<String, Object> query = new LinkedHashMap<>();
         Map<String, Object> known = new LinkedHashMap<>();
         options.forEach((k, v) -> {
-            if (k.startsWith("$")) {
+            if (StringHelper.startsWith(Olingo2Endpoint.java, '$')) {
                 query.put(k, v);
             } else {
                 known.put(k, v);

--- a/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Endpoint.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Endpoint.java
@@ -40,6 +40,7 @@ import org.apache.camel.support.PropertyBindingSupport;
 import org.apache.camel.support.component.AbstractApiEndpoint;
 import org.apache.camel.support.component.ApiMethod;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
+import org.apache.camel.util.StringHelper;
 
 /**
  * Communicate with OData 4.0 services using Apache Olingo OData API.

--- a/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Endpoint.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Endpoint.java
@@ -117,7 +117,7 @@ public class Olingo4Endpoint extends AbstractApiEndpoint<Olingo4ApiName, Olingo4
         Map<String, Object> query = new LinkedHashMap<>();
         Map<String, Object> known = new LinkedHashMap<>();
         options.forEach((k, v) -> {
-            if (k.startsWith("$")) {
+            if (StringHelper.startsWith(k, '$')) {
                 query.put(k, v);
             } else {
                 known.put(k, v);

--- a/components/camel-quickfix/src/main/java/org/apache/camel/component/quickfixj/converter/QuickfixjConverters.java
+++ b/components/camel-quickfix/src/main/java/org/apache/camel/component/quickfixj/converter/QuickfixjConverters.java
@@ -78,7 +78,7 @@ public final class QuickfixjConverters {
         // if message ends with any sort of newline trim it so QuickfixJ's doesn't fail while parsing the string
         if (message.endsWith("\r\n")) {
             message = message.substring(0, message.length() - 2);
-        } else if (message.endsWith("\r") || message.endsWith("\n")) {
+        } else if (StringHelper.endsWith(message, '\r') || StringHelper.endsWith(message, '\n')) {
             message = message.substring(0, message.length() - 1);
         }
 

--- a/components/camel-quickfix/src/main/java/org/apache/camel/component/quickfixj/converter/QuickfixjConverters.java
+++ b/components/camel-quickfix/src/main/java/org/apache/camel/component/quickfixj/converter/QuickfixjConverters.java
@@ -28,6 +28,7 @@ import org.apache.camel.ExchangePattern;
 import org.apache.camel.component.quickfixj.QuickfixjEndpoint;
 import org.apache.camel.component.quickfixj.QuickfixjEventCategory;
 import org.apache.camel.support.ExchangeHelper;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import quickfix.ConfigError;

--- a/components/camel-rest/src/main/java/org/apache/camel/component/rest/RestApiEndpoint.java
+++ b/components/camel-rest/src/main/java/org/apache/camel/component/rest/RestApiEndpoint.java
@@ -181,7 +181,7 @@ public class RestApiEndpoint extends DefaultEndpoint {
 
             // the base path should start with a leading slash
             String path = getPath();
-            if (path != null && !path.startsWith("/")) {
+            if (path != null && !StringHelper.startsWith(path, '/')) {
                 path = "/" + path;
             }
 
@@ -248,7 +248,7 @@ public class RestApiEndpoint extends DefaultEndpoint {
 
             // calculate the url to the rest API service
             String path = getPath();
-            if (path != null && !path.startsWith("/")) {
+            if (path != null && !StringHelper.startsWith(path, '/')) {
                 path = "/" + path;
             }
 

--- a/components/camel-rest/src/main/java/org/apache/camel/component/rest/RestApiEndpoint.java
+++ b/components/camel-rest/src/main/java/org/apache/camel/component/rest/RestApiEndpoint.java
@@ -38,6 +38,7 @@ import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.DefaultEndpoint;
 import org.apache.camel.util.HostUtils;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 
 /**
  * Expose OpenAPI Specification of the REST services defined using Camel REST DSL.

--- a/components/camel-rest/src/main/java/org/apache/camel/component/rest/RestEndpoint.java
+++ b/components/camel-rest/src/main/java/org/apache/camel/component/rest/RestEndpoint.java
@@ -556,7 +556,7 @@ public class RestEndpoint extends DefaultEndpoint {
 
             // calculate the url to the rest service
             String path = getPath();
-            if (!path.startsWith("/")) {
+            if (!StringHelper.startsWith(path, '/')) {
                 path = "/" + path;
             }
 
@@ -565,7 +565,7 @@ public class RestEndpoint extends DefaultEndpoint {
             // during init of the servlet
             String contextPath = config.getContextPath();
             if (contextPath != null) {
-                if (!contextPath.startsWith("/")) {
+                if (!StringHelper.startsWith(contextPath, '/')) {
                     path = "/" + contextPath + path;
                 } else {
                     path = contextPath + path;
@@ -577,7 +577,7 @@ public class RestEndpoint extends DefaultEndpoint {
             String url = baseUrl;
             if (uriTemplate != null) {
                 // make sure to avoid double slashes
-                if (uriTemplate.startsWith("/")) {
+                if (StringHelper.startsWith(uriTemplate, '/')) {
                     url = url + uriTemplate;
                 } else {
                     url = url + "/" + uriTemplate;

--- a/components/camel-rest/src/main/java/org/apache/camel/component/rest/RestEndpoint.java
+++ b/components/camel-rest/src/main/java/org/apache/camel/component/rest/RestEndpoint.java
@@ -40,6 +40,7 @@ import org.apache.camel.support.DefaultEndpoint;
 import org.apache.camel.support.component.PropertyConfigurerSupport;
 import org.apache.camel.util.HostUtils;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/components/camel-rest/src/main/java/org/apache/camel/component/rest/RestProducer.java
+++ b/components/camel-rest/src/main/java/org/apache/camel/component/rest/RestProducer.java
@@ -42,6 +42,7 @@ import org.apache.camel.support.PropertyBindingSupport;
 import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.URISupport;
 
 import static org.apache.camel.util.ObjectHelper.isEmpty;
@@ -410,10 +411,10 @@ public class RestProducer extends DefaultAsyncProducer {
                     String a = v.toString();
                     // decode the key as { may be decoded to %NN
                     a = URLDecoder.decode(a, "UTF-8");
-                    if (a.startsWith("{") && a.endsWith("}")) {
+                    if (StringHelper.startsWith(a, '{') && StringHelper.endsWith(a, '}')) {
                         String key = a.substring(1, a.length() - 1);
                         boolean optional = false;
-                        if (key.endsWith("?")) {
+                        if (StringHelper.endsWith(key, '?')) {
                             key = key.substring(0, key.length() - 1);
                             optional = true;
                         }
@@ -431,7 +432,7 @@ public class RestProducer extends DefaultAsyncProducer {
             }
             query = URISupport.createQueryString(params);
             // remove any dangling & caused by the absence of optional parameters
-            while (query.endsWith("&")) {
+            while (StringHelper.endsWith(query, '&')) {
                 query = query.substring(0, query.length() - 1);
             }
         }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceLoginConfig.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/SalesforceLoginConfig.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.salesforce;
 
 import org.apache.camel.support.jsse.KeyStoreParameters;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 
 /**
  * Configuration object for Salesforce login properties
@@ -95,7 +96,7 @@ public class SalesforceLoginConfig {
         this.loginUrl = loginUrl;
         if (loginUrl != null) {
             // strip trailing slash
-            this.loginUrl = loginUrl.endsWith("/") ? loginUrl.substring(0, loginUrl.length() - 1) : loginUrl;
+            this.loginUrl = StringHelper.endsWith(loginUrl, '/') ? loginUrl.substring(0, loginUrl.length() - 1) : loginUrl;
         }
     }
 

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/RawProcessor.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/processor/RawProcessor.java
@@ -33,6 +33,7 @@ import org.apache.camel.component.salesforce.api.SalesforceException;
 import org.apache.camel.component.salesforce.internal.PayloadFormat;
 import org.apache.camel.component.salesforce.internal.client.RawClient;
 import org.apache.camel.support.service.ServiceHelper;
+import org.apache.camel.util.StringHelper;
 import org.eclipse.jetty.util.StringUtil;
 
 public class RawProcessor extends AbstractSalesforceProcessor {
@@ -73,7 +74,7 @@ public class RawProcessor extends AbstractSalesforceProcessor {
             if (params != null) {
                 path.append("?");
                 for (String p : params.split(",")) {
-                    if (!path.toString().endsWith("?")) {
+                    if (!StringHelper.endsWith(path.toString(), '?')) {
                         path.append("&");
                     }
                     path.append(p).append("=");

--- a/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/ServletComponent.java
+++ b/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/ServletComponent.java
@@ -95,7 +95,7 @@ public class ServletComponent extends HttpCommonComponent implements RestConsume
             String scheme = StringHelper.before(uri, ":");
             String after = StringHelper.after(uri, ":");
             // rebuild uri to have exactly one leading slash
-            while (after.startsWith("/")) {
+            while (StringHelper.startsWith(after, '/')) {
                 after = after.substring(1);
             }
             after = "/" + after;
@@ -284,7 +284,7 @@ public class ServletComponent extends HttpCommonComponent implements RestConsume
         String path = basePath;
         if (uriTemplate != null) {
             // make sure to avoid double slashes
-            if (uriTemplate.startsWith("/")) {
+            if (StringHelper.startsWith(uriTemplate, '/')) {
                 path = path + uriTemplate;
             } else {
                 path = path + "/" + uriTemplate;

--- a/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/SoapDataFormat.java
+++ b/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/SoapDataFormat.java
@@ -36,6 +36,7 @@ import org.apache.camel.dataformat.soap.name.ElementNameStrategy;
 import org.apache.camel.dataformat.soap.name.ServiceInterfaceStrategy;
 import org.apache.camel.dataformat.soap.name.TypeNameStrategy;
 import org.apache.camel.spi.annotations.Dataformat;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -185,7 +186,7 @@ public class SoapDataFormat extends JaxbDataFormat {
         String soapAction = inMessage.getHeader(Exchange.SOAP_ACTION, String.class);
         if (soapAction == null) {
             soapAction = inMessage.getHeader("SOAPAction", String.class);
-            if (soapAction != null && soapAction.startsWith("\"")) {
+            if (soapAction != null && StringHelper.startsWith(soapAction, '\"')) {
                 soapAction = soapAction.substring(1, soapAction.length() - 1);
             }
         }

--- a/components/camel-spring-main/src/main/java/org/apache/camel/spring/Main.java
+++ b/components/camel-spring-main/src/main/java/org/apache/camel/spring/Main.java
@@ -34,6 +34,7 @@ import org.apache.camel.VetoCamelContextStartException;
 import org.apache.camel.main.MainCommandLineSupport;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.support.AbstractApplicationContext;
@@ -317,7 +318,7 @@ public class Main extends MainCommandLineSupport {
                         break;
                     }
                     line = line.trim();
-                    if (line.startsWith("#") || line.length() == 0) {
+                    if (StringHelper.startsWith(line, '#') || line.length() == 0) {
                         continue;
                     }
                     locations.add(line);

--- a/components/camel-sql/src/main/java/org/apache/camel/component/sql/DefaultSqlPrepareStatementStrategy.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/component/sql/DefaultSqlPrepareStatementStrategy.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
 import org.apache.camel.Exchange;
 import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.support.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.StringQuoteHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -265,7 +266,7 @@ public class DefaultSqlPrepareStatementStrategy implements SqlPrepareStatementSt
         Map<?, ?> headersMap = safeMap(exchange.getIn().getHeaders());
 
         Object answer = null;
-        if ((nextParam.startsWith("$simple{") || nextParam.startsWith("${")) && nextParam.endsWith("}")) {
+        if ((nextParam.startsWith("$simple{") || nextParam.startsWith("${")) && StringHelper.endsWith(nextParam, '}')) {
             answer = exchange.getContext().resolveLanguage("simple").createExpression(nextParam).evaluate(exchange,
                     Object.class);
         } else if (bodyMap.containsKey(nextParam)) {
@@ -281,7 +282,7 @@ public class DefaultSqlPrepareStatementStrategy implements SqlPrepareStatementSt
         Map<?, ?> bodyMap = safeMap(exchange.getContext().getTypeConverter().tryConvertTo(Map.class, body));
         Map<?, ?> headersMap = safeMap(exchange.getIn().getHeaders());
 
-        if ((nextParam.startsWith("$simple{") || nextParam.startsWith("${")) && nextParam.endsWith("}")) {
+        if ((nextParam.startsWith("$simple{") || nextParam.startsWith("${")) && StringHelper.endsWith(nextParam, '}')) {
             return true;
         } else if (bodyMap.containsKey(nextParam)) {
             return true;

--- a/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/TelegramComponent.java
+++ b/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/TelegramComponent.java
@@ -23,6 +23,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
+import org.apache.camel.util.StringHelper;
 
 @Component("telegram")
 public class TelegramComponent extends DefaultComponent {
@@ -46,7 +47,7 @@ public class TelegramComponent extends DefaultComponent {
         TelegramConfiguration configuration = new TelegramConfiguration();
 
         // ignore trailing slash
-        if (remaining.endsWith("/")) {
+        if (StringHelper.endsWith(remaining, '/')) {
             remaining = remaining.substring(0, remaining.length() - 1);
         }
         configuration.setType(remaining);

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowComponent.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowComponent.java
@@ -54,6 +54,7 @@ import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.PropertiesHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.URISupport;
 import org.apache.camel.util.UnsafeUriCharactersEncoder;
 import org.slf4j.Logger;
@@ -199,7 +200,7 @@ public class UndertowComponent extends DefaultComponent
         String path = basePath;
         if (uriTemplate != null) {
             // make sure to avoid double slashes
-            if (uriTemplate.startsWith("/")) {
+            if (StringHelper.startsWith(uriTemplate, '/')) {
                 path = path + uriTemplate;
             } else {
                 path = path + "/" + uriTemplate;

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHelper.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHelper.java
@@ -27,6 +27,7 @@ import io.undertow.util.Methods;
 import org.apache.camel.Exchange;
 import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.URISupport;
 import org.apache.camel.util.UnsafeUriCharactersEncoder;
 
@@ -63,13 +64,13 @@ public final class UndertowHelper {
         String path = exchange.getIn().getHeader(UndertowConstants.HTTP_PATH, String.class);
         // NOW the HTTP_PATH is just related path, we don't need to trim it
         if (path != null) {
-            if (path.startsWith("/")) {
+            if (StringHelper.startsWith(path, '/')) {
                 path = path.substring(1);
             }
             if (path.length() > 0) {
                 // make sure that there is exactly one "/" between HTTP_URI and
                 // HTTP_PATH
-                if (!uri.endsWith("/")) {
+                if (!StringHelper.endsWith(uri, '/')) {
                     uri = uri + "/";
                 }
                 uri = uri.concat(path);

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/cloud/UndertowServiceExpression.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/cloud/UndertowServiceExpression.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.undertow.cloud;
 
 import org.apache.camel.impl.cloud.DefaultServiceCallExpression;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 
 public final class UndertowServiceExpression extends DefaultServiceCallExpression {
     public UndertowServiceExpression() {
@@ -39,7 +40,7 @@ public final class UndertowServiceExpression extends DefaultServiceCallExpressio
         }
 
         if (contextPath != null) {
-            if (!contextPath.startsWith("/")) {
+            if (!StringHelper.startsWith(contextPath, '/')) {
                 contextPath = "/" + contextPath;
             }
 

--- a/components/camel-vertx/camel-vertx-http/src/main/java/org/apache/camel/component/vertx/http/VertxHttpHelper.java
+++ b/components/camel-vertx/camel-vertx-http/src/main/java/org/apache/camel/component/vertx/http/VertxHttpHelper.java
@@ -29,6 +29,7 @@ import org.apache.camel.ExchangePropertyKey;
 import org.apache.camel.Message;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.UnsafeUriCharactersEncoder;
 
 public final class VertxHttpHelper {
@@ -80,13 +81,13 @@ public final class VertxHttpHelper {
         // Append HTTP_PATH header value if is present
         String path = message.getHeader(VertxHttpConstants.HTTP_PATH, String.class);
         if (ObjectHelper.isNotEmpty(path)) {
-            if (path.startsWith("/")) {
+            if (StringHelper.startsWith(path, '/')) {
                 path = path.substring(1);
             }
             if (path.length() > 0) {
                 // make sure that there is exactly one "/" between HTTP_URI and
                 // HTTP_PATH
-                if (!uri.endsWith("/")) {
+                if (!StringHelper.endsWith(uri, '/')) {
                     uri = uri + "/";
                 }
                 uri = uri.concat(path);

--- a/components/camel-vertx/camel-vertx-websocket/src/main/java/org/apache/camel/component/vertx/websocket/VertxWebsocketComponent.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/main/java/org/apache/camel/component/vertx/websocket/VertxWebsocketComponent.java
@@ -30,6 +30,7 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.URISupport;
 import org.apache.camel.util.UnsafeUriCharactersEncoder;
 
@@ -69,7 +70,7 @@ public class VertxWebsocketComponent extends DefaultComponent implements SSLCont
             String scheme = "ws://";
             // Preserves backwards compatibility for the vertx-websocket  on camel-quarkus / camel-k where the HTTP
             // server is provided by the runtime platform and the host:port configuration is not strictly required
-            if (remaining.startsWith("/")) {
+            if (StringHelper.startsWith(remaining, '/')) {
                 wsUri = scheme + "/" + remaining.replaceAll("^/+", "");
             } else {
                 wsUri = scheme + remaining;

--- a/components/camel-vertx/camel-vertx-websocket/src/main/java/org/apache/camel/component/vertx/websocket/VertxWebsocketHelper.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/main/java/org/apache/camel/component/vertx/websocket/VertxWebsocketHelper.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import io.vertx.core.http.impl.HttpUtils;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 
 public final class VertxWebsocketHelper {
 
@@ -70,7 +71,7 @@ public final class VertxWebsocketHelper {
         }
 
         // Paths ending with '*' are Vert.x wildcard routes so match on the path prefix
-        if (hostPath.endsWith("*")) {
+        if (StringHelper.endsWith(hostPath, '*')) {
             exactPathMatch = false;
             hostPath = hostPath.substring(0, hostPath.lastIndexOf('*'));
         }
@@ -89,7 +90,7 @@ public final class VertxWebsocketHelper {
             for (int i = 0; i < hostPathElements.length; i++) {
                 String hostPathElement = hostPathElements[i];
                 String targetPathElement = targetPathElements[i];
-                if (!hostPathElement.startsWith("{") && !hostPathElement.endsWith("}")
+                if (!StringHelper.startsWith(hostPathElement, '{') && !StringHelper.endsWith(hostPathElement, '}')
                         && !hostPathElement.equals(targetPathElement)) {
                     return false;
                 }

--- a/components/camel-webhook/src/main/java/org/apache/camel/component/webhook/WebhookConfiguration.java
+++ b/components/camel-webhook/src/main/java/org/apache/camel/component/webhook/WebhookConfiguration.java
@@ -30,6 +30,7 @@ import org.apache.camel.spi.UriParams;
 import org.apache.camel.spi.UriPath;
 import org.apache.camel.util.HostUtils;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 
 /**
  * Configuration class for the webhook component.
@@ -115,12 +116,12 @@ public class WebhookConfiguration implements Cloneable {
         String path = webhookPath;
         if (path == null) {
             path = computeDefaultPath(endpointUri);
-        } else if (!path.startsWith("/")) {
+        } else if (!StringHelper.startsWith(path, '/')) {
             path = "/" + path;
         }
 
         if (webhookBasePath != null) {
-            if (!webhookBasePath.startsWith("/")) {
+            if (!StringHelper.startsWith(webhookBasePath, '/')) {
                 path = "/" + webhookBasePath + path;
             } else {
                 path = webhookBasePath + path;
@@ -130,7 +131,7 @@ public class WebhookConfiguration implements Cloneable {
         if (external) {
             String contextPath = restConfiguration.getContextPath();
             if (contextPath != null) {
-                if (!contextPath.startsWith("/")) {
+                if (!StringHelper.startsWith(contextPath, '/')) {
                     path = "/" + contextPath + path;
                 } else {
                     path = contextPath + path;

--- a/components/camel-whatsapp/src/main/java/org/apache/camel/component/whatsapp/WhatsAppComponent.java
+++ b/components/camel-whatsapp/src/main/java/org/apache/camel/component/whatsapp/WhatsAppComponent.java
@@ -24,6 +24,7 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 
 @Component("whatsapp")
 public class WhatsAppComponent extends DefaultComponent {
@@ -66,7 +67,7 @@ public class WhatsAppComponent extends DefaultComponent {
 
         configuration.setAuthorizationToken(authorizationToken);
 
-        if (remaining.endsWith("/")) {
+        if (StringHelper.endsWith(remaining, '/')) {
             remaining = remaining.substring(0, remaining.length() - 1);
         }
         configuration.setPhoneNumberId(remaining);

--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppComponent.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppComponent.java
@@ -25,6 +25,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
 import org.apache.camel.support.service.ServiceHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.URISupport;
 import org.jivesoftware.smack.ReconnectionManager;
 import org.slf4j.Logger;
@@ -66,7 +67,7 @@ public class XmppComponent extends DefaultComponent {
         }
         String remainingPath = u.getPath();
         if (remainingPath != null) {
-            if (remainingPath.startsWith("/")) {
+            if (StringHelper.startsWith(remainingPath, '/')) {
                 remainingPath = remainingPath.substring(1);
             }
 

--- a/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
@@ -1165,4 +1165,12 @@ public final class StringHelper {
         return true;
     }
 
+    public static boolean startsWith(String str, char ch) {
+        return !str.isEmpty() && str.charAt(0) == ch;
+    }
+
+    public static boolean endsWith(String str, char ch) {
+        return !str.isEmpty() && str.charAt(str.length() - 1) == ch;
+    }
+
 }

--- a/core/camel-util/src/test/java/org/apache/camel/util/StringHelperTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/StringHelperTest.java
@@ -233,4 +233,23 @@ public class StringHelperTest {
         assertEquals("----", StringHelper.fillChars('-', 4));
         assertEquals("..........", StringHelper.fillChars('.', 10));
     }
+
+    @Test
+    public void testStartsWith() {
+        assertTrue(StringHelper.startsWith("1", '1'));
+        assertTrue(StringHelper.startsWith("1_", '1'));
+        assertFalse(StringHelper.startsWith("", '1'));
+        assertFalse(StringHelper.startsWith("2", '1'));
+        assertFalse(StringHelper.startsWith("2_", '1'));
+    }
+
+    @Test
+    public void testEndsWith() {
+        assertTrue(StringHelper.endsWith("1", '1'));
+        assertTrue(StringHelper.endsWith("_1", '1'));
+        assertFalse(StringHelper.endsWith("", '1'));
+        assertFalse(StringHelper.endsWith("2", '1'));
+        assertFalse(StringHelper.endsWith("_2", '1'));
+    }
+
 }


### PR DESCRIPTION
fixed results of inspection "Single char arg in startsWith() and endsWith() can be substituted with charAt()". charAt() is more efficient
Added two helper methods into StringHelper in camel-util