### PR TITLE
Updating Jakarta El to 3.0.4

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -283,7 +283,7 @@
     <jakarta-jaxb-version>2.3.3</jakarta-jaxb-version>
     <jakarta-mail-version>1.6.7</jakarta-mail-version>
     <jakarta-xml-soap-api-version>1.4.2</jakarta-xml-soap-api-version>
-    <jakarta.el-version>3.0.3</jakarta.el-version>
+    <jakarta.el-version>3.0.4</jakarta.el-version>
     <jandex-version>3.1.0</jandex-version>
     <jansi-version>2.4.0</jansi-version>
     <jasminb-jsonapi-version>0.11</jasminb-jsonapi-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -281,7 +281,7 @@
         <javax-servlet-api-version>3.1.0</javax-servlet-api-version>
         <jakarta-cdi-api-version>2.0.2</jakarta-cdi-api-version>
         <jakarta-api-version>2.1.5</jakarta-api-version>
-        <jakarta.el-version>3.0.3</jakarta.el-version>
+        <jakarta.el-version>3.0.4</jakarta.el-version>
         <jakarta-inject-version>1.0.5</jakarta-inject-version>
         <jakarta-jaxb-version>2.3.3</jakarta-jaxb-version>
         <jakarta-xml-soap-api-version>1.4.2</jakarta-xml-soap-api-version>


### PR DESCRIPTION
A fix for:

| org.glassfish:jakarta.el (jakarta.el-3.0.3.jar)             │ CVE-2021-28170 │ MEDIUM   │ affected │ 3.0.3             │               │ jakarta-el: ELParserTokenManager enables invalid EL expressions to be evaluate  https://avd.aquasec.com/nvd/cve-2021-28170                   │