### PR TITLE
(chore) ci: avoid token exposure in pr-comment workflow

### DIFF
--- a/.github/actions/component-test/action.yaml
+++ b/.github/actions/component-test/action.yaml
@@ -65,7 +65,7 @@ runs:
         path: tests.log
     - name: Success comment
       if: success()
-      uses: peter-evans/create-or-update-comment@v3
+      uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666
       with:
         comment-id: ${{ inputs.comment-id }}
         body: |
@@ -74,7 +74,7 @@ runs:
           **Result** :white_check_mark: The tests passed successfully
     - name: Failure comment
       if: failure()
-      uses: peter-evans/create-or-update-comment@v3
+      uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666
       with:
         comment-id: ${{ inputs.comment-id }}
         body: |

--- a/.github/actions/component-test/action.yaml
+++ b/.github/actions/component-test/action.yaml
@@ -65,7 +65,7 @@ runs:
         path: tests.log
     - name: Success comment
       if: success()
-      uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666
+      uses: ./.github/actions/create-or-update-comment
       with:
         comment-id: ${{ inputs.comment-id }}
         body: |
@@ -74,7 +74,7 @@ runs:
           **Result** :white_check_mark: The tests passed successfully
     - name: Failure comment
       if: failure()
-      uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666
+      uses: ./.github/actions/create-or-update-comment
       with:
         comment-id: ${{ inputs.comment-id }}
         body: |

--- a/.github/actions/component-test/action.yaml
+++ b/.github/actions/component-test/action.yaml
@@ -18,9 +18,6 @@
 name: "Component Test Runner"
 description: "Runs tests of corresponding to the given comment"
 inputs:
-  github-token:
-    description: 'GitHub token to use to update the comment'
-    required: true
   run-id:
     description: 'Id of the job'
     required: true
@@ -68,31 +65,19 @@ runs:
         path: tests.log
     - name: Success comment
       if: success()
-      uses: actions/github-script@v6
+      uses: peter-evans/create-or-update-comment@v3
       with:
-        github-token: ${{ inputs.github-token }}
-        script: |
-          await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: ${{ inputs.pr-id }},
-                comment_id: ${{ inputs.comment-id }},
-                body: `${{ inputs.comment-body }}
+        comment-id: ${{ inputs.comment-id }}
+        body: |
+          ${{ inputs.comment-body }}
 
-          **Result** :white_check_mark: The tests passed successfully`
-          });
+          **Result** :white_check_mark: The tests passed successfully
     - name: Failure comment
       if: failure()
-      uses: actions/github-script@v6
+      uses: peter-evans/create-or-update-comment@v3
       with:
-        github-token: ${{ inputs.github-token }}
-        script: |
-          await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: ${{ inputs.pr-id }},
-                comment_id: ${{ inputs.comment-id }},
-                body: `${{ inputs.comment-body }}
+        comment-id: ${{ inputs.comment-id }}
+        body: |
+          ${{ inputs.comment-body }}
 
-          **Result** :x: The tests failed please [check the logs](https://github.com/apache/camel/actions/runs/${{ inputs.run-id }})`
-          });
+          **Result** :x: The tests failed please [check the logs](https://github.com/apache/camel/actions/runs/${{ inputs.run-id }})

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -63,7 +63,6 @@ jobs:
         name: Component test execution
         uses: ./.github/actions/component-test
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.run_id }}
           pr-id: ${{ github.event.issue.number }}
           comment-id: ${{ github.event.comment.id }}

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.pr_sha }}
+          submodules: recursive
       - id: install-packages
         uses: ./.github/actions/install-packages
       - name: Set up JDK ${{ matrix.java }}

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         java: [ '17' ]
     steps:
-      - uses: peter-evans/create-or-update-comment@v3
+      - uses: peter-evans/create-or-update-comment@v3.1.0
         with:
           issue-number: ${{ context.issue.number }}
           body: |

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -32,16 +32,11 @@ jobs:
       matrix:
         java: [ '17' ]
     steps:
-      - uses: actions/github-script@v6
+      - uses: peter-evans/create-or-update-comment@v3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `:robot: The Apache Camel test robot will run the tests for you :+1:`
-            })
+          issue-number: ${{ context.issue.number }}
+          body: |
+            :robot: The Apache Camel test robot will run the tests for you :+1:
       - name: Retrieve sha
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
## Motivation

To avoid potential vulnerabilities due to exposure of the `GITHUB_TOKEN`, it is recommended to use the Github action [create-or-update-comment](https://github.com/peter-evans/create-or-update-comment)

## Modifications:

* Use the local github action create-or-update-comment