### PR TITLE
chore: Allow DataTypeProcessor used as processor definition

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/transformer/DataTypeProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/transformer/DataTypeProcessor.java
@@ -72,7 +72,7 @@ public class DataTypeProcessor implements Processor {
         DataType fromDataType = DataType.ANY;
         if (fromType != null) {
             fromDataType = new DataType(fromType);
-        } else if (message instanceof DataTypeAware) {
+        } else if (message instanceof DataTypeAware && ((DataTypeAware) message).hasDataType()) {
             fromDataType = ((DataTypeAware) message).getDataType();
         }
 

--- a/core/camel-management/src/main/java/org/apache/camel/management/DefaultManagementObjectStrategy.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/DefaultManagementObjectStrategy.java
@@ -439,7 +439,7 @@ public class DefaultManagementObjectStrategy implements ManagementObjectStrategy
                 answer = new ManagedThrowException(context, (ThrowExceptionProcessor) target, definition);
             } else if (target instanceof TransformProcessor) {
                 answer = new ManagedTransformer(context, target, (TransformDefinition) definition);
-            } else if (target instanceof DataTypeProcessor) {
+            } else if (target instanceof DataTypeProcessor && definition instanceof TransformDefinition) {
                 answer = new ManagedTransformer(context, target, (TransformDefinition) definition);
             } else if (target instanceof PredicateValidatingProcessor) {
                 answer = new ManagedValidate(context, (PredicateValidatingProcessor) target, (ValidateDefinition) definition);


### PR DESCRIPTION
# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

- Avoid ClassCastException when DataTypeProcessor is used as part of a ProcessorDefinition
- Allows users to reference the DataTypeProcessor as a normal processor in a route as an addition to using it in TransformDefinition
