### PR TITLE
CAMEL-19490: camel-elasticsearch - Upgrade to 8.8.x

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -146,8 +146,8 @@
         <eddsa-version>0.3.0</eddsa-version>
         <egit-github-core-version>2.1.5</egit-github-core-version>
         <ehcache3-version>3.10.8</ehcache3-version>
-        <elasticsearch-java-client-version>8.7.1</elasticsearch-java-client-version>
-        <elasticsearch-java-client-sniffer-version>8.7.1</elasticsearch-java-client-sniffer-version>
+        <elasticsearch-java-client-version>8.8.1</elasticsearch-java-client-version>
+        <elasticsearch-java-client-sniffer-version>8.8.1</elasticsearch-java-client-sniffer-version>
         <elytron-web>1.10.2.Final</elytron-web>
         <exec-maven-plugin-version>3.1.0</exec-maven-plugin-version>
         <facebook4j-core-version>2.4.13</facebook4j-core-version>

--- a/components/camel-elasticsearch/pom.xml
+++ b/components/camel-elasticsearch/pom.xml
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson2.14-version}</version>
         </dependency>
 
         <!-- for testing -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -141,8 +141,8 @@
         <eddsa-version>0.3.0</eddsa-version>
         <egit-github-core-version>2.1.5</egit-github-core-version>
         <ehcache3-version>3.10.8</ehcache3-version>
-        <elasticsearch-java-client-version>8.7.1</elasticsearch-java-client-version>
-        <elasticsearch-java-client-sniffer-version>8.7.1</elasticsearch-java-client-sniffer-version>
+        <elasticsearch-java-client-version>8.8.1</elasticsearch-java-client-version>
+        <elasticsearch-java-client-sniffer-version>8.8.1</elasticsearch-java-client-sniffer-version>
         <elytron-web>1.10.2.Final</elytron-web>
         <exec-maven-plugin-version>3.1.0</exec-maven-plugin-version>
         <facebook4j-core-version>2.4.13</facebook4j-core-version>

--- a/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchLocalContainerService.java
+++ b/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchLocalContainerService.java
@@ -35,7 +35,7 @@ import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 public class ElasticSearchLocalContainerService implements ElasticSearchService, ContainerService<ElasticsearchContainer> {
-    public static final String DEFAULT_ELASTIC_SEARCH_CONTAINER = "docker.elastic.co/elasticsearch/elasticsearch:8.6.2";
+    public static final String DEFAULT_ELASTIC_SEARCH_CONTAINER = "docker.elastic.co/elasticsearch/elasticsearch:8.8.1";
     private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchLocalContainerService.class);
     private static final int ELASTIC_SEARCH_PORT = 9200;
     private static final String USER_NAME = "elastic";


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-19490

## Motivation

Elastic search 8.8 has just been released, we would like to upgrade to the latest version.

## Modifications:

* Updates the version of Elastic Search to `8.8.1`
* Updates the version of the docker image to `docker.elastic.co/elasticsearch/elasticsearch:8.8.1`
* Uses the default version of Jackson which is `2.15` as it is the version expected by the elastic search client