### PR TITLE
CAMEL-20008 - Improve assertion to compare xml and not string in XMLTokenExpressionIteratorTest

### DIFF
--- a/components/camel-stax/pom.xml
+++ b/components/camel-stax/pom.xml
@@ -74,6 +74,11 @@
             <artifactId>camel-jaxb</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-assertj3</artifactId>
+            <scope>test</scope>
+       </dependency>
 
     </dependencies>
 

--- a/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/XMLTokenExpressionIteratorTest.java
+++ b/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/XMLTokenExpressionIteratorTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.xmlunit.assertj3.XmlAssert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -490,7 +491,12 @@ public class XMLTokenExpressionIteratorTest {
 
         assertEquals(expected.length, results.size(), "token count");
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(expected[i], results.get(i), "mismatch [" + i + "]");
+            String expectedToken = expected[i];
+            if (expectedToken.startsWith("<")) {
+                XmlAssert.assertThat(results.get(i)).and(expectedToken).areIdentical();
+            } else {
+                assertEquals(expectedToken, results.get(i), "mismatch [" + i + "]");
+            }
         }
     }
 


### PR DESCRIPTION

* With Java 21, the order of attributes are different but it does not change the semantic
* factorize the xml-unit version in parent pom

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

