### PR TITLE
[Camel-19462] remove plexus-container-default

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/pom.xml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/pom.xml
@@ -72,10 +72,6 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
         </dependency>
         <dependency>

--- a/tooling/maven/bom-generator-maven-plugin/pom.xml
+++ b/tooling/maven/bom-generator-maven-plugin/pom.xml
@@ -75,10 +75,6 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
         </dependency>
         <dependency>

--- a/tooling/maven/camel-api-component-maven-plugin/pom.xml
+++ b/tooling/maven/camel-api-component-maven-plugin/pom.xml
@@ -95,31 +95,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.doxia</groupId>
-            <artifactId>doxia-module-xhtml</artifactId>
-            <version>1.12.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.doxia</groupId>
-            <artifactId>doxia-site-renderer</artifactId>
-            <version>1.11.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.velocity</groupId>
-                    <artifactId>velocity</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.velocity</groupId>
-                    <artifactId>velocity-tools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-beanutils</groupId>
-                    <artifactId>commons-beanutils</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
         </dependency>

--- a/tooling/maven/camel-api-component-maven-plugin/pom.xml
+++ b/tooling/maven/camel-api-component-maven-plugin/pom.xml
@@ -82,10 +82,6 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
         </dependency>
         <dependency>

--- a/tooling/maven/camel-eip-documentation-enricher-maven-plugin/pom.xml
+++ b/tooling/maven/camel-eip-documentation-enricher-maven-plugin/pom.xml
@@ -63,10 +63,6 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
         </dependency>
         <dependency>

--- a/tooling/maven/sync-properties-maven-plugin/pom.xml
+++ b/tooling/maven/sync-properties-maven-plugin/pom.xml
@@ -83,10 +83,6 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Updates to address the warning "Plugin depends on plexus-container-default, which is EOL"
1. Removed plexus-container-default dependencies from camel plugins.
2. Removed plexus dependencies since they are no longer used and doxia-site-renderer depends on plexus-container-default. Doxia hasn't been used in camel-api-component-maven-plugin since org.apache.camel.maven.DocumentGeneratorMojo was removed in camel-3.6.0


