### PR TITLE
Updating Californium to 2.7.4

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -79,7 +79,7 @@
     <c3p0-version>0.9.5.5</c3p0-version>
     <caffeine-version>3.1.2</caffeine-version>
     <californium-scandium-version>2.7.4</californium-scandium-version>
-    <californium-version>2.7.2</californium-version>
+    <californium-version>2.7.4</californium-version>
     <camel.failsafe.forkTimeout>600</camel.failsafe.forkTimeout>
     <camel.osgi.activator></camel.osgi.activator>
     <camel.osgi.dynamic></camel.osgi.dynamic>

--- a/components/camel-coap/pom.xml
+++ b/components/camel-coap/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.eclipse.californium</groupId>
             <artifactId>element-connector-tcp-netty</artifactId>
-            <version>${californium-version}</version>
+            <version>${californium-netty-version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>element-connector</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -95,6 +95,8 @@
         <c3p0-version>0.9.5.5</c3p0-version>
         <caffeine-version>3.1.2</caffeine-version>
         <californium-version>2.7.4</californium-version>
+        <!-- Remove once 2.7.5 comes out -->
+        <californium-netty-version>2.7.2</californium-netty-version>
         <californium-scandium-version>2.7.4</californium-scandium-version>
         <cassandra-driver-version>4.15.0</cassandra-driver-version>
         <cassandra-version>4.0.6</cassandra-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -94,7 +94,7 @@
         <build-helper-maven-plugin-version>3.3.0</build-helper-maven-plugin-version>
         <c3p0-version>0.9.5.5</c3p0-version>
         <caffeine-version>3.1.2</caffeine-version>
-        <californium-version>2.7.2</californium-version>
+        <californium-version>2.7.4</californium-version>
         <californium-scandium-version>2.7.4</californium-scandium-version>
         <cassandra-driver-version>4.15.0</cassandra-driver-version>
         <cassandra-version>4.0.6</cassandra-version>


### PR DESCRIPTION
# Description

Updating Californium to 2.7.4 to pick up CVE fixes.