### PR TITLE
(chores) camel-core: remove unused parameters in AbstractApiComponent

### DIFF
--- a/components/camel-as2/camel-as2-component/src/main/java/org/apache/camel/component/as2/AS2Component.java
+++ b/components/camel-as2/camel-as2-component/src/main/java/org/apache/camel/component/as2/AS2Component.java
@@ -35,11 +35,11 @@ public class AS2Component extends AbstractApiComponent<AS2ApiName, AS2Configurat
     private static final Logger LOG = LoggerFactory.getLogger(AS2Component.class);
 
     public AS2Component() {
-        super(AS2Endpoint.class, AS2ApiName.class, AS2ApiCollection.getCollection());
+        super(AS2ApiName.class, AS2ApiCollection.getCollection());
     }
 
     public AS2Component(CamelContext context) {
-        super(context, AS2Endpoint.class, AS2ApiName.class, AS2ApiCollection.getCollection());
+        super(context, AS2ApiName.class, AS2ApiCollection.getCollection());
     }
 
     @Override

--- a/components/camel-box/camel-box-component/src/main/java/org/apache/camel/component/box/BoxComponent.java
+++ b/components/camel-box/camel-box-component/src/main/java/org/apache/camel/component/box/BoxComponent.java
@@ -36,11 +36,11 @@ public class BoxComponent extends AbstractApiComponent<BoxApiName, BoxConfigurat
     BoxAPIConnection boxConnection;
 
     public BoxComponent() {
-        super(BoxEndpoint.class, BoxApiName.class, BoxApiCollection.getCollection());
+        super(BoxApiName.class, BoxApiCollection.getCollection());
     }
 
     public BoxComponent(CamelContext context) {
-        super(context, BoxEndpoint.class, BoxApiName.class, BoxApiCollection.getCollection());
+        super(context, BoxApiName.class, BoxApiCollection.getCollection());
     }
 
     @Override

--- a/components/camel-braintree/src/main/java/org/apache/camel/component/braintree/BraintreeComponent.java
+++ b/components/camel-braintree/src/main/java/org/apache/camel/component/braintree/BraintreeComponent.java
@@ -40,12 +40,12 @@ public class BraintreeComponent extends AbstractApiComponent<BraintreeApiName, B
     private final Map<String, BraintreeGateway> gateways;
 
     public BraintreeComponent() {
-        super(BraintreeEndpoint.class, BraintreeApiName.class, BraintreeApiCollection.getCollection());
+        super(BraintreeApiName.class, BraintreeApiCollection.getCollection());
         this.gateways = new HashMap<>();
     }
 
     public BraintreeComponent(CamelContext context) {
-        super(context, BraintreeEndpoint.class, BraintreeApiName.class, BraintreeApiCollection.getCollection());
+        super(context, BraintreeApiName.class, BraintreeApiCollection.getCollection());
         this.gateways = new HashMap<>();
     }
 

--- a/components/camel-dhis2/camel-dhis2-component/src/main/java/org/apache/camel/component/dhis2/Dhis2Component.java
+++ b/components/camel-dhis2/camel-dhis2-component/src/main/java/org/apache/camel/component/dhis2/Dhis2Component.java
@@ -33,11 +33,11 @@ public class Dhis2Component extends AbstractApiComponent<Dhis2ApiName, Dhis2Conf
     private Dhis2Client dhis2Client;
 
     public Dhis2Component() {
-        super(Dhis2Endpoint.class, Dhis2ApiName.class, Dhis2ApiCollection.getCollection());
+        super(Dhis2ApiName.class, Dhis2ApiCollection.getCollection());
     }
 
     public Dhis2Component(CamelContext context) {
-        super(context, Dhis2Endpoint.class, Dhis2ApiName.class, Dhis2ApiCollection.getCollection());
+        super(context, Dhis2ApiName.class, Dhis2ApiCollection.getCollection());
     }
 
     @Override

--- a/components/camel-fhir/camel-fhir-component/src/main/java/org/apache/camel/component/fhir/FhirComponent.java
+++ b/components/camel-fhir/camel-fhir-component/src/main/java/org/apache/camel/component/fhir/FhirComponent.java
@@ -33,11 +33,11 @@ public class FhirComponent extends AbstractApiComponent<FhirApiName, FhirConfigu
     private FhirConfiguration configuration;
 
     public FhirComponent() {
-        super(FhirEndpoint.class, FhirApiName.class, FhirApiCollection.getCollection());
+        super(FhirApiName.class, FhirApiCollection.getCollection());
     }
 
     public FhirComponent(CamelContext context) {
-        super(context, FhirEndpoint.class, FhirApiName.class, FhirApiCollection.getCollection());
+        super(context, FhirApiName.class, FhirApiCollection.getCollection());
     }
 
     @Override

