### PR TITLE
(chores) camel-components: replace duplicated code

### DIFF
--- a/components/camel-atmosphere-websocket/src/main/java/org/apache/camel/component/atmosphere/websocket/WebsocketEndpoint.java
+++ b/components/camel-atmosphere-websocket/src/main/java/org/apache/camel/component/atmosphere/websocket/WebsocketEndpoint.java
@@ -28,6 +28,7 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriPath;
+import org.apache.camel.util.StringHelper;
 
 /**
  * Expose WebSocket endpoints using the Atmosphere framework.
@@ -56,10 +57,7 @@ public class WebsocketEndpoint extends ServletEndpoint {
     public WebsocketEndpoint(String endPointURI, WebsocketComponent component, URI httpUri) throws URISyntaxException {
         super(endPointURI, component, httpUri);
 
-        //TODO find a better way of assigning the store
-        int idx = endPointURI.indexOf('?');
-
-        this.servicePath = idx > -1 ? endPointURI.substring(0, idx) : endPointURI;
+        this.servicePath = StringHelper.before(endPointURI, "?", endPointURI);
         this.store = component.getWebSocketStore(servicePath);
     }
 

--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/utils/AWS2S3Utils.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/utils/AWS2S3Utils.java
@@ -26,6 +26,7 @@ import org.apache.camel.StreamCache;
 import org.apache.camel.component.aws2.s3.AWS2S3Configuration;
 import org.apache.camel.component.aws2.s3.AWS2S3Constants;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 

--- a/components/camel-azure/camel-azure-files/src/main/java/org/apache/camel/component/file/azure/FilesConfiguration.java
+++ b/components/camel-azure/camel-azure-files/src/main/java/org/apache/camel/component/file/azure/FilesConfiguration.java
@@ -93,7 +93,6 @@ public class FilesConfiguration extends RemoteFileConfiguration {
     public void setHost(String accountOrHostname) {
         var dot = accountOrHostname.indexOf('.');
         var hasDot = dot >= 0;
-        account = hasDot ? accountOrHostname.substring(0, dot) : accountOrHostname;
         super.setHost(hasDot ? accountOrHostname : account + '.' + DEFAULT_INTERNET_DOMAIN);
     }
 

--- a/components/camel-azure/camel-azure-files/src/main/java/org/apache/camel/component/file/azure/FilesURIStrings.java
+++ b/components/camel-azure/camel-azure-files/src/main/java/org/apache/camel/component/file/azure/FilesURIStrings.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.URISupport;
 
 /**
@@ -41,10 +42,7 @@ final class FilesURIStrings {
      * $ for the expression (file language)
      */
     static URI getBaseURI(String uri) throws URISyntaxException {
-        String baseUri = uri;
-        if (uri.indexOf(QUERY_SEPARATOR) != -1) {
-            baseUri = uri.substring(0, uri.indexOf(QUERY_SEPARATOR));
-        }
+        String baseUri = StringHelper.before(uri, QUERY_SEPARATOR, uri);
         return new URI(baseUri);
     }
 

--- a/components/camel-disruptor/src/main/java/org/apache/camel/component/disruptor/DisruptorComponent.java
+++ b/components/camel-disruptor/src/main/java/org/apache/camel/component/disruptor/DisruptorComponent.java
@@ -23,6 +23,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -165,11 +166,7 @@ public class DisruptorComponent extends DefaultComponent {
     }
 
     public static String getDisruptorKey(String uri) {
-        if (uri.contains("?")) {
-            // strip parameters
-            uri = uri.substring(0, uri.indexOf('?'));
-        }
-        return uri;
+        return StringHelper.before(uri, "?", uri);
     }
 
     @Override

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpComponent.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpComponent.java
@@ -26,6 +26,7 @@ import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.EndpointHelper;
 import org.apache.camel.support.component.PropertyConfigurerSupport;
 import org.apache.camel.util.PropertiesHelper;
