### PR TITLE
(chores) camel-azure: avoid slow code paths

### DIFF
--- a/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/operations/BlobOperations.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/operations/BlobOperations.java
@@ -83,7 +83,9 @@ public class BlobOperations {
     }
 
     public BlobOperationResponse getBlob(final Exchange exchange) throws IOException {
-        LOG.trace("Getting a blob [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Getting a blob [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        }
 
         final Message message = BlobUtils.getInMessage(exchange);
         final OutputStream outputStream = ObjectHelper.isEmpty(message) ? null : message.getBody(OutputStream.class);
@@ -182,7 +184,9 @@ public class BlobOperations {
         final BlobStreamAndLength blobStreamAndLength = BlobStreamAndLength.createBlobStreamAndLengthFromExchangeBody(exchange);
         final BlobCommonRequestOptions commonRequestOptions = getCommonRequestOptions(exchange);
 
-        LOG.trace("Putting a block blob [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Putting a block blob [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        }
 
         try {
             final Response<BlockBlobItem> response = client.uploadBlockBlob(blobStreamAndLength.getInputStream(),
@@ -213,7 +217,10 @@ public class BlobOperations {
             throw new IllegalArgumentException("Illegal storageBlocks payload");
         }
 
-        LOG.trace("Putting a blob [{}] from blocks from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Putting a blob [{}] from blocks from exchange [{}]...", configurationProxy.getBlobName(exchange),
+                    exchange);
+        }
 
         final BlobCommonRequestOptions commonRequestOptions = getCommonRequestOptions(exchange);
 
@@ -256,7 +263,10 @@ public class BlobOperations {
             throw new IllegalArgumentException("Illegal commit block list payload");
         }
 
-        LOG.trace("Putting a blob [{}] block list from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Putting a blob [{}] block list from exchange [{}]...", configurationProxy.getBlobName(exchange),
+                    exchange);
+        }
 
         final BlobCommonRequestOptions commonRequestOptions = getCommonRequestOptions(exchange);
 
@@ -273,7 +283,10 @@ public class BlobOperations {
     }
 
     public BlobOperationResponse getBlobBlockList(final Exchange exchange) {
-        LOG.trace("Getting the blob block list [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Getting the blob block list [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange),
+                    exchange);
+        }
 
         final BlockListType blockListType = configurationProxy.getBlockListType(exchange);
         final BlobCommonRequestOptions commonRequestOptions = getCommonRequestOptions(exchange);
@@ -285,7 +298,9 @@ public class BlobOperations {
     }
 
     public BlobOperationResponse createAppendBlob(final Exchange exchange) {
-        LOG.trace("Creating an append blob [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Creating an append blob [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        }
 
         final BlobCommonRequestOptions commonRequestOptions = getCommonRequestOptions(exchange);
 
@@ -297,7 +312,9 @@ public class BlobOperations {
     }
 
     public BlobOperationResponse copyBlob(final Exchange exchange) {
-        LOG.trace("Creating an append blob [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Creating an append blob [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        }
 
         String sourceBlobName = configurationProxy.getBlobName(exchange);
         String sourceAccountName = exchange.getMessage().getHeader(BlobConstants.SOURCE_BLOB_ACCOUNT_NAME, String.class);
@@ -341,7 +358,9 @@ public class BlobOperations {
     }
 
     public BlobOperationResponse createPageBlob(final Exchange exchange) {
-        LOG.trace("Creating a page blob [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Creating a page blob [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        }
 
         final Long pageSize = getPageBlobSize(exchange);
         final BlobCommonRequestOptions requestOptions = getCommonRequestOptions(exchange);
@@ -384,7 +403,9 @@ public class BlobOperations {
     }
 
     public BlobOperationResponse resizePageBlob(final Exchange exchange) {
-        LOG.trace("Resizing a page blob [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Resizing a page blob [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange), exchange);
+        }
 
         final Long pageSize = getPageBlobSize(exchange);
         final BlobCommonRequestOptions requestOptions = getCommonRequestOptions(exchange);
@@ -417,8 +438,10 @@ public class BlobOperations {
         final BlobRange blobRange = configurationProxy.getBlobRange(exchange);
         final BlobCommonRequestOptions commonRequestOptions = getCommonRequestOptions(exchange);
 
-        LOG.trace("Getting the page blob ranges [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange),
-                exchange);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Getting the page blob ranges [{}] from exchange [{}]...", configurationProxy.getBlobName(exchange),
+                    exchange);
+        }
 
         final PagedIterable<PageRangeItem> response
                 = client.getPageBlobRanges(blobRange, commonRequestOptions.getBlobRequestConditions(),

--- a/components/camel-azure/camel-azure-storage-queue/src/main/java/org/apache/camel/component/azure/storage/queue/QueueConsumer.java
+++ b/components/camel-azure/camel-azure-storage-queue/src/main/java/org/apache/camel/component/azure/storage/queue/QueueConsumer.java
@@ -171,8 +171,10 @@ public class QueueConsumer extends ScheduledBatchPollingConsumer {
      */
     private void processCommit(final Exchange exchange) {
         try {
-            LOG.trace("Deleting message with pop receipt handle {}...",
-                    QueueExchangeHeaders.getPopReceiptFromHeaders(exchange));
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Deleting message with pop receipt handle {}...",
+                        QueueExchangeHeaders.getPopReceiptFromHeaders(exchange));
+            }
             queueOperations.deleteMessage(exchange);
         } catch (QueueStorageException ex) {
             getExceptionHandler().handleException("Error occurred during deleting message. This exception is ignored.",


### PR DESCRIPTION
Logging the exchange can alter its internal state.

Also void potentially slow code paths that require significantly deep calls to resolve logging parameters

* camel-azure-storage-blob
* camel-azure-storage-queue