### PR TITLE
CAMEL-19536: replaced Thread.sleep() in camel-micrometer

### DIFF
--- a/components/camel-micrometer/pom.xml
+++ b/components/camel-micrometer/pom.xml
@@ -111,10 +111,9 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.0</version>
+            <version>${awaitility-version}</version>
             <scope>test</scope>
         </dependency>
-
 
     </dependencies>
 

--- a/components/camel-micrometer/pom.xml
+++ b/components/camel-micrometer/pom.xml
@@ -108,6 +108,13 @@
             <version>${assertj-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
 
     </dependencies>
 

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierTest.java
@@ -25,6 +25,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.support.ExpressionAdapter;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_ROUTES_EXCHANGES_INFLIGHT;
@@ -54,13 +55,16 @@ public class MicrometerExchangeEventNotifierTest extends AbstractMicrometerEvent
             @Override
             public Object evaluate(Exchange exchange) {
                 try {
-                    Assertions.assertThat(currentInflightExchanges()).isEqualTo(1.0D, withPrecision(0.1D));
-                    Thread.sleep(SLEEP);
+                    Awaitility.await().pollDelay(SLEEP, TimeUnit.MILLISECONDS).catchUncaughtExceptions().untilAsserted(() ->
+                            Assertions.assertThat(currentInflightExchanges()).isEqualTo(1.0D, withPrecision(0.1D)));
                     return exchange.getIn().getBody();
-                } catch (InterruptedException e) {
-                    throw new CamelExecutionException(e.getMessage(), exchange, e);
+                } catch (Exception e) {
+                    if (e.getCause() instanceof InterruptedException) {
+                        throw new CamelExecutionException(e.getMessage(), exchange, e);
+                    } else {
+                        throw new RuntimeException("Unexpected Exception");
+                    }
                 }
-
             }
         });
         mock.expectedMessageCount(count);


### PR DESCRIPTION
Replaced Thread.sleep() with Awaitility class. Don't know if it's the right way to do this, however it's the only working scenario I could find