### PR TITLE
CAMEL-19571 - camel-parquet-avro: Add other compression codecs than gzip

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dataformats/parquetAvro.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dataformats/parquetAvro.json
@@ -16,7 +16,8 @@
     "modelJavaType": "org.apache.camel.model.dataformat.ParquetAvroDataFormat"
   },
   "properties": {
-    "unmarshalType": { "index": 0, "kind": "attribute", "displayName": "Unmarshal Type", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class to use when unmarshalling." },
-    "id": { "index": 1, "kind": "attribute", "displayName": "Id", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "The id of this node" }
+    "compressionCodecName": { "index": 0, "kind": "attribute", "displayName": "Compression Codec Name", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "defaultValue": "GZIP", "description": "Compression codec to use when marshalling." },
+    "unmarshalType": { "index": 1, "kind": "attribute", "displayName": "Unmarshal Type", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class to use when unmarshalling." },
+    "id": { "index": 2, "kind": "attribute", "displayName": "Id", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "The id of this node" }
   }
 }

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/parquetAvro.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/parquetAvro.json
@@ -13,7 +13,8 @@
     "output": false
   },
   "properties": {
-    "unmarshalType": { "index": 0, "kind": "attribute", "displayName": "Unmarshal Type", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class to use when unmarshalling." },
-    "id": { "index": 1, "kind": "attribute", "displayName": "Id", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "The id of this node" }
+    "compressionCodecName": { "index": 0, "kind": "attribute", "displayName": "Compression Codec Name", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "defaultValue": "GZIP", "description": "Compression codec to use when marshalling." },
+    "unmarshalType": { "index": 1, "kind": "attribute", "displayName": "Unmarshal Type", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class to use when unmarshalling." },
+    "id": { "index": 2, "kind": "attribute", "displayName": "Id", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "The id of this node" }
   }
 }

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
@@ -8730,6 +8730,15 @@ false. Default value: false
     <xs:complexContent>
       <xs:extension base="tns:dataFormat">
         <xs:sequence/>
+        <xs:attribute name="compressionCodecName" type="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+<![CDATA[
+Compression codec to use when marshalling. Default value: GZIP
+]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="unmarshalType" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">

