### PR TITLE
CAMEL-19986: created throttling executor in camel-test

### DIFF
--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/TestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/TestSupport.java
@@ -23,6 +23,8 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntConsumer;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
@@ -580,5 +582,12 @@ public final class TestSupport {
 
     public static String fileUri(Path testDirectory, String query) {
         return "file:" + testDirectory + (query.startsWith("?") ? "" : "/") + query;
+    }
+
+    public static void executeSlowly(int count, long interval, TimeUnit timeUnit, IntConsumer task) throws Exception {
+        for (int i = 0; i < count; i++) {
+            task.accept(i);
+            Thread.sleep(timeUnit.toMillis(interval));
+        }
     }
 }


### PR DESCRIPTION
example of using:

```
executeSlowly(size, 3, TimeUnit.MILLISECONDS, (i) -> template.sendBody(url, "Message " + i));
```