### PR TITLE
CAMEL-19859: camel-spring-rabbitmq set headerfilter not effective #11397

### DIFF
--- a/components/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/DefaultMessagePropertiesConverter.java
+++ b/components/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/DefaultMessagePropertiesConverter.java
@@ -31,11 +31,10 @@ import org.springframework.amqp.core.MessageProperties;
 public class DefaultMessagePropertiesConverter implements MessagePropertiesConverter {
 
     private final CamelContext camelContext;
-    private final HeaderFilterStrategy headerFilterStrategy;
+    private HeaderFilterStrategy headerFilterStrategy;
 
-    public DefaultMessagePropertiesConverter(CamelContext camelContext, HeaderFilterStrategy headerFilterStrategy) {
+    public DefaultMessagePropertiesConverter(CamelContext camelContext) {
         this.camelContext = camelContext;
-        this.headerFilterStrategy = headerFilterStrategy;
     }
 
     @Override
@@ -179,6 +178,11 @@ public class DefaultMessagePropertiesConverter implements MessagePropertiesConve
         }
 
         return answer;
+    }
+
+    @Override
+    public void setHeaderFilterStrategy(HeaderFilterStrategy headerFilterStrategy) {
+        this.headerFilterStrategy = headerFilterStrategy;
     }
 
     private void appendOutputHeader(MessageProperties answer, String headerName, Object headerValue, Exchange ex) {

--- a/components/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/MessagePropertiesConverter.java
+++ b/components/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/MessagePropertiesConverter.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.springrabbit;
 import java.util.Map;
 
 import org.apache.camel.Exchange;
+import org.apache.camel.spi.HeaderFilterStrategy;
 import org.springframework.amqp.core.MessageProperties;
 
 public interface MessagePropertiesConverter {
@@ -27,4 +28,5 @@ public interface MessagePropertiesConverter {
 
     Map<String, Object> fromMessageProperties(MessageProperties messageProperties, Exchange exchange);
 
+    void setHeaderFilterStrategy(HeaderFilterStrategy headerFilterStrategy);
 }

--- a/components/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/SpringRabbitMQComponent.java
+++ b/components/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/SpringRabbitMQComponent.java
@@ -124,7 +124,7 @@ public class SpringRabbitMQComponent extends HeaderFilterStrategyComponent {
             messageConverter = new DefaultMessageConverter(getCamelContext());
         }
         if (messagePropertiesConverter == null) {
-            messagePropertiesConverter = new DefaultMessagePropertiesConverter(getCamelContext(), getHeaderFilterStrategy());
+            messagePropertiesConverter = new DefaultMessagePropertiesConverter(getCamelContext());
         }
     }
 
@@ -134,6 +134,7 @@ public class SpringRabbitMQComponent extends HeaderFilterStrategyComponent {
         endpoint.setConnectionFactory(connectionFactory);
         endpoint.setTestConnectionOnStartup(testConnectionOnStartup);
         endpoint.setMessageConverter(messageConverter);
+        messagePropertiesConverter.setHeaderFilterStrategy(getHeaderFilterStrategy());
         endpoint.setMessagePropertiesConverter(messagePropertiesConverter);
         endpoint.setAutoStartup(autoStartup);
         endpoint.setAutoDeclare(autoDeclare);


### PR DESCRIPTION
# Description

if i use java code to config spring-rabbitmq component headerfilterstrategy, the doinit() method of SpringRabbitMQComponent will be executed before i config headerfilterstrategy, so the DefaultMessagePropertiesConverter may reference headerfilterStrategy the old value。

# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

