### PR TITLE
Fix for code inspection "initial size for Collection.toArray() should be zero". PR for components

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/AS2HeaderUtils.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/AS2HeaderUtils.java
@@ -141,7 +141,7 @@ public final class AS2HeaderUtils {
             }
         }
 
-        return new Parameter(name, importance, values.toArray(new String[values.size()]));
+        return new Parameter(name, importance, values.toArray(new String[0]));
     }
 
     public static String getParameterValue(Header[] headers, String headerName, String parameterName) {

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/DispositionNotificationContentUtils.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/DispositionNotificationContentUtils.java
@@ -246,9 +246,9 @@ public final class DispositionNotificationContentUtils {
                 dispositionMode,
                 dispositionType,
                 dispositionModifier,
-                failures.toArray(new String[failures.size()]),
-                errors.toArray(new String[errors.size()]),
-                warnings.toArray(new String[warnings.size()]),
+                failures.toArray(new String[0]),
+                errors.toArray(new String[0]),
+                warnings.toArray(new String[0]),
                 extensionFields,
                 receivedContentMic);
     }
@@ -270,7 +270,7 @@ public final class DispositionNotificationContentUtils {
             }
         }
 
-        return new Field(fieldName, elements.toArray(new Element[elements.size()]));
+        return new Field(fieldName, elements.toArray(new Element[0]));
     }
 
     public static Element parseDispositionFieldElement(CharArrayBuffer fieldLine, ParserCursor cursor) {
@@ -302,6 +302,6 @@ public final class DispositionNotificationContentUtils {
             }
         }
 
-        return new Element(value, parameters.toArray(new String[parameters.size()]));
+        return new Element(value, parameters.toArray(new String[0]));
     }
 }

