### PR TITLE
CAMEL-19812 add otel aligned attributes

### DIFF
--- a/components/camel-observation/src/main/java/org/apache/camel/observation/MicrometerObservationSpanAdapter.java
+++ b/components/camel-observation/src/main/java/org/apache/camel/observation/MicrometerObservationSpanAdapter.java
@@ -55,6 +55,7 @@ public class MicrometerObservationSpanAdapter implements SpanAdapter {
     @Override
     public void setTag(Tag key, String value) {
         this.observation.highCardinalityKeyValue(key.toString(), value);
+        this.observation.highCardinalityKeyValue(key.getAttribute(), value);
     }
 
     @Override
@@ -80,11 +81,13 @@ public class MicrometerObservationSpanAdapter implements SpanAdapter {
     @Override
     public void setLowCardinalityTag(Tag key, String value) {
         observation.lowCardinalityKeyValue(key.toString(), value);
+        observation.lowCardinalityKeyValue(key.getAttribute(), value);
     }
 
     @Override
     public void setLowCardinalityTag(Tag key, Number value) {
         observation.lowCardinalityKeyValue(key.toString(), value.toString());
+        observation.lowCardinalityKeyValue(key.getAttribute(), value.toString());
     }
 
     @Override

--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetrySpanAdapter.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetrySpanAdapter.java
@@ -16,31 +16,17 @@
  */
 package org.apache.camel.opentelemetry;
 
-import java.util.EnumMap;
 import java.util.Map;
 
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageBuilder;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.apache.camel.tracing.SpanAdapter;
 import org.apache.camel.tracing.Tag;
 
 public class OpenTelemetrySpanAdapter implements SpanAdapter {
     private static final String DEFAULT_EVENT_NAME = "log";
-    private static Map<Tag, String> tagMap = new EnumMap<>(Tag.class);
-
-    static {
-        tagMap.put(Tag.COMPONENT, "component");
-        tagMap.put(Tag.DB_TYPE, SemanticAttributes.DB_SYSTEM.getKey());
-        tagMap.put(Tag.DB_STATEMENT, SemanticAttributes.DB_STATEMENT.getKey());
-        tagMap.put(Tag.DB_INSTANCE, SemanticAttributes.DB_NAME.getKey());
-        tagMap.put(Tag.HTTP_METHOD, SemanticAttributes.HTTP_METHOD.getKey());
-        tagMap.put(Tag.HTTP_STATUS, SemanticAttributes.HTTP_STATUS_CODE.getKey());
-        tagMap.put(Tag.HTTP_URL, SemanticAttributes.HTTP_URL.getKey());
-        tagMap.put(Tag.MESSAGE_BUS_DESTINATION, "message_bus.destination");
-    }
 
     private Baggage baggage;
     private io.opentelemetry.api.trace.Span span;
@@ -70,12 +56,12 @@ public class OpenTelemetrySpanAdapter implements SpanAdapter {
 
     @Override
     public void setTag(Tag key, String value) {
-        this.span.setAttribute(tagMap.get(key), value);
+        this.span.setAttribute(key.getAttribute(), value);
     }
 
     @Override
     public void setTag(Tag key, Number value) {
-        this.span.setAttribute(tagMap.get(key), value.intValue());
+        this.span.setAttribute(key.getAttribute(), value.intValue());
     }
 
     @Override

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/Tag.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/Tag.java
@@ -17,13 +17,39 @@
 package org.apache.camel.tracing;
 
 public enum Tag {
-    COMPONENT,
-    HTTP_STATUS,
-    HTTP_METHOD,
-    HTTP_URL,
-    MESSAGE_BUS_DESTINATION,
-    DB_TYPE,
-    DB_INSTANCE,
-    DB_STATEMENT,
-    ERROR
+    COMPONENT("component"),
+    ERROR("error"),
+
+    // General Tags
+    SERVER_ADDRESS("server.address"),
+
+    // HTTP tags
+    HTTP_STATUS("http.status_code"),
+    HTTP_METHOD("http.method"),
+    HTTP_URL("http.url"),
+    URL_SCHEME("url.scheme"),
+    URL_PATH("url.path"),
+    URL_QUERY("url.query"),
+
+    // Messaging tags
+    MESSAGE_BUS_DESTINATION("messaging.destination.name"),
+    MESSAGE_ID("messaging.message.id"),
+
+    // Database tags
+    DB_TYPE("db.system"),
+    DB_INSTANCE("db.name"),
+    DB_STATEMENT("db.statement"),
+
+    // Exception tags
+    EXCEPTION_MESSAGE("exception.message");
+
+    Tag(String attribute) {
+        this.attribute = attribute;
+    }
+
+    private final String attribute;
+
+    public String getAttribute() {
+        return attribute;
+    }
 }

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractMessagingSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractMessagingSpanDecorator.java
@@ -46,6 +46,7 @@ public abstract class AbstractMessagingSpanDecorator extends AbstractSpanDecorat
         String messageId = getMessageId(exchange);
         if (messageId != null) {
             span.setTag(MESSAGE_BUS_ID, messageId);
+            span.setTag(Tag.MESSAGE_ID.getAttribute(), messageId);
         }
     }
 

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractSpanDecorator.java
@@ -20,11 +20,7 @@ import java.util.*;
 
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
-import org.apache.camel.tracing.ExtractAdapter;
-import org.apache.camel.tracing.InjectAdapter;
-import org.apache.camel.tracing.SpanAdapter;
-import org.apache.camel.tracing.SpanDecorator;
-import org.apache.camel.tracing.SpanKind;
+import org.apache.camel.tracing.*;
 import org.apache.camel.tracing.propagation.CamelHeadersExtractAdapter;
 import org.apache.camel.tracing.propagation.CamelHeadersInjectAdapter;
 import org.apache.camel.util.StringHelper;
@@ -99,9 +95,14 @@ public abstract class AbstractSpanDecorator implements SpanDecorator {
         span.setComponent(CAMEL_COMPONENT + scheme);
 
         // Including the endpoint URI provides access to any options that may
-        // have been provided, for
-        // subsequent analysis
-        span.setTag("camel.uri", URISupport.sanitizeUri(endpoint.getEndpointUri()));
+        // have been provided, for subsequent analysis
+        String uri = URISupport.sanitizeUri(endpoint.getEndpointUri());
+        span.setTag("camel.uri", uri);
+        span.setTag(Tag.URL_PATH, stripSchemeAndOptions(endpoint));
+        String query = URISupport.extractQuery(uri);
+        if (query != null) {
+            span.setTag(Tag.URL_QUERY, query);
+        }
     }
 
     @Override

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/ElasticsearchSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/ElasticsearchSpanDecorator.java
@@ -60,6 +60,7 @@ public class ElasticsearchSpanDecorator extends AbstractSpanDecorator {
         String cluster = stripSchemeAndOptions(endpoint);
         if (cluster != null) {
             span.setTag(ELASTICSEARCH_CLUSTER_TAG, cluster);
+            span.setTag(Tag.SERVER_ADDRESS.getAttribute(), cluster);
         }
     }
 

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/MockSpanAdapter.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/MockSpanAdapter.java
@@ -54,11 +54,13 @@ public class MockSpanAdapter implements SpanAdapter {
     @Override
     public void setTag(Tag key, String value) {
         this.tags.put(key.name(), value);
+        this.tags.put(key.getAttribute(), value);
     }
 
     @Override
     public void setTag(Tag key, Number value) {
         this.tags.put(key.name(), value);
+        this.tags.put(key.getAttribute(), value);
     }
 
     @Override

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractMessagingSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractMessagingSpanDecoratorTest.java
@@ -104,6 +104,7 @@ public class AbstractMessagingSpanDecoratorTest {
         decorator.pre(span, exchange, endpoint);
 
         assertEquals(messageId, span.tags().get(AbstractMessagingSpanDecorator.MESSAGE_BUS_ID));
+        assertEquals(messageId, span.tags().get(Tag.MESSAGE_ID.getAttribute()));
     }
 
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/CqlSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/CqlSpanDecoratorTest.java
@@ -73,8 +73,11 @@ public class CqlSpanDecoratorTest {
         decorator.pre(span, exchange, endpoint);
 
         assertEquals(CqlSpanDecorator.CASSANDRA_DB_TYPE, span.tags().get(Tag.DB_TYPE.name()));
+        assertEquals(CqlSpanDecorator.CASSANDRA_DB_TYPE, span.tags().get(Tag.DB_TYPE.getAttribute()));
         assertEquals(cql, span.tags().get(Tag.DB_STATEMENT.name()));
+        assertEquals(cql, span.tags().get(Tag.DB_STATEMENT.getAttribute()));
         assertNull(span.tags().get(Tag.DB_INSTANCE.name()));
+        assertNull(span.tags().get(Tag.DB_INSTANCE.getAttribute()));
     }
 
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/ElasticsearchSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/ElasticsearchSpanDecoratorTest.java
@@ -62,8 +62,11 @@ public class ElasticsearchSpanDecoratorTest {
         decorator.pre(span, exchange, endpoint);
 
         assertEquals(ElasticsearchSpanDecorator.ELASTICSEARCH_DB_TYPE, span.tags().get(Tag.DB_TYPE.name()));
+        assertEquals(ElasticsearchSpanDecorator.ELASTICSEARCH_DB_TYPE, span.tags().get(Tag.DB_TYPE.getAttribute()));
         assertEquals(indexName, span.tags().get(Tag.DB_INSTANCE.name()));
+        assertEquals(indexName, span.tags().get(Tag.DB_INSTANCE.getAttribute()));
         assertEquals(cluster, span.tags().get(ElasticsearchSpanDecorator.ELASTICSEARCH_CLUSTER_TAG));
+        assertEquals(cluster, span.tags().get(Tag.SERVER_ADDRESS.getAttribute()));
     }
 
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/JdbcSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/JdbcSpanDecoratorTest.java
@@ -48,7 +48,9 @@ public class JdbcSpanDecoratorTest {
         decorator.pre(span, exchange, endpoint);
 
         assertEquals("sql", span.tags().get(Tag.DB_TYPE.name()));
+        assertEquals("sql", span.tags().get(Tag.DB_TYPE.getAttribute()));
         assertEquals(SQL_STATEMENT, span.tags().get(Tag.DB_STATEMENT.name()));
+        assertEquals(SQL_STATEMENT, span.tags().get(Tag.DB_STATEMENT.getAttribute()));
     }
 
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/MongoDBSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/MongoDBSpanDecoratorTest.java
@@ -65,8 +65,11 @@ public class MongoDBSpanDecoratorTest {
         decorator.pre(span, null, endpoint);
 
         assertEquals("mongodb", span.tags().get(Tag.DB_TYPE.name()));
+        assertEquals("mongodb", span.tags().get(Tag.DB_TYPE.getAttribute()));
         assertEquals("flights", span.tags().get(Tag.DB_INSTANCE.name()));
+        assertEquals("flights", span.tags().get(Tag.DB_INSTANCE.getAttribute()));
         assertTrue(span.tags().containsKey(Tag.DB_STATEMENT.name()));
+        assertTrue(span.tags().containsKey(Tag.DB_STATEMENT.getAttribute()));
     }
 
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/SqlSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/SqlSpanDecoratorTest.java
@@ -48,7 +48,9 @@ public class SqlSpanDecoratorTest {
         decorator.pre(span, exchange, endpoint);
 
         assertEquals("sql", span.tags().get(Tag.DB_TYPE.name()));
+        assertEquals("sql", span.tags().get(Tag.DB_TYPE.getAttribute()));
         assertEquals(SQL_STATEMENT, span.tags().get(Tag.DB_STATEMENT.name()));
+        assertEquals(SQL_STATEMENT, span.tags().get(Tag.DB_STATEMENT.getAttribute()));
     }
 
 }


### PR DESCRIPTION

Following on from comments left on https://github.com/apache/camel/pull/11354

Demo adding otel attributes to the Tag Enum allowing either the Tag name to be used and/or the Tag attribute when setting a span attribute.   