### PR TITLE
CAMEL-19798: Consistently set camel-kamelets version in Camel JBang

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.apache.camel.dsl.jbang.core.common.RuntimeCompletionCandidates;
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
+import org.apache.camel.dsl.jbang.core.common.VersionHelper;
 import org.apache.camel.tooling.maven.MavenGav;
 import org.apache.camel.util.CamelCaseOrderedProperties;
 import org.apache.camel.util.FileUtil;
@@ -108,7 +109,7 @@ abstract class ExportBaseCommand extends CamelCommand {
     protected String camelVersion;
 
     @CommandLine.Option(names = {
-            "--kamelets-version" }, description = "Apache Camel Kamelets version", defaultValue = "4.0.0-RC1")
+            "--kamelets-version" }, description = "Apache Camel Kamelets version")
     protected String kameletsVersion;
 
     @CommandLine.Option(names = { "--local-kamelet-dir" },
@@ -280,6 +281,10 @@ abstract class ExportBaseCommand extends CamelCommand {
             }
             return o1.compareTo(o2);
         });
+
+        if (kameletsVersion == null) {
+            kameletsVersion = VersionHelper.extractKameletsVersion();
+        }
 
         // custom dependencies
         if (dependencies != null) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Init.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Init.java
@@ -26,6 +26,7 @@ import java.util.StringJoiner;
 import org.apache.camel.CamelContext;
 import org.apache.camel.dsl.jbang.core.commands.catalog.KameletCatalogHelper;
 import org.apache.camel.dsl.jbang.core.common.ResourceDoesNotExist;
