### PR TITLE
(chore) ci: add github action create-or-update-comment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule ".github/actions/backport"]
 	path = .github/actions/backport
 	url = https://github.com/tibdex/backport
+[submodule ".github/actions/create-or-update-comment"]
+	path = .github/actions/create-or-update-comment
+	url = https://github.com/peter-evans/create-or-update-comment.git


### PR DESCRIPTION
## Motivation

To avoid potential vulnerabilities due to exposure of the `GITHUB_TOKEN`, it is recommended to use the Github action [create-or-update-comment](https://github.com/peter-evans/create-or-update-comment)

## Modifications:

* Add the action as a git submodule since the action has not been approved at the Apache organization level