### PR TITLE
(chores) camel-test-infra-artemis: hardening cleanups

### DIFF
--- a/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/AbstractArtemisEmbeddedService.java
+++ b/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/AbstractArtemisEmbeddedService.java
@@ -48,18 +48,18 @@ public abstract class AbstractArtemisEmbeddedService implements ArtemisService, 
     private Configuration artemisConfiguration;
 
     public AbstractArtemisEmbeddedService() {
-        defaultConfigturation();
+        defaultConfiguration();
 
         embeddedBrokerService.setConfiguration(getConfiguration(artemisConfiguration, AvailablePortFinder.getNextAvailable()));
     }
 
     public AbstractArtemisEmbeddedService(int port) {
-        defaultConfigturation();
+        defaultConfiguration();
 
         embeddedBrokerService.setConfiguration(getConfiguration(artemisConfiguration, port));
     }
 
-    private void defaultConfigturation() {
+    private void defaultConfiguration() {
         embeddedBrokerService = new EmbeddedActiveMQ();
 
         // Base configuration
@@ -68,6 +68,7 @@ public abstract class AbstractArtemisEmbeddedService implements ArtemisService, 
         BROKER_COUNT.increment();
         artemisConfiguration.setBrokerInstance(new File("target", "artemis-" + BROKER_COUNT.intValue()));
         artemisConfiguration.setJMXManagementEnabled(false);
+        artemisConfiguration.setMaxDiskUsage(98);
     }
 
     protected abstract Configuration getConfiguration(Configuration artemisConfiguration, int port);

--- a/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisAMQPService.java
+++ b/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisAMQPService.java
@@ -19,6 +19,7 @@ package org.apache.camel.test.infra.artemis.services;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.CoreAddressConfiguration;
+import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -38,6 +39,8 @@ public class ArtemisAMQPService extends AbstractArtemisEmbeddedService {
                     + "?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;amqpCredits=1000;amqpMinCredits=300";
 
         AddressSettings addressSettings = new AddressSettings();
+        addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.FAIL);
+
         // Disable auto create address to make sure that topic name is correct without prefix
         try {
             artemisConfiguration.addAcceptorConfiguration("amqp", brokerURL);
@@ -48,6 +51,7 @@ public class ArtemisAMQPService extends AbstractArtemisEmbeddedService {
         artemisConfiguration.setPersistenceEnabled(false);
         artemisConfiguration.addAddressesSetting("#", addressSettings);
         artemisConfiguration.setSecurityEnabled(false);
+        artemisConfiguration.setMaxDiskUsage(98);
 
         // Set explicit topic name
         CoreAddressConfiguration pingTopicConfig = new CoreAddressConfiguration();

--- a/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisTCPAllProtocolsService.java
+++ b/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisTCPAllProtocolsService.java
@@ -20,6 +20,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
+import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.camel.test.AvailablePortFinder;
 
@@ -49,6 +50,7 @@ public class ArtemisTCPAllProtocolsService extends AbstractArtemisEmbeddedServic
         }
         configuration.addAddressSetting("#",
                 new AddressSettings()
+                        .setAddressFullMessagePolicy(AddressFullMessagePolicy.FAIL)
                         .setDeadLetterAddress(SimpleString.toSimpleString("DLQ"))
                         .setExpiryAddress(SimpleString.toSimpleString("ExpiryQueue")));
 

--- a/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisVMService.java
+++ b/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisVMService.java
@@ -18,6 +18,7 @@ package org.apache.camel.test.infra.artemis.services;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -40,6 +41,7 @@ public class ArtemisVMService extends AbstractArtemisEmbeddedService {
         }
         configuration.addAddressSetting("#",
                 new AddressSettings()
+                        .setAddressFullMessagePolicy(AddressFullMessagePolicy.FAIL)
                         .setDeadLetterAddress(SimpleString.toSimpleString("DLQ"))
                         .setExpiryAddress(SimpleString.toSimpleString("ExpiryQueue")));
 


### PR DESCRIPTION
- increase the maximum disk usage accepted: use the same disk size use configuration originally added as part of change 9d0108757c4f6c27817dd0ce4a07ad93abcff511
- prevent blocking on disk full: use the same disk-full behavior originally added as part of change dd18711c75992f6d8e279c1a260c1f5b56ff2739