### PR TITLE
Enable Camel components on s390x

### DIFF
--- a/components/camel-cassandraql/pom.xml
+++ b/components/camel-cassandraql/pom.xml
@@ -33,11 +33,6 @@
     <name>Camel :: Cassandra CQL</name>
     <description>Cassandra CQL3 support</description>
 
-    <properties>
-        <!-- Cassandra is not available on this platform -->
-        <skipITs.s390x>true</skipITs.s390x>
-    </properties>
-
     <dependencies>
 
         <dependency>

--- a/components/camel-zookeeper-master/pom.xml
+++ b/components/camel-zookeeper-master/pom.xml
@@ -34,7 +34,6 @@
 
     <properties>
         <!-- Zookeeper container is not available on this platform -->
-        <skipITs.s390x>true</skipITs.s390x>
         <skipITs.aarch64>true</skipITs.aarch64>
     </properties>
 

--- a/components/camel-zookeeper/pom.xml
+++ b/components/camel-zookeeper/pom.xml
@@ -32,11 +32,6 @@
     <name>Camel :: Zookeeper</name>
     <description>Camel Zookeeper Support</description>
 
-    <properties>
-        <!-- Zookeeper container is not available on this platform -->
-        <skipITs.s390x>true</skipITs.s390x>
-    </properties>
-
     <dependencies>
 
         <dependency>


### PR DESCRIPTION
# Description

Re-enabling cassandraql component since the test suite is using `cassandra:4.1.2` and multi-arch support on s390x started with `cassandra:4.0.4`. Similar to the zookeeper components, multi-arch support on s390x for `zookeeper` started with zookeeper:3.8.1. 

I have tested all 3 components locally on s390x and they have passed.  

Also would like this to be backported to `4.0.x` if possible. 

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

