### PR TITLE
doc: Add default camel metrics to micrometer component

### DIFF
--- a/components/camel-micrometer/src/main/docs/micrometer-component.adoc
+++ b/components/camel-micrometer/src/main/docs/micrometer-component.adoc
@@ -125,6 +125,30 @@ class MyBean extends RouteBuilder {
 }
 ----
 
+== Default Camel Metrics
+
+
+Some Camel specific metrics are available out of the box.
+
+[width="100%",options="header"]
+|=====================================================
+|Name |Type |Description
+|camel.message.history|timer |Sample of performance of each node in the route when message history is enabled
+|camel.routes.added |gauge |Number of routes added
+|camel.routes.running |gauge |Number of routes runnning
+|camel.exchanges.inflight |gauge |Route inflight messages
+|camel.exchanges.total |counter |Total number of processed exchanges
+|camel.exchanges.succeeded |counter |Number of successfully completed exchange
+|camel.exchanges.failed |counter |Number of failed exchanges
+|camel.exchanges.failures.handled |counter |Number of failures handled
+|camel.exchanges.external.redeliveries |counter |Number of external initiated redeliveries (such as from JMS broker)
+|camel.exchange.event.notifier |gauge + summary | Metrics for message created, sent, completed, and failed events
+|camel.route.policy |gauge + summary |Route performance metrics
+|camel.route.policy.long.task |gauge + summary |Route long task metric
+|=====================================================
+
+
+
 == Usage of producers
 
 Each meter has type and name. Supported types are


### PR DESCRIPTION
# Description

Add the default Camel metrics on the micrometer component documentation. 

# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