+import org.apache.camel.util.StringHelper;
 import org.apache.commons.net.ftp.FTPFile;
 
 /**
@@ -66,11 +67,7 @@ public class FtpComponent extends RemoteFileComponent<FTPFile> {
      * $ for the expression (file language)
      */
     protected String getBaseUri(String uri) {
-        String baseUri = uri;
-        if (uri.indexOf('?') != -1) {
-            baseUri = uri.substring(0, uri.indexOf('?'));
-        }
-        return baseUri;
+        return StringHelper.before(uri, "?", uri);
     }
 
     /**

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpComponent.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpComponent.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.spi.annotations.Component;
+import org.apache.camel.util.StringHelper;
 
 /**
  * Secure FTP Component
@@ -45,10 +46,7 @@ public class SftpComponent extends RemoteFileComponent<SftpRemoteFile> {
         // and the URI constructor will regard $ as an illegal character and we
         // dont want to enforce end users to
         // to escape the $ for the expression (file language)
-        String baseUri = uri;
-        if (uri.contains("?")) {
-            baseUri = uri.substring(0, uri.indexOf('?'));
-        }
+        String baseUri = StringHelper.before(uri, "?", uri);
 
         // lets make sure we create a new configuration as each endpoint can
         // customize its own version

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsSendDynamicAware.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsSendDynamicAware.java
@@ -105,22 +105,23 @@ public class JmsSendDynamicAware extends ServiceSupport implements SendDynamicAw
     private String parseDestinationName(String uri) {
         // strip query
         uri = uri.replaceFirst(scheme + "://", ":");
-        int pos = uri.indexOf('?');
-        if (pos != -1) {
-            uri = uri.substring(0, pos);
-        }
+        uri = StringHelper.before(uri, "?", uri);
 
         // destination name is after last colon (but not after double colon)
         String shortUri = StringHelper.before(uri, "::");
-        pos = shortUri == null
-                ? uri.lastIndexOf(':')
-                : shortUri.lastIndexOf(':');
-
-        if (pos != -1) {
-            return uri.substring(pos + 1);
+        final int lastIdx = lastIndexOneOf(uri, shortUri);
+        if (lastIdx != -1) {
+            return uri.substring(lastIdx + 1);
         } else {
             return null;
         }
+    }
+
+    private static int lastIndexOneOf(String uri, String shortUri) {
+        if (shortUri == null) {
+            return uri.lastIndexOf(':');
+        }
+        return shortUri.lastIndexOf(':');
     }
 
 }

--- a/components/camel-jsch/src/main/java/org/apache/camel/component/scp/ScpComponent.java
+++ b/components/camel-jsch/src/main/java/org/apache/camel/component/scp/ScpComponent.java
@@ -25,6 +25,7 @@ import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.component.file.remote.RemoteFileComponent;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Component;
+import org.apache.camel.util.StringHelper;
 
 /**
  * Component providing secure messaging using JSch
@@ -45,8 +46,8 @@ public class ScpComponent extends RemoteFileComponent<ScpFile> {
     @Override
     protected GenericFileEndpoint<ScpFile> buildFileEndpoint(String uri, String remaining, Map<String, Object> parameters)
             throws Exception {
-        int query = uri.indexOf('?');
-        return new ScpEndpoint(uri, this, new ScpConfiguration(new URI(query >= 0 ? uri.substring(0, query) : uri)));
+        String tmp = StringHelper.before(uri, "?", uri);
+        return new ScpEndpoint(uri, this, new ScpConfiguration(new URI(tmp)));
     }
 
     @Override

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaSendDynamicAware.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaSendDynamicAware.java
@@ -104,12 +104,10 @@ public class KafkaSendDynamicAware extends ServiceSupport implements SendDynamic
 
     private String parseTopicName(String uri) {
         // strip query
-        int pos = uri.indexOf('?');
-        if (pos != -1) {
-            uri = uri.substring(0, pos);
-        }
+        uri = StringHelper.before(uri, "?", uri);
+
         // topic name is after first colon
-        pos = uri.indexOf(':');
+        int pos = uri.indexOf(':');
         if (pos != -1) {
             uri = uri.substring(pos + 1);
         } else {

--- a/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/MllpTcpClientProducer.java
+++ b/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/MllpTcpClientProducer.java
@@ -39,6 +39,7 @@ import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.component.mllp.internal.Hl7Util;
 import org.apache.camel.component.mllp.internal.MllpSocketBuffer;
 import org.apache.camel.support.DefaultProducer;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,12 +110,8 @@ public class MllpTcpClientProducer extends DefaultProducer implements Runnable {
         if (getConfiguration().hasIdleTimeout()) {
             // Get the URI without options
             String fullEndpointKey = getEndpoint().getEndpointKey();
-            String endpointKey;
-            if (fullEndpointKey.contains("?")) {
-                endpointKey = fullEndpointKey.substring(0, fullEndpointKey.indexOf('?'));
-            } else {
-                endpointKey = fullEndpointKey;
-            }
+            String endpointKey = StringHelper.before(fullEndpointKey, "?", fullEndpointKey);
+
 
             idleTimeoutExecutor = Executors.newSingleThreadScheduledExecutor(new IdleTimeoutThreadFactory(endpointKey));
         }

--- a/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/internal/TcpServerAcceptThread.java
+++ b/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/internal/TcpServerAcceptThread.java
@@ -25,6 +25,7 @@ import java.net.SocketTimeoutException;
 import org.apache.camel.Route;
 import org.apache.camel.component.mllp.MllpTcpServerConsumer;
 import org.apache.camel.spi.UnitOfWork;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -58,12 +59,7 @@ public class TcpServerAcceptThread extends Thread {
 
         // Get the URI without options
         String fullEndpointKey = consumer.getEndpoint().getEndpointKey();
-        String endpointKey;
-        if (fullEndpointKey.contains("?")) {
-            endpointKey = fullEndpointKey.substring(0, fullEndpointKey.indexOf('?'));
-        } else {
-            endpointKey = fullEndpointKey;
-        }
+        String endpointKey = StringHelper.before(fullEndpointKey, "?", fullEndpointKey);
 
         // Now put it all together
         return String.format("%s[%s] - %s", className, endpointKey, serverSocket.getLocalSocketAddress());

--- a/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/internal/TcpServerBindThread.java
+++ b/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/internal/TcpServerBindThread.java
@@ -28,6 +28,7 @@ import org.apache.camel.spi.UnitOfWork;
 import org.apache.camel.support.task.BlockingTask;
 import org.apache.camel.support.task.Tasks;
 import org.apache.camel.support.task.budget.Budgets;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -44,12 +45,7 @@ public class TcpServerBindThread extends Thread {
 
         // Get the URI without options
         String fullEndpointKey = consumer.getEndpoint().getEndpointKey();
-        String endpointKey;
-        if (fullEndpointKey.contains("?")) {
-            endpointKey = fullEndpointKey.substring(0, fullEndpointKey.indexOf('?'));
-        } else {
-            endpointKey = fullEndpointKey;
-        }
+        String endpointKey = StringHelper.before(fullEndpointKey, "?", fullEndpointKey);
 
         this.setName(String.format("%s - %s", this.getClass().getSimpleName(), endpointKey));
     }

--- a/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/internal/TcpServerConsumerValidationRunnable.java
+++ b/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/internal/TcpServerConsumerValidationRunnable.java
@@ -25,6 +25,7 @@ import org.apache.camel.Route;
 import org.apache.camel.component.mllp.MllpSocketException;
 import org.apache.camel.component.mllp.MllpTcpServerConsumer;
 import org.apache.camel.spi.UnitOfWork;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -104,12 +105,7 @@ public class TcpServerConsumerValidationRunnable implements Runnable {
     String createThreadName() {
         // Get the URI without options
         String fullEndpointKey = consumer.getEndpoint().getEndpointKey();
-        String endpointKey;
-        if (fullEndpointKey.contains("?")) {
-            endpointKey = fullEndpointKey.substring(0, fullEndpointKey.indexOf('?'));
-        } else {
-            endpointKey = fullEndpointKey;
-        }
+        String endpointKey = StringHelper.before(fullEndpointKey, "?", fullEndpointKey);
 
         // Now put it all together
         return String.format("%s[%s] - %s", this.getClass().getSimpleName(), endpointKey, combinedAddress);

--- a/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/internal/TcpSocketConsumerRunnable.java
+++ b/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/internal/TcpSocketConsumerRunnable.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.mllp.MllpInvalidMessageException;
 import org.apache.camel.component.mllp.MllpSocketException;
 import org.apache.camel.component.mllp.MllpTcpServerConsumer;
 import org.apache.camel.spi.UnitOfWork;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -110,12 +111,7 @@ public class TcpSocketConsumerRunnable implements Runnable {
     String createThreadName() {
         // Get the URI without options
         String fullEndpointKey = consumer.getEndpoint().getEndpointKey();
-        String endpointKey;
-        if (fullEndpointKey.contains("?")) {
-            endpointKey = fullEndpointKey.substring(0, fullEndpointKey.indexOf('?'));
-        } else {
-            endpointKey = fullEndpointKey;
-        }
+        String endpointKey = StringHelper.before(fullEndpointKey, "?", fullEndpointKey);
 
         // Now put it all together
         return String.format("%s[%s] - %s", this.getClass().getSimpleName(), endpointKey, combinedAddress);

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/handlers/HttpServerMultiplexChannelHandler.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/handlers/HttpServerMultiplexChannelHandler.java
@@ -42,6 +42,7 @@ import org.apache.camel.component.netty.http.NettyHttpConfiguration;
 import org.apache.camel.component.netty.http.NettyHttpConstants;
 import org.apache.camel.component.netty.http.NettyHttpConsumer;
 import org.apache.camel.support.RestConsumerContextPathMatcher;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.UnsafeUriCharactersEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -282,10 +283,7 @@ public class HttpServerMultiplexChannelHandler extends SimpleChannelInboundHandl
         }
 
         // strip out query parameters
-        int idx = path.indexOf('?');
-        if (idx > -1) {
-            path = path.substring(0, idx);
-        }
+        path = StringHelper.before(path, "?", path);
 
         // strip of ending /
         if (path.endsWith("/")) {

--- a/components/camel-paho-mqtt5/src/main/java/org/apache/camel/component/paho/mqtt5/PahoMqtt5SendDynamicAware.java
+++ b/components/camel-paho-mqtt5/src/main/java/org/apache/camel/component/paho/mqtt5/PahoMqtt5SendDynamicAware.java
@@ -105,12 +105,10 @@ public class PahoMqtt5SendDynamicAware extends ServiceSupport implements SendDyn
     private String parseTopicName(String uri) {
         // strip query
         uri = uri.replaceFirst(scheme + "://", ":");
-        int pos = uri.indexOf('?');
-        if (pos != -1) {
-            uri = uri.substring(0, pos);
-        }
+        uri = StringHelper.before(uri, "?", uri);
+
         // topic name is after first colon
-        pos = uri.indexOf(':');
+        int pos = uri.indexOf(':');
         if (pos != -1) {
             return uri.substring(pos + 1);
         } else {

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoSendDynamicAware.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoSendDynamicAware.java
@@ -105,12 +105,11 @@ public class PahoSendDynamicAware extends ServiceSupport implements SendDynamicA
     private String parseTopicName(String uri) {
         // strip query
         uri = uri.replaceFirst(scheme + "://", ":");
-        int pos = uri.indexOf('?');
-        if (pos != -1) {
-            uri = uri.substring(0, pos);
-        }
+
+        uri = StringHelper.before(uri, "?", uri);
         // topic name is after first colon
-        pos = uri.indexOf(':');
+
+        int pos = uri.indexOf(':');
         if (pos != -1) {
             return uri.substring(pos + 1);
         } else {

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsSendDynamicAware.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsSendDynamicAware.java
@@ -105,12 +105,10 @@ public class SjmsSendDynamicAware extends ServiceSupport implements SendDynamicA
     private String parseDestinationName(String uri) {
         // strip query
         uri = uri.replaceFirst(scheme + "://", ":");
-        int pos = uri.indexOf('?');
-        if (pos != -1) {
-            uri = uri.substring(0, pos);
-        }
+        uri = StringHelper.before(uri, "?", uri);
+
         // destination name is after last colon
-        pos = uri.lastIndexOf(':');
+        int pos = uri.lastIndexOf(':');
         if (pos != -1) {
             return uri.substring(pos + 1);
         } else {

--- a/components/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/SpringRabbitMQSendDynamicAware.java
+++ b/components/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/SpringRabbitMQSendDynamicAware.java
@@ -128,12 +128,10 @@ public class SpringRabbitMQSendDynamicAware extends ServiceSupport implements Se
     private String parseExchangeName(String uri) {
         // strip query
         uri = uri.replaceFirst(scheme + "://", ":");
-        int pos = uri.indexOf('?');
-        if (pos != -1) {
-            uri = uri.substring(0, pos);
-        }
+        uri = StringHelper.before(uri, "?", uri);
+
         // exchange name is after first colon
-        pos = uri.indexOf(':');
+        int pos = uri.indexOf(':');
         if (pos != -1) {
             return uri.substring(pos + 1);
         } else {

--- a/components/camel-stax/src/main/java/org/apache/camel/language/xtokenizer/XMLTokenExpressionIterator.java
+++ b/components/camel-stax/src/main/java/org/apache/camel/language/xtokenizer/XMLTokenExpressionIterator.java
@@ -210,7 +210,7 @@ public class XMLTokenExpressionIterator extends ExpressionAdapter implements Nam
                 String s = sl[i];
                 if (s.length() > 0) {
                     int d = s.indexOf(':');
-                    String pfx = d > 0 ? s.substring(0, d) : "";
+                    String pfx = StringHelper.before(s, ":", "");
                     this.splitpath[i] = new AttributedQName(
                             "*".equals(pfx) ? "*" : nsmap == null ? "" : nsmap.get(pfx), d > 0 ? s.substring(d + 1) : s, pfx);
                 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -873,11 +873,7 @@ public abstract class CamelTestSupport
             throw RuntimeCamelException.wrapRuntimeException(e);
         }
         // strip query
-        int idx = n.indexOf('?');
-        if (idx != -1) {
-            n = n.substring(0, idx);
-        }
-        final String target = n;
+        final String target = StringHelper.before(n, "?", n);
 
         // lookup endpoints in registry and try to find it
         MockEndpoint found = (MockEndpoint) context.getEndpointRegistry().values().stream()

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/handlers/RestRootHandler.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/handlers/RestRootHandler.java
@@ -29,6 +29,7 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 import org.apache.camel.component.undertow.UndertowConsumer;
 import org.apache.camel.support.RestConsumerContextPathMatcher;
+import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.UnsafeUriCharactersEncoder;
 
 /**
@@ -160,10 +161,7 @@ public class RestRootHandler implements HttpHandler {
         }
 
         // strip out query parameters
-        int idx = path.indexOf('?');
-        if (idx > -1) {
-            path = path.substring(0, idx);
-        }
+        path = StringHelper.before(path, "?", path);
 
         // strip of ending /
         if (path.endsWith("/")) {


### PR DESCRIPTION
Use the StringHelper before method as it avoids traversing the string twice and is already defined on StringHelper