### PR TITLE
(chore) ci: exclude integration tests

### DIFF
--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -22,8 +22,14 @@ maxNumberOfTestableProjects=50
 
 function findProjectRoot () {
   local path=${1}
-  while [[ "$path" != "." && ! -e "$path/pom.xml" ]]; do
-    path=$(dirname $path)
+  while [[ "$path" != "." ]]; do
+    if [[ ! -e "$path/pom.xml" ]] ; then
+      path=$(dirname $path)
+    elif [[ $(dirname $path) == */src/it ]] ; then
+      path=$(dirname $(dirname $path))
+    else
+      break
+    fi
   done
   echo "$path"
 }
@@ -58,7 +64,7 @@ function main() {
       local projectRoot
       projectRoot=$(findProjectRoot ${project})
       if [[ ${projectRoot} = "." ]] ; then
-        echo "There root project is affected, so a complete build is triggered"
+        echo "The root project is affected, so a complete build is triggered"
         buildAll=true
       elif [[ ${projectRoot} != "${lastProjectRoot}" ]] ; then
         (( totalAffected ++ ))


### PR DESCRIPTION
## Motivation

A change in an integration test where we have a complete project with a pom file can be seen as a project to test while we rather expect to test its parent project

## Modifications:

* Exclude integration test project from project root to test