### PR TITLE
CAMEL-19840: camel-core-api - Warn when the key store cannot be found

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/support/jsse/KeyStoreParameters.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/jsse/KeyStoreParameters.java
@@ -190,7 +190,13 @@ public class KeyStoreParameters extends JsseParameters {
             ks.load(null, ksPassword);
         } else {
             InputStream is = this.resolveResource(this.parsePropertyValue(this.resource));
-            ks.load(is, ksPassword);
+            if (is == null) {
+                LOG.warn("No keystore could be found at {}.", this.resource);
+            } else {
+                try (is) {
+                    ks.load(is, ksPassword);
+                }
+            }
         }
 
         if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19840 for 3.22

## Motivation

If `KeyStoreParameters` are configured with an incorrect path for the key store file, at runtime, we end up with an error that can be more or less easy to understand depending on the underlying component for which SSL has been configured.

## Modifications:

* Add a warning when the key store file cannot be found