### PR TITLE
(chore) ci: auto-generate list of submodules

### DIFF
--- a/.github/actions/component-test/component-test.sh
+++ b/.github/actions/component-test/component-test.sh
@@ -34,12 +34,21 @@ function main() {
   for component in ${componentList}
   do
     if [[ ${component} = camel-* ]] ; then
-      pl="$pl,components/${component}"
+      componentPath="components/${component}"
     else
-      pl="$pl,components/camel-${component}"
+      componentPath="components/camel-${component}"
+    fi
+    if [[ -d "${componentPath}" ]] ; then
+      pl="$pl$(find "${componentPath}" -name pom.xml -exec dirname {} \; | sort | tr -s "\n" ",")"
     fi
   done
-  pl="${pl:1}"
+  len=${#pl}
+  if [[ "$len" -gt "0" ]] ; then
+    pl="${pl::len-1}"
+  else
+    echo "The components to test don't exist"
+    exit 1
+  fi
 
   if [[ ${fastBuild} = "true" ]] ; then
     echo "Launching a fast build against the projects ${pl} and their dependencies"


### PR DESCRIPTION
## Motivation

When we have a component that has submodules, for now, we need to specify explicitly the list of submodules to test when using the GH `component-test` which leads to https://github.com/apache/camel/pull/11716#issuecomment-1761062508. Let's try to generate the list. 

## Modifications

* Auto-detect the pom files in subdirectories and include their directory to the list of projects to test
* Support the use case where the provided component name is incorrect 