--- a/components/camel-parquet-avro/src/generated/resources/org/apache/camel/dataformat/parquet/avro/parquetAvro.json
+++ b/components/camel-parquet-avro/src/generated/resources/org/apache/camel/dataformat/parquet/avro/parquetAvro.json
@@ -16,7 +16,8 @@
     "modelJavaType": "org.apache.camel.model.dataformat.ParquetAvroDataFormat"
   },
   "properties": {
-    "unmarshalType": { "index": 0, "kind": "attribute", "displayName": "Unmarshal Type", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class to use when unmarshalling." },
-    "id": { "index": 1, "kind": "attribute", "displayName": "Id", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "The id of this node" }
+    "compressionCodecName": { "index": 0, "kind": "attribute", "displayName": "Compression Codec Name", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "defaultValue": "GZIP", "description": "Compression codec to use when marshalling." },
+    "unmarshalType": { "index": 1, "kind": "attribute", "displayName": "Unmarshal Type", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class to use when unmarshalling." },
+    "id": { "index": 2, "kind": "attribute", "displayName": "Id", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "The id of this node" }
   }
 }

--- a/components/camel-parquet-avro/src/main/docs/parquetAvro-dataformat.adoc
+++ b/components/camel-parquet-avro/src/main/docs/parquetAvro-dataformat.adoc
@@ -11,7 +11,7 @@
 
 *Since Camel {since}*
 
-The ParquetAvro Data Format Data Format is a Camel Frameworks's data format implementation based on parquet-avro library for (de)/serialization purposes. Messages can be unmarshalled (conversion to simple Java POJO(s)) to plain Java objects. By the help of Camel's routing engine and data transformations you can then play with POJO(s) and apply customised formatting and call other Camel Component's to convert and send messages to upstream systems.
+The ParquetAvro Data Format is a Camel Framework's data format implementation based on parquet-avro library for (de)/serialization purposes. Messages can be unmarshalled (conversion to simple Java POJO(s)) to plain Java objects. By the help of Camel's routing engine and data transformations you can then play with POJO(s) and apply customised formatting and call other Camel Component's to convert and send messages to upstream systems.
 
 == Parquet Data Format Options
 

--- a/components/camel-parquet-avro/src/main/java/org/apache/camel/dataformat/parquet/avro/ParquetAvroDataFormat.java
+++ b/components/camel-parquet-avro/src/main/java/org/apache/camel/dataformat/parquet/avro/ParquetAvroDataFormat.java
@@ -35,6 +35,7 @@ import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 import static org.apache.parquet.hadoop.ParquetFileWriter.Mode.OVERWRITE;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
@@ -43,6 +44,8 @@ import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
 public class ParquetAvroDataFormat extends ServiceSupport implements DataFormat, DataFormatName {
 
     private static final DefaultUuidGenerator DEFAULT_UUID_GENERATOR = new DefaultUuidGenerator();
+
+    private CompressionCodecName compressionCodecName = GZIP;
 
     private Class<?> unmarshalType;
 
@@ -67,7 +70,7 @@ public class ParquetAvroDataFormat extends ServiceSupport implements DataFormat,
                 .withSchema(ReflectData.AllowNull.get().getSchema(unmarshalType)) // generate nullable fields
                 .withDataModel(ReflectData.get())
                 .withConf(conf)
-                .withCompressionCodec(GZIP)
+                .withCompressionCodec(compressionCodecName)
                 .withWriteMode(OVERWRITE)
                 .build()) {
             for (Object grapElem : list) {
@@ -112,6 +115,19 @@ public class ParquetAvroDataFormat extends ServiceSupport implements DataFormat,
     @Override
     protected void doStop() throws Exception {
         // no-op
+    }
+
+    public String getCompressionCodecName() {
+        return compressionCodecName.name();
+    }
+
+    /**
+     * Compression codec to use when marshalling. You can find the supported codecs at
+     * https://github.com/apache/parquet-format/blob/master/Compression.md#codecs. Note that some codecs may require you
+     * to include additional libraries into the classpath.
+     */
+    public void setCompressionCodecName(String compressionCodecName) {
+        this.compressionCodecName = CompressionCodecName.valueOf(compressionCodecName);
     }
 
     public Class<?> getUnmarshalType() {

--- a/components/camel-parquet-avro/src/test/java/org/apache/camel/dataformat/parquet/avro/ParquetAvroMarshalCompressionCodecTest.java
+++ b/components/camel-parquet-avro/src/test/java/org/apache/camel/dataformat/parquet/avro/ParquetAvroMarshalCompressionCodecTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.parquet.avro;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.support.DefaultUuidGenerator;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ParquetAvroMarshalCompressionCodecTest extends CamelTestSupport {
+
+    Collection<Pojo> in = List.of(
+            new Pojo(1, "airport"),
+            new Pojo(2, "penguin"),
+            new Pojo(3, "verb"));
+
+    DefaultUuidGenerator uuidGenerator = new DefaultUuidGenerator();
+
+    ParquetReadOptions readOptions = ParquetReadOptions.builder().build();
+
+    @Test
+    public void testMarshalCompressionCodec() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:default");
+        mock.expectedMessageCount(1);
+
+        template.requestBody("direct:default", in);
+        mock.assertIsSatisfied();
+
+        byte[] marshalled = mock.getExchanges().get(0).getIn().getBody(byte[].class);
+        ParquetInputStream inputStream = new ParquetInputStream(uuidGenerator.generateUuid(), marshalled);
+        try (ParquetFileReader reader = new ParquetFileReader(inputStream, readOptions)) {
+            CompressionCodecName codecName = reader.getRowGroups().get(0).getColumns().get(0).getCodec();
+            assertEquals(GZIP, codecName);
+        }
+    }
+
+    @Test
+    public void testMarshalCompressionCodecGzip() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:gzip");
+        mock.expectedMessageCount(1);
+
+        template.requestBody("direct:gzip", in);
+        mock.assertIsSatisfied();
+
+        byte[] marshalled = mock.getExchanges().get(0).getIn().getBody(byte[].class);
+        ParquetInputStream inputStream = new ParquetInputStream(uuidGenerator.generateUuid(), marshalled);
+        try (ParquetFileReader reader = new ParquetFileReader(inputStream, readOptions)) {
+            CompressionCodecName codecName = reader.getRowGroups().get(0).getColumns().get(0).getCodec();
+            assertEquals(GZIP, codecName);
+        }
+    }
+
+    @Test
+    public void testMarshalCompressionCodecSnappy() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:snappy");
+        mock.expectedMessageCount(1);
+
+        template.requestBody("direct:snappy", in);
+        mock.assertIsSatisfied();
+
+        byte[] marshalled = mock.getExchanges().get(0).getIn().getBody(byte[].class);
+        ParquetInputStream inputStream = new ParquetInputStream(uuidGenerator.generateUuid(), marshalled);
+        try (ParquetFileReader reader = new ParquetFileReader(inputStream, readOptions)) {
+            CompressionCodecName codecName = reader.getRowGroups().get(0).getColumns().get(0).getCodec();
+            assertEquals(SNAPPY, codecName);
+        }
+    }
+
+    @Test
+    public void testMarshalCompressionCodecUncompressed() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:uncompressed");
+        mock.expectedMessageCount(1);
+
+        template.requestBody("direct:uncompressed", in);
+        mock.assertIsSatisfied();
+
+        byte[] marshalled = mock.getExchanges().get(0).getIn().getBody(byte[].class);
+        ParquetInputStream inputStream = new ParquetInputStream(uuidGenerator.generateUuid(), marshalled);
+        try (ParquetFileReader reader = new ParquetFileReader(inputStream, readOptions)) {
+            CompressionCodecName codecName = reader.getRowGroups().get(0).getColumns().get(0).getCodec();
+            assertEquals(UNCOMPRESSED, codecName);
+        }
+    }
+
+    @Test
+    public void testMarshalCompressionCodecZstd() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:zstd");
+        mock.expectedMessageCount(1);
+
+        template.requestBody("direct:zstd", in);
+        mock.assertIsSatisfied();
+
+        byte[] marshalled = mock.getExchanges().get(0).getIn().getBody(byte[].class);
+        ParquetInputStream inputStream = new ParquetInputStream(uuidGenerator.generateUuid(), marshalled);
+        try (ParquetFileReader reader = new ParquetFileReader(inputStream, readOptions)) {
+            CompressionCodecName codecName = reader.getRowGroups().get(0).getColumns().get(0).getCodec();
+            assertEquals(ZSTD, codecName);
+        }
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+
+            @Override
+            public void configure() {
+                ParquetAvroDataFormat defaultFormat = new ParquetAvroDataFormat();
+                defaultFormat.setUnmarshalType(Pojo.class);
+                from("direct:default").marshal(defaultFormat).to("mock:default");
+
+                ParquetAvroDataFormat gzipFormat = new ParquetAvroDataFormat();
+                gzipFormat.setUnmarshalType(Pojo.class);
+                gzipFormat.setCompressionCodecName(GZIP.name());
+                from("direct:gzip").marshal(gzipFormat).to("mock:gzip");
+
+                ParquetAvroDataFormat snappyFormat = new ParquetAvroDataFormat();
+                snappyFormat.setUnmarshalType(Pojo.class);
+                snappyFormat.setCompressionCodecName(SNAPPY.name());
+                from("direct:snappy").marshal(snappyFormat).to("mock:snappy");
+
+                ParquetAvroDataFormat uncompressedFormat = new ParquetAvroDataFormat();
+                uncompressedFormat.setUnmarshalType(Pojo.class);
+                uncompressedFormat.setCompressionCodecName(UNCOMPRESSED.name());
+                from("direct:uncompressed").marshal(uncompressedFormat).to("mock:uncompressed");
+
+                ParquetAvroDataFormat zstdFormat = new ParquetAvroDataFormat();
+                zstdFormat.setUnmarshalType(Pojo.class);
+                zstdFormat.setCompressionCodecName(ZSTD.name());
+                from("direct:zstd").marshal(zstdFormat).to("mock:zstd");
+            }
+        };
+    }
+}

