### PR TITLE
(chores) doc: add missing word in getting-started guide

### DIFF
--- a/docs/main/modules/getting-started/pages/index.adoc
+++ b/docs/main/modules/getting-started/pages/index.adoc
@@ -280,7 +280,7 @@ Camel usually exposes these patterns via a Java Domain-Specific Language (Java D
 // ...
 ----
 
-The code above implements the Content Based Router by evaluating (`when()`) a predicate that tests if the body of the matches an https://en.wikipedia.org/wiki/XPath[xpath] expression (`xpath("/person/city = 'London'")`). If `true`, then the destination endpoint for the message should be `file:target/messages/uk`. Otherwise, the destination endpoint should be `file:target/messages/others`.
+The code above implements the Content Based Router by evaluating (`when()`) a predicate that tests if the body of the message matches an https://en.wikipedia.org/wiki/XPath[xpath] expression (`xpath("/person/city = 'London'")`). If `true`, then the destination endpoint for the message should be `file:target/messages/uk`. Otherwise, the destination endpoint should be `file:target/messages/others`.
 
 Camel supports most of the xref:components:eips:enterprise-integration-patterns.adoc[Enterprise Integration Patterns] from the excellent book by Gregor Hohpe and Bobby Woolf.
 


### PR DESCRIPTION
# Description

The part of the "Routes" section of the getting-started guide that reads "a predicate that tests if the body of the matches" seems to be missing the word "message" between "the body of the" and "matches". The purpose of this PR is to the add that word to that part of the guide in order to make it slightly clearer.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

