### PR TITLE
(chores) camel-core: use static inner classes

### DIFF
--- a/core/camel-core-model/src/main/java/org/apache/camel/builder/NotifyBuilder.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/builder/NotifyBuilder.java
@@ -1474,7 +1474,7 @@ public class NotifyBuilder {
         boolean onExchangeSent(Exchange exchange, Endpoint endpoint, long timeTaken);
     }
 
-    private abstract class EventPredicateSupport implements EventPredicate {
+    private abstract static class EventPredicateSupport implements EventPredicate {
 
         @Override
         public boolean isAbstract() {

--- a/core/camel-core/src/test/java/org/apache/camel/processor/PipelineStepWithEventTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/PipelineStepWithEventTest.java
@@ -143,7 +143,7 @@ public class PipelineStepWithEventTest extends ContextTestSupport {
         }
     }
 
-    private class MyInterceptStrategy implements InterceptStrategy {
+    private static class MyInterceptStrategy implements InterceptStrategy {
 
         @Override
         public Processor wrapProcessorInInterceptors(


### PR DESCRIPTION
This should avoid them keeping a reference to the parent class, which provides a very small memory usage reduction in some cases