### PR TITLE
[CAMEL-19575] Fixes camel-rabbitmq - RabbitMQConsumer keeps on consuming even when route shutdown is triggered.

### DIFF
--- a/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConsumer.java
+++ b/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/RabbitMQConsumer.java
@@ -155,13 +155,13 @@ public class RabbitMQConsumer extends DefaultConsumer implements Suspendable {
         if (startConsumerCallable != null) {
             startConsumerCallable.stop();
         }
-        for (RabbitConsumer consumer : this.consumers) {
+        this.consumers.parallelStream().forEach(consumer -> {
             try {
                 ServiceHelper.stopAndShutdownService(consumer);
             } catch (Exception e) {
                 LOG.warn("Error occurred while stopping consumer. This exception is ignored", e);
             }
-        }
+        });
         this.consumers.clear();
         if (conn != null) {
             LOG.debug("Closing connection: {} with timeout: {} ms.", conn, closeTimeout);


### PR DESCRIPTION
Closing all consumers in RabbitMqConsumer concurrently

# Description

## What
* Suspend RabbitConsumer in RabbitMQConsumer when doSuspend is called. 
* RabbitConsumer cancels the channel on suspend.

## Why
When we have multiple consumers and we stop them one by one. If first consumer is processing a message, then the channel of that consumer will close completely once the message is consumed. If that takes time to complete, then other channels won't stop and continue consuming.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

