### PR TITLE
[kafka] Add infra property for custom image

### DIFF
--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/common/KafkaProperties.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/common/KafkaProperties.java
@@ -20,6 +20,7 @@ package org.apache.camel.test.infra.kafka.common;
 public final class KafkaProperties {
     public static final String KAFKA_BOOTSTRAP_SERVERS = "kafka.bootstrap.servers";
     public static final String KAFKA_ZOOKEEPER_ADDRESS = "kafka.zookeeper.address";
+    public static final String KAFKA_CONTAINER = "kafka.container";
 
     private KafkaProperties() {
 

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalAuthKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalAuthKafkaService.java
@@ -31,7 +31,7 @@ public class ContainerLocalAuthKafkaService implements KafkaService, ContainerSe
 
     public static class TransientAuthenticatedKafkaContainer extends KafkaContainer {
         public TransientAuthenticatedKafkaContainer(String jaasConfigFile) {
-            super(DockerImageName.parse(ContainerLocalKafkaService.KAFKA3_IMAGE_NAME));
+            super(DockerImageName.parse(System.getProperty("kafka.container", ContainerLocalKafkaService.KAFKA3_IMAGE_NAME)).asCompatibleSubstituteFor(ContainerLocalKafkaService.KAFKA3_IMAGE_NAME));
 
             withEmbeddedZookeeper();
 

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
@@ -40,7 +40,8 @@ public class ContainerLocalKafkaService implements KafkaService, ContainerServic
     }
 
     protected KafkaContainer initContainer() {
-        return new KafkaContainer(DockerImageName.parse(KAFKA3_IMAGE_NAME)).withEmbeddedZookeeper();
+        return new KafkaContainer(DockerImageName.parse(System.getProperty("kafka.container", KAFKA3_IMAGE_NAME)))
+                .withEmbeddedZookeeper();
     }
 
     public String getBootstrapServers() {
@@ -71,14 +72,16 @@ public class ContainerLocalKafkaService implements KafkaService, ContainerServic
     }
 
     public static ContainerLocalKafkaService kafka2Container() {
-        KafkaContainer container = new KafkaContainer(DockerImageName.parse(KAFKA2_IMAGE_NAME));
+        KafkaContainer container
+                = new KafkaContainer(DockerImageName.parse(System.getProperty("kafka.container", KAFKA2_IMAGE_NAME)).asCompatibleSubstituteFor(ContainerLocalKafkaService.KAFKA2_IMAGE_NAME));
         container = container.withEmbeddedZookeeper();
 
         return new ContainerLocalKafkaService(container);
     }
 
     public static ContainerLocalKafkaService kafka3Container() {
-        KafkaContainer container = new KafkaContainer(DockerImageName.parse(KAFKA3_IMAGE_NAME));
+        KafkaContainer container
+                = new KafkaContainer(DockerImageName.parse(System.getProperty("kafka.container", KAFKA3_IMAGE_NAME)).asCompatibleSubstituteFor(ContainerLocalKafkaService.KAFKA3_IMAGE_NAME));
         container = container.withEmbeddedZookeeper();
 
         return new ContainerLocalKafkaService(container);


### PR DESCRIPTION
# Description

Add property _kafka.container_ to _camel-kafka-test-infra_ in order to externalize the image used. Otherwise, the default one is selected

# Target

- [ main ] 

