### PR TITLE
(chores) camel-aws2-sqs: fixed flaky test SqsBatchConsumerConcurrentConsumersIT

### DIFF
--- a/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/SqsBatchConsumerConcurrentConsumersIT.java
+++ b/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/SqsBatchConsumerConcurrentConsumersIT.java
@@ -31,7 +31,7 @@ public class SqsBatchConsumerConcurrentConsumersIT extends CamelTestSupport {
 
     @Test
     public void receiveBatch() throws Exception {
-        mock.expectedMessageCount(5);
+        mock.expectedMinimumMessageCount(5);
         MockEndpoint.assertIsSatisfied(context);
     }
 


### PR DESCRIPTION
On some systems, there's a chance that the concurrent consumers will round-robin and, as such, consume all messages sent. Nonetheless, they would still be consumed in batches.