### PR TITLE
CAMEL-19812 use open telemetry naming conventions

### DIFF
--- a/components/camel-observation/src/main/java/org/apache/camel/observation/MicrometerObservationSpanAdapter.java
+++ b/components/camel-observation/src/main/java/org/apache/camel/observation/MicrometerObservationSpanAdapter.java
@@ -55,6 +55,7 @@ public class MicrometerObservationSpanAdapter implements SpanAdapter {
     @Override
     public void setTag(Tag key, String value) {
         this.observation.highCardinalityKeyValue(key.toString(), value);
+        this.observation.highCardinalityKeyValue(key.getAttribute(), value);
     }
 
     @Override
@@ -80,11 +81,13 @@ public class MicrometerObservationSpanAdapter implements SpanAdapter {
     @Override
     public void setLowCardinalityTag(Tag key, String value) {
         observation.lowCardinalityKeyValue(key.toString(), value);
+        observation.lowCardinalityKeyValue(key.getAttribute(), value);
     }
 
     @Override
     public void setLowCardinalityTag(Tag key, Number value) {
         observation.lowCardinalityKeyValue(key.toString(), value.toString());
+        observation.lowCardinalityKeyValue(key.getAttribute(), value.toString());
     }
 
     @Override

--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetrySpanAdapter.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetrySpanAdapter.java
@@ -70,7 +70,11 @@ public class OpenTelemetrySpanAdapter implements SpanAdapter {
 
     @Override
     public void setTag(Tag key, String value) {
-        this.span.setAttribute(tagMap.getOrDefault(key, key.getAttribute()), value);
+        String attribute = tagMap.getOrDefault(key, key.getAttribute());
+        this.span.setAttribute(attribute, value);
+        if (!attribute.equals(key.getAttribute())) {
+            this.span.setAttribute(key.getAttribute(), value);
+        }
     }
 
     @Override

--- a/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetrySpanAdapter.java
+++ b/components/camel-opentelemetry/src/main/java/org/apache/camel/opentelemetry/OpenTelemetrySpanAdapter.java
@@ -70,12 +70,12 @@ public class OpenTelemetrySpanAdapter implements SpanAdapter {
 
     @Override
     public void setTag(Tag key, String value) {
-        this.span.setAttribute(tagMap.get(key), value);
+        this.span.setAttribute(tagMap.getOrDefault(key, key.getAttribute()), value);
     }
 
     @Override
     public void setTag(Tag key, Number value) {
-        this.span.setAttribute(tagMap.get(key), value.intValue());
+        this.span.setAttribute(tagMap.getOrDefault(key, key.getAttribute()), value.intValue());
     }
 
     @Override

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/SpanAdapter.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/SpanAdapter.java
@@ -23,8 +23,10 @@ public interface SpanAdapter {
 
     void setError(boolean error);
 
+    @Deprecated
     void setTag(Tag key, String value);
 
+    @Deprecated
     void setTag(Tag key, Number value);
 
     void setTag(String key, String value);
@@ -33,10 +35,12 @@ public interface SpanAdapter {
 
     void setTag(String key, Boolean value);
 
+    @Deprecated
     default void setLowCardinalityTag(Tag key, String value) {
         setTag(key, value);
     }
 
+    @Deprecated
     default void setLowCardinalityTag(Tag key, Number value) {
         setTag(key, value);
     }

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/Tag.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/Tag.java
@@ -16,14 +16,41 @@
  */
 package org.apache.camel.tracing;
 
+@Deprecated
 public enum Tag {
-    COMPONENT,
-    HTTP_STATUS,
-    HTTP_METHOD,
-    HTTP_URL,
-    MESSAGE_BUS_DESTINATION,
-    DB_TYPE,
-    DB_INSTANCE,
-    DB_STATEMENT,
-    ERROR
+    COMPONENT(TagConstants.COMPONENT),
+    ERROR(TagConstants.ERROR),
+
+    // General Tags
+    SERVER_ADDRESS(TagConstants.SERVER_ADDRESS),
+
+    // HTTP tags
+    HTTP_STATUS(TagConstants.HTTP_STATUS),
+    HTTP_METHOD(TagConstants.HTTP_METHOD),
+    HTTP_URL(TagConstants.HTTP_URL),
+    URL_SCHEME(TagConstants.URL_SCHEME),
+    URL_PATH(TagConstants.URL_PATH),
+    URL_QUERY(TagConstants.URL_QUERY),
+
+    // Messaging tags
+    MESSAGE_BUS_DESTINATION(TagConstants.MESSAGE_BUS_DESTINATION),
+    MESSAGE_ID(TagConstants.MESSAGE_ID),
+
+    // Database tags
+    DB_TYPE(TagConstants.DB_SYSTEM),
+    DB_INSTANCE(TagConstants.DB_NAME),
+    DB_STATEMENT(TagConstants.DB_STATEMENT),
+
+    // Exception tags
+    EXCEPTION_MESSAGE(TagConstants.EXCEPTION_MESSAGE);
+
+    Tag(String attribute) {
+        this.attribute = attribute;
+    }
+
+    private final String attribute;
+
+    public String getAttribute() {
+        return attribute;
+    }
 }

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/TagConstants.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/TagConstants.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.tracing;
+
+public class TagConstants {
+
+    public static final String ERROR = "error";
+    public static final String COMPONENT = "component";
+
+    // General attributes
+    public static final String SERVER_ADDRESS = "server.address";
+
+    // HTTP attributes
+    public static final String HTTP_STATUS = "http.status_code";
+    public static final String HTTP_METHOD = "http.method";
+    public static final String HTTP_URL = "http.url";
+    public static final String URL_SCHEME = "url.scheme";
+    public static final String URL_PATH = "url.path";
+    public static final String URL_QUERY = "url.query";
+
+    // Messaging attributes
+    public static final String MESSAGE_BUS_DESTINATION = "messaging.destination.name";
+    public static final String MESSAGE_ID = "messaging.message.id";
+
+    // Database attributes
+    public static final String DB_SYSTEM = "db.system";
+    public static final String DB_NAME = "db.name";
+    public static final String DB_STATEMENT = "db.statement";
+
+    // Exception attributes
+    public static final String EXCEPTION_ESCAPED = "exception.escaped";
+    public static final String EXCEPTION_MESSAGE = "exception.message";
+}

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractMessagingSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractMessagingSpanDecorator.java
@@ -25,11 +25,13 @@ import org.apache.camel.tracing.InjectAdapter;
 import org.apache.camel.tracing.SpanAdapter;
 import org.apache.camel.tracing.SpanKind;
 import org.apache.camel.tracing.Tag;
+import org.apache.camel.tracing.TagConstants;
 import org.apache.camel.tracing.propagation.CamelMessagingHeadersExtractAdapter;
 import org.apache.camel.tracing.propagation.CamelMessagingHeadersInjectAdapter;
 
 public abstract class AbstractMessagingSpanDecorator extends AbstractSpanDecorator {
 
+    @Deprecated
     public static final String MESSAGE_BUS_ID = "message_bus.id";
 
     @Override
@@ -46,6 +48,7 @@ public abstract class AbstractMessagingSpanDecorator extends AbstractSpanDecorat
         String messageId = getMessageId(exchange);
         if (messageId != null) {
             span.setTag(MESSAGE_BUS_ID, messageId);
+            span.setTag(TagConstants.MESSAGE_ID, messageId);
         }
     }
 

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractSpanDecorator.java
@@ -98,6 +98,7 @@ public abstract class AbstractSpanDecorator implements SpanDecorator {
     public void pre(SpanAdapter span, Exchange exchange, Endpoint endpoint) {
         String scheme = getComponentName(endpoint);
         span.setComponent(CAMEL_COMPONENT + scheme);
+        span.setTag(TagConstants.URL_SCHEME, scheme);
 
         // Including the endpoint URI provides access to any options that may
         // have been provided, for subsequent analysis

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractSpanDecorator.java
@@ -25,6 +25,7 @@ import org.apache.camel.tracing.InjectAdapter;
 import org.apache.camel.tracing.SpanAdapter;
 import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.SpanKind;
+import org.apache.camel.tracing.TagConstants;
 import org.apache.camel.tracing.propagation.CamelHeadersExtractAdapter;
 import org.apache.camel.tracing.propagation.CamelHeadersInjectAdapter;
 import org.apache.camel.util.StringHelper;
@@ -99,9 +100,14 @@ public abstract class AbstractSpanDecorator implements SpanDecorator {
         span.setComponent(CAMEL_COMPONENT + scheme);
 
         // Including the endpoint URI provides access to any options that may
-        // have been provided, for
-        // subsequent analysis
-        span.setTag("camel.uri", URISupport.sanitizeUri(endpoint.getEndpointUri()));
+        // have been provided, for subsequent analysis
+        String uri = URISupport.sanitizeUri(endpoint.getEndpointUri());
+        span.setTag("camel.uri", uri);
+        span.setTag(TagConstants.URL_PATH, stripSchemeAndOptions(endpoint));
+        String query = URISupport.extractQuery(uri);
+        if (query != null) {
+            span.setTag(TagConstants.URL_QUERY, query);
+        }
     }
 
     @Override

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/ElasticsearchSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/ElasticsearchSpanDecorator.java
@@ -22,11 +22,13 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.tracing.SpanAdapter;
 import org.apache.camel.tracing.Tag;
+import org.apache.camel.tracing.TagConstants;
 
 public class ElasticsearchSpanDecorator extends AbstractSpanDecorator {
 
     public static final String ELASTICSEARCH_DB_TYPE = "elasticsearch";
 
+    @Deprecated
     public static final String ELASTICSEARCH_CLUSTER_TAG = "elasticsearch.cluster";
 
     @Override
@@ -60,6 +62,7 @@ public class ElasticsearchSpanDecorator extends AbstractSpanDecorator {
         String cluster = stripSchemeAndOptions(endpoint);
         if (cluster != null) {
             span.setTag(ELASTICSEARCH_CLUSTER_TAG, cluster);
+            span.setTag(TagConstants.SERVER_ADDRESS, cluster);
         }
     }
 

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/MockSpanAdapter.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/MockSpanAdapter.java
@@ -44,21 +44,25 @@ public class MockSpanAdapter implements SpanAdapter {
     @Override
     public void setComponent(String component) {
         this.tags.put(Tag.COMPONENT.name(), component);
+        this.tags.put(TagConstants.COMPONENT, component);
     }
 
     @Override
     public void setError(boolean error) {
         this.tags.put(Tag.ERROR.name(), error);
+        this.tags.put(TagConstants.ERROR, error);
     }
 
     @Override
     public void setTag(Tag key, String value) {
         this.tags.put(key.name(), value);
+        this.tags.put(key.getAttribute(), value);
     }
 
     @Override
     public void setTag(Tag key, Number value) {
         this.tags.put(key.name(), value);
+        this.tags.put(key.getAttribute(), value);
     }
 
     @Override

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractHttpSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractHttpSpanDecoratorTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Message;
 import org.apache.camel.tracing.MockSpanAdapter;
 import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.Tag;
+import org.apache.camel.tracing.TagConstants;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -160,7 +161,9 @@ public class AbstractHttpSpanDecoratorTest {
         decorator.pre(span, exchange, endpoint);
 
         assertEquals(TEST_URI, span.tags().get(Tag.HTTP_URL.name()));
+        assertEquals(TEST_URI, span.tags().get(TagConstants.HTTP_URL));
         assertTrue(span.tags().containsKey(Tag.HTTP_METHOD.name()));
+        assertTrue(span.tags().containsKey(TagConstants.HTTP_METHOD));
     }
 
     @Test
@@ -287,6 +290,7 @@ public class AbstractHttpSpanDecoratorTest {
         decorator.post(span, exchange, null);
 
         assertEquals(200, span.tags().get(Tag.HTTP_STATUS.name()));
+        assertEquals(200, span.tags().get(TagConstants.HTTP_STATUS));
     }
 
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractMessagingSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractMessagingSpanDecoratorTest.java
@@ -21,6 +21,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.tracing.MockSpanAdapter;
 import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.Tag;
+import org.apache.camel.tracing.TagConstants;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -72,6 +73,7 @@ public class AbstractMessagingSpanDecoratorTest {
         decorator.pre(span, null, endpoint);
 
         assertEquals("MyQueue", span.tags().get(Tag.MESSAGE_BUS_DESTINATION.name()));
+        assertEquals("MyQueue", span.tags().get(TagConstants.MESSAGE_BUS_DESTINATION));
     }
 
     @Test
@@ -104,6 +106,7 @@ public class AbstractMessagingSpanDecoratorTest {
         decorator.pre(span, exchange, endpoint);
 
         assertEquals(messageId, span.tags().get(AbstractMessagingSpanDecorator.MESSAGE_BUS_ID));
+        assertEquals(messageId, span.tags().get(TagConstants.MESSAGE_ID));
     }
 
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractSpanDecoratorTest.java
@@ -21,6 +21,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.tracing.MockSpanAdapter;
 import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.Tag;
+import org.apache.camel.tracing.TagConstants;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -76,6 +77,7 @@ public class AbstractSpanDecoratorTest {
         decorator.pre(span, null, endpoint);
 
         assertEquals("camel-test", span.tags().get(Tag.COMPONENT.name()));
+        assertEquals("camel-test", span.tags().get(TagConstants.COMPONENT));
     }
 
     @Test
@@ -104,6 +106,7 @@ public class AbstractSpanDecoratorTest {
         decorator.post(span, exchange, null);
 
         assertEquals(true, span.tags().get(Tag.ERROR.name()));
+        assertEquals(true, span.tags().get(TagConstants.ERROR));
         assertEquals(1, span.logEntries().size());
         assertEquals("error", span.logEntries().get(0).fields().get("event"));
         assertEquals("Exception", span.logEntries().get(0).fields().get("error.kind"));

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractSpanDecoratorTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AbstractSpanDecoratorTest {
 
-    private static final String TEST_URI = "test:/uri";
+    private static final String TEST_URI = "test:/uri?query=hello";
 
     @Test
     public void testGetOperationName() {
@@ -78,6 +78,9 @@ public class AbstractSpanDecoratorTest {
 
         assertEquals("camel-test", span.tags().get(Tag.COMPONENT.name()));
         assertEquals("camel-test", span.tags().get(TagConstants.COMPONENT));
+        assertEquals("test", span.tags().get(TagConstants.URL_SCHEME));
+        assertEquals("uri", span.tags().get(TagConstants.URL_PATH));
+        assertEquals("query=hello", span.tags().get(TagConstants.URL_QUERY));
     }
 
     @Test

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/CqlSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/CqlSpanDecoratorTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Message;
 import org.apache.camel.tracing.MockSpanAdapter;
 import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.Tag;
+import org.apache.camel.tracing.TagConstants;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -50,8 +51,11 @@ public class CqlSpanDecoratorTest {
         decorator.pre(span, exchange, endpoint);
 
         assertEquals(CqlSpanDecorator.CASSANDRA_DB_TYPE, span.tags().get(Tag.DB_TYPE.name()));
+        assertEquals(CqlSpanDecorator.CASSANDRA_DB_TYPE, span.tags().get(TagConstants.DB_SYSTEM));
         assertEquals(cql, span.tags().get(Tag.DB_STATEMENT.name()));
+        assertEquals(cql, span.tags().get(TagConstants.DB_STATEMENT));
         assertEquals(keyspace, span.tags().get(Tag.DB_INSTANCE.name()));
+        assertEquals(keyspace, span.tags().get(TagConstants.DB_NAME));
     }
 
     @Test

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/ElasticsearchSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/ElasticsearchSpanDecoratorTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Message;
 import org.apache.camel.tracing.MockSpanAdapter;
 import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.Tag;
+import org.apache.camel.tracing.TagConstants;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -62,8 +63,11 @@ public class ElasticsearchSpanDecoratorTest {
         decorator.pre(span, exchange, endpoint);
 
         assertEquals(ElasticsearchSpanDecorator.ELASTICSEARCH_DB_TYPE, span.tags().get(Tag.DB_TYPE.name()));
+        assertEquals(ElasticsearchSpanDecorator.ELASTICSEARCH_DB_TYPE, span.tags().get(TagConstants.DB_SYSTEM));
         assertEquals(indexName, span.tags().get(Tag.DB_INSTANCE.name()));
+        assertEquals(indexName, span.tags().get(TagConstants.DB_NAME));
         assertEquals(cluster, span.tags().get(ElasticsearchSpanDecorator.ELASTICSEARCH_CLUSTER_TAG));
+        assertEquals(cluster, span.tags().get(TagConstants.SERVER_ADDRESS));
     }
 
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/JdbcSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/JdbcSpanDecoratorTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Message;
 import org.apache.camel.tracing.MockSpanAdapter;
 import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.Tag;
+import org.apache.camel.tracing.TagConstants;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -48,7 +49,9 @@ public class JdbcSpanDecoratorTest {
         decorator.pre(span, exchange, endpoint);
 
         assertEquals("sql", span.tags().get(Tag.DB_TYPE.name()));
+        assertEquals("sql", span.tags().get(TagConstants.DB_SYSTEM));
         assertEquals(SQL_STATEMENT, span.tags().get(Tag.DB_STATEMENT.name()));
+        assertEquals(SQL_STATEMENT, span.tags().get(TagConstants.DB_STATEMENT));
     }
 
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/MongoDBSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/MongoDBSpanDecoratorTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.tracing.MockSpanAdapter;
 import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.Tag;
+import org.apache.camel.tracing.TagConstants;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -65,8 +66,11 @@ public class MongoDBSpanDecoratorTest {
         decorator.pre(span, null, endpoint);
 
         assertEquals("mongodb", span.tags().get(Tag.DB_TYPE.name()));
+        assertEquals("mongodb", span.tags().get(TagConstants.DB_SYSTEM));
         assertEquals("flights", span.tags().get(Tag.DB_INSTANCE.name()));
+        assertEquals("flights", span.tags().get(TagConstants.DB_NAME));
         assertTrue(span.tags().containsKey(Tag.DB_STATEMENT.name()));
+        assertTrue(span.tags().containsKey(TagConstants.DB_STATEMENT));
     }
 
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/SqlSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/SqlSpanDecoratorTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Message;
 import org.apache.camel.tracing.MockSpanAdapter;
 import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.Tag;
+import org.apache.camel.tracing.TagConstants;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -48,7 +49,9 @@ public class SqlSpanDecoratorTest {
         decorator.pre(span, exchange, endpoint);
 
         assertEquals("sql", span.tags().get(Tag.DB_TYPE.name()));
+        assertEquals("sql", span.tags().get(TagConstants.DB_SYSTEM));
         assertEquals(SQL_STATEMENT, span.tags().get(Tag.DB_STATEMENT.name()));
+        assertEquals(SQL_STATEMENT, span.tags().get(TagConstants.DB_STATEMENT));
     }
 
 }


### PR DESCRIPTION

Updated camel-tracing to use open telemetry semantic conventions

Following on from this pr: https://github.com/apache/camel/pull/11354