### PR TITLE
Bugfix for californium update, as Netty 2.7.4 dependency isn't in mav…

### DIFF
--- a/components/camel-coap/pom.xml
+++ b/components/camel-coap/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.eclipse.californium</groupId>
             <artifactId>element-connector-tcp-netty</artifactId>
-            <version>${californium-version}</version>
+            <version>${californium-netty-version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>element-connector</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -96,6 +96,8 @@
         <c3p0-version>0.9.5.5</c3p0-version>
         <caffeine-version>3.1.2</caffeine-version>
         <californium-version>2.7.4</californium-version>
+        <!-- Remove once 2.7.5 comes out -->
+        <californium-netty-version>2.7.2</californium-netty-version>
         <californium-scandium-version>2.7.4</californium-scandium-version>
         <cassandra-driver-version>4.15.0</cassandra-driver-version>
         <cassandra-version>4.0.6</cassandra-version>


### PR DESCRIPTION
…en central

# Description

It seems the Netty californium dependency never made it to maven central for 2.7.4. Until 2.7.5 comes out, this just downgrades the Netty dependency.