### PR TITLE
Updating Hazelcast to 5.2.4

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -248,7 +248,7 @@
     <hapi-version>2.3</hapi-version>
     <hawtbuf-version>1.11</hawtbuf-version>
     <hawtdispatch-version>1.22</hawtdispatch-version>
-    <hazelcast-version>5.2.1</hazelcast-version>
+    <hazelcast-version>5.2.4</hazelcast-version>
     <hbase-version>2.5.2</hbase-version>
     <hdrhistrogram-version>2.1.11</hdrhistrogram-version>
     <hibernate-validator-version>6.2.5.Final</hibernate-validator-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -230,7 +230,7 @@
         <hapi-fhir-version>4.2.0</hapi-fhir-version>
         <hawtbuf-version>1.11</hawtbuf-version>
         <hawtdispatch-version>1.22</hawtdispatch-version>
-        <hazelcast-version>5.2.1</hazelcast-version>
+        <hazelcast-version>5.2.4</hazelcast-version>
         <hbase-version>2.5.2</hbase-version>
         <hdrhistrogram-version>2.1.11</hdrhistrogram-version>
         <hibernate-validator-version>6.2.5.Final</hibernate-validator-version>


### PR DESCRIPTION
# Description

Fixing two CVE issues:

 com.hazelcast:hazelcast (hazelcast-5.2.1.jar) │ CVE-2023-33264 │ MEDIUM   │ 5.2.1             │ 5.0.4, 5.1.6, 5.2.3 │ Improper password mask

org.json:json (hazelcast-5.2.1.jar)           │ CVE-2022-45688 │ HIGH     │ 20220320          │ 20230227            │ json stack overflow vulnerability

Already fixed on main.