### PR TITLE
CAMEL-19319: fix a type check cache miss on the UnitOfWorkHelper

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/MDCUnitOfWork.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/MDCUnitOfWork.java
@@ -212,6 +212,12 @@ public class MDCUnitOfWork extends DefaultUnitOfWork implements Service {
     }
 
     @Override
+    public void done(Exchange exchange) {
+        super.done(exchange);
+        clear();
+    }
+
+    @Override
     protected void onDone() {
         super.onDone();
         // clear MDC, so we do not leak as Camel is done using this UoW

--- a/core/camel-support/src/main/java/org/apache/camel/support/UnitOfWorkHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/UnitOfWorkHelper.java
@@ -22,11 +22,9 @@ import java.util.List;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Route;
-import org.apache.camel.Service;
 import org.apache.camel.spi.Synchronization;
 import org.apache.camel.spi.SynchronizationRouteAware;
 import org.apache.camel.spi.UnitOfWork;
-import org.apache.camel.support.service.ServiceHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,9 +51,6 @@ public final class UnitOfWorkHelper {
         // unit of work is done
         try {
             uow.done(exchange);
-            if (uow instanceof Service) {
-                ServiceHelper.stopService(uow);
-            }
         } catch (Throwable e) {
             LOG.warn("Exception occurred during done UnitOfWork for Exchange: {}. This exception will be ignored.",
                     exchange, e);


### PR DESCRIPTION
Only the MDCUnitOfWork class implements the Service interface, so move the clear() call to the done method and avoid the type check