### PR TITLE
Converter lookup once again matches subclass converters like in Camel 3

### DIFF
--- a/components/camel-jackson/src/main/java/org/apache/camel/component/jackson/converter/JacksonTypeConverters.java
+++ b/components/camel-jackson/src/main/java/org/apache/camel/component/jackson/converter/JacksonTypeConverters.java
@@ -172,12 +172,7 @@ public final class JacksonTypeConverters {
 
     @Converter
     public Boolean toBoolean(JsonNode node, Exchange exchange) throws Exception {
-        if (node instanceof BooleanNode) {
-            BooleanNode bn = (BooleanNode) node;
-            return bn.asBoolean();
-        }
-        String text = node.asText();
-        return org.apache.camel.util.ObjectHelper.toBoolean(text);
+        return node.asBoolean();
     }
 
     @Converter

--- a/core/camel-base/src/main/java/org/apache/camel/impl/converter/TypeResolverHelper.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/converter/TypeResolverHelper.java
@@ -115,7 +115,7 @@ final class TypeResolverHelper {
          matching both the "from type" and the "to type" which are NOT Object (we usually try this later).
          */
         for (var entry : converters.entrySet()) {
-            if (entry.getKey().isAssignableMatch(typeConvertible)) {
+            if (typeConvertible.isAssignableMatch(entry.getKey())) {
                 return entry.getValue();
             }
 

--- a/core/camel-base/src/main/java/org/apache/camel/impl/converter/TypeResolverHelper.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/converter/TypeResolverHelper.java
@@ -115,6 +115,12 @@ final class TypeResolverHelper {
          matching both the "from type" and the "to type" which are NOT Object (we usually try this later).
          */
         for (var entry : converters.entrySet()) {
+            if (entry.getKey().isAssignableMatch(typeConvertible)) {
+                return entry.getValue();
+            }
+
+        }
+        for (var entry : converters.entrySet()) {
             if (typeConvertible.isAssignableMatch(entry.getKey())) {
                 return entry.getValue();
             }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/converter/TypeResolverHelperTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/converter/TypeResolverHelperTest.java
@@ -1,0 +1,76 @@
+package org.apache.camel.impl.converter;
+
+import org.apache.camel.TypeConverter;
+import org.apache.camel.converter.TypeConvertible;
+import org.apache.camel.support.SimpleTypeConverter;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TypeResolverHelperTest {
+    private static final Map<TypeConvertible<?, ?>, TypeConverter> registeredConverters = new HashMap<>();
+
+    @BeforeAll
+    static void setUp() {
+        registeredConverters.put(new TypeConvertible<>(Source.class, Child.class), new SourceChildConverter());
+    }
+
+    @Test
+    public void testTryAssignableToChild() {
+        TypeConvertible<?, ?> requestedConverter = new TypeConvertible<>(Source.class, Child.class);
+        TypeConverter foundConverter = TypeResolverHelper.tryAssignableFrom(requestedConverter, registeredConverters);
+        assertNotNull(foundConverter);
+        Child result = foundConverter.tryConvertTo(Child.class, new Source("source"));
+        assertEquals("sourceP", result.parentField);
+        assertEquals("sourceC", result.childField);
+    }
+
+    // This general behaviour works in Camel 3 but stopped working in Camel 4 due to what looks like an accidental regression.
+    // See https://issues.apache.org/jira/browse/CAMEL-19828
+    @Test
+    public void testTryAssignableToParent() {
+        TypeConvertible<?, ?> requestedConverter = new TypeConvertible<>(Source.class, Parent.class);
+        TypeConverter foundConverter = TypeResolverHelper.tryAssignableFrom(requestedConverter, registeredConverters);
+        assertNotNull(foundConverter);
+        Parent result = foundConverter.tryConvertTo(Parent.class, new Source("source"));
+        assertEquals("sourceP", result.parentField);
+    }
+
+    private static class Child extends Parent {
+        final String childField;
+
+        private Child(String parentField, String childField) {
+            super(parentField);
+            this.childField = childField;
+        }
+    }
+
+    private static class Parent {
+        final String parentField;
+
+        private Parent(String parentField) {
+            this.parentField = parentField;
+        }
+    }
+
+    private static class Source {
+        final String sourceField;
+
+        private Source(String sourceField) {
+            this.sourceField = sourceField;
+        }
+    }
+
+    private static class SourceChildConverter extends SimpleTypeConverter {
+        private SourceChildConverter() {
+            super(true, (type, exchange, value) -> {
+                Source source = (Source) value;
+                return new Child(source.sourceField + "P", source.sourceField + "C");
+            });
+        }
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/impl/converter/TypeResolverHelperTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/converter/TypeResolverHelperTest.java
@@ -21,7 +21,7 @@ class TypeResolverHelperTest {
 
     @Test
     public void testTryAssignableToChild() {
-        TypeConvertible<?, ?> requestedConverter = new TypeConvertible<>(Source.class, Child.class);
+        TypeConvertible<Source, Child> requestedConverter = new TypeConvertible<>(Source.class, Child.class);
         TypeConverter foundConverter = TypeResolverHelper.tryAssignableFrom(requestedConverter, registeredConverters);
         assertNotNull(foundConverter);
         Child result = foundConverter.tryConvertTo(Child.class, new Source("source"));
@@ -33,7 +33,7 @@ class TypeResolverHelperTest {
     // See https://issues.apache.org/jira/browse/CAMEL-19828
     @Test
     public void testTryAssignableToParent() {
-        TypeConvertible<?, ?> requestedConverter = new TypeConvertible<>(Source.class, Parent.class);
+        TypeConvertible<Source, Parent> requestedConverter = new TypeConvertible<>(Source.class, Parent.class);
         TypeConverter foundConverter = TypeResolverHelper.tryAssignableFrom(requestedConverter, registeredConverters);
         assertNotNull(foundConverter);
         Parent result = foundConverter.tryConvertTo(Parent.class, new Source("source"));

--- a/core/camel-core/src/test/java/org/apache/camel/impl/converter/TypeResolverHelperTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/converter/TypeResolverHelperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.impl.converter;
 
 import org.apache.camel.TypeConverter;
@@ -9,7 +25,8 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class TypeResolverHelperTest {
     private static final Map<TypeConvertible<?, ?>, TypeConverter> registeredConverters = new HashMap<>();


### PR DESCRIPTION
This is a fix to what looks like an accidental regression in Camel 3 -> Camel 4.

Fix for https://issues.apache.org/jira/browse/CAMEL-19828

Closes #CAMEL-19828


