### PR TITLE
(chores) camel-plc4x: fix test flakiness

### DIFF
--- a/components/camel-plc4x/src/test/java/org/apache/camel/component/plc4x/Plc4XComponentTagTest.java
+++ b/components/camel-plc4x/src/test/java/org/apache/camel/component/plc4x/Plc4XComponentTagTest.java
@@ -31,8 +31,8 @@ public class Plc4XComponentTagTest extends CamelTestSupport {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMinimumMessageCount(1);
         mock.expectedMessageCount(2);
-        template.asyncSendBody("direct:plc4x", Collections.singletonList("irrelevant"));
-        template.asyncSendBody("direct:plc4x2", Collections.singletonList("irrelevant"));
+        template.sendBody("direct:plc4x", Collections.singletonList("irrelevant"));
+        template.sendBody("direct:plc4x2", Collections.singletonList("irrelevant"));
 
         MockEndpoint.assertIsSatisfied(context, 2, TimeUnit.SECONDS);
     }

--- a/components/camel-plc4x/src/test/java/org/apache/camel/component/plc4x/Plc4XComponentTest.java
+++ b/components/camel-plc4x/src/test/java/org/apache/camel/component/plc4x/Plc4XComponentTest.java
@@ -31,8 +31,8 @@ public class Plc4XComponentTest extends CamelTestSupport {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMinimumMessageCount(1);
         mock.expectedMessageCount(2);
-        template.asyncSendBody("direct:plc4x", Collections.singletonList("irrelevant"));
-        template.asyncSendBody("direct:plc4x2", Collections.singletonList("irrelevant"));
+        template.sendBody("direct:plc4x", Collections.singletonList("irrelevant"));
+        template.sendBody("direct:plc4x2", Collections.singletonList("irrelevant"));
 
         MockEndpoint.assertIsSatisfied(context, 2, TimeUnit.SECONDS);
     }


### PR DESCRIPTION
Send synchronously to avoid the unpredictable behavior of sending async and not checking the result

Signed-off-by: Otavio R. Piske <angusyoung@gmail.com>