### PR TITLE
CAMEL-19102: cache the producer and endpoint locally to avoid hitting the type check scalability issue

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/cache/DefaultProducerCache.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/cache/DefaultProducerCache.java
@@ -59,6 +59,9 @@ public class DefaultProducerCache extends ServiceSupport implements ProducerCach
     private boolean extendedStatistics;
     private final int maxCacheSize;
 
+    private Endpoint lastUsedEndpoint;
+    private AsyncProducer lastUsedProducer;
+
     public DefaultProducerCache(Object source, CamelContext camelContext, int cacheSize) {
         this.source = source;
         this.camelContext = camelContext;
@@ -120,11 +123,23 @@ public class DefaultProducerCache extends ServiceSupport implements ProducerCach
 
     @Override
     public AsyncProducer acquireProducer(Endpoint endpoint) {
+        // Try to favor thread locality as some data in the producer's cache may be shared among threads,
+        // triggering cases of false sharing
+        if (endpoint == lastUsedEndpoint && endpoint.isSingletonProducer()) {
+            return lastUsedProducer;
+        }
+
         try {
             AsyncProducer producer = producers.acquire(endpoint);
             if (statistics != null) {
                 statistics.onHit(endpoint.getEndpointUri());
             }
+
+            synchronized (this) {
+                lastUsedEndpoint = endpoint;
+                lastUsedProducer = producer;
+            }
+
             return producer;
         } catch (Throwable e) {
             throw new FailedToCreateProducerException(endpoint, e);


### PR DESCRIPTION
This reworks the patch originally added on  907a9d0c08d40c5308bb440ec9ebaaa4d7544dc4 so that there is no side effect when handling singleton endpoints