### PR TITLE
CAMEL-19130: Upgrade to snakeyaml 2.x

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -507,7 +507,7 @@
     <smallrye-health-version>3.3.0</smallrye-health-version>
     <smallrye-metrics-version>3.0.5</smallrye-metrics-version>
     <snakeyaml-engine-version>2.3</snakeyaml-engine-version>
-    <snakeyaml-version>1.33</snakeyaml-version>
+    <snakeyaml-version>2.0</snakeyaml-version>
     <snmp4j-version>2.6.3_1</snmp4j-version>
     <solr-version>8.11.2</solr-version>
     <solr-version-range>[8,9)</solr-version-range>

--- a/components/camel-snakeyaml/src/generated/resources/org/apache/camel/component/snakeyaml/snakeYaml.json
+++ b/components/camel-snakeyaml/src/generated/resources/org/apache/camel/component/snakeyaml/snakeYaml.json
@@ -16,7 +16,7 @@
     "modelJavaType": "org.apache.camel.model.dataformat.YAMLDataFormat"
   },
   "properties": {
-    "library": { "kind": "attribute", "displayName": "Library", "required": false, "type": "enum", "javaType": "org.apache.camel.model.dataformat.YAMLLibrary", "enum": [ "SnakeYAML" ], "deprecated": false, "autowired": false, "secret": false, "defaultValue": "SnakeYAML", "description": "Which yaml library to use. By default it is SnakeYAML" },
+    "library": { "kind": "attribute", "displayName": "Library", "required": false, "type": "enum", "javaType": "org.apache.camel.model.dataformat.YAMLLibrary", "enum": [ "snake-yaml" ], "deprecated": false, "autowired": false, "secret": false, "defaultValue": "SnakeYAML", "description": "Which yaml library to use. By default it is SnakeYAML" },
     "unmarshalType": { "kind": "attribute", "displayName": "Unmarshal Type", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class name of the java type to use when unmarshalling" },
     "constructor": { "kind": "attribute", "displayName": "Constructor", "label": "advanced", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "BaseConstructor to construct incoming documents." },
     "representer": { "kind": "attribute", "displayName": "Representer", "label": "advanced", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Representer to emit outgoing objects." },

--- a/components/camel-snakeyaml/src/main/java/org/apache/camel/component/snakeyaml/SnakeYAMLDataFormat.java
+++ b/components/camel-snakeyaml/src/main/java/org/apache/camel/component/snakeyaml/SnakeYAMLDataFormat.java
@@ -47,6 +47,7 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.BaseConstructor;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.inspector.TrustedTagInspector;
 import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Representer;
 import org.yaml.snakeyaml.resolver.Resolver;
@@ -142,6 +143,7 @@ public final class SnakeYAMLDataFormat extends ServiceSupport implements DataFor
 
         if (yaml == null) {
             LoaderOptions options = new LoaderOptions();
+            options.setTagInspector(new TrustedTagInspector());
             options.setAllowRecursiveKeys(allowRecursiveKeys);
             options.setMaxAliasesForCollections(maxAliasesForCollections);
 
@@ -389,6 +391,7 @@ public final class SnakeYAMLDataFormat extends ServiceSupport implements DataFor
         }
 
         LoaderOptions options = new LoaderOptions();
+        options.setTagInspector(new TrustedTagInspector());
         options.setAllowRecursiveKeys(allowRecursiveKeys);
         options.setMaxAliasesForCollections(maxAliasesForCollections);
 
@@ -416,7 +419,7 @@ public final class SnakeYAMLDataFormat extends ServiceSupport implements DataFor
     }
 
     private Representer defaultRepresenter(CamelContext context) {
-        Representer yamlRepresenter = new Representer();
+        Representer yamlRepresenter = new Representer(new DumperOptions());
 
         if (classTags != null) {
             for (Map.Entry<Class<?>, Tag> entry : classTags.entrySet()) {
@@ -443,7 +446,7 @@ public final class SnakeYAMLDataFormat extends ServiceSupport implements DataFor
     // ***************************
 
     private static Constructor typeFilterConstructor(final Collection<TypeFilter> typeFilters, LoaderOptions options) {
-        Constructor constructor = new Constructor(options) {
+        return new Constructor(options) {
             @Override
             protected Class<?> getClassForName(String name) throws ClassNotFoundException {
                 if (typeFilters.stream().noneMatch(f -> f.test(name))) {
@@ -453,13 +456,12 @@ public final class SnakeYAMLDataFormat extends ServiceSupport implements DataFor
                 return super.getClassForName(name);
             }
         };
-        return constructor;
     }
 
     private static Constructor typeFilterConstructor(
             final ClassLoader classLoader, final Collection<TypeFilter> typeFilters,
             LoaderOptions options) {
-        CustomClassLoaderConstructor constructor = new CustomClassLoaderConstructor(classLoader, options) {
+        return new CustomClassLoaderConstructor(classLoader, options) {
             @Override
             protected Class<?> getClassForName(String name) throws ClassNotFoundException {
                 if (typeFilters.stream().noneMatch(f -> f.test(name))) {
@@ -469,6 +471,5 @@ public final class SnakeYAMLDataFormat extends ServiceSupport implements DataFor
                 return super.getClassForName(name);
             }
         };
-        return constructor;
     }
 }

--- a/components/camel-snakeyaml/src/main/java/org/apache/camel/component/snakeyaml/custom/CustomClassLoaderConstructor.java
+++ b/components/camel-snakeyaml/src/main/java/org/apache/camel/component/snakeyaml/custom/CustomClassLoaderConstructor.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.snakeyaml.custom;
 
+import java.util.Objects;
+
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -24,14 +26,11 @@ import org.yaml.snakeyaml.constructor.Constructor;
  */
 public class CustomClassLoaderConstructor extends Constructor {
 
-    private ClassLoader loader = this.getClass().getClassLoader();
+    private final ClassLoader loader;
 
     public CustomClassLoaderConstructor(ClassLoader theLoader, LoaderOptions options) {
         super(Object.class, options);
-        if (theLoader == null) {
-            throw new NullPointerException("Loader must be provided.");
-        }
-        this.loader = theLoader;
+        this.loader = Objects.requireNonNull(theLoader, "Loader must be provided.");
     }
 
     @Override

--- a/components/camel-snakeyaml/src/test/java/org/apache/camel/component/snakeyaml/SnakeYAMLDoSTest.java
+++ b/components/camel-snakeyaml/src/test/java/org/apache/camel/component/snakeyaml/SnakeYAMLDoSTest.java
@@ -26,6 +26,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -42,14 +43,15 @@ public class SnakeYAMLDoSTest extends CamelTestSupport {
         assertNotNull(mock);
         mock.expectedMessageCount(1);
 
-        InputStream is = this.getClass().getClassLoader().getResourceAsStream("data.yaml");
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("data.yaml")) {
 
-        ProducerTemplate template = context.createProducerTemplate();
-        String result = template.requestBody("direct:back", is, String.class);
-        assertNotNull(result);
-        assertEquals("{name=Colm, location=Dublin}", result.trim());
+            ProducerTemplate template = context.createProducerTemplate();
+            String result = template.requestBody("direct:back", is, String.class);
+            assertNotNull(result);
+            assertEquals("{name=Colm, location=Dublin}", result.trim());
 
-        mock.assertIsSatisfied();
+            mock.assertIsSatisfied();
+        }
     }
 
     @Test
@@ -59,18 +61,19 @@ public class SnakeYAMLDoSTest extends CamelTestSupport {
         assertNotNull(mock);
         mock.expectedMessageCount(0);
 
-        InputStream is = this.getClass().getClassLoader().getResourceAsStream("data-dos.yaml");
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("data-dos.yaml")) {
 
-        ProducerTemplate template = context.createProducerTemplate();
+            ProducerTemplate template = context.createProducerTemplate();
 
-        Exception ex = assertThrows(CamelExecutionException.class,
-                () -> template.requestBody("direct:back", is, String.class),
-                "Failure expected on an alias expansion attack");
+            Exception ex = assertThrows(CamelExecutionException.class,
+                    () -> template.requestBody("direct:back", is, String.class),
+                    "Failure expected on an alias expansion attack");
 
-        Throwable cause = ex.getCause();
-        assertEquals("Number of aliases for non-scalar nodes exceeds the specified max=50", cause.getMessage());
+            Throwable cause = ex.getCause();
+            assertEquals("Number of aliases for non-scalar nodes exceeds the specified max=50", cause.getMessage());
 
-        mock.assertIsSatisfied();
+            mock.assertIsSatisfied();
+        }
     }
 
     @Test
@@ -139,7 +142,7 @@ public class SnakeYAMLDoSTest extends CamelTestSupport {
         f.put(f, "a");
         f.put("g", root);
 
-        Yaml yaml = new Yaml(new SafeConstructor());
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         return yaml.dump(f);
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CodeRestGenerator.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CodeRestGenerator.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.config.CodegenConfigurator;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import picocli.CommandLine;
@@ -99,7 +100,7 @@ public class CodeRestGenerator extends CamelCommand {
 
     private JsonNode readNodeFromYaml() throws FileNotFoundException {
         final ObjectMapper mapper = new ObjectMapper();
-        Yaml loader = new Yaml(new SafeConstructor());
+        Yaml loader = new Yaml(new SafeConstructor(new LoaderOptions()));
         Map map = loader.load(new FileInputStream(Paths.get(input).toFile()));
         return mapper.convertValue(map, JsonNode.class);
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -493,7 +493,7 @@
         <smallrye-metrics-version>3.0.5</smallrye-metrics-version>
         <smallrye-health-version>3.3.0</smallrye-health-version>
         <smallrye-fault-tolerance-version>5.6.0</smallrye-fault-tolerance-version>
-        <snakeyaml-version>1.33</snakeyaml-version>
+        <snakeyaml-version>2.0</snakeyaml-version>
         <snakeyaml-engine-version>2.3</snakeyaml-engine-version>
         <snmp4j-version>2.6.3_1</snmp4j-version>
         <!-- solr version aligned with lucene -->


### PR DESCRIPTION
Fix for  https://issues.apache.org/jira/browse/CAMEL-19130 (3.x)

## Motivation

In order to get the latest improvements and bug fixes, we need to upgrade to snakeyaml 2.

## Modifications:

* Updated the version of snakeyaml
* Upgared `camel-snakeyaml` and `camel-restdsl-openapi-plugin`
* Fixed some violations raised