### PR TITLE
(chores) ci: remove the checkstyle stage

### DIFF
--- a/Jenkinsfile.jdk17
+++ b/Jenkinsfile.jdk17
@@ -62,12 +62,6 @@ pipeline {
             }
         }
 
-        stage('Checks') {
-            steps {
-                sh "./mvnw $MAVEN_PARAMS -Darchetype.test.skip -Psourcecheck -Dcheckstyle.failOnViolation=false checkstyle:check"
-            }
-        }
-
         stage('Code Quality Review') {
             steps {
                 withCredentials([string(credentialsId: 'apache-camel-core', variable: 'SONAR_TOKEN')]) {

--- a/Jenkinsfile.ppc64le
+++ b/Jenkinsfile.ppc64le
@@ -71,12 +71,6 @@ pipeline {
             }
         }
 
-        stage('Checks') {
-            steps {
-                sh "./mvnw $MAVEN_PARAMS -Darchetype.test.skip -Psourcecheck -Dcheckstyle.failOnViolation=false checkstyle:check"
-            }
-        }
-
         stage('Test') {
             steps {
                 timeout(unit: 'HOURS', time: 7) {

--- a/Jenkinsfile.s390x
+++ b/Jenkinsfile.s390x
@@ -71,12 +71,6 @@ pipeline {
             }
         }
 
-        stage('Checks') {
-            steps {
-                sh "./mvnw $MAVEN_PARAMS -Darchetype.test.skip -Psourcecheck -Dcheckstyle.failOnViolation=false checkstyle:check"
-            }
-        }
-
         stage('Test') {
             steps {
                 timeout(unit: 'HOURS', time: 7) {


### PR DESCRIPTION
The code is now auto-formatted by default and this prints a lot of bogus output