### PR TITLE
CAMEL-19296: Configure checkstyle to prevent the violation

### DIFF
--- a/buildingtools/src/main/resources/camel-checkstyle-suppressions.xml
+++ b/buildingtools/src/main/resources/camel-checkstyle-suppressions.xml
@@ -69,4 +69,10 @@
     <suppress checks=".*"
               files=".*/camel-catalog/src/generated/.*"
               />
+    <suppress checks=".*"
+              files=".*/camel-xml-io-dsl/src/generated/.*"
+    />
+    <suppress checks=".*"
+              files=".*/camel-xml-jaxb-dsl/src/generated/.*"
+    />
 </suppressions>


### PR DESCRIPTION
## Motivation

A checkstyle issue is raised which prevents the build to pass.
```
[camel-xml-io-dsl] [INFO] --- maven-checkstyle-plugin:3.1.2:checkstyle (default-cli) @ camel-xml-io-dsl ---
[camel-xml-io-dsl] [INFO] Starting audit...
[ERROR] /home/runner/work/camel/camel/dsl/camel-xml-io-dsl/src/generated/resources/META-INF/services/org/apache/camel/routes-loader/camel.xml:1: Missing a header - not enough lines in file. [RegexpHeader]
```

## Modifications:

* Aligns the checkstyle configuration with the one of Camel 4.