### PR TITLE
CAMEL-19892: openapi-rest-dsl-generator - Use jakarta instead of javax

### DIFF
--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/customized-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/customized-v3/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <build>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/customized/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/customized/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <build>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/expanded-v3-yaml/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/expanded-v3-yaml/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -37,6 +39,11 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
       <version>@project.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>@jakarta-annotation-api-version@</version>
     </dependency>
   </dependencies>
 

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-dto-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-dto-v3/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-dto/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-dto/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-v3-yaml/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-v3-yaml/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -37,6 +39,11 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
       <version>@project.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>@jakarta-annotation-api-version@</version>
     </dependency>
   </dependencies>
 

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-v3/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -37,6 +39,11 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
       <version>@project.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>@jakarta-annotation-api-version@</version>
     </dependency>
   </dependencies>
 

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml-dto-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml-dto-v3/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml-dto/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml-dto/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml-v3/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <build>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-xml/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <build>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-yaml-dto-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-yaml-dto-v3/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-yaml-kamelet-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-yaml-kamelet-v3/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <build>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-yaml-v3/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple-yaml-v3/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <build>

--- a/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple/pom.xml
+++ b/tooling/maven/camel-restdsl-openapi-plugin/src/it/simple/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -37,6 +39,11 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
       <version>@project.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>@jakarta-annotation-api-version@</version>
     </dependency>
   </dependencies>
 

--- a/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/RestDslSourceCodeGenerator.java
+++ b/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/RestDslSourceCodeGenerator.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
-import javax.annotation.processing.Generated;
+import jakarta.annotation.Generated;
 import javax.lang.model.element.Modifier;
 
 import com.squareup.javapoet.AnnotationSpec;

--- a/tooling/openapi-rest-dsl-generator/src/test/resources/MyRestRoute.txt
+++ b/tooling/openapi-rest-dsl-generator/src/test/resources/MyRestRoute.txt
@@ -1,6 +1,6 @@
 package com.example;
 
-import javax.annotation.processing.Generated;
+import jakarta.annotation.Generated;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.CollectionFormat;
 import org.apache.camel.model.rest.RestParamType;

--- a/tooling/openapi-rest-dsl-generator/src/test/resources/MyRestRouteFilter.txt
+++ b/tooling/openapi-rest-dsl-generator/src/test/resources/MyRestRouteFilter.txt
@@ -1,6 +1,6 @@
 package com.example;
 
-import javax.annotation.processing.Generated;
+import jakarta.annotation.Generated;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.CollectionFormat;
 import org.apache.camel.model.rest.RestParamType;

--- a/tooling/openapi-rest-dsl-generator/src/test/resources/MyRestRouteFilterV3.txt
+++ b/tooling/openapi-rest-dsl-generator/src/test/resources/MyRestRouteFilterV3.txt
@@ -1,6 +1,6 @@
 package com.example;
 
-import javax.annotation.processing.Generated;
+import jakarta.annotation.Generated;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.CollectionFormat;
 import org.apache.camel.model.rest.RestParamType;

--- a/tooling/openapi-rest-dsl-generator/src/test/resources/MyRestRouteV3.txt
+++ b/tooling/openapi-rest-dsl-generator/src/test/resources/MyRestRouteV3.txt
@@ -1,6 +1,6 @@
 package com.example;
 
-import javax.annotation.processing.Generated;
+import jakarta.annotation.Generated;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.CollectionFormat;
 import org.apache.camel.model.rest.RestParamType;

--- a/tooling/openapi-rest-dsl-generator/src/test/resources/OpenApiPetstore.txt
+++ b/tooling/openapi-rest-dsl-generator/src/test/resources/OpenApiPetstore.txt
@@ -1,6 +1,6 @@
 package io.openapi.petstore;
 
-import javax.annotation.processing.Generated;
+import jakarta.annotation.Generated;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.CollectionFormat;
 import org.apache.camel.model.rest.RestParamType;

--- a/tooling/openapi-rest-dsl-generator/src/test/resources/OpenApiPetstoreWithRestComponent.txt
+++ b/tooling/openapi-rest-dsl-generator/src/test/resources/OpenApiPetstoreWithRestComponent.txt
@@ -1,6 +1,6 @@
 package io.openapi.petstore;
 
-import javax.annotation.processing.Generated;
+import jakarta.annotation.Generated;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.CollectionFormat;
 import org.apache.camel.model.rest.RestParamType;

--- a/tooling/openapi-rest-dsl-generator/src/test/resources/OpenApiV3Petstore.txt
+++ b/tooling/openapi-rest-dsl-generator/src/test/resources/OpenApiV3Petstore.txt
@@ -1,6 +1,6 @@
 package io.openapi.petstore;
 
-import javax.annotation.processing.Generated;
+import jakarta.annotation.Generated;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.CollectionFormat;
 import org.apache.camel.model.rest.RestParamType;

--- a/tooling/openapi-rest-dsl-generator/src/test/resources/OpenApiV3PetstoreWithRestComponent.txt
+++ b/tooling/openapi-rest-dsl-generator/src/test/resources/OpenApiV3PetstoreWithRestComponent.txt
@@ -1,6 +1,6 @@
 package io.openapi.petstore;
 
-import javax.annotation.processing.Generated;
+import jakarta.annotation.Generated;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.CollectionFormat;
 import org.apache.camel.model.rest.RestParamType;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-19892