### PR TITLE
CAMEL-19438: added missing knownHostsFile parameter

### DIFF
--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChangedReadLockIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChangedReadLockIT.java
@@ -41,7 +41,8 @@ public class SftpChangedReadLockIT extends SftpServerTestSupport {
 
     protected String getFtpUrl() {
         return "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}/changed" +
-               "?username=admin&password=admin&readLock=changed&readLockCheckInterval=1000&delete=true";
+               "?username=admin&password=admin&readLock=changed&readLockCheckInterval=1000&delete=true&knownHostsFile="
+               + service.getKnownHostsFile();
     }
 
     @Test

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChmodDirectoryIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChmodDirectoryIT.java
@@ -31,7 +31,8 @@ public class SftpChmodDirectoryIT extends SftpServerTestSupport {
     public void testSftpChmodDirectoryWriteable() {
         template.sendBodyAndHeader(
                 "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}/folder" +
-                                   "?username=admin&password=admin&chmod=777&chmodDirectory=770",
+                                   "?username=admin&password=admin&chmod=777&chmodDirectory=770&knownHostsFile="
+                                   + service.getKnownHostsFile(),
                 "Hello World", Exchange.FILE_NAME,
                 "hello.txt");
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChmodIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpChmodIT.java
@@ -31,7 +31,8 @@ public class SftpChmodIT extends SftpServerTestSupport {
     @Test
     public void testSftpChmod() {
         template.sendBodyAndHeader(
-                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&chmod=777",
+                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&chmod=777&knownHostsFile="
+                                   + service.getKnownHostsFile(),
                 "Hello World", Exchange.FILE_NAME,
                 "hello.txt");
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpConsumeTemplateIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpConsumeTemplateIT.java
@@ -32,7 +32,9 @@ public class SftpConsumeTemplateIT extends SftpServerTestSupport {
         template.sendBodyAndHeader("file://" + service.getFtpRootDir(), "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         String out = consumer.receiveBody(
-                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin", 5000,
+                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&knownHostsFile="
+                                          + service.getKnownHostsFile(),
+                5000,
                 String.class);
         assertNotNull(out);
         // Apache SSHD appends \u0000 at last byte in retrieved file

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpConsumerAutoCreateIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpConsumerAutoCreateIT.java
@@ -32,7 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnabledIf(value = "org.apache.camel.test.infra.ftp.services.embedded.SftpUtil#hasRequiredAlgorithms('src/test/resources/hostkey.pem')")
 public class SftpConsumerAutoCreateIT extends SftpServerTestSupport {
     protected String getFtpUrl() {
-        return "sftp://admin@localhost:{{ftp.server.port}}/{{ftp.root.dir}}/foo/bar/baz/xxx?password=admin";
+        return "sftp://admin@localhost:{{ftp.server.port}}/{{ftp.root.dir}}/foo/bar/baz/xxx?password=admin&knownHostsFile="
+               + service.getKnownHostsFile();
     }
 
     @AfterEach

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpConsumerDisconnectIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpConsumerDisconnectIT.java
@@ -88,7 +88,8 @@ public class SftpConsumerDisconnectIT extends SftpServerTestSupport {
             @Override
             public void configure() {
                 from("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                     + "?username=admin&password=admin&delete=true")
+                     + "?username=admin&password=admin&delete=true&knownHostsFile="
+                     + service.getKnownHostsFile())
                         .routeId("foo").noAutoStartup().process(new Processor() {
                             @Override
                             public void process(Exchange exchange) throws Exception {

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpConsumerProcessStrategyIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpConsumerProcessStrategyIT.java
@@ -44,7 +44,8 @@ public class SftpConsumerProcessStrategyIT extends SftpServerTestSupport {
         template.sendBodyAndHeader("file://" + service.getFtpRootDir(), "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         String out = consumer.receiveBody("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                                          + "?username=admin&password=admin&processStrategy=#myStrategy",
+                                          + "?username=admin&password=admin&processStrategy=#myStrategy&knownHostsFile="
+                                          + service.getKnownHostsFile(),
                 5000, String.class);
         assertNotNull(out);
         // Apache SSHD appends \u0000 at last byte in retrieved file

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpConsumerWithCharsetIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpConsumerWithCharsetIT.java
@@ -74,7 +74,8 @@ public class SftpConsumerWithCharsetIT extends SftpServerTestSupport {
             public void configure() {
                 from("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
                      + "?username=admin&password=admin&charset="
-                     + SAMPLE_FILE_CHARSET).routeId("foo").noAutoStartup()
+                     + SAMPLE_FILE_CHARSET + "&knownHostsFile="
+                     + service.getKnownHostsFile()).routeId("foo").noAutoStartup()
                         .to("mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpMoveWithOutMessageTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpMoveWithOutMessageTest.java
@@ -75,9 +75,13 @@ public class SftpMoveWithOutMessageTest extends SftpServerTestSupport {
             public void configure() {
                 from("seda:trigger")
                         .pollEnrich(
-                                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&delay=10000&disconnect=true&move=archive")
+                                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&delay="
+                                    + "10000&disconnect=true&move=archive&knownHostsFile="
+                                    + service.getKnownHostsFile())
                         .pollEnrich(
-                                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&delay=10000&disconnect=true&move=archive")
+                                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&delay="
+                                    + "10000&disconnect=true&move=archive&knownHostsFile="
+                                    + service.getKnownHostsFile())
                         .process(processor);
             }
         } };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpProduceTempFileIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpProduceTempFileIT.java
@@ -44,7 +44,8 @@ public class SftpProduceTempFileIT extends SftpServerTestSupport {
     @Test
     public void testSftpTempFileNoStartingPath() {
         template.sendBodyAndHeader(
-                "sftp://localhost:{{ftp.server.port}}/?username=admin&password=admin&tempFileName=temp-${file:name}",
+                "sftp://localhost:{{ftp.server.port}}/?username=admin&password=admin&tempFileName=temp-${file:name}"
+                                   + "&knownHostsFile=" + service.getKnownHostsFile(),
                 "Hello World", Exchange.FILE_NAME,
                 "hello.txt");
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpProducerFileWithPathIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpProducerFileWithPathIT.java
@@ -30,7 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SftpProducerFileWithPathIT extends SftpServerTestSupport {
 
     private String getFtpUrl() {
-        return "sftp://admin@localhost:{{ftp.server.port}}/{{ftp.root.dir}}?password=admin";
+        return "sftp://admin@localhost:{{ftp.server.port}}/{{ftp.root.dir}}?password=admin&knownHostsFile="
+               + service.getKnownHostsFile();
     }
 
     @Test

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpProducerFileWithPathNoStepwiseIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpProducerFileWithPathNoStepwiseIT.java
@@ -30,7 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SftpProducerFileWithPathNoStepwiseIT extends SftpServerTestSupport {
 
     private String getFtpUrl() {
-        return "sftp://admin@localhost:{{ftp.server.port}}/{{ftp.root.dir}}?password=admin&stepwise=false";
+        return "sftp://admin@localhost:{{ftp.server.port}}/{{ftp.root.dir}}?password=admin&stepwise=false&knownHostsFile="
+               + service.getKnownHostsFile();
     }
 
     @Test

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpProducerMoveExistingIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpProducerMoveExistingIT.java
@@ -37,7 +37,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SftpProducerMoveExistingIT extends SftpServerTestSupport {
 
     private String getFtpUrl() {
-        return "sftp://admin@localhost:{{ftp.server.port}}/{{ftp.root.dir}}/move?password=admin&fileExist=Move";
+        return "sftp://admin@localhost:{{ftp.server.port}}/{{ftp.root.dir}}/move?password=admin&fileExist=Move&knownHostsFile="
+               + service.getKnownHostsFile();
     }
 
     @BeforeEach

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpProducerWithCharsetIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpProducerWithCharsetIT.java
@@ -53,6 +53,6 @@ public class SftpProducerWithCharsetIT extends SftpServerTestSupport {
 
     private String getSftpUri() {
         return "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&charset="
-               + SAMPLE_FILE_CHARSET;
+               + SAMPLE_FILE_CHARSET + "&knownHostsFile=" + service.getKnownHostsFile();
     }
 }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSetCipherIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSetCipherIT.java
@@ -34,7 +34,7 @@ public class SftpSetCipherIT extends SftpServerTestSupport {
         String cipher = "aes256-ctr";
         String uri
                 = "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&ciphers="
-                  + cipher;
+                  + cipher + "&knownHostsFile=" + service.getKnownHostsFile();
         template.sendBodyAndHeader(uri, "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         // test setting the cipher doesn't interfere with message payload

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSetOperationsIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSetOperationsIT.java
@@ -33,7 +33,8 @@ public class SftpSetOperationsIT extends SftpServerTestSupport {
     public void testSftpSetOperations() {
         String preferredAuthentications = "password,publickey";
         String uri = "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                     + "?username=admin&password=admin&ciphers=aes256-ctr" + "&preferredAuthentications=password,publickey";
+                     + "?username=admin&password=admin&ciphers=aes256-ctr&knownHostsFile="
+                     + service.getKnownHostsFile() + "&preferredAuthentications=password,publickey";
         template.sendBodyAndHeader(uri, "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         // test setting the cipher doesn't interfere with message payload

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeIT.java
@@ -48,7 +48,8 @@ public class SftpSimpleConsumeIT extends SftpServerTestSupport {
             @Override
             public void configure() {
                 from("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                     + "?username=admin&password=admin&delay=10000&disconnect=true").routeId("foo").noAutoStartup()
+                     + "?username=admin&password=admin&delay=10000&disconnect=true&knownHostsFile="
+                     + service.getKnownHostsFile()).routeId("foo").noAutoStartup()
                         .to("mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeNoStartingDirIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeNoStartingDirIT.java
@@ -52,7 +52,8 @@ public class SftpSimpleConsumeNoStartingDirIT extends SftpServerTestSupport {
             @Override
             public void configure() {
                 from("sftp://localhost:{{ftp.server.port}}/"
-                     + "?fileName=a.txt&username=admin&password=admin&delay=10000&disconnect=true").routeId("foo")
+                     + "?fileName=a.txt&username=admin&password=admin&delay=10000&disconnect=true&knownHostsFile="
+                     + service.getKnownHostsFile()).routeId("foo")
                         .noAutoStartup().to("log:result", "mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeNotStepwiseIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeNotStepwiseIT.java
@@ -28,7 +28,8 @@ public class SftpSimpleConsumeNotStepwiseIT extends SftpSimpleConsumeIT {
             @Override
             public void configure() {
                 from("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                     + "?username=admin&password=admin&delay=10000&disconnect=true&stepwise=false").routeId("foo")
+                     + "?username=admin&password=admin&delay=10000&disconnect=true&stepwise=false&knownHostsFile="
+                     + service.getKnownHostsFile()).routeId("foo")
                         .noAutoStartup().to("mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeRecursiveIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeRecursiveIT.java
@@ -47,7 +47,8 @@ public class SftpSimpleConsumeRecursiveIT extends SftpServerTestSupport {
             @Override
             public void configure() {
                 from("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                     + "?username=admin&password=admin&delay=10000&disconnect=true&recursive=true").routeId("foo")
+                     + "?username=admin&password=admin&delay=10000&disconnect=true&recursive=true&knownHostsFile="
+                     + service.getKnownHostsFile()).routeId("foo")
                         .noAutoStartup().to("log:result", "mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeRecursiveNotStepwiseIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeRecursiveNotStepwiseIT.java
@@ -26,7 +26,8 @@ public class SftpSimpleConsumeRecursiveNotStepwiseIT extends SftpSimpleConsumeRe
             @Override
             public void configure() {
                 from("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                     + "?username=admin&password=admin&delay=10000&disconnect=true&recursive=true&stepwise=false")
+                     + "?username=admin&password=admin&delay=10000&disconnect=true&recursive=true&stepwise=false&knownHostsFile="
+                     + service.getKnownHostsFile())
                         .routeId("foo")
                         .noAutoStartup().to("log:result", "mock:result");
             }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeStreamingIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeStreamingIT.java
@@ -55,7 +55,8 @@ public class SftpSimpleConsumeStreamingIT extends SftpServerTestSupport {
             @Override
             public void configure() {
                 from("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                     + "?username=admin&password=admin&delay=10000&disconnect=true&streamDownload=true").routeId("foo")
+                     + "?username=admin&password=admin&delay=10000&disconnect=true&streamDownload=true&knownHostsFile="
+                     + service.getKnownHostsFile()).routeId("foo")
                         .noAutoStartup().to("mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeStreamingPartialReadIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeStreamingPartialReadIT.java
@@ -69,19 +69,20 @@ public class SftpSimpleConsumeStreamingPartialReadIT extends SftpServerTestSuppo
             public void configure() {
                 from("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
                      + "?username=admin&password=admin&delay=10000&disconnect=true&streamDownload=true"
-                     + "&move=done&moveFailed=failed").routeId("foo").noAutoStartup().process(new Processor() {
+                     + "&move=done&moveFailed=failed&knownHostsFile=" + service.getKnownHostsFile())
+                        .routeId("foo").noAutoStartup().process(new Processor() {
 
-                         @Override
-                         public void process(Exchange exchange) throws Exception {
-                             exchange.getIn().getBody(InputStream.class).read();
-                         }
-                     }).to("mock:result").process(new Processor() {
+                            @Override
+                            public void process(Exchange exchange) throws Exception {
+                                exchange.getIn().getBody(InputStream.class).read();
+                            }
+                        }).to("mock:result").process(new Processor() {
 
-                         @Override
-                         public void process(Exchange exchange) throws Exception {
-                             throw new Exception("INTENTIONAL ERROR");
-                         }
-                     });
+                            @Override
+                            public void process(Exchange exchange) throws Exception {
+                                throw new Exception("INTENTIONAL ERROR");
+                            }
+                        });
             }
         };
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeStreamingWithMultipleFilesIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeStreamingWithMultipleFilesIT.java
@@ -58,7 +58,8 @@ public class SftpSimpleConsumeStreamingWithMultipleFilesIT extends SftpServerTes
             @Override
             public void configure() {
                 from("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                     + "?username=admin&password=admin&delay=10000&disconnect=true&streamDownload=true").routeId("foo")
+                     + "?username=admin&password=admin&delay=10000&disconnect=true&streamDownload=true&knownHostsFile="
+                     + service.getKnownHostsFile()).routeId("foo")
                         .noAutoStartup().to("mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeThroughProxyIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleConsumeThroughProxyIT.java
@@ -82,7 +82,8 @@ public class SftpSimpleConsumeThroughProxyIT extends SftpServerTestSupport {
             @Override
             public void configure() {
                 from("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                     + "?username=admin&password=admin&delay=10000&disconnect=true&proxy=#proxy").routeId("foo").noAutoStartup()
+                     + "?username=admin&password=admin&delay=10000&disconnect=true&proxy=#proxy&knownHostsFile="
+                     + service.getKnownHostsFile()).routeId("foo").noAutoStartup()
                         .to("mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleIPV6ConsumeIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleIPV6ConsumeIT.java
@@ -50,7 +50,8 @@ public class SftpSimpleIPV6ConsumeIT extends SftpServerTestSupport {
             @Override
             public void configure() {
                 from("sftp://[::1]:{{ftp.server.port}}/{{ftp.root.dir}}"
-                     + "?username=admin&password=admin&delay=10000&disconnect=true").routeId("foo").noAutoStartup()
+                     + "?username=admin&password=admin&delay=10000&disconnect=true" +
+                     "&knownHostsFile=" + service.getKnownHostsFile()).routeId("foo").noAutoStartup()
                         .to("mock:result");
             }
         };

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleProduceDisconnectIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleProduceDisconnectIT.java
@@ -31,7 +31,8 @@ public class SftpSimpleProduceDisconnectIT extends SftpServerTestSupport {
     @Test
     public void testSftpSimpleProduce() throws Exception {
         template.sendBodyAndHeader(
-                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin",
+                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&knownHostsFile="
+                                   + service.getKnownHostsFile(),
                 "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         File file = ftpFile("hello.txt").toFile();
@@ -43,7 +44,8 @@ public class SftpSimpleProduceDisconnectIT extends SftpServerTestSupport {
         service.setUpServer();
 
         template.sendBodyAndHeader(
-                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin",
+                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&knownHostsFile="
+                                   + service.getKnownHostsFile(),
                 "Hello World", Exchange.FILE_NAME, "hello1.txt");
 
         file = ftpFile("hello1.txt").toFile();

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleProduceIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleProduceIT.java
@@ -31,7 +31,8 @@ public class SftpSimpleProduceIT extends SftpServerTestSupport {
     @Test
     public void testSftpSimpleProduce() {
         template.sendBodyAndHeader(
-                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin",
+                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&knownHostsFile="
+                                   + service.getKnownHostsFile(),
                 "Hello World", Exchange.FILE_NAME, "hello.txt");
 
         File file = ftpFile("hello.txt").toFile();
@@ -42,9 +43,9 @@ public class SftpSimpleProduceIT extends SftpServerTestSupport {
     @Test
     public void testSftpSimpleSubPathProduce() {
         template.sendBodyAndHeader(
-                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}/mysub?username=admin&password=admin",
-                "Bye World",
-                Exchange.FILE_NAME, "bye.txt");
+                "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}/mysub?username=admin&password=admin&knownHostsFile="
+                                   + service.getKnownHostsFile(),
+                "Bye World", Exchange.FILE_NAME, "bye.txt");
 
         File file = ftpFile("mysub/bye.txt").toFile();
         assertTrue(file.exists(), "File should exist: " + file);
@@ -55,7 +56,8 @@ public class SftpSimpleProduceIT extends SftpServerTestSupport {
     public void testSftpSimpleTwoSubPathProduce() {
         template.sendBodyAndHeader(
                 "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                                   + "/mysub/myother?username=admin&password=admin",
+                                   + "/mysub/myother?username=admin&password=admin&knownHostsFile="
+                                   + service.getKnownHostsFile(),
                 "Farewell World", Exchange.FILE_NAME,
                 "farewell.txt");
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleProduceThroughProxyIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpSimpleProduceThroughProxyIT.java
@@ -80,7 +80,8 @@ public class SftpSimpleProduceThroughProxyIT extends SftpServerTestSupport {
     public void testSftpSimpleSubPathProduceThroughProxy() {
         template.sendBodyAndHeader(
                 "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                                   + "/mysub?username=admin&password=admin&proxy=#proxy",
+                                   + "/mysub?username=admin&password=admin&proxy=#proxy&knownHostsFile="
+                                   + service.getKnownHostsFile(),
                 "Bye World", Exchange.FILE_NAME,
                 "bye.txt");
 
@@ -92,7 +93,8 @@ public class SftpSimpleProduceThroughProxyIT extends SftpServerTestSupport {
     @Test
     public void testSftpSimpleTwoSubPathProduceThroughProxy() {
         template.sendBodyAndHeader("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                                   + "/mysub/myother?username=admin&password=admin&proxy=#proxy",
+                                   + "/mysub/myother?username=admin&password=admin&proxy=#proxy&knownHostsFile="
+                                   + service.getKnownHostsFile(),
                 "Farewell World",
                 Exchange.FILE_NAME, "farewell.txt");
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpUseListFalseIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpUseListFalseIT.java
@@ -48,7 +48,8 @@ public class SftpUseListFalseIT extends SftpServerTestSupport {
             @Override
             public void configure() {
                 from("sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}"
-                     + "?username=admin&password=admin&delay=10000&disconnect=true&stepwise=false&useList=false&fileName=report.txt&delete=true")
+                     + "?username=admin&password=admin&delay=10000&disconnect=true&stepwise=false&useList="
+                     + "false&fileName=report.txt&delete=true&knownHostsFile=" + service.getKnownHostsFile())
                         .routeId("foo").noAutoStartup()
                         .to("mock:result");
             }


### PR DESCRIPTION
# Description

<!--
some tests were missing the URI setting "knownHostsFile" which was resulting in pollution of known host files.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

