### PR TITLE
CAMEL-20044 Removing the lastResult used in breakOnFirstError 

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
@@ -307,7 +307,7 @@ public class KafkaFetchRecords implements Runnable {
 
             long pollTimeoutMs = kafkaConsumer.getEndpoint().getConfiguration().getPollTimeoutMs();
             Duration pollDuration = Duration.ofMillis(pollTimeoutMs);
-            
+
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Polling {} from {} with timeout: {}", threadId, getPrintableTopic(), pollTimeoutMs);
             }
@@ -325,7 +325,7 @@ public class KafkaFetchRecords implements Runnable {
 
                 ProcessingResult result = recordProcessorFacade.processPolledRecords(allRecords);
                 updateTaskState();
-                
+
                 if (result != null && result.isBreakOnErrorHit() && !this.state.equals(State.PAUSED)) {
                     LOG.debug("We hit an error ... setting flags to force reconnect due to breakOnFirstError");
                     // force re-connect

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
@@ -297,8 +297,6 @@ public class KafkaFetchRecords implements Runnable {
     }
 
     protected void startPolling() {
-        // not sure what we are using this for
-        long partitionLastOffset = -1;
 
         try {
             /*
@@ -366,6 +364,7 @@ public class KafkaFetchRecords implements Runnable {
                         e.getClass().getName(), threadId, getPrintableTopic(), e.getMessage());
             }
 
+            long partitionLastOffset = -1;
             pollExceptionStrategy.handle(partitionLastOffset, e);
         } finally {
             // only close if not retry

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
@@ -332,7 +332,6 @@ public class KafkaFetchRecords implements Runnable {
                         LOG.trace("This polling iteration is using lastresult on partition {} and offset {}",
                                 lastResult.getPartition(), lastResult.getPartitionLastOffset());
                     }
-
                 } else {
                     if (LOG.isTraceEnabled()) {
                         LOG.trace("This polling iteration is using lastresult of null");
@@ -344,9 +343,8 @@ public class KafkaFetchRecords implements Runnable {
                 if (result != null) {
                     if (LOG.isTraceEnabled()) {
                         LOG.trace("This polling iteration had a result returned for partition {} and offset {}",
-                                result.getPartition(), result.getPartitionLastOffset());
+                            result.getPartition(), result.getPartitionLastOffset());
                     }
-
                 } else {
                     if (LOG.isTraceEnabled()) {
                         LOG.trace("This polling iteration had a result returned as null");
@@ -363,8 +361,8 @@ public class KafkaFetchRecords implements Runnable {
                     lastResult = result;
 
                     if (LOG.isTraceEnabled()) {
-                        LOG.trace("setting lastresult to partition {} and offset {}",
-                                lastResult.getPartition(), lastResult.getPartitionLastOffset());
+                        LOG.trace("Setting lastresult to partition {} and offset {}",
+                           lastResult.getPartition(), lastResult.getPartitionLastOffset());
                     }
                 }
 

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
@@ -352,7 +352,7 @@ public class KafkaFetchRecords implements Runnable {
                 }
 
                 updateTaskState();
-                if (result.isBreakOnErrorHit() && !this.state.equals(State.PAUSED)) {
+                if (result != null && result.isBreakOnErrorHit() && !this.state.equals(State.PAUSED)) {
                     LOG.debug("We hit an error ... setting flags to force reconnect");
                     // force re-connect
                     setReconnect(true);

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/support/KafkaRecordProcessor.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/support/KafkaRecordProcessor.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.kafka.consumer.support;
 
+import java.util.stream.StreamSupport;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
@@ -31,8 +33,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.stream.StreamSupport;
 
 public class KafkaRecordProcessor {
 
@@ -112,7 +112,7 @@ public class KafkaRecordProcessor {
         } catch (Exception e) {
             exchange.setException(e);
         }
-        
+
         ProcessingResult result = ProcessingResult.newUnprocessed();
         if (exchange.getException() != null) {
             LOG.debug("An exception was thrown for record at partition {} and offset {}",
@@ -121,13 +121,13 @@ public class KafkaRecordProcessor {
             boolean breakOnErrorExit = processException(exchange, topicPartition, record, exceptionHandler);
             result = new ProcessingResult(breakOnErrorExit, true);
         } else {
-            result = new  ProcessingResult(false, exchange.getException() != null);
+            result = new ProcessingResult(false, exchange.getException() != null);
         }
-        
+
         if (!result.isBreakOnErrorHit()) {
             commitManager.recordOffset(topicPartition, record.offset());
         }
-        
+
         return result;
     }
 
@@ -142,7 +142,7 @@ public class KafkaRecordProcessor {
                 Exception exc = exchange.getException();
                 LOG.warn("Error during processing {} from topic: {} due to {}", exchange, topicPartition.topic(),
                         exc.getMessage());
-                LOG.warn("Will seek consumer to offset {} on partition {} and start polling again.", 
+                LOG.warn("Will seek consumer to offset {} on partition {} and start polling again.",
                         record.offset(), record.partition());
             }
 

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/support/KafkaRecordProcessorFacade.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/support/KafkaRecordProcessorFacade.java
@@ -60,6 +60,8 @@ public class KafkaRecordProcessorFacade {
 
         Set<TopicPartition> partitions = allRecords.partitions();
         Iterator<TopicPartition> partitionIterator = partitions.iterator();
+        
+        LOG.debug("Poll received records on {} partitions", partitions.size());
 
         ProcessingResult lastResult
                 = resultFromPreviousPoll == null ? ProcessingResult.newUnprocessed() : resultFromPreviousPoll;
@@ -67,6 +69,8 @@ public class KafkaRecordProcessorFacade {
         while (partitionIterator.hasNext() && !isStopping()) {
             TopicPartition partition = partitionIterator.next();
 
+            LOG.debug("Processing records on partition {}", partition.partition());
+            
             List<ConsumerRecord<Object, Object>> partitionRecords = allRecords.records(partition);
             Iterator<ConsumerRecord<Object, Object>> recordIterator = partitionRecords.iterator();
 
@@ -75,11 +79,13 @@ public class KafkaRecordProcessorFacade {
             while (!lastResult.isBreakOnErrorHit() && recordIterator.hasNext() && !isStopping()) {
                 ConsumerRecord<Object, Object> record = recordIterator.next();
 
+                LOG.debug("Processing record on partition {} with offset {}", record.partition(), record.offset());
+                
                 lastResult = processRecord(partition, partitionIterator.hasNext(), recordIterator.hasNext(), lastResult,
                         kafkaRecordProcessor, record);
 
-                LOG.debug("Processed record on partition {} and offset {} and got result for partition {} and offset {}",
-                        record.partition(), record.offset(), lastResult.getPartition(), lastResult.getPartitionLastOffset());
+                LOG.debug("Processed record on partition {} with offset {} and got ProcessingResult for partition {} and offset {}",
+                    record.partition(), record.offset(), lastResult.getPartition(), lastResult.getPartitionLastOffset());
 
                 if (consumerListener != null) {
                     if (!consumerListener.afterProcess(lastResult)) {

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/support/KafkaRecordProcessorFacade.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/support/KafkaRecordProcessorFacade.java
@@ -54,21 +54,21 @@ public class KafkaRecordProcessorFacade {
         return camelKafkaConsumer.isStopping();
     }
 
-    public ProcessingResult processPolledRecords( ConsumerRecords<Object, Object> allRecords) {
+    public ProcessingResult processPolledRecords(ConsumerRecords<Object, Object> allRecords) {
         logRecords(allRecords);
-        
+
         ProcessingResult result = ProcessingResult.newUnprocessed();
 
         Set<TopicPartition> partitions = allRecords.partitions();
         Iterator<TopicPartition> partitionIterator = partitions.iterator();
-        
+
         LOG.debug("Poll received records on {} partitions", partitions.size());
 
         while (partitionIterator.hasNext() && !isStopping()) {
             TopicPartition topicPartition = partitionIterator.next();
 
             LOG.debug("Processing records on partition {}", topicPartition.partition());
-            
+
             List<ConsumerRecord<Object, Object>> partitionRecords = allRecords.records(topicPartition);
             Iterator<ConsumerRecord<Object, Object>> recordIterator = partitionRecords.iterator();
 
@@ -78,7 +78,7 @@ public class KafkaRecordProcessorFacade {
                 ConsumerRecord<Object, Object> record = recordIterator.next();
 
                 LOG.debug("Processing record on partition {} with offset {}", record.partition(), record.offset());
-                
+
                 result = processRecord(topicPartition, partitionIterator.hasNext(), recordIterator.hasNext(),
                         kafkaRecordProcessor, record);
 
@@ -127,7 +127,7 @@ public class KafkaRecordProcessorFacade {
         Exchange exchange = camelKafkaConsumer.createExchange(false);
 
         ProcessingResult result = kafkaRecordProcessor.processExchange(exchange, topicPartition, partitionHasNext,
-            recordHasNext, record, camelKafkaConsumer.getExceptionHandler());
+                recordHasNext, record, camelKafkaConsumer.getExceptionHandler());
 
         // success so release the exchange
         camelKafkaConsumer.releaseExchange(exchange, false);

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/support/ProcessingResult.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/support/ProcessingResult.java
@@ -17,37 +17,20 @@
 
 package org.apache.camel.component.kafka.consumer.support;
 
-import org.apache.camel.component.kafka.consumer.AbstractCommitManager;
-
 public final class ProcessingResult {
     private static final ProcessingResult UNPROCESSED_RESULT
-            = new ProcessingResult(
-                    false,
-                    AbstractCommitManager.NON_PARTITION,
-                    AbstractCommitManager.START_OFFSET, false);
+            = new ProcessingResult(false, false);
 
     private final boolean breakOnErrorHit;
-    private final long lastPartition;
-    private final long partitionLastOffset;
     private final boolean failed;
 
-    ProcessingResult(boolean breakOnErrorHit, long lastPartition, long partitionLastOffset, boolean failed) {
+    ProcessingResult(boolean breakOnErrorHit, boolean failed) {
         this.breakOnErrorHit = breakOnErrorHit;
-        this.lastPartition = lastPartition;
-        this.partitionLastOffset = partitionLastOffset;
         this.failed = failed;
     }
 
     public boolean isBreakOnErrorHit() {
         return breakOnErrorHit;
-    }
-
-    public long getPartitionLastOffset() {
-        return partitionLastOffset;
-    }
-
-    public long getPartition() {
-        return lastPartition;
     }
 
     public boolean isFailed() {

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorSeekIssueIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorSeekIssueIT.java
@@ -16,6 +16,11 @@
  */
 package org.apache.camel.component.kafka.integration;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.Endpoint;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
@@ -32,20 +37,11 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-
-
 /**
- * this will test breakOnFirstError functionality
- * and the issue that was surfaced in CAMEL-19894
- * regarding failure to correctly commit the offset
- * in a batch using the Synch Commit Manager
+ * this will test breakOnFirstError functionality and the issue that was surfaced in CAMEL-19894 regarding failure to
+ * correctly commit the offset in a batch using the Synch Commit Manager
  * 
- *  mimics the reproduction of the problem in 
- *  https://github.com/Krivda/camel-bug-reproduction
+ * mimics the reproduction of the problem in https://github.com/Krivda/camel-bug-reproduction
  */
 class KafkaBreakOnFirstErrorSeekIssueIT extends BaseEmbeddedKafkaTestSupport {
 
@@ -53,26 +49,26 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseEmbeddedKafkaTestSupport {
 
     public static final String ROUTE_ID = "breakOnFirstError-19894";
     public static final String TOPIC = "test-foobar";
-    
+
     @EndpointInject("kafka:" + TOPIC
-            + "?groupId=KafkaBreakOnFirstErrorIT"
-            + "&autoOffsetReset=earliest"
-            + "&autoCommitEnable=false"
-            + "&allowManualCommit=true"
-            + "&breakOnFirstError=true"
-            + "&maxPollRecords=8"
-            + "&pollTimeoutMs=1000"
-            + "&keyDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
-            + "&valueDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
-            + "&kafkaManualCommitFactory=#class:org.apache.camel.component.kafka.consumer.DefaultKafkaManualCommitFactory"
-            + "&interceptorClasses=org.apache.camel.component.kafka.MockConsumerInterceptor")
+                    + "?groupId=KafkaBreakOnFirstErrorIT"
+                    + "&autoOffsetReset=earliest"
+                    + "&autoCommitEnable=false"
+                    + "&allowManualCommit=true"
+                    + "&breakOnFirstError=true"
+                    + "&maxPollRecords=8"
+                    + "&pollTimeoutMs=1000"
+                    + "&keyDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+                    + "&valueDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+                    + "&kafkaManualCommitFactory=#class:org.apache.camel.component.kafka.consumer.DefaultKafkaManualCommitFactory"
+                    + "&interceptorClasses=org.apache.camel.component.kafka.MockConsumerInterceptor")
     private Endpoint from;
 
     @EndpointInject("mock:result")
     private MockEndpoint to;
-    
+
     private org.apache.kafka.clients.producer.KafkaProducer<String, String> producer;
-    
+
     @BeforeEach
     public void init() {
         // create the topic w/ 2 partitions
@@ -85,15 +81,15 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseEmbeddedKafkaTestSupport {
         MockConsumerInterceptor.recordsCaptured.clear();
     }
 
-     @AfterEach
-     public void after() {
-         if (producer != null) {
-             producer.close();
-         }
-         // clean all test topics
-         kafkaAdminClient.deleteTopics(Collections.singletonList(TOPIC)).all();
-     }
-    
+    @AfterEach
+    public void after() {
+        if (producer != null) {
+            producer.close();
+        }
+        // clean all test topics
+        kafkaAdminClient.deleteTopics(Collections.singletonList(TOPIC)).all();
+    }
+
     @Test
     void test_camel_19894_test_fix() throws Exception {
         to.reset();
@@ -103,20 +99,19 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseEmbeddedKafkaTestSupport {
         to.expectedBodiesReceived("1", "2", "3", "4");
 
         context.getRouteController().stopRoute(ROUTE_ID);
-        
-        this.publishMessagesToKafka();
-        
-        context.getRouteController().startRoute(ROUTE_ID);
-        
-        Awaitility.await()
-            .timeout(30, TimeUnit.SECONDS)
-            .pollDelay(20, TimeUnit.SECONDS)
-            .until(() -> to.getExchanges().size() == 4);
 
-        
+        this.publishMessagesToKafka();
+
+        context.getRouteController().startRoute(ROUTE_ID);
+
+        Awaitility.await()
+                .timeout(30, TimeUnit.SECONDS)
+                .pollDelay(20, TimeUnit.SECONDS)
+                .until(() -> to.getExchanges().size() == 4);
+
         to.assertIsSatisfied();
     }
-    
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -124,26 +119,26 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseEmbeddedKafkaTestSupport {
             @Override
             public void configure() {
                 from(from)
-                    .routeId(ROUTE_ID)
-                    .autoStartup(false)
-                    .process(exchange -> {
-                        LOG.debug(CamelKafkaUtil.buildKafkaLogMessage("Consuming", exchange, true));
-                    })
-                    .process(exchange -> {
-                        ifIsFifthRecordThrowException(exchange);
-                    })
-                    .to(to)
-                    .end();
+                        .routeId(ROUTE_ID)
+                        .autoStartup(false)
+                        .process(exchange -> {
+                            LOG.debug(CamelKafkaUtil.buildKafkaLogMessage("Consuming", exchange, true));
+                        })
+                        .process(exchange -> {
+                            ifIsFifthRecordThrowException(exchange);
+                        })
+                        .to(to)
+                        .end();
             }
         };
     }
-    
+
     private void ifIsFifthRecordThrowException(Exchange e) {
         if (e.getMessage().getBody().equals("5")) {
             throw new RuntimeException("ERROR_TRIGGERED_BY_TEST");
         }
     }
-    
+
     private void publishMessagesToKafka() {
         final List<String> producedRecordsPartition0 = List.of("5", "6", "7", "8"); //, "9", "10", "11");
         final List<String> producedRecordsPartition1 = List.of("1", "2", "3", "4");
@@ -152,7 +147,7 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseEmbeddedKafkaTestSupport {
             ProducerRecord<String, String> data = new ProducerRecord<>(TOPIC, "0", v);
             producer.send(data);
         });
-        
+
         producedRecordsPartition1.forEach(v -> {
             ProducerRecord<String, String> data = new ProducerRecord<>(TOPIC, "1", v);
             producer.send(data);

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorSeekIssueIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorSeekIssueIT.java
@@ -1,0 +1,146 @@
+package org.apache.camel.component.kafka.integration;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.kafka.MockConsumerInterceptor;
+import org.apache.camel.component.kafka.testutil.CamelKafkaUtil;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * this will test breakOnFirstError functionality
+ * and the issue that was surfaced in CAMEL-19894
+ * regarding failure to correctly commit the offset
+ * in a batch using the Synch Commit Manager
+ * 
+ *  mimics the reproduction of the problem in 
+ *  https://github.com/Krivda/camel-bug-reproduction
+ */
+class KafkaBreakOnFirstErrorSeekIssueIT extends BaseEmbeddedKafkaTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaBreakOnFirstErrorSeekIssueIT.class);
+
+    public static final String ROUTE_ID = "breakOnFirstError-19894";
+    public static final String TOPIC = "test-foobar";
+    
+    @EndpointInject("kafka:" + TOPIC
+            + "?groupId=KafkaBreakOnFirstErrorIT"
+            + "&autoOffsetReset=earliest"
+            + "&autoCommitEnable=false"
+            + "&allowManualCommit=true"
+            + "&breakOnFirstError=true"
+            + "&maxPollRecords=8"
+            + "&pollTimeoutMs=1000"
+            + "&keyDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+            + "&valueDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+            + "&kafkaManualCommitFactory=#class:org.apache.camel.component.kafka.consumer.DefaultKafkaManualCommitFactory"
+            + "&interceptorClasses=org.apache.camel.component.kafka.MockConsumerInterceptor")
+    private Endpoint from;
+
+    @EndpointInject("mock:result")
+    private MockEndpoint to;
+    
+    private org.apache.kafka.clients.producer.KafkaProducer<String, String> producer;
+    
+    @BeforeEach
+    public void init() {
+        // create the topic w/ 2 partitions
+        final NewTopic mytopic = new NewTopic(TOPIC, 2, (short) 1);
+        kafkaAdminClient.createTopics(Collections.singleton(mytopic));
+
+        // setup the producer
+        Properties props = getDefaultProperties();
+        producer = new org.apache.kafka.clients.producer.KafkaProducer<>(props);
+        MockConsumerInterceptor.recordsCaptured.clear();
+    }
+
+     @AfterEach
+     public void after() {
+         if (producer != null) {
+             producer.close();
+         }
+         // clean all test topics
+         kafkaAdminClient.deleteTopics(Collections.singletonList(TOPIC)).all();
+     }
+    
+    @Test
+    void test_camel_19894_test_fix() throws Exception {
+        to.reset();
+        // will consume the payloads from partition 0
+        // and will continually retry the payload with "5"
+        to.expectedMessageCount(4);
+        to.expectedBodiesReceived("1", "2", "3", "4");
+
+        context.getRouteController().stopRoute(ROUTE_ID);
+        
+        this.publishMessagesToKafka();
+        
+        context.getRouteController().startRoute(ROUTE_ID);
+        
+        Awaitility.await()
+            .timeout(30, TimeUnit.SECONDS)
+            .pollDelay(20, TimeUnit.SECONDS)
+            .until(() -> to.getExchanges().size() == 4);
+
+        
+        to.assertIsSatisfied();
+    }
+    
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+
+            @Override
+            public void configure() {
+                from(from)
+                    .routeId(ROUTE_ID)
+                    .autoStartup(false)
+                    .process(exchange -> {
+                        LOG.debug(CamelKafkaUtil.buildKafkaLogMessage("Consuming", exchange, true));
+                    })
+                    .process(exchange -> {
+                        ifIsFifthRecordThrowException(exchange);
+                    })
+                    .to(to)
+                    .end();
+            }
+        };
+    }
+    
+    private void ifIsFifthRecordThrowException(Exchange e) {
+        if (e.getMessage().getBody().equals("5")) {
+            throw new RuntimeException("ERROR_TRIGGERED_BY_TEST");
+        }
+    }
+    
+    private void publishMessagesToKafka() {
+        final List<String> producedRecordsPartition0 = List.of("5", "6", "7", "8"); //, "9", "10", "11");
+        final List<String> producedRecordsPartition1 = List.of("1", "2", "3", "4");
+
+        producedRecordsPartition0.forEach(v -> {
+            ProducerRecord<String, String> data = new ProducerRecord<>(TOPIC, "0", v);
+            producer.send(data);
+        });
+        
+        producedRecordsPartition1.forEach(v -> {
+            ProducerRecord<String, String> data = new ProducerRecord<>(TOPIC, "1", v);
+            producer.send(data);
+        });
+    }
+
+}

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorSeekIssueIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorSeekIssueIT.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.kafka.integration;
 
 import org.apache.camel.Endpoint;

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitIT.java
@@ -1,0 +1,159 @@
+package org.apache.camel.component.kafka.integration;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.kafka.KafkaConstants;
+import org.apache.camel.component.kafka.MockConsumerInterceptor;
+import org.apache.camel.component.kafka.consumer.KafkaManualCommit;
+import org.apache.camel.component.kafka.testutil.CamelKafkaUtil;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * this will test basic breakOnFirstError functionality
+ * uses allowManualCommit and KafkaManualCommit
+ * because relying on Camel default to use NOOP Commit Manager
+ * this means the route implementation MUST manage all offset commits
+ */
+class KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitIT extends BaseEmbeddedKafkaTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitIT.class);
+
+    public static final String ROUTE_ID = "breakOnFirstErrorBatchOnExceptionIT";
+    public static final String TOPIC = "test-foobar";
+
+    @EndpointInject("kafka:" + TOPIC
+            + "?groupId=KafkaBreakOnFirstErrorIT"
+            + "&autoOffsetReset=earliest"
+            + "&autoCommitEnable=false"
+            + "&allowManualCommit=true"
+            + "&breakOnFirstError=true"
+            + "&maxPollRecords=3"
+            + "&pollTimeoutMs=1000"
+            + "&keyDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+            + "&valueDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+            + "&interceptorClasses=org.apache.camel.component.kafka.MockConsumerInterceptor")
+    private Endpoint from;
+
+    @EndpointInject("mock:result")
+    private MockEndpoint to;
+
+    private org.apache.kafka.clients.producer.KafkaProducer<String, String> producer;
+
+    @BeforeEach
+    public void before() {
+        Properties props = getDefaultProperties();
+        producer = new org.apache.kafka.clients.producer.KafkaProducer<>(props);
+        MockConsumerInterceptor.recordsCaptured.clear();
+    }
+
+    @AfterEach
+    public void after() {
+        if (producer != null) {
+            producer.close();
+        }
+        // clean all test topics
+        kafkaAdminClient.deleteTopics(Collections.singletonList(TOPIC)).all();
+    }
+    
+    /**
+     * will continue to retry the message that is in error
+     */
+    @Test
+    public void kafkaBreakOnFirstErrorBasicCapabilityWithoutOnExcepton() throws Exception {
+        to.reset();
+        to.expectedMessageCount(7);
+        
+        // old behavior before the fix
+        // message-3 causes an error 
+        // and breakOnFirstError will cause it to be retried 1x
+        // then we move on
+        //to.expectedBodiesReceivedInAnyOrder("message-0", "message-1", "message-2", "message-3", "message-3", "message-4", "message-5");
+        
+        // new behavior w/ NOOP Commit Manager
+        to.expectedBodiesReceivedInAnyOrder("message-0", "message-1", "message-2", "message-3", "message-4", "message-5");
+        
+        this.publishMessagesToKafka();
+        
+        context.getRouteController().stopRoute(ROUTE_ID);
+        context.getRouteController().startRoute(ROUTE_ID);
+        
+        Awaitility.await()
+            .atMost(3, TimeUnit.SECONDS)
+            .until(() -> to.getExchanges().size() > 5);
+
+        to.assertIsSatisfied(3000);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+
+            @Override
+            public void configure() {
+                onException(Exception.class)
+                    .handled(false)
+                    // adding error message to end
+                    // so we can account for it
+                    .to(to)
+                    .process(exchange -> {
+                        // if we don't commit 
+                        // camel will continuously 
+                        // retry the message with an error
+                        doCommitOffset(exchange);
+                    });
+                
+                from(from)
+                    .routeId(ROUTE_ID)
+                    .process(exchange -> {
+                        LOG.debug(CamelKafkaUtil.buildKafkaLogMessage("Consuming", exchange, true));
+                    })
+                    .process(exchange -> {
+                        ifIsPayloadWithErrorThrowException(exchange);
+                    })
+                    .to(to)
+                    .process(exchange -> {
+                        doCommitOffset(exchange);
+                    });
+            }
+        };
+    }
+
+    private void publishMessagesToKafka() {
+        for (int i = 0; i < 6; i++) {
+            String msg = "message-" + i;
+            ProducerRecord<String, String> data = new ProducerRecord<>(TOPIC, null, msg);
+            producer.send(data);
+        }
+    }
+    
+    private void doCommitOffset(Exchange exchange) {
+        LOG.debug(CamelKafkaUtil.buildKafkaLogMessage("Committing", exchange, true));
+        KafkaManualCommit manual = exchange.getMessage()
+            .getHeader(KafkaConstants.MANUAL_COMMIT, KafkaManualCommit.class);
+        assertNotNull(manual);
+        manual.commit();
+    }
+    
+    private void ifIsPayloadWithErrorThrowException(Exchange exchange) {
+        String payload = exchange.getMessage().getBody(String.class);
+        if (payload.equals("message-3")) {
+            throw new RuntimeException("ERROR TRIGGERED BY TEST");
+        }
+    }
+    
+}

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitIT.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.kafka.integration;
 
 import org.apache.camel.Endpoint;

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT.java
@@ -1,0 +1,162 @@
+package org.apache.camel.component.kafka.integration;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.kafka.KafkaConstants;
+import org.apache.camel.component.kafka.MockConsumerInterceptor;
+import org.apache.camel.component.kafka.consumer.KafkaManualCommit;
+import org.apache.camel.component.kafka.testutil.CamelKafkaUtil;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * this will test basic breakOnFirstError functionality
+ * uses allowManualCommit and KafkaManualCommit
+ * because relying on Camel default to use NOOP Commit Manager
+ * this means the route implementation MUST manage all offset commits
+ * 
+ * will demonstrate how to retry
+ */
+class KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT extends BaseEmbeddedKafkaTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT.class);
+
+    public static final String ROUTE_ID = "breakOnFirstErrorBatchRetryIT";
+    public static final String TOPIC = "test-foobar";
+
+    @EndpointInject("kafka:" + TOPIC
+            + "?groupId=KafkaBreakOnFirstErrorIT"
+            + "&autoOffsetReset=earliest"
+            + "&autoCommitEnable=false"
+            + "&allowManualCommit=true"
+            + "&breakOnFirstError=true"
+            + "&maxPollRecords=3"
+            + "&pollTimeoutMs=1000"
+            + "&keyDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+            + "&valueDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+            + "&interceptorClasses=org.apache.camel.component.kafka.MockConsumerInterceptor")
+    private Endpoint from;
+
+    @EndpointInject("mock:result")
+    private MockEndpoint to;
+
+    private org.apache.kafka.clients.producer.KafkaProducer<String, String> producer;
+
+    @BeforeEach
+    public void before() {
+        Properties props = getDefaultProperties();
+        producer = new org.apache.kafka.clients.producer.KafkaProducer<>(props);
+        MockConsumerInterceptor.recordsCaptured.clear();
+    }
+
+    @AfterEach
+    public void after() {
+        if (producer != null) {
+            producer.close();
+        }
+        // clean all test topics
+        kafkaAdminClient.deleteTopics(Collections.singletonList(TOPIC)).all();
+    }
+    
+    /**
+     * will continue to retry the message that is in error
+     */
+    @Test
+    public void kafkaBreakOnFirstErrorBasicCapabilityWithoutOnExcepton() throws Exception {
+        to.reset();
+        
+        this.publishMessagesToKafka();
+        
+        context.getRouteController().stopRoute(ROUTE_ID);
+        context.getRouteController().startRoute(ROUTE_ID);
+        
+        Awaitility.await()
+            .atMost(3, TimeUnit.SECONDS)
+            .until(() -> to.getExchanges().size() > 7);
+        
+        
+        assertFalse(to.getExchanges().stream()
+            .anyMatch(exc -> "message-4".equals(exc.getMessage().getBody(String.class))));
+
+        assertFalse(to.getExchanges().stream()
+            .anyMatch(exc -> "message-5".equals(exc.getMessage().getBody(String.class))));
+
+       assertTrue(to.getExchanges().stream() 
+           .filter(exc -> "message-3".equals(exc.getMessage().getBody(String.class)))
+           .count() > 1);
+       
+        to.assertIsSatisfied(3000);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+
+            @Override
+            public void configure() {
+                onException(Exception.class)
+                    .handled(false)
+                    // adding error message to end
+                    // so we can account for it
+                    .to(to)
+                    // we are not 
+                    // going to commit offset
+                    // so will retry
+                    .end();
+                
+                from(from)
+                    .routeId(ROUTE_ID)
+                    .process(exchange -> {
+                        LOG.debug(CamelKafkaUtil.buildKafkaLogMessage("Consuming", exchange, true));
+                    })
+                    .process(exchange -> {
+                        ifIsPayloadWithErrorThrowException(exchange);
+                    })
+                    .to(to)
+                    .process(exchange -> {
+                        doCommitOffset(exchange);
+                    });
+            }
+        };
+    }
+
+    private void publishMessagesToKafka() {
+        for (int i = 0; i < 6; i++) {
+            String msg = "message-" + i;
+            ProducerRecord<String, String> data = new ProducerRecord<>(TOPIC, null, msg);
+            producer.send(data);
+        }
+    }
+    
+    private void doCommitOffset(Exchange exchange) {
+        LOG.debug(CamelKafkaUtil.buildKafkaLogMessage("Committing", exchange, true));
+        KafkaManualCommit manual = exchange.getMessage()
+            .getHeader(KafkaConstants.MANUAL_COMMIT, KafkaManualCommit.class);
+        assertNotNull(manual);
+        manual.commit();
+    }
+    
+    private void ifIsPayloadWithErrorThrowException(Exchange exchange) {
+        String payload = exchange.getMessage().getBody(String.class);
+        if (payload.equals("message-3")) {
+            throw new RuntimeException("ERROR TRIGGERED BY TEST");
+        }
+    }
+    
+}

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.kafka.integration;
 
 import org.apache.camel.Endpoint;

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT.java
@@ -16,6 +16,10 @@
  */
 package org.apache.camel.component.kafka.integration;
 
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.Endpoint;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
@@ -33,40 +37,35 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * this will test basic breakOnFirstError functionality
- * uses allowManualCommit and KafkaManualCommit
- * because relying on Camel default to use NOOP Commit Manager
- * this means the route implementation MUST manage all offset commits
+ * this will test basic breakOnFirstError functionality uses allowManualCommit and KafkaManualCommit because relying on
+ * Camel default to use NOOP Commit Manager this means the route implementation MUST manage all offset commits
  * 
  * will demonstrate how to retry
  */
 class KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT extends BaseEmbeddedKafkaTestSupport {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT.class);
