### PR TITLE
Camel 4.1 RFC: core converter code refactoring

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/TypeConverter.java
+++ b/core/camel-api/src/main/java/org/apache/camel/TypeConverter.java
@@ -106,5 +106,4 @@ public interface TypeConverter {
      * @return          the converted value, or <tt>null</tt> if not possible to convert
      */
     <T> T tryConvertTo(Class<T> type, Exchange exchange, Object value);
-
 }

--- a/core/camel-api/src/main/java/org/apache/camel/converter/ConverterFunction.java
+++ b/core/camel-api/src/main/java/org/apache/camel/converter/ConverterFunction.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.converter;
+
+import org.apache.camel.Exchange;
+
+@FunctionalInterface
+public interface ConverterFunction<F, T> {
+    T convert(F value, Exchange exchange) throws Exception;
+}

--- a/core/camel-api/src/main/java/org/apache/camel/converter/TypeConvertable.java
+++ b/core/camel-api/src/main/java/org/apache/camel/converter/TypeConvertable.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.converter;
+
+import java.util.Objects;
+
+public final class TypeConvertable<F, T> {
+    private final Class<F> from;
+    private final Class<T> to;
+
+    public TypeConvertable(Class<F> from, Class<T> to) {
+        this.from = from;
+        this.to = to;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TypeConvertable<?, ?> that = (TypeConvertable<?, ?>) o;
+        return Objects.equals(from, that.from) && Objects.equals(to, that.to);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        result = 31 * result + (from == null ? 0 : from.hashCode());
+        result = 31 * result + (to == null ? 0 : to.hashCode());
+
+        return result;
+    }
+
+    public Class<F> getFrom() {
+        return from;
+    }
+
+    public Class<T> getTo() {
+        return to;
+    }
+}

--- a/core/camel-api/src/main/java/org/apache/camel/spi/TypeConverterRegistry.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/TypeConverterRegistry.java
@@ -21,6 +21,7 @@ import org.apache.camel.LoggingLevel;
 import org.apache.camel.StaticService;
 import org.apache.camel.TypeConverter;
 import org.apache.camel.TypeConverterExists;
+import org.apache.camel.converter.TypeConvertable;
 
 /**
  * Registry for type converters.
@@ -186,5 +187,9 @@ public interface TypeConverterRegistry extends StaticService, CamelContextAware 
      * The default behavior is to ignore the duplicate.
      */
     void setTypeConverterExists(TypeConverterExists typeConverterExists);
+
+    default void addConverter(TypeConvertable<?, ?> typeConvertable, TypeConverter typeConverter) {
+
+    }
 
 }

--- a/core/camel-base/src/generated/java/org/apache/camel/converter/CamelBaseBulkConverterLoader.java
+++ b/core/camel-base/src/generated/java/org/apache/camel/converter/CamelBaseBulkConverterLoader.java
@@ -9,6 +9,7 @@ import org.apache.camel.Ordered;
 import org.apache.camel.TypeConversionException;
 import org.apache.camel.TypeConverterLoaderException;
 import org.apache.camel.TypeConverter;
+import org.apache.camel.converter.TypeConvertable;
 import org.apache.camel.spi.BulkTypeConverters;
 import org.apache.camel.spi.TypeConverterLoader;
 import org.apache.camel.spi.TypeConverterRegistry;
@@ -48,6 +49,7 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
     @Override
     public void load(TypeConverterRegistry registry) throws TypeConverterLoaderException {
         registry.addBulkTypeConverters(this);
+        doRegistration(registry);
     }
 
     @Override
@@ -501,6 +503,131 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             }
         }
         return null;
