### PR TITLE
Replaced the concatenation as an argument of StringBuilder.append() calls

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2SignedDataGenerator.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2SignedDataGenerator.java
@@ -97,7 +97,7 @@ public class AS2SignedDataGenerator extends CMSSignedDataGenerator {
      */
     public ContentType createMultipartSignedContentType(String boundary) {
         StringBuilder header = new StringBuilder(AS2MediaType.MULTIPART_SIGNED);
-        header.append("; boundary=" + boundary);
+        header.append("; boundary=").append(boundary);
         Set<String> micAlgSet = new HashSet<>();
 
         // Collect algorithm names used by pre-calculated signers

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/AS2HeaderUtils.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/AS2HeaderUtils.java
@@ -60,11 +60,11 @@ public final class AS2HeaderUtils {
             StringBuilder sb = new StringBuilder();
             sb.append(attribute);
             if (importance != null) {
-                sb.append("=" + importance.toString());
+                sb.append('=').append(importance);
             }
             if (values != null) {
                 for (String value : values) {
-                    sb.append("," + value);
+                    sb.append(',').append(value);
                 }
             }
             return sb.toString();
@@ -99,7 +99,7 @@ public final class AS2HeaderUtils {
             }
             sb.append(element[0]);
             if (element.length > 1) {
-                sb.append(NAME_VALUE_DELIMITER + element[1]);
+                sb.append(NAME_VALUE_DELIMITER).append(element[1]);
             }
         }
         return new BasicHeader(headerName, sb.toString());

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/DispositionNotificationContentUtils.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/DispositionNotificationContentUtils.java
@@ -101,7 +101,7 @@ public final class DispositionNotificationContentUtils {
             for (int i = 0; i < elements.length; i++) {
                 Element element = elements[i];
                 if (i > 0) {
-                    builder.append("; " + element);
+                    builder.append("; ").append(element);
                 } else {
                     builder.append(element);
                 }
@@ -113,11 +113,11 @@ public final class DispositionNotificationContentUtils {
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder();
-            sb.append(name + ": ");
+            sb.append(name).append(": ");
             for (int i = 0; i < elements.length; i++) {
                 Element element = elements[i];
                 if (i > 0) {
-                    sb.append("; " + element);
+                    sb.append("; ").append(element);
                 } else {
                     sb.append(element);
                 }

--- a/components/camel-bean-validator/src/main/java/org/apache/camel/component/bean/validator/BeanValidationException.java
+++ b/components/camel-bean-validator/src/main/java/org/apache/camel/component/bean/validator/BeanValidationException.java
@@ -43,10 +43,11 @@ public class BeanValidationException extends ValidationException {
 
         buffer.append(" errors: [");
         for (ConstraintViolation<Object> constraintViolation : constraintViolations) {
-            buffer.append("property: " + constraintViolation.getPropertyPath() + "; value: "
-                          + constraintViolation.getInvalidValue() + "; constraint: " + constraintViolation.getMessage() + "; ");
+            buffer.append("property: ").append(constraintViolation.getPropertyPath()).append("; value: ")
+                    .append(constraintViolation.getInvalidValue()).append("; constraint: ")
+                    .append(constraintViolation.getMessage()).append("; ");
         }
-        buffer.append("]");
+        buffer.append(']');
 
         return buffer.toString();
     }

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyKeyValuePairFactory.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyKeyValuePairFactory.java
@@ -565,7 +565,7 @@ public class BindyKeyValuePairFactory extends BindyAbstractFactory implements Bi
                     LOG.debug("Value added at the position ({}) : {}{}", posit, value, separator);
                 }
 
-                builder.append(value + separator);
+                builder.append(value).append(separator);
             }
         }
 

--- a/components/camel-cm-sms/src/main/java/org/apache/camel/component/cm/client/SMSMessage.java
+++ b/components/camel-cm-sms/src/main/java/org/apache/camel/component/cm/client/SMSMessage.java
@@ -105,10 +105,10 @@ public class SMSMessage {
     public String toString() {
         StringBuilder toS = new StringBuilder("{phoneNumber: " + phoneNumber + ", message: " + message);
         if (from != null && !from.isEmpty()) {
-            toS.append(", from: " + from);
+            toS.append(", from: ").append(from);
         }
         if (id != null && !id.isEmpty()) {
-            toS.append(", id: " + id);
+            toS.append(", id: ").append(id);
         }
         toS.append(" }");
         return toS.toString();

--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400PgmProducer.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400PgmProducer.java
@@ -213,11 +213,11 @@ public class Jt400PgmProducer extends DefaultProducer {
         for (int i = 0; i < messageList.length; ++i) {
             // Load additional message information.
             messageList[i].load();
-            outputMsg.append(i + ") ");
+            outputMsg.append(i).append(") ");
             outputMsg.append(messageList[i].getText());
             outputMsg.append(" - ");
             outputMsg.append(messageList[i].getHelp());
-            outputMsg.append("\n");
+            outputMsg.append('\n');
         }
         return outputMsg.toString();
     }

--- a/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/Kamelet.java
+++ b/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/Kamelet.java
@@ -112,7 +112,7 @@ public final class Kamelet {
             if (element == null) {
                 continue;
             }
-            prefixBuffer.append(element + ".");
+            prefixBuffer.append(element).append('.');
 
             Properties prefixed = pc.loadProperties(Kamelet.startsWith(prefixBuffer.toString()));
             for (String name : prefixed.stringPropertyNames()) {

--- a/components/camel-nats/src/main/java/org/apache/camel/component/nats/NatsConfiguration.java
+++ b/components/camel-nats/src/main/java/org/apache/camel/component/nats/NatsConfiguration.java
@@ -411,9 +411,9 @@ public class NatsConfiguration {
         String[] pieces = srvspec.split(",");
         for (int i = 0; i < pieces.length; i++) {
             if (i < pieces.length - 1) {
-                servers.append(prefix + pieces[i] + ",");
+                servers.append(prefix).append(pieces[i]).append(',');
             } else {
-                servers.append(prefix + pieces[i]);
+                servers.append(prefix).append(pieces[i]);
             }
         }
         return servers.toString();

--- a/components/camel-olingo4/camel-olingo4-api/src/main/java/org/apache/camel/component/olingo4/api/impl/Olingo4AppImpl.java
+++ b/components/camel-olingo4/camel-olingo4-api/src/main/java/org/apache/camel/component/olingo4/api/impl/Olingo4AppImpl.java
@@ -974,7 +974,7 @@ public final class Olingo4AppImpl implements Olingo4App {
 
         final StringBuilder absolutUri = new StringBuilder(resourceUri).append(SEPARATOR).append(resourcePath);
         if (queryOptions != null && !queryOptions.isEmpty()) {
-            absolutUri.append("?" + queryOptions);
+            absolutUri.append('?').append(queryOptions);
         }
         return absolutUri.toString();
 

--- a/components/camel-snmp/src/main/java/org/apache/camel/component/snmp/SnmpConverters.java
+++ b/components/camel-snmp/src/main/java/org/apache/camel/component/snmp/SnmpConverters.java
@@ -79,9 +79,9 @@ public final class SnmpConverters {
 
     private static void entryAppend(StringBuilder sb, String tag, String value) {
         sb.append(ENTRY_TAG_OPEN);
-        sb.append("<" + tag + ">");
+        sb.append('<').append(tag).append('>');
         sb.append(value);
-        sb.append("</" + tag + ">");
+        sb.append("</").append(tag).append('>');
         sb.append(ENTRY_TAG_CLOSE);
     }
 

--- a/components/camel-xpath/src/main/java/org/apache/camel/language/xpath/DefaultNamespaceContext.java
+++ b/components/camel-xpath/src/main/java/org/apache/camel/language/xpath/DefaultNamespaceContext.java
@@ -117,7 +117,7 @@ public class DefaultNamespaceContext implements NamespaceContext, NamespaceAware
     public String toString() {
         StringBuilder sb = new StringBuilder("[me: ");
         for (Entry<String, String> nsEntry : map.entrySet()) {
-            sb.append("{" + nsEntry.getKey() + " -> " + nsEntry.getValue() + "},");
+            sb.append('{').append(nsEntry.getKey()).append(" -> ").append(nsEntry.getValue()).append("},");
         }
         if (!map.isEmpty()) {
             // remove the last comma


### PR DESCRIPTION
Replaced the concatenation as an argument of StringBuilder.append() call with the chain of StringBuilder.append() calls. Converted single char strings to chars. PR for components

Under the hood each string concatenation is translated to a temporary StringBuilder and for the result its toString() value is assigned. We can avoid these temp StringBuilders.