### PR TITLE
CAMEL-19842: fix not creating/refreshing seda queues

### DIFF
--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
@@ -101,6 +101,7 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
     private boolean discardIfNoConsumers;
 
     private BlockingQueueFactory<Exchange> queueFactory;
+    private volatile QueueReference ref;
 
     public SedaEndpoint() {
         queueFactory = new LinkedBlockingQueueFactory<>();
@@ -214,11 +215,21 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
      * @return the reference, or <tt>null</tt> if no queue reference exists.
      */
     public QueueReference getQueueReference() {
-        String key = getComponent().getQueueKey(getEndpointUri());
-
-        synchronized (this) {
-            return getComponent().getQueueReference(key);
+        if (ref == null || ref.getCount() == 0) {
+            ref = tryQueueRefInit();
         }
+
+        return ref;
+    }
+
+    private QueueReference tryQueueRefInit() {
+        final SedaComponent component = getComponent();
+        if (component != null) {
+            final String key = component.getQueueKey(getEndpointUri());
+            return component.getQueueReference(key);
+        }
+
+        return null;
     }
 
     protected synchronized AsyncProcessor getConsumerMulticastProcessor() {
@@ -546,6 +557,8 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
         if (queue == null) {
             queue = getQueue();
         }
+
+        ref = tryQueueRefInit();
     }
 
     @Override
@@ -555,6 +568,8 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
         } else {
             LOG.debug("There is still active consumers.");
         }
+
+        ref = null;
     }
 
     @Override
@@ -586,6 +601,7 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
 
         // clear queue, as we are shutdown, so if re-created then the queue must be updated
         queue = null;
+        ref = null;
     }
 
 }


### PR DESCRIPTION
- Removing the cached queue references caused a regression in camel-zookeeper-master. This brings back the cached references (reverts: d66469d6ac7243f0ae790c41a500965b885d3180)
- Avoid keeping cached stalled references (ref: CAMEL-19815)