### PR TITLE
(chores) archetypes: should use 17 as the base Java version

### DIFF
--- a/archetypes/camel-archetype-api-component/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-api-component/src/main/resources/archetype-resources/pom.xml
@@ -56,7 +56,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin-version}</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
         </configuration>
       </plugin>
     </plugins>

--- a/archetypes/camel-archetype-component/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-component/src/main/resources/archetype-resources/pom.xml
@@ -84,7 +84,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin-version}</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
         </configuration>
       </plugin>
       

--- a/archetypes/camel-archetype-dataformat/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-dataformat/src/main/resources/archetype-resources/pom.xml
@@ -83,7 +83,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin-version}</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
         </configuration>
       </plugin>
 

--- a/archetypes/camel-archetype-java/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-java/src/main/resources/archetype-resources/pom.xml
@@ -88,7 +88,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin-version}</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
         </configuration>
       </plugin>
       <plugin>

--- a/archetypes/camel-archetype-main/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-main/src/main/resources/archetype-resources/pom.xml
@@ -104,7 +104,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin-version}</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
         </configuration>
       </plugin>
       <plugin>

--- a/archetypes/camel-archetype-spring/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-spring/src/main/resources/archetype-resources/pom.xml
@@ -91,7 +91,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin-version}</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Signed-off-by: Otavio R. Piske <angusyoung@gmail.com>