### PR TITLE
(chores) performance: use native array copying which may benefit from intrinsic functions

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
@@ -756,12 +756,7 @@ class AbstractExchange implements Exchange {
 
     void copyInternalProperties(Exchange target) {
         AbstractExchange ae = (AbstractExchange) target;
-        for (int i = 0; i < internalProperties.length; i++) {
-            Object value = internalProperties[i];
-            if (value != null) {
-                ae.internalProperties[i] = value;
-            }
-        }
+        System.arraycopy(internalProperties, 0, ae.internalProperties, 0, INTERNAL_LENGTH);
     }
 
     Map<String, Object> getInternalProperties() {


### PR DESCRIPTION
Java's `System.arraycopy` is instrinsified, so, in theory, it should provide better performance (when supported/available on the platform/etc) at best and equivalent performance to the existing one at worst.

Running on my test HW, it seems to indicate a small performance gain compared to existing code:

W/ this:

`
Geometric mean: 714894.9672412889
Standard deviation: 39656.14503166896
`

Baseline
`
Geometric mean: 666166.262717514
Standard deviation: 53664.56234237712
` 

But it was not an extensive test, so the results are probably overly dramatic here. 