### PR TITLE
Updating californium to 2.7.4

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -79,7 +79,7 @@
     <c3p0-version>0.9.5.5</c3p0-version>
     <caffeine-version>3.1.2</caffeine-version>
     <californium-scandium-version>2.7.4</californium-scandium-version>
-    <californium-version>2.7.2</californium-version>
+    <californium-version>2.7.4</californium-version>
     <camel.failsafe.forkTimeout>600</camel.failsafe.forkTimeout>
     <camel.osgi.activator></camel.osgi.activator>
     <camel.osgi.dynamic></camel.osgi.dynamic>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -95,7 +95,7 @@
         <build-helper-maven-plugin-version>3.2.0</build-helper-maven-plugin-version>
         <c3p0-version>0.9.5.5</c3p0-version>
         <caffeine-version>3.1.2</caffeine-version>
-        <californium-version>2.7.2</californium-version>
+        <californium-version>2.7.4</californium-version>
         <californium-scandium-version>2.7.4</californium-scandium-version>
         <cassandra-driver-version>4.15.0</cassandra-driver-version>
         <cassandra-version>4.0.6</cassandra-version>


### PR DESCRIPTION
# Description

Main is already updated to Californium 2.8.0. This updates to Californium 2.7.4 to fix https://nvd.nist.gov/vuln/detail/CVE-2022-39368

I will open separate PRs for 3.21.x/3.20.x