### PR TITLE
[CAMEL-19462] remove read-only element from parameters configured by the user

### DIFF
--- a/tooling/maven/bom-generator-maven-plugin/src/main/java/org/apache/camel/maven/bom/generator/BomGeneratorMojo.java
+++ b/tooling/maven/bom-generator-maven-plugin/src/main/java/org/apache/camel/maven/bom/generator/BomGeneratorMojo.java
@@ -94,13 +94,13 @@ public class BomGeneratorMojo extends AbstractMojo {
     /**
      * The user configuration
      */
-    @Parameter(readonly = true)
+    @Parameter
     protected DependencySet dependencies;
 
     /**
      * The conflict checks configured by the user
      */
-    @Parameter(readonly = true)
+    @Parameter
     protected ExternalBomConflictCheckSet checkConflicts;
 
     /**


### PR DESCRIPTION

Removed the read-only element from parameters used or intended to be used in POM-specific configuration. otherwise maven displays a warning.
