### PR TITLE
[BACKPORT-4.0.x] CAMEL-20086: Avoid losing kamelets-version setting in Camel JBang

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -728,9 +728,6 @@ public class Run extends CamelCommand {
         if (camelVersion != null) {
             cmds.remove("--camel-version=" + camelVersion);
         }
-        if (kameletsVersion != null) {
-            cmds.remove("--kamelets-version=" + kameletsVersion);
-        }
         // need to use jbang command to specify camel version
         List<String> jbangArgs = new ArrayList<>();
         jbangArgs.add("jbang");
@@ -836,7 +833,6 @@ public class Run extends CamelCommand {
         }
 
         cmds.remove("--camel-version=" + camelVersion);
-        cmds.remove("--kamelets-version=" + kameletsVersion);
         // need to use jbang command to specify camel version
         List<String> jbangArgs = new ArrayList<>();
         jbangArgs.add("jbang");


### PR DESCRIPTION
# Description

Avoids losing the `--kamelets-version` setting when the user also specifies a custom Camel version with `--camel-version`

# Target

Manual backport of CAMEL-20086 to 4.0.x
