### PR TITLE
(chores) camel-package-maven-plugin: ensure a modern version of the compiler plugin

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/src/it/HeaderSupport/pom.xml
+++ b/tooling/maven/camel-package-maven-plugin/src/it/HeaderSupport/pom.xml
@@ -66,6 +66,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This should force the integration test to use Java 17 as the base version