### PR TITLE
CAMEL-20044 Update Camel docs for breakOnFirstError 

### DIFF
--- a/components/camel-kafka/src/main/docs/kafka-component.adoc
+++ b/components/camel-kafka/src/main/docs/kafka-component.adoc
@@ -85,6 +85,24 @@ Camel components have.
 For advanced control a custom implementation of `org.apache.camel.component.kafka.PollExceptionStrategy` can be configured
 on the component level, which allows to control which exceptions causes which of the strategies above.
 
+== Consumer error handling (advanced)
+
+By default Camel will poll using the *ERROR_HANDLER* to process exceptions. 
+How Camel handles a message that results in an exception can be altered using the `breakOnFirstError` attribute in the configuration.
+Instead of continuing to poll next message, Camel will instead commit the offset so that the message that caused the exception will be retried.
+This is similar to the *RETRY* polling strategy above. 
+
+[source,java]
+----
+KafkaComponent kafka = new KafkaComponent();
+kafka.setBreakOnFirstError(true);
+...
+camelContext.addComponent("kafka", kafka);
+----
+
+It is recommended that you read the section below "Using manual commit with Kafka consumer" to understand how `breakOnFirstError`
+will work based on the `CommitManager` that is configured.
+
 == Samples
 
 === Consuming messages from Kafka
@@ -351,12 +369,15 @@ or on the endpoint, for example:
 [source,java]
 ----
 KafkaComponent kafka = new KafkaComponent();
+kafka.setAutoCommitEnable(false);
 kafka.setAllowManualCommit(true);
 ...
 camelContext.addComponent("kafka", kafka);
 ----
 
-Then you can use the `KafkaManualCommit` from Java code such as a Camel `Processor`:
+By default this will use the `NoopCommitManager` behind the scenes. In order to commit an offset you will 
+required you to use the `KafkaManualCommit` from Java code such as a Camel `Processor`:
+
 [source,java]
 ----
 public void process(Exchange exchange) {
@@ -366,13 +387,34 @@ public void process(Exchange exchange) {
 }
 ----
 
-This will force a synchronous commit which will block until the commit is acknowledged on Kafka, or if it fails an exception is thrown.
+The `KafkaManualCommit` will force a synchronous commit which will block until the commit is acknowledged on Kafka, or if it fails an exception is thrown.
 You can use an asynchronous commit as well by configuring the `KafkaManualCommitFactory` with the `DefaultKafkaManualAsyncCommitFactory` implementation.
 
 Then the commit will be done in the next consumer loop using the kafka asynchronous commit api.
 
 If you want to use a custom implementation of `KafkaManualCommit` then you can configure a custom `KafkaManualCommitFactory`
 on the `KafkaComponent` that creates instances of your custom implementation.
+
+When configuring a consumer to use manual commit and a specific `CommitManager` it is important to understand how these influence the behavior 
+of `breakOnFirstError`
+
+[source,java]
+----
+KafkaComponent kafka = new KafkaComponent();
+kafka.setAutoCommitEnable(false);
+kafka.setAllowManualCommit(true);
+kafka.setBreakOnFirstError(true);
+kafka.setKafkaManualCommitFactory(new DefaultKafkaManualCommitFactory());
+...
+camelContext.addComponent("kafka", kafka);
+----
+
+When the `CommitManager` is left to the default `NoopCommitManager` then `breakOnFirstError` will not automatically commit the offset so that the 
+message with an error is retried. The consumer must manage that in the route using `KafkaManualCommit`.
+
+
+When the `CommitManager` is changed to either the synch or asynch manager then `breakOnFirstError` will automatically commit the offset so that the 
+message with an error is retried. This message will be continually retried until it can be processed without an error.
 
 *Note 1*: records from a partition must be processed and committed by the same thread as the consumer. This means that certain EIPs, async or concurrent operations
 in the DSL, may cause the commit to fail. In such circumstances, tyring to commit the transaction will cause the Kafka client to throw a `java.util.ConcurrentModificationException`

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConfiguration.java
@@ -819,7 +819,14 @@ public class KafkaConfiguration implements Cloneable, HeaderFilterStrategyAware 
     /**
      * This options controls what happens when a consumer is processing an exchange and it fails. If the option is
      * <tt>false</tt> then the consumer continues to the next message and processes it. If the option is <tt>true</tt>
-     * then the consumer breaks out, and will seek back to offset of the message that caused a failure, and then
+     * then the consumer breaks out. 
+     * 
+     * Using the default NoopCommitManager will cause the consumer to not commit the offset so 
+     * that the message is re-attempted. The consumer should use the KafkaManualCommit to
+     * determine the best way to handle the message.
+     * 
+     * Using either the SynchCommitManager or the AsynchCommitManager the consumer will 
+     * seek back to the offset of the message that caused a failure, and then
      * re-attempt to process this message. However this can lead to endless processing of the same message if its bound
      * to fail every time, eg a poison message. Therefore its recommended to deal with that for example by using Camel's
      * error handler.

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_21.adoc
@@ -4,6 +4,22 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 3.x to 3.y. For example if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
 from both 3.0 to 3.1 and 3.1 to 3.2.
 
+== Upgrading Camel 3.21 to 3.21.3
+
+=== camel-kafka
+
+The behavior for `breakOnFirstError` was altered as numerous issues were fixed. The behavior related to committing 
+the offset is now determined by the `CommitManager` that is configured. 
+
+When the default `CommitManager` is used (`NoopCommitManager`) then no commit is performed. The route implementation will
+be responsible for managing the offset using `KafkaManualCommit` to manage the retrying of the payload.
+
+When using the `SyncCommitManager` then the offset will be committed so that the payload is continually retried. This was
+the behavior described in the documentation.
+
+When using the `AsyncCommitManager` then the offset will be committed so that the payload is continually retried. This was
+the behavior described in the documentation.
+
 == Upgrading Camel 3.20 to 3.21
 
 === camel-core


### PR DESCRIPTION
# Description

The PRs associated with CAMEL-20044 impact how `breakOnFirstError` works based on how the `CommitManager` is configured. 

# Target

camel-3.21.x

# Tracking
CAMEL-20044