### PR TITLE
20008 xml tokenizer expected bodies check without xml unit dependency on camel mock

### DIFF
--- a/components/camel-mock/src/main/java/org/apache/camel/component/mock/ExpectedBodiesAssertionTask.java
+++ b/components/camel-mock/src/main/java/org/apache/camel/component/mock/ExpectedBodiesAssertionTask.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mock;
+
+import org.apache.camel.Exchange;
+
+public class ExpectedBodiesAssertionTask implements AssertionTask {
+
+    private final MockEndpoint mockEndpoint;
+
+    protected ExpectedBodiesAssertionTask(MockEndpoint mockEndpoint) {
+        this.mockEndpoint = mockEndpoint;
+    }
+
+    @Override
+    public void assertOnIndex(int i) {
+        Exchange exchange = this.mockEndpoint.getReceivedExchange(i);
+
+        Object expectedBody = this.mockEndpoint.expectedBodyValues.get(i);
+        Object actualBody = null;
+        if (i < this.mockEndpoint.actualBodyValues.size()) {
+            actualBody = this.mockEndpoint.actualBodyValues.get(i);
+        }
+        actualBody = this.mockEndpoint.extractActualValue(exchange, actualBody, expectedBody);
+        assertOnExtractedBody(i, expectedBody, actualBody);
+    }
+
+    protected void assertOnExtractedBody(int index, Object expectedBody, Object actualBody) {
+        this.mockEndpoint.assertEquals("Body of message: " + index, expectedBody, actualBody);
+    }
+
+    public void run() {
+        for (int i = 0; i < this.mockEndpoint.expectedBodyValues.size(); i++) {
+            assertOnIndex(i);
+        }
+    }
+}

--- a/components/camel-stax/pom.xml
+++ b/components/camel-stax/pom.xml
@@ -74,6 +74,11 @@
             <artifactId>camel-jaxb</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-assertj3</artifactId>
+            <scope>test</scope>
+       </dependency>
 
     </dependencies>
 

--- a/components/camel-stax/src/test/java/org/apache/camel/component/stax/ExpectedBodiesComparedByXMLSimilarityAssertionTask.java
+++ b/components/camel-stax/src/test/java/org/apache/camel/component/stax/ExpectedBodiesComparedByXMLSimilarityAssertionTask.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.stax;
+
+import org.apache.camel.component.mock.ExpectedBodiesAssertionTask;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.xmlunit.assertj3.XmlAssert;
+
+public class ExpectedBodiesComparedByXMLSimilarityAssertionTask extends ExpectedBodiesAssertionTask {
+
+    public ExpectedBodiesComparedByXMLSimilarityAssertionTask(MockEndpoint mockEndpoint) {
+        super(mockEndpoint);
+    }
+
+    protected void assertOnExtractedBody(int index, Object expectedBody, Object actualBody) {
+        XmlAssert.assertThat(actualBody).and(expectedBody).areSimilar();
+    }
+
+}

--- a/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/XMLTokenExpressionIteratorTest.java
+++ b/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/XMLTokenExpressionIteratorTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.xmlunit.assertj3.XmlAssert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -490,7 +491,12 @@ public class XMLTokenExpressionIteratorTest {
 
         assertEquals(expected.length, results.size(), "token count");
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(expected[i], results.get(i), "mismatch [" + i + "]");
+            String expectedToken = expected[i];
+            if (expectedToken.startsWith("<")) {
+                XmlAssert.assertThat(results.get(i)).and(expectedToken).areIdentical();
+            } else {
+                assertEquals(expectedToken, results.get(i), "mismatch [" + i + "]");
+            }
         }
     }
 

--- a/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/XMLTokenizeLanguageGroupingTest.java
+++ b/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/XMLTokenizeLanguageGroupingTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.camel.language.xtokenizer;
 
+import java.util.Arrays;
+
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.component.stax.ExpectedBodiesComparedByXMLSimilarityAssertionTask;
 import org.apache.camel.support.builder.Namespaces;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
@@ -125,8 +128,10 @@ public class XMLTokenizeLanguageGroupingTest extends CamelTestSupport {
     public void testSendMoreParentsMessageToTokenize() throws Exception {
         MockEndpoint result = getMockEndpoint("mock:result");
         result.expectedBodiesReceived(
-                "<group><c:child some_attr='a' anotherAttr='a' xmlns:c=\"urn:c\" xmlns:d=\"urn:d\" xmlns:g=\"urn:g\"></c:child>"
-                                      + "<c:child some_attr='b' anotherAttr='b' xmlns:c=\"urn:c\" xmlns:d=\"urn:d\" xmlns:g=\"urn:g\"/></group>");
+                Arrays.asList(
+                        "<group><c:child some_attr='a' anotherAttr='a' xmlns:c=\"urn:c\" xmlns:d=\"urn:d\" xmlns:g=\"urn:g\"></c:child>"
+                              + "<c:child some_attr='b' anotherAttr='b' xmlns:c=\"urn:c\" xmlns:d=\"urn:d\" xmlns:g=\"urn:g\"/></group>"),
+                new ExpectedBodiesComparedByXMLSimilarityAssertionTask(result));
 
         template
                 .sendBody("direct:start",

--- a/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/XMLTokenizeLanguageTest.java
+++ b/components/camel-stax/src/test/java/org/apache/camel/language/xtokenizer/XMLTokenizeLanguageTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.camel.language.xtokenizer;
 
+import java.util.Arrays;
+
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.component.stax.ExpectedBodiesComparedByXMLSimilarityAssertionTask;
 import org.apache.camel.support.builder.Namespaces;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
@@ -123,8 +126,10 @@ public class XMLTokenizeLanguageTest extends CamelTestSupport {
     public void testSendMoreParentsMessageToTokenize() throws Exception {
         MockEndpoint result = getMockEndpoint("mock:result");
         result.expectedBodiesReceived(
-                "<c:child some_attr='a' anotherAttr='a' xmlns:c=\"urn:c\" xmlns:d=\"urn:d\" xmlns:g=\"urn:g\"></c:child>",
-                "<c:child some_attr='b' anotherAttr='b' xmlns:c=\"urn:c\" xmlns:d=\"urn:d\" xmlns:g=\"urn:g\"/>");
+                Arrays.asList(
+                        "<c:child some_attr='a' anotherAttr='a' xmlns:c=\"urn:c\" xmlns:d=\"urn:d\" xmlns:g=\"urn:g\"></c:child>",
+                        "<c:child some_attr='b' anotherAttr='b' xmlns:c=\"urn:c\" xmlns:d=\"urn:d\" xmlns:g=\"urn:g\"/>"),
+                new ExpectedBodiesComparedByXMLSimilarityAssertionTask(result));
 
         template
                 .sendBody("direct:start",


### PR DESCRIPTION
# Description

alternative implementation without a new dependency on an xml library on camel-mock

see https://github.com/apache/camel/pull/11756

include commit from https://github.com/apache/camel/pull/11754

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

