### PR TITLE
Refactor assertTrue(!) with assertFalse & Add explanatory messages

### DIFF
--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/RawMailMessageTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/RawMailMessageTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Unit test for Mail using camel headers to set recipient subject.
@@ -84,7 +84,7 @@ public class RawMailMessageTest extends CamelTestSupport {
         // START SNIPPET: e1
         // get access to the raw jakarta.mail.Message as shown below
         Message javaMailMessage = exchange.getIn(MailMessage.class).getMessage();
-        assertNotNull(javaMailMessage);
+        assertNotNull("The mail message should not be null", javaMailMessage);
 
         assertEquals("Camel rocks", javaMailMessage.getSubject());
         // END SNIPPET: e1
@@ -102,7 +102,7 @@ public class RawMailMessageTest extends CamelTestSupport {
 
     private void testRawMessageConsumer(String type, MailboxUser user) throws Exception {
         Mailbox mailboxRaw = user.getInbox();
-        assertEquals(1, mailboxRaw.getMessageCount());
+        assertEquals("expected 1 message in the mailbox", 1, mailboxRaw.getMessageCount());
 
         MockEndpoint mock = getMockEndpoint("mock://rawMessage" + type);
         mock.expectedMessageCount(1);
@@ -115,8 +115,8 @@ public class RawMailMessageTest extends CamelTestSupport {
         assertEquals("hurz", mailMessage.getSubject(), "mail subject should be hurz");
 
         Map<String, Object> headers = mock.getExchanges().get(0).getIn().getHeaders();
-        assertNotNull(headers);
-        assertTrue(!headers.isEmpty());
+        assertNotNull("headers should not be null", headers);
+        assertFalse("headers should not be empty", headers.isEmpty());
     }
 
     @Test
@@ -131,7 +131,7 @@ public class RawMailMessageTest extends CamelTestSupport {
 
     private void testNormalMessageConsumer(String type, MailboxUser user) throws Exception {
         Mailbox mailbox = user.getInbox();
-        assertEquals(1, mailbox.getMessageCount());
+        assertEquals("expected 1 message in the mailbox", 1, mailbox.getMessageCount());
 
         MockEndpoint mock = getMockEndpoint("mock://normalMessage" + type);
         mock.expectedMessageCount(1);
@@ -145,8 +145,8 @@ public class RawMailMessageTest extends CamelTestSupport {
         assertNull(subject, "mail subject should not be available");
 
         Map<String, Object> headers = mock.getExchanges().get(0).getIn().getHeaders();
-        assertNotNull(headers);
-        assertTrue(!headers.isEmpty());
+        assertNotNull("headers should not be null", headers);
+        assertFalse("headers should not be empty", headers.isEmpty());
     }
 
     private void prepareMailbox(MailboxUser user) throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/RawMailMessageTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/RawMailMessageTest.java
@@ -84,7 +84,7 @@ public class RawMailMessageTest extends CamelTestSupport {
         // START SNIPPET: e1
         // get access to the raw jakarta.mail.Message as shown below
         Message javaMailMessage = exchange.getIn(MailMessage.class).getMessage();
-        assertNotNull("The mail message should not be null", javaMailMessage);
+        assertNotNull(javaMailMessage, "The mail message should not be null");
 
         assertEquals("Camel rocks", javaMailMessage.getSubject());
         // END SNIPPET: e1
@@ -102,7 +102,7 @@ public class RawMailMessageTest extends CamelTestSupport {
 
     private void testRawMessageConsumer(String type, MailboxUser user) throws Exception {
         Mailbox mailboxRaw = user.getInbox();
-        assertEquals("expected 1 message in the mailbox", 1, mailboxRaw.getMessageCount());
+        assertEquals(1, mailboxRaw.getMessageCount(), "expected 1 message in the mailbox");
 
         MockEndpoint mock = getMockEndpoint("mock://rawMessage" + type);
         mock.expectedMessageCount(1);
@@ -115,8 +115,8 @@ public class RawMailMessageTest extends CamelTestSupport {
         assertEquals("hurz", mailMessage.getSubject(), "mail subject should be hurz");
 
         Map<String, Object> headers = mock.getExchanges().get(0).getIn().getHeaders();
-        assertNotNull("headers should not be null", headers);
-        assertFalse("headers should not be empty", headers.isEmpty());
+        assertNotNull(headers, "headers should not be null");
+        assertFalse(headers.isEmpty(), "headers should not be empty");
     }
 
     @Test
@@ -131,7 +131,7 @@ public class RawMailMessageTest extends CamelTestSupport {
 
     private void testNormalMessageConsumer(String type, MailboxUser user) throws Exception {
         Mailbox mailbox = user.getInbox();
-        assertEquals("expected 1 message in the mailbox", 1, mailbox.getMessageCount());
+        assertEquals(1, mailbox.getMessageCount(), "expected 1 message in the mailbox");
 
         MockEndpoint mock = getMockEndpoint("mock://normalMessage" + type);
         mock.expectedMessageCount(1);
@@ -145,8 +145,8 @@ public class RawMailMessageTest extends CamelTestSupport {
         assertNull(subject, "mail subject should not be available");
 
         Map<String, Object> headers = mock.getExchanges().get(0).getIn().getHeaders();
-        assertNotNull("headers should not be null", headers);
-        assertFalse("headers should not be empty", headers.isEmpty());
+        assertNotNull(headers, "headers should not be null");
+        assertFalse(headers.isEmpty(), "headers should not be empty");
     }
 
     private void prepareMailbox(MailboxUser user) throws Exception {


### PR DESCRIPTION
I am working on research that investigates test smell refactoring in which we identify alternative implementations of test cases, study how commonly used these refactorings are, and assess how acceptable they are in practice.

The first smell is when inappropriate assertions are used, while there exist better alternatives. For example, in [RawMailMessageTest.java](https://github.com/apache/camel/commit/f777f422ea24b21022a89d6a425f5ed0f211b8ea#diff-04960f3b28d9765e85f40286d286eee23603cb949def41f69a79b7af1a65fb0a), I refactored `assertTrue(!headers.isEmpty());` using `assertFalse(headers.isEmpty());` instead.

The second smell is known as Assertion Roulette, where a test method has multiple asserts and some or all of them have no explanatory messages, which can sometimes make it difficult to identify which assert has failed. Therefore, I made all asserts in the test methods in [RawMailMessageTest.java](https://github.com/apache/camel/commit/f777f422ea24b21022a89d6a425f5ed0f211b8ea#diff-04960f3b28d9765e85f40286d286eee23603cb949def41f69a79b7af1a65fb0a) have exploratory messages.

I would like to get your feedback on these particular test smells and their refactorings. Thanks in advance for your input.