### PR TITLE
CAMEL-19939: camel-jbang - dependency copy - Use camel-tooling-maven

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
@@ -2192,7 +2192,6 @@ org.apache.camel.kamelets:camel-kamelets:0.9.3
 === Copying dependency JARs to a specific directory
 
 You can use the `camel dependency copy` command to copy the required JARs to a specific folder.
-This command reuses Maven by invoking the `mvn dependency:copy-dependencies` command.
 
 IMPORTANT: The `camel dependency copy` and `camel dependency list` uses Apache Maven,
 This requires having Apache Maven installed, and `mvn` command in PATH environment, so Camel JBang

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyCopy.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyCopy.java
@@ -16,21 +16,28 @@
  */
 package org.apache.camel.dsl.jbang.core.commands;
 
-import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
+import java.util.List;
+import java.util.Set;
 
-import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
-import org.apache.camel.util.CamelCaseOrderedProperties;
+import org.apache.camel.tooling.maven.MavenArtifact;
+import org.apache.camel.tooling.maven.MavenDownloader;
+import org.apache.camel.tooling.maven.MavenDownloaderImpl;
+import org.apache.camel.tooling.maven.MavenGav;
+import org.apache.camel.tooling.maven.MavenResolutionException;
 import org.apache.camel.util.FileUtil;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "copy",
                      description = "Copies all Camel dependencies required to run to a specific directory")
