### PR TITLE
Fix message header mapping docs to show underscores

### DIFF
--- a/components/camel-jms/src/main/docs/jms-component.adoc
+++ b/components/camel-jms/src/main/docs/jms-component.adoc
@@ -160,9 +160,9 @@ filename header for the File Component, and so on.
 The current header name strategy for accepting header names in Camel is
 as follows:
 
-* Dots are replaced by `_DOT_` and the replacement is reversed when
+* Dots are replaced by `\_DOT_` and the replacement is reversed when
 Camel consume the message
-* Hyphen is replaced by `_HYPHEN_` and the replacement is reversed when
+* Hyphen is replaced by `\_HYPHEN_` and the replacement is reversed when
 Camel consumes the message
 
 You can configure many different properties on the JMS endpoint, which


### PR DESCRIPTION
# Description

This fixes the docs for the JMS component to show that e.g. `-` is converted to `_HYPHEN_` and not `HYPHEN` (in italics) as it was showing

Before: 

![camel-jms-docs](https://github.com/apache/camel/assets/2513147/bcefd4d1-dcb6-4201-8449-9e0bdd853523)

After:

https://github.com/josephearl/camel/blob/main/components/camel-jms/src/main/docs/jms-component.adoc#message-header-mapping

![Screenshot 2023-10-30 at 11 51 30](https://github.com/apache/camel/assets/2513147/6a683351-c9b6-4f14-b535-46ba5124334d)

