### PR TITLE
bump zookeeper version to 3.9.0

### DIFF
--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/AvailablePortFinder.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/AvailablePortFinder.java
@@ -21,6 +21,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -128,6 +129,21 @@ public final class AvailablePortFinder {
      */
     public static int getNextAvailable() {
         try (Port port = INSTANCE.findPort()) {
+            return port.getPort();
+        }
+    }
+
+    /**
+     * Gets the next available port.
+     *
+     * @throws IllegalStateException if there are no ports available
+     * @return                       the available port
+     */
+    public static int getNextRandomAvailable() {
+        Random random = new Random();
+        int fromPort = random.nextInt(10000, 65500);
+        int toPort = random.nextInt(fromPort, 65500);
+        try (Port port = INSTANCE.findPort(fromPort, toPort)) {
             return port.getPort();
         }
     }

--- a/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/group/GroupIT.java
+++ b/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/group/GroupIT.java
@@ -117,7 +117,7 @@ public class GroupIT {
 
     @Test
     public void testOrder() throws Exception {
-        int port = AvailablePortFinder.getNextAvailable();
+        int port = AvailablePortFinder.getNextRandomAvailable();
 
         CuratorFramework curator = CuratorFrameworkFactory.builder()
                 .connectString("localhost:" + port)
@@ -179,7 +179,7 @@ public class GroupIT {
 
     @Test
     public void testJoinAfterConnect() throws Exception {
-        int port = AvailablePortFinder.getNextAvailable();
+        int port = AvailablePortFinder.getNextRandomAvailable();
 
         CuratorFramework curator = CuratorFrameworkFactory.builder()
                 .connectString("localhost:" + port)
@@ -229,7 +229,7 @@ public class GroupIT {
 
     @Test
     public void testJoinBeforeConnect() throws Exception {
-        int port = AvailablePortFinder.getNextAvailable();
+        int port = AvailablePortFinder.getNextRandomAvailable();
 
         CuratorFramework curator = CuratorFrameworkFactory.builder()
                 .connectString("localhost:" + port)
@@ -273,7 +273,7 @@ public class GroupIT {
 
     @Test
     public void testRejoinAfterDisconnect() throws Exception {
-        int port = AvailablePortFinder.getNextAvailable();
+        int port = AvailablePortFinder.getNextRandomAvailable();
 
         CuratorFramework curator = CuratorFrameworkFactory.builder()
                 .connectString("localhost:" + port)
@@ -332,7 +332,7 @@ public class GroupIT {
     //(see  https://github.com/jboss-fuse/fuse/issues/133)
     @Test
     public void testGroupClose() throws Exception {
-        int port = AvailablePortFinder.getNextAvailable();
+        int port = AvailablePortFinder.getNextRandomAvailable();
         ZooKeeperContainer container = null;
         Path dataDir = Files.createTempDirectory("zk-");
 
@@ -380,7 +380,7 @@ public class GroupIT {
     @Test
     public void testAddFieldIgnoredOnParse() throws Exception {
 
-        int port = AvailablePortFinder.getNextAvailable();
+        int port = AvailablePortFinder.getNextRandomAvailable();
         ZooKeeperContainer container = null;
         Path dataDir = Files.createTempDirectory("zk-");
 

--- a/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/group/internal/ZooKeeperGroupTest.java
+++ b/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/group/internal/ZooKeeperGroupTest.java
@@ -45,7 +45,7 @@ public class ZooKeeperGroupTest {
     private ZooKeeperGroup<NodeState> group;
 
     private int findFreePort() {
-        return AvailablePortFinder.getNextAvailable();
+        return AvailablePortFinder.getNextRandomAvailable();
     }
 
     @BeforeEach

--- a/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/cloud/integration/ZooKeeperServiceCallRouteIT.java
+++ b/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/cloud/integration/ZooKeeperServiceCallRouteIT.java
@@ -80,7 +80,7 @@ public class ZooKeeperServiceCallRouteIT extends CamelTestSupport {
             ServiceInstance<MetaData> instance
                     = ServiceInstance.<MetaData> builder()
                             .address("127.0.0.1")
-                            .port(AvailablePortFinder.getNextAvailable())
+                            .port(AvailablePortFinder.getNextRandomAvailable())
                             .name(SERVICE_NAME)
                             .id("service-" + i)
                             .build();

--- a/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/cloud/integration/ZooKeeperServiceDiscoveryIT.java
+++ b/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/cloud/integration/ZooKeeperServiceDiscoveryIT.java
@@ -69,7 +69,7 @@ class ZooKeeperServiceDiscoveryIT {
                     ServiceInstance<MetaData> instance
                             = ServiceInstance.<MetaData> builder()
                                     .address("127.0.0.1")
-                                    .port(AvailablePortFinder.getNextAvailable())
+                                    .port(AvailablePortFinder.getNextRandomAvailable())
                                     .name("my-service")
                                     .id("service-" + i)
                                     .build();

--- a/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/cloud/integration/ZooKeeperServiceRegistrationITBase.java
+++ b/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/cloud/integration/ZooKeeperServiceRegistrationITBase.java
@@ -49,7 +49,7 @@ public abstract class ZooKeeperServiceRegistrationITBase extends CamelTestSuppor
     protected static final String SERVICE_NAME = "my-service";
     protected static final String SERVICE_HOST = "localhost";
     protected static final String SERVICE_PATH = "/camel";
-    protected static final int SERVICE_PORT = AvailablePortFinder.getNextAvailable();
+    protected static final int SERVICE_PORT = AvailablePortFinder.getNextRandomAvailable();
 
     protected ZooKeeperContainer container;
     protected CuratorFramework curator;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -476,7 +476,7 @@
         <yetus-audience-annotations-version>0.14.1</yetus-audience-annotations-version>
         <zeebe.version>8.2.11</zeebe.version>
         <zendesk-client-version>0.23.0</zendesk-client-version>
-        <zookeeper-version>3.8.2</zookeeper-version>
+        <zookeeper-version>3.9.0</zookeeper-version>
         <zxing-version>3.5.2</zxing-version>
     </properties>
 


### PR DESCRIPTION
The zookeeper tests were flaky because the nextAvailablePort was picked but the server is started later in the test, therefore there are case were the same port would be picked, that is why getNextRandomAvailable was created.