### PR TITLE
CAMEL-19286: camel-ignite - Support the REPLACE operation in the Ignite Cache Producer

### DIFF
--- a/components/camel-ignite/src/main/java/org/apache/camel/component/ignite/IgniteConstants.java
+++ b/components/camel-ignite/src/main/java/org/apache/camel/component/ignite/IgniteConstants.java
@@ -55,8 +55,8 @@ public final class IgniteConstants {
                             "It does not allow you to dynamically change the cache against which a producer operation is performed. Use EIPs for that (e.g. recipient list, dynamic router).",
               javaType = "String", applicableFor = SCHEME_CACHE)
     public static final String IGNITE_CACHE_NAME = "CamelIgniteCacheName";
-    @Metadata(label = "consumer",
-              description = "This header carries the old cache value when passed in the incoming cache event.",
+    @Metadata(description = "(producer) The old cache value to be replaced when invoking the REPLACE operation. \n" +
+                            "(consumer) This header carries the old cache value when passed in the incoming cache event.",
               javaType = "Object", applicableFor = SCHEME_CACHE)
     public static final String IGNITE_CACHE_OLD_VALUE = "CamelIgniteCacheOldValue";
 

--- a/components/camel-ignite/src/main/java/org/apache/camel/component/ignite/cache/IgniteCacheOperation.java
+++ b/components/camel-ignite/src/main/java/org/apache/camel/component/ignite/cache/IgniteCacheOperation.java
@@ -27,6 +27,7 @@ public enum IgniteCacheOperation {
     SIZE,
     REBALANCE,
     QUERY,
-    CLEAR
+    CLEAR,
+    REPLACE,
 
 }

--- a/components/camel-ignite/src/test/java/org/apache/camel/component/ignite/IgniteCacheTest.java
+++ b/components/camel-ignite/src/test/java/org/apache/camel/component/ignite/IgniteCacheTest.java
@@ -180,6 +180,31 @@ public class IgniteCacheTest extends AbstractIgniteTest {
     }
 
     @Test
+    public void testReplaceEntry() {
+        template.requestBodyAndHeader("ignite-cache:" + resourceUid + "?operation=REPLACE", "5678",
+                IgniteConstants.IGNITE_CACHE_KEY, "abcd");
+        IgniteCache<String, String> cache = ignite().getOrCreateCache(resourceUid);
+        Assertions.assertThat(cache.size(CachePeekMode.ALL)).isEqualTo(0);
+
+        cache.put("abcd", "1234");
+        template.requestBodyAndHeader("ignite-cache:" + resourceUid + "?operation=REPLACE", "5678",
+                IgniteConstants.IGNITE_CACHE_KEY, "abcd");
+        Assertions.assertThat(cache.size(CachePeekMode.ALL)).isEqualTo(1);
+        Assertions.assertThat(cache.get("abcd")).isEqualTo("5678");
+
+        Map<String, Object> headers
+                = Map.of(IgniteConstants.IGNITE_CACHE_KEY, "abcd", IgniteConstants.IGNITE_CACHE_OLD_VALUE, "1234");
+        template.requestBodyAndHeaders("ignite-cache:" + resourceUid + "?operation=REPLACE", "9", headers);
+        Assertions.assertThat(cache.size(CachePeekMode.ALL)).isEqualTo(1);
+        Assertions.assertThat(cache.get("abcd")).isEqualTo("5678");
+
+        headers = Map.of(IgniteConstants.IGNITE_CACHE_KEY, "abcd", IgniteConstants.IGNITE_CACHE_OLD_VALUE, "5678");
+        template.requestBodyAndHeaders("ignite-cache:" + resourceUid + "?operation=REPLACE", "9", headers);
+        Assertions.assertThat(cache.size(CachePeekMode.ALL)).isEqualTo(1);
+        Assertions.assertThat(cache.get("abcd")).isEqualTo("9");
+    }
+
+    @Test
     public void testClearCache() {
         IgniteCache<String, String> cache = ignite().getOrCreateCache(resourceUid);
         for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
# Description

Currently, the Ignite Cache component doesn't support some operations provided by Ignite itself. This PR adds the REPLACE operation to the producer as the first step.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`