### PR TITLE
CAMEL-19615 chmodDirectory option try for each junk to change the dir…

### DIFF
--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
@@ -577,8 +577,10 @@ public class SftpOperations implements RemoteFileOperations<SftpRemoteFile> {
                     success = buildDirectoryChunks(directory);
                 }
 
-                // after creating directory, we may set chmod on the file
-                chmodOfDirectory(directory);
+                // only after successfully creating directory, we may set chmod on the file
+                if (success) {
+                    chmodOfDirectory(directory);
+                }
             }
         } catch (SftpException e) {
             throw new GenericFileOperationFailedException("Cannot build directory: " + directory, e);
@@ -619,8 +621,10 @@ public class SftpOperations implements RemoteFileOperations<SftpRemoteFile> {
                     // ignore keep trying to create the rest of the path
                 }
 
-                // after creating directory, we may set chmod on the file
-                chmodOfDirectory(directory);
+                // only after successfully creating directory, we may set chmod on the file
+                if (success) {
+                    chmodOfDirectory(directory);
+                }
             }
         }
 


### PR DESCRIPTION

# Description

The current implementation steps down the directory and try to create each junk. If the chmodDirectory option is set then it will try for each (already existing junk) to change the directory permission and fails.
 
Expected Behaviour:
It should only try to change the permission if the directory does not yet exists

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

