### PR TITLE
CAMEL-19398: use Java's builtin custom boolean parser

### DIFF
--- a/core/camel-base/src/main/java/org/apache/camel/impl/converter/CoreTypeConverterRegistry.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/converter/CoreTypeConverterRegistry.java
@@ -175,32 +175,13 @@ public abstract class CoreTypeConverterRegistry extends ServiceSupport implement
         return (T) doConvertToAndStat(type, exchange, value, false);
     }
 
-    // must be 4 or 5 in length
     private static Boolean customParseBoolean(String str) {
-        int len = str.length();
-        // fast check the value as-is in lower case which is most common
-        if (len == 4) {
-            if ("true".equals(str)) {
-                return Boolean.TRUE;
-            }
-
-            if ("TRUE".equals(str.toUpperCase())) {
-                return Boolean.TRUE;
-            }
-
-            return null;
+        if ("true".equalsIgnoreCase(str)) {
+            return Boolean.TRUE;
         }
 
-        if (len == 5) {
-            if ("false".equals(str)) {
-                return Boolean.FALSE;
-            }
-
-            if ("FALSE".equals(str.toUpperCase())) {
-                return Boolean.FALSE;
-            }
-
-            return null;
+        if ("false".equalsIgnoreCase(str)) {
+            return Boolean.FALSE;
         }
 
         return null;


### PR DESCRIPTION
Note: this changes the behavior for converting string to boolean when invalid data is passed. Previously the code would return `null`. With this, it defaults to `false`. 

Obs.: keeping as a draft as I would like @davsclaus opinion on this (and he is on PTO).