### PR TITLE
CAMEL-18608: camel-itest - Avoid client and server resources mix-up

### DIFF
--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsXaTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsXaTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.itest.sql;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
-import org.apache.camel.itest.ITestSupport;
 import org.apache.camel.itest.utils.extensions.JmsServiceExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,7 +68,6 @@ public class FromJmsToJdbcIdempotentConsumerToJmsXaTest extends FromJmsToJdbcIde
 
     @Override
     protected AbstractApplicationContext createApplicationContext() {
-        ITestSupport.getPort1();
         return new ClassPathXmlApplicationContext("org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsXaTest.xml");
     }
 }

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/utils/extensions/JmsServiceExtension.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/utils/extensions/JmsServiceExtension.java
@@ -29,37 +29,30 @@ import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.camel.component.jms.JmsComponent;
 import org.apache.camel.itest.CamelJmsTestHelper;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.Extension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public final class JmsServiceExtension implements BeforeAllCallback, AfterAllCallback {
+public final class JmsServiceExtension implements Extension {
 
     private static final Logger LOG = LoggerFactory.getLogger(JmsServiceExtension.class);
 
     private static JmsServiceExtension instance;
 
-    private JmsComponent amq;
-
-    private EmbeddedActiveMQ embeddedBrokerService;
-
-    private Configuration artemisConfiguration;
-    private String brokerURL;
+    private final JmsComponent amq;
 
     private JmsServiceExtension() throws JMSException {
-        embeddedBrokerService = new EmbeddedActiveMQ();
+        EmbeddedActiveMQ embeddedBrokerService = new EmbeddedActiveMQ();
 
-        artemisConfiguration = new ConfigurationImpl();
+        Configuration artemisConfiguration = new ConfigurationImpl();
         artemisConfiguration.setSecurityEnabled(false);
         artemisConfiguration.setBrokerInstance(new File("target", "artemis-itest-jms"));
         artemisConfiguration.setJMXManagementEnabled(false);
         artemisConfiguration.setPersistenceEnabled(false);
-        brokerURL = "vm://itest-jms";
+        String brokerURL = "vm://itest-jms";
         try {
             artemisConfiguration.addAcceptorConfiguration("in-vm", brokerURL);
         } catch (Exception e) {
@@ -85,15 +78,6 @@ public final class JmsServiceExtension implements BeforeAllCallback, AfterAllCal
         amq = jmsComponentAutoAcknowledge(connectionFactory);
 
         connectionFactory.createConnection();
-    }
-
-    @Override
-    public void afterAll(ExtensionContext extensionContext) throws Exception {
-    }
-
-    @Override
-    public void beforeAll(ExtensionContext extensionContext) throws Exception {
-
     }
 
     public JmsComponent getComponent() {

--- a/tests/camel-itest/src/test/resources/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsTest.xml
+++ b/tests/camel-itest/src/test/resources/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsTest.xml
@@ -19,11 +19,9 @@
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-       xmlns:broker="http://activemq.apache.org/schema/core"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-           http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-           http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+           http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"/>
 

--- a/tests/camel-itest/src/test/resources/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsXaTest.xml
+++ b/tests/camel-itest/src/test/resources/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsXaTest.xml
@@ -18,10 +18,8 @@
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:broker="http://activemq.apache.org/schema/core"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-           http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"/>
 


### PR DESCRIPTION
## Motivation

The test `FromJmsToJdbcIdempotentConsumerToJmsXaTest.testJmsToJdbcJmsRollbackAtA` is [failing on Jenkins](https://ci-builds.apache.org/job/Camel/job/Camel%20JDK17/job/main/902/testReport/org.apache.camel.itest.sql/FromJmsToJdbcIdempotentConsumerToJmsXaTest/testJmsToJdbcJmsRollbackAtA/) and should be fixed.

## Modifications:

* Start by checking the DLQ queue to prevent a mix-up between client and server resources being part of the same transaction
* Code cleanup