### PR TITLE
Remove hard coded username

### DIFF
--- a/components/camel-pgevent/src/main/java/org/apache/camel/component/pgevent/PgEventEndpoint.java
+++ b/components/camel-pgevent/src/main/java/org/apache/camel/component/pgevent/PgEventEndpoint.java
@@ -63,7 +63,7 @@ public class PgEventEndpoint extends DefaultEndpoint {
     @Metadata(required = true)
     private String channel;
     @UriParam(defaultValue = "postgres", label = "security", secret = true)
-    private String user = "postgres";
+    private String user;
     @UriParam(label = "security", secret = true)
     private String pass;
     @UriParam


### PR DESCRIPTION
PGEventEndpoint.java is failing SAST tests because of a hard coded username.     From my reading of the code, setting the user to postgres (9 years ago) predates the defaultValue of the URIParam for user, and I think it can be removed because of the default value being set in the URIParam annotation for user.