### PR TITLE
Upgrade batik version to 1.16 (#9718)

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -565,7 +565,7 @@
     <xml-apis-ext-version>1.3.04</xml-apis-ext-version>
     <xml-apis-version>1.4.01</xml-apis-version>
     <xml-resolver-version>1.2</xml-resolver-version>
-    <xmlgraphics-batik-version>1.15</xmlgraphics-batik-version>
+    <xmlgraphics-batik-version>1.16</xmlgraphics-batik-version>
     <xmlsec-version>2.2.3</xmlsec-version>
     <xmlunit-version>2.9.1</xmlunit-version>
     <xpp3-version>1.1.4c</xpp3-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -554,7 +554,7 @@
         <xml-apis-version>1.4.01</xml-apis-version>
         <xml-apis-ext-version>1.3.04</xml-apis-ext-version>
         <xml-resolver-version>1.2</xml-resolver-version>
-        <xmlgraphics-batik-version>1.15</xmlgraphics-batik-version>
+        <xmlgraphics-batik-version>1.16</xmlgraphics-batik-version>
         <xmlsec-version>2.2.3</xmlsec-version>
         <xmlunit-version>2.9.1</xmlunit-version>
         <xpp3-version>1.1.4c</xpp3-version>


### PR DESCRIPTION
# Description

Backporting upgrade from main to fix:

org.apache.xmlgraphics:batik-bridge (batik-bridge-1.15.jar)  │ CVE-2022-41704 │          │ 1.15              │ 1.16                           │ Apache XML Graphics Batik vulnerable to code execution via  │
│                                                              │                │          │                   │                                │ SVG                                                         │
│                                                              │                │          │                   │                                │ https://avd.aquasec.com/nvd/cve-2022-41704                  │
├──────────────────────────────────────────────────────────────┤                │          │                   │                                │                                                             │
│ org.apache.xmlgraphics:batik-dom (batik-dom-1.15.jar)        │                │          │                   │                                │                                                             │
│                                                              │                │          │                   │                                │                                                             │
│                                                              │                │          │                   │                                │                                                             │
│                                                              ├────────────────┤          │                   │                                ├─────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2022-42890 │          │                   │                                │ Untrusted code execution in Apache XML Graphics Batik       │
│                                                              │                │          │                   │                                │ https://avd.aquasec.com/nvd/cve-2022-42890                  │
├──────────────────────────────────────────────────────────────┤                │          │                   │                                │                                                             │
│ org.apache.xmlgraphics:batik-script (batik-script-1.15.jar)  │                │          │                   │                                │                                                             │
│                                                              │                │          │                   │                                │                                                             │

I also intend to open PRs against 3.21.x + 3.20.x