### PR TITLE
CAMEL-19982: camel-jbang - Allow --jvm-debug as last parameter

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelCommand.java
@@ -144,7 +144,7 @@ public abstract class CamelCommand implements Callable<Integer> {
 
         @Override
         public void consumeParameters(Stack<String> args, ArgSpec argSpec, CommandSpec cmdSpec) {
-            if (args.isEmpty()) {
+            if (failIfEmptyArgs() && args.isEmpty()) {
                 throw new ParameterException(cmdSpec.commandLine(), "Error: missing required parameter");
             }
             T cmd = (T) cmdSpec.userObject();
@@ -152,6 +152,10 @@ public abstract class CamelCommand implements Callable<Integer> {
         }
 
         protected abstract void doConsumeParameters(Stack<String> args, T cmd);
+
+        protected boolean failIfEmptyArgs() {
+            return true;
+        }
     }
 
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -1249,7 +1249,7 @@ public class Run extends CamelCommand {
         if (f.exists() && f.isDirectory()) {
             return true;
         }
-        
+
         if (FileUtil.onlyExt(name) == null) {
             return true;
         }
@@ -1411,7 +1411,7 @@ public class Run extends CamelCommand {
 
         @Override
         protected void doConsumeParameters(Stack<String> args, Run cmd) {
-            String arg = args.peek();
+            String arg = args.isEmpty() ? "" : args.peek();
             if (DEBUG_ARG_VALUE_PATTERN.asPredicate().test(arg)) {
                 // The value matches with the expected format so let's assume that it is a debug argument value
                 args.pop();
@@ -1420,6 +1420,11 @@ public class Run extends CamelCommand {
                 arg = "true";
             }
             cmd.jvmDebugPort = parseJvmDebugPort(arg);
+        }
+
+        @Override
+        protected boolean failIfEmptyArgs() {
+            return false;
         }
     }
 }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19982

## Motivation

When `--jvm-debug` is used as last parameter in a run command like `camel run MyKafka.java --jvm-debug`, it fails with the next error `Error: missing required parameter`

## Modifications:

* Allow to prevent throwing exception when there are no arguments left in `ParameterConsumer`
* Add support of empty arguments in `DebugConsumer`