### PR TITLE
Add archetypeCatalog setting of local to prevent repository==null error in generation

### DIFF
--- a/components/camel-olingo2/camel-olingo2-component/pom.xml
+++ b/components/camel-olingo2/camel-olingo2-component/pom.xml
@@ -299,6 +299,7 @@
                                 <configuration>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                     <interactiveMode>false</interactiveMode>
+                                    <archetypeCatalog>local</archetypeCatalog>
                                     <archetypeGroupId>org.apache.olingo</archetypeGroupId>
                                     <archetypeArtifactId>olingo-odata2-sample-cars-annotation-archetype
                                     </archetypeArtifactId>


### PR DESCRIPTION
I'm getting the following error in building RC2 locally : 

```
[INFO] --- archetype:3.2.1:generate (generate-my-car-service) @ camel-olingo2 ---
[INFO] Generating project in Batch mode
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.036 s
[INFO] Finished at: 2023-07-28T11:08:52-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-archetype-plugin:3.2.1:generate (generate-my-car-service) on project camel-olingo2: Cannot invoke "org.apache.maven.artifact.repository.ArtifactRepository.getUrl()" because "repository" is null -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```

Looking at the documentation for the maven-archetype-plugin generate goal, it looks like `<archetypeCatalog/>` controls the catalog search and local might be the most appropriate setting?

https://maven.apache.org/archetype/maven-archetype-plugin/generate-mojo.html#archetypeCatalog

This change fixed the build error locally for me.