### PR TITLE
CAMEL-19888 Preserve openapi tags order while generating api-doc

### DIFF
--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiReader.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiReader.java
@@ -18,21 +18,7 @@ package org.apache.camel.openapi;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -170,7 +156,11 @@ public class RestOpenApiReader {
             openApi.setTags(new ArrayList<>(
                     openApi.getTags()
                             .stream()
-                            .collect(Collectors.toMap(Tag::getName, Function.identity(), (prev, current) -> prev))
+                            .collect(Collectors.toMap(
+                                    Tag::getName,
+                                    Function.identity(),
+                                    (prev, current) -> prev,
+                                    LinkedHashMap::new))
                             .values()));
         }
 

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderTest.java
@@ -182,7 +182,7 @@ public class RestOpenApiReaderTest extends CamelTestSupport {
         assertTrue(flatJson.contains(
                 "\"/tag/multiple/b\" : { \"get\" : { \"tags\" : [ \"Organisation\", \"Group B\" ], \"consumes\" : [ \"application/json\" ], \"produces\" : [ \"application/json\" ], "));
         assertTrue(flatJson.contains(
-                "\"tags\" : [ { \"name\" : \"Group B\" }, { \"name\" : \"Organisation\" }, { \"name\" : \"Group A\" }, { \"name\" : \"/hello\" } ]"));
+                "\"tags\" : [ { \"name\" : \"/hello\" }, { \"name\" : \"Organisation\" }, { \"name\" : \"Group A\" }, { \"name\" : \"Group B\" } ]"));
 
         context.stop();
     }
@@ -226,8 +226,7 @@ public class RestOpenApiReaderTest extends CamelTestSupport {
         assertTrue(
                 json.matches(".*\"/tag/multiple/b\" : \\{ \"get\" : .*\"tags\" : \\[ \"Organisation\", \"Group B\" ],.*"));
         assertTrue(json.contains(
-                "\"tags\" : [ { \"name\" : \"Group B\" }, { \"name\" : \"Organisation\" }, { \"name\" : \"Group A\" }, { \"name\" : \"/hello\" } ]"));
-
+                "\"tags\" : [ { \"name\" : \"/hello\" }, { \"name\" : \"Organisation\" }, { \"name\" : \"Group A\" }, { \"name\" : \"Group B\" } ]"));
         context.stop();
     }
 


### PR DESCRIPTION
# Description
In RestOpenApiReader.class, while aggregating the tags for api-doc, the HashMap was used instead of LinkedHashMap, which broke the original order of the tags. A LinkedHashMap is used now instead. There is no way of sorting the tags after that, and their order influences, for example, the UI of the swagger.

