### PR TITLE
[CAMEL-19462] remove maven-compat

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/pom.xml
+++ b/tooling/maven/camel-package-maven-plugin/pom.xml
@@ -86,10 +86,6 @@
             <version>${maven-shared-utils-plugin-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-tree</artifactId>
         </dependency>


### PR DESCRIPTION

Removed the maven-compat dependency that was causing deprecation warnings.  





