### PR TITLE
Add camel-catalog as dependency to prevent parallel build failures

### DIFF
--- a/dsl/camel-endpointdsl/pom.xml
+++ b/dsl/camel-endpointdsl/pom.xml
@@ -94,6 +94,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Add it explicitly to prevent parallel build failures -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-catalog</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
## Motivation

In the case of a parallel build, since `camel-catalog` is not explicitly defined as a dependency of `camel-endpointdsl`, they could be built in parallel which causes error of the following type:
```
[ERROR] Failed to execute goal org.apache.camel:camel-package-maven-plugin:4.0.0-SNAPSHOT:generate-endpoint-dsl (generate-endpoint-dsl) on project camel-endpointdsl: Execution generate-endpoint-dsl of goal org.apache.camel:camel-package-maven-plugin:4.0.0-SNAPSHOT:generate-endpoint-dsl failed: Error reading json file: /home/runner/work/camel/camel/dsl/camel-endpointdsl/target/../../../catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/lpr.json -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.camel:camel-package-maven-plugin:4.0.0-SNAPSHOT:generate-endpoint-dsl (generate-endpoint-dsl) on project camel-endpointdsl: Execution generate-endpoint-dsl of goal org.apache.camel:camel-package-maven-plugin:4.0.0-SNAPSHOT:generate-endpoint-dsl failed: Error reading json file: /home/runner/work/camel/camel/dsl/camel-endpointdsl/target/../../../catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/lpr.json
```

## Modifications

* Add explicitly `camel-catalog` as provided dependency of `camel-endpointdsl`