### PR TITLE
CAMEL-19751: disable misbehaved camel-xchange tests

### DIFF
--- a/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/account/AccountProducerTest.java
+++ b/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/account/AccountProducerTest.java
@@ -21,8 +21,8 @@ import java.util.List;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.xchange.XChangeComponent;
 import org.apache.camel.component.xchange.XChangeTestSupport;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.FundingRecord;
@@ -31,8 +31,7 @@ import org.knowm.xchange.dto.account.Wallet;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
-                          disabledReason = "These tests do no run reliably on the Apache CI")
+@Disabled("See CAMEL-19751 before enabling")
 public class AccountProducerTest extends XChangeTestSupport {
 
     @Override

--- a/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/market/MarketDataProducerTest.java
+++ b/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/market/MarketDataProducerTest.java
@@ -18,16 +18,15 @@ package org.apache.camel.component.xchange.market;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.xchange.XChangeTestSupport;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 
 import static org.apache.camel.component.xchange.XChangeConfiguration.HEADER_CURRENCY_PAIR;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
-                          disabledReason = "These tests do no run reliably on the Apache CI")
+@Disabled("See CAMEL-19751 before enabling")
 public class MarketDataProducerTest extends XChangeTestSupport {
 
     @Override

--- a/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/metadata/MetaDataProducerTest.java
+++ b/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/metadata/MetaDataProducerTest.java
@@ -20,8 +20,8 @@ import java.util.List;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.xchange.XChangeTestSupport;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.meta.CurrencyMetaData;
@@ -32,8 +32,7 @@ import static org.apache.camel.component.xchange.XChangeConfiguration.HEADER_CUR
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
-                          disabledReason = "These tests do no run reliably on the Apache CI")
+@Disabled("See CAMEL-19751 before enabling")
 public class MetaDataProducerTest extends XChangeTestSupport {
 
     @Override


### PR DESCRIPTION
The camel-xchange tests keep hitting the address https://fapi.binance.com/fapi/v1/exchangeInfo which both abuse the owner of the address and contribute to their flakiness.