### PR TITLE
Fix for code inspection "initial size for Collection.toArray() should  be zero". Related to performance. PR for tooling

### DIFF
--- a/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/MethodBodySourceCodeEmitter.java
+++ b/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/MethodBodySourceCodeEmitter.java
@@ -152,7 +152,7 @@ class MethodBodySourceCodeEmitter implements CodeEmitter<MethodSpec> {
             }
         }
 
-        return arguments.toArray(new Object[arguments.size()]);
+        return arguments.toArray(new Object[0]);
     }
 
     static Object[] extend(final Object first, final Object... others) {

--- a/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/OperationVisitor.java
+++ b/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/OperationVisitor.java
@@ -155,7 +155,7 @@ class OperationVisitor<T> {
             return emitter;
         }
 
-        return emitter.emit(method, new Object[] { values.toArray(new String[values.size()]) });
+        return emitter.emit(method, new Object[] { values.toArray(new String[0]) });
     }
 
     CodeEmitter<T> emit(final String method, final Object value) {

--- a/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/RestDefinitionEmitter.java
+++ b/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/RestDefinitionEmitter.java
@@ -69,7 +69,7 @@ class RestDefinitionEmitter implements CodeEmitter<RestsDefinition> {
             }
         }
 
-        return arguments.toArray(new Object[arguments.size()]);
+        return arguments.toArray(new Object[0]);
     }
 
     static Class<?>[] parameterTypesOf(final Object[] args) {


### PR DESCRIPTION
Fix for code inspection "initial size for Collection.toArray() should be zero". Related to performance. PR for tooling

#Justification

Reports Collection.toArray() calls not in the preferred style, and suggests applying the preferred style.
There are two styles to convert a collection to an array:
 
A pre-sized array, for example, c.toArray(new String[c.size()])
An empty array, for example, c.toArray(new String[0])
 
In older Java versions, using a pre-sized array was recommended, as the reflection call necessary to create an array of proper size was quite slow.
However, since late updates of OpenJDK 6, this call was intrinsified, making the performance of the empty array version the same, and sometimes even better, compared to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or synchronized collection as a data race is possible between the size and toArray calls. This may result in extra nulls at the end of the array if the collection was concurrently shrunk during the operation.