### PR TITLE
[4.0.x] CAMEL-19843: HTTP/2 pseudo-headers such as :status should not be propagated from CXF message to Camel message

### DIFF
--- a/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/DefaultCxfBinding.java
+++ b/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/DefaultCxfBinding.java
@@ -674,6 +674,9 @@ public class DefaultCxfBinding implements CxfBinding, HeaderFilterStrategyAware 
                         // SOAPAction header may contain quoted value. Remove the quotes here.
                         soapAction = StringHelper.removeLeadingAndEndingQuotes(soapAction);
                         camelHeaders.put(SoapBindingConstants.SOAP_ACTION, soapAction);
+                    } else if (entry.getKey().startsWith(":")) {
+                        /* Ignore HTTP/2 pseudo headers such as :status */
+                        continue;
                     } else {
                         LOG.trace("Populate header from CXF header={} value={}",
                                 entry.getKey(), entry.getValue());

--- a/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfProducerRouterTest.java
+++ b/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfProducerRouterTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.cxf.jaxws;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
@@ -150,6 +151,18 @@ public class CxfProducerRouterTest extends CamelTestSupport {
         assertTrue(response.indexOf("echo " + TEST_MESSAGE) > 0, "It should has the echo message");
         assertTrue(response.indexOf("echoResponse") > 0, "It should has the echoResponse tag");
 
+    }
+
+    @Test
+    public void testIgnorePseudoHeaders() throws Exception {
+        Exchange senderExchange = new DefaultExchange(context, ExchangePattern.InOut);
+        senderExchange.getIn().setBody(REQUEST_MESSAGE);
+        Exchange exchange = template.send("direct:EndpointB", senderExchange);
+
+        org.apache.camel.Message out = exchange.getMessage();
+        final List<String> pseudoHeaders
+                = out.getHeaders().keySet().stream().filter(key -> key.startsWith(":")).collect(Collectors.toList());
+        assertTrue(pseudoHeaders.isEmpty(), "Pseudo-headers such as :status should be filtered out; found: " + pseudoHeaders);
     }
 
     @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/CEQ-6982