### PR TITLE
Fix for code inspection "initial size for Collection.toArray() should be zero". PR for core

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/support/jsse/BaseSSLContextParameters.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/jsse/BaseSSLContextParameters.java
@@ -344,7 +344,7 @@ public abstract class BaseSSLContextParameters extends JsseParameters {
                             filteredCipherSuites);
                 }
 
-                engine.setEnabledCipherSuites(filteredCipherSuites.toArray(new String[filteredCipherSuites.size()]));
+                engine.setEnabledCipherSuites(filteredCipherSuites.toArray(new String[0]));
 
                 Collection<String> filteredSecureSocketProtocols = BaseSSLContextParameters.this
                         .filter(enabledSecureSocketProtocols, Arrays.asList(engine.getSSLParameters().getProtocols()),
@@ -364,7 +364,7 @@ public abstract class BaseSSLContextParameters extends JsseParameters {
                 }
 
                 engine.setEnabledProtocols(
-                        filteredSecureSocketProtocols.toArray(new String[filteredSecureSocketProtocols.size()]));
+                        filteredSecureSocketProtocols.toArray(new String[0]));
 
                 return engine;
             }
@@ -516,7 +516,7 @@ public abstract class BaseSSLContextParameters extends JsseParameters {
                             filteredCipherSuites);
                 }
 
-                socket.setEnabledCipherSuites(filteredCipherSuites.toArray(new String[filteredCipherSuites.size()]));
+                socket.setEnabledCipherSuites(filteredCipherSuites.toArray(new String[0]));
 
                 Collection<String> filteredSecureSocketProtocols = BaseSSLContextParameters.this
                         .filter(enabledSecureSocketProtocols, Arrays.asList(socket.getSSLParameters().getProtocols()),
@@ -536,7 +536,7 @@ public abstract class BaseSSLContextParameters extends JsseParameters {
                 }
 
                 socket.setEnabledProtocols(
-                        filteredSecureSocketProtocols.toArray(new String[filteredSecureSocketProtocols.size()]));
+                        filteredSecureSocketProtocols.toArray(new String[0]));
                 return socket;
             }
         };
@@ -612,7 +612,7 @@ public abstract class BaseSSLContextParameters extends JsseParameters {
                             filteredCipherSuites);
                 }
 
-                socket.setEnabledCipherSuites(filteredCipherSuites.toArray(new String[filteredCipherSuites.size()]));
+                socket.setEnabledCipherSuites(filteredCipherSuites.toArray(new String[0]));
 
                 Collection<String> filteredSecureSocketProtocols = BaseSSLContextParameters.this
                         .filter(enabledSecureSocketProtocols, Arrays.asList(socket.getSupportedProtocols()),
@@ -632,7 +632,7 @@ public abstract class BaseSSLContextParameters extends JsseParameters {
                 }
 
                 socket.setEnabledProtocols(
-                        filteredSecureSocketProtocols.toArray(new String[filteredSecureSocketProtocols.size()]));
+                        filteredSecureSocketProtocols.toArray(new String[0]));
                 return socket;
             }
         };

--- a/core/camel-api/src/main/java/org/apache/camel/support/jsse/FilterParameters.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/jsse/FilterParameters.java
@@ -140,9 +140,9 @@ public class FilterParameters extends JsseParameters {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append("FilterParameters[include=");
-        builder.append(Arrays.toString(getInclude().toArray(new String[getInclude().size()])));
+        builder.append(Arrays.toString(getInclude().toArray(new String[0])));
         builder.append(", exclude=");
-        builder.append(Arrays.toString(getExclude().toArray(new String[getExclude().size()])));
+        builder.append(Arrays.toString(getExclude().toArray(new String[0])));
         builder.append("]");
         return builder.toString();
     }

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/IntrospectionSupport.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/IntrospectionSupport.java
@@ -328,7 +328,7 @@ final class IntrospectionSupport {
             }
         }
 
-        answer.methods = found.toArray(new BeanIntrospection.MethodInfo[found.size()]);
+        answer.methods = found.toArray(new BeanIntrospection.MethodInfo[0]);
         return answer;
     }
 

