### PR TITLE
chore: Align json-schema-validator for camel-yaml-dsl tests to what i…

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/pom.xml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/pom.xml
@@ -212,9 +212,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.java-json-tools</groupId>
+            <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>${json-schema-validator-version}</version>
+            <version>${networknt-json-schema-validator-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/support/YamlTestSupport.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/support/YamlTestSupport.groovy
@@ -18,8 +18,8 @@ package org.apache.camel.dsl.yaml.support
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.github.fge.jackson.JsonLoader
-import com.github.fge.jsonschema.main.JsonSchemaFactory
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersionDetector
 import groovy.util.logging.Slf4j
 import org.apache.camel.CamelContext
 import org.apache.camel.FluentProducerTemplate
@@ -30,7 +30,6 @@ import org.apache.camel.impl.DefaultCamelContext
 import org.apache.camel.model.RouteTemplateDefinition
 import org.apache.camel.spi.HasCamelContext
 import org.apache.camel.spi.Resource
-import org.apache.camel.spi.ResourceLoader
 import org.apache.camel.support.PluginHelper
 import org.apache.camel.support.ResourceHelper
 import spock.lang.AutoCleanup
@@ -41,8 +40,9 @@ import java.nio.charset.StandardCharsets
 @Slf4j
 class YamlTestSupport extends Specification implements HasCamelContext {
     static def MAPPER = new ObjectMapper(new YAMLFactory())
-    static def SCHEMA_RES = JsonLoader.fromResource('/schema/camel-yaml-dsl.json')
-    static def SCHEMA = JsonSchemaFactory.byDefault().getJsonSchema(SCHEMA_RES)
+    static def SCHEMA_NODE = MAPPER.readTree(ResourceHelper.getResourceAsStream('/schema/camel-yaml-dsl.json'));
+    static def FACTORY = JsonSchemaFactory.getInstance(SpecVersionDetector.detect(SCHEMA_NODE));
+    static def SCHEMA = FACTORY.getSchema(SCHEMA_NODE);
 
     @AutoCleanup
     def context = new DefaultCamelContext()
@@ -52,8 +52,7 @@ class YamlTestSupport extends Specification implements HasCamelContext {
             for (def resource : resources) {
                 def target = MAPPER.readTree(resource.inputStream)
                 def report = SCHEMA.validate(target)
-
-                if (!report.isSuccess()) {
+                if (!report.isEmpty()) {
                     throw new IllegalArgumentException("${report}")
                 }
             }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -285,7 +285,6 @@
         <json-patch-version>1.13</json-patch-version>
         <json-smart-version>2.5.0</json-smart-version>
         <jsonata4java-version>2.4.3</jsonata4java-version>
-        <json-schema-validator-version>2.2.14</json-schema-validator-version>
         <json-unit-version>3.0.0</json-unit-version>
         <jsoup-version>1.16.1</jsoup-version>
         <jt400-version>20.0.0</jt400-version>


### PR DESCRIPTION
…s used for camel-json-validator component

# Description
camel-yaml-dsl validation tests use java-json-tools/json-schema-validator which stopped the development in 2020 with JSON schema draft 4. Let's migrate it to networknt/json-schema-validator which is already used for camel-json-validator component and supports newer drafts.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

