### PR TITLE
(chores) fixed incorrectly named tests

### DIFF
--- a/components/camel-test/camel-test-spring-junit5/src/test/java/org/apache/camel/test/issues/AdviceWithOnExceptionTransactedTest.java
+++ b/components/camel-test/camel-test-spring-junit5/src/test/java/org/apache/camel/test/issues/AdviceWithOnExceptionTransactedTest.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.TransactionStatus;
 
 import static org.apache.camel.builder.Builder.constant;
 
-public class AdviceWithOnExceptionTransacted extends CamelSpringTestSupport {
+public class AdviceWithOnExceptionTransactedTest extends CamelSpringTestSupport {
 
     @Override
     protected AbstractApplicationContext createApplicationContext() {

--- a/core/camel-core/src/test/java/org/apache/camel/issues/TwoTimerWithJMXIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/TwoTimerWithJMXIssueTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Trying to reproduce CAMEL-927.
  */
-public class TwoTimerWithJMXIssue extends ContextTestSupport {
+public class TwoTimerWithJMXIssueTest extends ContextTestSupport {
 
     private static int counter;
 


### PR DESCRIPTION
These tests were skipped because their names did not match the convention setup on surefire