### PR TITLE
(chores) camel-core-model: fold method reference

### DIFF
--- a/core/camel-core-model/src/main/java/org/apache/camel/builder/PredicateClause.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/builder/PredicateClause.java
@@ -45,7 +45,7 @@ public class PredicateClause<T> implements org.apache.camel.Predicate {
      * Define a {@link org.apache.camel.Predicate} which targets the Exchange.
      */
     public T exchange(final Predicate<Exchange> predicate) {
-        this.predicate = predicate::test;
+        this.predicate = predicate;
         return parent;
     }
 


### PR DESCRIPTION
This should avoid an unnecessary object allocation

Signed-off-by: Otavio R. Piske <angusyoung@gmail.com>