### PR TITLE
(chores) camel-test-infra-kafka: zookeeper container should be the same one used by Kafka

### DIFF
--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/StrimziContainer.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/StrimziContainer.java
@@ -24,7 +24,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public class StrimziContainer extends GenericContainer<StrimziContainer> {
     public static final String DEFAULT_STRIMZI_CONTAINER = "quay.io/strimzi/kafka:latest-kafka-3.5.1";
-    private static final String STRIMZI_CONTAINER
+    static final String STRIMZI_CONTAINER
             = System.getProperty("itest.strimzi.container.image", DEFAULT_STRIMZI_CONTAINER);
     private static final int KAFKA_PORT = 9092;
 

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ZookeeperContainer.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ZookeeperContainer.java
@@ -23,8 +23,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 public class ZookeeperContainer extends GenericContainer<ZookeeperContainer> {
-    private static final String ZOOKEEPER_CONTAINER = System.getProperty("itest.zookeeper.container.image",
-            StrimziContainer.DEFAULT_STRIMZI_CONTAINER);
+    private static final String ZOOKEEPER_CONTAINER = StrimziContainer.STRIMZI_CONTAINER;
     private static final int ZOOKEEPER_PORT = 2181;
 
     public ZookeeperContainer(Network network, String name) {


### PR DESCRIPTION
Signed-off-by: Otavio R. Piske <angusyoung@gmail.com>