### PR TITLE
CAMEL-19669: fix camel-jms test flakiness

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/AbstractJMSTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/AbstractJMSTest.java
@@ -58,7 +58,8 @@ public abstract class AbstractJMSTest implements CamelTestSupportHelper, Configu
         return buildComponent(connectionFactory);
     }
 
-    protected JmsComponent setupComponent(CamelContext camelContext, ArtemisService service, String componentName) {
+    protected JmsComponent setupComponent(
+            CamelContext camelContext, ArtemisService service, String componentName) {
         ConnectionFactory connectionFactory = ConnectionFactoryHelper.createConnectionFactory(service);
 
         return setupComponent(camelContext, connectionFactory, componentName);
@@ -68,7 +69,7 @@ public abstract class AbstractJMSTest implements CamelTestSupportHelper, Configu
 
     @ContextFixture
     @Override
-    public void configureContext(CamelContext context) throws Exception {
+    public synchronized void configureContext(CamelContext context) throws Exception {
         JmsComponent component = setupComponent(context, service, getComponentName());
         context.addComponent(getComponentName(), component);
     }

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/AbstractSpringJMSTestSupport.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/AbstractSpringJMSTestSupport.java
@@ -22,6 +22,11 @@ import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.context.support.AbstractApplicationContext;
 
+/**
+ * Do not create tests using Spring: CamelSpringTestSupport does not provide a safe environment for concurrent
+ * execution.
+ */
+@Deprecated
 public class AbstractSpringJMSTestSupport extends CamelSpringTestSupport {
 
     @RegisterExtension

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsAutoStartupTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsAutoStartupTest.java
@@ -24,12 +24,10 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @Timeout(60)
-@Isolated
 public class JmsAutoStartupTest extends AbstractPersistentJMSTest {
 
     private JmsEndpoint endpoint;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsBatchResequencerJMSPriorityTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsBatchResequencerJMSPriorityTest.java
@@ -29,12 +29,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * JMSPriority being ordered using the resequencer in batch mode.
  */
-@Isolated
 public class JmsBatchResequencerJMSPriorityTest extends AbstractJMSTest {
 
     @Order(2)

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsHeaderFilteringWithSpringTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsHeaderFilteringWithSpringTest.java
@@ -21,10 +21,11 @@ import org.apache.camel.spring.SpringCamelContext;
 import org.apache.camel.test.infra.core.annotations.ContextProvider;
 import org.apache.camel.util.IOHelper;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-@Isolated
+@Tags({ @Tag("not-parallel"), @Tag("spring") })
 public class JmsHeaderFilteringWithSpringTest extends JmsHeaderFilteringTest {
 
     private ClassPathXmlApplicationContext applicationContext;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutFixedReplyQueueTimeoutTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOutFixedReplyQueueTimeoutTest.java
@@ -32,15 +32,16 @@ import org.apache.camel.test.infra.core.TransientCamelContextExtension;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Isolated
+@Tags({ @Tag("not-parallel"), @Tag("spring") })
 public class JmsInOutFixedReplyQueueTimeoutTest extends AbstractJMSTest {
 
     @Order(2)

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRequestReplyExclusiveReplyToConcurrentTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRequestReplyExclusiveReplyToConcurrentTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.parallel.Isolated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +40,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Isolated
 public class JmsRequestReplyExclusiveReplyToConcurrentTest extends AbstractJMSTest {
 
     @Order(2)

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRequestReplyExclusiveReplyToTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRequestReplyExclusiveReplyToTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Using exclusive fixed replyTo queues should be faster as there is no need for JMSMessage selectors.
  */
-@Isolated
 public class JmsRequestReplyExclusiveReplyToTest extends AbstractJMSTest {
 
     @Order(2)

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteUsingSpringAndJmsNameTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteUsingSpringAndJmsNameTest.java
@@ -17,9 +17,12 @@
 package org.apache.camel.component.jms;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring") })
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 public class JmsRouteUsingSpringAndJmsNameTest extends JmsRouteUsingSpringTest {
 

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteUsingSpringJMSTemplateTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteUsingSpringJMSTemplateTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.camel.component.jms;
 
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring") })
 public class JmsRouteUsingSpringJMSTemplateTest extends JmsRouteUsingSpringAndJmsNameTest {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteUsingSpringTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteUsingSpringTest.java
@@ -21,12 +21,11 @@ import org.apache.camel.spring.SpringCamelContext;
 import org.apache.camel.test.infra.core.annotations.ContextProvider;
 import org.apache.camel.util.IOHelper;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-@Isolated
-@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@Tags({ @Tag("not-parallel"), @Tag("spring") })
 public class JmsRouteUsingSpringTest extends JmsRouteTest {
     private ClassPathXmlApplicationContext applicationContext;
 

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteUsingSpringWithAutoWireTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteUsingSpringWithAutoWireTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.camel.component.jms;
 
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring") })
 public class JmsRouteUsingSpringWithAutoWireTest extends JmsRouteUsingSpringAndJmsNameTest {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSelectorInTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSelectorInTest.java
@@ -31,12 +31,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Timeout(30)
-@Isolated
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class JmsSelectorInTest extends AbstractJMSTest {
 

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSpringLoadBalanceFailoverJMSTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSpringLoadBalanceFailoverJMSTest.java
@@ -17,8 +17,9 @@
 package org.apache.camel.component.jms;
 
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
@@ -27,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Unit test for Camel loadbalancer failover with JMS
  */
-@Isolated
+@Tags({ @Tag("not-parallel"), @Tag("spring") })
 public class JmsSpringLoadBalanceFailoverJMSTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/SpringJmsRoutingSlipInOutTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/SpringJmsRoutingSlipInOutTest.java
@@ -20,13 +20,13 @@ import java.util.Map;
 
 import org.apache.camel.Headers;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-/**
- *
- */
+@Tags({ @Tag("not-parallel"), @Tag("spring") })
 public class SpringJmsRoutingSlipInOutTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/SpringJmsSelectorTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/SpringJmsSelectorTest.java
@@ -17,10 +17,13 @@
 package org.apache.camel.component.jms;
 
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring") })
 public class SpringJmsSelectorTest extends AbstractSpringJMSTestSupport {
 
     @Test

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/SpringJmsXPathHeaderTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/SpringJmsXPathHeaderTest.java
@@ -17,6 +17,8 @@
 package org.apache.camel.component.jms;
 
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -24,6 +26,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 /**
  * JMS with XPath
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring") })
 public class SpringJmsXPathHeaderTest extends AbstractSpringJMSTestSupport {
 
     @Test

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/activemq/TwoEmbeddedActiveMQBrokersTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/activemq/TwoEmbeddedActiveMQBrokersTest.java
@@ -21,13 +21,13 @@ import org.apache.camel.test.infra.artemis.services.ArtemisService;
 import org.apache.camel.test.infra.artemis.services.ArtemisVMService;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.apache.xbean.spring.context.ClassPathXmlApplicationContext;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 
-/**
- *
- */
+@Tags({ @Tag("not-parallel"), @Tag("spring") })
 public class TwoEmbeddedActiveMQBrokersTest extends CamelSpringTestSupport {
 
     @RegisterExtension

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/bind/JmsMessageBindTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/bind/JmsMessageBindTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.jms.JmsBinding;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
@@ -29,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("bind") })
 public class JmsMessageBindTest extends AbstractSpringJMSTestSupport {
 
     @Test

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/CamelBrokerClientTestSupport.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/CamelBrokerClientTestSupport.java
@@ -21,9 +21,12 @@ import org.apache.camel.test.infra.artemis.services.ArtemisEmbeddedServiceBuilde
 import org.apache.camel.test.infra.artemis.services.ArtemisService;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.apache.xbean.spring.context.ClassPathXmlApplicationContext;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.context.support.AbstractApplicationContext;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring") })
 public class CamelBrokerClientTestSupport extends CamelSpringTestSupport {
 
     @RegisterExtension

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOutWithSpringRestartIssueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOutWithSpringRestartIssueTest.java
@@ -18,12 +18,15 @@ package org.apache.camel.component.jms.issues;
 
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("issues") })
 public class JmsInOutWithSpringRestartIssueTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsResequencerTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsResequencerTest.java
@@ -18,6 +18,8 @@ package org.apache.camel.component.jms.issues;
 
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -25,6 +27,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 /**
  * Unit test for issues CAMEL-1034 and CAMEL-1037
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("issues") })
 public class JmsResequencerTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsTXForceShutdownIssueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsTXForceShutdownIssueTest.java
@@ -19,13 +19,13 @@ package org.apache.camel.component.jms.issues;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-/**
- *
- */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("issues") })
 public class JmsTXForceShutdownIssueTest extends CamelSpringTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/TransactionErrorHandlerRedeliveryDelayTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/TransactionErrorHandlerRedeliveryDelayTest.java
@@ -22,6 +22,8 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -31,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Unit test for issue CAMEL-706
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("issues") })
 public class TransactionErrorHandlerRedeliveryDelayTest extends AbstractSpringJMSTestSupport {
 
     private static final LongAdder COUNTER = new LongAdder();

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AbstractTransactionTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AbstractTransactionTest.java
@@ -29,6 +29,8 @@ import org.apache.camel.processor.errorhandler.DefaultErrorHandler;
 import org.apache.camel.spring.spi.TransactionErrorHandler;
 import org.apache.xbean.spring.context.ClassPathXmlApplicationContext;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 
 import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
@@ -39,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * Test case derived from: http://camel.apache.org/transactional-client.html and Martin Krasser's sample:
  * http://www.nabble.com/JMS-Transactions---How-To-td15168958s22882.html#a15198803
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public abstract class AbstractTransactionTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTX2Test.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTX2Test.java
@@ -20,12 +20,15 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.jms.async.MyAsyncComponent;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class AsyncEndpointJmsTX2Test extends AbstractSpringJMSTestSupport {
     private static String beforeThreadName;
     private static String afterThreadName;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXMulticastTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXMulticastTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.jms.async.MyAsyncComponent;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class AsyncEndpointJmsTXMulticastTest extends AbstractSpringJMSTestSupport {
     private static String beforeThreadName;
     private static String afterThreadName;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXRecipientListTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXRecipientListTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.jms.async.MyAsyncComponent;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class AsyncEndpointJmsTXRecipientListTest extends AbstractSpringJMSTestSupport {
     private static String beforeThreadName;
     private static String afterThreadName;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXRollback2Test.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXRollback2Test.java
@@ -20,12 +20,15 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.jms.async.MyAsyncComponent;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class AsyncEndpointJmsTXRollback2Test extends AbstractSpringJMSTestSupport {
 
     private static int invoked;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXRollbackTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXRollbackTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.jms.async.MyAsyncComponent;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class AsyncEndpointJmsTXRollbackTest extends AbstractSpringJMSTestSupport {
 
     private static int invoked;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXRoutingSlipTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXRoutingSlipTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.jms.async.MyAsyncComponent;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class AsyncEndpointJmsTXRoutingSlipTest extends AbstractSpringJMSTestSupport {
 
     private static String beforeThreadName;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.jms.async.MyAsyncComponent;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class AsyncEndpointJmsTXTest extends AbstractSpringJMSTestSupport {
     private static String beforeThreadName;
     private static String afterThreadName;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXTryCatchFinallyTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXTryCatchFinallyTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.jms.async.MyAsyncComponent;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class AsyncEndpointJmsTXTryCatchFinallyTest extends AbstractSpringJMSTestSupport {
 
     private static String beforeThreadName;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXWireTapTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/AsyncEndpointJmsTXWireTapTest.java
@@ -20,6 +20,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.jms.async.MyAsyncComponent;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -27,6 +29,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class AsyncEndpointJmsTXWireTapTest extends AbstractSpringJMSTestSupport {
     private static String beforeThreadName;
     private static String afterThreadName;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTXInOutPersistentQueueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTXInOutPersistentQueueTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.ExchangePattern;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class JMSTXInOutPersistentQueueTest extends AbstractSpringJMSTestSupport {
 
     private static int counter;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionErrorHandlerTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionErrorHandlerTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * To demonstrate transacted with minimal configuration.
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class JMSTransactionErrorHandlerTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionIsTransactedRedeliveredTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionIsTransactedRedeliveredTest.java
@@ -30,6 +30,8 @@ import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.awaitility.Awaitility;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
@@ -37,9 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- *
- */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class JMSTransactionIsTransactedRedeliveredTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionRollbackTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionRollbackTest.java
@@ -20,12 +20,12 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-/**
- *
- */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class JMSTransactionRollbackTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionThrottlingRoutePolicyTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionThrottlingRoutePolicyTest.java
@@ -19,11 +19,14 @@ package org.apache.camel.component.jms.tx;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class JMSTransactionThrottlingRoutePolicyTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionalClientTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionalClientTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * Simple unit test for transaction client EIP pattern and JMS.
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class JMSTransactionalClientTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionalClientWithRollbackTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMSTransactionalClientWithRollbackTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * Simple unit test for transaction client EIP pattern and JMS.
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class JMSTransactionalClientWithRollbackTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMXTXUseOriginalBodyTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMXTXUseOriginalBodyTest.java
@@ -24,10 +24,13 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class JMXTXUseOriginalBodyTest extends AbstractSpringJMSTestSupport {
 
     @EndpointInject("mock:end")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMXTXUseOriginalBodyWithDLCErrorHandlerTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMXTXUseOriginalBodyWithDLCErrorHandlerTest.java
@@ -23,10 +23,13 @@ import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class JMXTXUseOriginalBodyWithDLCErrorHandlerTest extends JMXTXUseOriginalBodyTest {
 
     @EndpointInject("mock:end")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMXTXUseOriginalBodyWithTXErrorHandlerTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JMXTXUseOriginalBodyWithTXErrorHandlerTest.java
@@ -24,10 +24,13 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spring.spi.LegacyTransactionErrorHandlerBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class JMXTXUseOriginalBodyWithTXErrorHandlerTest extends JMXTXUseOriginalBodyTest {
 
     @EndpointInject("mock:end")

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JmsToJmsTransactedTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/JmsToJmsTransactedTest.java
@@ -20,6 +20,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -27,6 +29,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class JmsToJmsTransactedTest extends AbstractSpringJMSTestSupport {
 
     @BeforeEach

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/QueueToProcessorTransactionTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/QueueToProcessorTransactionTest.java
@@ -19,6 +19,8 @@ package org.apache.camel.component.jms.tx;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spi.Policy;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.Test;
  * NOTE: had to split into separate test classes as I was unable to fully tear down and isolate the test cases, I'm not
  * sure why, but as soon as we know the Transaction classes can be joined into one.
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class QueueToProcessorTransactionTest extends AbstractTransactionTest {
 
     @Test

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/QueueToQueueRequestReplyTransactionTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/QueueToQueueRequestReplyTransactionTest.java
@@ -20,6 +20,8 @@ import org.apache.camel.Message;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spi.Policy;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * NOTE: had to split into separate test classes as I was unable to fully tear down and isolate the test cases, I'm not
  * sure why, but as soon as we know the Transaction classes can be joined into one.
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class QueueToQueueRequestReplyTransactionTest extends AbstractTransactionTest {
 
     @Test

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/QueueToQueueTransactionTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/QueueToQueueTransactionTest.java
@@ -19,6 +19,8 @@ package org.apache.camel.component.jms.tx;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spi.Policy;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
  * classes as I was unable to fully tear down and isolate the test cases, I'm not sure why, but as soon as we know the
  * Transaction classes can be joined into one.
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class QueueToQueueTransactionTest extends AbstractTransactionTest {
 
     @Test

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/QueueToQueueTransactionWithoutDefineTransactionManagerTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/QueueToQueueTransactionWithoutDefineTransactionManagerTest.java
@@ -19,11 +19,14 @@ package org.apache.camel.component.jms.tx;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.xbean.spring.context.ClassPathXmlApplicationContext;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class QueueToQueueTransactionWithoutDefineTransactionManagerTest extends AbstractTransactionTest {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/RouteIdTransactedTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/RouteIdTransactedTest.java
@@ -19,11 +19,14 @@ package org.apache.camel.component.jms.tx;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class RouteIdTransactedTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactedAsyncUsingThreadsTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactedAsyncUsingThreadsTest.java
@@ -20,11 +20,14 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class TransactedAsyncUsingThreadsTest extends AbstractSpringJMSTestSupport {
 
     private static int counter;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionErrorHandlerBuilderAsSpringBeanTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionErrorHandlerBuilderAsSpringBeanTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * To demonstrate the TransactionErrorHandlerBuilder configured in Spring XML.
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class TransactionErrorHandlerBuilderAsSpringBeanTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionErrorHandlerCustomerSpringParserTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionErrorHandlerCustomerSpringParserTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * To demonstrate the TransactionErrorHandlerBuilder configured in Spring XML.
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class TransactionErrorHandlerCustomerSpringParserTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionInterceptSendToEndpointTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionInterceptSendToEndpointTest.java
@@ -18,12 +18,16 @@ package org.apache.camel.component.jms.tx;
 
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * End user on forum issue
  */
+
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class TransactionInterceptSendToEndpointTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/TransactionMinimalConfigurationTest.java
@@ -20,12 +20,15 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.jms.AbstractSpringJMSTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * To demonstrate transacted with minimal configuration.
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class TransactionMinimalConfigurationTest extends AbstractSpringJMSTestSupport {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/XMLQueueToProcessorTransactionTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/XMLQueueToProcessorTransactionTest.java
@@ -17,6 +17,8 @@
 package org.apache.camel.component.jms.tx;
 
 import org.apache.xbean.spring.context.ClassPathXmlApplicationContext;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 
@@ -26,6 +28,7 @@ import org.springframework.context.support.AbstractXmlApplicationContext;
  * classes as I was unable to fully tear down and isolate the test cases, I'm not sure why, but as soon as we know the
  * Transaction classes can be joined into one.
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class XMLQueueToProcessorTransactionTest extends AbstractTransactionTest {
 
     @Override

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/XMLQueueToQueueTransactionTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/tx/XMLQueueToQueueTransactionTest.java
@@ -17,6 +17,8 @@
 package org.apache.camel.component.jms.tx;
 
 import org.apache.xbean.spring.context.ClassPathXmlApplicationContext;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 
@@ -26,6 +28,7 @@ import org.springframework.context.support.AbstractXmlApplicationContext;
  * classes as I was unable to fully tear down and isolate the test cases, I'm not sure why, but as soon as we know the
  * Transaction classes can be joined into one.
  */
+@Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
 public class XMLQueueToQueueTransactionTest extends AbstractTransactionTest {
 
     @Override


### PR DESCRIPTION
- spring-based tests are not safe for concurrent execution
- avoid concurrently trying to set up the component
- remove isolation for safe tests