### PR TITLE
Upgrade Zookeeper Testcontainers to 3.8

### DIFF
--- a/test-infra/camel-test-infra-zookeeper/src/test/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperContainer.java
+++ b/test-infra/camel-test-infra-zookeeper/src/test/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperContainer.java
@@ -23,7 +23,7 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 public class ZooKeeperContainer extends GenericContainer {
-    public static final String CONTAINER_IMAGE = "zookeeper:3.5";
+    public static final String CONTAINER_IMAGE = "zookeeper:3.8";
     public static final String CONTAINER_NAME = "zookeeper";
     public static final int CLIENT_PORT = 2181;
 


### PR DESCRIPTION
# Description

This PR upgrades Zookeeper Testcontainers to 3.8 for aligning its version with the one used by the camel-zookeeper component.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

No corresponding JIRA issue since it's just a minor container version upgrade.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->