### PR TITLE
Use jakarta API in ITs

### DIFF
--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/expanded-v3-yaml/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/expanded-v3-yaml/pom.xml
@@ -32,6 +32,14 @@
     <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-dto-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-dto-v3/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-      <version>${jakarta-annotation-api-version}</version>
+      <version>@jakarta-annotation-api-version@</version>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-dto/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-dto/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-      <version>${jakarta-annotation-api-version}</version>
+      <version>@jakarta-annotation-api-version@</version>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-v3-yaml/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-v3-yaml/pom.xml
@@ -32,6 +32,14 @@
     <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-v3/pom.xml
@@ -32,6 +32,14 @@
     <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml-dto-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml-dto-v3/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-      <version>${jakarta-annotation-api-version}</version>
+      <version>@jakarta-annotation-api-version@</version>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
@@ -106,7 +106,7 @@
                 <dependency>
                   <groupId>jakarta.xml.bind</groupId>
                   <artifactId>jakarta.xml.bind-api</artifactId>
-                  <version>${jakarta-xml-bind-api-version}</version>
+                  <version>@jakarta-xml-bind-api-version@</version>
                 </dependency>
                 <dependency>
                   <groupId>org.glassfish.jaxb</groupId>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml-dto/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml-dto/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-      <version>${jakarta-annotation-api-version}</version>
+      <version>@jakarta-annotation-api-version@</version>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
@@ -106,7 +106,7 @@
                 <dependency>
                   <groupId>jakarta.xml.bind</groupId>
                   <artifactId>jakarta.xml.bind-api</artifactId>
-                  <version>${jakarta-xml-bind-api-version}</version>
+                  <version>@jakarta-xml-bind-api-version@</version>
                 </dependency>
                 <dependency>
                   <groupId>org.glassfish.jaxb</groupId>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml-v3/pom.xml
@@ -70,7 +70,7 @@
                 <dependency>
                   <groupId>jakarta.xml.bind</groupId>
                   <artifactId>jakarta.xml.bind-api</artifactId>
-                  <version>${jakarta-xml-bind-api-version}</version>
+                  <version>@jakarta-xml-bind-api-version@</version>
                 </dependency>
                 <dependency>
                   <groupId>org.glassfish.jaxb</groupId>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml/pom.xml
@@ -70,7 +70,7 @@
                 <dependency>
                   <groupId>jakarta.xml.bind</groupId>
                   <artifactId>jakarta.xml.bind-api</artifactId>
-                  <version>${jakarta-xml-bind-api-version}</version>
+                  <version>@jakarta-xml-bind-api-version@</version>
                 </dependency>
                 <dependency>
                   <groupId>org.glassfish.jaxb</groupId>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-yaml-dto-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-yaml-dto-v3/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-      <version>${jakarta-annotation-api-version}</version>
+      <version>@jakarta-annotation-api-version@</version>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
@@ -106,7 +106,7 @@
                 <dependency>
                   <groupId>jakarta.xml.bind</groupId>
                   <artifactId>jakarta.xml.bind-api</artifactId>
-                  <version>${jakarta-xml-bind-api-version}</version>
+                  <version>@jakarta-xml-bind-api-version@</version>
                 </dependency>
                 <dependency>
                   <groupId>org.glassfish.jaxb</groupId>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-yaml-kamelet-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-yaml-kamelet-v3/pom.xml
@@ -70,7 +70,7 @@
                 <dependency>
                   <groupId>jakarta.xml.bind</groupId>
                   <artifactId>jakarta.xml.bind-api</artifactId>
-                  <version>${jakarta-xml-bind-api-version}</version>
+                  <version>@jakarta-xml-bind-api-version@</version>
                 </dependency>
                 <dependency>
                   <groupId>org.glassfish.jaxb</groupId>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-yaml-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-yaml-v3/pom.xml
@@ -69,7 +69,7 @@
                 <dependency>
                   <groupId>jakarta.xml.bind</groupId>
                   <artifactId>jakarta.xml.bind-api</artifactId>
-                  <version>${jakarta-xml-bind-api-version}</version>
+                  <version>@jakarta-xml-bind-api-version@</version>
                 </dependency>
                 <dependency>
                   <groupId>org.glassfish.jaxb</groupId>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple/pom.xml
@@ -32,6 +32,14 @@
     <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/AbstractGenerateMojo.java
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/main/java/org/apache/camel/maven/generator/openapi/AbstractGenerateMojo.java
@@ -126,7 +126,7 @@ abstract class AbstractGenerateMojo extends AbstractMojo {
     @Parameter
     String basePath;
 
-    @Parameter(defaultValue = "3.0.36")
+    @Parameter(defaultValue = "3.0.42")
     String swaggerCodegenMavenPluginVersion;
 
     @Parameter(defaultValue = "${project}", readonly = true)
@@ -214,13 +214,19 @@ abstract class AbstractGenerateMojo extends AbstractMojo {
         if (modelWithXml != null) {
             elements.add(new MojoExecutor.Element("withXml", modelWithXml));
         }
-        if (configOptions != null) {
-            elements.add(new MojoExecutor.Element(
-                    "configOptions", configOptions.entrySet().stream()
-                            .map(e -> new MojoExecutor.Element(e.getKey(), e.getValue()))
-                            .toArray(MojoExecutor.Element[]::new)));
+        if (configOptions == null) {
+            configOptions = new HashMap<>(1);
         }
-
+        /* workaround for https://github.com/swagger-api/swagger-codegen/issues/11797
+         * with the next release jakarta=true should be used
+         * https://github.com/swagger-api/swagger-codegen-generators/pull/1131
+         */
+        configOptions.put("hideGenerationTimestamp", "true");
+        elements.add(new MojoExecutor.Element(
+                "configOptions", configOptions.entrySet().stream()
+                    .map(e -> new MojoExecutor.Element(e.getKey(), e.getValue()))
+                    .toArray(MojoExecutor.Element[]::new)));
+        
         executeMojo(
                 plugin(
                         groupId("io.swagger.codegen.v3"),


### PR DESCRIPTION
Generated DTOs will be generated without timestamp since swagger-codegen does not fully support jakarta yet.

Should we use openapi codegen maven plugin instead of swagger?