### PR TITLE
Fix typo on SSLContextParameters javadocs

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/support/jsse/BaseSSLContextParameters.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/jsse/BaseSSLContextParameters.java
@@ -777,7 +777,7 @@ public abstract class BaseSSLContextParameters extends JsseParameters {
     /**
      * Configures a {@code T} based on the related configuration options.
      */
-    interface Configurer<T> {
+    protected interface Configurer<T> {
 
         /**
          * Configures a {@code T} based on the related configuration options. The return value from this method may be

--- a/core/camel-api/src/main/java/org/apache/camel/support/jsse/SSLContextParameters.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/jsse/SSLContextParameters.java
@@ -57,7 +57,7 @@ public class SSLContextParameters extends BaseSSLContextParameters {
 
     /**
      * The optional secure random configuration options to use for constructing the {@link SecureRandom} used in the
-     * creation of an {@link SSLContext].
+     * creation of an {@link SSLContext}.
      */
     private SecureRandomParameters secureRandom;
 


### PR DESCRIPTION
# Description

Fix a typo in the javadocs, and also fix a visibility issue on `BaseSSLContextParameters` class hierarchy

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