--- a/core/camel-base/src/main/java/org/apache/camel/impl/converter/AnnotationTypeConverterLoader.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/converter/AnnotationTypeConverterLoader.java
@@ -199,7 +199,7 @@ public class AnnotationTypeConverterLoader implements TypeConverterLoader {
         }
 
         // return the packages which is not FQN classes
-        return packages.toArray(new String[packages.size()]);
+        return packages.toArray(new String[0]);
     }
 
     /**
@@ -220,7 +220,7 @@ public class AnnotationTypeConverterLoader implements TypeConverterLoader {
             findPackages(packages, ccl);
         }
         findPackages(packages, getClass().getClassLoader());
-        return packages.toArray(new String[packages.size()]);
+        return packages.toArray(new String[0]);
     }
 
     protected void findPackages(Set<String> packages, ClassLoader classLoader) throws IOException {
@@ -435,7 +435,7 @@ public class AnnotationTypeConverterLoader implements TypeConverterLoader {
             }
         }
 
-        return packages.toArray(new String[packages.size()]);
+        return packages.toArray(new String[0]);
     }
 
 }

--- a/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/AbstractCamelCatalog.java
+++ b/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/AbstractCamelCatalog.java
@@ -1028,7 +1028,7 @@ public abstract class AbstractCamelCatalog {
             }
         }
 
-        return tokens.toArray(new String[tokens.size()]);
+        return tokens.toArray(new String[0]);
     }
 
     public ConfigurationPropertiesValidationResult validateConfigurationProperty(String line) {

--- a/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBean.java
+++ b/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBean.java
@@ -1464,7 +1464,7 @@ public abstract class AbstractCamelContextFactoryBean<T extends ModelCamelContex
                 packages.add(name);
             }
         }
-        return packages.toArray(new String[packages.size()]);
+        return packages.toArray(new String[0]);
     }
 
     private void setupCustomServices() {

--- a/core/camel-management/src/main/java/org/apache/camel/management/DefaultManagementAgent.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/DefaultManagementAgent.java
@@ -391,7 +391,7 @@ public class DefaultManagementAgent extends ServiceSupport implements Management
         }
 
         // Using the array to hold the busMBeans to avoid the CurrentModificationException
-        ObjectName[] mBeans = mbeansRegistered.keySet().toArray(new ObjectName[mbeansRegistered.size()]);
+        ObjectName[] mBeans = mbeansRegistered.keySet().toArray(new ObjectName[0]);
         int caught = 0;
         for (ObjectName name : mBeans) {
             try {

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedEventNotifier.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedEventNotifier.java
@@ -183,7 +183,7 @@ public class ManagedEventNotifier extends NotificationBroadcasterSupport impleme
             infos.add(info);
         }
 
-        return infos.toArray(new MBeanNotificationInfo[infos.size()]);
+        return infos.toArray(new MBeanNotificationInfo[0]);
     }
 
 }

--- a/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
@@ -1593,7 +1593,7 @@ public final class PropertyBindingSupport {
             parts.add(sb.toString());
         }
 
-        return parts.toArray(new String[parts.size()]);
+        return parts.toArray(new String[0]);
     }
 
     @FunctionalInterface

--- a/core/camel-support/src/main/java/org/apache/camel/support/builder/ValueBuilder.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/builder/ValueBuilder.java
@@ -134,7 +134,7 @@ public class ValueBuilder implements Expression, Predicate {
             Predicate predicate = onNewPredicate(PredicateBuilder.isEqualTo(expression, right));
             predicates.add(predicate);
         }
-        return in(predicates.toArray(new Predicate[predicates.size()]));
+        return in(predicates.toArray(new Predicate[0]));
     }
 
     public Predicate in(Predicate... predicates) {

--- a/core/camel-support/src/main/java/org/apache/camel/support/component/ApiMethodHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/component/ApiMethodHelper.java
@@ -478,7 +478,7 @@ public final class ApiMethodHelper<T extends Enum<T> & ApiMethod> {
         final List<String> argNames = method.getArgNames();
         final Object[] values = new Object[argNames.size()];
         final List<Class<?>> argTypes = method.getArgTypes();
-        final Class<?>[] types = argTypes.toArray(new Class[argTypes.size()]);
+        final Class<?>[] types = argTypes.toArray(new Class[0]);
         int index = 0;
         for (String name : argNames) {
             Object value = properties.get(name);

--- a/core/camel-support/src/main/java/org/apache/camel/support/component/ApiMethodParser.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/component/ApiMethodParser.java
@@ -196,7 +196,7 @@ public abstract class ApiMethodParser<T> {
 
             Method method;
             try {
-                method = proxyType.getMethod(name, argTypes.toArray(new Class<?>[argTypes.size()]));
+                method = proxyType.getMethod(name, argTypes.toArray(new Class<?>[0]));
             } catch (NoSuchMethodException e) {
                 throw new IllegalArgumentException("Method not found [" + signature + "] in type " + proxyType.getName());
             }

--- a/core/camel-support/src/main/java/org/apache/camel/support/management/MBeanInfoAssembler.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/management/MBeanInfoAssembler.java
@@ -140,11 +140,11 @@ public class MBeanInfoAssembler implements Service {
         String name = getName(customManagedBean != null ? customManagedBean : defaultManagedBean, objectName);
         String description = getDescription(customManagedBean != null ? customManagedBean : defaultManagedBean, objectName);
         ModelMBeanAttributeInfo[] arrayAttributes
-                = mBeanAttributes.toArray(new ModelMBeanAttributeInfo[mBeanAttributes.size()]);
+                = mBeanAttributes.toArray(new ModelMBeanAttributeInfo[0]);
         ModelMBeanOperationInfo[] arrayOperations
-                = mBeanOperations.toArray(new ModelMBeanOperationInfo[mBeanOperations.size()]);
+                = mBeanOperations.toArray(new ModelMBeanOperationInfo[0]);
         ModelMBeanNotificationInfo[] arrayNotifications
-                = mBeanNotifications.toArray(new ModelMBeanNotificationInfo[mBeanNotifications.size()]);
+                = mBeanNotifications.toArray(new ModelMBeanNotificationInfo[0]);
 
         ModelMBeanInfo info
                 = new ModelMBeanInfoSupport(name, description, arrayAttributes, null, arrayOperations, arrayNotifications);

--- a/core/camel-util/src/main/java/org/apache/camel/util/AntPathMatcher.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/AntPathMatcher.java
@@ -458,7 +458,7 @@ public class AntPathMatcher {
                 tokens.add(token);
             }
         }
-        return tokens.toArray(new String[tokens.size()]);
+        return tokens.toArray(new String[0]);
     }
 
     private static boolean different(boolean caseSensitive, char ch, char other) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/HostUtils.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/HostUtils.java
@@ -92,7 +92,7 @@ public final class HostUtils {
             return InetAddress.getLocalHost();
         } else if (addresses != null && !addresses.isEmpty()) {
             //else return the first available addrress
-            return addresses.toArray(new InetAddress[addresses.size()])[0];
+            return addresses.toArray(new InetAddress[0])[0];
         } else {
             //else we are forcedt to use the localhost address.
             return InetAddress.getLocalHost();

--- a/core/camel-util/src/main/java/org/apache/camel/util/StringQuoteHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringQuoteHelper.java
@@ -215,7 +215,7 @@ public final class StringQuoteHelper {
             answer.add(text);
         }
 
-        return answer.toArray(new String[answer.size()]);
+        return answer.toArray(new String[0]);
     }
 
 }


### PR DESCRIPTION
Fix for code inspection "initial size for Collection.toArray() should be zero". Related to performance. PR for core

#Justification

Reports Collection.toArray() calls not in the preferred style, and suggests applying the preferred style.
There are two styles to convert a collection to an array:

A pre-sized array, for example, c.toArray(new String[c.size()])
An empty array, for example, c.toArray(new String[0])

In older Java versions, using a pre-sized array was recommended, as the reflection call necessary to create an array of proper size was quite slow.
However, since late updates of OpenJDK 6, this call was intrinsified, making the performance of the empty array version the same, and sometimes even better, compared to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or synchronized collection as a data race is possible between the size and toArray calls. This may result in extra nulls at the end of the array if the collection was concurrently shrunk during the operation.