### PR TITLE
Handle -Pfastinstall as an alias of -Dquickly

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,3 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
+    <extension>
+        <groupId>org.l2x6.cq</groupId>
+        <artifactId>cq-alias-fastinstall-quickly-extension</artifactId>
+        <version>4.4.0</version>
+    </extension>
 </extensions>


### PR DESCRIPTION
This PR addresses the requests on camel-dev ML to keep the old `fastinstall` profile in some form for backwards compatibility reasons. Hence this PR adds a small maven extension that does just that: when `-Pfastinstall` is present among maven command line arguments, the `full` profile is made inactive programmatically. Passing `-Dquickly` does the same. 