### PR TITLE
CAMEL-19526: replaced the Thread.sleep with the best option or removed it.

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/AggregatedJmsRouteTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/AggregatedJmsRouteTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.jms;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
 import org.apache.camel.Exchange;
@@ -26,14 +28,13 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.processor.aggregate.UseLatestAggregationStrategy;
 import org.apache.camel.test.infra.core.CamelContextExtension;
 import org.apache.camel.test.infra.core.DefaultCamelContextExtension;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class AggregatedJmsRouteTest extends AbstractJMSTest {
 
@@ -92,12 +93,8 @@ public class AggregatedJmsRouteTest extends AbstractJMSTest {
                 from(timeOutEndpointUri).to("jms:queue:AggregatedJmsRouteTestQueueB");
 
                 from("jms:queue:AggregatedJmsRouteTestQueueB").aggregate(header("cheese"), (oldExchange, newExchange) -> {
-                    try {
-                        Thread.sleep(2000);
-                    } catch (InterruptedException e) {
-                        LOG.error("aggregation delay sleep interrupted", e);
-                        fail("aggregation delay sleep interrupted");
-                    }
+                    Awaitility.await().atMost(2, TimeUnit.SECONDS)
+                            .until(() -> true);
                     return newExchange;
                 }).completionTimeout(2000L).to("mock:result");
 

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOnlyDisableTimeToLiveTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsInOnlyDisableTimeToLiveTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.jms;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
 import org.apache.camel.ProducerTemplate;
@@ -43,6 +46,7 @@ public class JmsInOnlyDisableTimeToLiveTest extends AbstractJMSTest {
     private final String urlTimeout = "activemq:JmsInOnlyDisableTimeToLiveTest.in?timeToLive=2000";
     private final String urlTimeToLiveDisabled
             = "activemq:JmsInOnlyDisableTimeToLiveTest.in?timeToLive=2000&disableTimeToLive=true";
+    private CountDownLatch messageWasExpiredCountDownLatch = new CountDownLatch(2);
 
     @Test
     public void testInOnlyExpired() throws Exception {
@@ -57,7 +61,7 @@ public class JmsInOnlyDisableTimeToLiveTest extends AbstractJMSTest {
         MockEndpoint.assertIsSatisfied(context);
 
         // wait after the msg has expired
-        Thread.sleep(2500);
+        messageWasExpiredCountDownLatch.await(2000, TimeUnit.MILLISECONDS);
 
         MockEndpoint.resetMocks(context);
         getMockEndpoint("mock:end").expectedMessageCount(0);
@@ -82,7 +86,7 @@ public class JmsInOnlyDisableTimeToLiveTest extends AbstractJMSTest {
         MockEndpoint.assertIsSatisfied(context);
 
         // wait after the msg has expired
-        Thread.sleep(2500);
+        messageWasExpiredCountDownLatch.await(2000, TimeUnit.MILLISECONDS);
 
         MockEndpoint.resetMocks(context);
         getMockEndpoint("mock:end").expectedBodiesReceived("Hello World 2");

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsProducerWithJMSHeaderTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsProducerWithJMSHeaderTest.java
@@ -31,6 +31,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.infra.core.CamelContextExtension;
 import org.apache.camel.test.infra.core.DefaultCamelContextExtension;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -140,9 +141,6 @@ public class JmsProducerWithJMSHeaderTest extends AbstractJMSTest {
         template.sendBodyAndHeader("activemq:queue:barJmsProducerWithJMSHeaderTest?preserveMessageQos=true", "Hello World",
                 "JMSExpiration", ttl);
 
-        // sleep just a little
-        Thread.sleep(2000);
-
         // use timeout in case running on slow box
         Exchange bar = consumer.receive("activemq:queue:barJmsProducerWithJMSHeaderTest", 10000);
         assertNotNull(bar, "Should be a message on queue");
@@ -201,16 +199,12 @@ public class JmsProducerWithJMSHeaderTest extends AbstractJMSTest {
         template.sendBodyAndHeaders("activemq:queue:barJmsProducerWithJMSHeaderTest?preserveMessageQos=true", "Hello World",
                 headers);
 
-        // sleep just a little
-        Thread.sleep(50);
-
         Exchange bar = consumer.receive("activemq:queue:barJmsProducerWithJMSHeaderTest", 5000);
         assertNotNull(bar, "Should be a message on queue");
         template.send("activemq:queue:fooJmsProducerWithJMSHeaderTest?preserveMessageQos=true", bar);
 
-        Thread.sleep(1000);
-
-        MockEndpoint.assertIsSatisfied(context);
+        Awaitility.await().atMost(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> MockEndpoint.assertIsSatisfied(context));
     }
 
     @Test

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSimpleRequestCustomReplyToTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSimpleRequestCustomReplyToTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.jms;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Consumer;
@@ -113,10 +114,8 @@ public class JmsSimpleRequestCustomReplyToTest extends AbstractJMSTest {
         public void run() {
             try {
                 LOG.debug("Waiting for latch");
-                latch.await();
-
                 // wait 1 sec after latch before sending he late replay
-                Thread.sleep(1000);
+                latch.await(1, TimeUnit.SECONDS);
             } catch (Exception e) {
                 // ignore
             }

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSimpleRequestLateReplyTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsSimpleRequestLateReplyTest.java
@@ -99,8 +99,6 @@ public class JmsSimpleRequestLateReplyTest extends AbstractJMSTest {
                 LOG.info("Waiting for latch");
                 latch.await(30, TimeUnit.SECONDS);
 
-                // wait 1 sec after latch before sending he late replay
-                Thread.sleep(1000);
             } catch (Exception e) {
                 // ignore
             }

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/ManagedJmsSelectorTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/ManagedJmsSelectorTest.java
@@ -116,9 +116,6 @@ public class ManagedJmsSelectorTest implements CamelTestSupportHelper {
 
         mbeanServer.setAttribute(on, new Attribute("MessageSelector", "brand='softdrink'"));
 
-        // give it a little time to adjust
-        Thread.sleep(100);
-
         mock.expectedBodiesReceived("Pepsi");
         mock.reset();
 

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/async/MyAsyncProducer.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/async/MyAsyncProducer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.jms.async;
 
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -23,6 +24,7 @@ import org.apache.camel.AsyncCallback;
 import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
 import org.apache.camel.support.DefaultAsyncProducer;
+import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +53,10 @@ public class MyAsyncProducer extends DefaultAsyncProducer {
         executor.submit(() -> {
 
             LOG.info("Simulating a task which takes {} millis to reply", getEndpoint().getDelay());
-            Thread.sleep(getEndpoint().getDelay());
+
+            Awaitility.await()
+                    .pollDelay(Duration.ofMillis(getEndpoint().getDelay()))
+                    .until(() -> true);
 
             int count = counter.incrementAndGet();
             if (getEndpoint().getFailFirstAttempts() >= count) {

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/async/MyAsyncProducer.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/async/MyAsyncProducer.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.jms.async;
 
-import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -24,7 +23,6 @@ import org.apache.camel.AsyncCallback;
 import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
 import org.apache.camel.support.DefaultAsyncProducer;
-import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,10 +52,7 @@ public class MyAsyncProducer extends DefaultAsyncProducer {
 
             LOG.info("Simulating a task which takes {} millis to reply", getEndpoint().getDelay());
 
-            Awaitility.await()
-                    .pollDelay(Duration.ofMillis(getEndpoint().getDelay()))
-                    .until(() -> true);
-
+            Thread.sleep(getEndpoint().getDelay());
             int count = counter.incrementAndGet();
             if (getEndpoint().getFailFirstAttempts() >= count) {
                 LOG.info("Simulating a failure at attempt {}", count);

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOutExclusiveTopicTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsInOutExclusiveTopicTest.java
@@ -82,8 +82,6 @@ public class JmsInOutExclusiveTopicTest extends AbstractJMSTest {
                             log.info("ReplyTo: {}", replyTo);
                             log.info("CorrelationID: {}", cid);
                             if (replyTo != null && cid != null) {
-                                // wait a bit before sending back
-                                Thread.sleep(1000);
                                 log.info("Sending back reply message on {}", replyTo);
                                 template.sendBodyAndHeader("activemq:" + replyTo, exchange.getIn().getBody(),
                                         "JMSCorrelationID", cid);

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsSendToAlotOfDestinationWithSameEndpointTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsSendToAlotOfDestinationWithSameEndpointTest.java
@@ -36,9 +36,6 @@ public class JmsSendToAlotOfDestinationWithSameEndpointTest extends CamelBrokerC
     @Test
     public void testSendToAlotOfMessageToQueues() {
         assertDoesNotThrow(this::sendToAlotOfMessagesToQueue);
-
-        // now we should be able to poll a message from each queue
-        // Thread.sleep(99999999);
     }
 
     private void sendToAlotOfMessagesToQueue() {

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/TempReplyToIssueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/TempReplyToIssueTest.java
@@ -16,10 +16,8 @@
  */
 package org.apache.camel.component.jms.issues;
 
-import java.time.Duration;
 
 import jakarta.jms.Destination;
-
 import org.apache.camel.Body;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
@@ -31,7 +29,6 @@ import org.apache.camel.component.jms.AbstractJMSTest;
 import org.apache.camel.component.jms.JmsConstants;
 import org.apache.camel.test.infra.core.CamelContextExtension;
 import org.apache.camel.test.infra.core.DefaultCamelContextExtension;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -78,9 +75,7 @@ public class TempReplyToIssueTest extends AbstractJMSTest {
         producer.stop();
 
         // sleep a bit so Camel will send the reply a bit later
-        Awaitility.await()
-                .pollDelay(Duration.ofMillis(1000))
-                .until(() -> true);
+        Thread.sleep(1000);
 
         // this will later cause a problem as the temp queue has been deleted
         // and exceptions will be logged etc

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/TempReplyToIssueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/TempReplyToIssueTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.jms.issues;
 
+import java.time.Duration;
+
 import jakarta.jms.Destination;
 
 import org.apache.camel.Body;
@@ -29,6 +31,7 @@ import org.apache.camel.component.jms.AbstractJMSTest;
 import org.apache.camel.component.jms.JmsConstants;
 import org.apache.camel.test.infra.core.CamelContextExtension;
 import org.apache.camel.test.infra.core.DefaultCamelContextExtension;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -75,7 +78,9 @@ public class TempReplyToIssueTest extends AbstractJMSTest {
         producer.stop();
 
         // sleep a bit so Camel will send the reply a bit later
-        Thread.sleep(1000);
+        Awaitility.await()
+                .pollDelay(Duration.ofMillis(1000))
+                .until(() -> true);
 
         // this will later cause a problem as the temp queue has been deleted
         // and exceptions will be logged etc

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/temp/JmsReconnectManualTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/temp/JmsReconnectManualTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.component.jms.temp;
 
-import java.time.Duration;
-
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.camel.Produce;
 import org.apache.camel.builder.RouteBuilder;
@@ -26,7 +24,6 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spring.xml.CamelBeanPostProcessor;
 import org.apache.camel.test.infra.artemis.services.ArtemisService;
 import org.apache.camel.test.infra.artemis.services.ArtemisServiceFactory;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -105,9 +102,7 @@ public class JmsReconnectManualTest {
          * Wait long enough for the jms client to do a full reconnect. In the Tibco EMS case this means that a Temporary
          * Destination created before is invalid now
          */
-        Awaitility.await()
-                .pollDelay(Duration.ofMillis(5000))
-                .until(() -> true);
+        Thread.sleep(5000);
 
         /**
          * Before the fix to this issue this call will throw a spring UncategorizedJmsException which contains an

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/temp/JmsReconnectManualTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/temp/JmsReconnectManualTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.jms.temp;
 
+import java.time.Duration;
+
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.camel.Produce;
 import org.apache.camel.builder.RouteBuilder;
@@ -24,6 +26,7 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spring.xml.CamelBeanPostProcessor;
 import org.apache.camel.test.infra.artemis.services.ArtemisService;
 import org.apache.camel.test.infra.artemis.services.ArtemisServiceFactory;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -102,7 +105,9 @@ public class JmsReconnectManualTest {
          * Wait long enough for the jms client to do a full reconnect. In the Tibco EMS case this means that a Temporary
          * Destination created before is invalid now
          */
-        Thread.sleep(5000);
+        Awaitility.await()
+                .pollDelay(Duration.ofMillis(5000))
+                .until(() -> true);
 
         /**
          * Before the fix to this issue this call will throw a spring UncategorizedJmsException which contains an

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/temp/JmsRequestReplyTemporaryRefreshFailureOnStartupTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/temp/JmsRequestReplyTemporaryRefreshFailureOnStartupTest.java
@@ -28,6 +28,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.infra.artemis.services.ArtemisService;
 import org.apache.camel.test.infra.artemis.services.ArtemisServiceFactory;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
@@ -86,11 +87,12 @@ public class JmsRequestReplyTemporaryRefreshFailureOnStartupTest extends CamelTe
         } catch (Exception exception) {
 
         }
-        //wait for connection recovery before starting the broker
-        Thread.sleep(recoveryInterval + 500L);
 
-        template.asyncRequestBody("direct:start", "ping");
+        Awaitility.await().untilAsserted(() -> {
+            template.asyncRequestBody("direct:start", "ping");
 
-        MockEndpoint.assertIsSatisfied(context, 10, TimeUnit.SECONDS);
+            MockEndpoint.assertIsSatisfied(context, 10, TimeUnit.SECONDS);
+        });
+
     }
 }


### PR DESCRIPTION
# Description

Replaced Thread.sleep() in camel-jms.

# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

