### PR TITLE
Disable FileExclusiveReadManuelTest and FileExclusiveReadLockCopyTest on

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileExclusiveReadLockCopyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileExclusiveReadLockCopyTest.java
@@ -21,12 +21,15 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 public class FileExclusiveReadLockCopyTest extends ContextTestSupport {
 
     private String fileUrl = fileUri("?readLock=fileLock&initialDelay=0&delay=10");
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void testCopy() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileExclusiveReadManuelTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileExclusiveReadManuelTest.java
@@ -20,6 +20,8 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /**
  * Unit test to verify exclusive read by for manual testing.
@@ -29,6 +31,7 @@ public class FileExclusiveReadManuelTest extends ContextTestSupport {
     private String fileUrl = fileUri("?readLock=fileLock&initialDelay=0&delay=10");
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void testManually() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         // this is used for manual testing where you can copy/lock files etc.


### PR DESCRIPTION
Windows

it is based on readlock parameter which is mentioned as not supported in the documentation.

The code is throwing when used on Windows:
```
Caused by: java.lang.IllegalArgumentException: The readLock=fileLock
option is not supported on Windows
	at org.apache.camel.component.file.GenericFileEndpoint.doInit(GenericFileEndpoint.java:1763)
```

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

