### PR TITLE
CAMEL-19870 Camel AS2: Should accept MDN field name Disposition as case insensitive

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/DispositionMode.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/DispositionMode.java
@@ -44,14 +44,14 @@ public enum DispositionMode {
     }
 
     public static DispositionMode parseDispositionMode(String dispositionModeString) {
-        switch (dispositionModeString) {
-            case "manual-action/MDN-sent-manually":
+        switch (dispositionModeString.toLowerCase()) {
+            case "manual-action/mdn-sent-manually":
                 return MANUAL_ACTION_MDN_SENT_MANUALLY;
-            case "manual-actionMDN-sent-automatically":
+            case "manual-action/mdn-sent-automatically":
                 return MANUAL_ACTION_MDN_SENT_AUTOMATICALLY;
-            case "automatic-action/MDN-sent-manually":
+            case "automatic-action/mdn-sent-manually":
                 return AUTOMATIC_ACTION_MDN_SENT_MANUALLY;
-            case "automatic-action/MDN-sent-automatically":
+            case "automatic-action/mdn-sent-automatically":
                 return AUTOMATIC_ACTION_MDN_SENT_AUTOMATICALLY;
             default:
                 return null;

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/util/DispositionNotificationContentUtilsTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/util/DispositionNotificationContentUtilsTest.java
@@ -118,4 +118,18 @@ public class DispositionNotificationContentUtilsTest {
                 "Unexpected Digest Algorithm ID");
     }
 
+    @Test
+    public void testDispoistionTypeCaseSensitivity() throws Exception {
+        String dispoistionTypeMixedCase = "automatic-action/MDN-Sent-automatically";
+        String dispoistionTypeLowerCase = "automatic-action/mdn-sent-automatically";
+
+        DispositionMode resultMixedCase = DispositionMode.parseDispositionMode(dispoistionTypeMixedCase);
+        DispositionMode resultLowerCase = DispositionMode.parseDispositionMode(dispoistionTypeLowerCase);
+
+        assertEquals(DispositionMode.AUTOMATIC_ACTION_MDN_SENT_AUTOMATICALLY, resultMixedCase,
+                "DispositionMode should be case insensitive");
+        assertEquals(DispositionMode.AUTOMATIC_ACTION_MDN_SENT_AUTOMATICALLY, resultLowerCase,
+                "DispositionMode should be case insensitive");
+    }
+
 }


### PR DESCRIPTION
# Description

- The third party AS2 server returning the MDN response with disposition field case insensitive which is as per the spec (https://www.ietf.org/rfc/rfc4130.txt) but camel as2 validates this field with case sensitive hence it fails.
- This fix is already applied to main branch and this PR is a backport to camel 3.21.x branch.

# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

