### PR TITLE
Adding additional logging to scope creation and closing

### DIFF
--- a/components/camel-observation/src/test/java/org/apache/camel/observation/CamelMicrometerObservationTestSupport.java
+++ b/components/camel-observation/src/test/java/org/apache/camel/observation/CamelMicrometerObservationTestSupport.java
@@ -57,7 +57,9 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.apache.camel.CamelContext;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.tracing.SpanDecorator;
+import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,6 +87,11 @@ class CamelMicrometerObservationTestSupport extends CamelTestSupport {
 
     CamelMicrometerObservationTestSupport(SpanTestData[] expected) {
         this.expected = expected;
+    }
+
+    @AfterEach
+    void noLeakingContext() {
+        Assertions.assertThat(Context.current()).as("There must be no leaking span after test").isSameAs(Context.root());
     }
 
     @Override

--- a/components/camel-observation/src/test/resources/log4j2.properties
+++ b/components/camel-observation/src/test/resources/log4j2.properties
@@ -25,5 +25,7 @@ appender.out.layout.type=PatternLayout
 appender.out.layout.pattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
 logger.opentelemetry.name=org.apache.camel.observation
 logger.opentelemetry.level=INFO
+logger.tracing.name=org.apache.camel.tracing
+logger.tracing.level=TRACE
 rootLogger.level=INFO
 rootLogger.appenderRef.file.ref=file

--- a/components/camel-observation/src/test/resources/log4j2.properties
+++ b/components/camel-observation/src/test/resources/log4j2.properties
@@ -26,6 +26,6 @@ appender.out.layout.pattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
 logger.opentelemetry.name=org.apache.camel.observation
 logger.opentelemetry.level=INFO
 logger.tracing.name=org.apache.camel.tracing
-logger.tracing.level=TRACE
+logger.tracing.level=INFO
 rootLogger.level=INFO
 rootLogger.appenderRef.file.ref=file

--- a/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/CamelOpenTelemetryTestSupport.java
+++ b/components/camel-opentelemetry/src/test/java/org/apache/camel/opentelemetry/CamelOpenTelemetryTestSupport.java
@@ -41,6 +41,8 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.tracing.SpanDecorator;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +66,11 @@ class CamelOpenTelemetryTestSupport extends CamelTestSupport {
 
     CamelOpenTelemetryTestSupport(SpanTestData[] expected) {
         this.expected = expected;
+    }
+
+    @AfterEach
+    void noLeakingContext() {
+        Assertions.assertSame(Context.root(), Context.current(), "There must be no leaking span after test");
     }
 
     @Override

--- a/components/camel-opentelemetry/src/test/resources/log4j2.properties
+++ b/components/camel-opentelemetry/src/test/resources/log4j2.properties
@@ -26,6 +26,6 @@ appender.out.layout.pattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
 logger.opentelemetry.name=org.apache.camel.opentelemetry
 logger.opentelemetry.level=INFO
 logger.tracing.name=org.apache.camel.tracing
-logger.tracing.level=TRACE
+logger.tracing.level=INFO
 rootLogger.level=INFO
 rootLogger.appenderRef.file.ref=file

--- a/components/camel-opentelemetry/src/test/resources/log4j2.properties
+++ b/components/camel-opentelemetry/src/test/resources/log4j2.properties
@@ -25,5 +25,7 @@ appender.out.layout.type=PatternLayout
 appender.out.layout.pattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
 logger.opentelemetry.name=org.apache.camel.opentelemetry
 logger.opentelemetry.level=INFO
+logger.tracing.name=org.apache.camel.tracing
+logger.tracing.level=TRACE
 rootLogger.level=INFO
 rootLogger.appenderRef.file.ref=file

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/ActiveSpanManager.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/ActiveSpanManager.java
@@ -119,7 +119,10 @@ public final class ActiveSpanManager {
         public Holder(Holder parent, SpanAdapter span) {
             this.parent = parent;
             this.span = span;
-            this.scope = new ScopeWrapper(span.makeCurrent(), Thread.currentThread().getId());
+            this.scope = span.makeCurrent();
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Tracing: started scope={}", this.scope);
+            }
         }
 
         public Holder getParent() {
@@ -131,52 +134,13 @@ public final class ActiveSpanManager {
         }
 
         private void closeScope() {
-            if (scope != null) {
-                try {
-                    scope.close();
-                } catch (Exception e) {
-                    LOG.debug("Failed to close span scope", e);
-                }
-                this.scope = null;
-            }
-        }
-    }
-
-    /**
-     * Makes closing scopes idempotent and prevents restoring scope on the wrong thread: Should be removed if
-     * https://github.com/open-telemetry/opentelemetry-java/issues/5055 is fixed.
-     */
-    private static class ScopeWrapper implements AutoCloseable {
-        private final long startThreadId;
-        private final AutoCloseable inner;
-        private boolean closed;
-
-        private Throwable exceptionForStacktrace;
-
-        public ScopeWrapper(AutoCloseable inner, long startThreadId) {
-            this.startThreadId = startThreadId;
-            this.inner = inner;
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Created scope {}", inner);
-                this.exceptionForStacktrace = new RuntimeException("To see where this scope got created");
-            }
-        }
-
-        @Override
-        public void close() throws Exception {
-            if (!closed && Thread.currentThread().getId() == startThreadId) {
-                closed = true;
+            try {
                 if (LOG.isTraceEnabled()) {
-                    LOG.trace("Closing scope {}", inner);
+                    LOG.trace("Tracing: closing scope={}", this.scope);
                 }
-                inner.close();
-            } else {
-                LOG.debug("not closing scope, closed - {}, started on thread - '{}', current thread - '{}'",
-                        closed, startThreadId, Thread.currentThread().getId());
-                if (LOG.isTraceEnabled() && this.exceptionForStacktrace != null) {
-                    LOG.trace("Stacktrace of where we are", new RuntimeException());
-                    LOG.trace("Stacktrace of where the scope was created", this.exceptionForStacktrace);
-                }
+                scope.close();
+            } catch (Exception e) {
+                LOG.debug("Failed to close span scope", e);
             }
         }
     }

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/Tracer.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/Tracer.java
@@ -273,7 +273,7 @@ public abstract class Tracer extends ServiceSupport implements RoutePolicyFactor
                     SpanAdapter span = ActiveSpanManager.getSpan(ese.getExchange());
                     if (span != null) {
                         if (LOG.isTraceEnabled()) {
-                            LOG.trace("Tracing: start client span={}", span);
+                            LOG.trace("Tracing: stop client span={}", span);
                         }
                         sd.post(span, ese.getExchange(), ese.getEndpoint());
                         ActiveSpanManager.deactivate(ese.getExchange());


### PR DESCRIPTION
the problem we have is that one of the spans in one of the tests (most probably MulticastRouteTest) is not being closed and the span is left in the test thread. Due to this other tests are failing.

This PR removes the workaround that conditionally closes scopes. With these changes we're always closing scopes even multiple times.

related to pr gh-10539

closes https://issues.apache.org/jira/browse/CAMEL-19569