### PR TITLE
CAMEL-19400: camel-elasticsearch - Use singleton service to speed up

### DIFF
--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchScrollSearchIT.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchScrollSearchIT.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ElasticsearchScrollSearchIT extends ElasticsearchTestSupport {
 
-    private static final String TWITTER_ES_INDEX_NAME = "twitter";
+    private static final String TWITTER_ES_INDEX_NAME = "scroll-search";
     private static final String SPLIT_TWITTER_ES_INDEX_NAME = "split-" + TWITTER_ES_INDEX_NAME;
 
     @Test

--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchSizeLimitIT.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchSizeLimitIT.java
@@ -51,11 +51,11 @@ class ElasticsearchSizeLimitIT extends ElasticsearchTestSupport {
             @Override
             public void configure() {
                 from("direct:index")
-                        .to("elasticsearch://elasticsearch?operation=Index&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=Index&indexName=size-limit");
                 from("direct:searchWithSizeTwo")
-                        .to("elasticsearch://elasticsearch?operation=Search&indexName=twitter&size=2");
+                        .to("elasticsearch://elasticsearch?operation=Search&indexName=size-limit&size=2");
                 from("direct:searchFrom3")
-                        .to("elasticsearch://elasticsearch?operation=Search&indexName=twitter&from=3");
+                        .to("elasticsearch://elasticsearch?operation=Search&indexName=size-limit&from=3");
             }
         };
     }

--- a/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/common/ElasticSearchProperties.java
+++ b/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/common/ElasticSearchProperties.java
@@ -22,6 +22,9 @@ import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 public final class ElasticSearchProperties {
     public static final String ELASTIC_SEARCH_HOST = "elasticsearch.host";
     public static final String ELASTIC_SEARCH_PORT = "elasticsearch.port";
+    public static final String ELASTIC_SEARCH_CERTIFICATE_PATH = "elasticsearch.certificate.path";
+    public static final String ELASTIC_SEARCH_USERNAME = "elasticsearch.username";
+    public static final String ELASTIC_SEARCH_PASSWORD = "elasticsearch.password";
     public static final String ELASTIC_SEARCH_CONTAINER = "elasticsearch.container";
     public static final String ELASTIC_SEARCH_CONTAINER_STARTUP
             = ELASTIC_SEARCH_CONTAINER + ContainerEnvironmentUtil.STARTUP_ATTEMPTS_PROPERTY;

--- a/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchService.java
+++ b/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchService.java
@@ -17,6 +17,10 @@
 
 package org.apache.camel.test.infra.elasticsearch.services;
 
+import java.util.Optional;
+
+import javax.net.ssl.SSLContext;
+
 import org.apache.camel.test.infra.common.services.TestService;
 
 public interface ElasticSearchService extends TestService {
@@ -28,4 +32,12 @@ public interface ElasticSearchService extends TestService {
     default String getHttpHostAddress() {
         return String.format("%s:%d", getElasticSearchHost(), getPort());
     }
+
+    Optional<String> getCertificatePath();
+
+    Optional<SSLContext> getSslContext();
+
+    String getUsername();
+
+    String getPassword();
 }

--- a/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchServiceFactory.java
+++ b/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchServiceFactory.java
@@ -17,9 +17,56 @@
 
 package org.apache.camel.test.infra.elasticsearch.services;
 
+import java.util.Optional;
+
+import javax.net.ssl.SSLContext;
+
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class ElasticSearchServiceFactory {
+
+    static class SingletonElasticSearchService extends SingletonService<ElasticSearchService> implements ElasticSearchService {
+        public SingletonElasticSearchService(ElasticSearchService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public int getPort() {
+            return getService().getPort();
+        }
+
+        @Override
+        public String getElasticSearchHost() {
+            return getService().getElasticSearchHost();
+        }
+
+        @Override
+        public String getHttpHostAddress() {
+            return getService().getHttpHostAddress();
+        }
+
+        @Override
+        public Optional<String> getCertificatePath() {
+            return getService().getCertificatePath();
+        }
+
+        @Override
+        public Optional<SSLContext> getSslContext() {
+            return getService().getSslContext();
+        }
+
+        @Override
+        public String getUsername() {
+            return getService().getUsername();
+        }
+
+        @Override
+        public String getPassword() {
+            return getService().getPassword();
+        }
+    }
+
     private ElasticSearchServiceFactory() {
 
     }
@@ -33,5 +80,20 @@ public final class ElasticSearchServiceFactory {
                 .addLocalMapping(ElasticSearchLocalContainerService::new)
                 .addRemoteMapping(RemoteElasticSearchService::new)
                 .build();
+    }
+
+    public static ElasticSearchService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final ElasticSearchService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<ElasticSearchService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonElasticSearchService(new ElasticSearchLocalContainerService(), "elastic"))
+                    .addRemoteMapping(RemoteElasticSearchService::new);
+            INSTANCE = instance.build();
+        }
     }
 }

--- a/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/RemoteElasticSearchService.java
+++ b/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/RemoteElasticSearchService.java
@@ -17,6 +17,10 @@
 
 package org.apache.camel.test.infra.elasticsearch.services;
 
+import java.util.Optional;
+
+import javax.net.ssl.SSLContext;
+
 import org.apache.camel.test.infra.elasticsearch.common.ElasticSearchProperties;
 
 public class RemoteElasticSearchService implements ElasticSearchService {
@@ -51,5 +55,25 @@ public class RemoteElasticSearchService implements ElasticSearchService {
     @Override
     public void shutdown() {
         // NO-OP
+    }
+
+    @Override
+    public Optional<String> getCertificatePath() {
+        return Optional.ofNullable(System.getProperty(ElasticSearchProperties.ELASTIC_SEARCH_CERTIFICATE_PATH));
+    }
+
+    @Override
+    public Optional<SSLContext> getSslContext() {
+        return Optional.empty();
+    }
+
+    @Override
+    public String getUsername() {
+        return System.getProperty(ElasticSearchProperties.ELASTIC_SEARCH_USERNAME);
+    }
+
+    @Override
+    public String getPassword() {
+        return System.getProperty(ElasticSearchProperties.ELASTIC_SEARCH_PASSWORD);
     }
 }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19400

## Motivation

The build on Jenkins takes between 7h and 8h which is much too long especially when we know that the max duration allowed is about 9 h.

## Modifications:

* Adds a `SingletonService` to the `ElasticSearchServiceFactory`
* Adds the management of the authentication to the `ElasticSearchService`
* Adds the integration tests to use a singleton service to start only once an ES instance

## Result:

In my local machine, with the old approach, the tests take about 200 seconds while it now takes about 50 seconds.