### PR TITLE
[CAMEL-18985] Updated `SyncCommitManager` to perform offsets auto-commit only if it's enabled.

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/SyncCommitManager.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/SyncCommitManager.java
@@ -46,8 +46,10 @@ public class SyncCommitManager extends AbstractCommitManager {
 
     @Override
     public void commit() {
-        LOG.info("Auto commitSync {} from {}", threadId, printableTopic);
-        consumer.commitSync();
+        if (kafkaConsumer.getEndpoint().getConfiguration().isAutoCommitEnable()) {
+            LOG.info("Auto commitSync {} from {}", threadId, printableTopic);
+            consumer.commitSync();
+        }
     }
 
     @Override


### PR DESCRIPTION
Bug CAMEL-18985 is caused by [SyncCommitManager.commit()](https://github.com/apache/camel/blob/camel-3.20.x/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/SyncCommitManager.java#L48) method which doesn't have logic to check whether auto-commit is enabled. As result of this [KafkaConsumer.commitSync()](https://kafka.apache.org/33/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#commitSync()) method is getting called in scope of the [KafkaFetchRecords.startPolling()](https://github.com/apache/camel/blob/camel-3.20.x/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java#L343) method. The `KafkaConsumer.commitSync()` method commits offsets returned on the *last* `poll()` for all the subscribed list of topics and partitions regardless of the fact whether events have been successfully processed or not. It's undesirable behaviour, because the component is configured with `autoCommitEnable=false`, `allowManualCommit=true` and `breakOnFirstError=true` to guarantee "at least once" events processing. 

The fix goes inline with existing logic in the [AsyncCommitManager.commit()](https://github.com/apache/camel/blob/camel-3.20.x/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/AsyncCommitManager.java#L50) method which respects the auto-commit configuration. Basically, the same logic is added to the [SyncCommitManager.commit()](https://github.com/apache/camel/blob/camel-3.20.x/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/SyncCommitManager.java#L48) as part of the fix.

Also the auto-commit configuration was respected for sync/async/noop commits in the class `DefaultCommitManager` which was removed as part of the [refactoring](https://github.com/apache/camel/commit/2d46024a7836e7b24dce7257a17d4f9499c48f7b).