### PR TITLE
Upgrade Johnzon JsonB to version 1.2.21

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -336,7 +336,7 @@
     <jira-rest-client-api-version>5.2.4</jira-rest-client-api-version>
     <jnats-version>2.16.5</jnats-version>
     <jodatime2-version>2.11.1</jodatime2-version>
-    <johnzon-version>1.2.20</johnzon-version>
+    <johnzon-version>1.2.21</johnzon-version>
     <jolokia-version>1.7.2</jolokia-version>
     <jolt-version>0.1.7</jolt-version>
     <jool-version>0.9.14</jool-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -328,7 +328,7 @@
         <jool-version>0.9.14</jool-version>
         <jooq-version>3.16.11</jooq-version>
         <joor-version>0.9.14</joor-version>
-        <johnzon-version>1.2.20</johnzon-version>
+        <johnzon-version>1.2.21</johnzon-version>
         <jose4j-version>0.6.4</jose4j-version>
         <jslt-version>0.1.11</jslt-version>
         <jsmpp-version>2.3.11</jsmpp-version>


### PR DESCRIPTION
# Description

Backporting a fix for https://nvd.nist.gov/vuln/detail/CVE-2023-33008