### PR TITLE
CAMEL-19871: camel-jooq - Set the proper scope to all test dependencies

### DIFF
--- a/components/camel-jooq/pom.xml
+++ b/components/camel-jooq/pom.xml
@@ -84,11 +84,13 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>${spring-version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
             <version>${spring-version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -100,6 +102,7 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${awaitility-version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hsqldb</groupId>


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19871 for 4.1

## Motivation

There are many test dependencies of the camel-joor component for which no scope has been set which pulls useless dependencies at runtime.

## Modifications:

* Add the test scope to all test dependencies to avoid getting the default scope which is compile