### PR TITLE
CAMEL-19650: Camel Kafka doesn't honor 'workerPool' configuration

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
@@ -170,7 +170,7 @@ public class KafkaProducer extends DefaultAsyncProducer {
         // if we are in asynchronous mode we need a worker pool
         if (!configuration.isSynchronous() && workerPool == null) {
             // If custom worker pool is provided, then use it, else create a new one.
-            if(configuration.getWorkerPool() != null) {
+            if (configuration.getWorkerPool() != null) {
                 workerPool = configuration.getWorkerPool();
                 shutdownWorkerPool = false;
             } else {
@@ -178,7 +178,6 @@ public class KafkaProducer extends DefaultAsyncProducer {
                 // we create a thread pool so we should also shut it down
                 shutdownWorkerPool = true;
             }
-
         }
 
         // init client id which we may need to get from the kafka producer via reflection

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
@@ -169,9 +169,16 @@ public class KafkaProducer extends DefaultAsyncProducer {
 
         // if we are in asynchronous mode we need a worker pool
         if (!configuration.isSynchronous() && workerPool == null) {
-            workerPool = endpoint.createProducerExecutor();
-            // we create a thread pool so we should also shut it down
-            shutdownWorkerPool = true;
+            // If custom worker pool is provided, then use it, else create a new one.
+            if(configuration.getWorkerPool() != null) {
+                workerPool = configuration.getWorkerPool();
+                shutdownWorkerPool = false;
+            } else {
+                workerPool = endpoint.createProducerExecutor();
+                // we create a thread pool so we should also shut it down
+                shutdownWorkerPool = true;
+            }
+
         }
 
         // init client id which we may need to get from the kafka producer via reflection


### PR DESCRIPTION

# Description

# What
The camel kafka component when provided with a custom worker pool is not used.

# Why
The KafkaProducer.java code in doStart() function doesn't check the configuration of whether a custom worker pool is provided or not. It directly goes ahead and creates a new one. This is now fixed by adding a check and using the worker pool if provided.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

