### PR TITLE
Add possibility to override LRAClient & LRARoutes

### DIFF
--- a/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRAClient.java
+++ b/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRAClient.java
@@ -47,9 +47,16 @@ public class LRAClient implements Closeable {
     private final String lraUrl;
 
     public LRAClient(LRASagaService sagaService) {
-        this.sagaService = sagaService;
+        this(sagaService, HttpClient.newHttpClient());
+    }
 
-        client = HttpClient.newHttpClient();
+    public LRAClient(LRASagaService sagaService, HttpClient client) {
+        if (client == null) {
+            throw new IllegalArgumentException("HttpClient must not be null");
+        }
+
+        this.sagaService = sagaService;
+        this.client = client;
 
         lraUrl = new LRAUrlBuilder()
                 .host(sagaService.getCoordinatorUrl())

--- a/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRASagaService.java
+++ b/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRASagaService.java
@@ -94,8 +94,18 @@ public class LRASagaService extends ServiceSupport implements StaticService, Cam
                     .newDefaultScheduledThreadPool(this, "saga-lra");
         }
         if (this.client == null) {
-            this.client = new LRAClient(this);
+            this.client = createLRAClient();
         }
+    }
+
+    /**
+     * Use this method to override some behavior within the LRAClient
+     *
+     * @return the LRAClient to be used within the LRASagaService
+     *
+     */
+    protected LRAClient createLRAClient() {
+        return new LRAClient(this);
     }
 
     @Override
