### PR TITLE
[backport 3.18.x] CAMEL-18834: camel-core - StringQuoteHelper should remove quotes for …

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/util/StingQuoteHelperTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/util/StingQuoteHelperTest.java
@@ -124,6 +124,40 @@ public class StingQuoteHelperTest {
         assertEquals("*", out[0]);
         assertEquals("", out[1]);
         assertEquals("arg3", out[2]);
+
+        out = StringQuoteHelper.splitSafeQuote("'Hello'", ',', true);
+        assertEquals(1, out.length);
+        assertEquals("Hello", out[0]);
+
+        out = StringQuoteHelper.splitSafeQuote("' Hello '", ',', true);
+        assertEquals(1, out.length);
+        assertEquals("Hello", out[0]);
+
+        out = StringQuoteHelper.splitSafeQuote("' Hello '", ',', false);
+        assertEquals(1, out.length);
+        assertEquals(" Hello ", out[0]);
+
+        out = StringQuoteHelper.splitSafeQuote("'Hello', 'World'", ',', true);
+        assertEquals(2, out.length);
+        assertEquals("Hello", out[0]);
+        assertEquals("World", out[1]);
+
+        out = StringQuoteHelper.splitSafeQuote("\"Hello\"", ',', true);
+        assertEquals(1, out.length);
+        assertEquals("Hello", out[0]);
+
+        out = StringQuoteHelper.splitSafeQuote("\" Hello \"", ',', true);
+        assertEquals(1, out.length);
+        assertEquals("Hello", out[0]);
+
+        out = StringQuoteHelper.splitSafeQuote("\" Hello \"", ',', false);
+        assertEquals(1, out.length);
+        assertEquals(" Hello ", out[0]);
+
+        out = StringQuoteHelper.splitSafeQuote("\"Hello\", \"World\"", ',', true);
+        assertEquals(2, out.length);
+        assertEquals("Hello", out[0]);
+        assertEquals("World", out[1]);
     }
 
     @Test

--- a/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
@@ -1226,7 +1226,7 @@ public final class PropertyBindingSupport {
      */
     public static Object newInstanceConstructorParameters(CamelContext camelContext, Class<?> type, String parameters)
             throws Exception {
-        String[] params = StringQuoteHelper.splitSafeQuote(parameters, ',');
+        String[] params = StringQuoteHelper.splitSafeQuote(parameters, ',', false);
         Constructor found = findMatchingConstructor(type.getConstructors(), params);
         if (found != null) {
             Object[] arr = new Object[found.getParameterCount()];
@@ -1324,7 +1324,7 @@ public final class PropertyBindingSupport {
     public static Object newInstanceFactoryParameters(
             CamelContext camelContext, Class<?> type, String factoryMethod, String parameters)
             throws Exception {
-        String[] params = StringQuoteHelper.splitSafeQuote(parameters, ',');
+        String[] params = StringQuoteHelper.splitSafeQuote(parameters, ',', false);
         Method found = findMatchingFactoryMethod(type.getMethods(), factoryMethod, params);
         if (found != null) {
             Object[] arr = new Object[found.getParameterCount()];


### PR DESCRIPTION
…… (#8941)

CAMEL-18834: camel-core - StringQuoteHelper should remove quotes for single element

Currentlyt `RouteTemplateLocalBeanTest#testLocalBeanFactoryMethod` is failing without this fix.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

