### PR TITLE
camel-netty - Fix doc about SSL configuration

### DIFF
--- a/components/camel-netty/src/main/docs/netty-component.adoc
+++ b/components/camel-netty/src/main/docs/netty-component.adoc
@@ -236,7 +236,7 @@ SSLContextParameters scp = new SSLContextParameters();
 scp.setKeyManagers(kmp);
 
 NettyComponent nettyComponent = getContext().getComponent("netty", NettyComponent.class);
-nettyComponent.setSslContextParameters(scp);
+nettyComponent.getConfiguration().setSslContextParameters(scp);
 ----
 
 [[Netty-SpringDSLbasedconfigurationofendpoint]]


### PR DESCRIPTION
## Motivation

[Someone from the community](https://stackoverflow.com/questions/76991186/cannot-resolve-method-setsslcontextparameters-in-nettycomponent) raised the fact that the code snippet describing how to configure SSL in the netty component is invalid/outdated and should be fixed.

## Modifications:

* Set the SSL configuration from the `NettyConfiguration` instead of `NettyComponent`