### PR TITLE
CAMEL-19871: camel-jooq - Set the proper scope to all test dependencies

### DIFF
--- a/components/camel-jooq/pom.xml
+++ b/components/camel-jooq/pom.xml
@@ -84,11 +84,13 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>${spring-version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
             <version>${spring-version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -100,6 +102,7 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${awaitility-version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hsqldb</groupId>
@@ -231,6 +234,15 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration combine.self="override">
+                    <!-- Prevent the maven-javadoc-plugin from generating the Javadoc of the test classes generated
+                    by jooq-codegen-maven -->
+                    <sourcepath>${project.build.sourceDirectory};src/generated/java</sourcepath>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19871 for 4.1

## Motivation

There are many test dependencies of the camel-joor component for which no scope has been set which pulls useless dependencies at runtime.

## Modifications:

* Add the test scope to all test dependencies to avoid getting the default scope which is compile
* Prevent the maven-javadoc-plugin from generating the Javadoc of the test classes generated by jooq-codegen-maven