### PR TITLE
(chores) camel-core: cleanup parameter with constant value

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/Splitter.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/Splitter.java
@@ -193,7 +193,7 @@ public class Splitter extends MulticastProcessor implements AsyncProcessor, Trac
                 this.iterator = ObjectHelper.createIterator(value, delimiter);
             }
 
-            this.copy = copyAndPrepareSubExchange(exchange, true);
+            this.copy = copyAndPrepareSubExchange(exchange);
             this.route = ExchangeHelper.getRoute(exchange);
         }
 
@@ -328,12 +328,10 @@ public class Splitter extends MulticastProcessor implements AsyncProcessor, Trac
         return expression;
     }
 
-    private Exchange copyAndPrepareSubExchange(Exchange exchange, boolean preserveExchangeId) {
+    private Exchange copyAndPrepareSubExchange(Exchange exchange) {
         Exchange answer = processorExchangeFactory.createCopy(exchange);
-        if (preserveExchangeId) {
-            // must preserve exchange id
-            answer.setExchangeId(exchange.getExchangeId());
-        }
+        // must preserve exchange id
+        answer.setExchangeId(exchange.getExchangeId());
         if (exchange.getContext().isMessageHistory()) {
             // we do not want to copy the message history for split sub-messages
             answer.removeProperty(ExchangePropertyKey.MESSAGE_HISTORY);


### PR DESCRIPTION
Remove preserveExchangeId from copyAndPrepareSubExchange as it is always true