### PR TITLE
(chores) cli: remove quick test in main

### DIFF
--- a/.github/workflows/component-pr.yaml
+++ b/.github/workflows/component-pr.yaml
@@ -26,7 +26,7 @@ on:
       - 'core/**'
       - 'components/**'
   workflow_run:
-    workflows: [ "PR Build (Camel 3.x)", "PR Build (Camel 4)" ]
+    workflows: [ "PR Build (Camel 3.x)" ]
     types:
       - completed
 

--- a/.github/workflows/pr-build-camel-3.yml
+++ b/.github/workflows/pr-build-camel-3.yml
@@ -24,6 +24,7 @@ on:
       - camel-3.18.x
       - camel-3.x
     paths-ignore:
+      - .github/**
       - README.md
       - SECURITY.md
       - Jenkinsfile

--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -22,6 +22,7 @@ on:
     branches:
       - main
     paths-ignore:
+      - .github/**
       - README.md
       - SECURITY.md
       - Jenkinsfile


### PR DESCRIPTION
## Motivation

The message still appears for PRs targeted to the main branch whereas the quick test is no more used

## Modifications:

* Enable the workflow only for Camel 3
* Ignores github actions changes