### PR TITLE
CAMEL-19811: restore multi-shard handling.

### DIFF
--- a/components/camel-aws/camel-aws2-kinesis/src/test/java/org/apache/camel/component/aws2/kinesis/KinesisConsumerClosedShardWithFailTest.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/test/java/org/apache/camel/component/aws2/kinesis/KinesisConsumerClosedShardWithFailTest.java
@@ -41,7 +41,9 @@ import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -92,6 +94,11 @@ public class KinesisConsumerClosedShardWithFailTest {
 
     @Test
     public void itObtainsAShardIteratorOnFirstPoll() {
+        try {
+            underTest.poll();
+        } catch (Exception e) {
+            fail("The first call should not throw an exception");
+        }
         assertThrows(IllegalStateException.class, () -> {
             underTest.poll();
         });
@@ -106,7 +113,7 @@ public class KinesisConsumerClosedShardWithFailTest {
         assertThat(getShardIteratorReqCap.getValue().shardId(), is("shardId"));
         assertThat(getShardIteratorReqCap.getValue().shardIteratorType(), is(ShardIteratorType.LATEST));
 
-        verify(kinesisClient).listShards(getListShardsCap.capture());
+        verify(kinesisClient, times(2)).listShards(getListShardsCap.capture());
         assertThat(getListShardsCap.getValue().streamName(), is("streamName"));
     }
 }

--- a/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/clients/KinesisUtils.java
+++ b/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/clients/KinesisUtils.java
@@ -57,10 +57,10 @@ public final class KinesisUtils {
 
     }
 
-    private static void doCreateStream(KinesisClient kinesisClient, String streamName) {
+    private static void doCreateStream(KinesisClient kinesisClient, String streamName, int shardCount) {
         CreateStreamRequest request = CreateStreamRequest.builder()
                 .streamName(streamName)
-                .shardCount(1)
+                .shardCount(shardCount)
                 .build();
 
         try {
@@ -78,6 +78,10 @@ public final class KinesisUtils {
     }
 
     public static void createStream(KinesisClient kinesisClient, String streamName) {
+        createStream(kinesisClient, streamName, 1);
+    }
+
+    public static void createStream(KinesisClient kinesisClient, String streamName, int shardCount) {
         try {
             LOG.info("Checking whether the stream exists already");
             int status = getStreamStatus(kinesisClient, streamName);
@@ -89,7 +93,7 @@ public final class KinesisUtils {
                 LOG.info("The stream does not exist, auto creating it: {}", e.getMessage());
             }
 
-            doCreateStream(kinesisClient, streamName);
+            doCreateStream(kinesisClient, streamName, shardCount);
             TestUtils.waitFor(() -> {
                 try {
                     GetRecordsRequest getRecordsRequest = KinesisUtils.getGetRecordsRequest(kinesisClient, streamName);


### PR DESCRIPTION
Adapt the handling of closed streams.
Modify KinesisUtils to be able to create a stream with multiple shards. Modify KinesisConsumerIT to test a stream with 2 shards.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

