### PR TITLE
camel-elasticsearch: Downgrade the jackson version to 2.14.3

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -239,6 +239,8 @@
         <jackson-jq-version>1.0.0-preview.20230409</jackson-jq-version>
         <jackson-version>1.9.12</jackson-version>
         <jackson2-version>2.15.1</jackson2-version>
+        <!-- For projects not yet compatible with Jackson 2.15 -->
+        <jackson2.14-version>2.14.3</jackson2.14-version>
         <jackson2-module-scala-version>2.15.1</jackson2-module-scala-version>
         <jackrabbit-version>2.21.16</jackrabbit-version>
         <jasminb-jsonapi-version>0.11</jasminb-jsonapi-version>

--- a/components/camel-elasticsearch/pom.xml
+++ b/components/camel-elasticsearch/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson2-version}</version>
+            <version>${jackson2.14-version}</version>
         </dependency>
 
         <!-- for testing -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -234,6 +234,8 @@
         <jackson-jq-version>1.0.0-preview.20230409</jackson-jq-version>
         <jackson-version>1.9.12</jackson-version>
         <jackson2-version>2.15.1</jackson2-version>
+        <!-- For projects not yet compatible with Jackson 2.15 -->
+        <jackson2.14-version>2.14.3</jackson2.14-version>
         <jackson2-module-scala-version>2.15.1</jackson2-module-scala-version>
         <jackrabbit-version>2.21.16</jackrabbit-version>
         <jasminb-jsonapi-version>0.11</jasminb-jsonapi-version>


### PR DESCRIPTION
## Motivation

The integration tests of the component `camel-elasticsearch` fail due to a `NoClassDefFoundError: com/fasterxml/jackson/core/StreamReadConstraints`, this class has actually a different package name in Jackson 2.15.

## Modifications:

* Downgrade the version of Jackson specifically for the component `camel-elasticsearch` until a version of `elasticsearch-java` supports Jackson 2.15.