+    private static final Logger LOG
+            = LoggerFactory.getLogger(KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT.class);
 
     public static final String ROUTE_ID = "breakOnFirstErrorBatchRetryIT";
     public static final String TOPIC = "test-foobar";
 
     @EndpointInject("kafka:" + TOPIC
-            + "?groupId=KafkaBreakOnFirstErrorIT"
-            + "&autoOffsetReset=earliest"
-            + "&autoCommitEnable=false"
-            + "&allowManualCommit=true"
-            + "&breakOnFirstError=true"
-            + "&maxPollRecords=3"
-            + "&pollTimeoutMs=1000"
-            + "&keyDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
-            + "&valueDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
-            + "&interceptorClasses=org.apache.camel.component.kafka.MockConsumerInterceptor")
+                    + "?groupId=KafkaBreakOnFirstErrorIT"
+                    + "&autoOffsetReset=earliest"
+                    + "&autoCommitEnable=false"
+                    + "&allowManualCommit=true"
+                    + "&breakOnFirstError=true"
+                    + "&maxPollRecords=3"
+                    + "&pollTimeoutMs=1000"
+                    + "&keyDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+                    + "&valueDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+                    + "&interceptorClasses=org.apache.camel.component.kafka.MockConsumerInterceptor")
     private Endpoint from;
 
     @EndpointInject("mock:result")
