### PR TITLE
CAMEL-19365: disable endpoint verification

### DIFF
--- a/components/camel-undertow/pom.xml
+++ b/components/camel-undertow/pom.xml
@@ -158,4 +158,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${camel.surefire.fork.vmargs} -Dio.undertow.client.https.disableEndpointIdentification=true</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHttpsSpringTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowHttpsSpringTest.java
@@ -26,7 +26,6 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -36,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "/SpringTest.xml" })
-@Disabled("Disabled due to CAMEL-19365")
 public class UndertowHttpsSpringTest {
 
     private Integer port;


### PR DESCRIPTION
The test uses a generic certificate that would fail the validation

Thanks Freeman for providing the fix