### PR TITLE
CAMEL-19399: camel-cxf - Don't add entry in Converter cache on error

### DIFF
--- a/components/camel-cxf/camel-cxf-common/src/main/java/org/apache/camel/component/cxf/converter/CxfPayloadConverter.java
+++ b/components/camel-cxf/camel-cxf-common/src/main/java/org/apache/camel/component/cxf/converter/CxfPayloadConverter.java
@@ -179,6 +179,7 @@ public final class CxfPayloadConverter {
             } catch (RuntimeCamelException e) {
                 // the internal conversion to XML can throw an exception if the content is not XML
                 // ignore this and return MISS_VALUE to indicate that we cannot convert this
+                return (T) MISS_VALUE;
             }
             // Let other fallback converter try
             return null;


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19399 (3.20)

## Motivation

If an error occurs while converting a value thanks to the CxfPayloadConverter, the value null is returned to let other fallback converters to try but if there are no such fallback converters, the cache of converters will keep the information that no converter exists which is not incorrect.

## Modifications

* Returns `MISS_VALUE` instead of `null` in case of an error to ensure that the result won't be stored in the cache.