@@ -114,13 +124,23 @@ public class LRASagaService extends ServiceSupport implements StaticService, Cam
     public void setCamelContext(CamelContext camelContext) {
         this.camelContext = camelContext;
         if (this.routes == null) {
-            this.routes = new LRASagaRoutes(this);
+            this.routes = createLRASagaRoutes(camelContext);
             try {
                 this.camelContext.addRoutes(this.routes);
             } catch (Exception ex) {
                 throw RuntimeCamelException.wrapRuntimeException(ex);
             }
         }
+    }
+
+    /**
+     * Use this method to override the creation of LRASagaRoutes
+     *
+     * @param  camelContext
+     * @return              the LRASagaRoutes instance to use in this service
+     */
+    protected LRASagaRoutes createLRASagaRoutes(CamelContext camelContext) {
+        return new LRASagaRoutes(this);
     }
 
     @Override

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAClientTest.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAClientTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.service.lra;
+
+import java.net.http.HttpClient;
+
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class LRAClientTest extends CamelTestSupport {
+
+    public LRAClientTest() {
+        setUseRouteBuilder(false);
+    }
+
+    @DisplayName("Tests whether LRAClient is using a default HttpClient")
+    @Test
+    void testCanCreateLRAClient() throws Exception {
+        LRASagaService sagaService = new LRASagaService();
+        applyMockProperties(sagaService);
+        LRAClient client = new LRAClient(sagaService);
+        Assertions.assertNotNull(client, "client must not be null after initializing");
+    }
+
+    @DisplayName("Tests whether LRAClient is using a custom set HttpClient")
+    @Test
+    void testCanCreateLRAClientWithCustomHttpClient() throws Exception {
+        LRASagaService sagaService = new LRASagaService();
+        applyMockProperties(sagaService);
+        LRAClient client = new LRAClient(sagaService, HttpClient.newBuilder().build());
+        Assertions.assertNotNull(client, "client must not be null after initializing");
+    }
+
+    @DisplayName("Tests whether LRAClient is throwing an exception if httpclient is null")
+    @Test
+    void testCannotCreateLRAClientWithoutHttpClient() throws Exception {
+        LRASagaService sagaService = new LRASagaService();
+        applyMockProperties(sagaService);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new LRAClient(sagaService, null),
+                "no client should result in IllegalArgumentException");
+    }
+
+    private void applyMockProperties(LRASagaService sagaService) {
+        sagaService.setCoordinatorUrl("mockCoordinatorUrl");
+        sagaService.setLocalParticipantUrl("mockLocalParticipantUrl");
+        sagaService.setLocalParticipantContextPath("mockLocalParticipantContextPath");
+        sagaService.setCoordinatorContextPath("mockCoordinatorContextPath");
+    }
+
+}

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRASagaServiceTest.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRASagaServiceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.service.lra;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.model.Model;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class LRASagaServiceTest extends CamelTestSupport {
+
+    public LRASagaServiceTest() {
+        setUseRouteBuilder(false);
+    }
+
+    @DisplayName("Tests whether doStart() is creating a LRAClient")
+    @Test
+    void testCanCreateLRAClient() throws Exception {
+        LRASagaService sagaService = new LRASagaService();
+        applyMockProperties(sagaService);
+        sagaService.setCamelContext(this.context());
+        sagaService.doStart();
+
+        LRAClient client = sagaService.getClient();
+        Assertions.assertNotNull(client, "lraClient must not be null");
+    }
+
+    @DisplayName("Tests whether doStart() is creating an alternative LRAClient")
+    @Test
+    void testCanCreateAlternativeLRAClient() throws Exception {
+        LRASagaService sagaService = new AlternativeLRASagaService();
+        applyMockProperties(sagaService);
+        sagaService.setCamelContext(this.context());
+        sagaService.doStart();
+
+        LRAClient client = sagaService.getClient();
+        Assertions.assertNotNull(client, "lraClient must not be null");
+
+        Assertions.assertInstanceOf(AlternativeLRAClient.class, client, "client must be an instance of AlternativeLRAClient");
+    }
+
+    @DisplayName("Tests whether setCamelContext() is creating a LRARoutes in the context")
+    @Test
+    void testCanCreateLRARoutes() throws Exception {
+        LRASagaService sagaService = new LRASagaService();
+        sagaService.setCamelContext(this.context());
+
+        Assertions.assertNotNull(this.context().getRoutes(), "routes of the context must not be null");
+        Assertions.assertEquals(4,
+                context().getExtension(Model.class).getRouteDefinitions().size());
+    }
+
+    @DisplayName("Tests whether setCamelContext() is creating AlternativeLRARoutes in the context")
+    @Test
+    void testCanCreateAlternativeLRARoutes() throws Exception {
+        AlternativeLRASagaService sagaService = new AlternativeLRASagaService();
+        sagaService.setCamelContext(this.context());
+
+        Assertions.assertNotNull(this.context().getRoutes(), "routes of the context must not be null");
+        Assertions.assertEquals(5,
+                context().getExtension(Model.class).getRouteDefinitions().size());
+    }
+
+    private void applyMockProperties(LRASagaService sagaService) {
+        sagaService.setCoordinatorUrl("mockCoordinatorUrl");
+        sagaService.setLocalParticipantUrl("mockLocalParticipantUrl");
+        sagaService.setLocalParticipantContextPath("mockLocalParticipantContextPath");
+        sagaService.setCoordinatorContextPath("mockCoordinatorContextPath");
+    }
+
+    private class AlternativeLRASagaService extends LRASagaService {
+        protected LRAClient createLRAClient() {
+            return new AlternativeLRAClient(this);
+        }
+
+        protected LRASagaRoutes createLRASagaRoutes(CamelContext camelContext) {
+            return new AlternativeLRASagaRoutes(this);
+        }
+    }
+
+    private class AlternativeLRAClient extends LRAClient {
+        public AlternativeLRAClient(LRASagaService sagaService) {
+            super(sagaService);
+        }
+    }
+
+    private class AlternativeLRASagaRoutes extends LRASagaRoutes {
+        public AlternativeLRASagaRoutes(LRASagaService sagaService) {
+            super(sagaService);
+        }
+
+        public void configure() throws Exception {
+            super.configure();
+            from("direct:test").log("another route");
+        }
+    }
+}


### PR DESCRIPTION
# Description

The Saga EIP pattern is using rest based communication for interaction with the lra-coordinator (e.g. narayana). Although there are ways to secure the communication with the coordinator, this is not supported by the underlying code. Also, it is not possible to easily override some implementations, since they are created by intenral constructors.

This change is targeting, that one can override (influence) the creation of the LRAClient and LRASagaRoutes in the LRASagaService. With those "extensions", it is then possible to override some default behavior and for example you can set the HttpClient and use your own adjusted instance with an Authenticator.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] ~~If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).~~
I do consider this change as a small change, since the default behavior is not touched.


# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes
