### PR TITLE
(chores) camel-core: replace duplicated code

### DIFF
--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaComponent.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaComponent.java
@@ -25,6 +25,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.support.DefaultComponent;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -284,11 +285,7 @@ public class SedaComponent extends DefaultComponent {
     }
 
     public String getQueueKey(String uri) {
-        if (uri.contains("?")) {
-            // strip parameters
-            uri = uri.substring(0, uri.indexOf('?'));
-        }
-        return uri;
+        return StringHelper.before(uri, "?", uri);
     }
 
     @Override

--- a/core/camel-api/src/main/java/org/apache/camel/Endpoint.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Endpoint.java
@@ -19,6 +19,7 @@ package org.apache.camel;
 import java.util.Map;
 
 import org.apache.camel.support.service.ServiceSupport;
+import org.apache.camel.util.StringHelper;
 
 /**
  * An <a href="http://camel.apache.org/endpoint.html">endpoint</a> implements the
@@ -47,11 +48,8 @@ public interface Endpoint extends IsSingleton, Service, ComponentAware {
      */
     default String getEndpointBaseUri() {
         String value = getEndpointUri();
-        int pos = value.indexOf('?');
-        if (pos > 0) {
-            value = value.substring(0, pos);
-        }
-        return value;
+
+        return StringHelper.before(value, "?", value);
     }
 
     /**

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/BasePackageScanResolver.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/BasePackageScanResolver.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
 import org.apache.camel.support.service.ServiceSupport;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -178,10 +179,7 @@ public abstract class BasePackageScanResolver extends ServiceSupport implements 
         }
 
         // Else it's in a JAR, grab the path to the jar
-        if (urlPath.indexOf('!') > 0) {
-            urlPath = urlPath.substring(0, urlPath.indexOf('!'));
-        }
-        return urlPath;
+        return StringHelper.before(urlPath, "!", urlPath);
     }
 
     protected Enumeration<URL> getUrls(String packageName, ClassLoader loader) {

--- a/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/AbstractCamelCatalog.java
+++ b/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/AbstractCamelCatalog.java
@@ -813,10 +813,7 @@ public abstract class AbstractCamelCatalog {
 
     public String endpointComponentName(String uri) {
         if (uri != null) {
-            int idx = uri.indexOf(':');
-            if (idx > 0) {
-                return uri.substring(0, idx);
-            }
+            return StringHelper.before(uri, ":");
         }
         return null;
     }

--- a/core/camel-core/src/test/java/org/apache/camel/builder/xml/XPathTransformTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/builder/xml/XPathTransformTest.java
@@ -24,6 +24,7 @@ import org.w3c.dom.NodeList;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.language.xpath.XPathBuilder;
+import org.apache.camel.util.StringHelper;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -117,15 +118,8 @@ public class XPathTransformTest extends ContextTestSupport {
         if (version.startsWith("1.")) {
             version = version.substring(2, 3);
         } else {
-            int pos = version.indexOf('.');
-            if (pos != -1) {
-                version = version.substring(0, pos);
-            }
-            pos = version.indexOf('-');
-            if (pos != -1) {
-                version = version.substring(0, pos);
-            }
-
+            version = StringHelper.before(version, ".", version);
+            version = StringHelper.before(version, "-", version);
         }
         return Integer.parseInt(version);
     }

--- a/core/camel-management/src/main/java/org/apache/camel/management/DefaultManagementObjectNameStrategy.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/DefaultManagementObjectNameStrategy.java
@@ -59,6 +59,7 @@ import org.apache.camel.spi.ManagementObjectNameStrategy;
 import org.apache.camel.spi.RouteController;
 import org.apache.camel.util.InetAddressUtil;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.URISupport;
 
 /**
@@ -476,8 +477,7 @@ public class DefaultManagementObjectNameStrategy implements ManagementObjectName
         } else {
             // non singleton then add hashcoded id
             String uri = ep.getEndpointKey();
-            int pos = uri.indexOf('?');
-            String id = (pos == -1) ? uri : uri.substring(0, pos);
+            String id = StringHelper.before(uri, "?", uri);
             id += "?id=" + ObjectHelper.getIdentityHashCode(ep);
             return id;
         }

--- a/core/camel-support/src/main/java/org/apache/camel/converter/stream/CipherPair.java
+++ b/core/camel-support/src/main/java/org/apache/camel/converter/stream/CipherPair.java
@@ -24,6 +24,8 @@ import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.spec.IvParameterSpec;
 
+import org.apache.camel.util.StringHelper;
+
 /**
  * A class to hold a pair of encryption and decryption ciphers.
  */