-public class DependencyCopy extends Export {
+public class DependencyCopy extends DependencyList {
+    private static final Set<String> EXCLUDED_GROUP_IDS = Set.of("org.fusesource.jansi", "org.apache.logging.log4j");
 
-    protected static final String EXPORT_DIR = ".camel-jbang/export";
+    private MavenDownloader downloader;
 
     @CommandLine.Option(names = { "--output-directory" }, description = "Directory where dependencies should be copied",
                         defaultValue = "lib", required = true)
@@ -40,83 +47,53 @@ public class DependencyCopy extends Export {
         super(main);
     }
 
-    @Override
-    public Integer doCall() throws Exception {
-        this.quiet = true; // be quiet and generate from fresh data to ensure the output is up-to-date
-        return super.doCall();
-    }
-
-    @Override
-    protected Integer export() throws Exception {
-        Integer answer = doExport();
-        if (answer == 0) {
-            File buildDir = new File(EXPORT_DIR);
-            String outputDirectoryParameter = "-DoutputDirectory=";
-            if (Paths.get(outputDirectory).isAbsolute()) {
-                outputDirectoryParameter += outputDirectory;
+    private void createOutputDirectory() {
+        Path outputDirectoryPath = Paths.get(outputDirectory);
+        if (Files.exists(outputDirectoryPath)) {
+            if (Files.isDirectory(outputDirectoryPath)) {
+                FileUtil.removeDir(outputDirectoryPath.toFile());
             } else {
-                outputDirectoryParameter += "../../" + outputDirectory;
+                System.err.println("Error creating the output directory: " + outputDirectory
+                                   + " is not a directory");
+                return;
             }
-            Process p = Runtime.getRuntime()
-                    .exec("mvn dependency:copy-dependencies -DincludeScope=compile -DexcludeGroupIds=org.fusesource.jansi,org.apache.logging.log4j "
-                          + outputDirectoryParameter,
-                            null,
-                            buildDir);
-            boolean done = p.waitFor(60, TimeUnit.SECONDS);
-            if (!done) {
-                answer = 1;
-            }
-            if (p.exitValue() != 0) {
-                answer = p.exitValue();
-            }
-            // cleanup dir after complete
-            FileUtil.removeDir(buildDir);
         }
-        return answer;
-    }
-
-    protected Integer doExport() throws Exception {
-        // read runtime and gav from profile if not configured
-        File profile = new File(getProfile() + ".properties");
-        if (profile.exists()) {
-            Properties prop = new CamelCaseOrderedProperties();
-            RuntimeUtil.loadProperties(prop, profile);
-            if (this.runtime == null) {
-                this.runtime = prop.getProperty("camel.jbang.runtime");
-            }
-            if (this.gav == null) {
-                this.gav = prop.getProperty("camel.jbang.gav");
-            }
-            // allow configuring versions from profile
-            this.javaVersion = prop.getProperty("camel.jbang.javaVersion", this.javaVersion);
-            this.camelVersion = prop.getProperty("camel.jbang.camelVersion", this.camelVersion);
-            this.kameletsVersion = prop.getProperty("camel.jbang.kameletsVersion", this.kameletsVersion);
-            this.localKameletDir = prop.getProperty("camel.jbang.localKameletDir", this.localKameletDir);
-            this.quarkusGroupId = prop.getProperty("camel.jbang.quarkusGroupId", this.quarkusGroupId);
-            this.quarkusArtifactId = prop.getProperty("camel.jbang.quarkusArtifactId", this.quarkusArtifactId);
-            this.quarkusVersion = prop.getProperty("camel.jbang.quarkusVersion", this.quarkusVersion);
-            this.springBootVersion = prop.getProperty("camel.jbang.springBootVersion", this.springBootVersion);
-        }
-
-        // use temporary export dir
-        exportDir = EXPORT_DIR;
-        if (gav == null) {
-            gav = "org.apache.camel:camel-jbang-dummy:1.0";
-        }
-        if (runtime == null) {
-            runtime = "camel-main";
-        }
-
-        if ("spring-boot".equals(runtime) || "camel-spring-boot".equals(runtime)) {
-            return export(new ExportSpringBoot(getMain()));
-        } else if ("quarkus".equals(runtime) || "camel-quarkus".equals(runtime)) {
-            return export(new ExportQuarkus(getMain()));
-        } else if ("main".equals(runtime) || "camel-main".equals(runtime)) {
-            return export(new ExportCamelMain(getMain()));
-        } else {
-            System.err.println("Unknown runtime: " + runtime);
-            return 1;
+        try {
+            Files.createDirectories(outputDirectoryPath);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Error creating the output directory: " + outputDirectory, e);
         }
     }
 
+    @Override
+    protected void outputGav(MavenGav gav) {
+        try {
+            List<MavenArtifact> artifacts = getDownloader().resolveArtifacts(
+                    List.of(gav.toString()), Set.of(), true, gav.getVersion().contains("SNAPSHOT"));
+            for (MavenArtifact artifact : artifacts) {
+                Path target = Paths.get(outputDirectory, artifact.getFile().getName());
+                if (Files.exists(target) || EXCLUDED_GROUP_IDS.contains(artifact.getGav().getGroupId())) {
+                    continue;
+                }
+                Files.copy(artifact.getFile().toPath(), target);
+            }
+        } catch (MavenResolutionException e) {
+            System.err.println("Error resolving the artifact: " + gav + " due to: " + e.getMessage());
+        } catch (IOException e) {
+            System.err.println("Error copying the artifact: " + gav + " due to: " + e.getMessage());
+        }
+    }
+
+    private MavenDownloader getDownloader() {
+        if (downloader == null) {
+            init();
+        }
+        return downloader;
+    }
+
+    private void init() {
+        this.downloader = new MavenDownloaderImpl();
+        ((MavenDownloaderImpl) downloader).build();
+        createOutputDirectory();
+    }
 }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19939

## Motivation

Instead of export and invoking mvn copy dependency plugin, then we can see if we can use camels own camel-tooling-maven, and resolve dependencies, and gather urls to the local m2 files, which we can then copy directly from.

We need to include transitive dependencies, to ensure all JARs are included.

## Modifications:

* Gets the list of direct dependencies by extending `DependencyList`
* Resolves each direct dependency and the transitive dependencies using the Maven API

## Result

On a simple project created with `camel init hello.java`, if we launch the next 2 commands:
```
$ jbang -Dcamel.jbang.version=4.0.1 camel@apache/camel dependency copy --output-directory lib.4.0
[jbang] Resolving dependencies...
[jbang]    org.apache.camel:camel-bom:4.0.1@pom
[jbang]    org.apache.camel:camel-jbang-core:4.0.1
[jbang]    org.apache.camel.kamelets:camel-kamelets:4.0.1
[jbang] Dependencies resolved
[jbang] Building jar for CamelJBang.java...

$ jbang --fresh -Dcamel.jbang.version=4.1.0-SNAPSHOT camel@apache/camel dependency copy --output-directory lib.4.1
[jbang] Resolving dependencies...
[jbang]    org.apache.camel:camel-bom:4.1.0-SNAPSHOT@pom
[jbang]    org.apache.camel:camel-jbang-core:4.1.0-SNAPSHOT
[jbang]    org.apache.camel.kamelets:camel-kamelets:4.0.1
[jbang] Dependencies resolved
[jbang] Building jar for CamelJBang.java...

```
We get the same dependencies as we can see below:
```
$ tree
.
├── hello.java
├── lib.4.0
│   ├── camel-api-4.0.1.jar
│   ├── camel-base-4.0.1.jar
│   ├── camel-base-engine-4.0.1.jar
│   ├── camel-core-engine-4.0.1.jar
│   ├── camel-core-languages-4.0.1.jar
│   ├── camel-core-model-4.0.1.jar
│   ├── camel-core-processor-4.0.1.jar
│   ├── camel-core-reifier-4.0.1.jar
│   ├── camel-health-4.0.1.jar
│   ├── camel-main-4.0.1.jar
│   ├── camel-management-api-4.0.1.jar
│   ├── camel-rest-4.0.1.jar
│   ├── camel-support-4.0.1.jar
│   ├── camel-timer-4.0.1.jar
│   ├── camel-tooling-model-4.0.1.jar
│   ├── camel-util-4.0.1.jar
│   ├── camel-util-json-4.0.1.jar
│   ├── camel-xml-jaxp-util-4.0.1.jar
│   ├── jakarta.activation-api-2.1.0.jar
│   ├── jakarta.xml.bind-api-4.0.0.jar
│   └── slf4j-api-2.0.7.jar
└── lib.4.1
    ├── camel-api-4.1.0-SNAPSHOT.jar
    ├── camel-base-4.1.0-SNAPSHOT.jar
    ├── camel-base-engine-4.1.0-SNAPSHOT.jar
    ├── camel-core-engine-4.1.0-SNAPSHOT.jar
    ├── camel-core-languages-4.1.0-SNAPSHOT.jar
    ├── camel-core-model-4.1.0-SNAPSHOT.jar
    ├── camel-core-processor-4.1.0-SNAPSHOT.jar
    ├── camel-core-reifier-4.1.0-SNAPSHOT.jar
    ├── camel-health-4.1.0-SNAPSHOT.jar
    ├── camel-main-4.1.0-SNAPSHOT.jar
    ├── camel-management-api-4.1.0-SNAPSHOT.jar
    ├── camel-rest-4.1.0-SNAPSHOT.jar
    ├── camel-support-4.1.0-SNAPSHOT.jar
    ├── camel-timer-4.1.0-SNAPSHOT.jar
    ├── camel-tooling-model-4.1.0-SNAPSHOT.jar
    ├── camel-util-4.1.0-SNAPSHOT.jar
    ├── camel-util-json-4.1.0-SNAPSHOT.jar
    ├── camel-xml-jaxp-util-4.1.0-SNAPSHOT.jar
    ├── jakarta.activation-api-2.1.0.jar
    ├── jakarta.xml.bind-api-4.0.0.jar
    └── slf4j-api-2.0.7.jar

```