### PR TITLE
CAMEL-19868: removed unused exception in URISupport.normalizeUri

### DIFF
--- a/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/service/TelegramServiceRestBotAPIAdapter.java
+++ b/components/camel-telegram/src/main/java/org/apache/camel/component/telegram/service/TelegramServiceRestBotAPIAdapter.java
@@ -140,7 +140,7 @@ public class TelegramServiceRestBotAPIAdapter implements TelegramService {
 
             final HttpRequest request = HttpRequest.newBuilder().uri(URI.create(uri)).GET().build();
             return sendSyncRequest(request, UpdateResult.class);
-        } catch (URISyntaxException | UnsupportedEncodingException e) {
+        } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -17,6 +17,7 @@
 package org.apache.camel.test.junit5;
 
 import java.lang.annotation.Annotation;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -869,7 +870,7 @@ public abstract class CamelTestSupport
         String n;
         try {
             n = URISupport.normalizeUri(uri);
-        } catch (Exception e) {
+        } catch (URISyntaxException e) {
             throw RuntimeCamelException.wrapRuntimeException(e);
         }
         // strip query

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/RouteDefinitionHelper.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/RouteDefinitionHelper.java
@@ -114,7 +114,7 @@ public final class RouteDefinitionHelper {
     private static String normalizeUri(String uri) {
         try {
             return URISupport.normalizeUri(uri);
-        } catch (UnsupportedEncodingException | URISyntaxException e) {
+        } catch (URISyntaxException e) {
             // ignore
         }
         return null;

--- a/core/camel-support/src/main/java/org/apache/camel/support/EndpointHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/EndpointHelper.java
@@ -161,7 +161,7 @@ public final class EndpointHelper {
     public static String normalizeEndpointUri(String uri) {
         try {
             uri = URISupport.normalizeUri(uri);
-        } catch (Exception e) {
+        } catch (URISyntaxException e) {
             throw new ResolveEndpointFailedException(uri, e);
         }
         return uri;

--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -541,7 +541,7 @@ public final class URISupport {
      * @throws UnsupportedEncodingException is thrown if encoding error
      */
     public static String appendParametersToURI(String originalURI, Map<String, Object> newParameters)
-            throws URISyntaxException, UnsupportedEncodingException {
+            throws URISyntaxException {
         URI uri = new URI(normalizeUri(originalURI));
         Map<String, Object> parameters = parseParameters(uri);
         parameters.putAll(newParameters);
@@ -559,12 +559,11 @@ public final class URISupport {
      * @param  uri                          the uri
      * @return                              the normalized uri
      * @throws URISyntaxException           in thrown if the uri syntax is invalid
-     * @throws UnsupportedEncodingException is thrown if encoding error
      * @see                                 #RAW_TOKEN_PREFIX
      * @see                                 #RAW_TOKEN_START
      * @see                                 #RAW_TOKEN_END
      */
-    public static String normalizeUri(String uri) throws URISyntaxException, UnsupportedEncodingException {
+    public static String normalizeUri(String uri) throws URISyntaxException {
         // try to parse using the simpler and faster Camel URI parser
         String[] parts = CamelURIParser.fastParseUri(uri);
         if (parts != null) {

--- a/test-infra/camel-test-infra-core/src/test/java/org/apache/camel/test/infra/core/MockUtils.java
+++ b/test-infra/camel-test-infra-core/src/test/java/org/apache/camel/test/infra/core/MockUtils.java
@@ -17,6 +17,8 @@
 
 package org.apache.camel.test.infra.core;
 
+import java.net.URISyntaxException;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.NoSuchEndpointException;
@@ -73,7 +75,7 @@ public final class MockUtils {
         String n;
         try {
             n = URISupport.normalizeUri(uri);
-        } catch (Exception e) {
+        } catch (URISyntaxException e) {
             throw RuntimeCamelException.wrapRuntimeException(e);
         }
         // strip query


### PR DESCRIPTION
This should simplify consolidating duplicate code from camel-core-catalog