### PR TITLE
(chores) camel-core: use static inner classes in tests

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanInfoAMoreComplexOverloadedTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanInfoAMoreComplexOverloadedTest.java
@@ -81,7 +81,7 @@ public class BeanInfoAMoreComplexOverloadedTest extends ContextTestSupport {
         }
     }
 
-    class Bean {
+    static class Bean {
         public void doSomething(RequestA request) {
         }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanInfoOverloadedWithSubTypeParamTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanInfoOverloadedWithSubTypeParamTest.java
@@ -29,7 +29,7 @@ public class BeanInfoOverloadedWithSubTypeParamTest extends ContextTestSupport {
         assertEquals(2, beanInfo.getMethods().size());
     }
 
-    class Bean {
+    static class Bean {
 
         public void doSomething(RequestB request) {
         }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/ProducerCacheNonSingletonTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/ProducerCacheNonSingletonTest.java
@@ -63,7 +63,7 @@ public class ProducerCacheNonSingletonTest extends ContextTestSupport {
         assertTrue(producer.getStatus().isStopped(), "Should be stopped");
     }
 
-    public class MyDummyComponent extends DefaultComponent {
+    public static class MyDummyComponent extends DefaultComponent {
 
         @Override
         protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultSupervisingRouteControllerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultSupervisingRouteControllerTest.java
@@ -135,7 +135,7 @@ public class DefaultSupervisingRouteControllerTest extends ContextTestSupport {
         }
     }
 
-    private class MyJmsComponent extends SedaComponent {
+    private static class MyJmsComponent extends SedaComponent {
 
         @Override
         protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/IntrospectionSupportTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/IntrospectionSupportTest.java
@@ -136,7 +136,7 @@ public class IntrospectionSupportTest extends ContextTestSupport {
     public static class MyOtherBuilderBean extends MyBuilderBean {
     }
 
-    public class MyOtherOtherBuilderBean extends MyOtherBuilderBean {
+    public static class MyOtherOtherBuilderBean extends MyOtherBuilderBean {
 
         @Override
         public MyOtherOtherBuilderBean setName(String name) {

--- a/core/camel-core/src/test/java/org/apache/camel/issues/RouteStartupFailShouldStopAlsoIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/RouteStartupFailShouldStopAlsoIssueTest.java
@@ -80,7 +80,7 @@ public class RouteStartupFailShouldStopAlsoIssueTest extends ContextTestSupport 
         assertEquals("doStop", EVENTS.get(2));
     }
 
-    private class MyComponent extends DefaultComponent {
+    private static class MyComponent extends DefaultComponent {
 
         public MyComponent(CamelContext context) {
             super(context);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ConsumerRouteIdAwareTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ConsumerRouteIdAwareTest.java
@@ -53,7 +53,7 @@ public class ConsumerRouteIdAwareTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
     }
 
-    private class MyComponent extends DefaultComponent {
+    private static class MyComponent extends DefaultComponent {
 
         public MyComponent(CamelContext context) {
             super(context);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/PipelineStepWithEventTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/PipelineStepWithEventTest.java
@@ -143,7 +143,7 @@ public class PipelineStepWithEventTest extends ContextTestSupport {
         }
     }
 
-    private class MyInterceptStrategy implements InterceptStrategy {
+    private static class MyInterceptStrategy implements InterceptStrategy {
 
         @Override
         public Processor wrapProcessorInInterceptors(

--- a/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionUseOriginalMessageStreamTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/onexception/OnExceptionUseOriginalMessageStreamTest.java
@@ -140,15 +140,15 @@ public class OnExceptionUseOriginalMessageStreamTest extends ContextTestSupport 
         };
     }
 
-    public class ExceptionOne extends Exception {
+    public static class ExceptionOne extends Exception {
 
     }
 
-    public class ExceptionTwo extends Exception {
+    public static class ExceptionTwo extends Exception {
 
     }
 
-    public class MyDataFormatException extends Exception {
+    public static class MyDataFormatException extends Exception {
 
         public MyDataFormatException(String message) {
             super(message);

--- a/core/camel-main/src/test/java/org/apache/camel/main/MainSupervisingRouteControllerFilterFailToStartRouteTest.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/MainSupervisingRouteControllerFilterFailToStartRouteTest.java
@@ -94,7 +94,7 @@ public class MainSupervisingRouteControllerFilterFailToStartRouteTest {
         }
     }
 
-    private class MyJmsConsumer extends SedaConsumer {
+    private static class MyJmsConsumer extends SedaConsumer {
 
         public MyJmsConsumer(SedaEndpoint endpoint, Processor processor) {
             super(endpoint, processor);

--- a/core/camel-main/src/test/java/org/apache/camel/main/MainSupervisingRouteControllerTest.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/MainSupervisingRouteControllerTest.java
@@ -161,7 +161,7 @@ public class MainSupervisingRouteControllerTest {
         }
     }
 
-    private class MyJmsConsumer extends SedaConsumer {
+    private static class MyJmsConsumer extends SedaConsumer {
 
         private int counter;
 

--- a/core/camel-main/src/test/java/org/apache/camel/main/MainSupportCommandLineTest.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/MainSupportCommandLineTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 public class MainSupportCommandLineTest {
 
-    private class MyMainSupport extends MainCommandLineSupport {
+    private static class MyMainSupport extends MainCommandLineSupport {
 
         private CamelContext context = new DefaultCamelContext();
 

--- a/core/camel-main/src/test/java/org/apache/camel/main/MainVetoTest.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/MainVetoTest.java
@@ -47,14 +47,14 @@ public class MainVetoTest {
         assertEquals(0, main.getExitCode());
     }
 
-    private class MyRoute extends RouteBuilder {
+    private static class MyRoute extends RouteBuilder {
         @Override
         public void configure() throws Exception {
             from("timer:foo").to("mock:foo");
         }
     }
 
-    private class MyVetoLifecycle extends LifecycleStrategySupport {
+    private static class MyVetoLifecycle extends LifecycleStrategySupport {
         @Override
         public void onContextStarting(CamelContext context) throws VetoCamelContextStartException {
             throw new VetoCamelContextStartException("We do not like this route", context, false);

--- a/core/camel-management/src/test/java/org/apache/camel/management/LoadTimerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/LoadTimerTest.java
@@ -62,7 +62,7 @@ public class LoadTimerTest extends ContextTestSupport {
         myTimer.stop();
     }
 
-    private class TestLoadAware implements TimerListener {
+    private static class TestLoadAware implements TimerListener {
 
         volatile int counter;
         LoadTriplet load = new LoadTriplet();

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedNonManagedServiceTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedNonManagedServiceTest.java
@@ -83,7 +83,7 @@ public class ManagedNonManagedServiceTest extends ManagementTestSupport {
         };
     }
 
-    private final class MyService extends ServiceSupport {
+    private static final class MyService extends ServiceSupport {
 
         @Override
         protected void doStart() throws Exception {
@@ -96,7 +96,7 @@ public class ManagedNonManagedServiceTest extends ManagementTestSupport {
         }
     }
 
-    private final class MyNonService extends ServiceSupport implements NonManagedService {
+    private static final class MyNonService extends ServiceSupport implements NonManagedService {
 
         @Override
         protected void doStart() throws Exception {

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedRouteRestartTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedRouteRestartTest.java
@@ -97,7 +97,7 @@ public class ManagedRouteRestartTest extends ManagementTestSupport {
         };
     }
 
-    private final class MyRoutePolicy extends RoutePolicySupport {
+    private static final class MyRoutePolicy extends RoutePolicySupport {
 
         private int start;
         private int stop;

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedSupervisingRouteControllerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedSupervisingRouteControllerTest.java
@@ -136,7 +136,7 @@ public class ManagedSupervisingRouteControllerTest extends ManagementTestSupport
         }
     }
 
-    private class MyJmsConsumer extends SedaConsumer {
+    private static class MyJmsConsumer extends SedaConsumer {
 
         public MyJmsConsumer(SedaEndpoint endpoint, Processor processor) {
             super(endpoint, processor);

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedThrottlingExceptionRoutePolicyTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedThrottlingExceptionRoutePolicyTest.java
@@ -155,7 +155,7 @@ public class ManagedThrottlingExceptionRoutePolicyTest extends ManagementTestSup
         };
     }
 
-    class BoomProcess implements Processor {
+    static class BoomProcess implements Processor {
 
         @Override
         public void process(Exchange exchange) throws Exception {
@@ -166,7 +166,7 @@ public class ManagedThrottlingExceptionRoutePolicyTest extends ManagementTestSup
 
     }
 
-    class DummyHandler implements ThrottlingExceptionHalfOpenHandler {
+    static class DummyHandler implements ThrottlingExceptionHalfOpenHandler {
 
         @Override
         public boolean isReadyToBeClosed() {


### PR DESCRIPTION
These are mostly cosmetic, but help reduce noise when generating code quality reports