### PR TITLE
CAMEL-20070: avoid unnecessary costly comparisons

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/converter/TypeConvertible.java
+++ b/core/camel-api/src/main/java/org/apache/camel/converter/TypeConvertible.java
@@ -98,6 +98,11 @@ public final class TypeConvertible<F, T> {
             return true;
         }
 
+        // They are the same, but the thisTo and thatTo don't match.
+        if (thisFrom == thatFrom) {
+            return false;
+        }
+
         /* Try interfaces:
          * Try to resolve a TypeConverter by looking at the interfaces implemented by a given "from" type. It looks at the
          * type hierarchy of the target "from type" trying to match a suitable converter (i.e.: Integer -> Number). It will


### PR DESCRIPTION
This avoids unnecessary costly comparisons when we can eagerly determine that the types won't match. We can avoid these comparisons when both the from types are the same, but their to type are not, because we only use the from types to compute the match.