### PR TITLE
CAMEL-19497: prevent unhandled exceptions from blocking indefinitely

### DIFF
--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/AbstractBeanProcessor.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/AbstractBeanProcessor.java
@@ -108,8 +108,10 @@ public abstract class AbstractBeanProcessor extends AsyncProcessorSupport {
                     target.process(exchange);
                 } catch (AssertionError | Exception e) {
                     exchange.setException(e);
+                } finally {
+                    callback.done(true);
                 }
-                callback.done(true);
+
                 return true;
             }
         }


### PR DESCRIPTION
This ensures that the done callback will be called (or, at least, tried to be called) in the case of unhandled exceptions (a few rare cases involving Throwables)