@@ -36,13 +38,7 @@ public class CipherPair {
     public CipherPair(String transformation) throws GeneralSecurityException {
         this.transformation = transformation;
 
-        int d = transformation.indexOf('/');
-        String a;
-        if (d > 0) {
-            a = transformation.substring(0, d);
-        } else {
-            a = transformation;
-        }
+        String a = StringHelper.before(transformation, "/", transformation);
 
         KeyGenerator keygen = KeyGenerator.getInstance(a);
         keygen.init(new SecureRandom());

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultEndpoint.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultEndpoint.java
@@ -176,11 +176,7 @@ public abstract class DefaultEndpoint extends ServiceSupport implements Endpoint
         if (isLenientProperties()) {
             // only use the endpoint uri without parameters as the properties are lenient
             String uri = getEndpointUri();
-            if (uri.indexOf('?') != -1) {
-                return StringHelper.before(uri, "?");
-            } else {
-                return uri;
-            }
+            return StringHelper.before(uri, "?", uri);
         } else {
             // use the full endpoint uri
             return getEndpointUri();

--- a/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
@@ -382,11 +382,8 @@ public final class PropertyBindingSupport {
                 // now lets update the target/name/class before next iterator (next part)
                 if (configurer instanceof PropertyConfigurerGetter) {
                     // lets see if we have a specialized configurer
-                    String key = part;
-                    int pos = part.indexOf('[');
-                    if (pos != -1) {
-                        key = part.substring(0, pos);
-                    }
+                    String key = StringHelper.before(part, "[", part);
+
                     // if its a map/list/array type then find out what type the collection uses
                     // so we can use that to lookup as configurer
                     Class<?> collectionType = (Class<?>) ((PropertyConfigurerGetter) configurer)
@@ -451,11 +448,7 @@ public final class PropertyBindingSupport {
             boolean ignoreCase, PropertyConfigurer configurer) {
 
         // if the name has collection lookup then ignore that as we want to create the instance
-        String key = name;
-        int pos = name.indexOf('[');
-        if (pos != -1) {
-            key = name.substring(0, pos);
-        }
+        String key = StringHelper.before(name, "[", name);
 
         Object answer = null;
         Class<?> parameterType = null;

--- a/core/camel-support/src/main/java/org/apache/camel/support/component/SendDynamicAwareSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/component/SendDynamicAwareSupport.java
@@ -25,6 +25,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.spi.EndpointUriFactory;
 import org.apache.camel.spi.SendDynamicAware;
 import org.apache.camel.support.service.ServiceSupport;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.URISupport;
 
 /**
@@ -136,15 +137,9 @@ public abstract class SendDynamicAwareSupport extends ServiceSupport implements 
     }
 
     public String asEndpointUri(Exchange exchange, String uri, Map<String, Object> properties) throws Exception {
-        String answer;
         String query = URISupport.createQueryString(properties, false);
-        int pos = uri.indexOf('?');
-        if (pos != -1) {
-            answer = uri.substring(0, pos) + "?" + query;
-        } else {
-            answer = uri + "?" + query;
-        }
-        return answer;
+
+        return StringHelper.before(uri, "?", uri) + "?" + query;
     }
 
 }

--- a/core/camel-util/src/main/java/org/apache/camel/util/InetAddressUtil.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/InetAddressUtil.java
@@ -51,10 +51,7 @@ public final class InetAddressUtil {
         } catch (UnknownHostException uhe) {
             String host = uhe.getMessage(); // host = "hostname: hostname"
             if (host != null) {
-                int colon = host.indexOf(':');
-                if (colon > 0) {
-                    return host.substring(0, colon);
-                }
+                return StringHelper.before(host, ":");
             }
             throw uhe;
         }

--- a/core/camel-util/src/main/java/org/apache/camel/util/OgnlHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/OgnlHelper.java
@@ -139,11 +139,7 @@ public final class OgnlHelper {
      * @return                the Camel OGNL expression without any trailing operators.
      */
     public static String removeTrailingOperators(String ognlExpression) {
-        int pos = ognlExpression.indexOf('[');
-        if (pos != -1) {
-            return ognlExpression.substring(0, pos);
-        }
-        return ognlExpression;
+        return StringHelper.before(ognlExpression, "[", ognlExpression);
     }
 
     public static String removeOperators(String ognlExpression) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
@@ -655,8 +655,21 @@ public final class StringHelper {
      * @return              the text before the token, or the supplied defaultValue if text does not contain the token
      */
     public static String before(String text, String before, String defaultValue) {
-        String answer = before(text, before);
-        return answer != null ? answer : defaultValue;
+        int pos = text.indexOf(before);
+        return pos == -1 ? defaultValue : text.substring(0, pos);
+    }
+
+    /**
+     * Returns the string before the given token, or the default value
+     *
+     * @param  text         the text
+     * @param  before       the token
+     * @param  defaultValue the value to return if text does not contain the token
+     * @return              the text before the token, or the supplied defaultValue if text does not contain the token
+     */
+    public static String before(String text, char before, String defaultValue) {
+        int pos = text.indexOf(before);
+        return pos == -1 ? defaultValue : text.substring(0, pos);
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -115,12 +115,8 @@ public final class URISupport {
         if (path.startsWith("//")) {
             path = path.substring(2);
         }
-        int idx = path.indexOf('?');
-        if (idx > -1) {
-            path = path.substring(0, idx);
-        }
 
-        return path;
+        return StringHelper.before(path, "?", path);
     }
 
     /**
@@ -148,11 +144,7 @@ public final class URISupport {
      * @return     the uri without the query parameter
      */
     public static String stripQuery(String uri) {
-        int idx = uri.indexOf('?');
-        if (idx > -1) {
-            uri = uri.substring(0, idx);
-        }
-        return uri;
+        return StringHelper.before(uri, "?", uri);
     }
 
     /**


### PR DESCRIPTION
Use the StringHelper before method as it avoids traversing the string twice and is already defined on StringHelper