--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -415,7 +415,7 @@ public class BeanInfo {
         for (int i = 0; i < size; i++) {
             Class<?> parameterType = parameterTypes[i];
             Annotation[] parameterAnnotations
-                    = parametersAnnotations[i].toArray(new Annotation[parametersAnnotations[i].size()]);
+                    = parametersAnnotations[i].toArray(new Annotation[0]);
             Expression expression = createParameterUnmarshalExpression(method, parameterType, parameterAnnotations);
             hasCustomAnnotation |= expression != null;
 

--- a/components/camel-couchbase/src/main/java/org/apache/camel/component/couchbase/CouchbaseEndpoint.java
+++ b/components/camel-couchbase/src/main/java/org/apache/camel/component/couchbase/CouchbaseEndpoint.java
@@ -506,7 +506,7 @@ public class CouchbaseEndpoint extends ScheduledPollEndpoint {
         hostList.add(hostname);
         hostList.addAll(Arrays.asList(hosts));
         Set<String> hostSet = new LinkedHashSet<>(hostList);
-        hosts = hostSet.toArray(new String[hostSet.size()]);
+        hosts = hostSet.toArray(new String[0]);
 
         URI[] uriArray = new URI[hosts.length];
 

--- a/components/camel-disruptor/src/main/java/org/apache/camel/component/disruptor/DisruptorReference.java
+++ b/components/camel-disruptor/src/main/java/org/apache/camel/component/disruptor/DisruptorReference.java
@@ -216,7 +216,7 @@ public class DisruptorReference {
 
         LOGGER.debug("Disruptor created with {} event handlers", eventHandlers.size());
         handleEventsWith(newDisruptor,
-                eventHandlers.toArray(new LifecycleAwareExchangeEventHandler[eventHandlers.size()]));
+                eventHandlers.toArray(new LifecycleAwareExchangeEventHandler[0]));
 
         return newDisruptor;
     }

--- a/components/camel-facebook/src/main/java/org/apache/camel/component/facebook/FacebookConsumer.java
+++ b/components/camel-facebook/src/main/java/org/apache/camel/component/facebook/FacebookConsumer.java
@@ -125,7 +125,7 @@ public class FacebookConsumer extends ScheduledPollConsumer {
         // add reading property for polling, if it doesn't already exist!
         argNames.add(READING_PROPERTY);
 
-        final String[] argNamesArray = argNames.toArray(new String[argNames.size()]);
+        final String[] argNamesArray = argNames.toArray(new String[0]);
         List<FacebookMethodsType> filteredMethods = filterMethods(
                 endpoint.getCandidates(), MatchType.SUPER_SET, argNamesArray);
 
@@ -208,7 +208,7 @@ public class FacebookConsumer extends ScheduledPollConsumer {
         // must be a Collection
         // TODO add support for Paging using ResponseList
         Collection<?> collection = (Collection<?>) result;
-        return collection.toArray(new Object[collection.size()]);
+        return collection.toArray(new Object[0]);
     }
 
     private Map<String, Object> getMethodArguments() {

--- a/components/camel-facebook/src/main/java/org/apache/camel/component/facebook/FacebookEndpoint.java
+++ b/components/camel-facebook/src/main/java/org/apache/camel/component/facebook/FacebookEndpoint.java
@@ -130,7 +130,7 @@ public class FacebookEndpoint extends DefaultEndpoint implements FacebookConstan
         if (inBody != null) {
             arguments.add(inBody);
         }
-        final String[] argNames = arguments.toArray(new String[arguments.size()]);
+        final String[] argNames = arguments.toArray(new String[0]);
 
         candidates = new ArrayList<>();
         candidates.addAll(getCandidateMethods(method, argNames));

--- a/components/camel-facebook/src/main/java/org/apache/camel/component/facebook/FacebookProducer.java
+++ b/components/camel-facebook/src/main/java/org/apache/camel/component/facebook/FacebookProducer.java
@@ -130,7 +130,7 @@ public class FacebookProducer extends DefaultAsyncProducer {
             // filter candidates based on endpoint and exchange properties
             final Set<String> argNames = properties.keySet();
             final List<FacebookMethodsType> filteredMethods = filterMethods(candidates, MatchType.SUPER_SET,
-                    argNames.toArray(new String[argNames.size()]));
+                    argNames.toArray(new String[0]));
 
             // get the method to call
             if (filteredMethods.isEmpty()) {

--- a/components/camel-facebook/src/main/java/org/apache/camel/component/facebook/data/FacebookMethodsTypeHelper.java
+++ b/components/camel-facebook/src/main/java/org/apache/camel/component/facebook/data/FacebookMethodsTypeHelper.java
@@ -314,7 +314,7 @@ public final class FacebookMethodsTypeHelper {
         final List<String> argNames = method.getArgNames();
         final Object[] values = new Object[argNames.size()];
         final List<Class<?>> argTypes = method.getArgTypes();
-        final Class<?>[] types = argTypes.toArray(new Class[argTypes.size()]);
+        final Class<?>[] types = argTypes.toArray(new Class[0]);
         int index = 0;
         for (String name : argNames) {
             Object value = properties.get(name);

--- a/components/camel-flink/src/main/java/org/apache/camel/component/flink/DataSetFlinkProducer.java
+++ b/components/camel-flink/src/main/java/org/apache/camel/component/flink/DataSetFlinkProducer.java
@@ -41,7 +41,7 @@ public class DataSetFlinkProducer extends DefaultProducer {
             Thread.currentThread().setContextClassLoader(DataSet.class.getClassLoader());
             if (body instanceof List) {
                 List list = (List) body;
-                Object[] array = list.toArray(new Object[list.size()]);
+                Object[] array = list.toArray(new Object[0]);
                 result = dataSetCallback.onDataSet(ds, array);
             } else {
                 result = dataSetCallback.onDataSet(ds, body);

--- a/components/camel-flink/src/main/java/org/apache/camel/component/flink/annotations/AnnotatedDataSetCallback.java
+++ b/components/camel-flink/src/main/java/org/apache/camel/component/flink/annotations/AnnotatedDataSetCallback.java
@@ -73,7 +73,7 @@ public class AnnotatedDataSetCallback implements org.apache.camel.component.flin
                 }
             }
 
-            Object[] args = arguments.toArray(new Object[arguments.size()]);
+            Object[] args = arguments.toArray(new Object[0]);
             return invokeMethodSafe(callbackMethod, objectWithCallback, args);
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeCamelException(e);

--- a/components/camel-gson/src/main/java/org/apache/camel/component/gson/GsonDataFormat.java
+++ b/components/camel-gson/src/main/java/org/apache/camel/component/gson/GsonDataFormat.java
@@ -179,7 +179,7 @@ public class GsonDataFormat extends ServiceSupport
         if (gson == null) {
             GsonBuilder builder = new GsonBuilder();
             if (exclusionStrategies != null && !exclusionStrategies.isEmpty()) {
-                ExclusionStrategy[] strategies = exclusionStrategies.toArray(new ExclusionStrategy[exclusionStrategies.size()]);
+                ExclusionStrategy[] strategies = exclusionStrategies.toArray(new ExclusionStrategy[0]);
                 builder.setExclusionStrategies(strategies);
             }
             if (longSerializationPolicy != null) {

--- a/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
+++ b/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
@@ -654,28 +654,28 @@ public abstract class JettyHttpComponent extends HttpCommonComponent
         if (ssl != null && ssl.getCipherSuitesFilter() != null) {
             List<String> includeCiphers = ssl.getCipherSuitesFilter().getInclude();
             if (includeCiphers != null && !includeCiphers.isEmpty()) {
-                String[] arr = includeCiphers.toArray(new String[includeCiphers.size()]);
+                String[] arr = includeCiphers.toArray(new String[0]);
                 answer.setIncludeCipherSuites(arr);
             } else {
                 answer.setIncludeCipherSuites(".*");
             }
             List<String> excludeCiphers = ssl.getCipherSuitesFilter().getExclude();
             if (excludeCiphers != null && !excludeCiphers.isEmpty()) {
-                String[] arr = excludeCiphers.toArray(new String[excludeCiphers.size()]);
+                String[] arr = excludeCiphers.toArray(new String[0]);
                 answer.setExcludeCipherSuites(arr);
             }
         }
         if (ssl != null && ssl.getSecureSocketProtocolsFilter() != null) {
             List<String> includeProtocols = ssl.getSecureSocketProtocolsFilter().getInclude();
             if (includeProtocols != null && !includeProtocols.isEmpty()) {
-                String[] arr = includeProtocols.toArray(new String[includeProtocols.size()]);
+                String[] arr = includeProtocols.toArray(new String[0]);
                 answer.setIncludeProtocols(arr);
             } else {
                 answer.setIncludeProtocols(".*");
             }
             List<String> excludeProtocols = ssl.getSecureSocketProtocolsFilter().getExclude();
             if (excludeProtocols != null && !excludeProtocols.isEmpty()) {
-                String[] arr = excludeProtocols.toArray(new String[excludeProtocols.size()]);
+                String[] arr = excludeProtocols.toArray(new String[0]);
                 answer.setExcludeProtocols(arr);
             }
         }

--- a/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/easypredicate/EasyPredicateParser.java
+++ b/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/easypredicate/EasyPredicateParser.java
@@ -123,7 +123,7 @@ public class EasyPredicateParser {
             list.add(part.toString());
         }
 
-        return list.toArray(new String[list.size()]);
+        return list.toArray(new String[0]);
     }
 
 }

--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailBinding.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailBinding.java
@@ -149,7 +149,7 @@ public class MailBinding {
                 replyToAddresses
                         .add(asEncodedInternetAddress(reply.trim(), determineCharSet(endpoint.getConfiguration(), exchange)));
             }
-            mimeMessage.setReplyTo(replyToAddresses.toArray(new InternetAddress[replyToAddresses.size()]));
+            mimeMessage.setReplyTo(replyToAddresses.toArray(new InternetAddress[0]));
         }
 
         // must have at least one recipients otherwise we do not know where to send the mail
@@ -835,7 +835,7 @@ public class MailBinding {
         }
 
         mimeMessage.addRecipients(asRecipientType(type),
-                recipientsAddresses.toArray(new InternetAddress[recipientsAddresses.size()]));
+                recipientsAddresses.toArray(new InternetAddress[0]));
     }
 
     private static String[] splitRecipients(String recipients) {

--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConsumer.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConsumer.java
@@ -358,7 +358,7 @@ public class MailConsumer extends ScheduledBatchPollingConsumer {
                 }
             }
         }
-        return msgs.toArray(new Message[msgs.size()]);
+        return msgs.toArray(new Message[0]);
     }
 
     private boolean isValidMessage(String key, Message msg) {

--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConverters.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConverters.java
@@ -249,7 +249,7 @@ public final class MailConverters {
             }
         }
         if (!result.isEmpty()) {
-            return result.toArray(new SortTerm[result.size()]);
+            return result.toArray(new SortTerm[0]);
         } else {
             return null;
         }

--- a/components/camel-mock/src/main/java/org/apache/camel/component/mock/MockValueBuilder.java
+++ b/components/camel-mock/src/main/java/org/apache/camel/component/mock/MockValueBuilder.java
@@ -169,7 +169,7 @@ public class MockValueBuilder implements Expression, Predicate {
             Predicate predicate = PredicateBuilder.isEqualTo(expression, right);
             predicates.add(predicate);
         }
-        return in(predicates.toArray(new Predicate[predicates.size()]));
+        return in(predicates.toArray(new Predicate[0]));
     }
 
     public Predicate in(Predicate... predicates) {

--- a/components/camel-robotframework/src/main/java/org/apache/camel/component/robotframework/RobotFrameworkArguments.java
+++ b/components/camel-robotframework/src/main/java/org/apache/camel/component/robotframework/RobotFrameworkArguments.java
@@ -87,7 +87,7 @@ public class RobotFrameworkArguments {
     }
 
     public String[] toArray() {
-        return arguments.toArray(new String[arguments.size()]);
+        return arguments.toArray(new String[0]);
     }
 
 }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/SalesforceReportResultsToListConverter.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/api/SalesforceReportResultsToListConverter.java
@@ -478,7 +478,7 @@ public final class SalesforceReportResultsToListConverter {
             }
         }
 
