### PR TITLE
CAMEL-19783: Added reconnection, even if a message has not yet been received

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/PubSubApiConsumer.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/PubSubApiConsumer.java
@@ -38,7 +38,7 @@ public class PubSubApiConsumer extends DefaultConsumer {
     private static final Logger LOG = LoggerFactory.getLogger(PubSubApiConsumer.class);
     private final String topic;
     private final ReplayPreset initialReplayPreset;
-    private final String initialReplayId;
+    private String initialReplayId;
     private final SalesforceEndpoint endpoint;
 
     private final int batchSize;
@@ -46,6 +46,8 @@ public class PubSubApiConsumer extends DefaultConsumer {
     private Class<?> pojoClass;
     private PubSubApiClient pubSubClient;
     private Map<String, Class<?>> eventClassMap;
+
+    private boolean usePlainTextConnection = false;
 
     public PubSubApiConsumer(SalesforceEndpoint endpoint, Processor processor) throws ClassNotFoundException {
         super(endpoint, processor);
@@ -86,6 +88,7 @@ public class PubSubApiConsumer extends DefaultConsumer {
                 endpoint.getComponent().getSession(), endpoint.getComponent().getLoginConfig(),
                 endpoint.getComponent().getPubSubHost(), endpoint.getComponent().getPubSubPort(),
                 endpoint.getConfiguration().getBackoffIncrement(), endpoint.getConfiguration().getMaxBackoff());
+        this.pubSubClient.setUsePlainTextConnection(this.usePlainTextConnection);
 
         ServiceHelper.startService(pubSubClient);
         pubSubClient.subscribe(this, initialReplayPreset, initialReplayId);
@@ -115,5 +118,21 @@ public class PubSubApiConsumer extends DefaultConsumer {
 
     public Class<?> getPojoClass() {
         return pojoClass;
+    }
+
+    // ability to use Plain Text (http) for test contexts
+    public void setUsePlainTextConnection(boolean usePlainTextConnection) {
+        this.usePlainTextConnection = usePlainTextConnection;
+    }
+
+
+    /**
+     * This updates the initial replay id. This will only take effect after the route is restarted, and should
+     * generally only be done while the route is stopped.
+     *
+     * @param initialReplayId
+     */
+    public void updateInitialReplayId(String initialReplayId) {
+        this.initialReplayId = initialReplayId;
     }
 }

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/PubSubApiTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/PubSubApiTest.java
@@ -25,19 +25,110 @@ import io.grpc.ServerBuilder;
 import org.apache.camel.component.salesforce.internal.SalesforceSession;
 import org.apache.camel.component.salesforce.internal.client.PubSubApiClient;
 import org.apache.camel.component.salesforce.internal.pubsub.AuthErrorPubSubServer;
+import org.apache.camel.component.salesforce.internal.pubsub.SendOneMessagePubSubServer;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class PubSubApiTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(PubSubApiTest.class);
+
+    @Test
+    public void testReconnectOnErrorAfterReplayIdNonNull() throws Exception {
+        final SalesforceSession session = mock(SalesforceSession.class);
+        when(session.getAccessToken()).thenReturn("faketoken");
+        when(session.getInstanceUrl()).thenReturn("https://myinstance");
+        when(session.getOrgId()).thenReturn("00D123123123");
+
+        final PubSubApiConsumer consumer = mock(PubSubApiConsumer.class);
+        when(consumer.getTopic()).thenReturn("/event/FakeTopic");
+        when(consumer.getBatchSize()).thenReturn(100);
+
+        int port = getPort();
+        LOG.debug("Starting server on port {}", port);
+        final Server grpcServer = ServerBuilder.forPort(port)
+            .addService(new SendOneMessagePubSubServer())
+            .build();
+        grpcServer.start();
+
+        PubSubApiClient client = Mockito.spy(new PubSubApiClient(
+            session, new SalesforceLoginConfig(), "localhost",
+            port, 1000, 10000));
+        client.setUsePlainTextConnection(true);
+        client.start();
+        client.subscribe(consumer, ReplayPreset.LATEST, null);
+
+        verify(session, timeout(5000)).attemptLoginUntilSuccessful(anyLong(), anyLong());
+        verify(client, times(1)).subscribe(consumer, ReplayPreset.LATEST, null);
+        verify(client, times(1)).subscribe(consumer, ReplayPreset.CUSTOM, "MTIz");
+    }
+
+    @Test
+    public void testReconnectOnErrorCustomWithInitialReplayId() throws Exception {
+        final SalesforceSession session = mock(SalesforceSession.class);
+        when(session.getAccessToken()).thenReturn("faketoken");
+        when(session.getInstanceUrl()).thenReturn("https://myinstance");
+        when(session.getOrgId()).thenReturn("00D123123123");
+
+        final PubSubApiConsumer consumer = mock(PubSubApiConsumer.class);
+        when(consumer.getTopic()).thenReturn("/event/FakeTopic");
+        when(consumer.getBatchSize()).thenReturn(100);
+
+        int port = getPort();
+        LOG.debug("Starting server on port {}", port);
+        final Server grpcServer = ServerBuilder.forPort(port)
+            .addService(new AuthErrorPubSubServer())
+            .build();
+        grpcServer.start();
+
+        PubSubApiClient client = Mockito.spy(new PubSubApiClient(
+            session, new SalesforceLoginConfig(), "localhost",
+            port, 1000, 10000));
+        client.setUsePlainTextConnection(true);
+        client.start();
+        client.subscribe(consumer, ReplayPreset.CUSTOM, "initial");
+
+        verify(session, timeout(5000)).attemptLoginUntilSuccessful(anyLong(), anyLong());
+        verify(client, times(2)).subscribe(consumer, ReplayPreset.CUSTOM, "initial");
+    }
+
+    @Test
+    public void testReconnectOnErrorWithNullInitialReplayId() throws Exception {
+        final SalesforceSession session = mock(SalesforceSession.class);
+        when(session.getAccessToken()).thenReturn("faketoken");
+        when(session.getInstanceUrl()).thenReturn("https://myinstance");
+        when(session.getOrgId()).thenReturn("00D123123123");
+
+        final PubSubApiConsumer consumer = mock(PubSubApiConsumer.class);
+        when(consumer.getTopic()).thenReturn("/event/FakeTopic");
+        when(consumer.getBatchSize()).thenReturn(100);
+
+        int port = getPort();
+        LOG.debug("Starting server on port {}", port);
+        final Server grpcServer = ServerBuilder.forPort(port)
+            .addService(new AuthErrorPubSubServer())
+            .build();
+        grpcServer.start();
+
+        PubSubApiClient client = Mockito.spy(new PubSubApiClient(
+            session, new SalesforceLoginConfig(), "localhost",
+            port, 1000, 10000));
+        client.setUsePlainTextConnection(true);
+        client.start();
+        client.subscribe(consumer, ReplayPreset.LATEST, null);
+
+        verify(session, timeout(5000)).attemptLoginUntilSuccessful(anyLong(), anyLong());
+        verify(client, times(2)).subscribe(consumer, ReplayPreset.LATEST, null);
+    }
 
     @Test
     public void shouldAuthenticateAndSubscribeAfterAuthError() throws IOException {

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/pubsub/SendOneMessagePubSubServer.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/pubsub/SendOneMessagePubSubServer.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.salesforce.internal.pubsub;
+
+import com.google.protobuf.ByteString;
+import com.salesforce.eventbus.protobuf.ConsumerEvent;
+import com.salesforce.eventbus.protobuf.EventHeader;
+import com.salesforce.eventbus.protobuf.FetchRequest;
+import com.salesforce.eventbus.protobuf.FetchResponse;
+import com.salesforce.eventbus.protobuf.ProducerEvent;
+import com.salesforce.eventbus.protobuf.PubSubGrpc;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import static org.apache.camel.component.salesforce.internal.client.PubSubApiClient.PUBSUB_ERROR_AUTH_ERROR;
+
+public class SendOneMessagePubSubServer extends PubSubGrpc.PubSubImplBase {
+
+  public int onNextCalls = 0;
+
+  @Override
+  public StreamObserver<FetchRequest> subscribe(StreamObserver<FetchResponse> client) {
+
+    return new StreamObserver<>() {
+      @Override
+      public void onNext(FetchRequest request) {
+        onNextCalls = onNextCalls + 1;
+        if (onNextCalls > 1) {
+          TimerTask task = new TimerTask() {
+            public void run() {
+              StatusRuntimeException e = new StatusRuntimeException(Status.UNAUTHENTICATED, new Metadata());
+              e.getTrailers().put(Metadata.Key.of("error-code", Metadata.ASCII_STRING_MARSHALLER),
+                  PUBSUB_ERROR_AUTH_ERROR);
+              client.onError(e);
+            }
+          };
+          Timer timer = new Timer("Timer");
+          long delay = 1000L;
+          timer.schedule(task, delay);
+          return;
+        }
+        TimerTask task = new TimerTask() {
+          public void run() {
+            FetchResponse response = FetchResponse.newBuilder()
+                .setLatestReplayId(ByteString.copyFromUtf8("123"))
+                .build();
+            client.onNext(response);
+          }
+        };
+        Timer timer = new Timer("Timer");
+        long delay = 1000L;
+        timer.schedule(task, delay);
+      }
+
+      @Override
+      public void onError(Throwable t) {
+
+      }
+
+      @Override
+      public void onCompleted() {
+
+      }
+    };
+  }
+}


### PR DESCRIPTION


# Description

This makes the following changes:
 - Reconnect automatically with sensible defaults if we get an error before receiving the first message
 - Expose an API for updating the initialReplayId. At first, this might sound silly. "initialReplayId" is effectively a constant, right? But there's a notable exception in cases where the client restarts the route dynamically and may pull a new replay id from another source. This can happen in the case of clustering, where only one route is active at a time and failover may occur.
 - Expose an API to force plaintext via the consumer. This is for a similar reason to the existing method, but also makes it available to other test frameworks. We use a fake grpc endpoint to test the service and this will simplify that work.
 

# Target

- [x ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

