### PR TITLE
Fix SimpleTest pretty print of expression on Windows

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/language/simple/SimpleTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/simple/SimpleTest.java
@@ -1976,13 +1976,13 @@ public class SimpleTest extends LanguageTestSupport {
 
         StringBuilder expectedJson = new StringBuilder();
         expectedJson.append("{");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
         expectedJson.append("\t\"firstName\": \"foo\",");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
         expectedJson.append("\t\"lastName\": \"bar\"");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
         expectedJson.append("}");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
 
         exchange.getIn().setBody("{\"firstName\": \"foo\", \"lastName\": \"bar\"}");
         assertExpression("${prettyBody}", expectedJson.toString());
@@ -1991,25 +1991,25 @@ public class SimpleTest extends LanguageTestSupport {
 
         expectedJson = new StringBuilder();
         expectedJson.append("[");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
         expectedJson.append("\t{");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
         expectedJson.append("\t\t\"firstName\": \"foo\",");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
         expectedJson.append("\t\t\"lastName\": \"bar\"");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
         expectedJson.append("\t},");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
         expectedJson.append("\t{");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
         expectedJson.append("\t\t\"firstName\": \"foo\",");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
         expectedJson.append("\t\t\"lastName\": \"bar\"");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
         expectedJson.append("\t}");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
         expectedJson.append("]");
-        expectedJson.append(System.lineSeparator());
+        expectedJson.append("\n");
 
         exchange.getIn()
                 .setBody("[{\"firstName\": \"foo\", \"lastName\": \"bar\"},{\"firstName\": \"foo\", \"lastName\": \"bar\"}]");
@@ -2023,19 +2023,19 @@ public class SimpleTest extends LanguageTestSupport {
     public void testXMLPrettyPrint() throws Exception {
         StringBuilder expectedXml = new StringBuilder();
         expectedXml.append("<person>");
-        expectedXml.append(System.lineSeparator());
+        expectedXml.append("\n");
         expectedXml.append("  <firstName>");
-        expectedXml.append(System.lineSeparator());
+        expectedXml.append("\n");
         expectedXml.append("    foo");
-        expectedXml.append(System.lineSeparator());
+        expectedXml.append("\n");
         expectedXml.append("  </firstName>");
-        expectedXml.append(System.lineSeparator());
+        expectedXml.append("\n");
         expectedXml.append("  <lastName>");
-        expectedXml.append(System.lineSeparator());
+        expectedXml.append("\n");
         expectedXml.append("    bar");
-        expectedXml.append(System.lineSeparator());
+        expectedXml.append("\n");
         expectedXml.append("  </lastName>");
-        expectedXml.append(System.lineSeparator());
+        expectedXml.append("\n");
         expectedXml.append("</person>");
 
         exchange.getIn().setBody("<person><firstName>foo</firstName><lastName>bar</lastName></person>");


### PR DESCRIPTION
# Description

The test was requesting a platform dependent line separator but the production code is not doing that. I adapted the test. I'm not sure if we want to adapt the test or change the runtime behavior to use platform dependent end of line for the pretty print of expressions

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

