### PR TITLE
Avoid duplicates when generating SBOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -739,6 +739,7 @@
                    <configuration>
                         <outputName>camel-sbom</outputName>
                         <outputDirectory>${project.basedir}/camel-sbom/</outputDirectory>
+                        <excludeArtifactId>camel-allcomponents</excludeArtifactId>
                    </configuration>
                    <executions>
                        <execution>


### PR DESCRIPTION
Excluding `camel-allcomponents` the resulting graph in dependency-track is much clear