+    }
+
+    private void doRegistration(TypeConverterRegistry registry) {
+        registry.addConverter(new TypeConvertable<>(java.nio.ByteBuffer.class, byte[].class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.spi.Resource.class, byte[].class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, byte[].class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.BufferedReader.class, byte[].class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.Reader.class, byte[].class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, byte[].class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, byte[].class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.ByteArrayOutputStream.class, byte[].class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, char[].class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, char[].class), this);
+        registry.addConverter(new TypeConvertable<>(java.util.Collection.class, java.lang.Object[].class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Object.class, boolean.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, char.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, char.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, java.io.BufferedReader.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, java.io.BufferedWriter.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.io.File.class), this);
+        registry.addConverter(new TypeConvertable<>(java.util.stream.Stream.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.spi.Resource.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(java.net.URL.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(java.nio.ByteBuffer.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.StringBuffer.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.StringBuilder.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.BufferedReader.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.ByteArrayOutputStream.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, java.io.ObjectInput.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.OutputStream.class, java.io.ObjectOutput.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, java.io.OutputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.spi.Resource.class, java.io.Reader.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, java.io.Reader.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.io.Reader.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.io.Reader.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.OutputStream.class, java.io.Writer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Object.class, java.lang.Boolean.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.lang.Boolean.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.lang.Boolean.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Number.class, java.lang.Byte.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.lang.Byte.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.lang.Byte.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.lang.Character.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.lang.Character.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.lang.Class.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Number.class, java.lang.Double.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.lang.Double.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.lang.Double.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Number.class, java.lang.Float.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.lang.Float.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.lang.Float.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Number.class, java.lang.Integer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.lang.Integer.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.lang.Integer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Object.class, java.lang.Iterable.class), this);
+        registry.addConverter(new TypeConvertable<>(java.time.Duration.class, java.lang.Long.class), this);
+        registry.addConverter(new TypeConvertable<>(java.sql.Timestamp.class, java.lang.Long.class), this);
+        registry.addConverter(new TypeConvertable<>(java.util.Date.class, java.lang.Long.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Number.class, java.lang.Long.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.lang.Long.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.lang.Long.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.lang.Number.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.lang.Number.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Number.class, java.lang.Short.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.lang.Short.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.lang.Short.class), this);
+        registry.addConverter(new TypeConvertable<>(java.net.URI.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.nio.ByteBuffer.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.time.Duration.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.spi.Resource.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(char[].class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.net.URL.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.BufferedReader.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.Reader.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.ByteArrayOutputStream.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Integer.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Long.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Boolean.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.StringBuffer.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.StringBuilder.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Object.class, java.math.BigInteger.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.CharSequence.class, java.net.URI.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, java.nio.ByteBuffer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.ByteArrayOutputStream.class, java.nio.ByteBuffer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, java.nio.ByteBuffer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.nio.ByteBuffer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Short.class, java.nio.ByteBuffer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Integer.class, java.nio.ByteBuffer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Long.class, java.nio.ByteBuffer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Float.class, java.nio.ByteBuffer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Double.class, java.nio.ByteBuffer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, java.nio.ByteBuffer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Long.class, java.sql.Timestamp.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Long.class, java.time.Duration.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.time.Duration.class), this);
+        registry.addConverter(new TypeConvertable<>(java.util.Iterator.class, java.util.ArrayList.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Iterable.class, java.util.ArrayList.class), this);
+        registry.addConverter(new TypeConvertable<>(java.util.Map.class, java.util.Collection.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Long.class, java.util.Date.class), this);
+        registry.addConverter(new TypeConvertable<>(java.util.Map.class, java.util.HashMap.class), this);
+        registry.addConverter(new TypeConvertable<>(java.util.Map.class, java.util.Hashtable.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Object.class, java.util.Iterator.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Object[].class, java.util.List.class), this);
+        registry.addConverter(new TypeConvertable<>(java.util.Collection.class, java.util.List.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Iterable.class, java.util.List.class), this);
+        registry.addConverter(new TypeConvertable<>(java.util.Iterator.class, java.util.List.class), this);
+        registry.addConverter(new TypeConvertable<>(java.util.Map.class, java.util.Properties.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, java.util.Properties.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, java.util.Properties.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.Reader.class, java.util.Properties.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.Object[].class, java.util.Set.class), this);
+        registry.addConverter(new TypeConvertable<>(java.util.Collection.class, java.util.Set.class), this);
+        registry.addConverter(new TypeConvertable<>(java.util.Map.class, java.util.Set.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, java.util.TimeZone.class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.Expression.class, org.apache.camel.Processor.class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.Predicate.class, org.apache.camel.Processor.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, org.apache.camel.spi.Resource.class), this);
+        
+        
     }
 
     public TypeConverter lookup(Class<?> to, Class<?> from) {

--- a/core/camel-base/src/main/java/org/apache/camel/impl/converter/DefaultTypeConverter.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/converter/DefaultTypeConverter.java
@@ -66,7 +66,7 @@ public class DefaultTypeConverter extends BaseTypeConverterRegistry implements A
         loadCoreAndFastTypeConverters();
 
         String time = TimeUtils.printDuration(watch.taken(), true);
-        LOG.debug("Loaded {} type converters in {}", typeMappings.size(), time);
+        LOG.debug("Loaded {} type converters in {}", size(), time);
 
         if (!loadTypeConvertersDone && isLoadTypeConverters()) {
             scanTypeConverters();
@@ -94,18 +94,8 @@ public class DefaultTypeConverter extends BaseTypeConverterRegistry implements A
                 typeConverterLoaders.add(createScanTypeConverterLoader());
             }
 
-            int fast = typeMappings.size();
             // load type converters up front
             loadTypeConverters();
-            int additional = typeMappings.size() - fast;
-
-            // report how many type converters we have loaded
-            if (additional > 0) {
-                LOG.debug("Type converters loaded (fast: {}, scanned: {})", fast, additional);
-                LOG.warn(
-                        "Annotation scanning mode loaded {} type converters. Its recommended to migrate to @Converter(loader = true) for fast type converter mode.",
-                        additional);
-            }
 
             // lets clear the cache from the resolver as its often only used during startup
             if (resolver != null) {
@@ -114,7 +104,7 @@ public class DefaultTypeConverter extends BaseTypeConverterRegistry implements A
         }
 
         String time = TimeUtils.printDuration(watch.taken(), true);
-        LOG.debug("Scanned {} type converters in {}", typeMappings.size(), time);
+        LOG.debug("Loaded {} type converters in {}", size(), time);
     }
 
     /**

--- a/core/camel-base/src/main/java/org/apache/camel/impl/converter/TypeResolverHelper.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/converter/TypeResolverHelper.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.impl.converter;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.camel.TypeConverter;
+import org.apache.camel.converter.TypeConvertable;
+
+import static org.apache.camel.util.ObjectHelper.convertPrimitiveTypeToWrapperType;
+
+/**
+ * Helper methods for resolving the type conversions. This is an internal API and not meant for public usages.
+ *
+ * In a broader sense: the methods of this code help with traversing the class hierarchy of the types involved in a
+ * conversion, so that the correct TypeConverter can be used. This is a helper class to CoreTypeConverterRegistry.
+ *
+ * In the CoreTypeConverterRegistry class, the registry of types if maintained in a ConcurrentMap that associates a type
+ * pair with the resolver for it (i.e.: it associates pair representing a conversion from String to Integer to a type
+ * converter - such as CamelBaseBulkConverterLoader).
+ *
+ * NOTE: a lot of this code is in the hot path of the core engine, so change with extreme caution to prevent performance
+ * issues on the core code.
+ */
+final class TypeResolverHelper {
+    private TypeResolverHelper() {
+
+    }
+
+    /**
+     * Lookup the type converter in the registry (given a type to convert to and a type to convert from, along with a
+     * mapping of all known converters)
+     *
+     * @param  toType     the type to convert to
+     * @param  fromType   the type to convert from
+     * @param  isSuper    whether is passing the super class of a previously given type
+     * @param  converters the map of all known converters
+     * @return            the type converter or null if unknown
+     */
+    static TypeConverter doLookup(
+            Class<?> toType, Class<?> fromType, boolean isSuper, Map<TypeConvertable<?, ?>, TypeConverter> converters) {
+        return doLookup(new TypeConvertable<>(fromType, toType), isSuper, converters);
+    }
+
+    private static TypeConverter doLookup(
+            TypeConvertable<?, ?> typeConvertable, boolean isSuper, Map<TypeConvertable<?, ?>, TypeConverter> converters) {
+        if (typeConvertable.getFrom() != null) {
+
+            // try with base converters first
+            final TypeConverter baseConverters = tryBaseConverters(typeConvertable, converters);
+            if (baseConverters != null) {
+                return baseConverters;
+            }
+
+            // try the interfaces
+            final TypeConverter interfaceConverter = tryInterfaceConverters(typeConvertable, converters);
+            if (interfaceConverter != null) {
+                return interfaceConverter;
+            }
+
+            // try super then
+            final TypeConverter superConverter = trySuperConverters(typeConvertable, converters);
+            if (superConverter != null) {
+                return superConverter;
+            }
+        }
+
+        // only do these tests as fallback and only on the target type (eg not on its super)
+        if (!isSuper) {
+            if (typeConvertable.getFrom() != null && !typeConvertable.getFrom().equals(Object.class)) {
+
+                final TypeConverter assignableConverter
+                        = tryAssignableFrom(typeConvertable.getFrom(), typeConvertable.getTo(), converters);
+                if (assignableConverter != null) {
+                    return assignableConverter;
+                }
+
+                final TypeConverter objConverter = converters.get(new TypeConvertable<>(Object.class, typeConvertable.getTo()));
+                if (objConverter != null) {
+                    return objConverter;
+                }
+            }
+        }
+
+        // none found
+        return null;
+    }
+
+    /**
+     * Try the base converters. That is, those matching a direct conversion (i.e.: when the from and to types requested
+     * do exist on the converters' map OR when the from and to types requested match for a _primitive type).
+     *
+     * For instance: From String.class, To: int.class (would match a method such as myConverter(String, Integer) or
+     * myConverter(String, int).
+     *
+     * @param  typeConvertable the type converter pair
+     * @param  converters      the map of all known converters
+     * @return                 the type converter or null if unknown
+     */
+    static TypeConverter tryBaseConverters(
+            TypeConvertable<?, ?> typeConvertable, Map<TypeConvertable<?, ?>, TypeConverter> converters) {
+
+        final TypeConverter tc = tryDirectMatchConverters(typeConvertable, converters);
+        if (tc == null && typeConvertable.getTo().isPrimitive()) {
+            return converters
+                    .get(new TypeConvertable<>(
+                            typeConvertable.getFrom(), convertPrimitiveTypeToWrapperType(typeConvertable.getTo())));
+        }
+
+        return tc;
+    }
+
+    private static TypeConverter tryAssignableFrom(
+            Class<?> fromType, Class<?> toType, Map<TypeConvertable<?, ?>, TypeConverter> converters) {
+        /*
+         Let's try classes derived from this toType: basically it traverses the entries looking for assignable types
+         matching both the "from type" and the "to type" which are NOT Object (we usually try this later).
+         */
+        final Optional<Map.Entry<TypeConvertable<?, ?>, TypeConverter>> first = converters.entrySet().stream()
+                .filter(v -> v.getKey().getTo().isAssignableFrom(toType))
+                .filter(v -> !v.getKey().getFrom().equals(Object.class) && v.getKey().getFrom().isAssignableFrom(fromType))
+                .findFirst();
+
+        return first.map(Map.Entry::getValue).orElse(null);
+
+    }
+
+    /**
+     * Try a direct match conversion (i.e.: those which the type conversion pair have a direct entry on the converters)
+     *
+     * @param  typeConvertable the type converter pair
+     * @param  converters      the map of all known converters
+     * @return                 the type converter or null if unknown
+     */
+    static TypeConverter tryDirectMatchConverters(
+            TypeConvertable<?, ?> typeConvertable, Map<TypeConvertable<?, ?>, TypeConverter> converters) {
+        final TypeConverter typeConverter = converters.get(typeConvertable);
+        if (typeConverter != null) {
+            return typeConverter;
+        }
+
+        return null;
+    }
+
+    /**
+     * Try to resolve a TypeConverter by looking at the parent class of a given "from" type. It looks at the type
+     * hierarchy of the "from type" trying to match a suitable converter (i.e.: Integer -> Number). It will recursively
+     * analyze the whole hierarchy, and it will also evaluate the interfaces implemented by such type.
+     *
+     * @param  typeConvertable the type converter pair
+     * @param  converters      the map of all known converters
+     * @return                 the type converter or null if unknown
+     */
+    static TypeConverter trySuperConverters(
+            TypeConvertable<?, ?> typeConvertable, Map<TypeConvertable<?, ?>, TypeConverter> converters) {
+
+        return doLookup(typeConvertable.getTo(), typeConvertable.getFrom().getSuperclass(), true, converters);
+    }
+
+    private static TypeConverter tryInterfaceConverters(
+            Class<?> fromType, Class<?> toType, Map<TypeConvertable<?, ?>, TypeConverter> converters) {
+        final Class<?>[] interfaceTypes = fromType.getInterfaces();
+
+        for (Class<?> interfaceType : interfaceTypes) {
+            final TypeConvertable<?, ?> interfaceTypeConvertable = new TypeConvertable<>(interfaceType, toType);
+
+            TypeConverter typeConverter = tryBaseConverters(interfaceTypeConvertable, converters);
+            if (typeConverter != null) {
+                return typeConverter;
+            } else {
+                if (fromType.isArray()) {
+                    typeConverter = tryNativeArrayConverters(interfaceTypeConvertable, converters);
+                    if (typeConverter != null) {
+                        return typeConverter;
+                    }
+                } else {
+                    typeConverter = tryInterfaceConverters(interfaceTypeConvertable, converters);
+                    if (typeConverter != null) {
+                        return typeConverter;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Try to resolve a TypeConverter by looking at the interfaces implemented by a given "from" type. It looks at the
+     * type hierarchy of the "from type" trying to match a suitable converter (i.e.: Integer -> Number). It will
+     * recursively analyze the whole hierarchy.
+     *
+     * @param  typeConvertable the type converter pair
+     * @param  converters      the map of all known converters
+     * @return                 the type converter or null if unknown
+     */
+    static TypeConverter tryInterfaceConverters(
+            TypeConvertable<?, ?> typeConvertable, Map<TypeConvertable<?, ?>, TypeConverter> converters) {
+        return tryInterfaceConverters(typeConvertable.getFrom(), typeConvertable.getTo(), converters);
+    }
+
+    private static TypeConverter tryNativeArrayConverters(
+            Class<?> fromType, Class<?> toType, Map<TypeConvertable<?, ?>, TypeConverter> converters) {
+        if (fromType.isArray()) {
+            // Let the fallback converters handle the primitive arrays
+            if (!fromType.getComponentType().isPrimitive()) {
+                /* We usually define our converters are receiving an object array (Object[]), however, this won't easily match:
+                 * because an object array is not an interface or a super class of other array types (i.e.: not a super class
+                 * of String[]). So, we take the direct road here and try check for an object array converter right away.
+                 */
+                return converters.get(new TypeConvertable<>(Object[].class, toType));
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Try to resolve a TypeConverter by looking at Array matches for a given "from" type. This also includes evaluating
+     * candidates matching a receiver of Object[] type.
+     *
+     * @param  typeConvertable the type converter pair
+     * @param  converters      the map of all known converters
+     * @return                 the type converter or null if unknown
+     */
+    static TypeConverter tryNativeArrayConverters(
+            TypeConvertable<?, ?> typeConvertable, Map<TypeConvertable<?, ?>, TypeConverter> converters) {
+
+        return tryNativeArrayConverters(typeConvertable.getFrom(), typeConvertable.getTo(), converters);
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/converter/ConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/converter/ConverterTest.java
@@ -113,6 +113,7 @@ public class ConverterTest extends TestSupport {
         assertEquals(2, list.size(), "List size: " + list);
 
         Collection<?> collection = converter.convertTo(Collection.class, array);
+        assertNotNull(collection, "Returned object must not be null");
         assertEquals(2, collection.size(), "Collection size: " + collection);
 
         Set<?> set = converter.convertTo(Set.class, array);

--- a/core/camel-core/src/test/java/org/apache/camel/converter/DurationConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/converter/DurationConverterTest.java
@@ -45,7 +45,7 @@ public class DurationConverterTest extends ContextTestSupport {
             context.getTypeConverter().convertTo(long.class, duration);
             fail("Should throw exception");
         } catch (TypeConversionException e) {
-            assertIsInstanceOf(ArithmeticException.class, e.getCause().getCause());
+            assertIsInstanceOf(ArithmeticException.class, e.getCause());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/converter/DurationConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/converter/DurationConverterTest.java
@@ -45,7 +45,7 @@ public class DurationConverterTest extends ContextTestSupport {
             context.getTypeConverter().convertTo(long.class, duration);
             fail("Should throw exception");
         } catch (TypeConversionException e) {
-            assertIsInstanceOf(ArithmeticException.class, e.getCause());
+            assertIsInstanceOf(ArithmeticException.class, e.getCause().getCause());
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/CustomBulkTypeConvertersTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/CustomBulkTypeConvertersTest.java
@@ -21,6 +21,7 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.TypeConversionException;
 import org.apache.camel.TypeConverter;
+import org.apache.camel.converter.TypeConvertable;
 import org.apache.camel.spi.BulkTypeConverters;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +33,13 @@ public class CustomBulkTypeConvertersTest extends ContextTestSupport {
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext context = super.createCamelContext();
-        context.getTypeConverterRegistry().addBulkTypeConverters(new CustomBulkTypeConverters());
+
+        final CustomBulkTypeConverters customBulkTypeConverters = new CustomBulkTypeConverters();
+        context.getTypeConverterRegistry().addBulkTypeConverters(customBulkTypeConverters);
+        context.getTypeConverterRegistry().addConverter(new TypeConvertable<>(String.class, MyOrder.class),
+                customBulkTypeConverters);
+        context.getTypeConverterRegistry().addConverter(new TypeConvertable<>(Integer.class, MyOrder.class),
+                customBulkTypeConverters);
         return context;
     }
 

--- a/core/camel-support/src/generated/java/org/apache/camel/converter/stream/StreamCacheBulkConverterLoader.java
+++ b/core/camel-support/src/generated/java/org/apache/camel/converter/stream/StreamCacheBulkConverterLoader.java
@@ -9,6 +9,7 @@ import org.apache.camel.Ordered;
 import org.apache.camel.TypeConversionException;
 import org.apache.camel.TypeConverterLoaderException;
 import org.apache.camel.TypeConverter;
+import org.apache.camel.converter.TypeConvertable;
 import org.apache.camel.spi.BulkTypeConverters;
 import org.apache.camel.spi.TypeConverterLoader;
 import org.apache.camel.spi.TypeConverterRegistry;
@@ -43,6 +44,7 @@ public final class StreamCacheBulkConverterLoader implements TypeConverterLoader
     @Override
     public void load(TypeConverterRegistry registry) throws TypeConverterLoaderException {
         registry.addBulkTypeConverters(this);
+        doRegistration(registry);
     }
 
     @Override
@@ -85,6 +87,17 @@ public final class StreamCacheBulkConverterLoader implements TypeConverterLoader
             }
         }
         return null;
+    }
+
+    private void doRegistration(TypeConverterRegistry registry) {
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.StreamCache.class, byte[].class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.StreamCache.class, java.nio.ByteBuffer.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.ByteArrayInputStream.class, org.apache.camel.StreamCache.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, org.apache.camel.StreamCache.class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.converter.stream.CachedOutputStream.class, org.apache.camel.StreamCache.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.Reader.class, org.apache.camel.StreamCache.class), this);
+        
+        
     }
 
     public TypeConverter lookup(Class<?> to, Class<?> from) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/DoubleMap.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/DoubleMap.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 
 import org.apache.camel.util.function.TriConsumer;
 
+@Deprecated
 @SuppressWarnings("unchecked")
 public class DoubleMap<K1, K2, V> {
 

--- a/core/camel-xml-jaxp/src/generated/java/org/apache/camel/converter/jaxp/CamelXmlJaxpBulkConverterLoader.java
+++ b/core/camel-xml-jaxp/src/generated/java/org/apache/camel/converter/jaxp/CamelXmlJaxpBulkConverterLoader.java
@@ -9,6 +9,7 @@ import org.apache.camel.Ordered;
 import org.apache.camel.TypeConversionException;
 import org.apache.camel.TypeConverterLoaderException;
 import org.apache.camel.TypeConverter;
+import org.apache.camel.converter.TypeConvertable;
 import org.apache.camel.spi.BulkTypeConverters;
 import org.apache.camel.spi.TypeConverterLoader;
 import org.apache.camel.spi.TypeConverterRegistry;
@@ -43,6 +44,7 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
     @Override
     public void load(TypeConverterRegistry registry) throws TypeConverterLoaderException {
         registry.addBulkTypeConverters(this);
+        doRegistration(registry);
     }
 
     @Override
@@ -390,6 +392,106 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
             }
         }
         return null;
+    }
+
+    private void doRegistration(TypeConverterRegistry registry) {
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.NodeList.class, byte[].class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Source.class, byte[].class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.NodeList.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.stream.XMLStreamReader.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.dom.DOMSource.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.Document.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.stream.StreamSource.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.stream.XMLStreamReader.class, java.io.Reader.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.stream.StreamSource.class, java.io.Reader.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Source.class, java.io.Reader.class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.StreamCache.class, java.io.Serializable.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.NodeList.class, java.lang.Boolean.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.NodeList.class, java.lang.Integer.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.NodeList.class, java.lang.Long.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.NodeList.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.Node.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Source.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.NodeList.class, java.util.List.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, javax.xml.namespace.QName.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, javax.xml.stream.XMLEventReader.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, javax.xml.stream.XMLEventReader.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.Reader.class, javax.xml.stream.XMLEventReader.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.stream.XMLStreamReader.class, javax.xml.stream.XMLEventReader.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Source.class, javax.xml.stream.XMLEventReader.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.OutputStream.class, javax.xml.stream.XMLEventWriter.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.Writer.class, javax.xml.stream.XMLEventWriter.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Result.class, javax.xml.stream.XMLEventWriter.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, javax.xml.stream.XMLStreamReader.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, javax.xml.stream.XMLStreamReader.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.Reader.class, javax.xml.stream.XMLStreamReader.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Source.class, javax.xml.stream.XMLStreamReader.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, javax.xml.stream.XMLStreamReader.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.OutputStream.class, javax.xml.stream.XMLStreamWriter.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.Writer.class, javax.xml.stream.XMLStreamWriter.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Result.class, javax.xml.stream.XMLStreamWriter.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, javax.xml.transform.Source.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, javax.xml.transform.Source.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.Document.class, javax.xml.transform.Source.class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.StreamCache.class, javax.xml.transform.Source.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.Document.class, javax.xml.transform.dom.DOMSource.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.Node.class, javax.xml.transform.dom.DOMSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, javax.xml.transform.dom.DOMSource.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, javax.xml.transform.dom.DOMSource.class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.StreamCache.class, javax.xml.transform.dom.DOMSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, javax.xml.transform.dom.DOMSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, javax.xml.transform.dom.DOMSource.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.stream.StreamSource.class, javax.xml.transform.dom.DOMSource.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.sax.SAXSource.class, javax.xml.transform.dom.DOMSource.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.stax.StAXSource.class, javax.xml.transform.dom.DOMSource.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Source.class, javax.xml.transform.dom.DOMSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, javax.xml.transform.sax.SAXSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, javax.xml.transform.sax.SAXSource.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, javax.xml.transform.sax.SAXSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, javax.xml.transform.sax.SAXSource.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.stream.StreamSource.class, javax.xml.transform.sax.SAXSource.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.dom.DOMSource.class, javax.xml.transform.sax.SAXSource.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.stax.StAXSource.class, javax.xml.transform.sax.SAXSource.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Source.class, javax.xml.transform.sax.SAXSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, javax.xml.transform.stax.StAXSource.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, javax.xml.transform.stax.StAXSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, javax.xml.transform.stax.StAXSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, javax.xml.transform.stax.StAXSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, javax.xml.transform.stream.StreamSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, javax.xml.transform.stream.StreamSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.Reader.class, javax.xml.transform.stream.StreamSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, javax.xml.transform.stream.StreamSource.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, javax.xml.transform.stream.StreamSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.nio.ByteBuffer.class, javax.xml.transform.stream.StreamSource.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.sax.SAXSource.class, javax.xml.transform.stream.StreamSource.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.dom.DOMSource.class, javax.xml.transform.stream.StreamSource.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.stax.StAXSource.class, javax.xml.transform.stream.StreamSource.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Source.class, javax.xml.transform.stream.StreamSource.class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.util.xml.BytesSource.class, org.apache.camel.StreamCache.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.stream.StreamSource.class, org.apache.camel.StreamCache.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.sax.SAXSource.class, org.apache.camel.StreamCache.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, org.apache.camel.util.xml.BytesSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, org.apache.camel.util.xml.StringSource.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.Node.class, org.w3c.dom.Document.class), this);
+        registry.addConverter(new TypeConvertable<>(byte[].class, org.w3c.dom.Document.class), this);
+        registry.addConverter(new TypeConvertable<>(org.apache.camel.StreamCache.class, org.w3c.dom.Document.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, org.w3c.dom.Document.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.Reader.class, org.w3c.dom.Document.class), this);
+        registry.addConverter(new TypeConvertable<>(org.xml.sax.InputSource.class, org.w3c.dom.Document.class), this);
+        registry.addConverter(new TypeConvertable<>(java.lang.String.class, org.w3c.dom.Document.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, org.w3c.dom.Document.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Source.class, org.w3c.dom.Document.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.NodeList.class, org.w3c.dom.Document.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Source.class, org.w3c.dom.Element.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.Node.class, org.w3c.dom.Element.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.sax.SAXSource.class, org.w3c.dom.Node.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.stax.StAXSource.class, org.w3c.dom.Node.class), this);
+        registry.addConverter(new TypeConvertable<>(org.w3c.dom.NodeList.class, org.w3c.dom.Node.class), this);
+        registry.addConverter(new TypeConvertable<>(javax.xml.transform.Source.class, org.w3c.dom.Node.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.InputStream.class, org.xml.sax.InputSource.class), this);
+        registry.addConverter(new TypeConvertable<>(java.io.File.class, org.xml.sax.InputSource.class), this);
+        
+        
     }
 
     public TypeConverter lookup(Class<?> to, Class<?> from) {

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/TypeConverterLoaderGeneratorMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/TypeConverterLoaderGeneratorMojo.java
@@ -186,6 +186,7 @@ public class TypeConverterLoaderGeneratorMojo extends AbstractGeneratorMojo {
         writer.append("import org.apache.camel.TypeConversionException;\n");
         writer.append("import org.apache.camel.TypeConverterLoaderException;\n");
         writer.append("import org.apache.camel.TypeConverter;\n");
+        writer.append("import org.apache.camel.converter.TypeConvertable;\n");
         writer.append("import org.apache.camel.spi.BulkTypeConverters;\n");
         writer.append("import org.apache.camel.spi.TypeConverterLoader;\n");
         writer.append("import org.apache.camel.spi.TypeConverterRegistry;\n");
@@ -233,6 +234,7 @@ public class TypeConverterLoaderGeneratorMojo extends AbstractGeneratorMojo {
         writer.append("    @Override\n");
         writer.append("    public void load(TypeConverterRegistry registry) throws TypeConverterLoaderException {\n");
         writer.append("        registry.addBulkTypeConverters(this);\n");
+        writer.append("        doRegistration(registry);\n");
         writer.append("    }\n");
         writer.append("\n");
         writer.append("    @Override\n");
@@ -260,6 +262,14 @@ public class TypeConverterLoaderGeneratorMojo extends AbstractGeneratorMojo {
         writer.append("    }\n");
         writer.append("\n");
         writer.append(
+                "    private void doRegistration(TypeConverterRegistry registry) {\n");
+        writeRegistration(converters, writer, converterClasses, false);
+        writer.append("        \n");
+        writer.append("        \n");
+        writer.append("    }\n");
+        writer.append("\n");
+
+        writer.append(
                 "    public TypeConverter lookup(Class<?> to, Class<?> from) {\n");
         writeLoader(converters, writer, converterClasses, true);
         writer.append("        }\n");
@@ -283,18 +293,115 @@ public class TypeConverterLoaderGeneratorMojo extends AbstractGeneratorMojo {
         return writer.toString();
     }
 
+    private void writeRegistration(List<MethodInfo> converters, StringBuilder writer, Set<String> converterClasses, boolean lookup) {
+        for (MethodInfo method : converters) {
+
+            writer.append("        registry.addConverter(new TypeConvertable<>(")
+                    .append(getGenericArgumentsForTypeConvertable(method))
+                    .append("), ")
+                    .append("this);")
+
+                    .append("\n");
+        }
+    }
+
+    /**
+     * This resolves the method to be called for conversion. There are 2 possibilities here: either it
+     * calls a static method, in which case we can refer to it directly ... Or it uses one of the
+     * converter classes to do so. In this case, we do a bit of hacking "by convention" to call the
+     * getter of said converter and use it to call the converter method (i.e.;
+     * getDomConverter().myConverter method). There are some cases (like when dealing with jaxp that
+     * require this)
+     * @param method The converter method
+     * @return The resolved converter method to use
+     */
+    private static String resolveMethod(MethodInfo method) {
+        if (Modifier.isStatic(method.flags())) {
+            return method.declaringClass().toString() + "." + method.name();
+        } else {
+            return "get" + method.declaringClass().simpleName() + "()." + method.name();
+        }
+    }
+
+    /**
+     * This generates the cast part of the method
+     * @param method The converter method
+     * @return The cast string to use
+     */
+    private static String generateCast(MethodInfo method) {
+        StringBuilder writer = new StringBuilder(128);
+
+        if (method.parameterTypes().get(0).kind() == Type.Kind.ARRAY || method.parameterTypes().get(0).kind() == Type.Kind.CLASS) {
+            writer.append(method.parameterTypes().get(0).toString());
+        } else {
+            writer.append(method.parameterTypes().get(0).name().toString());
+        }
+
+        return writer.toString();
+    }
+
+    /**
+     * This generates the template arguments for the type convertable.
+     * @param method The converter method
+     * @return A string with the converter arguments
+     */
+
+    private static String getGenericArgumentsForTypeConvertable(MethodInfo method) {
+        StringBuilder writer = new StringBuilder(4096);
+
+        if (method.parameterTypes().get(0).kind() == Type.Kind.ARRAY || method.parameterTypes().get(0).kind() == Type.Kind.CLASS) {
+            writer.append(method.parameterTypes().get(0).toString());
+        } else {
+            writer.append(method.parameterTypes().get(0).name().toString());
+        }
+
+        writer.append(".class, ");
+        writer.append(getToMethod(method));
+        writer.append(".class");
+
+        return writer.toString();
+    }
+
+    /**
+     * This generates the arguments to be passed to the converter method. For instance, given a list of methods, it traverses
+     * the parameter types and generates something like this: "exchange, camelContext".
+     *
+     * @param method The converter method
+     * @return A string instance with the converter methods or an empty String if none exist.
+     */
+    private static String getArgumentsForConverter(MethodInfo method) {
+        StringBuilder writer = new StringBuilder(128);
+
+        for (Type type : method.parameterTypes()) {
+
+            if (type.name().withoutPackagePrefix().equalsIgnoreCase("CamelContext")) {
+                writer.append(", camelContext");
+            }
+
+            if (type.name().withoutPackagePrefix().equalsIgnoreCase("Exchange")) {
+                writer.append(", exchange");
+            }
+        }
+
+        return writer.toString();
+    }
+
+    private static String getToMethod(MethodInfo method) {
+        if (Type.Kind.PRIMITIVE.equals(method.returnType().kind())) {
+            return method.returnType().toString();
+        } else if (Type.Kind.ARRAY.equals(method.returnType().kind())) {
+            return method.returnType().toString();
+        } else {
+            return method.returnType().name().toString();
+        }
+    }
+
     private void writeLoader(
             List<MethodInfo> converters, StringBuilder writer, Set<String> converterClasses, boolean lookup) {
         String prevTo = null;
         for (MethodInfo method : converters) {
-            String to;
-            if (Type.Kind.PRIMITIVE.equals(method.returnType().kind())) {
-                to = method.returnType().toString();
-            } else if (Type.Kind.ARRAY.equals(method.returnType().kind())) {
-                to = method.returnType().toString();
-            } else {
-                to = method.returnType().name().toString();
-            }
+            String to = getToMethod(method);
+
             String from = method.parameterTypes().get(0).toString();
             // clip generics
             if (to.indexOf('<') != -1) {


### PR DESCRIPTION
This is a proposed refactoring of the core type conversion code. 

After analyzing the performance of a content-based router, I found out that the core conversion code has some bottlenecks, and a few significant performance problems (such as the one described in [CAMEL-19398](https://issues.apache.org/jira/browse/CAMEL-19398)).

This suggestion reworks the way the CoreTypeConverterRegistry works and: 
* Implements an internal cache of known type conversions to TypeConverters
* Cache conversions misses after they are resolved for the first time (original code did that too, but in a more complicated way)
* Improve the performance (initial estimates indicate something between 5%-10% improvement - but a lot more tests are needed). This seems to be corroborated by the improved resource usage (IPC increases from around ~0.95 to ~1.05 with this code). 


That said, this touches a few critical parts of the core code. Reviews and comments are more than welcome. 




