### PR TITLE
Jsse fix res check

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/support/jsse/JsseParameters.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/jsse/JsseParameters.java
@@ -116,7 +116,7 @@ public class JsseParameters implements CamelContextAware {
 
         Resource res
                 = getCamelContext().getCamelContextExtension().getContextPlugin(ResourceLoader.class).resolveResource(resource);
-        if (res == null) {
+        if (res == null || !res.exists()) {
             throw new IOException("Could not open " + resource + " as a file, class path resource, or URL.");
         }
         return res.getInputStream();


### PR DESCRIPTION
# Description

Add checks that keystore/trustore resources realy exists. We should call exist() method because in some cases resolveResource returns ResourceSupport object.


