### PR TITLE
Updating drill to 1.21.1

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -37,7 +37,7 @@
     <activemq-artemis-version>2.28.0</activemq-artemis-version>
     <activemq-version>5.17.4</activemq-version>
     <apache-any23-version>2.7</apache-any23-version>
-    <apache-drill-version>1.19.0</apache-drill-version>
+    <apache-drill-version>1.21.1</apache-drill-version>
     <apache-gora-version>0.9</apache-gora-version>
     <apacheds-version>2.0.0.AM26</apacheds-version>
     <apicurio-version>1.1.26</apicurio-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -55,7 +55,7 @@
         <activemq-artemis-version>2.28.0</activemq-artemis-version>
         <apacheds-version>2.0.0.AM26</apacheds-version>
         <apache-any23-version>2.7</apache-any23-version>
-        <apache-drill-version>1.19.0</apache-drill-version>
+        <apache-drill-version>1.20.2</apache-drill-version>
         <apache-gora-version>0.9</apache-gora-version>
         <apicurio-version>1.1.26</apicurio-version>
         <arangodb-java-version>6.20.0</arangodb-java-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -55,7 +55,7 @@
         <activemq-artemis-version>2.28.0</activemq-artemis-version>
         <apacheds-version>2.0.0.AM26</apacheds-version>
         <apache-any23-version>2.7</apache-any23-version>
-        <apache-drill-version>1.21.0</apache-drill-version>
+        <apache-drill-version>1.21.1</apache-drill-version>
         <apache-gora-version>0.9</apache-gora-version>
         <apicurio-version>1.1.26</apicurio-version>
         <arangodb-java-version>6.20.0</arangodb-java-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -55,7 +55,7 @@
         <activemq-artemis-version>2.28.0</activemq-artemis-version>
         <apacheds-version>2.0.0.AM26</apacheds-version>
         <apache-any23-version>2.7</apache-any23-version>
-        <apache-drill-version>1.20.2</apache-drill-version>
+        <apache-drill-version>1.21.0</apache-drill-version>
         <apache-gora-version>0.9</apache-gora-version>
         <apicurio-version>1.1.26</apicurio-version>
         <arangodb-java-version>6.20.0</arangodb-java-version>


### PR DESCRIPTION
# Description

drill-jdbc-all shades many dependencies. 1.19.0 on 3.x downwards contains CVEs in jackson-databind (e.g. https://nvd.nist.gov/vuln/detail/CVE-2020-365180, guava, Netty, etc.