### PR TITLE
(chores) camel-support: use static inner class

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/PooledObjectFactorySupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/PooledObjectFactorySupport.java
@@ -134,7 +134,7 @@ public abstract class PooledObjectFactorySupport<T> extends ServiceSupport imple
     /**
      * Represents utilization statistics
      */
-    protected final class UtilizationStatistics implements PooledObjectFactory.Statistics {
+    protected static final class UtilizationStatistics implements PooledObjectFactory.Statistics {
 
         public final LongAdder created = new LongAdder();
         public final LongAdder acquired = new LongAdder();

--- a/core/camel-support/src/main/java/org/apache/camel/support/PrototypeObjectFactorySupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/PrototypeObjectFactorySupport.java
@@ -95,7 +95,7 @@ public abstract class PrototypeObjectFactorySupport<T> extends ServiceSupport im
     /**
      * Represents utilization statistics
      */
-    protected final class UtilizationStatistics implements Statistics {
+    protected static final class UtilizationStatistics implements Statistics {
 
         public final LongAdder created = new LongAdder();
         public final LongAdder acquired = new LongAdder();


### PR DESCRIPTION
This should avoid keeping a reference to the enclosing class, potentially saving a bit of memory