### PR TITLE
CAMEL-19058: rework the Message to avoid hitting the type-check scalability issue

### DIFF
--- a/components/camel-attachments/src/main/java/org/apache/camel/attachment/DefaultAttachmentMessage.java
+++ b/components/camel-attachments/src/main/java/org/apache/camel/attachment/DefaultAttachmentMessage.java
@@ -26,9 +26,9 @@ import jakarta.activation.DataHandler;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.trait.message.MessageTrait;
 
 public final class DefaultAttachmentMessage implements AttachmentMessage {
-
     /*
      * Attachments are stores as a property on the {@link Exchange} which ensures they are propagated
      * during routing and we dont have to pollute the generic {@link Message} with attachment APIs
@@ -286,4 +286,18 @@ public final class DefaultAttachmentMessage implements AttachmentMessage {
         return map != null && !map.isEmpty();
     }
 
+    @Override
+    public boolean hasTrait(MessageTrait trait) {
+        return delegate.hasTrait(trait);
+    }
+
+    @Override
+    public Object getPayloadForTrait(MessageTrait trait) {
+        return delegate.getPayloadForTrait(trait);
+    }
+
+    @Override
+    public void setPayloadForTrait(MessageTrait trait, Object object) {
+        delegate.setPayloadForTrait(trait, object);
+    }
 }

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessage.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessage.java
@@ -30,6 +30,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.support.DefaultMessage;
 import org.apache.camel.support.ExchangeHelper;
+import org.apache.camel.trait.message.MessageTrait;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +42,7 @@ import static org.apache.camel.support.MessageHelper.copyBody;
  */
 public class JmsMessage extends DefaultMessage {
     private static final Logger LOG = LoggerFactory.getLogger(JmsMessage.class);
+
     private Message jmsMessage;
     private Session jmsSession;
     private JmsBinding binding;
@@ -148,6 +150,7 @@ public class JmsMessage extends DefaultMessage {
             }
         }
         this.jmsMessage = jmsMessage;
+        setPayloadForTrait(MessageTrait.REDELIVERY, JmsMessageHelper.evalRedeliveryMessageTrait(jmsMessage));
     }
 
     /**
@@ -269,15 +272,6 @@ public class JmsMessage extends DefaultMessage {
         }
     }
 
-    @Override
-    protected Boolean isTransactedRedelivered() {
-        if (jmsMessage != null) {
-            return JmsMessageHelper.getJMSRedelivered(jmsMessage);
-        } else {
-            return null;
-        }
-    }
-
     private String getDestinationAsString(Destination destination) throws JMSException {
         String result = null;
         if (destination == null) {
@@ -293,5 +287,4 @@ public class JmsMessage extends DefaultMessage {
     private String getSanitizedString(Object value) {
         return value != null ? value.toString().replaceAll("[^a-zA-Z0-9\\.\\_\\-]", "_") : "";
     }
-
 }

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessageHelper.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessageHelper.java
@@ -28,6 +28,8 @@ import jakarta.jms.Message;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.support.ExchangeHelper;
+import org.apache.camel.trait.message.MessageTrait;
+import org.apache.camel.trait.message.RedeliveryTraitPayload;
 import org.apache.camel.util.ObjectHelper;
 
 import static org.apache.camel.component.jms.JmsConfiguration.QUEUE_PREFIX;
@@ -347,6 +349,28 @@ public final class JmsMessageHelper {
         }
 
         return null;
+    }
+
+    /**
+     * For a given message, evaluates what is the redelivery state for it and gives the appropriate {@link MessageTrait}
+     * for that redelivery state
+     *
+     * @param  message the message to evalute
+     * @return         The appropriate MessageTrait for the redelivery state (one of MessageTrait.UNDEFINED_REDELIVERY,
+     *                 MessageTrait.IS_REDELIVERY or MessageTrait.NON_REDELIVERY).
+     */
+    public static RedeliveryTraitPayload evalRedeliveryMessageTrait(Message message) {
+        final Boolean redelivered = JmsMessageHelper.getJMSRedelivered(message);
+
+        if (redelivered == null) {
+            return RedeliveryTraitPayload.UNDEFINED_REDELIVERY;
+        }
+
+        if (Boolean.TRUE.equals(redelivered)) {
+            return RedeliveryTraitPayload.IS_REDELIVERY;
+        }
+
+        return RedeliveryTraitPayload.NON_REDELIVERY;
     }
 
     /**

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsMessage.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsMessage.java
@@ -32,6 +32,7 @@ import org.apache.camel.component.sjms.jms.JmsBinding;
 import org.apache.camel.component.sjms.jms.JmsMessageHelper;
 import org.apache.camel.support.DefaultMessage;
 import org.apache.camel.support.ExchangeHelper;
+import org.apache.camel.trait.message.MessageTrait;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,7 @@ import static org.apache.camel.support.MessageHelper.copyBody;
  */
 public class SjmsMessage extends DefaultMessage {
     private static final Logger LOG = LoggerFactory.getLogger(SjmsMessage.class);
+
     private Message jmsMessage;
     private Session jmsSession;
     private JmsBinding binding;
@@ -52,6 +54,8 @@ public class SjmsMessage extends DefaultMessage {
         setJmsMessage(jmsMessage);
         setJmsSession(jmsSession);
         setBinding(binding);
+
+        setPayloadForTrait(MessageTrait.REDELIVERY, JmsMessageHelper.evalRedeliveryMessageTrait(jmsMessage));
     }
 
     public void init(Exchange exchange, Message jmsMessage, Session jmsSession, JmsBinding binding) {
@@ -61,6 +65,8 @@ public class SjmsMessage extends DefaultMessage {
         setBinding(binding);
         // need to populate initial headers when we use pooled exchanges
         populateInitialHeaders(getHeaders());
+
+        setPayloadForTrait(MessageTrait.REDELIVERY, JmsMessageHelper.evalRedeliveryMessageTrait(jmsMessage));
     }
 
     @Override
@@ -284,15 +290,6 @@ public class SjmsMessage extends DefaultMessage {
             return getSanitizedString(id);
         } catch (JMSException e) {
             throw new RuntimeExchangeException("Unable to retrieve JMSMessageID from JMS Message", getExchange(), e);
-        }
-    }
-
-    @Override
-    protected Boolean isTransactedRedelivered() {
-        if (jmsMessage != null) {
-            return JmsMessageHelper.getJMSRedelivered(jmsMessage);
-        } else {
-            return null;
         }
     }
 

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/jms/JmsMessageHelper.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/jms/JmsMessageHelper.java
@@ -27,6 +27,8 @@ import jakarta.jms.Message;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.support.ExchangeHelper;
+import org.apache.camel.trait.message.MessageTrait;
+import org.apache.camel.trait.message.RedeliveryTraitPayload;
 import org.apache.camel.util.ObjectHelper;
 
 import static org.apache.camel.util.StringHelper.removeStartingCharacters;
@@ -326,6 +328,28 @@ public final class JmsMessageHelper {
         }
 
         return null;
+    }
+
+    /**
+     * For a given message, evaluates what is the redelivery state for it and gives the appropriate {@link MessageTrait}
+     * for that redelivery state
+     *
+     * @param  message the message to evalute
+     * @return         The appropriate MessageTrait for the redelivery state (one of MessageTrait.UNDEFINED_REDELIVERY,
+     *                 MessageTrait.IS_REDELIVERY or MessageTrait.NON_REDELIVERY).
+     */
+    public static RedeliveryTraitPayload evalRedeliveryMessageTrait(Message message) {
+        final Boolean redelivered = JmsMessageHelper.getJMSRedelivered(message);
+
+        if (redelivered == null) {
+            return RedeliveryTraitPayload.UNDEFINED_REDELIVERY;
+        }
+
+        if (Boolean.TRUE.equals(redelivered)) {
+            return RedeliveryTraitPayload.IS_REDELIVERY;
+        }
+
+        return RedeliveryTraitPayload.NON_REDELIVERY;
     }
 
     /**

--- a/core/camel-api/src/main/java/org/apache/camel/Message.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Message.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import org.apache.camel.spi.HeadersMapFactory;
+import org.apache.camel.trait.message.MessageTrait;
 
 /**
  * Implements the <a href="http://camel.apache.org/message.html">Message</a> pattern and represents an inbound or
@@ -318,5 +319,29 @@ public interface Message {
      * @param newBody the new body to use
      */
     void copyFromWithNewBody(Message message, Object newBody);
