### PR TITLE
Artemis test-infra typo on configuration properties

### DIFF
--- a/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisService.java
+++ b/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisService.java
@@ -41,7 +41,7 @@ public interface ArtemisService
         System.setProperty(ArtemisProperties.SERVICE_ADDRESS, serviceAddress());
         System.setProperty(ArtemisProperties.ARTEMIS_EXTERNAL, serviceAddress());
         System.setProperty(ArtemisProperties.ARTEMIS_USERNAME, userName());
-        System.setProperty(ArtemisProperties.ARTEMIS_PASSWORD, userName());
+        System.setProperty(ArtemisProperties.ARTEMIS_PASSWORD, password());
     }
 
     @Override

--- a/test-infra/camel-test-infra-messaging-common/src/test/java/org/apache/camel/test/infra/messaging/services/MessagingServiceBuilder.java
+++ b/test-infra/camel-test-infra-messaging-common/src/test/java/org/apache/camel/test/infra/messaging/services/MessagingServiceBuilder.java
@@ -35,7 +35,7 @@ public class MessagingServiceBuilder<T extends GenericContainer<T>> {
     }
 
     public static <T extends GenericContainer<T>> MessagingServiceBuilder<T> newBuilder(Supplier<T> containerSupplier) {
-        MessagingServiceBuilder messagingServiceBuilder = new MessagingServiceBuilder<>();
+        MessagingServiceBuilder<T> messagingServiceBuilder = new MessagingServiceBuilder<>();
 
         messagingServiceBuilder.withContainer(containerSupplier);
 
@@ -59,7 +59,7 @@ public class MessagingServiceBuilder<T extends GenericContainer<T>> {
 
         if (instanceType == null || instanceType.isEmpty()) {
             LOG.info("Creating a new messaging local container service");
-            return new MessagingLocalContainerService(containerSupplier.get(), this.endpointFunction);
+            return new MessagingLocalContainerService<>(containerSupplier.get(), this.endpointFunction);
         }
 
         if (instanceType.equals("remote")) {


### PR DESCRIPTION
# Description

Fix a typo in Artemis Test Infra configuration properties

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`
