### PR TITLE
Enable Camel components on s390x

### DIFF
--- a/components/camel-cassandraql/pom.xml
+++ b/components/camel-cassandraql/pom.xml
@@ -36,7 +36,6 @@
     <properties>
         <!-- Cassandra is not available on these platforms -->
         <skipITs.ppc64le>true</skipITs.ppc64le>
-        <skipITs.s390x>true</skipITs.s390x>
     </properties>
 
     <dependencies>

--- a/components/camel-rocketmq/pom.xml
+++ b/components/camel-rocketmq/pom.xml
@@ -32,6 +32,14 @@
     <name>Camel :: RocketMQ</name>
     <description>Camel RocketMQ Component</description>
 
+    <properties>
+        <!-- RocketMQ container is only available on x86 -->
+        <skipTests.ppc64le>true</skipTests.ppc64le>
+        <skipTests.s390x>true</skipTests.s390x>
+        <skipTests.aarch64>true</skipTests.aarch64>
+    </properties>
+
+
     <dependencies>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/components/camel-zookeeper-master/pom.xml
+++ b/components/camel-zookeeper-master/pom.xml
@@ -34,7 +34,6 @@
 
     <properties>
         <!-- Zookeeper container is not available on this platform -->
-        <skipITs.s390x>true</skipITs.s390x>
         <skipITs.aarch64>true</skipITs.aarch64>
     </properties>
 

--- a/components/camel-zookeeper/pom.xml
+++ b/components/camel-zookeeper/pom.xml
@@ -32,11 +32,6 @@
     <name>Camel :: Zookeeper</name>
     <description>Camel Zookeeper Support</description>
 
-    <properties>
-        <!-- Zookeeper container is not available on this platform -->
-        <skipITs.s390x>true</skipITs.s390x>
-    </properties>
-
     <dependencies>
 
         <dependency>


### PR DESCRIPTION
# Description

Backporting changes to `4.0.x` from https://github.com/apache/camel/pull/11629. Re-enabling cassandraql component since the test suite is using `cassandra:4.1.2` and multi-arch support on s390x started with `cassandra:4.0.4`. Similar to the zookeeper components, multi-arch support on s390x for zookeeper started with `zookeeper:3.8.1`.

Also cherry-picking commit to disable RocketMQ component on unsupported archs. 

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

