### PR TITLE
Fix integration test of camel-package-maven-plugin

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/pom.xml
+++ b/tooling/maven/camel-package-maven-plugin/pom.xml
@@ -248,6 +248,29 @@
                             </dependency>
                         </dependencies>
                     </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>post-integration-test</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>-c</argument>
+                                <argument>cat target/it/HeaderSupport/build.log | grep "BUILD FAILURE" &amp;&amp; cat target/it/HeaderSupport/build.log</argument>
+                            </arguments>
+                            <successCodes>
+                                <successCode>0</successCode>
+                                <successCode>1</successCode>
+                            </successCodes>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/tooling/maven/camel-package-maven-plugin/src/it/HeaderSupport/invoker.properties
+++ b/tooling/maven/camel-package-maven-plugin/src/it/HeaderSupport/invoker.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+invoker.goals = clean install -e
+invoker.mavenOpts = -Xms512m -Xmx1024m


### PR DESCRIPTION
## Motivation

The integration test of the project camel-package-maven-plugin fails regularly on the GH CI, so it needs to be investigated and fixed.

## Modifications

* Display log file content in case of a failure
* Increase the heap size of the IT