### PR TITLE
(chores) camel-util: cleanups and perf improvements

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/URIScanner.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URIScanner.java
@@ -161,7 +161,8 @@ class URIScanner {
             text = value.toString();
         } else {
             // need to replace % with %25 to avoid losing "%" when decoding
-            String s = value.toString().replace("%", "%25");
+            final String s = replacePercent(value.toString());
+
             text = URLDecoder.decode(s, CHARSET);
         }
 
@@ -257,6 +258,14 @@ class URIScanner {
 
         // not RAW value
         return null;
+    }
+
+    public static String replacePercent(String input) {
+        if (input.contains("%")) {
+            return input.replace("%", "%25");
+        }
+
+        return input;
     }
 
 }

--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -512,7 +512,7 @@ public final class URISupport {
         if (raw != null) {
             // do not encode RAW parameters unless it has %
             // need to replace % with %25 to avoid losing "%" when decoding
-            String s = value.replace("%", "%25");
+            final String s = URIScanner.replacePercent(value);
             rc.append(s);
         } else {
             if (encode) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -24,6 +24,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -210,7 +211,7 @@ public final class URISupport {
     public static Map<String, Object> parseQuery(String uri, boolean useRaw, boolean lenient) throws URISyntaxException {
         if (uri == null || uri.isEmpty()) {
             // return an empty map
-            return new LinkedHashMap<>(0);
+            return Collections.emptyMap();
         }
 
         // must check for trailing & as the uri.split("&") will ignore those


### PR DESCRIPTION
On my test machine, the throughput for a test that resolves the URI every single time (as is usual) increased by about 30k exchanges/sec (~3% improvement). In a test machine, I see the following with JMH:

Baseline:
```
Benchmark                               Mode  Cnt       Score      Error  Units
URISupportTest.normalizeFastUri           ss   20   71344.492 ± 1473.562  us/op
URISupportTest.normalizeFastUriWithRAW    ss   20  106508.881 ± 5621.090  us/op
```

This patch:
```
Benchmark                               Mode  Cnt      Score      Error  Units
URISupportTest.normalizeFastUri           ss   20  61024.779 ± 2892.150  us/op
URISupportTest.normalizeFastUriWithRAW    ss   20  96992.700 ± 6245.092  us/op
```