@@ -89,34 +88,33 @@ class KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT extends BaseE
         // clean all test topics
         kafkaAdminClient.deleteTopics(Collections.singletonList(TOPIC)).all();
     }
-    
+
     /**
      * will continue to retry the message that is in error
      */
     @Test
     public void kafkaBreakOnFirstErrorBasicCapabilityWithoutOnExcepton() throws Exception {
         to.reset();
-        
+
         this.publishMessagesToKafka();
-        
+
         context.getRouteController().stopRoute(ROUTE_ID);
         context.getRouteController().startRoute(ROUTE_ID);
-        
+
         Awaitility.await()
-            .atMost(3, TimeUnit.SECONDS)
-            .until(() -> to.getExchanges().size() > 7);
-        
-        
-        assertFalse(to.getExchanges().stream()
-            .anyMatch(exc -> "message-4".equals(exc.getMessage().getBody(String.class))));
+                .atMost(3, TimeUnit.SECONDS)
+                .until(() -> to.getExchanges().size() > 7);
 
         assertFalse(to.getExchanges().stream()
-            .anyMatch(exc -> "message-5".equals(exc.getMessage().getBody(String.class))));
+                .anyMatch(exc -> "message-4".equals(exc.getMessage().getBody(String.class))));
 
-       assertTrue(to.getExchanges().stream() 
-           .filter(exc -> "message-3".equals(exc.getMessage().getBody(String.class)))
-           .count() > 1);
-       
+        assertFalse(to.getExchanges().stream()
+                .anyMatch(exc -> "message-5".equals(exc.getMessage().getBody(String.class))));
+
+        assertTrue(to.getExchanges().stream()
+                .filter(exc -> "message-3".equals(exc.getMessage().getBody(String.class)))
+                .count() > 1);
+
         to.assertIsSatisfied(3000);
     }
 
