### PR TITLE
(chores) camel-core: reduce method size to force inlining

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/errorhandler/RedeliveryErrorHandler.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/errorhandler/RedeliveryErrorHandler.java
@@ -428,26 +428,11 @@ public abstract class RedeliveryErrorHandler extends ErrorHandlerSupport
                 run = false;
             }
             if (!run) {
-                LOG.trace("Run not allowed, will reject executing exchange: {}", exchange);
-                if (exchange.getException() == null) {
-                    exchange.setException(new RejectedExecutionException());
-                }
-                AsyncCallback cb = callback;
-                taskFactory.release(this);
-                cb.done(false);
+                runNotAllowed();
                 return;
             }
             if (exchange.getExchangeExtension().isInterrupted()) {
-                // mark the exchange to stop continue routing when interrupted
-                // as we do not want to continue routing (for example a task has been cancelled)
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("Is exchangeId: {} interrupted? true", exchange.getExchangeId());
-                }
-                exchange.setRouteStop(true);
-                // we should not continue routing so call callback
-                AsyncCallback cb = callback;
-                taskFactory.release(this);
-                cb.done(false);
+                runInterrupted();
                 return;
             }
 
@@ -462,13 +447,7 @@ public abstract class RedeliveryErrorHandler extends ErrorHandlerSupport
 
             if (failure || bridge) {
                 // previous processing cause an exception
-                handleException();
-                onExceptionOccurred();
-                prepareExchangeAfterFailure(exchange);
-                // we do not support redelivery so continue callback
-                AsyncCallback cb = callback;
-                taskFactory.release(this);
-                reactiveExecutor.schedule(cb);
+                handlePreviousFailure();
             } else if (first) {
                 // first time call the target processor
                 first = false;
@@ -479,6 +458,39 @@ public abstract class RedeliveryErrorHandler extends ErrorHandlerSupport
                 taskFactory.release(this);
                 reactiveExecutor.schedule(cb);
             }
+        }
+
+        private void handlePreviousFailure() {
+            handleException();
+            onExceptionOccurred();
+            prepareExchangeAfterFailure(exchange);
+            // we do not support redelivery so continue callback
+            AsyncCallback cb = callback;
+            taskFactory.release(this);
+            reactiveExecutor.schedule(cb);
+        }
+
+        private void runInterrupted() {
+            // mark the exchange to stop continue routing when interrupted
+            // as we do not want to continue routing (for example a task has been cancelled)
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Is exchangeId: {} interrupted? true", exchange.getExchangeId());
+            }
+            exchange.setRouteStop(true);
+            // we should not continue routing so call callback
+            AsyncCallback cb = callback;
+            taskFactory.release(this);
+            cb.done(false);
+        }
+
+        private void runNotAllowed() {
+            LOG.trace("Run not allowed, will reject executing exchange: {}", exchange);
+            if (exchange.getException() == null) {
+                exchange.setException(new RejectedExecutionException());
+            }
+            AsyncCallback cb = callback;
+            taskFactory.release(this);
+            cb.done(false);
         }
 
         protected void handleException() {

--- a/core/camel-support/src/main/java/org/apache/camel/support/MessageSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/MessageSupport.java
@@ -217,12 +217,7 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
 
         // the headers may be the same instance if the end user has made some mistake
         // and set the OUT message with the same header instance of the IN message etc
-        boolean sameHeadersInstance = false;
-        if (hasHeaders() && that.hasHeaders() && getHeaders() == that.getHeaders()) {
-            sameHeadersInstance = true;
-        }
-
-        if (!sameHeadersInstance) {
+        if (!sameHeaders(that)) {
             if (hasHeaders()) {
                 // okay its safe to clear the headers
                 getHeaders().clear();
@@ -231,6 +226,10 @@ public abstract class MessageSupport implements Message, CamelContextAware, Data
                 getHeaders().putAll(that.getHeaders());
             }
         }
+    }
+
+    private boolean sameHeaders(Message that) {
+        return hasHeaders() && that.hasHeaders() && getHeaders() == that.getHeaders();
     }
 
     @Override


### PR DESCRIPTION
Reduce the size of a few hot methods, so that their byte code size is smaller than 325 bytes, to increase the chance that the JVM will inline them when possible.