### PR TITLE
CAMEL-19731: AS2 - Set the correct application entity class

### DIFF
--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ClientManagerIT.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ClientManagerIT.java
@@ -340,8 +340,8 @@ public class AS2ClientManagerIT extends AbstractAS2ITSupport {
         assertTrue(request instanceof HttpEntityEnclosingRequest, "Request does not contain body");
         HttpEntity entity = ((HttpEntityEnclosingRequest) request).getEntity();
         assertNotNull(entity, "Request body");
-        assertTrue(entity instanceof ApplicationEntity, "Request body does not contain EDI entity");
-        String ediMessage = ((ApplicationEntity) entity).getEdiMessage();
+        assertTrue(entity instanceof ApplicationEDIEntity, "Request body does not contain EDI entity");
+        String ediMessage = ((ApplicationEDIEntity) entity).getEdiMessage();
         assertEquals(EDI_MESSAGE.replaceAll("[\n\r]", ""), ediMessage.replaceAll("[\n\r]", ""), "EDI message is different");
 
         assertNotNull(response, "Response");


### PR DESCRIPTION
## Motivation

In 3.20, a compilation error is raised by the build due to the application entity class used.

## Modifications:

* Update the unit test to set the correct application entity class