### PR TITLE
CAMEL-19402: test-infra - Reduce the boilerplate code needed

### DIFF
--- a/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBService.java
+++ b/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBService.java
@@ -17,15 +17,11 @@
 package org.apache.camel.test.infra.arangodb.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for ArangoDB
  */
-public interface ArangoDBService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface ArangoDBService extends TestService {
 
     int getPort();
 
@@ -33,15 +29,5 @@ public interface ArangoDBService extends BeforeAllCallback, AfterAllCallback, Te
 
     default String getServiceAddress() {
         return String.format("%s:%d", getHost(), getPort());
-    }
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
     }
 }

--- a/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBServiceFactory.java
+++ b/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBServiceFactory.java
@@ -36,9 +36,6 @@ public final class ArangoDBServiceFactory {
         }
     }
 
-    private static SimpleTestServiceBuilder<ArangoDBService> instance;
-    private static ArangoDBService arangoDBService;
-
     private ArangoDBServiceFactory() {
 
     }
@@ -55,19 +52,18 @@ public final class ArangoDBServiceFactory {
     }
 
     public static ArangoDBService createSingletonService() {
-        if (arangoDBService == null) {
+        return SingletonServiceHolder.INSTANCE;
+    }
 
-            if (instance == null) {
-                instance = builder();
+    private static class SingletonServiceHolder {
+        static final ArangoDBService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<ArangoDBService> instance = builder();
+            instance.addLocalMapping(() -> new SingletonArangoDBService(new ArangoDBLocalContainerService(), "arangoDB"))
+                    .addRemoteMapping(ArangoDBRemoteService::new)
+                    .build();
 
-                instance.addLocalMapping(() -> new SingletonArangoDBService(new ArangoDBLocalContainerService(), "arangoDB"))
-                        .addRemoteMapping(ArangoDBRemoteService::new)
-                        .build();
-            }
-
-            arangoDBService = instance.build();
+            INSTANCE = instance.build();
         }
-
-        return arangoDBService;
     }
 }

