### PR TITLE
[CAMEL-20037] camel-http builds StringEntity with wrong contentEncoding

### DIFF
--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
@@ -778,7 +778,7 @@ public class HttpProducer extends DefaultProducer {
                             contentType = ContentType.parse(contentType + ";charset=" + charset);
                         }
 
-                        answer = new StringEntity(content, contentType, charset, false);
+                        answer = new StringEntity(content, contentType, false);
                     }
 
                     // fallback as input stream

--- a/components/camel-http/src/main/java/org/apache/camel/component/http/OAuth2ClientConfigurer.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/OAuth2ClientConfigurer.java
@@ -63,7 +63,8 @@ public class OAuth2ClientConfigurer implements HttpClientConfigurer {
                         String accessToken = ((JsonObject) Jsoner.deserialize(responseString)).getString("access_token");
                         request.addHeader(HttpHeaders.AUTHORIZATION, accessToken);
                     } else {
-                        throw new HttpException("Received error response from token request with Status Code: " + response.getCode());
+                        throw new HttpException(
+                                "Received error response from token request with Status Code: " + response.getCode());
                     }
 
                 } catch (DeserializationException e) {

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpProducerContentTypeWithCharsetTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpProducerContentTypeWithCharsetTest.java
@@ -51,6 +51,7 @@ public class HttpProducerContentTypeWithCharsetTest extends BaseHttpTest {
                     String contentType = request.getFirstHeader(Exchange.CONTENT_TYPE).getValue();
 
                     assertEquals(CONTENT_TYPE_WITH_CHARSET.replace(";", "; "), contentType);
+                    assertFalse(request.containsHeader(Exchange.CONTENT_ENCODING));
 
                     response.setEntity(new StringEntity(contentType, StandardCharsets.US_ASCII));
                     response.setCode(HttpStatus.SC_OK);

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpProducerWithSpecialCharsBodyTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpProducerWithSpecialCharsBodyTest.java
@@ -28,8 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.Exchange.CHARSET_NAME;
 import static org.apache.hc.core5.http.ContentType.APPLICATION_JSON;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -71,7 +70,7 @@ class HttpProducerWithSpecialCharsBodyTest {
         assertTrue(requestEntity instanceof StringEntity);
         StringEntity entity = (StringEntity) requestEntity;
         assertEquals(APPLICATION_JSON_UTF8, entity.getContentType(), "Content type should be given content type and charset");
-        assertEquals(StandardCharsets.UTF_8.name(), entity.getContentEncoding(), "Content encoding should be given charset");
+        assertNull(entity.getContentEncoding(), "Content encoding should not be given");
         assertEquals(TEST_MESSAGE_WITH_SPECIAL_CHARACTERS,
                 new String(entity.getContent().readAllBytes(), StandardCharsets.UTF_8),
                 "Reading entity content with intended charset should result in the original (readable) message");
@@ -95,7 +94,7 @@ class HttpProducerWithSpecialCharsBodyTest {
         assertTrue(requestEntity instanceof StringEntity);
         StringEntity entity = (StringEntity) requestEntity;
         assertEquals(APPLICATION_JSON_UTF8, entity.getContentType(), "Content type should be given content type and charset");
-        assertEquals(StandardCharsets.UTF_8.name(), entity.getContentEncoding(), "Content encoding should be given charset");
+        assertNull(entity.getContentEncoding(), "Content encoding should not be given");
         assertEquals(TEST_MESSAGE_WITH_SPECIAL_CHARACTERS,
                 new String(entity.getContent().readAllBytes(), StandardCharsets.UTF_8),
                 "Reading entity content with intended charset should result in the original (readable) message");


### PR DESCRIPTION
# Description

A fix for [CAMEL-20037](https://issues.apache.org/jira/browse/CAMEL-20037) camel-http builds StringEntity with wrong contentEncoding.

camel-http must not create StringEntity having charset as content encoding

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

There was a change to a non related source file OAuth2ClientConfigurer.java.