### PR TITLE
[4.0.x] CAMEL-19816: Add headers to camel-platform-http-vertx for the connection local and remote address

### DIFF
--- a/components/camel-platform-http-vertx/src/main/docs/platform-http-vertx.adoc
+++ b/components/camel-platform-http-vertx/src/main/docs/platform-http-vertx.adoc
@@ -27,7 +27,9 @@ and the platform http component should auto-detect this.
 |=======================================================================
 |Name |Type |Description
 
-|`CamelVertxPlatformHttpAuthenticatedUser` |`io.vertx.ext.auth.User` |If an authenticated user is present on the Vert.x Web `RoutingContext`, this header is populated with a `User` object continaing the `Principal`.
+|`CamelVertxPlatformHttpAuthenticatedUser` |`io.vertx.ext.auth.User` |If an authenticated user is present on the Vert.x Web `RoutingContext`, this header is populated with a `User` object containing the `Principal`.
+|`CamelVertxPlatformHttpLocalAddress` |`io.vertx.core.net.SocketAddress` |The local address for the connection if present on the Vert.x Web `RoutingContext`.
+|`CamelVertxPlatformHttpRemoteAddress` |`io.vertx.core.net.SocketAddress` |The remote address for the connection if present on the Vert.x Web `RoutingContext`.
 |=======================================================================
 
 Camel also populates *all* request.parameter and Camel also populates *all* request.parameter and request.headers. For

--- a/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpConstants.java
+++ b/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpConstants.java
@@ -19,6 +19,8 @@ package org.apache.camel.component.platform.http.vertx;
 public final class VertxPlatformHttpConstants {
 
     public static final String AUTHENTICATED_USER = "CamelVertxPlatformHttpAuthenticatedUser";
+    public static final String LOCAL_ADDRESS = "CamelVertxPlatformHttpLocalAddress";
+    public static final String REMOTE_ADDRESS = "CamelVertxPlatformHttpRemoteAddress";
 
     private VertxPlatformHttpConstants() {
     }

--- a/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpSupport.java
+++ b/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpSupport.java
@@ -31,6 +31,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.RoutingContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -252,6 +253,16 @@ public final class VertxPlatformHttpSupport {
         // Path parameters
         for (Map.Entry<String, String> en : ctx.pathParams().entrySet()) {
             appendHeader(headersMap, en.getKey(), en.getValue());
+        }
+
+        SocketAddress localAddress = request.localAddress();
+        if (localAddress != null) {
+            headersMap.put(VertxPlatformHttpConstants.LOCAL_ADDRESS, localAddress);
+        }
+
+        SocketAddress remoteAddress = request.remoteAddress();
+        if (remoteAddress != null) {
+            headersMap.put(VertxPlatformHttpConstants.REMOTE_ADDRESS, remoteAddress);
         }
 
         // NOTE: these headers is applied using the same logic as camel-http/camel-jetty to be consistent


### PR DESCRIPTION
Hopefully this is ok to be considered for backport. It's a pretty minor change.