### PR TITLE
CAMEL-19388: OSGI - Allow to use CXF 3.6+

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -150,8 +150,8 @@
     <corda-version>4.9.3</corda-version>
     <couchbase-client-version>3.4.1</couchbase-client-version>
     <curator-version>4.3.0</curator-version>
-    <cxf-codegen-plugin-version>3.5.5</cxf-codegen-plugin-version>
-    <cxf-version>3.5.5</cxf-version>
+    <cxf-codegen-plugin-version>3.5.6</cxf-codegen-plugin-version>
+    <cxf-version>3.5.6</cxf-version>
     <cxf-version-range>[3.5,4.0)</cxf-version-range>
     <cxf-xjc-plugin-version>3.3.2</cxf-xjc-plugin-version>
     <cxf-xjc-utils-version>3.3.2</cxf-xjc-utils-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -133,9 +133,9 @@
         <corda-version>4.9.3</corda-version>
         <couchbase-client-version>3.4.1</couchbase-client-version>
         <curator-version>4.3.0</curator-version>
-        <cxf-version>3.5.5</cxf-version>
+        <cxf-version>3.5.6</cxf-version>
         <cxf-version-range>[3.5,4.0)</cxf-version-range>
-        <cxf-codegen-plugin-version>3.5.5</cxf-codegen-plugin-version>
+        <cxf-codegen-plugin-version>3.5.6</cxf-codegen-plugin-version>
         <!-- cxf-xjc is not released as often -->
         <cxf-xjc-plugin-version>3.3.2</cxf-xjc-plugin-version>
         <cxf-xjc-utils-version>3.3.2</cxf-xjc-utils-version>


### PR DESCRIPTION
## Motivation

Since Apache Camel 3.20 is an LTS version and CXF 3.5 should not be maintained anymore soon as 3.6 and 4.0 have been released, the goal of this task is to extend the version range of CXF to allow OSGI users to choose a higher version of CXF 3 that will remain backward compatible with CXF 3.5.

## Modifications:

* Extends the range of versions of CXF to `[3.5,4.0)`
* Upgrades CXF to the latest maintenance version of 3.5