--- a/components/camel-google/camel-google-calendar/src/main/java/org/apache/camel/component/google/calendar/GoogleCalendarComponent.java
+++ b/components/camel-google/camel-google-calendar/src/main/java/org/apache/camel/component/google/calendar/GoogleCalendarComponent.java
@@ -37,11 +37,11 @@ public class GoogleCalendarComponent
     private GoogleCalendarClientFactory clientFactory;
 
     public GoogleCalendarComponent() {
-        super(GoogleCalendarEndpoint.class, GoogleCalendarApiName.class, GoogleCalendarApiCollection.getCollection());
+        super(GoogleCalendarApiName.class, GoogleCalendarApiCollection.getCollection());
     }
 
     public GoogleCalendarComponent(CamelContext context) {
-        super(context, GoogleCalendarEndpoint.class, GoogleCalendarApiName.class, GoogleCalendarApiCollection.getCollection());
+        super(context, GoogleCalendarApiName.class, GoogleCalendarApiCollection.getCollection());
     }
 
     @Override

--- a/components/camel-google/camel-google-drive/src/main/java/org/apache/camel/component/google/drive/GoogleDriveComponent.java
+++ b/components/camel-google/camel-google-drive/src/main/java/org/apache/camel/component/google/drive/GoogleDriveComponent.java
@@ -38,11 +38,11 @@ public class GoogleDriveComponent
     private GoogleDriveClientFactory clientFactory;
 
     public GoogleDriveComponent() {
-        super(GoogleDriveEndpoint.class, GoogleDriveApiName.class, GoogleDriveApiCollection.getCollection());
+        super(GoogleDriveApiName.class, GoogleDriveApiCollection.getCollection());
     }
 
     public GoogleDriveComponent(CamelContext context) {
-        super(context, GoogleDriveEndpoint.class, GoogleDriveApiName.class, GoogleDriveApiCollection.getCollection());
+        super(context, GoogleDriveApiName.class, GoogleDriveApiCollection.getCollection());
     }
 
     @Override

--- a/components/camel-google/camel-google-mail/src/main/java/org/apache/camel/component/google/mail/GoogleMailComponent.java
+++ b/components/camel-google/camel-google-mail/src/main/java/org/apache/camel/component/google/mail/GoogleMailComponent.java
@@ -37,12 +37,12 @@ public class GoogleMailComponent
     private GoogleMailClientFactory clientFactory;
 
     public GoogleMailComponent() {
-        super(GoogleMailEndpoint.class, GoogleMailApiName.class, GoogleMailApiCollection.getCollection());
+        super(GoogleMailApiName.class, GoogleMailApiCollection.getCollection());
         registerExtension(new GoogleMailComponentVerifierExtension());
     }
 
     public GoogleMailComponent(CamelContext context) {
-        super(context, GoogleMailEndpoint.class, GoogleMailApiName.class, GoogleMailApiCollection.getCollection());
+        super(context, GoogleMailApiName.class, GoogleMailApiCollection.getCollection());
         registerExtension(new GoogleMailComponentVerifierExtension());
     }
 

--- a/components/camel-google/camel-google-sheets/src/main/java/org/apache/camel/component/google/sheets/GoogleSheetsComponent.java
+++ b/components/camel-google/camel-google-sheets/src/main/java/org/apache/camel/component/google/sheets/GoogleSheetsComponent.java
@@ -38,12 +38,12 @@ public class GoogleSheetsComponent
     private GoogleSheetsClientFactory clientFactory;
 
     public GoogleSheetsComponent() {
-        super(GoogleSheetsEndpoint.class, GoogleSheetsApiName.class, GoogleSheetsApiCollection.getCollection());
+        super(GoogleSheetsApiName.class, GoogleSheetsApiCollection.getCollection());
         registerExtension(new GoogleSheetsVerifierExtension("google-sheets"));
     }
 
     public GoogleSheetsComponent(CamelContext context) {
-        super(context, GoogleSheetsEndpoint.class, GoogleSheetsApiName.class, GoogleSheetsApiCollection.getCollection());
+        super(context, GoogleSheetsApiName.class, GoogleSheetsApiCollection.getCollection());
         registerExtension(new GoogleSheetsVerifierExtension("google-sheets", context));
     }
 

--- a/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Component.java
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Component.java
@@ -53,11 +53,11 @@ public class Olingo2Component extends AbstractApiComponent<Olingo2ApiName, Oling
     private Olingo2AppWrapper apiProxy;
 
     public Olingo2Component() {
-        super(Olingo2Endpoint.class, Olingo2ApiName.class, Olingo2ApiCollection.getCollection());
+        super(Olingo2ApiName.class, Olingo2ApiCollection.getCollection());
     }
 
     public Olingo2Component(CamelContext context) {
-        super(context, Olingo2Endpoint.class, Olingo2ApiName.class, Olingo2ApiCollection.getCollection());
+        super(context, Olingo2ApiName.class, Olingo2ApiCollection.getCollection());
     }
 
     @Override

