### PR TITLE
CAMEL-19408: camel-swift - Upgrade to SRU2022-10.0.1

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -416,7 +416,7 @@
         <protobuf-maven-plugin-version>0.6.1</protobuf-maven-plugin-version>
         <protonpack-version>1.8</protonpack-version>
         <protostream-version>4.6.2.Final</protostream-version>
-        <prowide-version>SRU2022-10.0.0</prowide-version>
+        <prowide-version>SRU2022-10.0.1</prowide-version>
         <pubnub-version>6.3.5</pubnub-version>
         <pulsar-version>2.11.1</pulsar-version>
         <qpid-broker-version>9.0.0</qpid-broker-version>

--- a/components/camel-swift/pom.xml
+++ b/components/camel-swift/pom.xml
@@ -81,15 +81,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>--add-opens java.base/java.time=ALL-UNNAMED
-                    </argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -411,7 +411,7 @@
         <protobuf-maven-plugin-version>0.6.1</protobuf-maven-plugin-version>
         <protonpack-version>1.8</protonpack-version>
         <protostream-version>4.6.2.Final</protostream-version>
-        <prowide-version>SRU2022-10.0.0</prowide-version>
+        <prowide-version>SRU2022-10.0.1</prowide-version>
         <pubnub-version>6.3.5</pubnub-version>
         <pulsar-version>2.11.1</pulsar-version>
         <qpid-broker-version>9.0.0</qpid-broker-version>


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19408 (part 2)

## Motivation

After migrating to Upgrade to SRU2022-10.0.0, some tests failed due to [a reflection issue when serializing the MX messages in JSON ](https://github.com/prowide/prowide-iso20022/pull/83#issuecomment-1580150900).

## Modifications

* Upgrades to SRU2022-10.0.1 that contains the bug fix
* Removes the temporary workaround