### PR TITLE
camel-lra: provide additional unit tests

### DIFF
--- a/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRASagaService.java
+++ b/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRASagaService.java
@@ -66,7 +66,6 @@ public class LRASagaService extends ServiceSupport implements StaticService, Cam
                 .thenApply(url -> new LRASagaCoordinator(LRASagaService.this, url));
     }
 
-
     @Override
     public CompletableFuture<CamelSagaCoordinator> getSaga(String id) {
         CompletableFuture<CamelSagaCoordinator> coordinator;

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAClientTest.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAClientTest.java
@@ -16,12 +16,18 @@
  */
 package org.apache.camel.service.lra;
 
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class LRAClientTest extends CamelTestSupport {
 
@@ -56,6 +62,76 @@ public class LRAClientTest extends CamelTestSupport {
                 "no client should result in IllegalArgumentException");
     }
 
+    @DisplayName("Tests whether LRAClient is calling prepareRequest with exchange from newLRA()")
+    @Test
+    void testCallsPrepareRequestWithExchangeInNewLra() {
+        LRASagaService sagaService = new LRASagaService();
+        applyMockProperties(sagaService);
+        LRAClient client = new LRAClient(sagaService) {
+            protected HttpRequest.Builder prepareRequest(URI uri, Exchange exchange) {
+                throw new ExchangeRuntimeException(exchange);
+            }
+        };
+        Exchange exchange = Mockito.mock(Exchange.class);
+        try {
+            client.newLRA(exchange);
+            Assertions.fail("there should have been the special testing exception ExchangeRuntimeException");
+        } catch (ExchangeRuntimeException ex) {
+            Assertions.assertSame(exchange, ex.get());
+        }
+    }
+
+    @DisplayName("Tests whether LRAClient is calling prepareRequest with exchange from compensate()")
+    @Test
+    void testCallsPrepareRequestWithExchangeInCompensate() throws MalformedURLException {
+        LRASagaService sagaService = new LRASagaService();
+        applyMockProperties(sagaService);
+        LRAClient client = new LRAClient(sagaService) {
+            protected HttpRequest.Builder prepareRequest(URI uri, Exchange exchange) {
+                throw new ExchangeRuntimeException(exchange);
+            }
+        };
+        Exchange exchange = Mockito.mock(Exchange.class);
+        try {
+            client.complete(new URL("https://localhost/saga"), exchange);
+            Assertions.fail("there should have been the special testing exception ExchangeRuntimeException");
+        } catch (ExchangeRuntimeException ex) {
+            Assertions.assertSame(exchange, ex.get());
+        }
+    }
+
+    @DisplayName("Tests whether LRAClient is calling prepareRequest with exchange from complete()")
+    @Test
+    void testCallsPrepareRequestWithExchangeInComplete() throws MalformedURLException {
+        LRASagaService sagaService = new LRASagaService();
+        applyMockProperties(sagaService);
+        LRAClient client = new LRAClient(sagaService) {
+            protected HttpRequest.Builder prepareRequest(URI uri, Exchange exchange) {
+                throw new ExchangeRuntimeException(exchange);
+            }
+        };
+        Exchange exchange = Mockito.mock(Exchange.class);
+        try {
+            client.complete(new URL("https://localhost/saga"), exchange);
+            Assertions.fail("there should have been the special testing exception ExchangeRuntimeException");
+        } catch (ExchangeRuntimeException ex) {
+            Assertions.assertSame(exchange, ex.get());
+        }
+    }
+
+    @DisplayName("Tests prepare request works without exchange")
+    @Test
+    void testPrepareRequestWithoutExchange() throws Exception {
+        LRASagaService sagaService = new LRASagaService();
+        applyMockProperties(sagaService);
+        LRAClient client = new LRAClient(sagaService);
+        URI uri = new URI("https://lcoalhost/someURI");
+        HttpRequest.Builder expected = HttpRequest.newBuilder(uri);
+        HttpRequest.Builder actual = client.prepareRequest(uri, null);
+
+        Assertions.assertEquals(actual.build(), expected.build());
+    }
+
     private void applyMockProperties(LRASagaService sagaService) {
         sagaService.setCoordinatorUrl("mockCoordinatorUrl");
         sagaService.setLocalParticipantUrl("mockLocalParticipantUrl");
@@ -63,4 +139,15 @@ public class LRAClientTest extends CamelTestSupport {
         sagaService.setCoordinatorContextPath("mockCoordinatorContextPath");
     }
 
+    private static class ExchangeRuntimeException extends RuntimeException {
+        private Exchange exchange;
+
+        public ExchangeRuntimeException(Exchange exchange) {
+            this.exchange = exchange;
+        }
+
+        public Exchange get() {
+            return exchange;
+        }
+    }
 }

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAClientTest.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAClientTest.java
@@ -73,12 +73,7 @@ public class LRAClientTest extends CamelTestSupport {
             }
         };
         Exchange exchange = Mockito.mock(Exchange.class);
