### PR TITLE
(chores) camel-core: prevent ThrottlerTest from running on GH

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerTest.java
@@ -24,12 +24,15 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+// time-bound that does not run well in shared environments
 @DisabledOnOs(OS.WINDOWS)
+@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
 public class ThrottlerTest extends ContextTestSupport {
     private static final int INTERVAL = 500;
     private static final int TOLERANCE = 50;


### PR DESCRIPTION
This test is time-bound and that does not run well in shared environments