### PR TITLE
CAMEL-19666: stop auto-deleting queues

### DIFF
--- a/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisVMService.java
+++ b/test-infra/camel-test-infra-artemis/src/test/java/org/apache/camel/test/infra/artemis/services/ArtemisVMService.java
@@ -48,6 +48,7 @@ public class ArtemisVMService extends AbstractArtemisEmbeddedService {
         configuration.addAddressSetting("#",
                 new AddressSettings()
                         .setAddressFullMessagePolicy(AddressFullMessagePolicy.FAIL)
+                        .setAutoDeleteQueues(false)
                         .setDeadLetterAddress(SimpleString.toSimpleString("DLQ"))
                         .setExpiryAddress(SimpleString.toSimpleString("ExpiryQueue")));
 


### PR DESCRIPTION
When running with a lot of threads, sometimes the tests hang while the broker is auto-deleting queues/addresses