### PR TITLE
fixed bad spelling in whatsapp-component TemplateMessage

### DIFF
--- a/components/camel-whatsapp/src/main/java/org/apache/camel/component/whatsapp/model/TemplateMessage.java
+++ b/components/camel-whatsapp/src/main/java/org/apache/camel/component/whatsapp/model/TemplateMessage.java
@@ -18,13 +18,13 @@ package org.apache.camel.component.whatsapp.model;
 
 import java.util.List;
 
-public class TempalteMessage {
+public class TemplateMessage {
 
     private String name;
     private Language language;
     private List<Component> components;
 
-    public TempalteMessage() {
+    public TemplateMessage() {
     }
 
     public String getName() {

--- a/components/camel-whatsapp/src/main/java/org/apache/camel/component/whatsapp/model/TemplateMessageRequest.java
+++ b/components/camel-whatsapp/src/main/java/org/apache/camel/component/whatsapp/model/TemplateMessageRequest.java
@@ -18,17 +18,17 @@ package org.apache.camel.component.whatsapp.model;
 
 public class TemplateMessageRequest extends BaseMessage {
 
-    private TempalteMessage template;
+    private TemplateMessage template;
 
     public TemplateMessageRequest() {
         setType("template");
     }
 
-    public TempalteMessage getTemplate() {
+    public TemplateMessage getTemplate() {
         return template;
     }
 
-    public void setTemplate(TempalteMessage template) {
+    public void setTemplate(TemplateMessage template) {
         this.template = template;
     }
 


### PR DESCRIPTION
# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->
There is a bad spellig in whatsapp-component class `org.apache.camel.component.whatsapp.model.TempalteMessage`. I have changed the name to `org.apache.camel.component.whatsapp.model.TemplateMessage`.

This is my first contribution to the project.

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

