### PR TITLE
CAMEL-19741: applied concurrency configuration to pom file

### DIFF
--- a/components/camel-sjms/pom.xml
+++ b/components/camel-sjms/pom.xml
@@ -32,7 +32,12 @@
     <description>A pure Java JMS Camel Component</description>
 
     <properties>
-        <camel.surefire.forkTimeout>6000</camel.surefire.forkTimeout>
+        <camel.surefire.reuseForks>true</camel.surefire.reuseForks>
+        <camel.surefire.forkCount>1</camel.surefire.forkCount>
+        <camel.surefire.forkTimeout>1200</camel.surefire.forkTimeout>
+        <camel.surefire.parallel>true</camel.surefire.parallel>
+        <camel.surefire.parallel.factor>0.5</camel.surefire.parallel.factor>
+        <camel.surefire.fork.additional-vmargs>-Xmx1G</camel.surefire.fork.additional-vmargs>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Decreased  surefire.parallel.factor from 1 to 0.5 because it crashed on CI tests 
