### PR TITLE
Fix camel-netty-http tests for 3.18.x

### DIFF
--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpBridgeEncodedPathTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpBridgeEncodedPathTest.java
@@ -88,13 +88,11 @@ public class NettyHttpBridgeEncodedPathTest extends BaseNettyTest {
                 };
 
                 from("netty-http:http://localhost:" + port2 + "/nettyTestRouteA?matchOnUriPrefix=true")
-                        .log("${body} ${headers}")
                         .log("Using NettyTestRouteA route: CamelHttpPath=[${header.CamelHttpPath}], CamelHttpUri=[${header.CamelHttpUri}]")
                         .to("netty-http:http://localhost:" + port1
                             + "/nettyTestRouteB?throwExceptionOnFailure=false&bridgeEndpoint=true");
 
                 from("netty-http:http://localhost:" + port1 + "/nettyTestRouteB?matchOnUriPrefix=true")
-                        .log("${body} ${headers}")
                         .log("Using NettyTestRouteB route: CamelHttpPath=[${header.CamelHttpPath}], CamelHttpUri=[${header.CamelHttpUri}]")
                         .process(serviceProc);
 

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpBridgeEncodedPathTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpBridgeEncodedPathTest.java
@@ -45,9 +45,9 @@ public class NettyHttpBridgeEncodedPathTest extends BaseNettyTest {
 
     @Test
     public void testEncodedQuery() {
-        String response = template.requestBody("http://localhost:" + port2 + "/nettyTestRouteA?param1=%2B447777111222", null,
+        String response = template.requestBody("http://localhost:" + port2 + "/nettyTestRouteA?param1=44777%2B7111222", null,
                 String.class);
-        assertEquals("param1=+447777111222", response, "Get a wrong response");
+        assertEquals("param1=44777+7111222", response, "Get a wrong response");
     }
 
     @Test
@@ -80,19 +80,21 @@ public class NettyHttpBridgeEncodedPathTest extends BaseNettyTest {
                     // %2B becomes decoded to a space
                     Object s = exchange.getIn().getHeader("param1");
                     // can be either + or %2B
-                    assertTrue(s.equals(" 447777111222") || s.equals("%20447777111222") || s.equals("+447777111222")
-                            || s.equals("%2B447777111222"));
+                    assertTrue(s.equals("44777 7111222") || s.equals("44777%207111222") || s.equals("44777+7111222")
+                            || s.equals("44777%2B7111222"));
 
                     // send back the query
                     exchange.getMessage().setBody(exchange.getIn().getHeader(Exchange.HTTP_QUERY));
                 };
 
                 from("netty-http:http://localhost:" + port2 + "/nettyTestRouteA?matchOnUriPrefix=true")
+                        .log("${body} ${headers}")
                         .log("Using NettyTestRouteA route: CamelHttpPath=[${header.CamelHttpPath}], CamelHttpUri=[${header.CamelHttpUri}]")
                         .to("netty-http:http://localhost:" + port1
                             + "/nettyTestRouteB?throwExceptionOnFailure=false&bridgeEndpoint=true");
 
                 from("netty-http:http://localhost:" + port1 + "/nettyTestRouteB?matchOnUriPrefix=true")
+                        .log("${body} ${headers}")
                         .log("Using NettyTestRouteB route: CamelHttpPath=[${header.CamelHttpPath}], CamelHttpUri=[${header.CamelHttpUri}]")
                         .process(serviceProc);
 

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpGetWithParamAsExchangeHeaderTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpGetWithParamAsExchangeHeaderTest.java
@@ -68,11 +68,11 @@ public class NettyHttpGetWithParamAsExchangeHeaderTest extends BaseNettyTest {
     public void testHttpGetWithSpaceEncodedInParams() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
-        mock.expectedHeaderReceived("message", " World");
+        mock.expectedHeaderReceived("message", "Wor ld");
         mock.expectedHeaderReceived(Exchange.HTTP_METHOD, "GET");
 
         // parameter starts with a space using %20 as decimal encoded
-        template.requestBody(serverUri + "&message=%20World", null, Object.class);
+        template.requestBody(serverUri + "&message=Wor%20ld", null, Object.class);
 
         assertMockEndpointsSatisfied();
     }
@@ -81,11 +81,11 @@ public class NettyHttpGetWithParamAsExchangeHeaderTest extends BaseNettyTest {
     public void testHttpGetWithSpaceInParams() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
-        mock.expectedHeaderReceived("message", " World");
+        mock.expectedHeaderReceived("message", "Wor ld");
         mock.expectedHeaderReceived(Exchange.HTTP_METHOD, "GET");
 
         // parameter starts with a space
-        template.requestBody(serverUri + "&message= World", null, Object.class);
+        template.requestBody(serverUri + "&message=Wor ld", null, Object.class);
 
         assertMockEndpointsSatisfied();
     }
@@ -94,11 +94,11 @@ public class NettyHttpGetWithParamAsExchangeHeaderTest extends BaseNettyTest {
     public void testHttpGetWithSpaceAsPlusInParams() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
-        mock.expectedHeaderReceived("message", " World");
+        mock.expectedHeaderReceived("message", "Wor ld");
         mock.expectedHeaderReceived(Exchange.HTTP_METHOD, "GET");
 
         // parameter starts with a space
-        template.requestBody(serverUri + "&message=+World", null, Object.class);
+        template.requestBody(serverUri + "&message=Wor+ld", null, Object.class);
 
         assertMockEndpointsSatisfied();
     }


### PR DESCRIPTION
Tests were hanging in a couple of places. Cherry-picked some commits that seem to fix things.