### PR TITLE
(chores) camel-core: remove unnecessary volatile

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
@@ -195,7 +195,7 @@ public abstract class AbstractCamelContext extends BaseService
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractCamelContext.class);
 
-    protected final InternalServiceManager internalServiceManager;
+    private final InternalServiceManager internalServiceManager;
 
     private final DefaultCamelContextExtension camelContextExtension = new DefaultCamelContextExtension(this);
     private final AtomicInteger endpointKeyCounter = new AtomicInteger();
@@ -219,7 +219,7 @@ public abstract class AbstractCamelContext extends BaseService
     private String managementName;
     private ClassLoader applicationContextClassLoader;
     private boolean autoCreateComponents = true;
-    private volatile VaultConfiguration vaultConfiguration = new VaultConfiguration();
+    private VaultConfiguration vaultConfiguration = new VaultConfiguration();
 
     private final List<RoutePolicyFactory> routePolicyFactories = new ArrayList<>();
     // special flags to control the first startup which can are special


### PR DESCRIPTION
Volatile only guarantees visibility, but not atomicity. This could mislead maintainers into thinking it's thread-safe when it's not.

This aligns this variable with the rest of the other member variables in this class.