### PR TITLE
CAMEL-19561: upgrade Artemis to version 2.30.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -50,8 +50,7 @@
 
         <!-- dependency versions -->
         <activemq-version>5.18.2</activemq-version>
-        <!-- Artemis upgrade blocked by CAMEL-19561 -->
-        <activemq-artemis-version>2.28.0</activemq-artemis-version>
+        <activemq-artemis-version>2.30.0</activemq-artemis-version>
         <angus-mail-version>2.0.2</angus-mail-version>
         <apacheds-version>2.0.0.AM26</apacheds-version>
         <apache-drill-version>1.21.1</apache-drill-version>


### PR DESCRIPTION
The upgrade was originally blocked by ARTEMIS-4338, but the issue is now resolved.