-        return columnNames.toArray(new String[columnNames.size()]);
+        return columnNames.toArray(new String[0]);
     }
 
     private static void addColumnHeaders(

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBase.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/AbstractClientBase.java
@@ -184,7 +184,7 @@ public abstract class AbstractClientBase extends ServiceSupport
             for (ByteBuffer buffer : content) {
                 buffers.add(buffer);
             }
-            request.content(new ByteBufferContentProvider(buffers.toArray(new ByteBuffer[buffers.size()])));
+            request.content(new ByteBufferContentProvider(buffers.toArray(new ByteBuffer[0])));
             buffers.clear();
         }
 

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppDataSmCommand.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppDataSmCommand.java
@@ -203,12 +203,12 @@ public class SmppDataSmCommand extends AbstractSmppCommand {
         Map<java.lang.Short, Object> optinalParamater = in.getHeader(SmppConstants.OPTIONAL_PARAMETER, Map.class);
         if (optinalParamater != null) {
             List<OptionalParameter> optParams = createOptionalParametersByCode(optinalParamater);
-            dataSm.setOptionalParameters(optParams.toArray(new OptionalParameter[optParams.size()]));
+            dataSm.setOptionalParameters(optParams.toArray(new OptionalParameter[0]));
         } else {
             Map<String, String> optinalParamaters = in.getHeader(SmppConstants.OPTIONAL_PARAMETERS, Map.class);
             if (optinalParamaters != null) {
                 List<OptionalParameter> optParams = createOptionalParametersByName(optinalParamaters);
-                dataSm.setOptionalParameters(optParams.toArray(new OptionalParameter[optParams.size()]));
+                dataSm.setOptionalParameters(optParams.toArray(new OptionalParameter[0]));
             } else {
                 dataSm.setOptionalParameters();
             }

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSubmitMultiCommand.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSubmitMultiCommand.java
@@ -264,12 +264,12 @@ public class SmppSubmitMultiCommand extends SmppSmCommand {
         Map<java.lang.Short, Object> optinalParamater = in.getHeader(SmppConstants.OPTIONAL_PARAMETER, Map.class);
         if (optinalParamater != null) {
             List<OptionalParameter> optParams = createOptionalParametersByCode(optinalParamater);
-            submitMulti.setOptionalParameters(optParams.toArray(new OptionalParameter[optParams.size()]));
+            submitMulti.setOptionalParameters(optParams.toArray(new OptionalParameter[0]));
         } else {
             Map<String, String> optinalParamaters = in.getHeader(SmppConstants.OPTIONAL_PARAMETERS, Map.class);
             if (optinalParamaters != null) {
                 List<OptionalParameter> optParams = createOptionalParametersByName(optinalParamaters);
-                submitMulti.setOptionalParameters(optParams.toArray(new OptionalParameter[optParams.size()]));
+                submitMulti.setOptionalParameters(optParams.toArray(new OptionalParameter[0]));
             } else {
                 submitMulti.setOptionalParameters(new OptionalParameter[] {});
             }

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSubmitSmCommand.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppSubmitSmCommand.java
@@ -224,12 +224,12 @@ public class SmppSubmitSmCommand extends SmppSmCommand {
         Map<java.lang.Short, Object> optinalParamater = in.getHeader(SmppConstants.OPTIONAL_PARAMETER, Map.class);
         if (optinalParamater != null) {
             List<OptionalParameter> optParams = createOptionalParametersByCode(optinalParamater);
-            submitSm.setOptionalParameters(optParams.toArray(new OptionalParameter[optParams.size()]));
+            submitSm.setOptionalParameters(optParams.toArray(new OptionalParameter[0]));
         } else {
             Map<String, String> optinalParamaters = in.getHeader(SmppConstants.OPTIONAL_PARAMETERS, Map.class);
             if (optinalParamaters != null) {
                 List<OptionalParameter> optParams = createOptionalParametersByName(optinalParamaters);
-                submitSm.setOptionalParameters(optParams.toArray(new OptionalParameter[optParams.size()]));
+                submitSm.setOptionalParameters(optParams.toArray(new OptionalParameter[0]));
             } else {
                 submitSm.setOptionalParameters();
             }

--- a/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/name/ServiceInterfaceStrategy.java
+++ b/components/camel-soap/src/main/java/org/apache/camel/dataformat/soap/name/ServiceInterfaceStrategy.java
@@ -149,7 +149,7 @@ public class ServiceInterfaceStrategy implements ElementNameStrategy {
         String soapAction = (webMethod != null) ? webMethod.action() : null;
         return new MethodInfo(
                 method.getName(), soapAction,
-                inInfos.toArray(new TypeInfo[inInfos.size()]), outInfo);
+                inInfos.toArray(new TypeInfo[0]), outInfo);
     }
 
     private void analyzeServiceInterface(Class<?> serviceInterface) {

--- a/components/camel-spring-main/src/main/java/org/apache/camel/spring/Main.java
+++ b/components/camel-spring-main/src/main/java/org/apache/camel/spring/Main.java
@@ -282,7 +282,7 @@ public class Main extends MainCommandLineSupport {
                     }
                 }
                 LOG.info("Using Spring annotation scanning in packages: {}", packages);
-                ac.scan(packages.toArray(new String[packages.size()]));
+                ac.scan(packages.toArray(new String[0]));
                 ac.refresh();
                 return ac;
             } else {
@@ -298,7 +298,7 @@ public class Main extends MainCommandLineSupport {
         if (!locations.isEmpty()) {
             LOG.info("Found locations for additional Spring XML files: {}", locations);
 
-            String[] locs = locations.toArray(new String[locations.size()]);
+            String[] locs = locations.toArray(new String[0]);
             return new ClassPathXmlApplicationContext(locs);
         } else {
             return null;


### PR DESCRIPTION
Fix for code inspection "initial size for Collection.toArray() should be zero". Related to performance. PR for components

#Justification

Reports Collection.toArray() calls not in the preferred style, and suggests applying the preferred style.
There are two styles to convert a collection to an array:

A pre-sized array, for example, c.toArray(new String[c.size()])
An empty array, for example, c.toArray(new String[0])

In older Java versions, using a pre-sized array was recommended, as the reflection call necessary to create an array of proper size was quite slow.
However, since late updates of OpenJDK 6, this call was intrinsified, making the performance of the empty array version the same, and sometimes even better, compared to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or synchronized collection as a data race is possible between the size and toArray calls. This may result in extra nulls at the end of the array if the collection was concurrently shrunk during the operation.