### PR TITLE
CAMEL-17946 candidate hotfix for AS2 POM. Sorry

### DIFF
--- a/components/camel-as2/camel-as2-component/pom.xml
+++ b/components/camel-as2/camel-as2-component/pom.xml
@@ -40,7 +40,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <version>${commons-io-version}</version>
+        <commons-io-version>2.11.0</commons-io-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
# Description

@oscerd @davsclaus 
The nightly build may fail because of this line in POM. Found this issue while back porting HTTPS for AS2 into came-3.x branch
You may want to ask: how could it happen? I disabled auto reimport of the project in the event of POM changes and forgot to reload it manually.
My bad, sorry