### PR TITLE
[CAMEL-19700] camel-yaml-dsl: Add "additionalProperties: false" on ev…

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/generated/java/org/apache/camel/dsl/yaml/deserializers/ModelDeserializers.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/generated/java/org/apache/camel/dsl/yaml/deserializers/ModelDeserializers.java
@@ -6844,6 +6844,7 @@ public final class ModelDeserializers extends YamlDeserializerSupport {
         }
     }
 
+    @YamlIn
     @YamlType(
             nodes = "intercept",
             types = org.apache.camel.model.InterceptDefinition.class,
@@ -6905,6 +6906,7 @@ public final class ModelDeserializers extends YamlDeserializerSupport {
         }
     }
 
+    @YamlIn
     @YamlType(
             nodes = {
                     "intercept-from",
@@ -6981,6 +6983,7 @@ public final class ModelDeserializers extends YamlDeserializerSupport {
         }
     }
 
+    @YamlIn
     @YamlType(
             nodes = {
                     "intercept-send-to-endpoint",
@@ -9594,6 +9597,7 @@ public final class ModelDeserializers extends YamlDeserializerSupport {
         }
     }
 
+    @YamlIn
     @YamlType(
             nodes = {
                     "on-completion",

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlDeserializersMojo.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlDeserializersMojo.java
@@ -414,7 +414,19 @@ public class GenerateYamlDeserializersMojo extends GenerateYamlSupportMojo {
         TypeSpecHolder.put(attributes, "type", info.name().toString());
 
         //TODO: add an option on Camel's definitions to distinguish between IN/OUT types
+        if (info.name().toString().equals("org.apache.camel.model.InterceptDefinition")) {
+            builder.addAnnotation(CN_YAML_IN);
+        }
+        if (info.name().toString().equals("org.apache.camel.model.InterceptFromDefinition")) {
+            builder.addAnnotation(CN_YAML_IN);
+        }
+        if (info.name().toString().equals("org.apache.camel.model.InterceptSendToEndpointDefinition")) {
+            builder.addAnnotation(CN_YAML_IN);
+        }
         if (info.name().toString().equals("org.apache.camel.model.OnExceptionDefinition")) {
+            builder.addAnnotation(CN_YAML_IN);
+        }
+        if (info.name().toString().equals("org.apache.camel.model.OnCompletionDefinition")) {
             builder.addAnnotation(CN_YAML_IN);
         }
         if (info.name().toString().equals("org.apache.camel.model.rest.RestDefinition")) {

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/pom.xml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/pom.xml
@@ -278,6 +278,7 @@
                         </goals>
                         <configuration>
                             <kebabCase>false</kebabCase>
+                            <additionalProperties>false</additionalProperties>
                             <outputFile>src/generated/resources/schema/camelYamlDsl.json</outputFile>
                         </configuration>
                     </execution>

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
@@ -3,10 +3,12 @@
   "type" : "array",
   "items" : {
     "maxProperties" : 1,
+    "additionalProperties" : false,
     "definitions" : {
       "org.apache.camel.model.ProcessorDefinition" : {
         "type" : "object",
         "maxProperties" : 1,
+        "additionalProperties" : false,
         "properties" : {
           "aggregate" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.AggregateDefinition"
@@ -47,15 +49,6 @@
           "idempotentConsumer" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.IdempotentConsumerDefinition"
           },
-          "intercept" : {
-            "$ref" : "#/items/definitions/org.apache.camel.model.InterceptDefinition"
-          },
-          "interceptFrom" : {
-            "$ref" : "#/items/definitions/org.apache.camel.model.InterceptFromDefinition"
-          },
-          "interceptSendToEndpoint" : {
-            "$ref" : "#/items/definitions/org.apache.camel.model.InterceptSendToEndpointDefinition"
-          },
           "kamelet" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.KameletDefinition"
           },
@@ -73,9 +66,6 @@
           },
           "multicast" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.MulticastDefinition"
-          },
-          "onCompletion" : {
-            "$ref" : "#/items/definitions/org.apache.camel.model.OnCompletionDefinition"
           },
           "onFallback" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.OnFallbackDefinition"
@@ -204,12 +194,14 @@
       },
       "org.apache.camel.dsl.yaml.deserializers.BeansDeserializer" : {
         "type" : "array",
+        "additionalProperties" : false,
         "items" : {
           "$ref" : "#/items/definitions/org.apache.camel.model.app.RegistryBeanDefinition"
         }
       },
       "org.apache.camel.dsl.yaml.deserializers.ErrorHandlerBuilderDeserializer" : {
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "type" : "object",
@@ -222,17 +214,17 @@
           }, {
             "not" : {
               "anyOf" : [ {
-                "required" : [ "dead-letter-channel" ]
+                "required" : [ "deadLetterChannel" ]
               }, {
-                "required" : [ "default-error-handler" ]
+                "required" : [ "defaultErrorHandler" ]
               }, {
-                "required" : [ "jta-transaction-error-handler" ]
+                "required" : [ "jtaTransactionErrorHandler" ]
               }, {
-                "required" : [ "no-error-handler" ]
+                "required" : [ "noErrorHandler" ]
               }, {
-                "required" : [ "ref-error-handler" ]
+                "required" : [ "refErrorHandler" ]
               }, {
-                "required" : [ "spring-transaction-error-handler" ]
+                "required" : [ "springTransactionErrorHandler" ]
               } ]
             }
           }, {
@@ -312,6 +304,7 @@
       },
       "org.apache.camel.dsl.yaml.deserializers.RouteFromDefinitionDeserializer" : {
         "type" : "object",
+        "additionalProperties" : false,
         "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.OutputAwareFromDefinition",
         "properties" : {
           "description" : {
@@ -339,6 +332,7 @@
         "title" : "Aggregate",
         "description" : "Aggregates many messages into a single message",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "aggregateController" : {
             "type" : "string",
@@ -510,6 +504,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "beanType" : {
               "type" : "string",
@@ -558,6 +553,7 @@
         "title" : "Do Catch",
         "description" : "Catches exceptions as part of a try, catch, finally block",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -602,6 +598,7 @@
         "title" : "Choice",
         "description" : "Route messages based on a series of predicates",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -651,6 +648,7 @@
         "title" : "Circuit Breaker",
         "description" : "Route messages in a fault tolerance way using Circuit Breaker",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "configuration" : {
             "type" : "string",
@@ -702,6 +700,7 @@
         "title" : "Claim Check",
         "description" : "The Claim Check EIP allows you to replace message content with a claim check (a unique key), which can be used to retrieve the message content at a later time.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "aggregationStrategy" : {
             "type" : "string",
@@ -753,6 +752,7 @@
         "title" : "Context Scan",
         "description" : "Scans for Java org.apache.camel.builder.RouteBuilder instances in the context org.apache.camel.spi.Registry .",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "excludes" : {
             "type" : "array",
@@ -784,6 +784,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "charset" : {
               "type" : "string",
@@ -824,6 +825,7 @@
       },
       "org.apache.camel.model.DataFormatDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string"
@@ -834,6 +836,7 @@
         "title" : "Delay",
         "description" : "Delays processing for a specified length of time",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -967,6 +970,7 @@
         "title" : "Dynamic Router",
         "description" : "Route messages based on dynamic rules",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -1101,6 +1105,7 @@
         "title" : "Enrich",
         "description" : "Enriches a message with data from a secondary resource",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -1259,6 +1264,7 @@
         "title" : "Error Handler",
         "description" : "Camel error handling.",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "type" : "object",
@@ -1271,15 +1277,15 @@
           }, {
             "not" : {
               "anyOf" : [ {
-                "required" : [ "dead-letter-channel" ]
+                "required" : [ "deadLetterChannel" ]
               }, {
-                "required" : [ "default-error-handler" ]
+                "required" : [ "defaultErrorHandler" ]
               }, {
-                "required" : [ "jta-transaction-error-handler" ]
+                "required" : [ "jtaTransactionErrorHandler" ]
               }, {
-                "required" : [ "no-error-handler" ]
+                "required" : [ "noErrorHandler" ]
               }, {
-                "required" : [ "spring-transaction-error-handler" ]
+                "required" : [ "springTransactionErrorHandler" ]
               } ]
             }
           }, {
@@ -1331,6 +1337,7 @@
       },
       "org.apache.camel.model.ExpressionSubElementDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "type" : "object",
@@ -1349,7 +1356,7 @@
               }, {
                 "required" : [ "datasonnet" ]
               }, {
-                "required" : [ "exchange-property" ]
+                "required" : [ "exchangeProperty" ]
               }, {
                 "required" : [ "exchangeProperty" ]
               }, {
@@ -1608,6 +1615,7 @@
         "title" : "Fault Tolerance Configuration",
         "description" : "MicroProfile Fault Tolerance Circuit Breaker EIP configuration",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "bulkheadEnabled" : {
             "type" : "boolean",
@@ -1693,6 +1701,7 @@
         "title" : "Filter",
         "description" : "Filter out messages based using a predicate",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -1822,6 +1831,7 @@
         "title" : "Do Finally",
         "description" : "Path traversed when a try, catch, finally block exits",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -1851,6 +1861,7 @@
       },
       "org.apache.camel.model.FromDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string"
@@ -1877,6 +1888,7 @@
         "title" : "Global Option",
         "description" : "Models a string key/value pair for configuring some global options on a Camel context such as max debug log length.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "key" : {
             "type" : "string",
@@ -1895,6 +1907,7 @@
         "title" : "Global Options",
         "description" : "Models a series of string key/value pairs for configuring some global options on a Camel context such as max debug log length.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "globalOption" : {
             "type" : "array",
@@ -1910,6 +1923,7 @@
         "title" : "Idempotent Consumer",
         "description" : "Filters out duplicate messages",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -2060,6 +2074,7 @@
         "title" : "Input Type",
         "description" : "Set the expected data type of the input message. If the actual message type is different at runtime, camel look for a required Transformer and apply if exists. If validate attribute is true then camel applies Validator as well. Type name consists of two parts, 'scheme' and 'name' connected with ':'. For Java type 'name' is a fully qualified class name. For example {code java:java.lang.String} , {code json:ABCOrder} . It's also possible to specify only scheme part, so that it works like a wildcard. If only 'xml' is specified, all the XML message matches. It's handy to add only one transformer/validator for all the transformation from/to XML.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -2088,6 +2103,7 @@
         "title" : "Intercept",
         "description" : "Intercepts a message at each step in the route",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -2122,6 +2138,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "description" : {
               "type" : "string",
@@ -2162,6 +2179,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "afterUri" : {
               "type" : "string",
@@ -2211,6 +2229,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "inheritErrorHandler" : {
               "type" : "boolean"
@@ -2235,6 +2254,7 @@
         "title" : "Load Balance",
         "description" : "Balances message processing among a number of nodes",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "type" : "object",
@@ -2247,13 +2267,13 @@
           }, {
             "not" : {
               "anyOf" : [ {
-                "required" : [ "custom-load-balancer" ]
+                "required" : [ "customLoadBalancer" ]
               }, {
                 "required" : [ "failover" ]
               }, {
                 "required" : [ "random" ]
               }, {
-                "required" : [ "round-robin" ]
+                "required" : [ "roundRobin" ]
               }, {
                 "required" : [ "sticky" ]
               }, {
@@ -2355,6 +2375,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "description" : {
               "type" : "string",
@@ -2409,6 +2430,7 @@
         "title" : "Loop",
         "description" : "Processes a message multiple times",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -2548,6 +2570,7 @@
         "title" : "Marshal",
         "description" : "Marshals data into a specified format for transmission over a transport or component",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "type" : "object",
@@ -2578,33 +2601,33 @@
               }, {
                 "required" : [ "custom" ]
               }, {
-                "required" : [ "fhir-json" ]
+                "required" : [ "fhirJson" ]
               }, {
-                "required" : [ "fhir-xml" ]
+                "required" : [ "fhirXml" ]
               }, {
                 "required" : [ "flatpack" ]
               }, {
                 "required" : [ "grok" ]
               }, {
-                "required" : [ "gzip-deflater" ]
+                "required" : [ "gzipDeflater" ]
               }, {
                 "required" : [ "hl7" ]
               }, {
                 "required" : [ "ical" ]
               }, {
-                "required" : [ "jackson-xml" ]
+                "required" : [ "jacksonXml" ]
               }, {
                 "required" : [ "jaxb" ]
               }, {
                 "required" : [ "json" ]
               }, {
-                "required" : [ "json-api" ]
+                "required" : [ "jsonApi" ]
               }, {
                 "required" : [ "lzf" ]
               }, {
-                "required" : [ "mime-multipart" ]
+                "required" : [ "mimeMultipart" ]
               }, {
-                "required" : [ "parquet-avro" ]
+                "required" : [ "parquetAvro" ]
               }, {
                 "required" : [ "pgp" ]
               }, {
@@ -2614,31 +2637,31 @@
               }, {
                 "required" : [ "soap" ]
               }, {
-                "required" : [ "swift-mt" ]
+                "required" : [ "swiftMt" ]
               }, {
-                "required" : [ "swift-mx" ]
+                "required" : [ "swiftMx" ]
               }, {
                 "required" : [ "syslog" ]
               }, {
-                "required" : [ "tar-file" ]
+                "required" : [ "tarFile" ]
               }, {
                 "required" : [ "thrift" ]
               }, {
-                "required" : [ "tidy-markup" ]
+                "required" : [ "tidyMarkup" ]
               }, {
-                "required" : [ "univocity-csv" ]
+                "required" : [ "univocityCsv" ]
               }, {
-                "required" : [ "univocity-fixed" ]
+                "required" : [ "univocityFixed" ]
               }, {
-                "required" : [ "univocity-tsv" ]
+                "required" : [ "univocityTsv" ]
               }, {
-                "required" : [ "xml-security" ]
+                "required" : [ "xmlSecurity" ]
               }, {
                 "required" : [ "yaml" ]
               }, {
-                "required" : [ "zip-deflater" ]
+                "required" : [ "zipDeflater" ]
               }, {
-                "required" : [ "zip-file" ]
+                "required" : [ "zipFile" ]
               } ]
             }
           }, {
@@ -3020,6 +3043,7 @@
         "title" : "Multicast",
         "description" : "Routes the same message to multiple paths either sequentially or in parallel.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "aggregationStrategy" : {
             "type" : "string",
@@ -3112,6 +3136,7 @@
         "title" : "On Completion",
         "description" : "Route to be executed when normal route processing completes",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -3180,6 +3205,7 @@
         "title" : "On Exception",
         "description" : "Route to be executed when an exception is thrown",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "continued" : {
             "title" : "Continued",
@@ -3269,6 +3295,7 @@
         "title" : "On Fallback",
         "description" : "Route to be executed when Circuit Breaker EIP executes fallback",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -3305,6 +3332,7 @@
         "title" : "Optimistic Lock Retry Policy",
         "description" : "To configure optimistic locking",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "exponentialBackOff" : {
             "type" : "boolean",
@@ -3339,6 +3367,7 @@
         "title" : "Otherwise",
         "description" : "Route to be executed when all other choices evaluate to false",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -3368,6 +3397,7 @@
       },
       "org.apache.camel.model.OutputDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string"
@@ -3393,6 +3423,7 @@
         "title" : "Output Type",
         "description" : "Set the expected data type of the output message. If the actual message type is different at runtime, camel look for a required Transformer and apply if exists. If validate attribute is true then camel applies Validator as well. Type name consists of two parts, 'scheme' and 'name' connected with ':'. For Java type 'name' is a fully qualified class name. For example {code java:java.lang.String} , {code json:ABCOrder} . It's also possible to specify only scheme part, so that it works like a wildcard. If only 'xml' is specified, all the XML message matches. It's handy to add only one transformer/validator for all the XML-Java transformation.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -3421,6 +3452,7 @@
         "title" : "Package Scan",
         "description" : "Scans for Java org.apache.camel.builder.RouteBuilder classes in java packages",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "excludes" : {
             "type" : "array",
@@ -3452,6 +3484,7 @@
         "title" : "Pausable",
         "description" : "Pausable EIP to support resuming processing from last known offset.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "consumerListener" : {
             "type" : "string",
@@ -3488,6 +3521,7 @@
         "title" : "Pipeline",
         "description" : "Routes the message to a sequence of processors.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -3519,6 +3553,7 @@
         "title" : "Policy",
         "description" : "Defines a policy the route will use",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -3556,6 +3591,7 @@
         "title" : "Poll Enrich",
         "description" : "Enriches messages with data polled from a secondary resource",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -3710,6 +3746,7 @@
         "title" : "Process",
         "description" : "Calls a Camel processor",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -3741,6 +3778,7 @@
         "title" : "Property",
         "description" : "A key value pair where the value is a literal value",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "key" : {
             "type" : "string",
@@ -3759,6 +3797,7 @@
         "title" : "Property Expression",
         "description" : "A key value pair where the value is an expression.",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "type" : "object",
@@ -3792,6 +3831,7 @@
         "title" : "Recipient List",
         "description" : "Route messages to a number of dynamically specified recipients",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -3987,6 +4027,7 @@
         "title" : "Redelivery Policy",
         "description" : "To configure re-delivery for error handling",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowRedeliveryWhileStopping" : {
             "type" : "boolean",
@@ -4129,6 +4170,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "description" : {
               "type" : "string",
@@ -4164,6 +4206,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "description" : {
               "type" : "string",
@@ -4204,6 +4247,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "description" : {
               "type" : "string",
@@ -4244,6 +4288,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "description" : {
               "type" : "string",
@@ -4276,6 +4321,7 @@
         "title" : "Resequence",
         "description" : "Resequences (re-order) messages based on an expression",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -4356,9 +4402,9 @@
           }, {
             "not" : {
               "anyOf" : [ {
-                "required" : [ "batch-config" ]
+                "required" : [ "batchConfig" ]
               }, {
-                "required" : [ "stream-config" ]
+                "required" : [ "streamConfig" ]
               } ]
             }
           }, {
@@ -4428,6 +4474,7 @@
         "title" : "Resilience4j Configuration",
         "description" : "Resilience4j Circuit Breaker EIP configuration",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "automaticTransitionFromOpenToHalfOpenEnabled" : {
             "type" : "boolean",
@@ -4555,6 +4602,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "ref" : {
               "type" : "string",
@@ -4569,6 +4617,7 @@
         "title" : "Resumable",
         "description" : "Resume EIP to support resuming processing from last known offset.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -4614,6 +4663,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "description" : {
               "type" : "string",
@@ -4658,6 +4708,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "id" : {
               "type" : "string",
@@ -4680,6 +4731,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "ref" : {
               "type" : "string",
@@ -4692,6 +4744,7 @@
       },
       "org.apache.camel.model.RouteConfigurationDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "errorHandler" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.ErrorHandlerDefinition"
@@ -4702,6 +4755,7 @@
           "intercept" : {
             "type" : "array",
             "items" : {
+              "additionalProperties" : false,
               "type" : "object",
               "properties" : {
                 "intercept" : {
@@ -4713,6 +4767,7 @@
           "interceptFrom" : {
             "type" : "array",
             "items" : {
+              "additionalProperties" : false,
               "type" : "object",
               "properties" : {
                 "interceptFrom" : {
@@ -4724,6 +4779,7 @@
           "interceptSendToEndpoint" : {
             "type" : "array",
             "items" : {
+              "additionalProperties" : false,
               "type" : "object",
               "properties" : {
                 "interceptSendToEndpoint" : {
@@ -4735,6 +4791,7 @@
           "onCompletion" : {
             "type" : "array",
             "items" : {
+              "additionalProperties" : false,
               "type" : "object",
               "properties" : {
                 "onCompletion" : {
@@ -4746,6 +4803,7 @@
           "onException" : {
             "type" : "array",
             "items" : {
+              "additionalProperties" : false,
               "type" : "object",
               "properties" : {
                 "onException" : {
@@ -4766,6 +4824,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "ref" : {
               "type" : "string",
@@ -4778,6 +4837,7 @@
       },
       "org.apache.camel.model.RouteDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "autoStartup" : {
             "type" : "boolean"
@@ -4832,6 +4892,7 @@
       },
       "org.apache.camel.model.RouteTemplateBeanDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "beanType" : {
             "type" : "string"
@@ -4859,6 +4920,7 @@
       },
       "org.apache.camel.model.RouteTemplateDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "beans" : {
             "type" : "array",
@@ -4891,6 +4953,7 @@
         "title" : "Template Parameter",
         "description" : "A route template parameter",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "defaultValue" : {
             "type" : "string",
@@ -4922,6 +4985,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "anyOf" : [ {
             "oneOf" : [ {
               "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -5058,6 +5122,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "description" : {
               "type" : "string"
@@ -5085,6 +5150,7 @@
         "title" : "Saga",
         "description" : "Enables Sagas on the route",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "compensation" : {
             "title" : "Compensation",
@@ -5161,6 +5227,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "description" : {
               "type" : "string",
@@ -5198,6 +5265,7 @@
         "title" : "Script",
         "description" : "Executes a script from a language which does not change the message body.",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -5316,6 +5384,7 @@
         "title" : "Set Body",
         "description" : "Sets the contents of the message body",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -5437,6 +5506,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "description" : {
               "type" : "string",
@@ -5469,6 +5539,7 @@
         "title" : "Set Header",
         "description" : "Sets the value of a message header",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -5593,6 +5664,7 @@
         "title" : "Set Property",
         "description" : "Sets a named property on the message exchange",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -5717,6 +5789,7 @@
         "title" : "Sort",
         "description" : "Sorts the contents of the message",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -5840,6 +5913,7 @@
         "title" : "Split",
         "description" : "Splits a single message into many sub-messages.",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -6031,6 +6105,7 @@
         "title" : "Step",
         "description" : "Routes the message to a sequence of processors which is grouped together as one logical name",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -6062,6 +6137,7 @@
         "title" : "Stop",
         "description" : "Stops the processing of the current message",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -6085,6 +6161,7 @@
       },
       "org.apache.camel.model.TemplatedRouteBeanDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "beanType" : {
             "type" : "string"
@@ -6112,6 +6189,7 @@
       },
       "org.apache.camel.model.TemplatedRouteDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "beans" : {
             "type" : "array",
@@ -6141,6 +6219,7 @@
         "title" : "Templated Route Parameter",
         "description" : "An input parameter of a route template.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "name" : {
             "type" : "string",
@@ -6159,6 +6238,7 @@
         "title" : "Thread Pool Profile",
         "description" : "To configure thread pools",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowCoreThreadTimeOut" : {
             "type" : "boolean",
@@ -6218,6 +6298,7 @@
         "title" : "Threads",
         "description" : "Specifies that all steps after this node are processed asynchronously",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowCoreThreadTimeOut" : {
             "type" : "boolean",
@@ -6297,6 +6378,7 @@
         "title" : "Throttle",
         "description" : "Controls the rate at which messages are passed to the next node in the route",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -6446,6 +6528,7 @@
         "title" : "Throw Exception",
         "description" : "Throws an exception",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -6489,6 +6572,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "description" : {
               "type" : "string",
@@ -6533,6 +6617,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "allowOptimisedComponents" : {
               "type" : "boolean",
@@ -6594,6 +6679,7 @@
         "title" : "Transacted",
         "description" : "Enables transaction on the route",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -6630,6 +6716,7 @@
         "title" : "Transform",
         "description" : "Transforms the message body based on an expression",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -6758,6 +6845,7 @@
         "title" : "Do Try",
         "description" : "Marks the beginning of a try, catch, finally block",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -6798,6 +6886,7 @@
         "title" : "Unmarshal",
         "description" : "Converts the message data received from the wire into a format that Apache Camel processors can consume",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowNullBody" : {
             "type" : "boolean",
@@ -6893,33 +6982,33 @@
               }, {
                 "required" : [ "custom" ]
               }, {
-                "required" : [ "fhir-json" ]
+                "required" : [ "fhirJson" ]
               }, {
-                "required" : [ "fhir-xml" ]
+                "required" : [ "fhirXml" ]
               }, {
                 "required" : [ "flatpack" ]
               }, {
                 "required" : [ "grok" ]
               }, {
-                "required" : [ "gzip-deflater" ]
+                "required" : [ "gzipDeflater" ]
               }, {
                 "required" : [ "hl7" ]
               }, {
                 "required" : [ "ical" ]
               }, {
-                "required" : [ "jackson-xml" ]
+                "required" : [ "jacksonXml" ]
               }, {
                 "required" : [ "jaxb" ]
               }, {
                 "required" : [ "json" ]
               }, {
-                "required" : [ "json-api" ]
+                "required" : [ "jsonApi" ]
               }, {
                 "required" : [ "lzf" ]
               }, {
-                "required" : [ "mime-multipart" ]
+                "required" : [ "mimeMultipart" ]
               }, {
-                "required" : [ "parquet-avro" ]
+                "required" : [ "parquetAvro" ]
               }, {
                 "required" : [ "pgp" ]
               }, {
@@ -6929,31 +7018,31 @@
               }, {
                 "required" : [ "soap" ]
               }, {
-                "required" : [ "swift-mt" ]
+                "required" : [ "swiftMt" ]
               }, {
-                "required" : [ "swift-mx" ]
+                "required" : [ "swiftMx" ]
               }, {
                 "required" : [ "syslog" ]
               }, {
-                "required" : [ "tar-file" ]
+                "required" : [ "tarFile" ]
               }, {
                 "required" : [ "thrift" ]
               }, {
-                "required" : [ "tidy-markup" ]
+                "required" : [ "tidyMarkup" ]
               }, {
-                "required" : [ "univocity-csv" ]
+                "required" : [ "univocityCsv" ]
               }, {
-                "required" : [ "univocity-fixed" ]
+                "required" : [ "univocityFixed" ]
               }, {
-                "required" : [ "univocity-tsv" ]
+                "required" : [ "univocityTsv" ]
               }, {
-                "required" : [ "xml-security" ]
+                "required" : [ "xmlSecurity" ]
               }, {
                 "required" : [ "yaml" ]
               }, {
-                "required" : [ "zip-deflater" ]
+                "required" : [ "zipDeflater" ]
               }, {
-                "required" : [ "zip-file" ]
+                "required" : [ "zipFile" ]
               } ]
             }
           }, {
@@ -7275,6 +7364,7 @@
         "title" : "Validate",
         "description" : "Validates a message based on an expression",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -7401,6 +7491,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "value" : {
               "type" : "string",
@@ -7414,6 +7505,7 @@
         "title" : "When",
         "description" : "Triggers a route when the expression evaluates to true",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -7538,6 +7630,7 @@
         "title" : "When Skip Send To Endpoint",
         "description" : "Predicate to determine if the message should be sent or not to the endpoint, when using interceptSentToEndpoint.",
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -7662,6 +7755,7 @@
         "title" : "Wire Tap",
         "description" : "Routes a copy of a message (or creates a new message) to a secondary destination while continue routing the original message.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowOptimisedComponents" : {
             "type" : "boolean",
@@ -7742,6 +7836,7 @@
         "title" : "Camel",
         "description" : "If beans reminds Spring application too much, we can use camel.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "bean" : {
             "type" : "array",
@@ -7802,6 +7897,7 @@
       },
       "org.apache.camel.model.app.BeanPropertiesDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "property" : {
             "type" : "array",
@@ -7813,6 +7909,7 @@
       },
       "org.apache.camel.model.app.BeanPropertyDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "key" : {
             "type" : "string"
@@ -7829,6 +7926,7 @@
         "title" : "Beans",
         "description" : "A grouping POJO (and related XML root element) that's historically associated with entire application (or its distinguished fragment). This class is not meant to be used with Camel Java DSL, but it's needed to generate XML Schema and MX parser methods.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "bean" : {
             "type" : "array",
@@ -7889,6 +7987,7 @@
       },
       "org.apache.camel.model.app.ComponentScanDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "basePackage" : {
             "type" : "string"
@@ -7897,6 +7996,7 @@
       },
       "org.apache.camel.model.app.RegistryBeanDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "name" : {
             "type" : "string"
@@ -7913,6 +8013,7 @@
         "title" : "Blacklist Service Filter",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -7941,6 +8042,7 @@
         "title" : "Caching Service Discovery",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "type" : "object",
@@ -7953,15 +8055,15 @@
           }, {
             "not" : {
               "anyOf" : [ {
-                "required" : [ "combined-service-discovery" ]
+                "required" : [ "combinedServiceDiscovery" ]
               }, {
-                "required" : [ "consul-service-discovery" ]
+                "required" : [ "consulServiceDiscovery" ]
               }, {
-                "required" : [ "dns-service-discovery" ]
+                "required" : [ "dnsServiceDiscovery" ]
               }, {
-                "required" : [ "kubernetes-service-discovery" ]
+                "required" : [ "kubernetesServiceDiscovery" ]
               }, {
-                "required" : [ "static-service-discovery" ]
+                "required" : [ "staticServiceDiscovery" ]
               } ]
             }
           }, {
@@ -8036,6 +8138,7 @@
         "title" : "Combined Service Discovery",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "cachingServiceDiscovery" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CachingServiceCallServiceDiscoveryConfiguration"
@@ -8071,6 +8174,7 @@
         "title" : "Combined Service Filter",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "blacklistServiceFilter" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.cloud.BlacklistServiceCallServiceFilterConfiguration"
@@ -8103,6 +8207,7 @@
         "title" : "Consul Service Discovery",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "aclToken" : {
             "type" : "string",
@@ -8169,6 +8274,7 @@
         "title" : "Custom Service Filter",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -8194,6 +8300,7 @@
         "title" : "Default Load Balancer",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -8214,6 +8321,7 @@
         "title" : "Dns Service Discovery",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "domain" : {
             "type" : "string",
@@ -8245,6 +8353,7 @@
         "title" : "Healthy Service Filter",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -8265,6 +8374,7 @@
         "title" : "Kubernetes Service Discovery",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "apiVersion" : {
             "type" : "string",
@@ -8382,6 +8492,7 @@
         "title" : "Pass Through Service Filter",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -8403,6 +8514,7 @@
         "description" : "Remote service call configuration",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "type" : "object",
@@ -8415,15 +8527,15 @@
           }, {
             "not" : {
               "anyOf" : [ {
-                "required" : [ "blacklist-service-filter" ]
+                "required" : [ "blacklistServiceFilter" ]
               }, {
-                "required" : [ "combined-service-filter" ]
+                "required" : [ "combinedServiceFilter" ]
               }, {
-                "required" : [ "custom-service-filter" ]
+                "required" : [ "customServiceFilter" ]
               }, {
-                "required" : [ "healthy-service-filter" ]
+                "required" : [ "healthyServiceFilter" ]
               }, {
-                "required" : [ "pass-through-service-filter" ]
+                "required" : [ "passThroughServiceFilter" ]
               } ]
             }
           }, {
@@ -8471,19 +8583,19 @@
           }, {
             "not" : {
               "anyOf" : [ {
-                "required" : [ "caching-service-discovery" ]
+                "required" : [ "cachingServiceDiscovery" ]
               }, {
-                "required" : [ "combined-service-discovery" ]
+                "required" : [ "combinedServiceDiscovery" ]
               }, {
-                "required" : [ "consul-service-discovery" ]
+                "required" : [ "consulServiceDiscovery" ]
               }, {
-                "required" : [ "dns-service-discovery" ]
+                "required" : [ "dnsServiceDiscovery" ]
               }, {
-                "required" : [ "kubernetes-service-discovery" ]
+                "required" : [ "kubernetesServiceDiscovery" ]
               }, {
-                "required" : [ "static-service-discovery" ]
+                "required" : [ "staticServiceDiscovery" ]
               }, {
-                "required" : [ "zookeeper-service-discovery" ]
+                "required" : [ "zookeeperServiceDiscovery" ]
               } ]
             }
           }, {
@@ -8547,7 +8659,7 @@
           }, {
             "not" : {
               "anyOf" : [ {
-                "required" : [ "default-load-balancer" ]
+                "required" : [ "defaultLoadBalancer" ]
               } ]
             }
           } ]
@@ -8642,6 +8754,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "anyOf" : [ {
             "oneOf" : [ {
               "type" : "object",
@@ -8654,15 +8767,15 @@
             }, {
               "not" : {
                 "anyOf" : [ {
-                  "required" : [ "blacklist-service-filter" ]
+                  "required" : [ "blacklistServiceFilter" ]
                 }, {
-                  "required" : [ "combined-service-filter" ]
+                  "required" : [ "combinedServiceFilter" ]
                 }, {
-                  "required" : [ "custom-service-filter" ]
+                  "required" : [ "customServiceFilter" ]
                 }, {
-                  "required" : [ "healthy-service-filter" ]
+                  "required" : [ "healthyServiceFilter" ]
                 }, {
-                  "required" : [ "pass-through-service-filter" ]
+                  "required" : [ "passThroughServiceFilter" ]
                 } ]
               }
             }, {
@@ -8710,19 +8823,19 @@
             }, {
               "not" : {
                 "anyOf" : [ {
-                  "required" : [ "caching-service-discovery" ]
+                  "required" : [ "cachingServiceDiscovery" ]
                 }, {
-                  "required" : [ "combined-service-discovery" ]
+                  "required" : [ "combinedServiceDiscovery" ]
                 }, {
-                  "required" : [ "consul-service-discovery" ]
+                  "required" : [ "consulServiceDiscovery" ]
                 }, {
-                  "required" : [ "dns-service-discovery" ]
+                  "required" : [ "dnsServiceDiscovery" ]
                 }, {
-                  "required" : [ "kubernetes-service-discovery" ]
+                  "required" : [ "kubernetesServiceDiscovery" ]
                 }, {
-                  "required" : [ "static-service-discovery" ]
+                  "required" : [ "staticServiceDiscovery" ]
                 }, {
-                  "required" : [ "zookeeper-service-discovery" ]
+                  "required" : [ "zookeeperServiceDiscovery" ]
                 } ]
               }
             }, {
@@ -8786,7 +8899,7 @@
             }, {
               "not" : {
                 "anyOf" : [ {
-                  "required" : [ "default-load-balancer" ]
+                  "required" : [ "defaultLoadBalancer" ]
                 } ]
               }
             } ]
@@ -8902,6 +9015,7 @@
         "title" : "Service Expression",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "expressionType" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
@@ -8937,6 +9051,7 @@
         "title" : "Service Chooser Configuration",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -8957,6 +9072,7 @@
         "title" : "Service Discovery Configuration",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -8977,6 +9093,7 @@
         "title" : "Service Filter Configuration",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -8997,6 +9114,7 @@
         "title" : "Load Balancer Configuration",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -9017,6 +9135,7 @@
         "title" : "Static Service Discovery",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -9045,6 +9164,7 @@
         "title" : "Zookeeper Service Discovery",
         "deprecated" : true,
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "basePath" : {
             "type" : "string",
@@ -9106,6 +9226,7 @@
         "title" : "Batch-config",
         "description" : "Configures batch-processing resequence eip.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowDuplicates" : {
             "type" : "boolean",
@@ -9140,6 +9261,7 @@
         "title" : "Stream-config",
         "description" : "Configures stream-processing resequence eip.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "capacity" : {
             "type" : "number",
@@ -9183,6 +9305,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "id" : {
               "type" : "string",
@@ -9209,6 +9332,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "allowJmsType" : {
               "type" : "boolean",
@@ -9324,6 +9448,7 @@
         "title" : "Barcode",
         "description" : "Transform strings to various 1D/2D barcode bitmap formats and back.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "barcodeFormat" : {
             "type" : "string",
@@ -9356,6 +9481,7 @@
         "title" : "Base64",
         "description" : "Encode and decode data using Base64.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -9384,6 +9510,7 @@
         "title" : "Bindy",
         "description" : "Marshal and unmarshal Java beans from and to flat payloads (such as CSV, delimited, fixed length formats, or FIX messages).",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowEmptyStream" : {
             "type" : "boolean",
@@ -9422,6 +9549,7 @@
         "title" : "CBOR",
         "description" : "Unmarshal a CBOR payload to POJO and back.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowJmsType" : {
             "type" : "boolean",
@@ -9484,6 +9612,7 @@
         "title" : "Crypto (Java Cryptographic Extension)",
         "description" : "Encrypt and decrypt messages using Java Cryptography Extension (JCE).",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "algorithm" : {
             "type" : "string",
@@ -9544,6 +9673,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "allowMissingColumnNames" : {
               "type" : "boolean",
@@ -9711,6 +9841,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "id" : {
               "type" : "string",
@@ -9730,6 +9861,7 @@
         "title" : "Data formats",
         "description" : "Configure data formats.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "asn1" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ASN1DataFormat"
@@ -9857,6 +9989,7 @@
         "title" : "FHIR JSon",
         "description" : "Marshall and unmarshall FHIR objects to/from JSON.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "contentTypeHeader" : {
             "type" : "boolean",
@@ -9961,6 +10094,7 @@
         "title" : "FHIR XML",
         "description" : "Marshall and unmarshall FHIR objects to/from XML.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "contentTypeHeader" : {
             "type" : "boolean",
@@ -10065,6 +10199,7 @@
         "title" : "Flatpack",
         "description" : "Marshal and unmarshal Java lists and maps to/from flat files (such as CSV, delimited, or fixed length formats) using Flatpack library.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowShortLines" : {
             "type" : "boolean",
@@ -10118,6 +10253,7 @@
         "title" : "Grok",
         "description" : "Unmarshal unstructured data to objects using Logstash based Grok patterns.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowMultipleMatchesPerLine" : {
             "type" : "boolean",
@@ -10151,6 +10287,7 @@
         "title" : "GZip Deflater",
         "description" : "Compress and decompress messages using java.util.zip.GZIPStream.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -10163,6 +10300,7 @@
         "title" : "HL7",
         "description" : "Marshal and unmarshal HL7 (Health Care) model objects using the HL7 MLLP codec.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -10180,6 +10318,7 @@
         "title" : "iCal",
         "description" : "Marshal and unmarshal iCal (.ics) documents to/from model objects.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -10197,6 +10336,7 @@
         "title" : "Jackson XML",
         "description" : "Unmarshal an XML payloads to POJOs and back using XMLMapper extension of Jackson.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowJmsType" : {
             "type" : "boolean",
@@ -10289,6 +10429,7 @@
         "title" : "JAXB",
         "description" : "Unmarshal XML payloads to POJOs and back using JAXB2 XML marshalling standard.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "accessExternalSchemaProtocols" : {
             "type" : "string",
@@ -10401,6 +10542,7 @@
         "title" : "JSonApi",
         "description" : "Marshal and unmarshal JSON:API resources using JSONAPI-Converter library.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "dataFormatTypes" : {
             "type" : "string",
@@ -10423,6 +10565,7 @@
         "title" : "JSon",
         "description" : "Marshal POJOs to JSON and back.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowJmsType" : {
             "type" : "boolean",
@@ -10547,6 +10690,7 @@
         "title" : "LZF Deflate Compression",
         "description" : "Compress and decompress streams using LZF deflate algorithm.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -10564,6 +10708,7 @@
         "title" : "MIME Multipart",
         "description" : "Marshal Camel messages with attachments into MIME-Multipart messages and back.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "binaryContent" : {
             "type" : "boolean",
@@ -10602,6 +10747,7 @@
         "title" : "PGP",
         "description" : "Encrypt and decrypt messages using Java Cryptographic Extension (JCE) and PGP.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "algorithm" : {
             "type" : "number",
@@ -10687,6 +10833,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "compressionCodecName" : {
               "type" : "string",
@@ -10714,6 +10861,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "allowJmsType" : {
               "type" : "boolean",
@@ -10836,6 +10984,7 @@
         "title" : "RSS",
         "description" : "Transform from ROME SyndFeed Java Objects to XML and vice-versa.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -10851,6 +11000,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "contextPath" : {
               "type" : "string",
@@ -10900,6 +11050,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "id" : {
               "type" : "string",
@@ -10918,6 +11069,7 @@
         "title" : "SWIFT MX",
         "description" : "Encode and decode SWIFT MX messages.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -10950,6 +11102,7 @@
         "title" : "Syslog",
         "description" : "Marshall SyslogMessages to RFC3164 and RFC5424 messages and back.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -10962,6 +11115,7 @@
         "title" : "Tar File",
         "description" : "Archive files into tarballs or extract files from tarballs.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowEmptyDirectory" : {
             "type" : "boolean",
@@ -10998,6 +11152,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "contentTypeFormat" : {
               "type" : "string",
@@ -11028,6 +11183,7 @@
         "title" : "TidyMarkup",
         "description" : "Parse (potentially invalid) HTML into valid HTML or DOM.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "dataObjectType" : {
             "type" : "string",
@@ -11052,6 +11208,7 @@
         "title" : "uniVocity CSV",
         "description" : "Marshal and unmarshal Java objects from and to CSV (Comma Separated Values) using UniVocity Parsers.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "asMap" : {
             "type" : "boolean",
@@ -11160,6 +11317,7 @@
         "title" : "uniVocity Fixed Length",
         "description" : "Marshal and unmarshal Java objects from and to fixed length records using UniVocity Parsers.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "asMap" : {
             "type" : "boolean",
@@ -11260,6 +11418,7 @@
         "title" : "uniVocity Header",
         "description" : "To configure headers for UniVocity data formats.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "length" : {
             "type" : "string",
@@ -11277,6 +11436,7 @@
         "title" : "uniVocity TSV",
         "description" : "Marshal and unmarshal Java objects from and to TSV (Tab-Separated Values) records using UniVocity Parsers.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "asMap" : {
             "type" : "boolean",
@@ -11368,6 +11528,7 @@
         "title" : "XML Security",
         "description" : "Encrypt and decrypt XML payloads using Apache Santuario.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "addKeyValueForEncryptedKey" : {
             "type" : "boolean",
@@ -11449,6 +11610,7 @@
         "title" : "YAML",
         "description" : "Marshal and unmarshal Java objects to and from YAML.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowAnyType" : {
             "type" : "boolean",
@@ -11526,6 +11688,7 @@
       "org.apache.camel.model.dataformat.YAMLTypeFilterDefinition" : {
         "title" : "YAML Type Filter",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "type" : {
             "type" : "string",
@@ -11543,6 +11706,7 @@
         "title" : "Zip Deflater",
         "description" : "Compress and decompress streams using java.util.zip.Deflater and java.util.zip.Inflater.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "compressionLevel" : {
             "type" : "string",
@@ -11562,6 +11726,7 @@
         "title" : "Zip File",
         "description" : "Compression and decompress streams using java.util.zip.ZipStream.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowEmptyDirectory" : {
             "type" : "boolean",
@@ -11595,6 +11760,7 @@
         "title" : "Dead Letter Channel",
         "description" : "Error handler with dead letter queue.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "deadLetterHandleNewException" : {
             "type" : "boolean",
@@ -11680,6 +11846,7 @@
         "title" : "Default Error Handler",
         "description" : "The default error handler.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "executorServiceRef" : {
             "type" : "string",
@@ -11754,6 +11921,7 @@
         "title" : "Jta Transaction Error Handler",
         "description" : "JTA based transactional error handler (requires camel-jta).",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "executorServiceRef" : {
             "type" : "string",
@@ -11840,6 +12008,7 @@
         "title" : "No Error Handler",
         "description" : "To not use an error handler.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -11855,6 +12024,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "id" : {
               "type" : "string",
@@ -11874,6 +12044,7 @@
         "title" : "Spring Transaction Error Handler",
         "description" : "Spring based transactional error handler (requires camel-spring).",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "executorServiceRef" : {
             "type" : "string",
@@ -11963,6 +12134,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -11995,6 +12167,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12027,6 +12200,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "bodyMediaType" : {
               "type" : "string",
@@ -12069,6 +12243,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12319,6 +12494,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12351,6 +12527,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12378,6 +12555,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12420,6 +12598,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12452,6 +12631,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12494,6 +12674,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12536,6 +12717,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "allowEasyPredicate" : {
               "type" : "boolean",
@@ -12606,6 +12788,7 @@
         "title" : "Language",
         "description" : "Evaluates a custom language.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "expression" : {
             "type" : "string",
@@ -12637,6 +12820,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "beanType" : {
               "type" : "string",
@@ -12685,6 +12869,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12717,6 +12902,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12749,6 +12935,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12781,6 +12968,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12813,6 +13001,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12845,6 +13034,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -12877,6 +13067,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "endToken" : {
               "type" : "string",
@@ -12954,6 +13145,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string",
@@ -13011,6 +13203,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "documentType" : {
               "type" : "string",
@@ -13098,6 +13291,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "configurationRef" : {
               "type" : "string",
@@ -13158,6 +13352,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "id" : {
               "type" : "string",
@@ -13177,6 +13372,7 @@
         "title" : "Failover",
         "description" : "In case of failures the exchange will be tried on the next endpoint.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "exception" : {
             "type" : "array",
@@ -13213,6 +13409,7 @@
         "title" : "Random",
         "description" : "The destination endpoints are selected by random.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -13225,6 +13422,7 @@
         "title" : "Round Robin",
         "description" : "The destination endpoints are selected in a round-robin fashion. This is a well known and classic policy, which spreads the load evenly.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -13237,6 +13435,7 @@
         "title" : "Sticky",
         "description" : "Sticky load balancing using an expression to calculate a correlation key to perform the sticky load balancing.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "correlationExpression" : {
             "title" : "Correlation Expression",
@@ -13254,6 +13453,7 @@
         "title" : "Topic",
         "description" : "Topic which sends to all destinations.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "id" : {
             "type" : "string",
@@ -13266,6 +13466,7 @@
         "title" : "Weighted",
         "description" : "Uses a weighted load distribution ratio for each server with respect to others.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "distributionRatio" : {
             "type" : "string",
@@ -13295,6 +13496,7 @@
         "title" : "Api Key",
         "description" : "Rest security basic auth definition",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -13333,6 +13535,7 @@
         "title" : "Basic Auth",
         "description" : "Rest security basic auth definition",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -13351,6 +13554,7 @@
         "title" : "Bearer Token",
         "description" : "Rest security bearer token authentication definition",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -13374,6 +13578,7 @@
         "title" : "Delete",
         "description" : "Rest DELETE command",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "apiDocs" : {
             "type" : "boolean",
@@ -13479,6 +13684,7 @@
         "title" : "Get",
         "description" : "Rest GET command",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "apiDocs" : {
             "type" : "boolean",
@@ -13584,6 +13790,7 @@
         "title" : "Head",
         "description" : "Rest HEAD command",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "apiDocs" : {
             "type" : "boolean",
@@ -13689,6 +13896,7 @@
         "title" : "Mutual TLS",
         "description" : "Rest security mutual TLS authentication definition",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -13707,6 +13915,7 @@
         "title" : "Oauth2",
         "description" : "Rest security OAuth2 definition",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "authorizationUrl" : {
             "type" : "string",
@@ -13754,6 +13963,7 @@
         "title" : "Open Id Connect",
         "description" : "Rest security OpenID Connect definition",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -13777,6 +13987,7 @@
         "title" : "Param",
         "description" : "To specify the rest operation parameters.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowableValues" : {
             "type" : "array",
@@ -13852,6 +14063,7 @@
         "title" : "Patch",
         "description" : "Rest PATCH command",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "apiDocs" : {
             "type" : "boolean",
@@ -13957,6 +14169,7 @@
         "title" : "Post",
         "description" : "Rest POST command",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "apiDocs" : {
             "type" : "boolean",
@@ -14062,6 +14275,7 @@
         "title" : "Put",
         "description" : "Rest PUT command",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "apiDocs" : {
             "type" : "boolean",
@@ -14167,6 +14381,7 @@
         "title" : "Response Header",
         "description" : "To specify the rest operation response headers.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "allowableValues" : {
             "type" : "array",
@@ -14222,6 +14437,7 @@
         "title" : "Response Message",
         "description" : "To specify the rest operation response messages.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "code" : {
             "type" : "string",
@@ -14262,6 +14478,7 @@
         "title" : "Rest Binding",
         "description" : "To configure rest binding",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "bindingMode" : {
             "type" : "string",
@@ -14324,6 +14541,7 @@
         "title" : "Rest Configuration",
         "description" : "To configure rest",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "apiComponent" : {
             "type" : "string",
@@ -14489,6 +14707,7 @@
         "title" : "Rest",
         "description" : "Defines a rest service using the rest-dsl",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "apiDocs" : {
             "type" : "boolean",
@@ -14605,6 +14824,7 @@
         "title" : "Rest Property",
         "description" : "A key value pair",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "key" : {
             "type" : "string",
@@ -14623,6 +14843,7 @@
         "title" : "Rest Security Definitions",
         "description" : "To configure rest security definitions.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "apiKey" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.rest.ApiKeyDefinition"
@@ -14648,6 +14869,7 @@
         "title" : "Rests",
         "description" : "A series of rest services defined using the rest-dsl",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string",
@@ -14671,6 +14893,7 @@
         "title" : "Rest Security",
         "description" : "Rest security definition",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "key" : {
             "type" : "string",
@@ -14687,6 +14910,7 @@
       },
       "org.apache.camel.model.transformer.CustomTransformerDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "className" : {
             "type" : "string"
@@ -14710,6 +14934,7 @@
       },
       "org.apache.camel.model.transformer.DataFormatTransformerDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "type" : "object",
@@ -14740,33 +14965,33 @@
               }, {
                 "required" : [ "custom" ]
               }, {
-                "required" : [ "fhir-json" ]
+                "required" : [ "fhirJson" ]
               }, {
-                "required" : [ "fhir-xml" ]
+                "required" : [ "fhirXml" ]
               }, {
                 "required" : [ "flatpack" ]
               }, {
                 "required" : [ "grok" ]
               }, {
-                "required" : [ "gzip-deflater" ]
+                "required" : [ "gzipDeflater" ]
               }, {
                 "required" : [ "hl7" ]
               }, {
                 "required" : [ "ical" ]
               }, {
-                "required" : [ "jackson-xml" ]
+                "required" : [ "jacksonXml" ]
               }, {
                 "required" : [ "jaxb" ]
               }, {
                 "required" : [ "json" ]
               }, {
-                "required" : [ "json-api" ]
+                "required" : [ "jsonApi" ]
               }, {
                 "required" : [ "lzf" ]
               }, {
-                "required" : [ "mime-multipart" ]
+                "required" : [ "mimeMultipart" ]
               }, {
-                "required" : [ "parquet-avro" ]
+                "required" : [ "parquetAvro" ]
               }, {
                 "required" : [ "pgp" ]
               }, {
@@ -14776,31 +15001,31 @@
               }, {
                 "required" : [ "soap" ]
               }, {
-                "required" : [ "swift-mt" ]
+                "required" : [ "swiftMt" ]
               }, {
-                "required" : [ "swift-mx" ]
+                "required" : [ "swiftMx" ]
               }, {
                 "required" : [ "syslog" ]
               }, {
-                "required" : [ "tar-file" ]
+                "required" : [ "tarFile" ]
               }, {
                 "required" : [ "thrift" ]
               }, {
-                "required" : [ "tidy-markup" ]
+                "required" : [ "tidyMarkup" ]
               }, {
-                "required" : [ "univocity-csv" ]
+                "required" : [ "univocityCsv" ]
               }, {
-                "required" : [ "univocity-fixed" ]
+                "required" : [ "univocityFixed" ]
               }, {
-                "required" : [ "univocity-tsv" ]
+                "required" : [ "univocityTsv" ]
               }, {
-                "required" : [ "xml-security" ]
+                "required" : [ "xmlSecurity" ]
               }, {
                 "required" : [ "yaml" ]
               }, {
-                "required" : [ "zip-deflater" ]
+                "required" : [ "zipDeflater" ]
               }, {
-                "required" : [ "zip-file" ]
+                "required" : [ "zipFile" ]
               } ]
             }
           }, {
@@ -15174,6 +15399,7 @@
       },
       "org.apache.camel.model.transformer.EndpointTransformerDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "fromType" : {
             "type" : "string"
@@ -15197,6 +15423,7 @@
       },
       "org.apache.camel.model.transformer.LoadTransformerDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "defaults" : {
             "type" : "boolean"
@@ -15222,6 +15449,7 @@
         "title" : "Transformations",
         "description" : "To configure transformers.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "customTransformer" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.transformer.CustomTransformerDefinition"
@@ -15239,6 +15467,7 @@
       },
       "org.apache.camel.model.validator.CustomValidatorDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "className" : {
             "type" : "string"
@@ -15253,6 +15482,7 @@
       },
       "org.apache.camel.model.validator.EndpointValidatorDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "ref" : {
             "type" : "string"
@@ -15267,6 +15497,7 @@
       },
       "org.apache.camel.model.validator.PredicateValidatorDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "type" : "object",
@@ -15295,6 +15526,7 @@
         "title" : "Validations",
         "description" : "To configure validators.",
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "customValidator" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.validator.CustomValidatorDefinition"
@@ -15317,6 +15549,18 @@
       },
       "from" : {
         "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.RouteFromDefinitionDeserializer"
+      },
+      "intercept" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.InterceptDefinition"
+      },
+      "interceptFrom" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.InterceptFromDefinition"
+      },
+      "interceptSendToEndpoint" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.InterceptSendToEndpointDefinition"
+      },
+      "onCompletion" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.OnCompletionDefinition"
       },
       "onException" : {
         "$ref" : "#/items/definitions/org.apache.camel.model.OnExceptionDefinition"

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/BeanTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/BeanTest.groovy
@@ -19,35 +19,11 @@ package org.apache.camel.dsl.yaml
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.dsl.yaml.support.model.MyUppercaseProcessor
+import org.junit.jupiter.api.Assertions
 
 class BeanTest extends YamlTestSupport {
 
     def "bean"() {
-        setup:
-            loadRoutes """
-                - from:
-                   uri: "direct:route"
-                   steps:
-                     - bean:
-                         bean-type: ${MyUppercaseProcessor.name}
-                     - to: "mock:route"
-            """
-
-            withMock('mock:route') {
-                expectedBodiesReceived 'TEST'
-            }
-
-        when:
-            context.start()
-
-            withTemplate {
-                to('direct:route').withBody('test').send()
-            }
-        then:
-            MockEndpoint.assertIsSatisfied(context)
-    }
-
-    def "bean-camelCase"() {
         setup:
             loadRoutes """
                 - from:
@@ -71,4 +47,23 @@ class BeanTest extends YamlTestSupport {
         then:
             MockEndpoint.assertIsSatisfied(context)
     }
-}
+
+    def "Error: kebab-case: bean-type"() {
+        when:
+        var route = """
+                - from:
+                   uri: "direct:route"
+                   steps:
+                     - bean:
+                         bean-type: ${MyUppercaseProcessor.name}
+                     - to: "mock:route"
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            assert e.message.contains("additional properties")
+        }
+    }
+ }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/CircuitBreakerTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/CircuitBreakerTest.groovy
@@ -21,44 +21,11 @@ import org.apache.camel.model.CircuitBreakerDefinition
 import org.apache.camel.model.LogDefinition
 import org.apache.camel.model.RouteDefinition
 import org.apache.camel.model.ToDefinition
+import org.junit.jupiter.api.Assertions
 
 class CircuitBreakerTest extends YamlTestSupport {
 
-    def "circuit-breaker"() {
-        when:
-            loadRoutes '''
-                - from:
-                    uri: "direct:start"
-                    steps:
-                      - circuit-breaker:   
-                         steps:
-                           - log: "test"                           
-                         configuration: "my-config"
-                         resilience4j-configuration:
-                           failure-rate-threshold: 10
-                         on-fallback:
-                           fallback-via-network: true
-            '''
-        then:
-            with(context.routeDefinitions[0], RouteDefinition) {
-                input.endpointUri == 'direct:start'
-
-                with(outputs[0], CircuitBreakerDefinition) {
-                    configuration == 'my-config'
-
-                    resilience4jConfiguration != null
-                    resilience4jConfiguration.failureRateThreshold == '10'
-
-                    onFallback != null
-                    onFallback.fallbackViaNetwork == "true"
-
-                    with (outputs[0], LogDefinition) {
-                        message == "test"
-                    }
-                }
-            }
-    }
-    def "circuit-breaker-camelCase"() {
+    def "circuitBreaker"() {
         when:
             loadRoutes '''
                 - from:
@@ -93,17 +60,17 @@ class CircuitBreakerTest extends YamlTestSupport {
             }
     }
 
-    def "circuit-breaker with on-fallback steps"() {
+    def "circuitBreaker with onFallback steps"() {
         when:
             loadRoutes '''
                 - from:
                     uri: "direct:start"
                     steps:
-                      - circuit-breaker: 
+                      - circuitBreaker: 
                          # TODO: steps need to be defined before on-fallback             
                          steps:
                            - to: "log:cb"
-                         on-fallback:
+                         onFallback:
                              steps:
                                - to: "log:fb" 
             '''
@@ -120,5 +87,125 @@ class CircuitBreakerTest extends YamlTestSupport {
                     }
                 }
             }
+    }
+
+    def "Error: kebab-case: circuit-breaker"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - circuit-breaker:   
+                         steps:
+                           - log: "test"                           
+                         configuration: "my-config"
+                         resilience4jConfiguration:
+                           failureRateThreshold: 10
+                         onFallback:
+                           fallbackViaNetwork: true
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (IllegalArgumentException e) {
+            assert e.getMessage().contains("additional properties")
+        }
+    }
+
+    def "Error: kebab-case: resilience4j-configuration"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - circuitBreaker:   
+                         steps:
+                           - log: "test"                           
+                         configuration: "my-config"
+                         resilience4j-configuration:
+                           failureRateThreshold: 10
+                         onFallback:
+                           fallbackViaNetwork: true
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (IllegalArgumentException e) {
+            assert e.getMessage().contains("additional properties")
+        }
+    }
+
+    def "Error: kebab-case: failure-rate-threshold"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - circuitBreaker:   
+                         steps:
+                           - log: "test"                           
+                         configuration: "my-config"
+                         resilience4jConfiguration:
+                           failure-rate-threshold: 10
+                         onFallback:
+                           fallbackViaNetwork: true
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (IllegalArgumentException e) {
+            assert e.getMessage().contains("additional properties")
+        }
+    }
+
+    def "Error: kebab-case: on-fallback"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - circuitBreaker:   
+                         steps:
+                           - log: "test"                           
+                         configuration: "my-config"
+                         resilience4jConfiguration:
+                           failureRateThreshold: 10
+                         on-fallback:
+                           fallbackViaNetwork: true
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (IllegalArgumentException e) {
+            assert e.getMessage().contains("additional properties")
+        }
+    }
+
+    def "Error: kebab-case: fallback-via-network"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - circuitBreaker:   
+                         steps:
+                           - log: "test"                           
+                         configuration: "my-config"
+                         resilience4jConfiguration:
+                           failureRateThreshold: 10
+                         onFallback:
+                           fallback-via-network: true
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (IllegalArgumentException e) {
+            assert e.getMessage().contains("additional properties")
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/ClaimCheckTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/ClaimCheckTest.groovy
@@ -18,16 +18,17 @@ package org.apache.camel.dsl.yaml
 
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.model.ClaimCheckDefinition
+import org.junit.jupiter.api.Assertions
 
 class ClaimCheckTest extends YamlTestSupport {
 
-    def "claim-check definition"() {
+    def "claimCheck definition"() {
         when:
             loadRoutes '''
                 - from:
                     uri: "direct:start"
                     steps:    
-                      - claim-check:  
+                      - claimCheck:  
                           operation: "Push"
                           key: "foo"
                           filter: "header:(foo|bar)"
@@ -40,5 +41,25 @@ class ClaimCheckTest extends YamlTestSupport {
                 key == 'foo'
                 filter == 'header:(foo|bar)'
             }
+    }
+
+    def "Error: kebab-case: claim-check definition"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - claim-check:  
+                          operation: "Push"
+                          key: "foo"
+                          filter: "header:(foo|bar)"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            assert e.message.contains("additional properties")
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/ConvertBodyTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/ConvertBodyTest.groovy
@@ -19,42 +19,11 @@ package org.apache.camel.dsl.yaml
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.model.ConvertBodyDefinition
+import org.junit.jupiter.api.Assertions
 
 class ConvertBodyTest extends YamlTestSupport {
 
     def "convert-body-to"() {
-        setup:
-            loadRoutes '''
-                - from:
-                    uri: "direct:start"
-                    steps:    
-                      - convert-body-to:  
-                          type: "java.lang.String"
-                          charset: "UTF8"
-                      - to: "mock:result"
-            '''
-
-            withMock('mock:result') {
-                expectedBodiesReceived 'test'
-            }
-        when:
-            context.start()
-
-            withTemplate {
-                to('direct:start').withBody('test'.bytes).send()
-            }
-        then:
-            context.routeDefinitions.size() == 1
-
-            with(context.routeDefinitions[0].outputs[0], ConvertBodyDefinition) {
-                type == 'java.lang.String'
-                charset == 'UTF8'
-            }
-
-            MockEndpoint.assertIsSatisfied(context)
-    }
-
-    def "convert-body-to (camelCase)"() {
         setup:
             loadRoutes '''
                 - from:
@@ -84,5 +53,29 @@ class ConvertBodyTest extends YamlTestSupport {
             }
 
             MockEndpoint.assertIsSatisfied(context)
+    }
+
+    def "Error: kebab-case: convert-body-to"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - convert-body-to:  
+                          type: "java.lang.String"
+                          charset: "UTF8"
+                      - to: "mock:result"
+            '''
+
+        withMock('mock:result') {
+            expectedBodiesReceived 'test'
+        }
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            Assertions.assertTrue(e.message.contains("additional properties"))
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/ExpressionTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/ExpressionTest.groovy
@@ -109,7 +109,7 @@ class ExpressionTest extends YamlTestSupport {
             loadRoutes(route);
             Assertions.fail("Should have thrown exception")
         } catch (Exception e) {
-            Assertions.assertTrue(e.getMessage().contains("Unsupported field: notsimple"), e.getMessage());
+            Assertions.assertTrue(e.getMessage().contains("additional properties"), e.getMessage());
         }
     }
 

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/IdempotentConsumerTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/IdempotentConsumerTest.groovy
@@ -18,9 +18,10 @@ package org.apache.camel.dsl.yaml
 
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.component.mock.MockEndpoint
+import org.junit.jupiter.api.Assertions
 
 class IdempotentConsumerTest extends YamlTestSupport {
-    def 'idempotent-consumer'() {
+    def 'idempotentConsumer'() {
         setup:
             loadRoutes '''
                 - beans:
@@ -29,9 +30,9 @@ class IdempotentConsumerTest extends YamlTestSupport {
                 - from:
                     uri: "direct:route"
                     steps:
-                      - idempotent-consumer:
+                      - idempotentConsumer:
                           simple: "${header.id}"
-                          idempotent-repository: "myRepo"
+                          idempotentRepository: "myRepo"
                           steps:
                             - to: "mock:idempotent"
                       - to: "mock:route"
@@ -56,5 +57,55 @@ class IdempotentConsumerTest extends YamlTestSupport {
             }
         then:
             MockEndpoint.assertIsSatisfied(context)
+    }
+
+    def 'Error: kebab-case: idempotent-consumer'() {
+        when:
+        var route = '''
+                - beans:
+                  - name: myRepo
+                    type: org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository
+                - from:
+                    uri: "direct:route"
+                    steps:
+                      - idempotent-consumer:
+                          simple: "${header.id}"
+                          idempotentRepository: "myRepo"
+                          steps:
+                            - to: "mock:idempotent"
+                      - to: "mock:route"
+            '''
+        then:
+        try {
+            loadRoutes route
+            Assertions.fail('Should have thrown exception')
+        } catch (e) {
+            assert e.message.contains('additional properties')
+        }
+    }
+
+    def 'Error: kebab-case: idempotent-repository'() {
+        when:
+        var route = '''
+                - beans:
+                  - name: myRepo
+                    type: org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository
+                - from:
+                    uri: "direct:route"
+                    steps:
+                      - idempotentConsumer:
+                          simple: "${header.id}"
+                          idempotent-repository: "myRepo"
+                          steps:
+                            - to: "mock:idempotent"
+                      - to: "mock:route"
+            '''
+        then:
+        try {
+            loadRoutes route
+            Assertions.fail('Should have thrown exception')
+        } catch (e) {
+            assert e.message.contains('additional properties')
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/InterceptFromTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/InterceptFromTest.groovy
@@ -18,6 +18,7 @@ package org.apache.camel.dsl.yaml
 
 import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
+import org.junit.jupiter.api.Assertions
 
 class InterceptFromTest extends YamlTestSupport {
     def "interceptFrom"() {
@@ -30,7 +31,7 @@ class InterceptFromTest extends YamlTestSupport {
                     uri: "direct:start"
                     steps:
                       - to: "mock:foo"
-                      - set-body:
+                      - setBody:
                           constant: "Hello Bar"
                       - to: "mock:bar"
                       - to: "mock:result"
@@ -48,5 +49,29 @@ class InterceptFromTest extends YamlTestSupport {
             }
         then:
             MockEndpoint.assertIsSatisfied(context)
+    }
+
+    def "Error: kebab-case: intercept-from"() {
+        when:
+        var route = """
+                - intercept-from:
+                    steps:
+                      - to: "mock:intercepted"  
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - to: "mock:foo"
+                      - setBody:
+                          constant: "Hello Bar"
+                      - to: "mock:bar"
+                      - to: "mock:result"
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            assert e.message.contains("additional properties")
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/InterceptSendToEndpointTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/InterceptSendToEndpointTest.groovy
@@ -18,6 +18,7 @@ package org.apache.camel.dsl.yaml
 
 import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
+import org.junit.jupiter.api.Assertions
 
 class InterceptSendToEndpointTest extends YamlTestSupport {
     def "interceptSendToEndpoint"() {
@@ -31,7 +32,7 @@ class InterceptSendToEndpointTest extends YamlTestSupport {
                     uri: "direct:start"
                     steps:
                       - to: "mock:foo"
-                      - set-body:
+                      - setBody:
                           constant: "Hello Bar"
                       - to: "mock:bar"
                       - to: "mock:result"
@@ -50,4 +51,29 @@ class InterceptSendToEndpointTest extends YamlTestSupport {
         then:
             MockEndpoint.assertIsSatisfied(context)
     }
+
+    def "Error: kebab-case: intercept-send-to-endpoint"() {
+        when:
+        var route = """
+                - intercept-send-to-endpoint: 
+                    uri: "mock:bar"
+                    steps:
+                      - to: "mock:intercepted"  
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - to: "mock:foo"
+                      - setBody:
+                          constant: "Hello Bar"
+                      - to: "mock:bar"
+                      - to: "mock:result"
+            """
+        then:
+        try {
+            loadRoutes route
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            assert e.message.contains("additional properties")
+        }
+        }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/InterceptTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/InterceptTest.groovy
@@ -30,7 +30,7 @@ class InterceptTest extends YamlTestSupport {
                     uri: "direct:start"
                     steps:
                       - to: "mock:foo"
-                      - set-body:
+                      - setBody:
                           constant: "Hello Bar"
                       - to: "mock:bar"
                       - to: "mock:result"

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/JSonPathSuppressTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/JSonPathSuppressTest.groovy
@@ -84,7 +84,7 @@ class JSonPathSuppressTest extends YamlTestSupport {
                           when:
                           - jsonpath: 
                               expression: "person.middlename"
-                              suppress-exceptions: true
+                              suppressExceptions: true
                             steps:
                             - to: "mock:middle"
                           otherwise:
@@ -119,7 +119,7 @@ class JSonPathSuppressTest extends YamlTestSupport {
                           when:
                           - jsonpath: 
                               expression: "person.middlename"
-                              suppress-exceptions: true
+                              suppressExceptions: true
                             steps:
                             - to: "mock:middle"
                           otherwise:
@@ -154,12 +154,12 @@ class JSonPathSuppressTest extends YamlTestSupport {
                           when:
                           - jsonpath: 
                               expression: "person.middlename"
-                              suppress-exceptions: true
+                              suppressExceptions: true
                             steps:
                             - to: "mock:middle"
                           - jsonpath: 
                               expression: "person.lastname"
-                              suppress-exceptions: true
+                              suppressExceptions: true
                             steps:
                             - to: "mock:last"
                           otherwise:
@@ -185,5 +185,31 @@ class JSonPathSuppressTest extends YamlTestSupport {
         }
         then:
         MockEndpoint.assertIsSatisfied(context)
+    }
+
+    def "Error: kebab-case: suppress-exceptions"() {
+        when:
+        var route = """
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - choice:  
+                          when:
+                          - jsonpath: 
+                              expression: "person.middlename"
+                              suppress-exceptions: true
+                            steps:
+                            - to: "mock:middle"
+                          otherwise:
+                            steps:
+                              - to: "mock:other"
+            """
+        then:
+        try {
+            loadRoutes route
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            assert e.message.contains("additional properties")
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/KameletTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/KameletTest.groovy
@@ -299,12 +299,12 @@ class KameletTest extends YamlTestSupport {
                     id: "myTemplate"  
                     parameters:
                       - name: "myParameter"
-                        default-value: "myDefaultValue"
+                        defaultValue: "myDefaultValue"
                         description: "myParameterDescription"
                     from: 
                       uri: "kamelet:source"
                       steps:
-                        - set-body: 
+                        - setBody: 
                             constant: "{{myParameter}}"
                 - from:
                     uri: "direct:start"
@@ -332,12 +332,12 @@ class KameletTest extends YamlTestSupport {
                     id: "myTemplate"  
                     parameters:
                       - name: "myParameter"
-                        default-value: "myDefaultValue"
+                        defaultValue: "myDefaultValue"
                         description: "myParameterDescription"
                     from: 
                       uri: "kamelet:source"
                       steps:
-                        - set-body: 
+                        - setBody: 
                             constant: "{{myParameter}}"
                 - from:
                     uri: "direct:start"

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/LineNumberTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/LineNumberTest.groovy
@@ -33,9 +33,9 @@ class LineNumberTest extends YamlTestSupport {
                     uri: "direct:start"
                     steps:
                       - log:
-                         logging-level: "ERROR"
+                         loggingLevel: "ERROR"
                          message: "test"
-                         log-name: "yaml"
+                         logName: "yaml"
                       - to: "direct:result"
             '''
         then:

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/LoadBalanceTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/LoadBalanceTest.groovy
@@ -18,19 +18,20 @@ package org.apache.camel.dsl.yaml
 
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.component.mock.MockEndpoint
+import org.junit.jupiter.api.Assertions
 
 class LoadBalanceTest extends YamlTestSupport {
 
-    def "load-balance"() {
+    def "loadBalance"() {
         setup:
             loadRoutes '''
                 - from:
                    uri: "direct:start"
                    steps:
-                     - load-balance:
+                     - loadBalance:
                          weighted:
-                           distribution-ratio: "2,1"
-                           round-robin: false
+                           distributionRatio: "2,1"
+                           roundRobin: false
                          steps:
                            - to: "mock:x"
                            - to: "mock:y"
@@ -53,5 +54,51 @@ class LoadBalanceTest extends YamlTestSupport {
             }
         then:
             MockEndpoint.assertIsSatisfied(context)
+    }
+
+    def "Error: kebab-case: load-balance"() {
+        when:
+        var route = '''
+                - from:
+                   uri: "direct:start"
+                   steps:
+                     - load-balance:
+                         weighted:
+                           distributionRatio: "2,1"
+                           roundRobin: false
+                         steps:
+                           - to: "mock:x"
+                           - to: "mock:y"
+            '''
+        then:
+        try {
+            loadRoutes route
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            assert e.message.contains("additional properties")
+        }
+    }
+
+    def "Error: kebab-case: distribution-ratio"() {
+        when:
+        var route = '''
+                - from:
+                   uri: "direct:start"
+                   steps:
+                     - loadBalance:
+                         weighted:
+                           distribution-ratio: "2,1"
+                           roundRobin: false
+                         steps:
+                           - to: "mock:x"
+                           - to: "mock:y"
+            '''
+        then:
+        try {
+            loadRoutes route
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            assert e.message.contains("additional properties")
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/LogTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/LogTest.groovy
@@ -18,6 +18,7 @@ package org.apache.camel.dsl.yaml
 
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.model.LogDefinition
+import org.junit.jupiter.api.Assertions
 
 class LogTest extends YamlTestSupport {
 
@@ -28,9 +29,9 @@ class LogTest extends YamlTestSupport {
                     uri: "direct:start"
                     steps:    
                       - log:
-                         logging-level: "ERROR"
+                         loggingLevel: "ERROR"
                          message: "test"
-                         log-name: "yaml"
+                         logName: "yaml"
                       - to: "direct:_result"   
             '''
         then:
@@ -41,5 +42,26 @@ class LogTest extends YamlTestSupport {
                 message == 'test'
                 logName == 'yaml'
             }
+    }
+
+    def "Error: kebab-case: logging-level"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - log:
+                         logging-level: "ERROR"
+                         message: "test"
+                         logName: "yaml"
+                      - to: "direct:_result"   
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            assert e.message.contains("additional properties")
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/MulticastTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/MulticastTest.groovy
@@ -19,6 +19,7 @@ package org.apache.camel.dsl.yaml
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.model.MulticastDefinition
 import org.apache.camel.model.ToDefinition
+import org.junit.jupiter.api.Assertions
 
 class MulticastTest extends YamlTestSupport {
 
@@ -29,8 +30,8 @@ class MulticastTest extends YamlTestSupport {
                     uri: "direct:start"
                     steps:    
                       - multicast:  
-                         stop-on-exception: true
-                         parallel-processing: true
+                         stopOnException: true
+                         parallelProcessing: true
                          steps:
                            - to: "direct:a"
                            - to: "direct:b"
@@ -49,5 +50,29 @@ class MulticastTest extends YamlTestSupport {
                     endpointUri == 'direct:b'
                 }
             }
+    }
+
+    def "Error: kebab-case: stop-on-exception"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - multicast:  
+                         stop--on-exception: true
+                         parallelProcessing: true
+                         steps:
+                           - to: "direct:a"
+                           - to: "direct:b"
+                      - to: "direct:result" 
+            '''
+        then:
+        try {
+            loadRoutes route
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            e.message.contains("additional properties")
+
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/OnCompletionTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/OnCompletionTest.groovy
@@ -18,12 +18,13 @@ package org.apache.camel.dsl.yaml
 
 import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
+import org.junit.jupiter.api.Assertions
 
 class OnCompletionTest extends YamlTestSupport {
-    def "on-completion"() {
+    def "onCompletion"() {
         setup:
             loadRoutes """
-                - on-completion:
+                - onCompletion:
                     steps:
                       - transform:
                           constant: "Processed"
@@ -46,5 +47,31 @@ class OnCompletionTest extends YamlTestSupport {
             }
         then:
             MockEndpoint.assertIsSatisfied(context)
+    }
+
+    def "Error: kebab-case: on-completion"() {
+        when:
+        var route = """
+                - on-completion:
+                    steps:
+                      - transform:
+                          constant: "Processed"
+                      - to: "mock:on-success"  
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - to: "mock:end"
+            """
+
+        withMock('mock:on-success') {
+            expectedBodiesReceived 'Processed'
+        }
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            assert e.message.contains("additional properties")
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RemoveHeaderTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RemoveHeaderTest.groovy
@@ -21,10 +21,11 @@ import org.apache.camel.model.RemoveHeaderDefinition
 import org.apache.camel.model.RemoveHeadersDefinition
 import org.apache.camel.spi.Resource
 import org.apache.camel.support.PluginHelper
+import org.junit.jupiter.api.Assertions
 
 class RemoveHeaderTest extends YamlTestSupport {
 
-    def "remove-header definition (#resource.location)"(Resource resource) {
+    def "removeHeader definition (#resource.location)"(Resource resource) {
         when:
             PluginHelper.getRoutesLoader(context).loadRoutes(resource)
         then:
@@ -37,7 +38,7 @@ class RemoveHeaderTest extends YamlTestSupport {
                     - from:
                         uri: "direct:start"
                         steps:    
-                          - remove-header:
+                          - removeHeader:
                               name: test
                           - to: "mock:result"
                     '''),
@@ -45,22 +46,22 @@ class RemoveHeaderTest extends YamlTestSupport {
                     - from:
                         uri: "direct:start"
                         steps:    
-                          - remove-header:
+                          - removeHeader:
                               name: test
                           - to: "mock:result"
                     ''')
             ]
     }
 
-    def "remove-headers definition"() {
+    def "removeHeaders definition"() {
         when:
             loadRoutes'''
                 - from:
                     uri: "direct:start"
                     steps:    
-                      - remove-headers:
+                      - removeHeaders:
                           pattern: toRemove
-                          exclude-pattern: toExclude
+                          excludePattern: toExclude
                       - to: "mock:result"
             '''
         then:
@@ -68,5 +69,27 @@ class RemoveHeaderTest extends YamlTestSupport {
                 pattern == 'toRemove'
                 excludePattern == 'toExclude'
             }
+    }
+
+    def "Error: kebab-case: remove-headers definition"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - remove-headers:
+                          pattern: toRemove
+                          excludePattern: toExclude
+                      - to: "mock:result"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            with(e) {
+                message.contains("additional properties")
+            }
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RemovePropertyTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RemovePropertyTest.groovy
@@ -21,10 +21,11 @@ import org.apache.camel.model.RemovePropertiesDefinition
 import org.apache.camel.model.RemovePropertyDefinition
 import org.apache.camel.spi.Resource
 import org.apache.camel.support.PluginHelper
+import org.junit.jupiter.api.Assertions
 
 class RemovePropertyTest extends YamlTestSupport {
 
-    def "remove-property definition (#resource.location)"(Resource resource) {
+    def "removeProperty definition (#resource.location)"(Resource resource) {
         when:
             PluginHelper.getRoutesLoader(context).loadRoutes(resource)
         then:
@@ -37,7 +38,7 @@ class RemovePropertyTest extends YamlTestSupport {
                     - from:
                         uri: "direct:start"
                         steps:    
-                          - remove-property:
+                          - removeProperty:
                               name: test
                           - to: "mock:result"
                     '''),
@@ -45,22 +46,22 @@ class RemovePropertyTest extends YamlTestSupport {
                     - from:
                         uri: "direct:start"
                         steps:    
-                          - remove-property:
+                          - removeProperty:
                               name: test
                           - to: "mock:result"
                     ''')
             ]
     }
 
-    def "remove-properties definition"() {
+    def "removeProperties definition"() {
         when:
             loadRoutes'''
                 - from:
                     uri: "direct:start"
                     steps:    
-                      - remove-properties:
+                      - removeProperties:
                           pattern: toRemove
-                          exclude-pattern: toExclude
+                          excludePattern: toExclude
                       - to: "mock:result"
             '''
         then:
@@ -68,5 +69,24 @@ class RemovePropertyTest extends YamlTestSupport {
                 pattern == 'toRemove'
                 excludePattern == 'toExclude'
             }
+    }
+
+    def "Error: kebab-case: remove-property definition"() {
+        when:
+        var route = '''
+                    - from:
+                        uri: "direct:start"
+                        steps:    
+                          - remove-property:
+                              name: test
+                          - to: "mock:result"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            e.message.contains("additional properties")
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RestTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RestTest.groovy
@@ -27,6 +27,7 @@ import org.apache.camel.model.rest.PostDefinition
 import org.apache.camel.model.rest.RestDefinition
 import org.apache.camel.model.rest.VerbDefinition
 import org.apache.camel.support.PluginHelper
+import org.junit.jupiter.api.Assertions
 
 class RestTest extends YamlTestSupport {
 
@@ -36,9 +37,9 @@ class RestTest extends YamlTestSupport {
                 - beans:
                   - name: myRestConsumerFactory
                     type: ${MockRestConsumerFactory.name}
-                - rest-configuration:
+                - restConfiguration:
                     component: "servlet"
-                    context-path: "/foo"       
+                    contextPath: "/foo"       
             """
         then:
             context.restConfiguration.component == 'servlet'
@@ -55,7 +56,7 @@ class RestTest extends YamlTestSupport {
                     get:
                       - path: "/foo"
                         type: ${MyFooBar.name}
-                        out-type: ${MyBean.name}
+                        outType: ${MyBean.name}
                         to: "direct:bar"
                 - from:
                     uri: 'direct:bar'
@@ -90,7 +91,7 @@ class RestTest extends YamlTestSupport {
                     get:
                      -  path: "/foo"
                         type: ${MyFooBar.name}
-                        out-type: ${MyBean.name}
+                        outType: ${MyBean.name}
                         to: "direct:bar"
                 - from:
                     uri: 'direct:bar'
@@ -125,7 +126,7 @@ class RestTest extends YamlTestSupport {
                       - path: "/foo"
                         id: "foolish"
                         type: ${MyFooBar.name}
-                        out-type: ${MyBean.name}
+                        outType: ${MyBean.name}
                         to: "direct:foo"
                       - path: "/baz"
                         id: "bazzy"
@@ -208,5 +209,67 @@ class RestTest extends YamlTestSupport {
             }
     }
 
+    def "Error: kebab-case: rest-configuration"() {
+        when:
+        var route = """
+                - beans:
+                  - name: myRestConsumerFactory
+                    type: ${MockRestConsumerFactory.name}
+                - rest-configuration:
+                    component: "servlet"
+                    contextPath: "/foo"       
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
 
+    def "Error: kebab-case: context-path"() {
+        when:
+        var route = """
+                - beans:
+                  - name: myRestConsumerFactory
+                    type: ${MockRestConsumerFactory.name}
+                - restConfiguration:
+                    component: "servlet"
+                    context-path: "/foo"       
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
+
+    def "Error: kebab-case: out-type"() {
+        when:
+        var route = """
+                - beans:
+                  - name: myRestConsumerFactory
+                    type: ${MockRestConsumerFactory.name}
+                - rest:
+                    get:
+                      - path: "/foo"
+                        type: ${MyFooBar.name}
+                        out-type: ${MyBean.name}
+                        to: "direct:bar"
+                - from:
+                    uri: 'direct:bar'
+                    steps:
+                      - to: 'mock:bar'          
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RollbackTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RollbackTest.groovy
@@ -18,6 +18,7 @@ package org.apache.camel.dsl.yaml
 
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.model.RollbackDefinition
+import org.junit.jupiter.api.Assertions
 
 class RollbackTest extends YamlTestSupport {
 
@@ -28,7 +29,7 @@ class RollbackTest extends YamlTestSupport {
                     uri: "direct:start"
                     steps:    
                       - rollback:  
-                          mark-rollback-only: true
+                          markRollbackOnly: true
                           message: "test"
             '''
         then:
@@ -36,5 +37,24 @@ class RollbackTest extends YamlTestSupport {
                 markRollbackOnly == "true"
                 message == 'test'
             }
+    }
+
+    def "Error: kebab-case: mark-rollback-only"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - rollback:  
+                          mark-rollback-only: true
+                          message: "test"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RouteConfigurationTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RouteConfigurationTest.groovy
@@ -27,15 +27,15 @@ import org.junit.jupiter.api.Assertions
 import static org.apache.camel.util.PropertiesHelper.asProperties
 
 class RouteConfigurationTest extends YamlTestSupport {
-    def "route-configuration"() {
+    def "routeConfiguration"() {
         setup:
         loadRoutes """
                 - beans:
                   - name: myFailingProcessor
                     type: ${MyFailingProcessor.name}
-                - route-configuration:
-                    on-exception:
-                      - on-exception:
+                - routeConfiguration:
+                    onException:
+                      - onException:
                           handled:
                             constant: "true"
                           exception:
@@ -43,12 +43,12 @@ class RouteConfigurationTest extends YamlTestSupport {
                           steps:
                             - transform:
                                 constant: "Sorry"
-                            - to: "mock:on-exception"  
+                            - to: "mock:on-exception"
                 - from:
                     uri: "direct:start"
                     steps:
                       - process: 
-                          ref: "myFailingProcessor"            
+                          ref: "myFailingProcessor"
             """
 
         withMock('mock:on-exception') {
@@ -65,17 +65,47 @@ class RouteConfigurationTest extends YamlTestSupport {
         MockEndpoint.assertIsSatisfied(context)
     }
 
-    def "route-configuration-precondition"() {
+    def "routeConfiguration onCompletion"() {
+        setup:
+        loadRoutes """
+                - routeConfiguration:
+                    onCompletion:
+                      - onCompletion:
+                          steps:
+                            - transform:
+                                constant: "Completed"
+                            - to: "mock:on-completion"
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - log: "hello"
+            """
+
+        withMock('mock:on-completion') {
+            expectedBodiesReceived 'Completed'
+        }
+
+        when:
+        context.start()
+
+        withTemplate {
+            to('direct:start').withBody('hello').send()
+        }
+        then:
+        MockEndpoint.assertIsSatisfied(context)
+    }
+
+    def "routeConfiguration-precondition"() {
         setup:
         context.getPropertiesComponent().setInitialProperties(asProperties("activate", "true"))
         loadRoutes """
                 - beans:
                   - name: myFailingProcessor
                     type: ${MyFailingProcessor.name}
-                - route-configuration:
+                - routeConfiguration:
                     precondition: "{{!activate}}"
-                    on-exception:
-                      - on-exception:
+                    onException:
+                      - onException:
                           handled:
                             constant: "true"
                           exception:
@@ -83,11 +113,11 @@ class RouteConfigurationTest extends YamlTestSupport {
                           steps:
                             - transform:
                                 constant: "Not Activated"
-                            - to: "mock:on-exception"  
-                - route-configuration:
+                            - to: "mock:on-exception"
+                - routeConfiguration:
                     precondition: "{{activate}}"
-                    on-exception:
-                      - on-exception:
+                    onException:
+                      - onException:
                           handled:
                             constant: "true"
                           exception:
@@ -96,8 +126,8 @@ class RouteConfigurationTest extends YamlTestSupport {
                             - transform:
                                 constant: "Activated"
                             - to: "mock:on-exception"
-                    on-completion:
-                      - on-completion:
+                    onCompletion:
+                      - onCompletion:
                           steps:
                             - transform:
                                 constant: "Completed"
@@ -106,7 +136,7 @@ class RouteConfigurationTest extends YamlTestSupport {
                     uri: "direct:start"
                     steps:
                       - process: 
-                          ref: "myFailingProcessor"            
+                          ref: "myFailingProcessor"
             """
 
         withMock('mock:on-exception') {
@@ -132,24 +162,24 @@ class RouteConfigurationTest extends YamlTestSupport {
         }
     }
 
-    def "route-configuration-separate"() {
+    def "routeConfiguration-separate"() {
         setup:
         // global configurations
         loadRoutes """
                 - beans:
                   - name: myFailingProcessor
                     type: ${MyFailingProcessor.name}
-                - route-configuration:
-                    on-exception:
-                    - on-exception:
-                        handled:
-                          constant: "true"
-                        exception:
-                          - ${MyException.name}
-                        steps:
-                          - transform:
-                              constant: "Sorry"
-                          - to: "mock:on-exception"  
+                - routeConfiguration:
+                    onException:
+                      - onException:
+                          handled:
+                            constant: "true"
+                          exception:
+                            - ${MyException.name}
+                          steps:
+                            - transform:
+                                constant: "Sorry"
+                            - to: "mock:on-exception"
             """
         // routes
         loadRoutes """
@@ -157,12 +187,12 @@ class RouteConfigurationTest extends YamlTestSupport {
                     uri: "direct:start"
                     steps:
                       - process: 
-                          ref: "myFailingProcessor"            
+                          ref: "myFailingProcessor"
                 - from:
                     uri: "direct:start2"
                     steps:
                       - process: 
-                          ref: "myFailingProcessor"            
+                          ref: "myFailingProcessor"
             """
 
         withMock('mock:on-exception') {
@@ -180,17 +210,17 @@ class RouteConfigurationTest extends YamlTestSupport {
         MockEndpoint.assertIsSatisfied(context)
     }
 
-    def "route-configuration-id"() {
+    def "routeConfigurationId"() {
         setup:
         // global configurations
         loadRoutes """
                 - beans:
                   - name: myFailingProcessor
                     type: ${MyFailingProcessor.name}
-                - route-configuration:
+                - routeConfiguration:
                     id: handleError
-                    on-exception:
-                      - on-exception:
+                    onException:
+                      - onException:
                           handled:
                             constant: "true"
                           exception:
@@ -198,23 +228,23 @@ class RouteConfigurationTest extends YamlTestSupport {
                           steps:
                             - transform:
                                 constant: "Sorry"
-                            - to: "mock:on-exception"  
+                            - to: "mock:on-exception"
             """
         // routes
         loadRoutes """
                 - route:
-                    route-configuration-id: handleError 
+                    routeConfigurationId: handleError 
                     from:
                       uri: "direct:start"
                       steps:
                         - process: 
-                            ref: "myFailingProcessor"            
+                            ref: "myFailingProcessor"
                 - route:
                     from:
                       uri: "direct:start2"
                       steps:
                         - process: 
-                            ref: "myFailingProcessor"            
+                            ref: "myFailingProcessor"
             """
 
         withMock('mock:on-exception') {
@@ -238,30 +268,30 @@ class RouteConfigurationTest extends YamlTestSupport {
         Assertions.assertTrue(out2.isFailed())
     }
 
-    def "route-configuration-error-handler"() {
+    def "routeConfiguration-errorHandler"() {
         setup:
         // global configurations
         loadRoutes """
                 - beans:
                   - name: myFailingProcessor
                     type: ${MyFailingProcessor.name}
-                - route-configuration:
-                    error-handler:
-                      dead-letter-channel: 
-                        dead-letter-uri: "mock:on-error"
+                - routeConfiguration:
+                    errorHandler:
+                      deadLetterChannel:
+                        deadLetterUri: "mock:on-error"
             """
         // routes
         loadRoutes """
                 - from:
                     uri: "direct:start"
                     steps:
-                      - process: 
-                          ref: "myFailingProcessor"            
+                      - process:
+                          ref: "myFailingProcessor"
                 - from:
                     uri: "direct:start2"
                     steps:
-                      - process: 
-                          ref: "myFailingProcessor"            
+                      - process:
+                          ref: "myFailingProcessor"
             """
 
         withMock('mock:on-error') {
@@ -279,5 +309,232 @@ class RouteConfigurationTest extends YamlTestSupport {
         MockEndpoint.assertIsSatisfied(context)
     }
 
+    def "routeConfiguration intercept"() {
+        setup:
+        loadRoutesNoValidate """
+                - routeConfiguration:
+                    intercept:
+                      - intercept:
+                          steps:
+                            - transform:
+                                constant: "intercepted"
+                            - to: "mock:intercepted"
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - log: "hello"
+            """
+
+        withMock('mock:intercepted') {
+            expectedBodiesReceived 'intercepted'
+        }
+
+        when:
+        context.start()
+
+        withTemplate {
+            to('direct:start').withBody('hello').send()
+        }
+        then:
+        MockEndpoint.assertIsSatisfied(context)
+    }
+
+    def "routeConfiguration interceptFrom"() {
+        setup:
+        loadRoutesNoValidate """
+                - routeConfiguration:
+                    interceptFrom:
+                      - interceptFrom:
+                          uri: "direct:start"
+                          steps:
+                            - transform:
+                                constant: "intercepted"
+                            - to: "mock:intercepted"
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - log: "hello"
+            """
+
+        withMock('mock:intercepted') {
+            expectedBodiesReceived 'intercepted'
+        }
+
+        when:
+        context.start()
+
+        withTemplate {
+            to('direct:start').withBody('hello').send()
+        }
+        then:
+        MockEndpoint.assertIsSatisfied(context)
+    }
+
+    def "routeConfiguration interceptSendToEndpoint"() {
+        setup:
+        loadRoutesNoValidate """
+                - routeConfiguration:
+                    interceptSendToEndpoint:
+                      - interceptSendToEndpoint:
+                          uri: "direct:start"
+                          steps:
+                            - transform:
+                                constant: "intercepted"
+                            - to: "mock:intercepted"
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - log: "hello"
+            """
+
+        withMock('mock:intercepted') {
+            expectedBodiesReceived 'intercepted'
+        }
+
+        when:
+        context.start()
+
+        withTemplate {
+            to('direct:start').withBody('hello').send()
+        }
+        then:
+        MockEndpoint.assertIsSatisfied(context)
+    }
+
+    def "Error: kebab-case: route-configuration"() {
+        when:
+        var route = """
+                - beans:
+                  - name: myFailingProcessor
+                    type: ${MyFailingProcessor.name}
+                - route-configuration:
+                    onException:
+                      - onException:
+                          handled:
+                            constant: "true"
+                          exception:
+                            - ${MyException.name}
+                          steps:
+                            - transform:
+                                constant: "Sorry"
+                            - to: "mock:on-exception"
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - process: 
+                          ref: "myFailingProcessor"
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
+
+    def "Error: kebab-case: on-exception"() {
+        when:
+        var route = """
+                - beans:
+                  - name: myFailingProcessor
+                    type: ${MyFailingProcessor.name}
+                - routeConfiguration:
+                    on-exception:
+                      - onException:
+                          handled:
+                            constant: "true"
+                          exception:
+                            - ${MyException.name}
+                          steps:
+                            - transform:
+                                constant: "Sorry"
+                            - to: "mock:on-exception"
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - process:
+                          ref: "myFailingProcessor"
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
+
+    def "Error: kebab-case: onException/on-exception"() {
+        when:
+        var route = """
+                - beans:
+                  - name: myFailingProcessor
+                    type: ${MyFailingProcessor.name}
+                - routeConfiguration:
+                    onException:
+                      - on-exception:
+                          handled:
+                            constant: "true"
+                          exception:
+                            - ${MyException.name}
+                          steps:
+                            - transform:
+                                constant: "Sorry"
+                            - to: "mock:on-exception"
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - process: 
+                          ref: "myFailingProcessor"
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
+
+    def "Error: kebab-case: dead-letter-channel"() {
+        when:
+        var route = """
+                - beans:
+                  - name: myFailingProcessor
+                    type: ${MyFailingProcessor.name}
+                - routeConfiguration:
+                    errorHandler:
+                      dead-letter-channel:
+                        deadLetterUri: "mock:on-error"
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
+
+    def "Error: kebab-case: dead-letter-uri"() {
+        when:
+        var route = """
+                - beans:
+                  - name: myFailingProcessor
+                    type: ${MyFailingProcessor.name}
+                - routeConfiguration:
+                    errorHandler:
+                      deadLetterChannel:
+                        dead-letter-uri: "mock:on-error"
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
 
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RouteTemplateTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RouteTemplateTest.groovy
@@ -250,7 +250,7 @@ class RouteTemplateTest extends YamlTestSupport {
                     id: "myTemplate"
                     parameters:
                       - name: "foo"
-                        default-value: "myDefaultFoo"
+                        defaultValue: "myDefaultFoo"
                         description: "myFooDescription"
                       - name: "bar"
                         description: "myBarDescription"
@@ -422,40 +422,6 @@ class RouteTemplateTest extends YamlTestSupport {
             MockEndpoint.assertIsSatisfied(context)
     }
 
-    def "create route-template with parameters"() {
-        when:
-        loadRoutes """
-                - route-template:
-                    id: "myTemplate"
-                    parameters:
-                      - name: "foo"
-                      - name: "bar"
-                    from:
-                      uri: "direct:{{foo}}"
-                      steps:
-                        - log: "{{bar}}"
-            """
-        then:
-        context.routeTemplateDefinitions.size() == 1
-
-        with(context.routeTemplateDefinitions[0], RouteTemplateDefinition) {
-            id == 'myTemplate'
-            configurer == null
-
-            templateParameters.any {
-                it.name == 'foo'
-            }
-            templateParameters.any {
-                it.name == 'bar'
-            }
-
-            route.input.endpointUri == 'direct:{{foo}}'
-            with(route.outputs[0], LogDefinition) {
-                message == '{{bar}}'
-            }
-        }
-    }
-
     def "create routeTemplate with route"() {
         setup:
         loadRoutes """
@@ -525,4 +491,50 @@ class RouteTemplateTest extends YamlTestSupport {
         Assertions.assertEquals(3, context.getRoute("second").filter("bbb*").size());
     }
 
+    def "Error: kebab-case: route-template"() {
+        when:
+        var route = """
+                - route-template:
+                    id: "myTemplate"
+                    parameters:
+                      - name: "foo"
+                      - name: "bar"
+                    from:
+                      uri: "direct:{{foo}}"
+                      steps:
+                        - log: "{{bar}}"
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
+
+    def "Error: kebab-case: default-value"() {
+        when:
+        var route = """
+                - routeTemplate:
+                    id: "myTemplate"
+                    parameters:
+                      - name: "foo"
+                        default-value: "myDefaultFoo"
+                        description: "myFooDescription"
+                      - name: "bar"
+                        description: "myBarDescription"
+                    from:
+                      uri: "direct:{{foo}}"
+                      steps:
+                        - log: "{{bar}}"
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RoutesTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/RoutesTest.groovy
@@ -191,36 +191,6 @@ class RoutesTest extends YamlTestSupport {
         }
     }
 
-    def "load route inlined"() {
-        when:
-        loadRoutes '''
-                - route:
-                    id: demo-route
-                    stream-caching: true
-                    auto-startup: false
-                    startup-order: 123
-                    route-policy: "myPolicy"
-                    from:
-                      uri: "direct:info"
-                      steps:
-                        - log: "message"
-            '''
-        then:
-        context.routeDefinitions.size() == 1
-
-        with(context.routeDefinitions[0], RouteDefinition) {
-            routeId == 'demo-route'
-            streamCache == 'true'
-            autoStartup == 'false'
-            startupOrder == 123
-            routePolicyRef == 'myPolicy'
-            input.endpointUri == 'direct:info'
-
-            with (outputs[0], LogDefinition) {
-                message == 'message'
-            }
-        }
-    }
 
     def "load route inlined camelCase"() {
         when:
@@ -340,7 +310,7 @@ class RoutesTest extends YamlTestSupport {
         loadRoutes '''
                 - route:
                     id: foo
-                    node-prefix-id: aaa
+                    nodePrefixId: aaa
                     from:
                       uri: "direct:foo"
                       steps:
@@ -350,7 +320,7 @@ class RoutesTest extends YamlTestSupport {
                         - to: "seda:foo"
                 - route:
                     id: bar
-                    node-prefix-id: bbb
+                    nodePrefixId: bbb
                     from:
                       uri: "direct:bar"
                       steps:
@@ -367,4 +337,26 @@ class RoutesTest extends YamlTestSupport {
         Assertions.assertEquals(2, context.getRoute("bar").filter("bbb*").size());
     }
 
+    def "Error: kebab-case: stream-cacing"() {
+        when:
+        var route = '''
+                - route:
+                    id: demo-route
+                    stream-caching: true
+                    auto-startup: false
+                    startup-order: 123
+                    route-policy: "myPolicy"
+                    from:
+                      uri: "direct:info"
+                      steps:
+                        - log: "message"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/SampleTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/SampleTest.groovy
@@ -18,6 +18,7 @@ package org.apache.camel.dsl.yaml
 
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.model.SamplingDefinition
+import org.junit.jupiter.api.Assertions
 
 class SampleTest extends YamlTestSupport {
 
@@ -28,11 +29,29 @@ class SampleTest extends YamlTestSupport {
                     uri: "direct:start"
                     steps:    
                       - sample:  
-                          message-frequency: 5
+                          messageFrequency: 5
             '''
         then:
             with(context.routeDefinitions[0].outputs[0], SamplingDefinition) {
                 messageFrequency == '5'
             }
+    }
+
+    def "Error: kebab-case: message-frequency"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - sample:  
+                          message-frequency: 5
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/ServiceCallTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/ServiceCallTest.groovy
@@ -21,6 +21,7 @@ import org.apache.camel.model.RouteDefinition
 import org.apache.camel.model.cloud.BlacklistServiceCallServiceFilterConfiguration
 import org.apache.camel.model.cloud.ServiceCallDefinition
 import org.apache.camel.model.cloud.StaticServiceCallServiceDiscoveryConfiguration
+import org.junit.jupiter.api.Assertions
 
 class ServiceCallTest extends YamlTestSupport {
 
@@ -30,13 +31,13 @@ class ServiceCallTest extends YamlTestSupport {
                 - from:
                    uri: "direct:start"
                    steps:
-                     - service-call:
+                     - serviceCall:
                          name: "sc"
-                         static-service-discovery:
+                         staticServiceDiscovery:
                              servers:
                                  - "service1@host1"
                                  - "service1@host2"                         
-                         blacklist-service-filter:
+                         blacklistServiceFilter:
                              servers:
                                  - "service2@host1"
             '''
@@ -55,5 +56,55 @@ class ServiceCallTest extends YamlTestSupport {
                     }
                 }
             }
+    }
+
+    def "Error: kebab-case: service-call"() {
+        when:
+        var route = '''
+                - from:
+                   uri: "direct:start"
+                   steps:
+                     - service-call:
+                         name: "sc"
+                         staticServiceDiscovery:
+                             servers:
+                                 - "service1@host1"
+                                 - "service1@host2"                         
+                         blacklistServiceFilter:
+                             servers:
+                                 - "service2@host1"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
+
+    def "Error: kebab-case: static-service-discovery"() {
+        when:
+        var route = '''
+                - from:
+                   uri: "direct:start"
+                   steps:
+                     - serviceCall:
+                         name: "sc"
+                         static-service-discovery:
+                             servers:
+                                 - "service1@host1"
+                                 - "service1@host2"                         
+                         blacklistServiceFilter:
+                             servers:
+                                 - "service2@host1"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/SetExchangePatternTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/SetExchangePatternTest.groovy
@@ -19,20 +19,38 @@ package org.apache.camel.dsl.yaml
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.ExchangePattern
 import org.apache.camel.model.SetExchangePatternDefinition
+import org.junit.jupiter.api.Assertions
 
 class SetExchangePatternTest extends YamlTestSupport {
 
-    def "set-exchange-pattern definition"() {
+    def "setExchangePattern definition"() {
         when:
             loadRoutes '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - setExchangePattern: "InOut"
+            '''
+        then:
+            with(context.routeDefinitions[0].outputs[0], SetExchangePatternDefinition) {
+                pattern == ExchangePattern.InOut.name()
+            }
+    }
+
+    def "Error: kebab-case: set-exchange-pattern definition"() {
+        when:
+        var route = '''
                 - from:
                     uri: "direct:start"
                     steps:    
                       - set-exchange-pattern: "InOut"
             '''
         then:
-            with(context.routeDefinitions[0].outputs[0], SetExchangePatternDefinition) {
-                pattern == ExchangePattern.InOut.name()
-            }
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/SetHeaderTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/SetHeaderTest.groovy
@@ -22,10 +22,11 @@ import org.apache.camel.model.language.ExpressionDefinition
 import org.apache.camel.model.language.SimpleExpression
 import org.apache.camel.spi.Resource
 import org.apache.camel.support.PluginHelper
+import org.junit.jupiter.api.Assertions
 
 class SetHeaderTest extends YamlTestSupport {
 
-    def "set-header definition (#resource.location)"(Resource resource) {
+    def "setHeader definition (#resource.location)"(Resource resource) {
         when:
             PluginHelper.getRoutesLoader(context).loadRoutes(resource)
         then:
@@ -43,7 +44,7 @@ class SetHeaderTest extends YamlTestSupport {
                     - from:
                         uri: "direct:start"
                         steps:    
-                          - set-header:
+                          - setHeader:
                               name: test
                               simple: "${body}"
                           - to: "mock:result"
@@ -52,7 +53,7 @@ class SetHeaderTest extends YamlTestSupport {
                     - from:
                         uri: "direct:start"
                         steps:    
-                          - set-header:
+                          - setHeader:
                               name: test
                               expression:
                                 simple: "${body}"
@@ -61,17 +62,17 @@ class SetHeaderTest extends YamlTestSupport {
         ]
     }
 
-    def "setHeader result-type"() {
+    def "setHeader resultType"() {
         when:
         loadRoutes '''
                 - from:
                     uri: "direct:start"
                     steps:    
-                      - set-header:
+                      - setHeader:
                           name: test
                           simple:
                             expression: "${body}"
-                            result-type: "long" 
+                            resultType: "long" 
                       - to: "mock:result"
             '''
         then:
@@ -86,4 +87,45 @@ class SetHeaderTest extends YamlTestSupport {
         }
     }
 
+    def "Error: kebab-case: set-header"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - set-header:
+                          name: test
+                          simple: "${body}"
+                      - to: "mock:result"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
+
+    def "Error: kebab-case: result-type"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - setHeader:
+                          name: test
+                          simple:
+                            expression: "${body}"
+                            result-type: "long" 
+                      - to: "mock:result"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/SetPropertyTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/SetPropertyTest.groovy
@@ -21,10 +21,11 @@ import org.apache.camel.model.SetPropertyDefinition
 import org.apache.camel.model.language.ExpressionDefinition
 import org.apache.camel.spi.Resource
 import org.apache.camel.support.PluginHelper
+import org.junit.jupiter.api.Assertions
 
 class SetPropertyTest extends YamlTestSupport {
 
-    def "set-property definition (#resource.location)"(Resource resource) {
+    def "setProperty definition (#resource.location)"(Resource resource) {
         when:
             PluginHelper.getRoutesLoader(context).loadRoutes(resource)
         then:
@@ -42,7 +43,7 @@ class SetPropertyTest extends YamlTestSupport {
                     - from:
                         uri: "direct:start"
                         steps:    
-                          - set-property:
+                          - setProperty:
                               name: test
                               simple: "${body}"
                           - to: "mock:result"
@@ -51,12 +52,33 @@ class SetPropertyTest extends YamlTestSupport {
                     - from:
                         uri: "direct:start"
                         steps:    
-                          - set-property:
+                          - setProperty:
                               name: test
                               expression:
                                 simple: "${body}"
                           - to: "mock:result"
                     ''')
             ]
+    }
+
+    def "Error: kebab-case: set-property"() {
+        when:
+        var route = '''
+                    - from:
+                        uri: "direct:start"
+                        steps:    
+                          - set-property:
+                              name: test
+                              expression:
+                                simple: "${body}"
+                          - to: "mock:result"
+                    '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/TemplatedRouteTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/TemplatedRouteTest.groovy
@@ -20,6 +20,7 @@ import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.dsl.yaml.support.model.MyUppercaseProcessor
 import org.apache.camel.model.RouteDefinition
+import org.junit.jupiter.api.Assertions
 
 class TemplatedRouteTest extends YamlTestSupport {
 
@@ -80,10 +81,10 @@ class TemplatedRouteTest extends YamlTestSupport {
         MockEndpoint.assertIsSatisfied(context)
     }
 
-    def "create templated-route"() {
+    def "create templatedRoute"() {
         setup:
         loadRoutes """
-                - route-template:
+                - routeTemplate:
                     id: "myTemplate"
                     from:
                       uri: "direct:{{directName}}"
@@ -111,7 +112,7 @@ class TemplatedRouteTest extends YamlTestSupport {
                     beans:
                       - name: "myProcessor"
                         type: "groovy"
-                        bean-type: "org.apache.camel.Processor"
+                        beanType: "org.apache.camel.Processor"
                         script: "new ${MyUppercaseProcessor.class.name}()"                 
             """
         withMock('mock:result') {
@@ -135,6 +136,54 @@ class TemplatedRouteTest extends YamlTestSupport {
             routeId == 'myRoute2'
         }
         MockEndpoint.assertIsSatisfied(context)
+    }
+
+    def "Error: kebab-case: templated-route"() {
+        when:
+        var route = """
+                - templated-route:
+                    routeId: "myRoute"
+                    routeTemplateRef: "myTemplate"
+                    parameters:
+                      - name: "directName"
+                        value: "foo"
+                    beans:
+                      - name: "myProcessor"
+                        type: "groovy"
+                        script: |
+                            new ${MyUppercaseProcessor.class.name}()
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
+
+    def "Error: kebab-case: route-id"() {
+        when:
+        var route = """
+                - templatedRoute:
+                    route-id: "myRoute"
+                    routeTemplateRef: "myTemplate"
+                    parameters:
+                      - name: "directName"
+                        value: "foo"
+                    beans:
+                      - name: "myProcessor"
+                        type: "groovy"
+                        script: |
+                            new ${MyUppercaseProcessor.class.name}()
+            """
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
     }
 
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/ThreadsTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/ThreadsTest.groovy
@@ -18,6 +18,7 @@ package org.apache.camel.dsl.yaml
 
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.model.ThreadsDefinition
+import org.junit.jupiter.api.Assertions
 
 class ThreadsTest extends YamlTestSupport {
 
@@ -28,11 +29,29 @@ class ThreadsTest extends YamlTestSupport {
                     uri: "direct:start"
                     steps:    
                       - threads:  
-                          pool-size: 5
+                          poolSize: 5
             '''
         then:
             with(context.routeDefinitions[0].outputs[0], ThreadsDefinition) {
                 poolSize == '5'
             }
+    }
+
+    def "Error: kebab-case: pool-size"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - threads:  
+                          pool-size: 5
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/ThrowExceptionTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/ThrowExceptionTest.groovy
@@ -18,17 +18,18 @@ package org.apache.camel.dsl.yaml
 
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.model.ThrowExceptionDefinition
+import org.junit.jupiter.api.Assertions
 
 class ThrowExceptionTest extends YamlTestSupport {
 
-    def "throw-exception definition"() {
+    def "throwException definition"() {
         when:
             loadRoutes '''
                 - from:
                     uri: "direct:start"
                     steps:    
-                      - throw-exception:  
-                          exception-type: "java.lang.IllegalArgumentException"
+                      - throwException:  
+                          exceptionType: "java.lang.IllegalArgumentException"
                           message: "test"
             '''
         then:
@@ -36,5 +37,43 @@ class ThrowExceptionTest extends YamlTestSupport {
                 message == 'test'
                 exceptionType == "java.lang.IllegalArgumentException"
             }
+    }
+
+    def "Error: kebab-case: throw-exception"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - throw-exception:
+                          exceptionType: "java.lang.IllegalArgumentException"
+                          message: "test"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
+
+    def "Error: kebab-case: exception-type"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:    
+                      - throwException:
+                          exception-type: "java.lang.IllegalArgumentException"
+                          message: "test"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/TryTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/TryTest.groovy
@@ -20,20 +20,21 @@ import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.model.RouteDefinition
 import org.apache.camel.model.TryDefinition
 import org.apache.camel.model.language.SimpleExpression
+import org.junit.jupiter.api.Assertions
 
 class TryTest extends YamlTestSupport {
 
-    def "do-try"() {
+    def "doTry"() {
         when:
             loadRoutes '''
                 - from:
                     uri: "direct:start"
                     steps:
-                      - do-try:                              
+                      - doTry:                              
                          steps:
                            - to: "log:when-a"
                            - to: "log:when-b"
-                         do-catch:
+                         doCatch:
                            - exception: 
                                - "java.io.FileNotFoundException"
                                - "java.io.IOException"
@@ -55,21 +56,21 @@ class TryTest extends YamlTestSupport {
             }
     }
 
-    def "do-try with on-when"() {
+    def "doTry with onWhen"() {
         when:
             loadRoutes '''
                 - from:
                     uri: "direct:start"
                     steps:
-                      - do-try:
+                      - doTry:
                          steps:
                            - to: "log:when-a"
                            - to: "log:when-b"
-                         do-catch:
+                         doCatch:
                            - exception: 
                                - "java.io.FileNotFoundException"
                                - "java.io.IOException"
-                             on-when:
+                             onWhen:
                                simple: "${body.size()} == 1"
                              steps:
                                - to: "log:io-error"
@@ -93,25 +94,25 @@ class TryTest extends YamlTestSupport {
             }
     }
 
-    def "do-try with do-when and do-finally"() {
+    def "doTry with doWhen and doFinally"() {
         when:
             loadRoutes '''
                 - from:
                     uri: "direct:start"
                     steps:
-                      - do-try:
+                      - doTry:
                          steps:
                            - to: "log:when-a"
                            - to: "log:when-b"
-                         do-catch:
+                         doCatch:
                            - exception: 
                                - "java.io.FileNotFoundException"
                                - "java.io.IOException"
-                             on-when:
+                             onWhen:
                                simple: "${body.size()} == 1"
                              steps:
                                - to: "log:io-error"
-                         do-finally:
+                         doFinally:
                            steps:
                              - to: "log:finally"
             '''
@@ -139,17 +140,17 @@ class TryTest extends YamlTestSupport {
             }
     }
 
-    def "do-try with do-finally"() {
+    def "doTry with doFinally"() {
         when:
             loadRoutes '''
                 - from:
                     uri: "direct:start"
                     steps:
-                      - do-try:
+                      - doTry:
                          steps:
                            - to: "log:when-a"
                            - to: "log:when-b"
-                         do-finally:
+                         doFinally:
                            steps:
                              - to: "log:finally"
             '''
@@ -163,4 +164,86 @@ class TryTest extends YamlTestSupport {
             }
     }
 
+    def "Error: kebab-case: do-try"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - do-try:
+                         steps:
+                           - to: "log:when-a"
+                           - to: "log:when-b"
+                         doCatch:
+                           - exception: 
+                               - "java.io.FileNotFoundException"
+                               - "java.io.IOException"
+                             steps:
+                               - to: "log:io-error"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
+
+    def "Error: kebab-case: do-catch"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - doTry:
+                         steps:
+                           - to: "log:when-a"
+                           - to: "log:when-b"
+                         do-catch:
+                           - exception: 
+                               - "java.io.FileNotFoundException"
+                               - "java.io.IOException"
+                             steps:
+                               - to: "log:io-error"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
+
+    def "Error: kebab-case: do-catch"() {
+        when:
+        var route = '''
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - doTry:
+                         steps:
+                           - to: "log:when-a"
+                           - to: "log:when-b"
+                         doCatch:
+                           - exception: 
+                               - "java.io.FileNotFoundException"
+                               - "java.io.IOException"
+                             on-when:
+                               simple: "${body.size()} == 1"
+                             steps:
+                               - to: "log:io-error"
+                         doFinally:
+                           steps:
+                             - to: "log:finally"
+            '''
+        then:
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
+    }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/WireTapTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/WireTapTest.groovy
@@ -18,18 +18,17 @@ package org.apache.camel.dsl.yaml
 
 import org.apache.camel.dsl.yaml.support.YamlTestSupport
 import org.apache.camel.model.WireTapDefinition
-import org.apache.camel.model.language.ConstantExpression
-import org.apache.camel.model.language.SimpleExpression
+import org.junit.jupiter.api.Assertions
 
 class WireTapTest extends YamlTestSupport {
 
-    def "wire-tap definition (#resource.location)"() {
+    def "wireTap definition (#resource.location)"() {
         when:
             loadRoutes '''
                 - from:
                     uri: "direct:start"
                     steps:    
-                      - wire-tap:
+                      - wireTap:
                          uri: "direct:wt"
             '''
         then:
@@ -38,9 +37,26 @@ class WireTapTest extends YamlTestSupport {
             }
     }
 
-    def "wire-tap uri parameters (#resource.location)"() {
+    def "wireTap uri parameters (#resource.location)"() {
         when:
             loadRoutes '''
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - wireTap:
+                         uri: direct
+                         parameters:
+                           name: wt2  
+            '''
+        then:
+            with(context.routeDefinitions[0].outputs[0], WireTapDefinition) {
+                uri == "direct:wt2"
+            }
+    }
+
+    def "Error: kebab-case"() {
+        when:
+        var route = '''
                 - from:
                     uri: "direct:start"
                     steps:
@@ -50,8 +66,11 @@ class WireTapTest extends YamlTestSupport {
                            name: wt2  
             '''
         then:
-            with(context.routeDefinitions[0].outputs[0], WireTapDefinition) {
-                uri == "direct:wt2"
-            }
+        try {
+            loadRoutes(route)
+            Assertions.fail("Should have thrown exception")
+        } catch (Exception e) {
+            Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
+        }
     }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/resources/stuff/my-route-comment.yaml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/resources/stuff/my-route-comment.yaml
@@ -35,7 +35,7 @@
             when:
               - simple: "${body} == 'Hello'"
                 steps:
-                  - set-property:
+                  - setProperty:
                       # more blah blah
                       name: testProp
                       simple: "${body}"
@@ -43,7 +43,7 @@
             otherwise:
               steps:
                 # more blah blah
-                - set-property:
+                - setProperty:
                     name: testProp
                     constant: "NoDice"
           # more blah blah

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/resources/stuff/my-route.yaml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/resources/stuff/my-route.yaml
@@ -29,12 +29,12 @@
             when:
               - simple: "${body} == 'Hello'"
                 steps:
-                  - set-property:
+                  - setProperty:
                       name: testProp
                       simple: "${body}"
             otherwise:
               steps:
-                - set-property:
+                - setProperty:
                     name: testProp
                     constant: "NoDice"
         - log: "${header.textProp}"


### PR DESCRIPTION
…ery sub schema

Also:
* Fix kebabToCamelCase handling to address `required` as well
* Fix intecept/interceptFrom/interceptSendToEndpoint/onCompletion to be a top level properties (YamlIn) but not as a step
* Fix `addtionalProperties: false` to be also set on wrapped array properties

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).
https://issues.apache.org/jira/browse/CAMEL-19700

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes
