### PR TITLE
Camel 19433 handle error while consuming the records from topic

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
@@ -358,6 +358,10 @@ public class KafkaFetchRecords implements Runnable {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("The kafka consumer was woken up while polling on thread {} for {}", threadId, getPrintableTopic());
             }
+        } catch (Error e) { // NOSONAR - rethrown
+            LOG.error("Error {} while consuming from topic : {}", e.getMessage(), getPrintableTopic(), e);
+            safeUnsubscribe();
+            throw e;
         } catch (Exception e) {
             if (LOG.isDebugEnabled()) {
                 LOG.warn("Exception {} caught by thread {} while polling {} from kafka: {}",

--- a/core/camel-support/src/main/java/org/apache/camel/converter/stream/FileInputStreamCache.java
+++ b/core/camel-support/src/main/java/org/apache/camel/converter/stream/FileInputStreamCache.java
@@ -165,7 +165,7 @@ public final class FileInputStreamCache extends InputStream implements StreamCac
         return getInputStream().transferTo(out);
     }
 
-    protected InputStream getInputStream() throws IOException {
+    private InputStream getInputStream() throws IOException {
         if (stream == null) {
             stream = createInputStream(file);
         }


### PR DESCRIPTION
# Description

<!--
In the event of an error occurring during record consumption from a topic, the Kafka consumer will persistently send LeaveGroup requests to the coordinator due to consumer poll timeout has expired.

The camel Kafka consumer silently ignores it and throws no exceptions when fetching data for the topics.
Handling the error safely unsubscribe the consumer, accompanied by an appropriate log message
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--  
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I formatted the code using `mvn -Pformat,fastinstall install && mvn -Psourcecheck`

<!-- 
You can run the aforementioned command in your module so that the build auto-formats your code and the source check verifies that is complies with our coding style. This will also be verified as part of the checks and your PR may be rejected if the checkstyle does not pass.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

