### PR TITLE
(chores) came-jms: avoid failing the test due to session being closed

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutDisableTimeToLiveTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutDisableTimeToLiveTest.java
@@ -45,9 +45,7 @@ public class JmsInOutDisableTimeToLiveTest extends AbstractJMSTest {
 
     @Test
     public void testInOutExpired() throws Exception {
-        MyCoolBean cool = new MyCoolBean();
-        cool.setProducer(template);
-        cool.setConsumer(consumer);
+        MyCoolBean cool = new MyCoolBean(consumer, template, "JmsInOutDisableTimeToLiveTest");
 
         getMockEndpoint("mock:result").expectedMessageCount(0);
         getMockEndpoint("mock:end").expectedMessageCount(0);
@@ -66,9 +64,7 @@ public class JmsInOutDisableTimeToLiveTest extends AbstractJMSTest {
 
     @Test
     public void testInOutDisableTimeToLive() throws Exception {
-        MyCoolBean cool = new MyCoolBean();
-        cool.setProducer(template);
-        cool.setConsumer(consumer);
+        MyCoolBean cool = new MyCoolBean(consumer, template, "JmsInOutDisableTimeToLiveTest");
 
         getMockEndpoint("mock:result").expectedMessageCount(0);
         getMockEndpoint("mock:end").expectedBodiesReceived("Hello World 2");
@@ -121,37 +117,4 @@ public class JmsInOutDisableTimeToLiveTest extends AbstractJMSTest {
         template = camelContextExtension.getProducerTemplate();
         consumer = camelContextExtension.getConsumerTemplate();
     }
-
-    public static class MyCoolBean {
-        private int count;
-        private ConsumerTemplate consumer;
-        private ProducerTemplate producer;
-
-        public void setConsumer(ConsumerTemplate consumer) {
-            this.consumer = consumer;
-        }
-
-        public void setProducer(ProducerTemplate producer) {
-            this.producer = producer;
-        }
-
-        public void someBusinessLogic() {
-            // loop to empty queue
-            while (true) {
-                // receive the message from the queue, wait at most 2 sec
-                String msg = consumer.receiveBody("activemq:JmsInOutDisableTimeToLiveTest.in", 2000, String.class);
-                if (msg == null) {
-                    // no more messages in queue
-                    break;
-                }
-
-                // do something with body
-                msg = "Hello " + msg;
-
-                // send it to the next queue
-                producer.sendBodyAndHeader("activemq:JmsInOutDisableTimeToLiveTest.out", msg, "number", count++);
-            }
-        }
-    }
-
 }

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/MyCoolBean.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/MyCoolBean.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.component.jms;
+
+import org.apache.camel.ConsumerTemplate;
+import org.apache.camel.ProducerTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jms.IllegalStateException;
+
+final class MyCoolBean {
+    private static final Logger LOG = LoggerFactory.getLogger(MyCoolBean.class);
+
+    private int count;
+    private final ConsumerTemplate consumer;
+    private final ProducerTemplate producer;
+    private final String queueName;
+
+    public MyCoolBean(ConsumerTemplate consumer, ProducerTemplate producer, String queueName) {
+        this.consumer = consumer;
+        this.producer = producer;
+        this.queueName = queueName;
+    }
+
+    public void someBusinessLogic() {
+        // loop to empty queue
+        while (true) {
+            // receive the message from the queue, wait at most 2 sec
+            try {
+                String msg = consumer.receiveBody("activemq:" + queueName + ".in", 2000, String.class);
+                if (msg == null) {
+                    // no more messages in queue
+                    break;
+                }
+                // do something with body
+                msg = "Hello " + msg;
+
+                // send it to the next queue
+                producer.sendBodyAndHeader("activemq:" + queueName + ".out", msg, "number", count++);
+            } catch (IllegalStateException e) {
+                if (e.getCause() instanceof jakarta.jms.IllegalStateException) {
+                    // session is closed
+                    LOG.warn("JMS Session is closed");
+                    break;
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
This reuses the same approach from another commit and applies to another similar test (ref.: 2396b3c4b8d7f1df0b411330e5497fb16bc669d0)