### PR TITLE
(chore) ci: add failing tests list on error

### DIFF
--- a/.github/actions/component-test/component-test.sh
+++ b/.github/actions/component-test/component-test.sh
@@ -56,6 +56,15 @@ function main() {
   else
     echo "Launching tests of the projects ${pl}"
     $mavenBinary -l $log $MVND_OPTS install -pl "$pl"
+    ret=$?
+
+    if [[ ${ret} -ne 0 ]] ; then
+      echo "Processing surefire and failsafe reports to create the summary"
+      echo -e "| Failed Test | Duration | Failure Type |\n| --- | --- | --- |"  > "$GITHUB_STEP_SUMMARY"
+      find . -path '*target/*-reports*' -iname '*.txt' -exec .github/actions/incremental-build/parse_errors.sh {} \;
+    fi
+
+    exit $ret
   fi
 }
 

--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -144,9 +144,11 @@ function main() {
     fi
   fi
 
-  echo "Processing surefire and failsafe reports to create the summary"
-  echo -e "| Failed Test | Duration | Failure Type |\n| --- | --- | --- |"  > "$GITHUB_STEP_SUMMARY"
-  find . -path '*target/*-reports*' -iname '*.txt' -exec .github/actions/incremental-build/parse_errors.sh {} \;
+  if [[ ${ret} -ne 0 ]] ; then
+    echo "Processing surefire and failsafe reports to create the summary"
+    echo -e "| Failed Test | Duration | Failure Type |\n| --- | --- | --- |"  > "$GITHUB_STEP_SUMMARY"
+    find . -path '*target/*-reports*' -iname '*.txt' -exec .github/actions/incremental-build/parse_errors.sh {} \;
+  fi
 
   exit $ret
 }


### PR DESCRIPTION
## Motivation

When using the `component-test` Github action, in case of a failure, we would like to have the list of tests that failed to avoid having to look into the log file if possible.

## Modifications:

* Reuse the same approach as the one used with the `incremental-build` to parse and list the errors in case of a build failure
* Update the `incremental-build` to parse and list the errors only in case of a failure
