### PR TITLE
(chores) camel-xchange: prevent tests from running on ASF CI

### DIFF
--- a/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/account/AccountProducerTest.java
+++ b/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/account/AccountProducerTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.xchange.XChangeComponent;
 import org.apache.camel.component.xchange.XChangeTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.FundingRecord;
@@ -30,6 +31,8 @@ import org.knowm.xchange.dto.account.Wallet;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+        disabledReason = "These tests do no run reliably on the Apache CI")
 public class AccountProducerTest extends XChangeTestSupport {
 
     @Override

--- a/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/market/MarketDataProducerTest.java
+++ b/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/market/MarketDataProducerTest.java
@@ -19,12 +19,15 @@ package org.apache.camel.component.xchange.market;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.xchange.XChangeTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 
 import static org.apache.camel.component.xchange.XChangeConfiguration.HEADER_CURRENCY_PAIR;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+        disabledReason = "These tests do no run reliably on the Apache CI")
 public class MarketDataProducerTest extends XChangeTestSupport {
 
     @Override

--- a/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/metadata/MetaDataProducerTest.java
+++ b/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/metadata/MetaDataProducerTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.xchange.XChangeTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.meta.CurrencyMetaData;
@@ -31,6 +32,8 @@ import static org.apache.camel.component.xchange.XChangeConfiguration.HEADER_CUR
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+        disabledReason = "These tests do no run reliably on the Apache CI")
 public class MetaDataProducerTest extends XChangeTestSupport {
 
     @Override


### PR DESCRIPTION
These tests do not run reliably on ASF CI, failing due to HTTP 415.