### PR TITLE
Migrate from xmlunit-core to xmlunit-assertj to simplify code

### DIFF
--- a/components/camel-jmx/pom.xml
+++ b/components/camel-jmx/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-core</artifactId>
+            <artifactId>xmlunit-assertj3</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-jmx/src/test/java/org/apache/camel/component/jmx/XmlFixture.java
+++ b/components/camel-jmx/src/test/java/org/apache/camel/component/jmx/XmlFixture.java
@@ -26,11 +26,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
-import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.assertj3.XmlAssert;
 import org.xmlunit.builder.Input;
-import org.xmlunit.diff.Diff;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public final class XmlFixture {
 
@@ -46,15 +43,10 @@ public final class XmlFixture {
     }
 
     public static void assertXMLIgnorePrefix(String aMessage, Source aExpected, Source aActual) throws Exception {
-        Diff diff = DiffBuilder.compare(aExpected).withTest(aActual)
-                .ignoreComments().ignoreWhitespace()
-                .checkForSimilar().build();
-        try {
-            assertFalse(diff.hasDifferences(), aMessage + ":\n" + diff.toString());
-        } catch (Exception t) {
-            dump(aActual);
-            throw t;
-        }
+        XmlAssert.assertThat(aExpected).and(aActual)
+            .ignoreComments()
+            .ignoreWhitespace()
+            .areSimilar();
     }
 
     public static void dump(Source aActual)

--- a/components/camel-schematron/pom.xml
+++ b/components/camel-schematron/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-core</artifactId>
+            <artifactId>xmlunit-assertj3</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-xj/pom.xml
+++ b/components/camel-xj/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-core</artifactId>
+            <artifactId>xmlunit-assertj3</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-xj/src/test/java/org/apache/camel/component/xj/XJTestUtils.java
+++ b/components/camel-xj/src/test/java/org/apache/camel/component/xj/XJTestUtils.java
@@ -43,11 +43,8 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import org.apache.commons.io.IOUtils;
 import org.skyscreamer.jsonassert.JSONAssert;
-import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.assertj3.XmlAssert;
 import org.xmlunit.builder.Input;
-import org.xmlunit.diff.Diff;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 final class XJTestUtils {
 
@@ -161,24 +158,19 @@ final class XJTestUtils {
 
         final String expected = IOUtils.toString(referenceFile, StandardCharsets.UTF_8.name());
         final String result = byteArrayOutputStream.toString(StandardCharsets.UTF_8.name());
+        XmlAssert.assertThat(Input.fromString(expected))
+            .and(Input.fromString(result))
+            .ignoreElementContentWhitespace()
+            .withNodeFilter(toTest -> {
+                if (toTest instanceof Comment) {
+                    final Comment comment = (Comment) toTest;
+                    final String text = comment.getNodeValue();
 
-        final Diff diff = DiffBuilder
-                .compare(Input.fromString(expected))
-                .withTest(Input.fromString(result))
-                .ignoreElementContentWhitespace()
-                .withNodeFilter(toTest -> {
-                    if (toTest instanceof Comment) {
-                        final Comment comment = (Comment) toTest;
-                        final String text = comment.getNodeValue();
+                    return text == null || !text.contains("License");
+                }
 
-                        return text == null || !text.contains("License");
-                    }
-
-                    return true;
-                })
-                .checkForIdentical()
-                .build();
-
-        assertFalse(diff.hasDifferences(), "\nExpected: " + expected + "\n\nGot: " + result + "\n\nDiff: " + diff.toString());
+                return true;
+            })
+            .areIdentical();
     }
 }

--- a/components/camel-xmlsecurity/pom.xml
+++ b/components/camel-xmlsecurity/pom.xml
@@ -96,7 +96,7 @@
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-core</artifactId>
+            <artifactId>xmlunit-assertj3</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/components/camel-xmlsecurity/src/test/java/org/apache/camel/dataformat/xmlsecurity/TestHelper.java
+++ b/components/camel-xmlsecurity/src/test/java/org/apache/camel/dataformat/xmlsecurity/TestHelper.java
@@ -38,8 +38,7 @@ import org.apache.xml.security.encryption.XMLCipher;
 import org.apache.xml.security.encryption.XMLEncryptionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xmlunit.builder.DiffBuilder;
-import org.xmlunit.diff.Diff;
+import org.xmlunit.assertj3.XmlAssert;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -162,10 +161,7 @@ public class TestHelper {
         assertFalse(hasEncryptedData(inDoc), "The XML message has encrypted data.");
 
         // verify that the decrypted message matches what was sent
-        Diff xmlDiff = DiffBuilder.compare(fragment).withTest(inDoc).checkForIdentical().build();
-
-        assertFalse(xmlDiff.hasDifferences(),
-                "The decrypted document does not match the control document:\n" + xmlDiff.toString());
+        XmlAssert.assertThat(fragment).and(inDoc).areIdentical();
     }
 
     protected void testDecryption(CamelContext context) throws Exception {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2699,7 +2699,7 @@
             </dependency>
             <dependency>
                 <groupId>org.xmlunit</groupId>
-                <artifactId>xmlunit-core</artifactId>
+                <artifactId>xmlunit-assertj3</artifactId>
                 <version>${xmlunit-version}</version>
             </dependency>
 


### PR DESCRIPTION
based on https://github.com/apache/camel/pull/11767

this is to address this comment: https://github.com/apache/camel/pull/11754#discussion_r1363585298

# Description

* Simpler and more compact code
* Better error message built-in

The two libraries are part of the same project. The core part is the historic one.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

