### PR TITLE
Camel 17027 make aws streaming thread safe

### DIFF
--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/stream/AWS2S3StreamUploadProducer.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/stream/AWS2S3StreamUploadProducer.java
@@ -225,8 +225,11 @@ public class AWS2S3StreamUploadProducer extends DefaultProducer {
         if (ObjectHelper.isNotEmpty(state)) {
             // exchange wasn't large enough to send, batch it with subsequent exchanges.
             synchronized (lock) {
-                if (this.uploadAggregate == null) {
+                if (ObjectHelper.isEmpty(this.uploadAggregate)) {
                     this.uploadAggregate = state;
+                } else {
+                    // handle potential race condition.
+                    this.uploadAggregate.buffer.write(b);
                 }
             }
         }

--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/stream/AWS2S3StreamUploadProducer.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/stream/AWS2S3StreamUploadProducer.java
@@ -229,7 +229,7 @@ public class AWS2S3StreamUploadProducer extends DefaultProducer {
                     this.uploadAggregate = state;
                 } else {
                     // handle potential race condition.
-                    this.uploadAggregate.buffer.write(b);
+                    this.uploadAggregate.buffer.write(state.buffer.toByteArray());
                 }
             }
         }


### PR DESCRIPTION

Potential race condition when processing concurrent exchanges.

When processing multiple small exchanges in quick succession and there was no shared-state to aggregate exchanges, if an initial exchange acquired the lock and set the shared state and a subsequent exchange immediately followed after the lock was released the data would be lost.  
