### PR TITLE
CAMEL-19695: camel-google-bigquery - Bump org.json to 20230618 (3.22)

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -348,6 +348,7 @@
     <jslt-version>0.1.11</jslt-version>
     <jsmpp-version>2.3.11</jsmpp-version>
     <json-api>1.0</json-api>
+    <json-org-version>20230618</json-org-version>
     <json-patch-version>1.13</json-patch-version>
     <json-path-version>2.8.0</json-path-version>
     <json-schema-validator-version>2.2.14</json-schema-validator-version>

--- a/components/camel-google/camel-google-bigquery/pom.xml
+++ b/components/camel-google/camel-google-bigquery/pom.xml
@@ -76,7 +76,15 @@
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.json</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
         </dependency>
 
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -334,6 +334,7 @@
         <jsmpp-version>2.3.11</jsmpp-version>
         <jsch-version>0.2.1</jsch-version>
         <json-api>1.0</json-api>
+        <json-org-version>20230618</json-org-version>
         <jsonassert-version>1.5.1</jsonassert-version>
         <json-path-version>2.8.0</json-path-version>
         <json-patch-version>1.13</json-patch-version>
@@ -3233,6 +3234,11 @@
                 <groupId>com.sun.xml.parsers</groupId>
                 <artifactId>jaxp-ri</artifactId>
                 <version>1.4.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>${json-org-version}</version>
             </dependency>
 
             <!-- logging -->


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19695 for (3.22)

## Motivation

The component `camel-google-bigquery` indirectly depends on `org.json:json:jar:20200518:compile` which has a know CVE https://nvd.nist.gov/vuln/detail/CVE-2022-45688 that can be fixed by upgrading it to `20230227` or higher.

## Modifications:

* Add `org.json:json:20230618` to the dependencyManagement section
* Replace `org.json:json:20200518` with `org.json:json:20230618` in `camel-google-bigquery`
