### PR TITLE
(chores) camel-util: simplify StringHelper camelCaseToDash

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
@@ -1039,22 +1039,24 @@ public final class StringHelper {
             if (ch == '-' || ch == '_') {
                 answer.append("-");
             } else if (Character.isUpperCase(ch) && prev != null && !Character.isUpperCase(prev)) {
-                if (prev != '-' && prev != '_') {
-                    answer.append("-");
-                }
-                answer.append(ch);
+                applyDashPrefix(prev, answer, ch);
             } else if (Character.isUpperCase(ch) && prev != null && next != null && Character.isLowerCase(next)) {
-                if (prev != '-' && prev != '_') {
-                    answer.append("-");
-                }
-                answer.append(ch);
+                applyDashPrefix(prev, answer, ch);
             } else {
-                answer.append(ch);
+                answer.append(Character.toLowerCase(ch));
             }
             prev = ch;
         }
 
-        return answer.toString().toLowerCase(Locale.ENGLISH);
+
+        return answer.toString();
+    }
+
+    private static void applyDashPrefix(Character prev, StringBuilder answer, char ch) {
+        if (prev != '-' && prev != '_') {
+            answer.append("-");
+        }
+        answer.append(Character.toLowerCase(ch));
     }
 
     /**


### PR DESCRIPTION
Avoid the overhead of creating multiple String objects by lower casing on the fly

Camel 4.0.0
```
Benchmark                                           Mode  Cnt  Score    Error  Units
StringHelperTest.testCamelCaseToDashNegative        avgt   10  0.112 ±  0.001  us/op
StringHelperTest.testCamelCaseToDashPositive        avgt   10  0.236 ±  0.001  us/op
```

Camel 4.1.0-SNAPSHOT
```
Benchmark                                           Mode  Cnt  Score    Error  Units
StringHelperTest.testCamelCaseToDashNegative        avgt   10  0.111 ±  0.001  us/op
StringHelperTest.testCamelCaseToDashPositive        avgt   10  0.177 ±  0.001  us/op
```