### PR TITLE
CAMEL-19923 - Fix Camel JBang dependency copy on Windows

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -506,40 +506,6 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>full</id>
-            <activation>
-                <property>
-                    <name>!quickly</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <reuseForks>true</reuseForks>
-                            <forkedProcessTimeoutInSeconds>${camel.failsafe.forkTimeout}</forkedProcessTimeoutInSeconds>
-                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
-                            <systemPropertyVariables>
-                                <visibleassertions.silence>true</visibleassertions.silence>
-                            </systemPropertyVariables>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>integration-test</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
 </project>

--- a/dsl/camel-jbang/camel-jbang-core/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-core/pom.xml
@@ -151,6 +151,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        
+        <dependency>
+        	<groupId>org.junit.jupiter</groupId>
+        	<artifactId>junit-jupiter</artifactId>
+        	<scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyCopy.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyCopy.java
@@ -57,8 +57,15 @@ public class DependencyCopy extends Export {
             } else {
                 outputDirectoryParameter += "../../" + outputDirectory;
             }
+            String mvnProgramCall;
+            if (FileUtil.isWindows()) {
+                mvnProgramCall = "cmd /c mvn";
+            } else {
+                mvnProgramCall = "mvn";
+            }
             Process p = Runtime.getRuntime()
-                    .exec("mvn dependency:copy-dependencies -DincludeScope=compile -DexcludeGroupIds=org.fusesource.jansi,org.apache.logging.log4j "
+                    .exec(mvnProgramCall
+                          + " dependency:copy-dependencies -DincludeScope=compile -DexcludeGroupIds=org.fusesource.jansi,org.apache.logging.log4j "
                           + outputDirectoryParameter,
                             null,
                             buildDir);

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/DependencyCopyIT.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/DependencyCopyIT.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DependencyCopyIT {
+
+    @Test
+    @Disabled("Currently disabled as on first run of the day it always fail (when there are new artifacts pushed to Apache Snapshots). Issue not reproduced manually with a built version.")
+    void testCopy(@TempDir Path tempDirForOutput, @TempDir Path tempDirForCamelRoute) throws Exception {
+        DependencyCopy dependencyCopy = new DependencyCopy(new CamelJBangMain());
+        dependencyCopy.buildTool = "maven";
+        File route = new File(tempDirForCamelRoute.toFile(), "RouteForDependencyCopyTest.java");
+        Files.writeString(route.toPath(), """
+                import org.apache.camel.builder.RouteBuilder;
+
+                public class RouteForDependencyCopyTest extends RouteBuilder {
+
+                    public void configure() {
+                        from("timer:timerName?delay=1000")
+                			.to("log:mylogger");
+                    }
+
+                }
+                				""");
+        dependencyCopy.filePaths = new Path[] { route.toPath() };
+        dependencyCopy.mainClassname = "CamelApplication";
+        dependencyCopy.javaVersion = "17";
+        dependencyCopy.outputDirectory = tempDirForOutput.toString();
+        Assertions.assertEquals(0, dependencyCopy.doCall(), "The command to copy dependency exited with an error value.");
+        Assertions.assertTrue(tempDirForOutput.toFile().list().length > 0,
+                "No jar has been found in the folder where the dependencies are expected to be copied.");
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -3446,6 +3446,28 @@
                             </properties>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <reuseForks>true</reuseForks>
+                            <forkedProcessTimeoutInSeconds>${camel.failsafe.forkTimeout}</forkedProcessTimeoutInSeconds>
+                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                            <systemPropertyVariables>
+                                <visibleassertions.silence>true</visibleassertions.silence>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
the exec call from java requires to use a different notation to find the mvn program on the system path

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

