### PR TITLE
Use source:jar-no-fork to avoid failing duplicate artifact deploys

### DIFF
--- a/components/camel-as2/camel-as2-api/pom.xml
+++ b/components/camel-as2/camel-as2-api/pom.xml
@@ -115,7 +115,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/components/camel-box/camel-box-api/pom.xml
+++ b/components/camel-box/camel-box-api/pom.xml
@@ -62,7 +62,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/components/camel-fhir/camel-fhir-api/pom.xml
+++ b/components/camel-fhir/camel-fhir-api/pom.xml
@@ -69,7 +69,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/components/camel-olingo2/camel-olingo2-api/pom.xml
+++ b/components/camel-olingo2/camel-olingo2-api/pom.xml
@@ -78,7 +78,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/components/camel-olingo4/camel-olingo4-api/pom.xml
+++ b/components/camel-olingo4/camel-olingo4-api/pom.xml
@@ -93,7 +93,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/core/camel-api/pom.xml
+++ b/core/camel-api/pom.xml
@@ -68,7 +68,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/core/camel-core-model/pom.xml
+++ b/core/camel-core-model/pom.xml
@@ -79,7 +79,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/core/camel-core-xml/pom.xml
+++ b/core/camel-core-xml/pom.xml
@@ -84,7 +84,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/core/camel-util/pom.xml
+++ b/core/camel-util/pom.xml
@@ -82,7 +82,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Addresses the snapshot deployment issues mentioned in https://github.com/apache/camel/pull/10661