### PR TITLE
[CAMEL-19736] Add 'secret' as sensitive key for logging purposes.

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/SensitiveUtils.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/SensitiveUtils.java
@@ -81,6 +81,7 @@ public final class SensitiveUtils {
                     "sascredential",
                     "sasljaasconfig",
                     "sassignature",
+                    "secret",
                     "secretkey",
                     "securerandom",
                     "sharedaccesskey",

--- a/core/camel-util/src/test/java/org/apache/camel/util/SensitiveUtilsTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/SensitiveUtilsTest.java
@@ -35,6 +35,7 @@ class SensitiveUtilsTest {
         assertTrue(SensitiveUtils.containsSensitive("sasljaasconfig"));
         assertTrue(SensitiveUtils.containsSensitive("sasl-jaas-config"));
         assertTrue(SensitiveUtils.containsSensitive("saslJaasConfig"));
+        assertTrue(SensitiveUtils.containsSensitive("secret"));
         assertTrue(SensitiveUtils.containsSensitive("secretkey"));
         assertTrue(SensitiveUtils.containsSensitive("secret-key"));
         assertTrue(SensitiveUtils.containsSensitive("secretKey"));


### PR DESCRIPTION
# Description
Add 'secret' as sensitive data for masking purposes in logs.
Often we us 'secret' as (last) part of an environmentVariable especially if that matches the naming convention of an external party to keep easier overview of application & variables.
However these values aren't masked in the logging (as username/password are).

Add 'secret' as potentially sensitive data.

# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [CAMEL-19736](https://issues.apache.org/jira/browse/CAMEL-19736)

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.
- [X] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes