### PR TITLE
(chores) camel-core: cleanup parameter with constant value

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/BaseExecutorServiceManager.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/BaseExecutorServiceManager.java
@@ -372,20 +372,16 @@ public class BaseExecutorServiceManager extends ServiceSupport implements Execut
 
     @Override
     public List<Runnable> shutdownNow(ExecutorService executorService) {
-        return doShutdownNow(executorService, false);
+        return doShutdownNow(executorService);
     }
 
-    private List<Runnable> doShutdownNow(ExecutorService executorService, boolean failSafe) {
+    private List<Runnable> doShutdownNow(ExecutorService executorService) {
         ObjectHelper.notNull(executorService, "executorService");
 
         List<Runnable> answer = null;
         if (!executorService.isShutdown()) {
-            if (failSafe) {
-                // log as warn, as we shutdown as fail-safe, so end user should see more details in the log.
-                LOG.warn("Forcing shutdown of ExecutorService: {}", executorService);
-            } else {
-                LOG.debug("Forcing shutdown of ExecutorService: {}", executorService);
-            }
+            LOG.debug("Forcing shutdown of ExecutorService: {}", executorService);
+
             answer = executorService.shutdownNow();
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Shutdown of ExecutorService: {} is shutdown: {} and terminated: {}.",
@@ -393,7 +389,7 @@ public class BaseExecutorServiceManager extends ServiceSupport implements Execut
             }
         }
 
-        doRemove(executorService, failSafe);
+        doRemove(executorService, false);
 
         return answer;
     }


### PR DESCRIPTION
Remove failsafe from doShutdownNow as it is always false