-        try {
-            client.newLRA(exchange);
-            Assertions.fail("there should have been the special testing exception ExchangeRuntimeException");
-        } catch (ExchangeRuntimeException ex) {
-            Assertions.assertSame(exchange, ex.get());
-        }
+        Assertions.assertThrows(ExchangeRuntimeException.class, () -> client.newLRA(exchange));
     }
 
     @DisplayName("Tests whether LRAClient is calling prepareRequest with exchange from compensate()")
@@ -92,12 +87,8 @@ public class LRAClientTest extends CamelTestSupport {
             }
         };
         Exchange exchange = Mockito.mock(Exchange.class);
-        try {
-            client.complete(new URL("https://localhost/saga"), exchange);
-            Assertions.fail("there should have been the special testing exception ExchangeRuntimeException");
-        } catch (ExchangeRuntimeException ex) {
-            Assertions.assertSame(exchange, ex.get());
-        }
+        Assertions.assertThrows(ExchangeRuntimeException.class,
+                () -> client.compensate(new URL("https://localhost/saga"), exchange));
     }
 
     @DisplayName("Tests whether LRAClient is calling prepareRequest with exchange from complete()")
@@ -111,12 +102,8 @@ public class LRAClientTest extends CamelTestSupport {
             }
         };
         Exchange exchange = Mockito.mock(Exchange.class);
-        try {
-            client.complete(new URL("https://localhost/saga"), exchange);
-            Assertions.fail("there should have been the special testing exception ExchangeRuntimeException");
-        } catch (ExchangeRuntimeException ex) {
-            Assertions.assertSame(exchange, ex.get());
-        }
+        Assertions.assertThrows(ExchangeRuntimeException.class,
+                () -> client.complete(new URL("https://localhost/saga"), exchange));
     }
 
     @DisplayName("Tests prepare request works without exchange")

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRASagaCoordinatorTest.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRASagaCoordinatorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.service.lra;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.saga.CamelSagaStep;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class LRASagaCoordinatorTest extends CamelTestSupport {
+
+    private URL url;
+
+    private LRASagaService sagaService;
+
+    private LRAClient client;
+
+    private Exchange exchange;
+
+    private LRASagaCoordinator coordinator;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        url = new URL("https://localhost/saga");
+        sagaService = Mockito.mock(LRASagaService.class);
+        client = Mockito.mock(LRAClient.class);
+        Mockito.when(sagaService.getClient()).thenReturn(client);
+        exchange = Mockito.mock(Exchange.class);
+
+        coordinator = new LRASagaCoordinator(sagaService, url);
+    }
+
+    public LRASagaCoordinatorTest() {
+        setUseRouteBuilder(false);
+    }
+
+    @DisplayName("Tests whether no sagaService is causing exception")
+    @Test
+    void testSagaServiceIsNotNull() throws Exception {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new LRASagaCoordinator(null, url));
+    }
+
+    @DisplayName("Tests whether no sagaService is causing exception")
+    @Test
+    void testUrlIsNotNull() throws Exception {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new LRASagaCoordinator(sagaService, null));
+    }
+
+    @DisplayName("Tests whether join is called on LRAClient")
+    @Test
+    void testBeginStep() throws Exception {
+        CamelSagaStep step = new CamelSagaStep(Optional.empty(), Optional.empty(), Collections.emptyMap(), Optional.empty());
+
+        CompletableFuture<Void> expected = CompletableFuture.completedFuture(null);
+        Mockito.when(client.join(Mockito.eq(url), Mockito.any(LRASagaStep.class), Mockito.eq(exchange))).thenReturn(expected);
+
+        CompletableFuture<Void> actual = coordinator.beginStep(exchange, step);
+        Assertions.assertSame(expected, actual);
+
+        Mockito.verify(sagaService).getClient();
+        Mockito.verify(client).join(Mockito.eq(url), Mockito.any(LRASagaStep.class), Mockito.eq(exchange));
+    }
+
+    @DisplayName("Tests whether complete is called on LRAClient")
+    @Test
+    void testComplete() throws Exception {
+        CompletableFuture<Void> expected = CompletableFuture.completedFuture(null);
+        Mockito.when(client.complete(url, exchange)).thenReturn(expected);
+
+        CompletableFuture<Void> actual = coordinator.complete(exchange);
+
+        Assertions.assertSame(expected, actual);
+        Mockito.verify(sagaService).getClient();
+        Mockito.verify(client).complete(url, exchange);
+    }
+
+    @DisplayName("Tests whether compensate is called on LRAClient")
+    @Test
+    void testCompensate() throws Exception {
+        CompletableFuture<Void> expected = CompletableFuture.completedFuture(null);
+        Mockito.when(client.compensate(url, exchange)).thenReturn(expected);
+
+        CompletableFuture<Void> actual = coordinator.compensate(exchange);
+
+        Assertions.assertSame(expected, actual);
+        Mockito.verify(sagaService).getClient();
+        Mockito.verify(client).compensate(url, exchange);
+    }
+
+}


### PR DESCRIPTION
# Description

Add additional unit-tests to increase test-coverage.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] this is kind of the follow-up of [CAMEL-20016](https://issues.apache.org/jira/browse/CAMEL-20016) and adds additional unit-tests

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes


