### PR TITLE
CAMEL-19675: fixed not copying safe copy properties

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/ExchangeExtension.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExchangeExtension.java
@@ -218,6 +218,11 @@ public interface ExchangeExtension {
     void setSafeCopyProperty(String key, SafeCopyProperty value);
 
     /**
+     * Copy the safe copy properties from this exchange to the target exchange
+     */
+    void copySafeCopyPropertiesTo(ExchangeExtension target);
+
+    /**
      * Gets the internal properties from this exchange. The known set of internal keys is defined in
      * {@link ExchangePropertyKey}.
      * <p/>

--- a/core/camel-support/src/main/java/org/apache/camel/support/ExchangeHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/ExchangeHelper.java
@@ -46,6 +46,7 @@ import org.apache.camel.NoSuchPropertyException;
 import org.apache.camel.NoTypeConversionAvailableException;
 import org.apache.camel.Route;
 import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.SafeCopyProperty;
 import org.apache.camel.TypeConversionException;
 import org.apache.camel.WrappedFile;
 import org.apache.camel.spi.NormalizedEndpointUri;
@@ -383,6 +384,7 @@ public final class ExchangeHelper {
             result.getProperties().putAll(source.getProperties());
         }
         source.getExchangeExtension().copyInternalProperties(result);
+        source.getExchangeExtension().copySafeCopyPropertiesTo(result.getExchangeExtension());
 
         // copy over state
         result.setRouteStop(source.isRouteStop());
@@ -391,6 +393,7 @@ public final class ExchangeHelper {
         result.getExchangeExtension().setNotifyEvent(source.getExchangeExtension().isNotifyEvent());
         result.getExchangeExtension().setRedeliveryExhausted(source.getExchangeExtension().isRedeliveryExhausted());
         result.getExchangeExtension().setErrorHandlerHandled(source.getExchangeExtension().getErrorHandlerHandled());
+
         result.setException(source.getException());
     }
 

--- a/core/camel-support/src/main/java/org/apache/camel/support/ExtendedExchangeExtension.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/ExtendedExchangeExtension.java
@@ -288,6 +288,13 @@ public class ExtendedExchangeExtension implements ExchangeExtension {
         return this.exchange.getSafeCopyProperty(key, type);
     }
 
+    public void copySafeCopyPropertiesTo(ExchangeExtension target) {
+        if (exchange.safeCopyProperties != null && !exchange.safeCopyProperties.isEmpty()) {
+            exchange.safeCopyProperties.entrySet().stream()
+                    .forEach(entry -> target.setSafeCopyProperty(entry.getKey(), entry.getValue().safeCopy()));
+        }
+    }
+
     @Override
     public boolean isFailureHandled() {
         return this.failureHandled;


### PR DESCRIPTION
This could cause it to lose attachments when using multicast EIP