### PR TITLE
Camel-19627: paho-mqtt5 allow optional password when username provided

### DIFF
--- a/components/camel-paho-mqtt5/src/main/java/org/apache/camel/component/paho/mqtt5/PahoMqtt5Endpoint.java
+++ b/components/camel-paho-mqtt5/src/main/java/org/apache/camel/component/paho/mqtt5/PahoMqtt5Endpoint.java
@@ -85,9 +85,11 @@ public class PahoMqtt5Endpoint extends DefaultEndpoint {
     protected MqttConnectionOptions createMqttConnectionOptions() {
         PahoMqtt5Configuration config = getConfiguration();
         MqttConnectionOptions options = new MqttConnectionOptions();
-        if (ObjectHelper.isNotEmpty(config.getUserName()) && ObjectHelper.isNotEmpty(config.getPassword())) {
+        if (ObjectHelper.isNotEmpty(config.getUserName())) {
             options.setUserName(config.getUserName());
-            options.setPassword(config.getPassword().getBytes());
+            if (ObjectHelper.isNotEmpty(config.getPassword())) {
+                options.setPassword(config.getPassword().getBytes());
+            }
         }
         options.setAutomaticReconnect(config.isAutomaticReconnect());
         options.setCleanStart(config.isCleanStart());

--- a/components/camel-paho-mqtt5/src/test/java/org/apache/camel/component/paho/mqtt5/PahoMqtt5ComponentMqtt5Test.java
+++ b/components/camel-paho-mqtt5/src/test/java/org/apache/camel/component/paho/mqtt5/PahoMqtt5ComponentMqtt5Test.java
@@ -77,7 +77,7 @@ public class PahoMqtt5ComponentMqtt5Test extends PahoMqtt5TestSupport {
 
     @Test
     public void checkUserNameOnly() {
-        String uri = "paho-mqtt5:/test/topic" + "?brokerUrl=tcp://localhost:" + mqttPort + "&userName=test";
+        String uri = "paho-mqtt5:/test/topic?brokerUrl=tcp://localhost:" + mqttPort + "&userName=test";
 
         PahoMqtt5Endpoint endpoint = getMandatoryEndpoint(uri, PahoMqtt5Endpoint.class);
 
@@ -86,8 +86,8 @@ public class PahoMqtt5ComponentMqtt5Test extends PahoMqtt5TestSupport {
 
     @Test
     public void checkUserNameAndPassword() {
-        String uri = "paho-mqtt5:/test/topic" + "?brokerUrl=tcp://localhost:" + mqttPort
-                     + "&userName=test" + "&password=testpass";
+        String uri = "paho-mqtt5:/test/topic?brokerUrl=tcp://localhost:" + mqttPort
+                     + "&userName=test&password=testpass";
 
         PahoMqtt5Endpoint endpoint = getMandatoryEndpoint(uri, PahoMqtt5Endpoint.class);
 

--- a/components/camel-paho-mqtt5/src/test/java/org/apache/camel/component/paho/mqtt5/PahoMqtt5ComponentMqtt5Test.java
+++ b/components/camel-paho-mqtt5/src/test/java/org/apache/camel/component/paho/mqtt5/PahoMqtt5ComponentMqtt5Test.java
@@ -53,7 +53,8 @@ public class PahoMqtt5ComponentMqtt5Test extends PahoMqtt5TestSupport {
                         .to("mock:persistenceTest");
 
                 from("direct:testCustomizedPaho").to("customizedPaho:testCustomizedPaho?brokerUrl=tcp://localhost:" + mqttPort);
-                from("paho-mqtt5:testCustomizedPaho?brokerUrl=tcp://localhost:" + mqttPort).to("mock:testCustomizedPaho");
+                from("paho-mqtt5:testCustomizedPaho?brokerUrl=tcp://localhost:" + mqttPort + "&userName=test")
+                        .to("mock:testCustomizedPaho");
             }
         };
     }
@@ -63,7 +64,7 @@ public class PahoMqtt5ComponentMqtt5Test extends PahoMqtt5TestSupport {
     @Test
     public void checkOptions() {
         String uri = "paho-mqtt5:/test/topic" + "?clientId=sampleClient" + "&brokerUrl=tcp://localhost:" + mqttPort + "&qos=2"
-                     + "&persistence=file";
+                     + "&persistence=file" + "&userName=test";
 
         PahoMqtt5Endpoint endpoint = getMandatoryEndpoint(uri, PahoMqtt5Endpoint.class);
 
@@ -73,6 +74,26 @@ public class PahoMqtt5ComponentMqtt5Test extends PahoMqtt5TestSupport {
         assertEquals("tcp://localhost:" + mqttPort, endpoint.getConfiguration().getBrokerUrl());
         assertEquals(2, endpoint.getConfiguration().getQos());
         assertEquals(PahoMqtt5Persistence.FILE, endpoint.getConfiguration().getPersistence());
+    }
+
+    @Test
+    public void checkUserNameOnly() {
+        String uri = "paho-mqtt5:/test/topic" + "?brokerUrl=tcp://localhost:" + mqttPort + "&userName=test";
+
+        PahoMqtt5Endpoint endpoint = getMandatoryEndpoint(uri, PahoMqtt5Endpoint.class);
+
+        assertEquals("test", endpoint.getConfiguration().getUserName());
+    }
+
+    @Test
+    public void checkUserNameAndPassword() {
+        String uri = "paho-mqtt5:/test/topic" + "?brokerUrl=tcp://localhost:" + mqttPort
+                     + "&userName=test" + "&password=testpass";
+
+        PahoMqtt5Endpoint endpoint = getMandatoryEndpoint(uri, PahoMqtt5Endpoint.class);
+
+        assertEquals("test", endpoint.getConfiguration().getUserName());
+        assertEquals("testpass", endpoint.getConfiguration().getPassword());
     }
 
     @Test

--- a/components/camel-paho-mqtt5/src/test/java/org/apache/camel/component/paho/mqtt5/PahoMqtt5ComponentMqtt5Test.java
+++ b/components/camel-paho-mqtt5/src/test/java/org/apache/camel/component/paho/mqtt5/PahoMqtt5ComponentMqtt5Test.java
@@ -53,8 +53,7 @@ public class PahoMqtt5ComponentMqtt5Test extends PahoMqtt5TestSupport {
                         .to("mock:persistenceTest");
 
                 from("direct:testCustomizedPaho").to("customizedPaho:testCustomizedPaho?brokerUrl=tcp://localhost:" + mqttPort);
-                from("paho-mqtt5:testCustomizedPaho?brokerUrl=tcp://localhost:" + mqttPort + "&userName=test")
-                        .to("mock:testCustomizedPaho");
+                from("paho-mqtt5:testCustomizedPaho?brokerUrl=tcp://localhost:" + mqttPort).to("mock:testCustomizedPaho");
             }
         };
     }
@@ -64,7 +63,7 @@ public class PahoMqtt5ComponentMqtt5Test extends PahoMqtt5TestSupport {
     @Test
     public void checkOptions() {
         String uri = "paho-mqtt5:/test/topic" + "?clientId=sampleClient" + "&brokerUrl=tcp://localhost:" + mqttPort + "&qos=2"
-                     + "&persistence=file" + "&userName=test";
+                     + "&persistence=file";
 
         PahoMqtt5Endpoint endpoint = getMandatoryEndpoint(uri, PahoMqtt5Endpoint.class);
 


### PR DESCRIPTION

Allow a username without password for the paho-mqtt5 component.