### PR TITLE
Upgrades micrometer

### DIFF
--- a/components/camel-observation/src/main/java/org/apache/camel/observation/MicrometerObservationTracer.java
+++ b/components/camel-observation/src/main/java/org/apache/camel/observation/MicrometerObservationTracer.java
@@ -24,7 +24,9 @@ import io.micrometer.observation.transport.ReceiverContext;
 import io.micrometer.observation.transport.RequestReplyReceiverContext;
 import io.micrometer.observation.transport.RequestReplySenderContext;
 import io.micrometer.observation.transport.SenderContext;
+import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.TracingObservationHandler;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.api.management.ManagedResource;
@@ -130,18 +132,35 @@ public class MicrometerObservationTracer extends org.apache.camel.tracing.Tracer
 
     @Override
     protected SpanAdapter startSendingEventSpan(
-            String operationName, SpanKind kind, SpanAdapter parentObservation, Exchange exchange,
+            String operationName, SpanKind kind, SpanAdapter parent, Exchange exchange,
             InjectAdapter injectAdapter) {
         Observation.Context context = spanKindToContextOnInject(kind, injectAdapter, exchange);
         Observation observation = Observation.createNotStarted(CAMEL_CONTEXT_NAME, () -> context, observationRegistry);
         observation.contextualName(operationName);
-        if (parentObservation != null) {
-            observation.parentObservation(getParentObservation(parentObservation));
+        Observation parentObservation = getParentObservation(parent);
+        Tracer.SpanInScope scope = null;
+        try {
+            if (parentObservation != observationRegistry.getCurrentObservation()) {
+                // Because Camel allows to close scopes multiple times
+                TracingObservationHandler.TracingContext tracingContext = parentObservation.getContextView().get(TracingObservationHandler.TracingContext.class);
+                Span parentSpan = tracingContext.getSpan();
+                scope = tracer.withSpan(parentSpan);
+            }
+            if (parentObservation != null) {
+                observation.parentObservation(parentObservation);
+            }
+            return new MicrometerObservationSpanAdapter(observation.start(), tracer);
+        } finally {
+            if (scope != null) {
+                scope.close();
+            }
         }
-        return new MicrometerObservationSpanAdapter(observation.start(), tracer);
     }
 
     private static Observation getParentObservation(SpanAdapter parentObservation) {
+        if (parentObservation == null) {
+            return null;
+        }
         MicrometerObservationSpanAdapter observationWrapper = (MicrometerObservationSpanAdapter) parentObservation;
         return observationWrapper.getMicrometerObservation();
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -393,8 +393,8 @@
         <maven-wagon-version>3.5.2</maven-wagon-version>
         <maven-war-plugin-version>3.3.1</maven-war-plugin-version>
         <metrics-version>4.2.15</metrics-version>
-        <micrometer-version>1.10.5</micrometer-version>
-        <micrometer-tracing-version>1.0.3</micrometer-tracing-version>
+        <micrometer-version>1.10.7</micrometer-version>
+        <micrometer-tracing-version>1.0.6</micrometer-tracing-version>
         <microprofile-config-version>2.0.1</microprofile-config-version>
         <microprofile-metrics-version>3.0.1</microprofile-metrics-version>
         <microprofile-fault-tolerance-version>3.0</microprofile-fault-tolerance-version>


### PR DESCRIPTION
Camel Tracing assumes that you can close the scope multiple times. By fixing Micrometer Tracing's parent span checking we've broken it here. What we have to do is to temporarily put the parent span in scope again so that the what is represented in the parent observation is the same as what is there in thread local