### PR TITLE
Revert "CAMEL-19398: remove isStatisticsEnabled (#11494)"

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/spi/TypeConverterRegistry.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/TypeConverterRegistry.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.spi;
 
-import java.util.function.LongConsumer;
-import java.util.function.LongSupplier;
-
 import org.apache.camel.CamelContextAware;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.StaticService;
@@ -70,9 +67,10 @@ public interface TypeConverterRegistry extends StaticService, CamelContextAware 
          */
         void reset();
 
-        default void computeIfEnabled(LongSupplier supplier, LongConsumer consumer) {
-            consumer.accept(supplier.getAsLong());
-        }
+        /**
+         * Whether statistics is enabled.
+         */
+        boolean isStatisticsEnabled();
     }
 
     /**

--- a/core/camel-base/src/main/java/org/apache/camel/impl/converter/CoreTypeConverterRegistry.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/converter/CoreTypeConverterRegistry.java
@@ -613,9 +613,10 @@ public abstract class CoreTypeConverterRegistry extends ServiceSupport implement
     protected void doStop() throws Exception {
         super.doStop();
         // log utilization statistics when stopping, including mappings
-
-        final String info = generateMappingStatisticsMessage();
-        LOG.info(info);
+        if (statistics.isStatisticsEnabled()) {
+            final String info = generateMappingStatisticsMessage();
+            LOG.info(info);
+        }
 
         statistics.reset();
     }

--- a/core/camel-base/src/main/java/org/apache/camel/impl/converter/NoopTypeConverterStatistics.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/converter/NoopTypeConverterStatistics.java
@@ -49,6 +49,11 @@ final class NoopTypeConverterStatistics implements ConverterStatistics {
     }
 
     @Override
+    public boolean isStatisticsEnabled() {
+        return false;
+    }
+
+    @Override
     public void incrementFailed() {
         // NO-OP
     }
@@ -71,11 +76,5 @@ final class NoopTypeConverterStatistics implements ConverterStatistics {
     @Override
     public void incrementAttempt() {
         // NO-OP
-    }
-
-    @Override
-    public String toString() {
-        return String.format("NoopTypeConverterStatistics utilization[noop=%s, attempts=%s, hits=%s, misses=%s, failures=%s]",
-                getNoopCounter(), getAttemptCounter(), getHitCounter(), getMissCounter(), getFailedCounter());
     }
 }

--- a/core/camel-base/src/main/java/org/apache/camel/impl/converter/TypeConverterStatistics.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/converter/TypeConverterStatistics.java
@@ -90,8 +90,13 @@ final class TypeConverterStatistics implements ConverterStatistics {
     }
 
     @Override
+    public boolean isStatisticsEnabled() {
+        return true;
+    }
+
+    @Override
     public String toString() {
-        return String.format("TypeConverterStatistics utilization[noop=%s, attempts=%s, hits=%s, misses=%s, failures=%s]",
+        return String.format("TypeConverterRegistry utilization[noop=%s, attempts=%s, hits=%s, misses=%s, failures=%s]",
                 getNoopCounter(), getAttemptCounter(), getHitCounter(), getMissCounter(), getFailedCounter());
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/TypeConverterConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/TypeConverterConsole.java
@@ -38,13 +38,13 @@ public class TypeConverterConsole extends AbstractDevConsole {
         sb.append(String.format("\n    Converters: %s", reg.size()));
         sb.append(String.format("\n    Exists: %s", reg.getTypeConverterExists().name()));
         sb.append(String.format("\n    Exists LoggingLevel: %s", reg.getTypeConverterExistsLoggingLevel()));
-        final TypeConverterRegistry.Statistics statistics = reg.getStatistics();
-
-        statistics.computeIfEnabled(statistics::getAttemptCounter, v -> sb.append(String.format("\n    Attempts: %s", v)));
-        statistics.computeIfEnabled(statistics::getHitCounter, v -> sb.append(String.format("\n    Hit: %s", v)));
-        statistics.computeIfEnabled(statistics::getMissCounter, v -> sb.append(String.format("\n    Miss: %s", v)));
-        statistics.computeIfEnabled(statistics::getFailedCounter, v -> sb.append(String.format("\n    Failed: %s", v)));
-        statistics.computeIfEnabled(statistics::getNoopCounter, v -> sb.append(String.format("\n    Noop: %s", v)));
+        if (reg.getStatistics().isStatisticsEnabled()) {
+            sb.append(String.format("\n    Attempts: %s", reg.getStatistics().getAttemptCounter()));
+            sb.append(String.format("\n    Hit: %s", reg.getStatistics().getHitCounter()));
+            sb.append(String.format("\n    Miss: %s", reg.getStatistics().getMissCounter()));
+            sb.append(String.format("\n    Failed: %s", reg.getStatistics().getFailedCounter()));
+            sb.append(String.format("\n    Noop: %s", reg.getStatistics().getNoopCounter()));
+        }
 
         return sb.toString();
     }
@@ -57,18 +57,14 @@ public class TypeConverterConsole extends AbstractDevConsole {
         root.put("size", reg.size());
         root.put("exists", reg.getTypeConverterExists().name());
         root.put("existsLoggingLevel", reg.getTypeConverterExistsLoggingLevel().name());
-
-        final TypeConverterRegistry.Statistics statistics = reg.getStatistics();
-        JsonObject props = new JsonObject();
-
-        statistics.computeIfEnabled(statistics::getAttemptCounter, v -> props.put("attemptCounter", v));
-        statistics.computeIfEnabled(statistics::getHitCounter, v -> props.put("hitCounter", v));
-        statistics.computeIfEnabled(statistics::getMissCounter, v -> props.put("missCounter", v));
-        statistics.computeIfEnabled(statistics::getFailedCounter, v -> props.put("failedCounter", v));
-        statistics.computeIfEnabled(statistics::getFailedCounter, v -> props.put("noopCounter", v));
-
-        if (!props.isEmpty()) {
+        if (reg.getStatistics().isStatisticsEnabled()) {
+            JsonObject props = new JsonObject();
             root.put("statistics", props);
+            props.put("attemptCounter", reg.getStatistics().getAttemptCounter());
+            props.put("hitCounter", reg.getStatistics().getHitCounter());
+            props.put("missCounter", reg.getStatistics().getAttemptCounter());
+            props.put("failedCounter", reg.getStatistics().getFailedCounter());
+            props.put("noopCounter", reg.getStatistics().getNoopCounter());
         }
 
         return root;

--- a/core/camel-core/src/test/java/org/apache/camel/impl/TypeConverterRegistryStatisticsEnabledNoStreamCachingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/TypeConverterRegistryStatisticsEnabledNoStreamCachingTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TypeConverterRegistryStatisticsEnabledNoStreamCachingTest extends ContextTestSupport {
 
@@ -48,6 +49,7 @@ public class TypeConverterRegistryStatisticsEnabledNoStreamCachingTest extends C
         assertMockEndpointsSatisfied();
 
         TypeConverterRegistry reg = context.getTypeConverterRegistry();
+        assertTrue(reg.getStatistics().isStatisticsEnabled(), "Should be enabled");
 
         Long failed = reg.getStatistics().getFailedCounter();
         assertEquals(0, failed.intValue());

--- a/core/camel-core/src/test/java/org/apache/camel/impl/TypeConverterRegistryStatisticsEnabledTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/TypeConverterRegistryStatisticsEnabledTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TypeConverterRegistryStatisticsEnabledTest extends ContextTestSupport {
 
@@ -44,6 +45,7 @@ public class TypeConverterRegistryStatisticsEnabledTest extends ContextTestSuppo
         assertMockEndpointsSatisfied();
 
         TypeConverterRegistry reg = context.getTypeConverterRegistry();
+        assertTrue(reg.getStatistics().isStatisticsEnabled(), "Should be enabled");
 
         Long failed = reg.getStatistics().getFailedCounter();
         assertEquals(0, failed.intValue());

--- a/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedTypeConverterRegistryMBean.java
+++ b/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedTypeConverterRegistryMBean.java
@@ -39,6 +39,9 @@ public interface ManagedTypeConverterRegistryMBean extends ManagedServiceMBean {
     @ManagedOperation(description = "Resets the type conversion counters")
     void resetTypeConversionCounters();
 
+    @ManagedAttribute(description = "Utilization statistics enabled")
+    boolean isStatisticsEnabled();
+
     @ManagedAttribute(description = "Number of type converters in the registry")
     int getNumberOfTypeConverters();
 

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedTypeConverterRegistry.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedTypeConverterRegistry.java
@@ -70,6 +70,11 @@ public class ManagedTypeConverterRegistry extends ManagedService implements Mana
     }
 
     @Override
+    public boolean isStatisticsEnabled() {
+        return registry.getStatistics().isStatisticsEnabled();
+    }
+
+    @Override
     public int getNumberOfTypeConverters() {
         return registry.size();
     }


### PR DESCRIPTION
This reverts commit db7e5221b1f8df7c795782778c83e283c3a3c866.

This change seems to break some expectations from Spring XML (i.e; verified on SpringTypeConverterRegistryStatisticsEnabledTest) and can break backwards compatibility.