### PR TITLE
(chores) Minor cleanups

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultUuidGenerator.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultUuidGenerator.java
@@ -38,8 +38,8 @@ public class DefaultUuidGenerator implements UuidGenerator {
     }
 
     private static String longToHex(char[] seed, long v) {
-        int l = seed.length;
-        char[] hexChars = new char[16 + seed.length];
+        final int l = seed.length;
+        final char[] hexChars = new char[16 + seed.length];
         System.arraycopy(seed, 0, hexChars, 0, l);
         for (int j = 15; j >= 0; j--) {
             hexChars[l + j] = HEX_ARRAY[(int) (v & 0x0F)];

--- a/core/camel-support/src/main/java/org/apache/camel/support/MessageSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/MessageSupport.java
@@ -204,8 +204,6 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
             return;
         }
 
-        // must copy over CamelContext
-        CamelContextAware.trySetCamelContext(that, camelContext);
         // cover over exchange if none has been assigned
         if (getExchange() == null) {
             setExchange(that.getExchange());


### PR DESCRIPTION
- Avoid setting the context twice (and a type check as well)
- Use final where possible