### PR TITLE
CAMEL-19773 camel-jbang - use camel root tag in generated xml route

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_1.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_1.adoc
@@ -127,6 +127,8 @@ The `pipe` command has been renamed to `script`.
 
 The `--secrets-refresh` and `--secret-refresh-providers` have been removed, since they were logically incorrect in the export command context. More information at CAMEL-19927 issue.
 
+The generated xml route, created using the command `camel init`, now uses `<camel>` as the root tag instead of `<route>`.
+
 === camel-jetty / camel-servlet / camel-atmosphere-websocket / camel-http-common
 
 By default stack traces will not be included in HTTP responses,

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_1.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_1.adoc
@@ -127,7 +127,7 @@ The `pipe` command has been renamed to `script`.
 
 The `--secrets-refresh` and `--secret-refresh-providers` have been removed, since they were logically incorrect in the export command context. More information at CAMEL-19927 issue.
 
-The generated xml route, created using the command `camel init`, now uses `<camel>` as the root tag instead of `<route>`.
+The generated xml route, created using the command `camel init`, now uses `<camel>` as the root tag instead of `<routes>`.
 
 === camel-jetty / camel-servlet / camel-atmosphere-websocket / camel-http-common
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/xml.tmpl
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/xml.tmpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- camel-k: language=xml -->
 
-<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<camel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://camel.apache.org/schema/spring"
         xsi:schemaLocation="
             http://camel.apache.org/schema/spring
@@ -16,4 +16,4 @@
         <log message="${body}"/>
     </route>
 
-</routes>
+</camel>


### PR DESCRIPTION
Generate the xml route with the`camel` root tag instead of `route`

