### PR TITLE
(chore) ci: convert component-test parameters to env vars

### DIFF
--- a/.github/actions/component-test/action.yaml
+++ b/.github/actions/component-test/action.yaml
@@ -40,7 +40,12 @@ runs:
       uses: ./.github/actions/install-mvnd
     - name: maven build
       shell: bash
-      run: ${{ github.action_path }}/component-test.sh ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd "${{ inputs.comment-body }}" true build.log
+      run: ${{ github.action_path }}/component-test.sh
+      env:
+        MAVEN_BINARY: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd
+        COMMENT_BODY: ${{ inputs.comment-body }}
+        FAST_BUILD: "true"
+        LOG_FILE: build.log
     - name: archive logs
       uses: actions/upload-artifact@v3
       if: always()
@@ -49,7 +54,12 @@ runs:
         path: build.log
     - name: maven test
       shell: bash
-      run: ${{ github.action_path }}/component-test.sh ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd "${{ inputs.comment-body }}" false tests.log
+      run: ${{ github.action_path }}/component-test.sh
+      env:
+        MAVEN_BINARY: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd
+        COMMENT_BODY: ${{ inputs.comment-body }}
+        FAST_BUILD: "false"
+        LOG_FILE: build.log
     - name: archive logs
       uses: actions/upload-artifact@v3
       if: always()

--- a/.github/actions/component-test/component-test.sh
+++ b/.github/actions/component-test/component-test.sh
@@ -18,10 +18,10 @@
 echo "Using MVND_OPTS=$MVND_OPTS"
 
 function main() {
-  local mavenBinary=${1}
-  local commentBody=${2}
-  local fastBuild=${3}
-  local log=${4}
+  local mavenBinary=$MAVEN_BINARY
+  local commentBody=$COMMENT_BODY
+  local fastBuild=$FAST_BUILD
+  local log=$LOG_FILE
 
   if [[ ${commentBody} = /component-test* ]] ; then
     local componentList="${commentBody:16}"


### PR DESCRIPTION
## Modifications

* Use environment variables to avoid injections

## Result

The injection is no longer possible, the Github action simply fails