### PR TITLE
Fix velocity-component.adoc

### DIFF
--- a/components/camel-velocity/src/main/docs/velocity-component.adoc
+++ b/components/camel-velocity/src/main/docs/velocity-component.adoc
@@ -104,7 +104,7 @@ Camel will provide exchange information in the Velocity context (just a
 |=======================================================================
 
 You can setup a custom Velocity Context yourself by
-setting the message header *CamelVelocityContext *just like this
+setting property *allowTemplateFromHeader=true* and setting the message header *CamelVelocityContext* just like this
 
 [source,java]
 -----------------------------------------------------------------------


### PR DESCRIPTION
allowTemplateFromHeader=true is necessary to make the Velocity Context available from headers
