### PR TITLE
(chores) core: fix visibility mismatch

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/converter/stream/FileInputStreamCache.java
+++ b/core/camel-support/src/main/java/org/apache/camel/converter/stream/FileInputStreamCache.java
@@ -165,7 +165,7 @@ public final class FileInputStreamCache extends InputStream implements StreamCac
         return getInputStream().transferTo(out);
     }
 
-    protected InputStream getInputStream() throws IOException {
+    private InputStream getInputStream() throws IOException {
         if (stream == null) {
             stream = createInputStream(file);
         }


### PR DESCRIPTION
Do not use protected members on class marked as final