+
+    /**
+     * Checks whether the message has a given {@link MessageTrait}
+     *
+     * @param  trait the {@link MessageTrait} to check
+     * @return       true if the message instance has the trait or false otherwise
+     */
+    boolean hasTrait(MessageTrait trait);
+
+    /**
+     * Gets the payload for the {@link MessageTrait}
+     *
+     * @param  trait the {@link MessageTrait} to obtain the payload
+     * @return       The trait payload or null if not available
+     */
+    Object getPayloadForTrait(MessageTrait trait);
+
+    /**
+     * Sets the payload for the {@link MessageTrait}
+     *
+     * @param trait  the {@link MessageTrait} to set the payload
+     * @param object the payload
+     */
+    void setPayloadForTrait(MessageTrait trait, Object object);
 
 }

--- a/core/camel-api/src/main/java/org/apache/camel/trait/message/MessageTrait.java
+++ b/core/camel-api/src/main/java/org/apache/camel/trait/message/MessageTrait.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.trait.message;
+
+/**
+ * Message traits are runtime traits that can be associated with a message (for instance, the redelivery state, a data
+ * type, etc). This is specifically for internal usage of Camel and not a public API.
+ */
+public enum MessageTrait {
+    /**
+     * The redelivery trait for the message. See {@link RedeliveryTraitPayload}.
+     */
+    REDELIVERY,
+    /**
+     * Whether the message can store a data type. This carries the payload associated with the API specified in
+     * {@link org.apache.camel.spi.DataTypeAware}.
+     */
+    DATA_AWARE;
+}

