### PR TITLE
(chores) ci: restore component-test

### DIFF
--- a/.github/actions/component-test/action.yaml
+++ b/.github/actions/component-test/action.yaml
@@ -1,0 +1,88 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "Component Test Runner"
+description: "Runs tests of corresponding to the given comment"
+inputs:
+  github-token:
+    description: 'GitHub token to use to update the comment'
+    required: true
+  run-id:
+    description: 'Id of the job'
+    required: true
+  pr-id:
+    description: 'Id of the pull request to update'
+    required: true
+  comment-id:
+    description: 'Id of the comment to process'
+    required: true
+  comment-body:
+    description: 'Body of the comment to process'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - id: install-mvnd
+      uses: ./.github/actions/install-mvnd
+    - name: maven build
+      shell: bash
+      run: ${{ github.action_path }}/component-test.sh ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd "${{ inputs.comment-body }}" true build.log
+    - name: archive logs
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: build.log
+        path: build.log
+    - name: maven test
+      shell: bash
+      run: ${{ github.action_path }}/component-test.sh ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd "${{ inputs.comment-body }}" false tests.log
+    - name: archive logs
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: tests.log
+        path: tests.log
+    - name: Success comment
+      if: success()
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ inputs.pr-id }},
+                comment_id: ${{ inputs.comment-id }},
+                body: `${{ inputs.comment-body }}
+
+          **Result** :white_check_mark: The tests passed successfully`
+          });
+    - name: Failure comment
+      if: failure()
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ inputs.pr-id }},
+                comment_id: ${{ inputs.comment-id }},
+                body: `${{ inputs.comment-body }}
+
+          **Result** :x: The tests failed please [check the logs](https://github.com/apache/camel/actions/runs/${{ inputs.run-id }})`
+          });

--- a/.github/actions/component-test/component-test.sh
+++ b/.github/actions/component-test/component-test.sh
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+echo "Using MVND_OPTS=$MVND_OPTS"
+
+function main() {
+  local mavenBinary=${1}
+  local commentBody=${2}
+  local fastBuild=${3}
+  local log=${4}
+
+  if [[ ${commentBody} = /component-test* ]] ; then
+    local componentList="${commentBody:16}"
+    echo "The list of components to test is ${componentList}"
+  else
+    echo "No components has been detected, the expected format is '/component-test (camel-)component-name1 (camel-)component-name2...'"
+    exit 1
+  fi
+  local pl=""
+  for component in ${componentList}
+  do
+    if [[ ${component} = camel-* ]] ; then
+      pl="$pl,components/${component}"
+    else
+      pl="$pl,components/camel-${component}"
+    fi
+  done
+  pl="${pl:1}"
+
+  if [[ ${fastBuild} = "true" ]] ; then
+    echo "Launching a fast build against the projects ${pl} and their dependencies"
+    $mavenBinary -l $log $MVND_OPTS -Dquickly install -pl "$pl" -am
+  else
+    echo "Launching tests of the projects ${pl}"
+    $mavenBinary -l $log $MVND_OPTS install -pl "$pl"
+  fi
+}
+
+main "$@"

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: PR Comment Build
+
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  pr_commented:
+    name: PR comment
+    if: ${{ github.repository == 'apache/camel' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/component-test') }}
+    permissions:
+      pull-requests: write # to comment on a pull request
+      actions: read # to download artifact
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '17' ]
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `:robot: The Apache Camel test robot will run the tests for you :+1:`
+            })
+      - name: Retrieve sha
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.issue.number
+            });
+            core.exportVariable('pr_sha', pr.data.head.sha)
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.pr_sha }}
+      - id: install-packages
+        uses: ./.github/actions/install-packages
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+      - id: test
+        name: Component test execution
+        uses: ./.github/actions/component-test
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.run_id }}
+          pr-id: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}
+          comment-body: ${{ github.event.comment.body }}


### PR DESCRIPTION
## Motivation

When there are too many components to test, only the affected projects are tested so it can still be useful to be able to decide explicitly which components to test

## Modifications:

* Restore the `component-test` github action since it can still be useful in some specific cases