--- a/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBServiceFactory.java
+++ b/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBServiceFactory.java
@@ -18,22 +18,11 @@ package org.apache.camel.test.infra.arangodb.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
 import org.apache.camel.test.infra.common.services.SingletonService;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class ArangoDBServiceFactory {
     private static class SingletonArangoDBService extends SingletonService<ArangoDBService> implements ArangoDBService {
         public SingletonArangoDBService(ArangoDBService service, String name) {
             super(service, name);
-        }
-
-        @Override
-        public void beforeAll(ExtensionContext extensionContext) {
-            addToStore(extensionContext);
-        }
-
-        @Override
-        public void afterAll(ExtensionContext extensionContext) {
-            // NO-OP
         }
 
         @Override

--- a/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisService.java
+++ b/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisService.java
@@ -20,14 +20,11 @@ import org.apache.activemq.artemis.core.server.QueueQueryResult;
 import org.apache.camel.test.infra.artemis.common.ArtemisProperties;
 import org.apache.camel.test.infra.common.services.TestService;
 import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public interface ArtemisService
-        extends BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback, TestService {
+public interface ArtemisService extends BeforeEachCallback, AfterEachCallback, TestService {
 
     String serviceAddress();
 
@@ -43,16 +40,6 @@ public interface ArtemisService
         System.setProperty(ArtemisProperties.ARTEMIS_EXTERNAL, serviceAddress());
         System.setProperty(ArtemisProperties.ARTEMIS_USERNAME, userName());
         System.setProperty(ArtemisProperties.ARTEMIS_PASSWORD, password());
-    }
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
     }
 
     @Override

--- a/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisServiceFactory.java
+++ b/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisServiceFactory.java
@@ -80,22 +80,12 @@ public final class ArtemisServiceFactory {
         }
 
         @Override
-        public void beforeAll(ExtensionContext extensionContext) throws Exception {
-            addToStore(extensionContext);
-        }
-
-        @Override
-        public void afterAll(ExtensionContext extensionContext) throws Exception {
+        public void afterEach(ExtensionContext extensionContext) {
             // NO-OP
         }
 
         @Override
-        public void afterEach(ExtensionContext extensionContext) throws Exception {
-            // NO-OP
-        }
-
-        @Override
-        public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        public void beforeEach(ExtensionContext extensionContext) {
             addToStore(extensionContext);
         }
     }

--- a/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisServiceFactory.java
+++ b/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisServiceFactory.java
@@ -23,16 +23,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class ArtemisServiceFactory {
 
-    private static SimpleTestServiceBuilder<ArtemisService> nonPersistentInstanceBuilder;
-    private static SimpleTestServiceBuilder<ArtemisService> persistentInstanceBuilder;
-    private static SimpleTestServiceBuilder<ArtemisService> amqpInstanceBuilder;
-    private static SimpleTestServiceBuilder<ArtemisService> mqttInstanceBuilder;
-
-    private static ArtemisService persistentService;
-    private static ArtemisService nonPersistentService;
-    private static ArtemisService amqpService;
-    private static ArtemisService mqttService;
-
     public static class SingletonArtemisService extends SingletonService<ArtemisService> implements ArtemisService {
 
         public SingletonArtemisService(ArtemisService service, String name) {
@@ -106,67 +96,71 @@ public final class ArtemisServiceFactory {
         return new ArtemisAMQPService();
     }
 
-    public static synchronized ArtemisService createSingletonVMService() {
-        if (nonPersistentService == null) {
-            if (nonPersistentInstanceBuilder == null) {
-                nonPersistentInstanceBuilder = new SimpleTestServiceBuilder<>("artemis");
-
-                nonPersistentInstanceBuilder
-                        .addLocalMapping(() -> new SingletonArtemisService(new ArtemisVMService(), "artemis"));
-            }
-
-            nonPersistentService = nonPersistentInstanceBuilder.build();
-        }
-
-        return nonPersistentService;
+    public static ArtemisService createSingletonVMService() {
+        return SingletonVMServiceHolder.INSTANCE;
     }
 
-    public static synchronized ArtemisService createSingletonPersistentVMService() {
-        if (persistentService == null) {
-            if (persistentInstanceBuilder == null) {
-                persistentInstanceBuilder = new SimpleTestServiceBuilder<>("artemis");
-
-                persistentInstanceBuilder.addLocalMapping(
-                        () -> new SingletonArtemisService(new ArtemisPersistentVMService(), "artemis-persistent"));
-            }
-
-            persistentService = persistentInstanceBuilder.build();
-        }
-
-        return persistentService;
+    public static ArtemisService createSingletonPersistentVMService() {
+        return SingletonPersistentVMServiceHolder.INSTANCE;
     }
 
-    public static synchronized ArtemisService createSingletonAMQPService() {
-        if (amqpService == null) {
-            if (amqpInstanceBuilder == null) {
-                amqpInstanceBuilder = new SimpleTestServiceBuilder<>("artemis");
-
-                amqpInstanceBuilder
-                        .addLocalMapping(() -> new SingletonArtemisService(new ArtemisAMQPService(), "artemis-amqp"));
-            }
-
-            amqpService = amqpInstanceBuilder.build();
-        }
-
-        return amqpService;
+    public static ArtemisService createSingletonAMQPService() {
+        return SingletonAMQPServiceHolder.INSTANCE;
     }
 
-    public static synchronized ArtemisService createSingletonMQTTService() {
-        if (mqttService == null) {
-            if (mqttInstanceBuilder == null) {
-                mqttInstanceBuilder = new SimpleTestServiceBuilder<>("artemis");
-
-                mqttInstanceBuilder
-                        .addLocalMapping(() -> new SingletonArtemisService(new ArtemisMQTTService(), "artemis-mqtt"));
-            }
-
-            mqttService = mqttInstanceBuilder.build();
-        }
-
-        return mqttService;
+    public static ArtemisService createSingletonMQTTService() {
+        return SingletonMQTTServiceHolder.INSTANCE;
     }
 
     public static ArtemisService createTCPAllProtocolsService() {
         return new ArtemisTCPAllProtocolsService();
+    }
+
+    private static class SingletonVMServiceHolder {
+        static final ArtemisService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<ArtemisService> nonPersistentInstanceBuilder = new SimpleTestServiceBuilder<>("artemis");
+
+            nonPersistentInstanceBuilder
+                    .addLocalMapping(() -> new SingletonArtemisService(new ArtemisVMService(), "artemis"));
+
+            INSTANCE = nonPersistentInstanceBuilder.build();
+        }
+    }
+
+    private static class SingletonPersistentVMServiceHolder {
+        static final ArtemisService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<ArtemisService> persistentInstanceBuilder = new SimpleTestServiceBuilder<>("artemis");
+
+            persistentInstanceBuilder.addLocalMapping(
+                    () -> new SingletonArtemisService(new ArtemisPersistentVMService(), "artemis-persistent"));
+
+            INSTANCE = persistentInstanceBuilder.build();
+        }
+    }
+
+    private static class SingletonAMQPServiceHolder {
+        static final ArtemisService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<ArtemisService> amqpInstanceBuilder = new SimpleTestServiceBuilder<>("artemis");
+
+            amqpInstanceBuilder
+                    .addLocalMapping(() -> new SingletonArtemisService(new ArtemisAMQPService(), "artemis-amqp"));
+
+            INSTANCE = amqpInstanceBuilder.build();
+        }
+    }
+
+    private static class SingletonMQTTServiceHolder {
+        static final ArtemisService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<ArtemisService> mqttInstanceBuilder = new SimpleTestServiceBuilder<>("artemis");
+
+            mqttInstanceBuilder
+                    .addLocalMapping(() -> new SingletonArtemisService(new ArtemisMQTTService(), "artemis-mqtt"));
+
+            INSTANCE = mqttInstanceBuilder.build();
+        }
     }
 }

--- a/test-infra/camel-test-infra-aws-common/src/test/java/org/apache/camel/test/infra/aws/common/services/AWSService.java
+++ b/test-infra/camel-test-infra-aws-common/src/test/java/org/apache/camel/test/infra/aws/common/services/AWSService.java
@@ -20,22 +20,8 @@ package org.apache.camel.test.infra.aws.common.services;
 import java.util.Properties;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
-public interface AWSService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface AWSService extends TestService {
 
     Properties getConnectionProperties();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-azure-common/src/test/java/org/apache/camel/test/infra/azure/common/services/AzureService.java
+++ b/test-infra/camel-test-infra-azure-common/src/test/java/org/apache/camel/test/infra/azure/common/services/AzureService.java
@@ -19,12 +19,8 @@ package org.apache.camel.test.infra.azure.common.services;
 
 import org.apache.camel.test.infra.azure.common.AzureCredentialsHolder;
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
-public interface AzureService extends TestService, BeforeAllCallback, AfterAllCallback {
+public interface AzureService extends TestService {
 
     /**
      * Gets the credentials for the test service
@@ -32,14 +28,4 @@ public interface AzureService extends TestService, BeforeAllCallback, AfterAllCa
      * @return
      */
     AzureCredentialsHolder azureCredentials();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-cassandra/src/test/java/org/apache/camel/test/infra/cassandra/services/CassandraService.java
+++ b/test-infra/camel-test-infra-cassandra/src/test/java/org/apache/camel/test/infra/cassandra/services/CassandraService.java
@@ -18,15 +18,11 @@
 package org.apache.camel.test.infra.cassandra.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Represents an endpoint to a Cassandra instance
  */
-public interface CassandraService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface CassandraService extends TestService {
 
     int getCQL3Port();
 
@@ -35,14 +31,4 @@ public interface CassandraService extends BeforeAllCallback, AfterAllCallback, T
     }
 
     String getCassandraHost();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-chatscript/src/test/java/org/apache/camel/test/infra/chatscript/services/ChatScriptService.java
+++ b/test-infra/camel-test-infra-chatscript/src/test/java/org/apache/camel/test/infra/chatscript/services/ChatScriptService.java
@@ -18,29 +18,16 @@ package org.apache.camel.test.infra.chatscript.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
 import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for ChatScript
  */
-public interface ChatScriptService
-        extends BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback, TestService {
+public interface ChatScriptService extends BeforeEachCallback, AfterEachCallback, TestService {
 
     String serviceAddress();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 
     @Override
     default void afterEach(ExtensionContext extensionContext) throws Exception {

--- a/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/services/SingletonService.java
+++ b/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/services/SingletonService.java
@@ -54,6 +54,16 @@ public class SingletonService<T extends TestService> implements ExtensionContext
     }
 
     @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        addToStore(extensionContext);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        // NO-OP
+    }
+
+    @Override
     public void registerProperties() {
         service.registerProperties();
     }

--- a/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/services/TestService.java
+++ b/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/services/TestService.java
@@ -17,7 +17,11 @@
 
 package org.apache.camel.test.infra.common.services;
 
-public interface TestService extends AutoCloseable {
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public interface TestService extends AutoCloseable, BeforeAllCallback, AfterAllCallback {
 
     /**
      * Register service properties (such as using System.setProperties) so that they can be resolved at distance (ie.:
@@ -39,5 +43,15 @@ public interface TestService extends AutoCloseable {
     @Override
     default void close() {
         shutdown();
+    }
+
+    @Override
+    default void beforeAll(ExtensionContext extensionContext) throws Exception {
+        TestServiceUtil.tryInitialize(this, extensionContext);
+    }
+
+    @Override
+    default void afterAll(ExtensionContext extensionContext) throws Exception {
+        TestServiceUtil.tryShutdown(this, extensionContext);
     }
 }

--- a/test-infra/camel-test-infra-consul/src/test/java/org/apache/camel/test/infra/consul/services/ConsulService.java
+++ b/test-infra/camel-test-infra-consul/src/test/java/org/apache/camel/test/infra/consul/services/ConsulService.java
@@ -17,29 +17,15 @@
 package org.apache.camel.test.infra.consul.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Consul
  */
-public interface ConsulService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface ConsulService extends TestService {
 
     String getConsulUrl();
 
     String host();
 
     int port();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseService.java
+++ b/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseService.java
@@ -18,12 +18,8 @@
 package org.apache.camel.test.infra.couchbase.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
-public interface CouchbaseService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface CouchbaseService extends TestService {
 
     String getConnectionString();
 
@@ -34,14 +30,4 @@ public interface CouchbaseService extends BeforeAllCallback, AfterAllCallback, T
     String getHostname();
 
     int getPort();
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseServiceFactory.java
+++ b/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseServiceFactory.java
@@ -19,17 +19,11 @@ package org.apache.camel.test.infra.couchbase.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
 import org.apache.camel.test.infra.common.services.SingletonService;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class CouchbaseServiceFactory {
     static class SingletonCouchbaseService extends SingletonService<CouchbaseService> implements CouchbaseService {
         public SingletonCouchbaseService(CouchbaseService service, String name) {
             super(service, name);
-        }
-
-        @Override
-        public void beforeAll(ExtensionContext extensionContext) {
-            addToStore(extensionContext);
         }
 
         @Override
@@ -55,11 +49,6 @@ public final class CouchbaseServiceFactory {
         @Override
         public int getPort() {
             return getService().getPort();
-        }
-
-        @Override
-        public void afterAll(ExtensionContext extensionContext) {
-            // NO-OP
         }
     }
 

--- a/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseServiceFactory.java
+++ b/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseServiceFactory.java
@@ -52,9 +52,6 @@ public final class CouchbaseServiceFactory {
         }
     }
 
-    private static SimpleTestServiceBuilder<CouchbaseService> instance;
-    private static CouchbaseService service;
-
     private CouchbaseServiceFactory() {
 
     }
@@ -70,23 +67,24 @@ public final class CouchbaseServiceFactory {
                 .build();
     }
 
-    public static synchronized CouchbaseService createSingletonService() {
-        if (service == null) {
-            if (instance == null) {
-                instance = builder();
-
-                instance.addLocalMapping(() -> new SingletonCouchbaseService(new CouchbaseLocalContainerService(), "couchbase"))
-                        .addRemoteMapping(CouchbaseRemoteService::new);
-            }
-
-            service = instance.build();
-        }
-
-        return service;
+    public static CouchbaseService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
     }
 
     @Deprecated
     public static CouchbaseService getService() {
         return createService();
+    }
+
+    private static class SingletonServiceHolder {
+        static final CouchbaseService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<CouchbaseService> instance = builder();
+
+            instance.addLocalMapping(() -> new SingletonCouchbaseService(new CouchbaseLocalContainerService(), "couchbase"))
+                    .addRemoteMapping(CouchbaseRemoteService::new);
+
+            INSTANCE = instance.build();
+        }
     }
 }

--- a/test-infra/camel-test-infra-couchdb/src/test/java/org/apache/camel/test/infra/couchdb/services/CouchDbService.java
+++ b/test-infra/camel-test-infra-couchdb/src/test/java/org/apache/camel/test/infra/couchdb/services/CouchDbService.java
@@ -17,15 +17,11 @@
 package org.apache.camel.test.infra.couchdb.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for CouchDb
  */
-public interface CouchDbService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface CouchDbService extends TestService {
 
     String host();
 
@@ -33,15 +29,5 @@ public interface CouchDbService extends BeforeAllCallback, AfterAllCallback, Tes
 
     default String getServiceAddress() {
         return String.format("%s:%d", host(), port());
-    }
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
     }
 }

--- a/test-infra/camel-test-infra-couchdb/src/test/java/org/apache/camel/test/infra/couchdb/services/CouchDbServiceFactory.java
+++ b/test-infra/camel-test-infra-couchdb/src/test/java/org/apache/camel/test/infra/couchdb/services/CouchDbServiceFactory.java
@@ -41,9 +41,6 @@ public final class CouchDbServiceFactory {
         }
     }
 
-    private static SimpleTestServiceBuilder<CouchDbService> instance;
-    private static CouchDbService service;
-
     private CouchDbServiceFactory() {
 
     }
@@ -60,18 +57,18 @@ public final class CouchDbServiceFactory {
     }
 
     public static CouchDbService createSingletonService() {
-        if (service == null) {
-            if (instance == null) {
-                instance = builder();
+        return SingletonServiceHolder.INSTANCE;
+    }
 
-                instance.addLocalMapping(() -> new SingletonCouchDbService(new CouchDbLocalContainerService(), "couchdb"))
-                        .addRemoteMapping(CouchDbRemoteService::new);
+    private static class SingletonServiceHolder {
+        static final CouchDbService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<CouchDbService> instance = builder();
 
-            }
+            instance.addLocalMapping(() -> new SingletonCouchDbService(new CouchDbLocalContainerService(), "couchdb"))
+                    .addRemoteMapping(CouchDbRemoteService::new);
 
-            service = instance.build();
+            INSTANCE = instance.build();
         }
-
-        return service;
     }
 }

--- a/test-infra/camel-test-infra-couchdb/src/test/java/org/apache/camel/test/infra/couchdb/services/CouchDbServiceFactory.java
+++ b/test-infra/camel-test-infra-couchdb/src/test/java/org/apache/camel/test/infra/couchdb/services/CouchDbServiceFactory.java
@@ -18,22 +18,11 @@ package org.apache.camel.test.infra.couchdb.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
 import org.apache.camel.test.infra.common.services.SingletonService;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class CouchDbServiceFactory {
     static class SingletonCouchDbService extends SingletonService<CouchDbService> implements CouchDbService {
         public SingletonCouchDbService(CouchDbService service, String name) {
             super(service, name);
-        }
-
-        @Override
-        public void beforeAll(ExtensionContext extensionContext) {
-            addToStore(extensionContext);
-        }
-
-        @Override
-        public void afterAll(ExtensionContext extensionContext) {
-            // NO-OP
         }
 
         @Override

--- a/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchService.java
+++ b/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchService.java
@@ -18,12 +18,8 @@
 package org.apache.camel.test.infra.elasticsearch.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
-public interface ElasticSearchService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface ElasticSearchService extends TestService {
 
     int getPort();
 
@@ -31,15 +27,5 @@ public interface ElasticSearchService extends BeforeAllCallback, AfterAllCallbac
 
     default String getHttpHostAddress() {
         return String.format("%s:%d", getElasticSearchHost(), getPort());
-    }
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
     }
 }

--- a/test-infra/camel-test-infra-etcd3/src/test/java/org/apache/camel/test/infra/etcd3/services/Etcd3Service.java
+++ b/test-infra/camel-test-infra-etcd3/src/test/java/org/apache/camel/test/infra/etcd3/services/Etcd3Service.java
@@ -17,25 +17,11 @@
 package org.apache.camel.test.infra.etcd3.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for EtcD
  */
-public interface Etcd3Service extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface Etcd3Service extends TestService {
 
     String getServiceAddress();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-fhir/src/test/java/org/apache/camel/test/infra/fhir/services/FhirService.java
+++ b/test-infra/camel-test-infra-fhir/src/test/java/org/apache/camel/test/infra/fhir/services/FhirService.java
@@ -17,29 +17,15 @@
 package org.apache.camel.test.infra.fhir.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for FHIR
  */
-public interface FhirService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface FhirService extends TestService {
 
     String getServiceBaseURL();
 
     String getHost();
 
     Integer getPort();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-ftp/src/test/java/org/apache/camel/test/infra/ftp/services/FtpService.java
+++ b/test-infra/camel-test-infra-ftp/src/test/java/org/apache/camel/test/infra/ftp/services/FtpService.java
@@ -19,15 +19,13 @@ package org.apache.camel.test.infra.ftp.services;
 import java.nio.file.Path;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 
 /**
  * Test infra service for Ftp
  */
-public interface FtpService extends TestService, BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback {
+public interface FtpService extends TestService, BeforeEachCallback, AfterEachCallback {
     int getPort();
 
     Path getFtpRootDir();

--- a/test-infra/camel-test-infra-google-pubsub/src/test/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubService.java
+++ b/test-infra/camel-test-infra-google-pubsub/src/test/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubService.java
@@ -17,25 +17,11 @@
 package org.apache.camel.test.infra.google.pubsub.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for GooglePubSub
  */
-public interface GooglePubSubService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface GooglePubSubService extends TestService {
 
     String getServiceAddress();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-hashicorp-vault/src/test/java/org/apache/camel/test/infra/hashicorp/vault/services/HashicorpVaultService.java
+++ b/test-infra/camel-test-infra-hashicorp-vault/src/test/java/org/apache/camel/test/infra/hashicorp/vault/services/HashicorpVaultService.java
@@ -17,29 +17,15 @@
 package org.apache.camel.test.infra.hashicorp.vault.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Infinispan
  */
-public interface HashicorpVaultService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface HashicorpVaultService extends TestService {
 
     String token();
 
     int port();
 
     String host();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/HDFSService.java
+++ b/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/HDFSService.java
@@ -18,12 +18,8 @@
 package org.apache.camel.test.infra.hdfs.v2.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
-public interface HDFSService extends TestService, BeforeAllCallback, AfterAllCallback {
+public interface HDFSService extends TestService {
 
     /**
      * Gets the hostname of the HDFS server
@@ -38,14 +34,4 @@ public interface HDFSService extends TestService, BeforeAllCallback, AfterAllCal
      * @return
      */
     int getPort();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/HDFSServiceFactory.java
+++ b/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/HDFSServiceFactory.java
@@ -19,7 +19,6 @@ package org.apache.camel.test.infra.hdfs.v2.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
 import org.apache.camel.test.infra.common.services.SingletonService;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class HDFSServiceFactory {
 
@@ -36,16 +35,6 @@ public final class HDFSServiceFactory {
         @Override
         public int getPort() {
             return getService().getPort();
-        }
-
-        @Override
-        public void beforeAll(ExtensionContext extensionContext) {
-            addToStore(extensionContext);
-        }
-
-        @Override
-        public void afterAll(ExtensionContext extensionContext) {
-            // NO-OP
         }
     }
 

--- a/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/HDFSServiceFactory.java
+++ b/test-infra/camel-test-infra-hdfs/src/test/java/org/apache/camel/test/infra/hdfs/v2/services/HDFSServiceFactory.java
@@ -38,9 +38,6 @@ public final class HDFSServiceFactory {
         }
     }
 
-    private static SimpleTestServiceBuilder<HDFSService> instance;
-    private static HDFSService service;
-
     private HDFSServiceFactory() {
 
     }
@@ -50,13 +47,15 @@ public final class HDFSServiceFactory {
     }
 
     public static HDFSService createSingletonService() {
-        if (service == null) {
-            if (instance == null) {
-                instance = builder();
-                instance.addLocalMapping(() -> new SingletonHDFSService(new ContainerLocalHDFSService(), "hdfs"));
-            }
-            service = instance.build();
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final HDFSService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<HDFSService> instance = builder();
+            instance.addLocalMapping(() -> new SingletonHDFSService(new ContainerLocalHDFSService(), "hdfs"));
+            INSTANCE = instance.build();
         }
-        return service;
     }
 }

--- a/test-infra/camel-test-infra-ignite/src/test/java/org/apache/camel/test/infra/ignite/services/IgniteService.java
+++ b/test-infra/camel-test-infra-ignite/src/test/java/org/apache/camel/test/infra/ignite/services/IgniteService.java
@@ -17,25 +17,12 @@
 package org.apache.camel.test.infra.ignite.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
 import org.apache.ignite.configuration.IgniteConfiguration;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Ignite
  */
-public interface IgniteService extends BeforeAllCallback, AfterAllCallback, TestService {
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
+public interface IgniteService extends TestService {
 
     IgniteConfiguration createConfiguration();
 }

--- a/test-infra/camel-test-infra-infinispan/src/test/java/org/apache/camel/test/infra/infinispan/services/InfinispanService.java
+++ b/test-infra/camel-test-infra-infinispan/src/test/java/org/apache/camel/test/infra/infinispan/services/InfinispanService.java
@@ -17,15 +17,11 @@
 package org.apache.camel.test.infra.infinispan.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Infinispan
  */
-public interface InfinispanService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface InfinispanService extends TestService {
 
     String username();
 
@@ -36,14 +32,4 @@ public interface InfinispanService extends BeforeAllCallback, AfterAllCallback, 
     String host();
 
     String getServiceAddress();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-jdbc/src/test/java/org/apache/camel/test/infra/jdbc/services/JDBCService.java
+++ b/test-infra/camel-test-infra-jdbc/src/test/java/org/apache/camel/test/infra/jdbc/services/JDBCService.java
@@ -18,22 +18,8 @@
 package org.apache.camel.test.infra.jdbc.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
-public interface JDBCService extends TestService, BeforeAllCallback, AfterAllCallback {
+public interface JDBCService extends TestService {
 
     String jdbcUrl();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-jetty/src/test/java/org/apache/camel/test/infra/jetty/services/JettyService.java
+++ b/test-infra/camel-test-infra-jetty/src/test/java/org/apache/camel/test/infra/jetty/services/JettyService.java
@@ -17,24 +17,11 @@
 package org.apache.camel.test.infra.jetty.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Jetty
  */
-public interface JettyService extends BeforeAllCallback, AfterAllCallback, TestService {
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
+public interface JettyService extends TestService {
 
     /**
      * Gets the port used to run the service

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/KafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/KafkaService.java
@@ -18,9 +18,7 @@
 package org.apache.camel.test.infra.kafka.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
@@ -29,8 +27,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Provides an interface for any type of Kafka service: remote instances, local container, etc
  */
-public interface KafkaService
-        extends TestService, BeforeAllCallback, BeforeTestExecutionCallback, AfterAllCallback, AfterTestExecutionCallback {
+public interface KafkaService extends TestService, BeforeTestExecutionCallback, AfterTestExecutionCallback {
 
     /**
      * Gets the addresses of the bootstrap servers in the format host1:port,host2:port,etc
@@ -40,7 +37,7 @@ public interface KafkaService
     String getBootstrapServers();
 
     @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
+    default void beforeAll(ExtensionContext extensionContext) {
         try {
             initialize();
         } catch (Exception e) {
@@ -55,17 +52,17 @@ public interface KafkaService
     }
 
     @Override
-    default void beforeTestExecution(ExtensionContext extensionContext) throws Exception {
+    default void beforeTestExecution(ExtensionContext extensionContext) {
         //no op
     }
 
     @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
+    default void afterAll(ExtensionContext extensionContext) {
         shutdown();
     }
 
     @Override
-    default void afterTestExecution(ExtensionContext context) throws Exception {
+    default void afterTestExecution(ExtensionContext context) {
         //no op
     }
 }

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/KafkaServiceFactory.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/KafkaServiceFactory.java
@@ -32,9 +32,6 @@ public final class KafkaServiceFactory {
         }
     }
 
-    private static SimpleTestServiceBuilder<KafkaService> instance;
-    private static KafkaService kafkaService;
-
     private KafkaServiceFactory() {
 
     }
@@ -55,29 +52,28 @@ public final class KafkaServiceFactory {
                 .build();
     }
 
-    public static synchronized KafkaService createSingletonService() {
-        if (kafkaService == null) {
-            if (instance == null) {
-                instance = builder();
-
-                instance.addLocalMapping(
-                        () -> new SingletonKafkaService(ContainerLocalKafkaService.kafka3Container(), "kafka"))
-                        .addRemoteMapping(RemoteKafkaService::new)
-                        .addMapping("local-kafka3-container",
-                                () -> new SingletonKafkaService(ContainerLocalKafkaService.kafka3Container(), "kafka3"))
-                        .addMapping("local-kafka2-container",
-                                () -> new SingletonKafkaService(ContainerLocalKafkaService.kafka2Container(), "kafka2"))
-                        .addMapping("local-strimzi-container",
-                                () -> new SingletonKafkaService(new StrimziService(), "strimzi"))
-                        .addMapping("local-redpanda-container",
-                                () -> new SingletonKafkaService(new RedpandaService(), "redpanda"));
-
-            }
-
-            kafkaService = instance.build();
-        }
-
-        return kafkaService;
+    public static KafkaService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
     }
 
+    private static class SingletonServiceHolder {
+        static final KafkaService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<KafkaService> instance = builder();
+
+            instance.addLocalMapping(
+                    () -> new SingletonKafkaService(ContainerLocalKafkaService.kafka3Container(), "kafka"))
+                    .addRemoteMapping(RemoteKafkaService::new)
+                    .addMapping("local-kafka3-container",
+                            () -> new SingletonKafkaService(ContainerLocalKafkaService.kafka3Container(), "kafka3"))
+                    .addMapping("local-kafka2-container",
+                            () -> new SingletonKafkaService(ContainerLocalKafkaService.kafka2Container(), "kafka2"))
+                    .addMapping("local-strimzi-container",
+                            () -> new SingletonKafkaService(new StrimziService(), "strimzi"))
+                    .addMapping("local-redpanda-container",
+                            () -> new SingletonKafkaService(new RedpandaService(), "redpanda"));
+
+            INSTANCE = instance.build();
+        }
+    }
 }

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/KafkaServiceFactory.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/KafkaServiceFactory.java
@@ -19,7 +19,6 @@ package org.apache.camel.test.infra.kafka.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
 import org.apache.camel.test.infra.common.services.SingletonService;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class KafkaServiceFactory {
     static class SingletonKafkaService extends SingletonService<KafkaService> implements KafkaService {
@@ -30,16 +29,6 @@ public final class KafkaServiceFactory {
         @Override
         public String getBootstrapServers() {
             return getService().getBootstrapServers();
-        }
-
-        @Override
-        public void beforeAll(ExtensionContext extensionContext) {
-            addToStore(extensionContext);
-        }
-
-        @Override
-        public void afterAll(ExtensionContext extensionContext) {
-            // NO-OP
         }
     }
 

--- a/test-infra/camel-test-infra-messaging-common/src/test/java/org/apache/camel/test/infra/messaging/services/MessagingService.java
+++ b/test-infra/camel-test-infra-messaging-common/src/test/java/org/apache/camel/test/infra/messaging/services/MessagingService.java
@@ -18,12 +18,8 @@
 package org.apache.camel.test.infra.messaging.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
-public interface MessagingService extends TestService, BeforeAllCallback, AfterAllCallback {
+public interface MessagingService extends TestService {
 
     /**
      * Gets the default endpoint for the messaging service (ie.: amqp://host:port, or tcp://host:port, etc)
@@ -31,14 +27,4 @@ public interface MessagingService extends TestService, BeforeAllCallback, AfterA
      * @return the endpoint URL as a string in the specific format used by the service
      */
     String defaultEndpoint();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-microprofile-lra/src/test/java/org/apache/camel/test/infra/microprofile/lra/services/MicroprofileLRAService.java
+++ b/test-infra/camel-test-infra-microprofile-lra/src/test/java/org/apache/camel/test/infra/microprofile/lra/services/MicroprofileLRAService.java
@@ -17,15 +17,11 @@
 package org.apache.camel.test.infra.microprofile.lra.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Microprofile LRA
  */
-public interface MicroprofileLRAService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface MicroprofileLRAService extends TestService {
 
     String host();
 
@@ -35,15 +31,5 @@ public interface MicroprofileLRAService extends BeforeAllCallback, AfterAllCallb
 
     default String getServiceAddress() {
         return String.format("http://%s:%d", host(), port());
-    }
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
     }
 }

--- a/test-infra/camel-test-infra-minio/src/test/java/org/apache/camel/test/infra/minio/services/MinioService.java
+++ b/test-infra/camel-test-infra-minio/src/test/java/org/apache/camel/test/infra/minio/services/MinioService.java
@@ -17,15 +17,11 @@
 package org.apache.camel.test.infra.minio.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Minio
  */
-public interface MinioService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface MinioService extends TestService {
 
     String secretKey();
 
@@ -34,14 +30,4 @@ public interface MinioService extends BeforeAllCallback, AfterAllCallback, TestS
     int port();
 
     String host();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBService.java
+++ b/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBService.java
@@ -18,12 +18,8 @@
 package org.apache.camel.test.infra.mongodb.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
-public interface MongoDBService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface MongoDBService extends TestService {
 
     /**
      * The replica set URL in the format mongodb://host:port
@@ -38,14 +34,4 @@ public interface MongoDBService extends BeforeAllCallback, AfterAllCallback, Tes
      * @return the connection address
      */
     String getConnectionAddress();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBServiceFactory.java
+++ b/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBServiceFactory.java
@@ -19,22 +19,11 @@ package org.apache.camel.test.infra.mongodb.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
 import org.apache.camel.test.infra.common.services.SingletonService;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class MongoDBServiceFactory {
     static class SingletonMongoDBService extends SingletonService<MongoDBService> implements MongoDBService {
         public SingletonMongoDBService(MongoDBService service, String name) {
             super(service, name);
-        }
-
-        @Override
-        public void beforeAll(ExtensionContext extensionContext) {
-            addToStore(extensionContext);
-        }
-
-        @Override
-        public void afterAll(ExtensionContext extensionContext) {
-            // NO-OP
         }
 
         @Override

--- a/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBServiceFactory.java
+++ b/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBServiceFactory.java
@@ -37,9 +37,6 @@ public final class MongoDBServiceFactory {
         }
     }
 
-    private static SimpleTestServiceBuilder<MongoDBService> instance;
-    private static MongoDBService service;
-
     private MongoDBServiceFactory() {
 
     }
@@ -56,16 +53,17 @@ public final class MongoDBServiceFactory {
     }
 
     public static MongoDBService createSingletonService() {
-        if (service == null) {
-            if (instance == null) {
-                instance = builder();
-                instance.addLocalMapping(() -> new SingletonMongoDBService(new MongoDBLocalContainerService(), "mongo-db"))
-                        .addRemoteMapping(MongoDBRemoteService::new);
-            }
+        return SingletonServiceHolder.INSTANCE;
+    }
 
-            service = instance.build();
+    private static class SingletonServiceHolder {
+        static final MongoDBService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<MongoDBService> instance = builder();
+            instance.addLocalMapping(() -> new SingletonMongoDBService(new MongoDBLocalContainerService(), "mongo-db"))
+                    .addRemoteMapping(MongoDBRemoteService::new);
+
+            INSTANCE = instance.build();
         }
-
-        return service;
     }
 }

--- a/test-infra/camel-test-infra-mosquitto/src/test/java/org/apache/camel/test/infra/mosquitto/services/MosquittoService.java
+++ b/test-infra/camel-test-infra-mosquitto/src/test/java/org/apache/camel/test/infra/mosquitto/services/MosquittoService.java
@@ -17,25 +17,11 @@
 package org.apache.camel.test.infra.mosquitto.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Mosquitto
  */
-public interface MosquittoService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface MosquittoService extends TestService {
 
     Integer getPort();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-nats/src/test/java/org/apache/camel/test/infra/nats/services/NatsService.java
+++ b/test-infra/camel-test-infra-nats/src/test/java/org/apache/camel/test/infra/nats/services/NatsService.java
@@ -17,25 +17,11 @@
 package org.apache.camel.test.infra.nats.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Nats
  */
-public interface NatsService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface NatsService extends TestService {
 
     String getServiceAddress();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/OpenldapService.java
+++ b/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/OpenldapService.java
@@ -17,29 +17,15 @@
 package org.apache.camel.test.infra.openldap.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Openldap
  */
-public interface OpenldapService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface OpenldapService extends TestService {
 
     Integer getPort();
 
     Integer getSslPort();
 
     String getHost();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-postgres/src/test/java/org/apache/camel/test/infra/postgres/services/PostgresService.java
+++ b/test-infra/camel-test-infra-postgres/src/test/java/org/apache/camel/test/infra/postgres/services/PostgresService.java
@@ -17,15 +17,11 @@
 package org.apache.camel.test.infra.postgres.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Postgres
  */
-public interface PostgresService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface PostgresService extends TestService {
 
     String host();
 
@@ -36,14 +32,4 @@ public interface PostgresService extends BeforeAllCallback, AfterAllCallback, Te
     String password();
 
     String getServiceAddress();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-pulsar/src/test/java/org/apache/camel/test/infra/pulsar/services/PulsarService.java
+++ b/test-infra/camel-test-infra-pulsar/src/test/java/org/apache/camel/test/infra/pulsar/services/PulsarService.java
@@ -17,27 +17,13 @@
 package org.apache.camel.test.infra.pulsar.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Pulsar
  */
-public interface PulsarService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface PulsarService extends TestService {
 
     String getPulsarAdminUrl();
 
     String getPulsarBrokerUrl();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-rabbitmq/src/test/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQService.java
+++ b/test-infra/camel-test-infra-rabbitmq/src/test/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQService.java
@@ -18,12 +18,8 @@
 package org.apache.camel.test.infra.rabbitmq.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
-public interface RabbitMQService extends TestService, BeforeAllCallback, AfterAllCallback {
+public interface RabbitMQService extends TestService {
 
     /**
      * The connection properties for the service
@@ -58,14 +54,4 @@ public interface RabbitMQService extends TestService, BeforeAllCallback, AfterAl
      * Shuts down the service after the test has completed
      */
     void shutdown();
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-redis/src/test/java/org/apache/camel/test/infra/redis/services/RedisService.java
+++ b/test-infra/camel-test-infra-redis/src/test/java/org/apache/camel/test/infra/redis/services/RedisService.java
@@ -17,15 +17,11 @@
 package org.apache.camel.test.infra.redis.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Redis
  */
-public interface RedisService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface RedisService extends TestService {
 
     String host();
 
@@ -33,15 +29,5 @@ public interface RedisService extends BeforeAllCallback, AfterAllCallback, TestS
 
     default String getServiceAddress() {
         return String.format("%s:%d", host(), port());
-    }
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
     }
 }

--- a/test-infra/camel-test-infra-solr/src/test/java/org/apache/camel/test/infra/solr/services/SolrService.java
+++ b/test-infra/camel-test-infra-solr/src/test/java/org/apache/camel/test/infra/solr/services/SolrService.java
@@ -17,27 +17,13 @@
 package org.apache.camel.test.infra.solr.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Solr
  */
-public interface SolrService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface SolrService extends TestService {
 
     String getSolrBaseUrl();
 
     boolean isCloudMode();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-xmpp/src/test/java/org/apache/camel/test/infra/xmpp/services/XmppService.java
+++ b/test-infra/camel-test-infra-xmpp/src/test/java/org/apache/camel/test/infra/xmpp/services/XmppService.java
@@ -17,28 +17,14 @@
 package org.apache.camel.test.infra.xmpp.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Xmpp
  */
-public interface XmppService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface XmppService extends TestService {
     String host();
 
     int port();
 
     String getUrl();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }

--- a/test-infra/camel-test-infra-zookeeper/src/test/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperService.java
+++ b/test-infra/camel-test-infra-zookeeper/src/test/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperService.java
@@ -17,24 +17,10 @@
 package org.apache.camel.test.infra.zookeeper.services;
 
 import org.apache.camel.test.infra.common.services.TestService;
-import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for ZooKeeper
  */
-public interface ZooKeeperService extends BeforeAllCallback, AfterAllCallback, TestService {
+public interface ZooKeeperService extends TestService {
     String getConnectionString();
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
 }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19402

## Motivation

There is some duplicated code in test-infra. The goal of these changes is to reduce the boilerplate code needed to add a new service.

## Modifications:

* Move the default implementation of the `beforeAll` and `afterAll` callbacks in `TestService` as it is always the same
* Move the default implementation of the singleton `beforeAll` and `afterAll` callbacks in SingletonService  as it is always the same
* Apply [initialization-on-demand holder idiom](https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom) to initialize the `SingletonService` instances