@@ -127,27 +125,27 @@ class KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT extends BaseE
             @Override
             public void configure() {
                 onException(Exception.class)
-                    .handled(false)
-                    // adding error message to end
-                    // so we can account for it
-                    .to(to)
-                    // we are not 
-                    // going to commit offset
-                    // so will retry
-                    .end();
-                
+                        .handled(false)
+                        // adding error message to end
+                        // so we can account for it
+                        .to(to)
+                        // we are not 
+                        // going to commit offset
+                        // so will retry
+                        .end();
+
                 from(from)
-                    .routeId(ROUTE_ID)
-                    .process(exchange -> {
-                        LOG.debug(CamelKafkaUtil.buildKafkaLogMessage("Consuming", exchange, true));
-                    })
-                    .process(exchange -> {
-                        ifIsPayloadWithErrorThrowException(exchange);
-                    })
-                    .to(to)
-                    .process(exchange -> {
-                        doCommitOffset(exchange);
-                    });
+                        .routeId(ROUTE_ID)
+                        .process(exchange -> {
+                            LOG.debug(CamelKafkaUtil.buildKafkaLogMessage("Consuming", exchange, true));
+                        })
+                        .process(exchange -> {
+                            ifIsPayloadWithErrorThrowException(exchange);
+                        })
+                        .to(to)
+                        .process(exchange -> {
+                            doCommitOffset(exchange);
+                        });
             }
         };
     }
