### PR TITLE
camel-rest-openapi: Downgrade the jackson version to 2.14.3

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -474,9 +474,9 @@
         <sshd-version>2.9.2</sshd-version>
         <stompjms-version>1.19</stompjms-version>
         <swagger-java-version>1.6.10</swagger-java-version>
-        <swagger-openapi3-version>2.2.9</swagger-openapi3-version>
+        <swagger-openapi3-version>2.2.10</swagger-openapi3-version>
         <swagger-java-parser-version>1.0.65</swagger-java-parser-version>
-        <swagger-openapi3-java-parser-version>2.1.13</swagger-openapi3-java-parser-version>
+        <swagger-openapi3-java-parser-version>2.1.14</swagger-openapi3-java-parser-version>
         <stax-api-version>1.0.1</stax-api-version>
         <stringtemplate-version>4.3.4</stringtemplate-version>
         <templating-maven-plugin-version>1.0.0</templating-maven-plugin-version>

--- a/components/camel-rest-openapi/pom.xml
+++ b/components/camel-rest-openapi/pom.xml
@@ -64,17 +64,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson2-version}</version>
+            <version>${jackson2.14-version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson2-version}</version>
+            <version>${jackson2.14-version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson2-version}</version>
+            <version>${jackson2.14-version}</version>
         </dependency>
 
         <!-- test -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -469,9 +469,9 @@
         <sshd-version>2.9.2</sshd-version>
         <stompjms-version>1.19</stompjms-version>
         <swagger-java-version>1.6.10</swagger-java-version>
-        <swagger-openapi3-version>2.2.9</swagger-openapi3-version>
+        <swagger-openapi3-version>2.2.10</swagger-openapi3-version>
         <swagger-java-parser-version>1.0.65</swagger-java-parser-version>
-        <swagger-openapi3-java-parser-version>2.1.13</swagger-openapi3-java-parser-version>
+        <swagger-openapi3-java-parser-version>2.1.14</swagger-openapi3-java-parser-version>
         <stax-api-version>1.0.1</stax-api-version>
         <stringtemplate-version>4.3.4</stringtemplate-version>
         <templating-maven-plugin-version>1.0.0</templating-maven-plugin-version>


### PR DESCRIPTION
## Motivation

The test `RestOpenApiGlobalHttpsV31Test` of the component `camel-rest-openapi` fails due to a `java.lang.NoSuchFieldError: READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE`.

## Modifications:

* Downgrades the version of Jackson specifically for the component `camel-rest-openapi` until a version of `swagger-parser` supports Jackson 2.15.
* Upgrades `swagger-parser` and `swagger-models` to the latest bug fix version