### PR TITLE
Upgrade OpenSearch to 2.11.0 and its Java client to 2.8.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -362,9 +362,9 @@
         <ognl-version>3.4.1</ognl-version>
         <openapi-generator>6.6.0</openapi-generator>
         <openjpa-version>3.2.2</openjpa-version>
-        <opensearch-rest-client-version>2.9.0</opensearch-rest-client-version>
-        <opensearch-java-client-version>2.6.0</opensearch-java-client-version>
-        <opensearch-version>2.9.0</opensearch-version>
+        <opensearch-rest-client-version>2.11.0</opensearch-rest-client-version>
+        <opensearch-java-client-version>2.8.0</opensearch-java-client-version>
+        <opensearch-version>2.11.0</opensearch-version>
         <opensearch-testcontainers-version>2.0.0</opensearch-testcontainers-version>
         <openstack4j-version>3.11</openstack4j-version>
         <opentelemetry-version>1.28.0</opentelemetry-version>

--- a/test-infra/camel-test-infra-opensearch/src/test/java/org/apache/camel/test/infra/opensearch/services/OpenSearchLocalContainerService.java
+++ b/test-infra/camel-test-infra-opensearch/src/test/java/org/apache/camel/test/infra/opensearch/services/OpenSearchLocalContainerService.java
@@ -29,7 +29,7 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
 public class OpenSearchLocalContainerService implements OpenSearchService, ContainerService<OpensearchContainer> {
-    public static final String DEFAULT_OPEN_SEARCH_CONTAINER = "opensearchproject/opensearch:2.9.0";
+    public static final String DEFAULT_OPEN_SEARCH_CONTAINER = "opensearchproject/opensearch:2.11.0";
     private static final Logger LOG = LoggerFactory.getLogger(OpenSearchLocalContainerService.class);
     private static final int OPEN_SEARCH_PORT = 9200;
     private static final String USER_NAME = "admin";


### PR DESCRIPTION
# Description

This PR upgrades OpenSearch and its Java client to v2.11.0 and v2.8.0 respectively so that we can ensure the existing code works with the latest version of them.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

No corresponding JIRA issue since it just introduces minor version upgrade to OpenSearch.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

