### PR TITLE
Add the branch 4.0 to the Camel Daily Snapshot Deploy job

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -59,6 +59,7 @@ pipeline {
             when {
                 anyOf {
                     branch 'main'
+                    branch 'camel-4.0.x'
                     branch 'camel-3.x'
                     branch 'camel-3.21.x'
                     branch 'camel-3.20.x'


### PR DESCRIPTION
## Motivation

No snapshots are published for Camel 4.0.

## Modifications:

* Add `camel-4.0.x` to the list of branches for which the "Camel Daily Snapshot Deploy" must be launched