### PR TITLE
(chores) camel-main: use static inner class

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/MainCommandLineSupport.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/MainCommandLineSupport.java
@@ -275,7 +275,7 @@ public abstract class MainCommandLineSupport extends MainSupport {
         System.out.println();
     }
 
-    public abstract class Option {
+    public abstract static class Option {
         private final String abbreviation;
         private final String fullName;
         private final String description;


### PR DESCRIPTION
Signed-off-by: Otavio R. Piske <angusyoung@gmail.com>