### PR TITLE
(chores) camel-core: avoid hitting the JVM slow path

### DIFF
--- a/core/camel-base/src/main/java/org/apache/camel/impl/converter/CoreTypeConverterRegistry.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/converter/CoreTypeConverterRegistry.java
@@ -107,7 +107,7 @@ public abstract class CoreTypeConverterRegistry extends ServiceSupport implement
             return null;
         }
 
-        if (type.isInstance(value)) {
+        if (type.equals(value.getClass())) {
             // same instance
             return (T) value;
         }


### PR DESCRIPTION
In most cases, the type checks will be false, which causes the JVM to hit its slow path checking the type.

This already happens subsequently, so adjust it to check only for equality at first.