### PR TITLE
CAMEL-20022: camel-yaml-dsl: Add WARN log if kebab-case is detected

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/main/java/org/apache/camel/dsl/yaml/deserializers/CustomResolver.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/main/java/org/apache/camel/dsl/yaml/deserializers/CustomResolver.java
@@ -17,9 +17,14 @@
 package org.apache.camel.dsl.yaml.deserializers;
 
 import org.apache.camel.dsl.yaml.common.YamlDeserializerResolver;
+import org.apache.camel.util.StringHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.snakeyaml.engine.v2.api.ConstructNode;
 
 public class CustomResolver implements YamlDeserializerResolver {
+    public static final Logger LOG = LoggerFactory.getLogger(CustomResolver.class);
+
     @Override
     public int getOrder() {
         return YamlDeserializerResolver.ORDER_DEFAULT;
@@ -33,6 +38,12 @@ public class CustomResolver implements YamlDeserializerResolver {
 
     @Override
     public ConstructNode resolve(String id) {
+        if (id != null && id.contains("-")) {
+            LOG.warn(
+                    "The kebab-case '{}' is deprecated and it will be removed in the next version. Use the camelCase '{}' instead.",
+                    id, StringHelper.dashToCamelCase(id));
+        }
+
         switch (id) {
             //
             // Route

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/SetPropertyTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/SetPropertyTest.groovy
@@ -81,4 +81,29 @@ class SetPropertyTest extends YamlTestSupport {
             Assertions.assertTrue(e.message.contains("additional properties"), e.getMessage())
         }
     }
+
+    def "kebab-case: set-property no validation"() {
+        when:
+        var route = '''
+                    - from:
+                        uri: "direct:start"
+                        steps:    
+                          - set-property:
+                              name: test
+                              expression:
+                                simple: "${body}"
+                          - to: "mock:result"
+                    '''
+        loadRoutesNoValidate(route)
+
+        then:
+        with(context.routeDefinitions[0].outputs[0], SetPropertyDefinition) {
+            name == 'test'
+
+            with(expression, ExpressionDefinition) {
+                language == 'simple'
+                expression == '${body}'
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).
https://issues.apache.org/jira/browse/CAMEL-20022

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

Now it emits the following:
```
2023-10-24 16:09:45,536 [main           ] WARN  CustomResolver                 - The kebab-case 'set-body' is deprecated and it will be removed in the next version. Use the camelCase 'setBody' instead.
2023-10-24 16:09:45,536 [main           ] WARN  CustomResolver                 - The kebab-case 'set-header' is deprecated and it will be removed in the next version. Use the camelCase 'setHeader' instead.
2023-10-24 16:09:48,669 [main           ] WARN  CustomResolver                 - The kebab-case 'set-property' is deprecated and it will be removed in the next version. Use the camelCase 'setProperty' instead.
```