@@ -159,20 +157,20 @@ class KafkaBreakOnFirstErrorWithBatchUsingKafkaManualCommitRetryIT extends BaseE
             producer.send(data);
         }
     }
-    
+
     private void doCommitOffset(Exchange exchange) {
         LOG.debug(CamelKafkaUtil.buildKafkaLogMessage("Committing", exchange, true));
         KafkaManualCommit manual = exchange.getMessage()
-            .getHeader(KafkaConstants.MANUAL_COMMIT, KafkaManualCommit.class);
+                .getHeader(KafkaConstants.MANUAL_COMMIT, KafkaManualCommit.class);
         assertNotNull(manual);
         manual.commit();
     }
-    
+
     private void ifIsPayloadWithErrorThrowException(Exchange exchange) {
         String payload = exchange.getMessage().getBody(String.class);
         if (payload.equals("message-3")) {
             throw new RuntimeException("ERROR TRIGGERED BY TEST");
         }
     }
-    
+
 }

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingSynchCommitManagerIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingSynchCommitManagerIT.java
@@ -1,0 +1,140 @@
+package org.apache.camel.component.kafka.integration;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.kafka.MockConsumerInterceptor;
+import org.apache.camel.component.kafka.testutil.CamelKafkaUtil;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * this will test basic breakOnFirstError functionality
+ * uses allowManualCommit and set Synch Commit Manager
+ * this allows Camel to handle when to commit an offset
+ */
+class KafkaBreakOnFirstErrorWithBatchUsingSynchCommitManagerIT extends BaseEmbeddedKafkaTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaBreakOnFirstErrorWithBatchUsingSynchCommitManagerIT.class);
+
+    private final List<String> errorPayloads = new CopyOnWriteArrayList<>();
+    
+    public static final String ROUTE_ID = "breakOnFirstErrorBatchIT";
+    public static final String TOPIC = "test-foobar";
+
+    @EndpointInject("kafka:" + TOPIC
+            + "?groupId=KafkaBreakOnFirstErrorIT"
+            + "&autoOffsetReset=earliest"
+            + "&autoCommitEnable=false"
+            + "&allowManualCommit=true"
+            + "&breakOnFirstError=true"
+            + "&maxPollRecords=3"
+            + "&pollTimeoutMs=1000"
+            + "&keyDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+            + "&valueDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+            + "&kafkaManualCommitFactory=#class:org.apache.camel.component.kafka.consumer.DefaultKafkaManualCommitFactory"
+            + "&interceptorClasses=org.apache.camel.component.kafka.MockConsumerInterceptor")
+    private Endpoint from;
+
+    @EndpointInject("mock:result")
+    private MockEndpoint to;
+
+    private org.apache.kafka.clients.producer.KafkaProducer<String, String> producer;
+
+    @BeforeEach
+    public void before() {
+        Properties props = getDefaultProperties();
+        producer = new org.apache.kafka.clients.producer.KafkaProducer<>(props);
+        MockConsumerInterceptor.recordsCaptured.clear();
+    }
+
+    @AfterEach
+    public void after() {
+        if (producer != null) {
+            producer.close();
+        }
+        // clean all test topics
+        kafkaAdminClient.deleteTopics(Collections.singletonList(TOPIC)).all();
+    }
+    
+    /**
+     * will continue to retry the message that is in error
+     */
+    @Test
+    public void kafkaBreakOnFirstErrorBasicCapabilityWithoutOnExcepton() throws Exception {
+        to.reset();
+        to.expectedMessageCount(3);
+        // message-3 causes an error 
+        // and breakOnFirstError will cause it to be retried forever
+        // we will never get to message-4
+        to.expectedBodiesReceived("message-0", "message-1", "message-2");
+
+        context.getRouteController().stopRoute(ROUTE_ID);
+        
+        this.publishMessagesToKafka();
+
+        context.getRouteController().startRoute(ROUTE_ID);
+        
+        Awaitility.await()
+            .atMost(3, TimeUnit.SECONDS)
+            .until(() -> errorPayloads.size() > 3);
+
+        to.assertIsSatisfied();
+        
+        for (String payload : errorPayloads) {
+            assertEquals("message-3", payload);
+        }
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+
+            @Override
+            public void configure() {
+                from(from)
+                    .routeId(ROUTE_ID)
+                    .process(exchange -> {
+                        LOG.debug(CamelKafkaUtil.buildKafkaLogMessage("Consuming", exchange, true));
+                    })
+                    .process(exchange -> {
+                        ifIsPayloadWithErrorThrowException(exchange);
+                    })
+                    .to(to)
+                    .end();
+            }
+        };
+    }
+
+    private void publishMessagesToKafka() {
+        for (int i = 0; i < 5; i++) {
+            String msg = "message-" + i;
+            ProducerRecord<String, String> data = new ProducerRecord<>(TOPIC, null, msg);
+            producer.send(data);
+        }
+    }
+    
+    private void ifIsPayloadWithErrorThrowException(Exchange exchange) {
+        String payload = exchange.getMessage().getBody(String.class);
+        if (payload.equals("message-3")) {
+            errorPayloads.add(payload);
+            throw new RuntimeException("ERROR TRIGGERED BY TEST");
+        }
+    }
+    
+}

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingSynchCommitManagerIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingSynchCommitManagerIT.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.kafka.integration;
 
 import org.apache.camel.Endpoint;

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/testutil/CamelKafkaUtil.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/testutil/CamelKafkaUtil.java
@@ -1,0 +1,38 @@
+package org.apache.camel.component.kafka.testutil;
+
+
+import org.apache.camel.Exchange;
+import org.apache.camel.component.kafka.KafkaConstants;
+
+import java.util.Objects;
+
+public final class CamelKafkaUtil {
+
+    public static String buildKafkaLogMessage(String msg, Exchange exchange, boolean includeBody) {
+        String eol = "\n";
+
+        StringBuilder sb = new StringBuilder();
+        if (Objects.nonNull(msg)) {
+            sb.append(msg);
+            sb.append(eol);
+        }
+
+        sb.append("Message consumed from ");
+        sb.append(exchange.getMessage().getHeader(KafkaConstants.TOPIC, String.class));
+        sb.append(eol);
+        sb.append("The Partition:Offset is ");
+        sb.append(exchange.getMessage().getHeader(KafkaConstants.PARTITION, String.class));
+        sb.append(":");
+        sb.append(exchange.getMessage().getHeader(KafkaConstants.OFFSET, String.class));
+        sb.append(eol);
+        sb.append("The Key is ");
+        sb.append(exchange.getMessage().getHeader(KafkaConstants.KEY, String.class));
+        
+        if (includeBody) {
+            sb.append(eol);
+            sb.append(exchange.getMessage().getBody(String.class));
+        }
+
+        return sb.toString();
+    }
+}

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/testutil/CamelKafkaUtil.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/testutil/CamelKafkaUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.kafka.testutil;
 
 

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/testutil/CamelKafkaUtil.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/testutil/CamelKafkaUtil.java
@@ -16,11 +16,10 @@
  */
 package org.apache.camel.component.kafka.testutil;
 
+import java.util.Objects;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.component.kafka.KafkaConstants;
-
-import java.util.Objects;
 
 public final class CamelKafkaUtil {
 
@@ -43,7 +42,7 @@ public final class CamelKafkaUtil {
         sb.append(eol);
         sb.append("The Key is ");
         sb.append(exchange.getMessage().getHeader(KafkaConstants.KEY, String.class));
-        
+
         if (includeBody) {
             sb.append(eol);
             sb.append(exchange.getMessage().getBody(String.class));


### PR DESCRIPTION
# Description

This PR is adding onto what is in https://github.com/apache/camel/pull/11959
It shows that we can remove the `lastResult` from the code if we go with the changes proposed in this PR

# Target

camel-3.21.x

# Tracking
CAMEL-20044