+import org.apache.camel.dsl.jbang.core.common.VersionHelper;
 import org.apache.camel.github.GistResourceResolver;
 import org.apache.camel.github.GitHubResourceResolver;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -60,7 +61,7 @@ public class Init extends CamelCommand {
     private String fromKamelet;
 
     @Option(names = {
-            "--kamelets-version" }, description = "Apache Camel Kamelets version", defaultValue = "4.0.0-RC1")
+            "--kamelets-version" }, description = "Apache Camel Kamelets version")
     private String kameletsVersion;
 
     @Option(names = { "--integration" },
@@ -95,6 +96,9 @@ public class Init extends CamelCommand {
         InputStream is = null;
         if ("kamelet.yaml".equals(ext)) {
             if (fromKamelet != null) {
+                if (kameletsVersion == null) {
+                    kameletsVersion = VersionHelper.extractKameletsVersion();
+                }
                 // load existing kamelet
                 is = KameletCatalogHelper.loadKameletYamlSchema(fromKamelet, kameletsVersion);
             } else if (file.contains("source")) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -130,6 +130,9 @@ public class Run extends CamelCommand {
     @Option(names = { "--camel-version" }, description = "To run using a different Camel version than the default version.")
     String camelVersion;
 
+    @Option(names = { "--kamelets-version" }, description = "Apache Camel Kamelets version")
+    String kameletsVersion;
+
     @Option(names = { "--profile" }, scope = CommandLine.ScopeType.INHERIT, defaultValue = "application",
             description = "Profile to use, which refers to loading properties file with the given profile name. By default application.properties is loaded.")
     String profile;
@@ -482,6 +485,8 @@ public class Run extends CamelCommand {
         writeSetting(main, profileProperties, "camel.jbang.jfr", jfr || jfrProfile != null ? "jfr" : null); // TODO: "true" instead of "jfr" ?
         writeSetting(main, profileProperties, "camel.jbang.jfr-profile", jfrProfile != null ? jfrProfile : null);
 
+        writeSetting(main, profileProperties, "camel.jbang.kameletsVersion", kameletsVersion);
+
         StringJoiner js = new StringJoiner(",");
         StringJoiner sjReload = new StringJoiner(",");
         StringJoiner sjClasspathFiles = new StringJoiner(",");
@@ -750,8 +755,13 @@ public class Run extends CamelCommand {
             background = "true".equals(answer.getProperty("camel.jbang.background", background ? "true" : "false"));
             jvmDebug = "true".equals(answer.getProperty("camel.jbang.jvmDebug", jvmDebug ? "true" : "false"));
             camelVersion = answer.getProperty("camel.jbang.camel-version", camelVersion);
+            kameletsVersion = answer.getProperty("camel.jbang.kameletsVersion", kameletsVersion);
             gav = answer.getProperty("camel.jbang.gav", gav);
             stub = answer.getProperty("camel.jbang.stub", stub);
+        }
+
+        if (kameletsVersion == null) {
+            kameletsVersion = VersionHelper.extractKameletsVersion();
         }
         return answer;
     }
@@ -766,12 +776,18 @@ public class Run extends CamelCommand {
         if (camelVersion != null) {
             cmds.remove("--camel-version=" + camelVersion);
         }
+        if (kameletsVersion != null) {
+            cmds.remove("--kamelets-version=" + kameletsVersion);
+        }
         // need to use jbang command to specify camel version
         List<String> jbangArgs = new ArrayList<>();
         jbangArgs.add("jbang");
         jbangArgs.add("run");
         if (camelVersion != null) {
             jbangArgs.add("-Dcamel.jbang.version=" + camelVersion);
+        }
+        if (kameletsVersion != null) {
+            jbangArgs.add("-Dcamel-kamelets.version=" + kameletsVersion);
         }
         if (jvmDebug) {
             jbangArgs.add("--debug"); // jbang --debug
@@ -847,6 +863,10 @@ public class Run extends CamelCommand {
         }
         content = content.replaceFirst("\\{\\{ \\.CamelJBangDependencies }}", sb.toString());
 
+        sb = new StringBuilder();
+        sb.append(String.format("//DEPS org.apache.camel.kamelets:camel-kamelets:%s\n", kameletsVersion));
+        content = content.replaceFirst("\\{\\{ \\.CamelKameletsDependencies }}", sb.toString());
+
         String fn = WORK_DIR + "/CustomCamelJBang.java";
         Files.write(Paths.get(fn), content.getBytes(StandardCharsets.UTF_8));
 
@@ -864,6 +884,7 @@ public class Run extends CamelCommand {
         }
 
         cmds.remove("--camel-version=" + camelVersion);
+        cmds.remove("--kamelets-version=" + kameletsVersion);
         // need to use jbang command to specify camel version
         List<String> jbangArgs = new ArrayList<>();
         jbangArgs.add("jbang");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogKamelet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogKamelet.java
@@ -29,6 +29,7 @@ import com.github.freva.asciitable.Column;
 import com.github.freva.asciitable.HorizontalAlign;
 import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.common.VersionHelper;
 import org.apache.camel.main.download.DependencyDownloaderClassLoader;
 import org.apache.camel.main.download.MavenDependencyDownloader;
 import org.apache.camel.support.ObjectHelper;
@@ -52,7 +53,7 @@ public class CatalogKamelet extends CamelCommand {
     String filterName;
 
     @CommandLine.Option(names = {
-            "--kamelets-version" }, description = "Apache Camel Kamelets version", defaultValue = "4.0.0-RC1")
+            "--kamelets-version" }, description = "Apache Camel Kamelets version")
     String kameletsVersion;
 
     public CatalogKamelet(CamelJBangMain main) {
@@ -62,6 +63,10 @@ public class CatalogKamelet extends CamelCommand {
     @Override
     public Integer doCall() throws Exception {
         List<KameletModel> rows = new ArrayList<>();
+
+        if (kameletsVersion == null) {
+            kameletsVersion = VersionHelper.extractKameletsVersion();
+        }
 
         Map<String, Object> kamelets;
         try {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/VersionHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/VersionHelper.java
@@ -111,4 +111,7 @@ public final class VersionHelper {
         return s.compareTo(t);
     }
 
+    public static String extractKameletsVersion() {
+        return org.apache.camel.main.util.VersionHelper.extractKameletsVersion();
+    }
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/run-custom-camel-version.tmpl
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/run-custom-camel-version.tmpl
@@ -22,7 +22,7 @@
 //REPOS central=https://repo1.maven.org/maven2,apache-snapshot=http://repository.apache.org/content/groups/snapshots/
 {{ .CamelDependencies }}
 {{ .CamelJBangDependencies }}
-//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.0.0-RC1}
+{{ .CamelKameletsDependencies }}
 
 package main;
 

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DependencyDownloaderRoutesLoader.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DependencyDownloaderRoutesLoader.java
@@ -31,10 +31,16 @@ import org.apache.camel.support.service.ServiceHelper;
 public class DependencyDownloaderRoutesLoader extends DefaultRoutesLoader {
 
     private final DependencyDownloader downloader;
+    private final String kameletsVersion;
 
     public DependencyDownloaderRoutesLoader(CamelContext camelContext) {
+        this(camelContext, null);
+    }
+
+    public DependencyDownloaderRoutesLoader(CamelContext camelContext, String kameletsVersion) {
         setCamelContext(camelContext);
         this.downloader = camelContext.hasService(DependencyDownloader.class);
+        this.kameletsVersion = kameletsVersion;
     }
 
     @Override
@@ -65,7 +71,7 @@ public class DependencyDownloaderRoutesLoader extends DefaultRoutesLoader {
         // special for kamelet as we want to track loading kamelets
         RoutesBuilderLoader loader;
         if (KameletRoutesBuilderLoader.EXTENSION.equals(extension)) {
-            loader = new KnownKameletRoutesBuilderLoader();
+            loader = new KnownKameletRoutesBuilderLoader(kameletsVersion);
             CamelContextAware.trySetCamelContext(loader, getCamelContext());
             // allows for custom initialization
             initRoutesBuilderLoader(loader);

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/util/VersionHelper.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/util/VersionHelper.java
@@ -16,9 +16,18 @@
  */
 package org.apache.camel.main.util;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.apache.camel.util.StringHelper;
 
 public final class VersionHelper {
+
+    private static final String KAMELETS_DEFAULT_VERSION = "4.0.0-RC1";
+    private static final Pattern KAMELETS_LIBRARY = Pattern.compile("camel-kamelets-(\\d[A-Z\\d.-]*).jar", Pattern.DOTALL);
+    private static final String CP = System.getProperty("java.class.path");
 
     private VersionHelper() {
     }
@@ -83,4 +92,20 @@ public final class VersionHelper {
         return s.compareTo(t);
     }
 
+    public static String extractKameletsVersion() {
+        Matcher matcher = KAMELETS_LIBRARY.matcher(CP);
+        if (matcher.find() && matcher.groupCount() > 0) {
+            return matcher.group(1);
+        }
+
+        RuntimeMXBean mb = ManagementFactory.getRuntimeMXBean();
+        if (mb != null) {
+            matcher = KAMELETS_LIBRARY.matcher(mb.getClassPath());
+            if (matcher.find() && matcher.groupCount() > 0) {
+                return matcher.group(1);
+            }
+        }
+
+        return KAMELETS_DEFAULT_VERSION;
+    }
 }


### PR DESCRIPTION
# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

The PR improves the camel-kamelets version handling in Camel JBang and makes sure to consistently use the same version in all `camel-kamelets-*` libraries (e.g. camel-kamelets, camel-kamelets-utils, camel-kamelets-catalog, and so on). 

Users either set the version via system properties `-Dcamel-kamelets.version=` or via command line setting `--kamelets-version=` when using Camel JBang. As a fallback the value gets derived from the version used by the library `camel-kamelets` on the current JVM classpath (only when none of the user settings should be set).

- Avoids inconsistent versions on camel-kamelets dependencies (e.g. camel-kamelets-utils library)
- Make sure to use same version for camel-kamelets and camel-kamelets-utils dependency
- Add `--kamelets-version` setting on Camel JBang `run` command
- Propagate camel-kamelets version to KameletMain as initial property and use this version in Kamelet dependency downloader
- Fallback to deriving the camel-kamelets version from classpath only if version has not been set by the user
- Support `camel-kamelets:` prefix when referencing dependencies in Kamelets and Pipe/KameletBinding resources and resolve with proper camel-kamelets version

