### PR TITLE
Mapstruct: Method must be public in DefaultMapStructFinder.discoverMa…

### DIFF
--- a/components/camel-mapstruct/src/main/java/org/apache/camel/component/mapstruct/DefaultMapStructFinder.java
+++ b/components/camel-mapstruct/src/main/java/org/apache/camel/component/mapstruct/DefaultMapStructFinder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.mapstruct;
 
+import java.lang.reflect.Modifier;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.CamelContext;
@@ -59,6 +60,10 @@ public class DefaultMapStructFinder extends ServiceSupport implements MapStructM
             final Object mapper = Mappers.getMapper(clazz);
             if (mapper != null) {
                 ReflectionHelper.doWithMethods(mapper.getClass(), mc -> {
+                    // must be public
+                    if (!Modifier.isPublic(mc.getModifiers())) {
+                        return;
+                    }
                     // must not be a default method
                     if (mc.isDefault()) {
                         return;


### PR DESCRIPTION
Mapstruct component works with 4.0.0-RC2 version but It doesn't work with 4.0.0 version (get java.lang.IllegalAccessException).

In the 4.0.0, the method discoverMappings (class DefaultMapStructFinder) considers implementation classes (autogenerated) and not interfaces.

Sometimes, in the implementation classes, there are private methods and so discoverMappings method throws java.lang.IllegalAccessException.

## Skip private and protected methods
### org.apache.camel.component.mapstruct.DefaultMapStructFinder:discoverMappings
```java
    @Override
    public int discoverMappings(Class<?> clazz) {
        final AtomicInteger answer = new AtomicInteger();
        try {
            // is there a generated mapper
            final Object mapper = Mappers.getMapper(clazz);
            if (mapper != null) {
                ReflectionHelper.doWithMethods(mapper.getClass(), mc -> {
                    // must be public
                    if (!Modifier.isPublic(mc.getModifiers())) {
                        return;
                    }
............
```


