### PR TITLE
(chores) camel-observation: fix RouteConcurrentTest which needs to run in isolation

### DIFF
--- a/components/camel-observation/pom.xml
+++ b/components/camel-observation/pom.xml
@@ -36,6 +36,12 @@
         <firstVersion>3.21.0</firstVersion>
         <label>monitoring,microservice</label>
         <title>Micrometer Observability</title>
+
+        <camel.surefire.reuseForks>true</camel.surefire.reuseForks>
+        <camel.surefire.forkCount>1</camel.surefire.forkCount>
+        <camel.surefire.forkTimeout>1200</camel.surefire.forkTimeout>
+        <camel.surefire.parallel>true</camel.surefire.parallel>
+        <camel.surefire.parallel.factor>0.5</camel.surefire.parallel.factor>
     </properties>
 
     <dependencies>
@@ -78,5 +84,54 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${camel.surefire.fork.vmargs} -Xmx1024m</argLine>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <forkCount>1</forkCount>
+                            <reuseForks>true</reuseForks>
+                            <excludedGroups>not-parallel</excludedGroups>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>serials-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <forkCount>4</forkCount>
+                            <reuseForks>true</reuseForks>
+                            <groups>not-parallel</groups>
+                            <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
+                        </configuration>
+                    </execution>
+                </executions>
+
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>${basedir}/activemq-data</directory>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/components/camel-observation/src/test/java/org/apache/camel/observation/RouteConcurrentTest.java
+++ b/components/camel-observation/src/test/java/org/apache/camel/observation/RouteConcurrentTest.java
@@ -22,10 +22,13 @@ import io.opentelemetry.api.trace.SpanKind;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tags({ @Tag("not-parallel") })
 class RouteConcurrentTest extends CamelMicrometerObservationTestSupport {
 
     private static SpanTestData[] testdata = {


### PR DESCRIPTION
This also parallelizes the other tests, so it runs faster