--- a/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Component.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Component.java
@@ -53,11 +53,11 @@ public class Olingo4Component extends AbstractApiComponent<Olingo4ApiName, Oling
     private Olingo4AppWrapper apiProxy;
 
     public Olingo4Component() {
-        super(Olingo4Endpoint.class, Olingo4ApiName.class, Olingo4ApiCollection.getCollection());
+        super(Olingo4ApiName.class, Olingo4ApiCollection.getCollection());
     }
 
     public Olingo4Component(CamelContext context) {
-        super(context, Olingo4Endpoint.class, Olingo4ApiName.class, Olingo4ApiCollection.getCollection());
+        super(context, Olingo4ApiName.class, Olingo4ApiCollection.getCollection());
     }
 
     @Override

--- a/components/camel-twilio/src/main/java/org/apache/camel/component/twilio/TwilioComponent.java
+++ b/components/camel-twilio/src/main/java/org/apache/camel/component/twilio/TwilioComponent.java
@@ -41,11 +41,11 @@ public class TwilioComponent extends AbstractApiComponent<TwilioApiName, TwilioC
     private TwilioRestClient restClient;
 
     public TwilioComponent() {
-        super(TwilioEndpoint.class, TwilioApiName.class, TwilioApiCollection.getCollection());
+        super(TwilioApiName.class, TwilioApiCollection.getCollection());
     }
 
     public TwilioComponent(CamelContext context) {
-        super(context, TwilioEndpoint.class, TwilioApiName.class, TwilioApiCollection.getCollection());
+        super(context, TwilioApiName.class, TwilioApiCollection.getCollection());
     }
 
     @Override

--- a/components/camel-zendesk/src/main/java/org/apache/camel/component/zendesk/ZendeskComponent.java
+++ b/components/camel-zendesk/src/main/java/org/apache/camel/component/zendesk/ZendeskComponent.java
@@ -45,11 +45,11 @@ public class ZendeskComponent extends AbstractApiComponent<ZendeskApiName, Zende
     private Zendesk zendesk;
 
     public ZendeskComponent() {
-        super(ZendeskEndpoint.class, ZendeskApiName.class, ZendeskApiCollection.getCollection());
+        super(ZendeskApiName.class, ZendeskApiCollection.getCollection());
     }
 
     public ZendeskComponent(CamelContext context) {
-        super(context, ZendeskEndpoint.class, ZendeskApiName.class, ZendeskApiCollection.getCollection());
+        super(context, ZendeskApiName.class, ZendeskApiCollection.getCollection());
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/component/AbstractApiComponent.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/component/AbstractApiComponent.java
@@ -45,14 +45,50 @@ public abstract class AbstractApiComponent<E extends Enum<E> & ApiName, T, S ext
     // API name class
     protected final Class<E> apiNameClass;
 
-    public AbstractApiComponent(Class<? extends Endpoint> endpointClass,
-                                Class<E> apiNameClass, S collection) {
+    /**
+     * Deprecated constructor for AbstractApiComponent.
+     *
+     * @deprecated Use {@link AbstractApiComponent#AbstractApiComponent(Class, ApiCollection)}
+     * @param endpointClass This is deprecated. Do not use
+     * @param apiNameClass The API name class
+     * @param collection The collection of API methods
+     */
+    @Deprecated
+    public AbstractApiComponent(Class<? extends Endpoint> endpointClass, Class<E> apiNameClass, S collection) {
+        this(apiNameClass, collection);
+    }
+
+    /**
+     * Deprecated constructor for AbstractApiComponent.
+     *
+     * @deprecated Use {@link AbstractApiComponent#AbstractApiComponent(CamelContext, Class, ApiCollection)} instead
+     * @param context The CamelContext
+     * @param endpointClass This is deprecated. Do not use
+     * @param apiNameClass The API name class
+     * @param collection The collection of API methods
+     */
+    @Deprecated
+    public AbstractApiComponent(CamelContext context, Class<? extends Endpoint> endpointClass, Class<E> apiNameClass, S collection) {
+        this(context, apiNameClass, collection);
+    }
+
+    /**
+     * Creates a new AbstractApiComponent
+     * @param apiNameClass The API name class
+     * @param collection The collection of API methods
+     */
+    protected AbstractApiComponent(Class<E> apiNameClass, S collection) {
         this.collection = collection;
         this.apiNameClass = apiNameClass;
     }
 
-    public AbstractApiComponent(CamelContext context, Class<? extends Endpoint> endpointClass,
-                                Class<E> apiNameClass, S collection) {
+    /**
+     * Creates a new AbstractApiComponent
+     * @param context The CamelContext
+     * @param apiNameClass The API name class
+     * @param collection The collection of API methods
+     */
+    protected AbstractApiComponent(CamelContext context, Class<E> apiNameClass, S collection) {
         super(context);
         this.collection = collection;
         this.apiNameClass = apiNameClass;


### PR DESCRIPTION
Deprecate constructor using unused parameters and introduce new ones