### PR TITLE
(chores) camel-core: cleanup skipping tests on AIX

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/ConvertBodyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ConvertBodyTest.java
@@ -30,6 +30,8 @@ import org.apache.camel.builder.ExchangeBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -183,16 +185,10 @@ public class ConvertBodyTest extends ContextTestSupport {
         result.assertIsNotSatisfied();
     }
 
+    // does not work on AIX
+    @DisabledOnOs(OS.AIX)
     @Test
     public void testConvertToStringCharsetFail() throws Exception {
-
-        // does not work on AIX
-        String osName = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
-        boolean aix = osName.indexOf("aix") > -1;
-        if (aix) {
-            return;
-        }
-
         String body = "Hell\u00F6 W\u00F6rld";
 
         MockEndpoint result = getMockEndpoint("mock:result");


### PR DESCRIPTION
I am not even sure if it's worth keeping this AIX stuff on the code base (is anyone building/testing Camel there?), but let's clean it up.