--- a/core/camel-core-model/src/generated/resources/org/apache/camel/model/dataformat/parquetAvro.json
+++ b/core/camel-core-model/src/generated/resources/org/apache/camel/model/dataformat/parquetAvro.json
@@ -13,7 +13,8 @@
     "output": false
   },
   "properties": {
-    "unmarshalType": { "index": 0, "kind": "attribute", "displayName": "Unmarshal Type", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class to use when unmarshalling." },
-    "id": { "index": 1, "kind": "attribute", "displayName": "Id", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "The id of this node" }
+    "compressionCodecName": { "index": 0, "kind": "attribute", "displayName": "Compression Codec Name", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "defaultValue": "GZIP", "description": "Compression codec to use when marshalling." },
+    "unmarshalType": { "index": 1, "kind": "attribute", "displayName": "Unmarshal Type", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class to use when unmarshalling." },
+    "id": { "index": 2, "kind": "attribute", "displayName": "Id", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "The id of this node" }
   }
 }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ParquetAvroDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/ParquetAvroDataFormat.java
@@ -34,6 +34,10 @@ import org.apache.camel.spi.Metadata;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ParquetAvroDataFormat extends DataFormatDefinition {
 
+    @XmlAttribute
+    @Metadata(defaultValue = "GZIP")
+    private String compressionCodecName;
+
     @XmlTransient
     private Class<?> unmarshalType;
 
@@ -56,8 +60,20 @@ public class ParquetAvroDataFormat extends DataFormatDefinition {
 
     private ParquetAvroDataFormat(Builder builder) {
         this();
+        this.compressionCodecName = builder.compressionCodecName;
         this.unmarshalTypeName = builder.unmarshalTypeName;
         this.unmarshalType = builder.unmarshalType;
+    }
+
+    /**
+     * Compression codec to use when marshalling.
+     */
+    public void setCompressionCodecName(String compressionCodecName) {
+        this.compressionCodecName = compressionCodecName;
+    }
+
+    public String getCompressionCodecName() {
+        return compressionCodecName;
     }
 
     public Class<?> getUnmarshalType() {
@@ -88,8 +104,17 @@ public class ParquetAvroDataFormat extends DataFormatDefinition {
     @XmlTransient
     public static class Builder implements DataFormatBuilder<ParquetAvroDataFormat> {
 
+        private String compressionCodecName;
         private Class<?> unmarshalType;
         private String unmarshalTypeName;
+
+        /**
+         * Compression codec to use when marshalling.
+         */
+        public Builder compressionCodecName(String compressionCodecName) {
+            this.compressionCodecName = compressionCodecName;
+            return this;
+        }
 
         /**
          * Class to use when unmarshalling.

--- a/core/camel-xml-io/src/generated/java/org/apache/camel/xml/in/ModelParser.java
+++ b/core/camel-xml-io/src/generated/java/org/apache/camel/xml/in/ModelParser.java
@@ -2381,11 +2381,12 @@ public class ModelParser extends BaseParser {
     }
     protected ParquetAvroDataFormat doParseParquetAvroDataFormat() throws IOException, XmlPullParserException {
         return doParse(new ParquetAvroDataFormat(), (def, key, val) -> {
-            if ("unmarshalType".equals(key)) {
-                def.setUnmarshalTypeName(val);
-                return true;
+            switch (key) {
+                case "compressionCodecName": def.setCompressionCodecName(val); break;
+                case "unmarshalType": def.setUnmarshalTypeName(val); break;
+                default: return identifiedTypeAttributeHandler().accept(def, key, val);
             }
-            return identifiedTypeAttributeHandler().accept(def, key, val);
+            return true;
         }, noElementHandler(), noValueHandler());
     }
     protected ProtobufDataFormat doParseProtobufDataFormat() throws IOException, XmlPullParserException {

--- a/core/camel-xml-io/src/generated/java/org/apache/camel/xml/out/ModelWriter.java
+++ b/core/camel-xml-io/src/generated/java/org/apache/camel/xml/out/ModelWriter.java
@@ -3399,6 +3399,7 @@ public class ModelWriter extends BaseWriter {
             throws IOException {
         startElement(name);
         doWriteIdentifiedTypeAttributes(def);
+        doWriteAttribute("compressionCodecName", def.getCompressionCodecName());
         doWriteAttribute("unmarshalType", def.getUnmarshalTypeName());
         endElement(name);
     }

--- a/core/camel-yaml-io/src/generated/java/org/apache/camel/yaml/out/ModelWriter.java
+++ b/core/camel-yaml-io/src/generated/java/org/apache/camel/yaml/out/ModelWriter.java
@@ -3399,6 +3399,7 @@ public class ModelWriter extends BaseWriter {
             throws IOException {
         startElement(name);
         doWriteIdentifiedTypeAttributes(def);
+        doWriteAttribute("compressionCodecName", def.getCompressionCodecName());
         doWriteAttribute("unmarshalType", def.getUnmarshalTypeName());
         endElement(name);
     }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/generated/java/org/apache/camel/dsl/yaml/deserializers/ModelDeserializers.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/generated/java/org/apache/camel/dsl/yaml/deserializers/ModelDeserializers.java
@@ -10086,6 +10086,7 @@ public final class ModelDeserializers extends YamlDeserializerSupport {
             types = org.apache.camel.model.dataformat.ParquetAvroDataFormat.class,
             order = org.apache.camel.dsl.yaml.common.YamlDeserializerResolver.ORDER_LOWEST - 1,
             properties = {
+                    @YamlProperty(name = "compression-codec-name", type = "string"),
                     @YamlProperty(name = "id", type = "string"),
                     @YamlProperty(name = "unmarshal-type", type = "string")
             }
@@ -10109,6 +10110,11 @@ public final class ModelDeserializers extends YamlDeserializerSupport {
         protected boolean setProperty(ParquetAvroDataFormat target, String propertyKey,
                 String propertyName, Node node) {
             switch(propertyKey) {
+                case "compression-codec-name": {
+                    String val = asText(node);
+                    target.setCompressionCodecName(val);
+                    break;
+                }
                 case "id": {
                     String val = asText(node);
                     target.setId(val);

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camel-yaml-dsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camel-yaml-dsl.json
@@ -5449,6 +5449,9 @@
         }, {
           "type" : "object",
           "properties" : {
+            "compression-codec-name" : {
+              "type" : "string"
+            },
             "id" : {
               "type" : "string"
             },

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
@@ -5359,6 +5359,9 @@
         }, {
           "type" : "object",
           "properties" : {
+            "compressionCodecName" : {
+              "type" : "string"
+            },
             "id" : {
               "type" : "string"
             },


### PR DESCRIPTION
# Description

This PR adds other compression codecs than gzip to the Parquet-Avro data format for marshaling.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

