### PR TITLE
CAMEL-19815: use a ConcurrentHashMap instead of a blanket synchronize

### DIFF
--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/QueueReference.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/QueueReference.java
@@ -31,12 +31,12 @@ import org.apache.camel.Exchange;
 public final class QueueReference {
 
     private final BlockingQueue<Exchange> queue;
-    private Integer size;
+    private int size;
     private Boolean multipleConsumers;
 
     private List<SedaEndpoint> endpoints = new LinkedList<>();
 
-    QueueReference(BlockingQueue<Exchange> queue, Integer size, Boolean multipleConsumers) {
+    QueueReference(BlockingQueue<Exchange> queue, int size, Boolean multipleConsumers) {
         this.queue = queue;
         this.size = size;
         this.multipleConsumers = multipleConsumers;
@@ -70,7 +70,7 @@ public final class QueueReference {
      *
      * @return <tt>null</tt> if unbounded
      */
-    public Integer getSize() {
+    public int getSize() {
         return size;
     }
 

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaConstants.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaConstants.java
@@ -22,6 +22,8 @@ public final class SedaConstants {
     public static final int CONCURRENT_CONSUMERS = 1;
     public static final int QUEUE_SIZE = 1000;
 
+    public static final int UNDEFINED_SIZE = -1;
+
     private SedaConstants() {
     }
 

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
@@ -192,14 +192,14 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
         // can use the already existing queue referenced from the component
         if (getComponent() != null) {
             // use null to indicate default size (= use what the existing queue has been configured with)
-            Integer size = (getSize() == Integer.MAX_VALUE || getSize() == SedaConstants.QUEUE_SIZE) ? null : getSize();
+            int size = (getSize() == Integer.MAX_VALUE || getSize() == SedaConstants.QUEUE_SIZE) ? SedaConstants.UNDEFINED_SIZE : getSize();
             QueueReference ref = getComponent().getOrCreateQueue(this, size, isMultipleConsumers(), queueFactory);
             queue = ref.getQueue();
             String key = getComponent().getQueueKey(getEndpointUri());
             LOG.debug("Endpoint {} is using shared queue: {} with size: {}", this, key,
-                    ref.getSize() != null ? ref.getSize() : Integer.MAX_VALUE);
+                    ref.getSize() != SedaConstants.UNDEFINED_SIZE ? ref.getSize() : Integer.MAX_VALUE);
             // and set the size we are using
-            if (ref.getSize() != null) {
+            if (ref.getSize() != SedaConstants.UNDEFINED_SIZE) {
                 setSize(ref.getSize());
             }
         } else {

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
@@ -70,7 +70,7 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
     @Metadata(required = true)
     private String name;
     @UriParam(label = "advanced", description = "Define the queue instance which will be used by the endpoint")
-    private BlockingQueue<Exchange> queue;
+    private volatile BlockingQueue<Exchange> queue;
     @UriParam(defaultValue = "" + SedaConstants.QUEUE_SIZE)
     private int size = SedaConstants.QUEUE_SIZE;
 
@@ -174,30 +174,39 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
         return answer;
     }
 
-    public synchronized BlockingQueue<Exchange> getQueue() {
+    public BlockingQueue<Exchange> getQueue() {
         if (queue == null) {
-            // prefer to lookup queue from component, so if this endpoint is re-created or re-started
-            // then the existing queue from the component can be used, so new producers and consumers
-            // can use the already existing queue referenced from the component
-            if (getComponent() != null) {
-                // use null to indicate default size (= use what the existing queue has been configured with)
-                Integer size = (getSize() == Integer.MAX_VALUE || getSize() == SedaConstants.QUEUE_SIZE) ? null : getSize();
-                QueueReference ref = getComponent().getOrCreateQueue(this, size, isMultipleConsumers(), queueFactory);
-                queue = ref.getQueue();
-                String key = getComponent().getQueueKey(getEndpointUri());
-                LOG.debug("Endpoint {} is using shared queue: {} with size: {}", this, key,
-                        ref.getSize() != null ? ref.getSize() : Integer.MAX_VALUE);
-                // and set the size we are using
-                if (ref.getSize() != null) {
-                    setSize(ref.getSize());
+            synchronized (this) {
+                if (queue == null) {
+                    resolveQueue();
                 }
-            } else {
-                // fallback and create queue (as this endpoint has no component)
-                queue = createQueue();
-                LOG.debug("Endpoint {} is using queue: {} with size: {}", this, getEndpointUri(), getSize());
             }
+
         }
         return queue;
+    }
+
+    private void resolveQueue() {
+        // prefer to lookup queue from component, so if this endpoint is re-created or re-started
+        // then the existing queue from the component can be used, so new producers and consumers
+        // can use the already existing queue referenced from the component
+        if (getComponent() != null) {
+            // use null to indicate default size (= use what the existing queue has been configured with)
+            Integer size = (getSize() == Integer.MAX_VALUE || getSize() == SedaConstants.QUEUE_SIZE) ? null : getSize();
+            QueueReference ref = getComponent().getOrCreateQueue(this, size, isMultipleConsumers(), queueFactory);
+            queue = ref.getQueue();
+            String key = getComponent().getQueueKey(getEndpointUri());
+            LOG.debug("Endpoint {} is using shared queue: {} with size: {}", this, key,
+                    ref.getSize() != null ? ref.getSize() : Integer.MAX_VALUE);
+            // and set the size we are using
+            if (ref.getSize() != null) {
+                setSize(ref.getSize());
+            }
+        } else {
+            // fallback and create queue (as this endpoint has no component)
+            queue = createQueue();
+            LOG.debug("Endpoint {} is using queue: {} with size: {}", this, getEndpointUri(), getSize());
+        }
     }
 
     protected BlockingQueue<Exchange> createQueue() {
@@ -216,9 +225,7 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
     public QueueReference getQueueReference() {
         String key = getComponent().getQueueKey(getEndpointUri());
 
-        synchronized (this) {
-            return getComponent().getQueueReference(key);
-        }
+        return getComponent().getQueueReference(key);
     }
 
     protected synchronized AsyncProcessor getConsumerMulticastProcessor() {


### PR DESCRIPTION
This should help offset the performance impacts of removing the cached QueueReference on d66469d6ac7243f0ae790c41a500965b885d3180

**4.1 (this patch)**
```
Benchmark                                         Mode  Cnt    Score    Error   Units
SedaRoundTripTest.sendBlocking                   thrpt   10  925.275 ±  1.146  ops/ms
SedaRoundTripTest.sendBlockingWithMultipleTypes  thrpt   10  229.778 ±  0.107  ops/ms
SedaRoundTripTest.sendBlockingWithMultipleTypes   avgt   10    0.004 ±  0.001   ms/op
SedaRoundTripTest.sendBlocking                      ss   10    0.163 ±  0.035   ms/op
SedaRoundTripTest.sendBlockingWithMultipleTypes     ss   10    0.570 ±  0.047   ms/op
```

**4.1 (without the patch)**
```
Benchmark                                         Mode  Cnt    Score    Error   Units
SedaRoundTripTest.sendBlocking                   thrpt   10  915.329 ±  0.320  ops/ms
SedaRoundTripTest.sendBlockingWithMultipleTypes  thrpt   10  225.853 ±  0.459  ops/ms
SedaRoundTripTest.sendBlockingWithMultipleTypes   avgt   10    0.005 ±  0.001   ms/op
SedaRoundTripTest.sendBlocking                      ss   10    0.167 ±  0.025   ms/op
SedaRoundTripTest.sendBlockingWithMultipleTypes     ss   10    0.626 ±  0.222   ms/op
```

**4.0 (baseline)**
```
Benchmark                                         Mode  Cnt    Score    Error   Units
SedaRoundTripTest.sendBlocking                   thrpt   10  922.456 ±  0.462  ops/ms
SedaRoundTripTest.sendBlockingWithMultipleTypes  thrpt   10  242.381 ±  0.107  ops/ms
SedaRoundTripTest.sendBlockingWithMultipleTypes   avgt   10    0.004 ±  0.001   ms/op
SedaRoundTripTest.sendBlocking                      ss   10    0.162 ±  0.022   ms/op
SedaRoundTripTest.sendBlockingWithMultipleTypes     ss   10    0.573 ±  0.044   ms/op
```