### PR TITLE
CAMEL-19401: camel-test-infra-kafka - Fix Kafka docker image name

### DIFF
--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
@@ -25,7 +25,7 @@ import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class ContainerLocalKafkaService implements KafkaService, ContainerService<KafkaContainer> {
-    public static final String KAFKA3_IMAGE_NAME = "confluentinc/cp-kafkai:7.3.2";
+    public static final String KAFKA3_IMAGE_NAME = "confluentinc/cp-kafka:7.3.2";
 
     private static final Logger LOG = LoggerFactory.getLogger(ContainerLocalKafkaService.class);
     private final KafkaContainer kafka;


### PR DESCRIPTION
## Motivation

The name of the docker image of Kafka is misspelled

## Modifications:

* Fixes the typo