### PR TITLE
Updated spring boot component name for aws redshift

### DIFF
--- a/components/camel-aws/camel-aws2-redshift/src/main/docs/aws2-redshift-data-component.adoc
+++ b/components/camel-aws/camel-aws2-redshift/src/main/docs/aws2-redshift-data-component.adoc
@@ -9,7 +9,7 @@
 :component-header: Only producer is supported
 //Manually maintained attributes
 :group: AWS
-:camel-spring-boot-name: aws2-redshift-data
+:camel-spring-boot-name: aws2-redshift
 
 *Since Camel {since}*
 


### PR DESCRIPTION
Fix for https://github.com/apache/camel/pull/11429#issuecomment-1725632495 to update spring boot component name for aws2 redshift