### PR TITLE
(chores) camel-core: use lower-overhead immutable lists

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/support/jsse/BaseSSLContextParameters.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/jsse/BaseSSLContextParameters.java
@@ -56,16 +56,16 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseSSLContextParameters extends JsseParameters {
 
     protected static final List<String> DEFAULT_CIPHER_SUITES_FILTER_INCLUDE
-            = Collections.unmodifiableList(Arrays.asList(".*"));
+            = List.of(".*");
 
-    protected static final List<String> DEFAULT_CIPHER_SUITES_FILTER_EXCLUDE = Collections
-            .unmodifiableList(Arrays.asList(".*_NULL_.*", ".*_anon_.*", ".*_EXPORT_.*", ".*_DES_.*", ".*MD5", ".*RC4.*"));
+    protected static final List<String> DEFAULT_CIPHER_SUITES_FILTER_EXCLUDE =
+            List.of(".*_NULL_.*", ".*_anon_.*", ".*_EXPORT_.*", ".*_DES_.*", ".*MD5", ".*RC4.*");
 
     protected static final List<String> DEFAULT_SECURE_SOCKET_PROTOCOLS_FILTER_INCLUDE
-            = Collections.unmodifiableList(Arrays.asList(".*"));
+            = List.of(".*");
 
     protected static final List<String> DEFAULT_SECURE_SOCKET_PROTOCOLS_FILTER_EXCLUDE
-            = Collections.unmodifiableList(Arrays.asList("SSL.*"));
+            = List.of("SSL.*");
 
     private static final Logger LOG = LoggerFactory.getLogger(BaseSSLContextParameters.class);
 

--- a/core/camel-core-xml/src/test/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBeanTest.java
+++ b/core/camel-core-xml/src/test/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBeanTest.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.camel.ExtendedCamelContext;
@@ -96,7 +97,7 @@ public class AbstractCamelContextFactoryBeanTest {
                     "{{getInflightRepositoryBrowseEnabled}}"));
 
     // properties that should return value that can be converted to long
-    Set<String> valuesThatReturnLong = new HashSet<>(asList("{{getDelayer}}"));
+    Set<String> valuesThatReturnLong = new HashSet<>(List.of("{{getDelayer}}"));
 
     public AbstractCamelContextFactoryBeanTest() throws Exception {
         ((Service) typeConverter).start();

--- a/core/camel-xml-io/src/test/java/org/apache/camel/xml/in/ModelParserTest.java
+++ b/core/camel-xml-io/src/test/java/org/apache/camel/xml/in/ModelParserTest.java
@@ -52,8 +52,8 @@ public class ModelParserTest {
     public static final String NAMESPACE = "http://camel.apache.org/schema/spring";
     private static final List<String> REST_XMLS
             = Arrays.asList("barRest.xml", "simpleRest.xml", "simpleRestToD.xml", "restAllowedValues.xml");
-    private static final List<String> TEMPLATE_XMLS = Arrays.asList("barTemplate.xml");
-    private static final List<String> TEMPLATED_ROUTE_XMLS = Arrays.asList("barTemplatedRoute.xml");
+    private static final List<String> TEMPLATE_XMLS = List.of("barTemplate.xml");
+    private static final List<String> TEMPLATED_ROUTE_XMLS = List.of("barTemplatedRoute.xml");
 
     @Test
     public void testNoNamespace() throws Exception {


### PR DESCRIPTION
This avoids creating a mutable list and then wrapping it in an immutable one. Instead, creates an immutable list in a single shot.