### PR TITLE
(chores) camel-util: more aggressive micro-optimizations to StringHelper#capitalize

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
@@ -497,15 +497,14 @@ public final class StringHelper {
         }
 
         int length = ret.length();
-        if (length == 0) {
-            return ret;
-        }
+        final char[] chars = new char[length];
+        ret.getChars(0, length, chars, 0);
 
-        String answer = ret.substring(0, 1).toUpperCase(Locale.ENGLISH);
-        if (length > 1) {
-            answer += ret.substring(1, length);
-        }
-        return answer;
+        // We are OK with the limitations of Character.toUpperCase. The symbols and ideographs
+        // for which it does not return the capitalized value should not be used here (this is
+        // mostly used to capitalize setters/getters)
+        chars[0] = Character.toUpperCase(chars[0]);
+        return new String(chars);
     }
 
     /**


### PR DESCRIPTION
Camel 4.0.0
```
Benchmark                                          Mode  Cnt  Score    Error  Units
StringHelperTest.testCapitalize                    avgt   10  0.129 ±  0.001  us/op
StringHelperTest.testDashToCamelCaseNegative       avgt   10  0.144 ±  0.001  us/op
StringHelperTest.testDashToCamelCasePositive       avgt   10  0.141 ±  0.002  us/op
```

Camel 4.1.0-SNAPSHOT
```
Benchmark                                          Mode  Cnt  Score    Error  Units
StringHelperTest.testCapitalize                    avgt   10  0.035 ±  0.001  us/op
StringHelperTest.testDashToCamelCaseNegative       avgt   10  0.021 ±  0.001  us/op
StringHelperTest.testDashToCamelCasePositive       avgt   10  0.029 ±  0.001  us/op
```