--- a/core/camel-api/src/main/java/org/apache/camel/trait/message/RedeliveryTraitPayload.java
+++ b/core/camel-api/src/main/java/org/apache/camel/trait/message/RedeliveryTraitPayload.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.trait.message;
+
+/**
+ * Some messages can carry redelivery details which might affect routing (i.e; JMS messages). This trait allows
+ * implementations to assign a payload that determines the redelivery state for the message.
+ */
+public enum RedeliveryTraitPayload {
+    /**
+     * The default redelivery payload, as most messages don't support redeliveries
+     **/
+    UNDEFINED_REDELIVERY,
+    /**
+     * When a message supports redelivery, this indicates that this message is in a non-redelivery state
+     */
+    NON_REDELIVERY,
+
+    /**
+     * When a message supports redelivery, this indicates that this message is in a redelivery state
+     */
+    IS_REDELIVERY,
+}

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultMessage.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultMessage.java
@@ -341,24 +341,9 @@ public class DefaultMessage extends MessageSupport {
     }
 
     /**
-     * A strategy for component specific messages to determine whether the message is redelivered or not.
-     * <p/>
-     * <b>Important: </b> It is not always possible to determine if the transacted is a redelivery or not, and therefore
-     * <tt>null</tt> is returned. Such an example would be a JDBC message. However JMS brokers provides details if a
-     * transacted message is redelivered.
-     *
-     * @return <tt>true</tt> if redelivered, <tt>false</tt> if not, <tt>null</tt> if not able to determine
-     */
-    protected Boolean isTransactedRedelivered() {
-        // return null by default
-        return null;
-    }
-
-    /**
      * Returns true if the headers have been mutated in some way
      */
     protected boolean hasPopulatedHeaders() {
         return headers != null;
     }
-
 }

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultPooledExchange.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultPooledExchange.java
@@ -103,7 +103,6 @@ public final class DefaultPooledExchange extends AbstractExchange implements Poo
             // reset pattern to original
             this.pattern = originalPattern;
             // do not reset endpoint/fromRouteId as it would be the same consumer/endpoint again
-            this.externalRedelivered = null;
             this.routeStop = false;
             this.rollbackOnly = false;
             this.rollbackOnlyLast = false;

--- a/core/camel-support/src/main/java/org/apache/camel/support/MessageHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/MessageHelper.java
@@ -38,6 +38,7 @@ import org.apache.camel.WrappedFile;
 import org.apache.camel.spi.DataTypeAware;
 import org.apache.camel.spi.ExchangeFormatter;
 import org.apache.camel.spi.HeaderFilterStrategy;
+import org.apache.camel.trait.message.MessageTrait;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.StringHelper;
@@ -620,14 +621,14 @@ public final class MessageHelper {
      */
     public static void copyBody(Message source, Message target) {
         // Preserve the DataType if both messages are DataTypeAware
-        if (source instanceof DataTypeAware && target instanceof DataTypeAware) {
-            final DataTypeAware dataTypeAwareSource = (DataTypeAware) source;
-            if (dataTypeAwareSource.hasDataType()) {
-                final DataTypeAware dataTypeAwareTarget = (DataTypeAware) target;
-                dataTypeAwareTarget.setBody(source.getBody(), dataTypeAwareSource.getDataType());
-                return;
-            }
+        if (source.hasTrait(MessageTrait.DATA_AWARE)) {
+            target.setBody(source.getBody());
+            target.setPayloadForTrait(MessageTrait.DATA_AWARE,
+                    source.getPayloadForTrait(MessageTrait.DATA_AWARE));
+
+            return;
         }
+
         target.setBody(source.getBody());
     }
 

--- a/core/camel-support/src/test/java/org/apache/camel/support/MessageHelperTest.java
+++ b/core/camel-support/src/test/java/org/apache/camel/support/MessageHelperTest.java
@@ -24,6 +24,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
 import org.apache.camel.spi.DataType;
+import org.apache.camel.trait.message.MessageTrait;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.support.MessageHelper.copyBody;
@@ -229,6 +230,21 @@ class MessageHelperTest {
 
         @Override
         public void copyFromWithNewBody(Message message, Object newBody) {
+
+        }
+
+        @Override
+        public boolean hasTrait(MessageTrait trait) {
+            return false;
+        }
+
+        @Override
+        public Object getPayloadForTrait(MessageTrait trait) {
+            return null;
+        }
+
+        @Override
+        public void setPayloadForTrait(MessageTrait trait, Object object) {
 
         }
     }


### PR DESCRIPTION
This introduces a trait that works similarly to the internal properties one in the Exchange so that we carry certain details about the message without relying on type specifications.

Among other things this:

- avoids unnecessarily recreating the DefaultMessage multiple times
- moved the data type aware checks out of the hot path
- reworks the isTransactedRedelivered to avoid costlier checks for specific message types


This superseds the proposed changes on #9432.


Additionally, this implements the same pattern of using an array for
internal properties as we already do on the Exchange. Subsequently, my
idea is to abstract this complex array manipulation in an specific class
so we can reuse code and simplify maintenance.