### PR TITLE
Replaced the concatenation as an argument of StringBuilder.append() calls

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/CamelExchangeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelExchangeException.java
@@ -66,7 +66,8 @@ public class CamelExchangeException extends CamelException {
             if (sb.length() > 0) {
                 sb.append(". ");
             }
-            sb.append("Caused by: [" + cause.getClass().getName() + " - " + cause.getMessage() + "]");
+            sb.append("Caused by: [").append(cause.getClass().getName()).append(" - ")
+                    .append(cause.getMessage()).append(']');
         }
         return sb.toString().trim();
     }

--- a/core/camel-xml-io/src/main/java/org/apache/camel/xml/io/MXParser.java
+++ b/core/camel-xml-io/src/main/java/org/apache/camel/xml/io/MXParser.java
@@ -2873,8 +2873,8 @@ public class MXParser implements XmlPullParser {
                                                                  // one end tag
                             }
                             String tagName = new String(elRawName[i], 0, elRawNameEnd[i]);
-                            expectedTagStack.append(" start tag <" + tagName + ">");
-                            expectedTagStack.append(" from line " + elRawNameLine[i]);
+                            expectedTagStack.append(" start tag <").append(tagName).append('>');
+                            expectedTagStack.append(" from line ").append(elRawNameLine[i]);
                         }
                         expectedTagStack.append(", parser stopped on");
                     }


### PR DESCRIPTION
Replaced the concatenation as an argument of StringBuilder.append() call with the chain of StringBuilder.append() calls. Converted single char strings to chars. PR for core

Ubder the hood each string concatenation is translated to a temporary StringBuilder and for the result its toString() value is assigned. We can avoid these temp StringBuilders.