### PR TITLE
CAMEL-19541: replaced Thread.sleep() in camel-quartz

### DIFF
--- a/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/SpringQuartzConsumerTwoAppsClusteredFailoverTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/SpringQuartzConsumerTwoAppsClusteredFailoverTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Predicate;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.apache.camel.util.IOHelper;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,7 +66,15 @@ public class SpringQuartzConsumerTwoAppsClusteredFailoverTest {
         log.warn("Crashed...");
 
         // wait long enough until the second app takes it over...
-        Thread.sleep(2000);
+        Awaitility.await().untilAsserted(() -> {
+            CamelContext camel2 = app2.getBean("camelContext2-" + getClass().getSimpleName(), CamelContext.class);
+
+            MockEndpoint mock2 = camel2.getEndpoint("mock:result", MockEndpoint.class);
+            mock2.expectedMinimumMessageCount(3);
+            mock2.expectedMessagesMatches(new ClusteringPredicate(false));
+
+            mock2.assertIsSatisfied();
+        });
         // inside the logs one can then clearly see how the route of the second app ('app-two') starts consuming:
         // 2013-09-30 11:22:20,349 [main           ] WARN  erTwoAppsClusteredFailoverTest - Crashed...
         // 2013-09-30 11:22:20,349 [main           ] WARN  erTwoAppsClusteredFailoverTest - Crashed...
@@ -73,14 +82,6 @@ public class SpringQuartzConsumerTwoAppsClusteredFailoverTest {
         // 2013-09-30 11:22:35,340 [_ClusterManager] INFO  LocalDataSourceJobStore        - ClusterManager: detected 1 failed or restarted instances.
         // 2013-09-30 11:22:35,340 [_ClusterManager] INFO  LocalDataSourceJobStore        - ClusterManager: Scanning for instance "app-one"'s failed in-progress jobs.
         // 2013-09-30 11:22:35,369 [eduler_Worker-1] INFO  triggered                      - Exchange[ExchangePattern: InOnly, BodyType: String, Body: clustering PONGS!]
-
-        CamelContext camel2 = app2.getBean("camelContext2-" + getClass().getSimpleName(), CamelContext.class);
-
-        MockEndpoint mock2 = camel2.getEndpoint("mock:result", MockEndpoint.class);
-        mock2.expectedMinimumMessageCount(3);
-        mock2.expectedMessagesMatches(new ClusteringPredicate(false));
-
-        mock2.assertIsSatisfied();
 
         // and as the last step shutdown the second app as well as the database
         IOHelper.close(app2, db);

--- a/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/SpringQuartzConsumerTwoAppsClusteredRecoveryTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/SpringQuartzConsumerTwoAppsClusteredRecoveryTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.quartz;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Predicate;
@@ -23,6 +25,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.apache.camel.util.IOHelper;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +65,15 @@ public class SpringQuartzConsumerTwoAppsClusteredRecoveryTest {
         app2.start();
 
         // wait long enough until the second app takes it over...
-        Thread.sleep(2000);
+        Awaitility.await().untilAsserted(() -> {
+            CamelContext camel2 = app2.getBean("camelContext2-" + getClass().getSimpleName(), CamelContext.class);
+
+            MockEndpoint mock2 = camel2.getEndpoint("mock:result", MockEndpoint.class);
+            mock2.expectedMinimumMessageCount(2);
+            mock2.expectedMessagesMatches(new ClusteringPredicate(false));
+
+            mock2.assertIsSatisfied();
+        });
         // inside the logs one can then clearly see how the route of the second app ('app-two') starts consuming:
         // 2013-09-30 11:22:20,349 [main           ] WARN  erTwoAppsClusteredFailoverTest - Crashed...
         // 2013-09-30 11:22:20,349 [main           ] WARN  erTwoAppsClusteredFailoverTest - Crashed...
@@ -70,14 +81,6 @@ public class SpringQuartzConsumerTwoAppsClusteredRecoveryTest {
         // 2013-09-30 11:22:35,340 [_ClusterManager] INFO  LocalDataSourceJobStore        - ClusterManager: detected 1 failed or restarted instances.
         // 2013-09-30 11:22:35,340 [_ClusterManager] INFO  LocalDataSourceJobStore        - ClusterManager: Scanning for instance "app-one"'s failed in-progress jobs.
         // 2013-09-30 11:22:35,369 [eduler_Worker-1] INFO  triggered                      - Exchange[ExchangePattern: InOnly, BodyType: String, Body: clustering PONGS!]
-
-        CamelContext camel2 = app2.getBean("camelContext2-" + getClass().getSimpleName(), CamelContext.class);
-
-        MockEndpoint mock2 = camel2.getEndpoint("mock:result", MockEndpoint.class);
-        mock2.expectedMinimumMessageCount(2);
-        mock2.expectedMessagesMatches(new ClusteringPredicate(false));
-
-        mock2.assertIsSatisfied();
 
         // and as the last step shutdown the second app as well as the database
         IOHelper.close(app2, db);

--- a/components/camel-quartz/src/test/java/org/apache/camel/routepolicy/quartz/SimpleScheduledCombinedRoutePolicyTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/routepolicy/quartz/SimpleScheduledCombinedRoutePolicyTest.java
@@ -24,6 +24,7 @@ import org.apache.camel.component.direct.DirectComponent;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.quartz.QuartzComponent;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -63,11 +64,9 @@ public class SimpleScheduledCombinedRoutePolicyTest extends CamelTestSupport {
         });
         context.start();
 
-        Thread.sleep(5000);
-        assertSame(ServiceStatus.Started, context.getRouteController().getRouteStatus("test"));
+        Awaitility.await().untilAsserted(() -> assertSame(ServiceStatus.Started, context.getRouteController().getRouteStatus("test")));
         template.sendBody("direct:start", "Ready or not, Here, I come");
-        Thread.sleep(5000);
-        assertSame(ServiceStatus.Stopped, context.getRouteController().getRouteStatus("test"));
+        Awaitility.await().untilAsserted(() -> assertSame(ServiceStatus.Stopped, context.getRouteController().getRouteStatus("test")));
 
         context.getComponent("quartz", QuartzComponent.class).stop();
         success.assertIsSatisfied();

--- a/components/camel-quartz/src/test/java/org/apache/camel/routepolicy/quartz/SpringQuartzTwoAppsClusteredFailoverTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/routepolicy/quartz/SpringQuartzTwoAppsClusteredFailoverTest.java
@@ -21,6 +21,7 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.apache.camel.util.IOHelper;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.quartz.Scheduler;
 import org.slf4j.Logger;
@@ -52,11 +53,11 @@ public class SpringQuartzTwoAppsClusteredFailoverTest {
         mock.expectedBodiesReceived("clustering PINGS!");
 
         // wait a bit to make sure the route has already been properly started through the given route policy
-        Thread.sleep(500);
+        Awaitility.await().untilAsserted(() -> {
+            app.getBean("template", ProducerTemplate.class).sendBody("direct:start", "clustering");
 
-        app.getBean("template", ProducerTemplate.class).sendBody("direct:start", "clustering");
-
-        mock.assertIsSatisfied();
+            mock.assertIsSatisfied();
+        });
 
         // now let's simulate a crash of the first app (the quartz instance 'app-one')
         log.warn("The first app is going to crash NOW!");
@@ -71,7 +72,17 @@ public class SpringQuartzTwoAppsClusteredFailoverTest {
         log.warn("Crashed...");
 
         // wait long enough until the second app takes it over...
-        Thread.sleep(2000);
+        Awaitility.await().untilAsserted(() ->{
+            CamelContext camel2 = app2.getBean("camelContext2-" + getClass().getSimpleName(), CamelContext.class);
+
+            MockEndpoint mock2 = camel2.getEndpoint("mock:result", MockEndpoint.class);
+            mock2.expectedMessageCount(1);
+            mock2.expectedBodiesReceived("clustering PONGS!");
+
+            app2.getBean("template", ProducerTemplate.class).sendBody("direct:start", "clustering");
+
+            mock2.assertIsSatisfied();
+        });
         // inside the logs one can then clearly see how the route of the second app ('app-two') gets started:
         // 2013-09-29 08:15:17,038 [main           ] WARN  tzTwoAppsClusteredFailoverTest:65   - Crashed...
         // 2013-09-29 08:15:17,038 [main           ] WARN  tzTwoAppsClusteredFailoverTest:66   - Crashed...
@@ -79,16 +90,6 @@ public class SpringQuartzTwoAppsClusteredFailoverTest {
         // 2013-09-29 08:15:32,001 [_ClusterManager] INFO  LocalDataSourceJobStore       :3567 - ClusterManager: detected 1 failed or restarted instances.
         // 2013-09-29 08:15:32,001 [_ClusterManager] INFO  LocalDataSourceJobStore       :3426 - ClusterManager: Scanning for instance "app-one"'s failed in-progress jobs.
         // 2013-09-29 08:15:32,024 [eduler_Worker-1] INFO  SpringCamelContext            :2183 - Route: myRoute started and consuming from: Endpoint[direct://start]
-
-        CamelContext camel2 = app2.getBean("camelContext2-" + getClass().getSimpleName(), CamelContext.class);
-
-        MockEndpoint mock2 = camel2.getEndpoint("mock:result", MockEndpoint.class);
-        mock2.expectedMessageCount(1);
-        mock2.expectedBodiesReceived("clustering PONGS!");
-
-        app2.getBean("template", ProducerTemplate.class).sendBody("direct:start", "clustering");
-
-        mock2.assertIsSatisfied();
 
         // and as the last step shutdown the second app as well as the database
         IOHelper.close(app2, db);


### PR DESCRIPTION
Replaced Thread.sleep() in camel-quartz, however CronTest8 in CronScheduledRoutePolicyTest is still unstable in some cases. Sometimes it throws CamelExecutionException even if you catch it. I would be glad of any advice.
