### PR TITLE
CAMEL-19996 avoid NPE when handling exception without coordinator

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/saga/SagaProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/saga/SagaProcessor.java
@@ -76,10 +76,15 @@ public abstract class SagaProcessor extends DelegateAsyncProcessor implements Tr
             AsyncCallback callback) {
         if (this.completionMode == SagaCompletionMode.AUTO) {
             if (exchange.getException() != null) {
-                coordinator.compensate().whenComplete((done, ex) -> ifNotException(ex, exchange, callback, () -> {
-                    setCurrentSagaCoordinator(exchange, previousCoordinator);
+                if (coordinator != null) {
+                    coordinator.compensate().whenComplete((done, ex) -> ifNotException(ex, exchange, callback, () -> {
+                        setCurrentSagaCoordinator(exchange, previousCoordinator);
+                        callback.done(false);
+                    }));
+                } else {
+                    // No coordinator available, so no saga available.
                     callback.done(false);
-                }));
+                }
             } else {
                 coordinator.complete().whenComplete((done, ex) -> ifNotException(ex, exchange, callback, () -> {
                     setCurrentSagaCoordinator(exchange, previousCoordinator);


### PR DESCRIPTION
# Description

This PR is about to avoid a NullPointerException during the errorHandling of creating a new saga.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [CAMEL-19996](https://issues.apache.org/jira/browse/CAMEL-19996) filed for the change.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

Maybe we also need to check, if there is a backport needed

