### PR TITLE
CAMEL-19464: camel-kafka - Upgrade to 3.5.x

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -320,7 +320,7 @@
         <jython-version>2.7.3</jython-version>
         <jython-standalone-version>2.7.3</jython-standalone-version>
         <jzlib-version>1.1.3</jzlib-version>
-        <kafka-version>3.4.1</kafka-version>
+        <kafka-version>3.5.0</kafka-version>
         <kotlin-version>1.8.22</kotlin-version>
         <kubernetes-client-version>6.7.2</kubernetes-client-version>
         <kubernetes-model-version>6.7.2</kubernetes-model-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -315,7 +315,7 @@
         <jython-version>2.7.3</jython-version>
         <jython-standalone-version>2.7.3</jython-standalone-version>
         <jzlib-version>1.1.3</jzlib-version>
-        <kafka-version>3.4.1</kafka-version>
+        <kafka-version>3.5.0</kafka-version>
         <kotlin-version>1.8.22</kotlin-version>
         <kubernetes-client-version>6.7.2</kubernetes-client-version>
         <kubernetes-model-version>6.7.2</kubernetes-model-version>

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
@@ -25,7 +25,7 @@ import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class ContainerLocalKafkaService implements KafkaService, ContainerService<KafkaContainer> {
-    public static final String KAFKA3_IMAGE_NAME = "confluentinc/cp-kafka:7.3.2";
+    public static final String KAFKA3_IMAGE_NAME = "confluentinc/cp-kafka:7.4.0";
     public static final String KAFKA2_IMAGE_NAME = "confluentinc/cp-kafka:5.5.12";
 
     private static final Logger LOG = LoggerFactory.getLogger(ContainerLocalKafkaService.class);


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-19464

## Motivation

Kafka 3.5 has just been released, we would like to upgrade to the latest version.

## Modifications:

* Updates the version of Kafka to `3.5.0`
* Updates the version of the docker image to `confluentinc/cp-kafka:7.4.0`