### PR TITLE
(chores) camel-core: fix correlation ID handling.

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/Enricher.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/Enricher.java
@@ -261,10 +261,10 @@ public class Enricher extends AsyncProcessorSupport implements IdAware, RouteIdA
     }
 
     private static void copyResultsWithoutCorrelationId(Exchange target, Exchange source) {
-        Object correlationId = source.removeProperty(ExchangePropertyKey.CORRELATION_ID);
+        Object correlationId = target.removeProperty(ExchangePropertyKey.CORRELATION_ID);
         copyResultsPreservePattern(target, source);
         if (correlationId != null) {
-            source.setProperty(ExchangePropertyKey.CORRELATION_ID, correlationId);
+            target.setProperty(ExchangePropertyKey.CORRELATION_ID, correlationId);
         }
     }
 

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
@@ -801,10 +801,10 @@ public class MulticastProcessor extends AsyncProcessorSupport
             } else {
                 // copy the current result to original (preserve original correlation id),
                 // so it will contain this result of this eip
-                Object correlationId = subExchange.removeProperty(ExchangePropertyKey.CORRELATION_ID);
+                Object correlationId = original.removeProperty(ExchangePropertyKey.CORRELATION_ID);
                 ExchangeHelper.copyResults(original, subExchange);
                 if (correlationId != null) {
-                    subExchange.setProperty(ExchangePropertyKey.CORRELATION_ID, correlationId);
+                    original.setProperty(ExchangePropertyKey.CORRELATION_ID, correlationId);
                 }
             }
         }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/enricher/EnricherCorrelationIdTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/enricher/EnricherCorrelationIdTest.java
@@ -31,6 +31,7 @@ class EnricherCorrelationIdTest extends ContextTestSupport {
         String originalCorrelationId = "SOME_ID";
         Exchange exchange = template.request("direct:start", e -> e.setProperty(CORRELATION_ID, originalCorrelationId));
 
+        assertEquals("enrichment", exchange.getMessage().getBody(String.class));
         assertEquals(originalCorrelationId, exchange.getProperty(CORRELATION_ID));
     }
 


### PR DESCRIPTION
Previously (before patch d4626e9d9c82c490bf8a49e09c34b6d54492824a) the "copying" of the array was actually a merge operation. Due to the changes of the referenced patch, the code now fully copies the array.

This patch reworks the way correlation IDs are copied, introduced as part of CAMEL-19066, to retain the original correlation ID and behave like the previous code where this is needed.