### PR TITLE
CAMEL-20113: test module cleanups

### DIFF
--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/customerrelations/CustomerServicesTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/customerrelations/CustomerServicesTest.java
@@ -71,7 +71,7 @@ public class CustomerServicesTest {
         }
     }
 
-    class HeaderChecker extends AbstractPhaseInterceptor<Message> {
+    static class HeaderChecker extends AbstractPhaseInterceptor<Message> {
 
         HeaderChecker(String phase) {
             super(phase);

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/doc/DataFormatComponentConfigurationAndDocumentationTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/doc/DataFormatComponentConfigurationAndDocumentationTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @EnabledIfSystemProperty(named = "enable.documentation.itests", matches = "true")
@@ -58,11 +59,11 @@ public class DataFormatComponentConfigurationAndDocumentationTest extends CamelT
             assertNotNull(found);
             assertEquals("textQualifier", found.getName());
             assertEquals("attribute", found.getKind());
-            assertEquals(false, found.isRequired());
+            assertFalse(found.isRequired());
             assertEquals("string", found.getType());
             assertEquals("java.lang.String", found.getJavaType());
-            assertEquals(false, found.isDeprecated());
-            assertEquals(false, found.isSecret());
+            assertFalse(found.isDeprecated());
+            assertFalse(found.isSecret());
             assertEquals("If the text is qualified with a character. Uses quote character by default.", found.getDescription());
         }
     }
@@ -84,11 +85,11 @@ public class DataFormatComponentConfigurationAndDocumentationTest extends CamelT
             assertNotNull(found);
             assertEquals("escapeChar", found.getName());
             assertEquals("attribute", found.getKind());
-            assertEquals(false, found.isRequired());
+            assertFalse(found.isRequired());
             assertEquals("string", found.getType());
             assertEquals("java.lang.String", found.getJavaType());
-            assertEquals(false, found.isDeprecated());
-            assertEquals(false, found.isSecret());
+            assertFalse(found.isDeprecated());
+            assertFalse(found.isSecret());
             assertEquals("\\", found.getDefaultValue());
             assertEquals("The escape character.", found.getDescription());
         }

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/doc/EipDocumentationTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/doc/EipDocumentationTest.java
@@ -57,7 +57,7 @@ public class EipDocumentationTest extends CamelTestSupport {
         try (CamelContext context = new DefaultCamelContext()) {
             String json = ((CatalogCamelContext) context).getEipParameterJsonSchema("split");
             LOG.info(json);
-            assertNotNull("Should have found json for split", json);
+            assertNotNull(json, "Should have found json for split");
 
             assertTrue(json.contains("\"name\": \"split\""));
             // there should be javadoc included
@@ -73,7 +73,7 @@ public class EipDocumentationTest extends CamelTestSupport {
         try (CamelContext context = new DefaultCamelContext()) {
             String json = ((CatalogCamelContext) context).getEipParameterJsonSchema("simple");
             LOG.info(json);
-            assertNotNull("Should have found json for simple", json);
+            assertNotNull(json, "Should have found json for simple");
 
             assertTrue(json.contains("\"label\": \"language,core,java\""));
             assertTrue(json.contains("\"name\": \"simple\""));
@@ -85,7 +85,7 @@ public class EipDocumentationTest extends CamelTestSupport {
         try (CamelContext context = new DefaultCamelContext()) {
             String json = ((CatalogCamelContext) context).getEipParameterJsonSchema("failover");
             LOG.info(json);
-            assertNotNull("Should have found json for failover", json);
+            assertNotNull(json, "Should have found json for failover");
 
             assertTrue(json.contains("\"name\": \"failover\""));
             assertTrue(json.contains(

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/ftp/FtpInitialConnectTimeoutTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/ftp/FtpInitialConnectTimeoutTest.java
@@ -59,41 +59,35 @@ public class FtpInitialConnectTimeoutTest extends CamelTestSupport {
             final AtomicBoolean timeout = new AtomicBoolean();
 
             try {
-                doAnswer(new Answer<InputStream>() {
-                    @Override
-                    public InputStream answer(InvocationOnMock invocation) throws Throwable {
-                        final InputStream stream = (InputStream) invocation.callRealMethod();
+                doAnswer((Answer<InputStream>) invocation12 -> {
+                    final InputStream stream = (InputStream) invocation12.callRealMethod();
 
-                        InputStream inputStream = new InputStream() {
-                            @Override
-                            public int read() throws IOException {
-                                if (timeout.get()) {
-                                    // emulate a timeout occurring in _getReply()
-                                    throw new SocketTimeoutException();
-                                }
-                                return stream.read();
+                    InputStream inputStream = new InputStream() {
+                        @Override
+                        public int read() throws IOException {
+                            if (timeout.get()) {
+                                // emulate a timeout occurring in _getReply()
+                                throw new SocketTimeoutException();
                             }
-                        };
+                            return stream.read();
+                        }
+                    };
 
-                        return inputStream;
-                    }
+                    return inputStream;
                 }).when(socket).getInputStream();
             } catch (IOException ignored) {
             }
 
             try {
-                doAnswer(new Answer<Object>() {
-                    @Override
-                    public Object answer(InvocationOnMock invocation) throws Throwable {
-                        if ((Integer) invocation.getArguments()[0] == CONNECT_TIMEOUT) {
-                            // setting of connect timeout
-                            timeout.set(true);
-                        } else {
-                            // non-connect timeout
-                            timeout.set(false);
-                        }
-                        return invocation.callRealMethod();
+                doAnswer((Answer<Object>) invocation1 -> {
+                    if ((Integer) invocation1.getArguments()[0] == CONNECT_TIMEOUT) {
+                        // setting of connect timeout
+                        timeout.set(true);
+                    } else {
+                        // non-connect timeout
+                        timeout.set(false);
                     }
+                    return invocation1.callRealMethod();
                 }).when(socket).setSoTimeout(anyInt());
             } catch (SocketException e) {
                 throw new RuntimeException(e);

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/greeter/JettyRecipientListCxfIssueTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/greeter/JettyRecipientListCxfIssueTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.itest.greeter;
 import java.io.File;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.junit.jupiter.api.Test;
@@ -57,12 +56,9 @@ public class JettyRecipientListCxfIssueTest extends CamelSpringTestSupport {
         assertNotNull(request);
 
         // send a message to jetty
-        Exchange out = template.request("http://0.0.0.0:{{RecipientListCxfTest.port3}}/myapp", new Processor() {
-            @Override
-            public void process(Exchange exchange) {
-                exchange.getIn().setHeader("operationName", "greetMe");
-                exchange.getIn().setBody(request);
-            }
+        Exchange out = template.request("http://0.0.0.0:{{RecipientListCxfTest.port3}}/myapp", exchange -> {
+            exchange.getIn().setHeader("operationName", "greetMe");
+            exchange.getIn().setBody(request);
         });
 
         assertNotNull(out);

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/greeter/Server.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/greeter/Server.java
@@ -40,7 +40,7 @@ public class Server {
         }
     }
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
         Server server = new Server();
         LOG.info("Server ready...");
         server.start();

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/issues/JettyHttpFileCacheTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/issues/JettyHttpFileCacheTest.java
@@ -18,8 +18,6 @@ package org.apache.camel.itest.issues;
 
 import java.io.File;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import static org.apache.camel.test.junit5.TestSupport.createDirectory;
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class JettyHttpFileCacheTest extends CamelTestSupport {
     private static final String TEST_STRING = "This is a test string and it has enough"
@@ -52,6 +51,7 @@ public class JettyHttpFileCacheTest extends CamelTestSupport {
 
         File file = new File("target/cachedir");
         String[] files = file.list();
+        assertNotNull(files);
         assertEquals(0, files.length, "There should not have any temp file");
 
     }
@@ -66,13 +66,7 @@ public class JettyHttpFileCacheTest extends CamelTestSupport {
                         .to("http://localhost:9101?bridgeEndpoint=true");
 
                 from("jetty:http://localhost:9101?chunked=true&matchOnUriPrefix=true")
-                        .process(new Processor() {
-
-                            public void process(Exchange exchange) {
-                                exchange.getMessage().setBody(TEST_STRING);
-                            }
-
-                        });
+                        .process(exchange -> exchange.getMessage().setBody(TEST_STRING));
             }
         };
     }

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/issues/JettyHttpTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/issues/JettyHttpTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.itest.issues;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
@@ -55,11 +54,9 @@ public class JettyHttpTest extends CamelTestSupport {
             @Override
             public void configure() {
                 from(targetConsumerUri)
-                        .process(new Processor() {
-                            public void process(Exchange exchange) {
-                                String path = exchange.getIn().getHeader(Exchange.HTTP_URI, String.class);
-                                exchange.getMessage().setBody("Hi! " + path);
-                            }
+                        .process(exchange -> {
+                            String path = exchange.getIn().getHeader(Exchange.HTTP_URI, String.class);
+                            exchange.getMessage().setBody("Hi! " + path);
                         });
 
                 from(sourceUri)

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jaxb/JaxbFallbackTypeConverterTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jaxb/JaxbFallbackTypeConverterTest.java
@@ -18,9 +18,7 @@ package org.apache.camel.itest.jaxb;
 
 import java.io.InputStream;
 
-import org.apache.camel.Exchange;
 import org.apache.camel.Message;
-import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.converter.jaxb.FallbackTypeConverter;
 import org.apache.camel.itest.jaxb.example.Bar;
@@ -52,16 +50,11 @@ public class JaxbFallbackTypeConverterTest extends CamelTestSupport {
                 // setup the camel property for the PrettyPrint
                 context.getGlobalOptions().put(FallbackTypeConverter.PRETTY_PRINT, "false");
 
-                from("direct:start").process(new Processor() {
-
-                    @Override
-                    public void process(Exchange exchange) throws Exception {
-                        Message in = exchange.getIn();
-                        InputStream is = in.getMandatoryBody(InputStream.class);
-                        // make sure we can get the InputStream rightly.
-                        exchange.getMessage().setBody(is);
-                    }
-
+                from("direct:start").process(exchange -> {
+                    Message in = exchange.getIn();
+                    InputStream is = in.getMandatoryBody(InputStream.class);
+                    // make sure we can get the InputStream rightly.
+                    exchange.getMessage().setBody(is);
                 });
             }
         };

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyFailoverRoundRobinTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyFailoverRoundRobinTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.itest.jetty;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.AvailablePortFinder;
@@ -84,37 +83,25 @@ public class JettyFailoverRoundRobinTest extends CamelTestSupport {
 
                 from(bad)
                         .to("mock:bad")
-                        .process(new Processor() {
-                            public void process(Exchange exchange) {
-                                exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 500);
-                                exchange.getIn().setBody("Something bad happened");
-                            }
+                        .process(exchange -> {
+                            exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 500);
+                            exchange.getIn().setBody("Something bad happened");
                         });
 
                 from(bad2)
                         .to("mock:bad2")
-                        .process(new Processor() {
-                            public void process(Exchange exchange) {
-                                exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
-                                exchange.getIn().setBody("Not found");
-                            }
+                        .process(exchange -> {
+                            exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
+                            exchange.getIn().setBody("Not found");
                         });
 
                 from(good)
                         .to("mock:good")
-                        .process(new Processor() {
-                            public void process(Exchange exchange) {
-                                exchange.getIn().setBody("Good");
-                            }
-                        });
+                        .process(exchange -> exchange.getIn().setBody("Good"));
 
                 from(good2)
                         .to("mock:good2")
-                        .process(new Processor() {
-                            public void process(Exchange exchange) {
-                                exchange.getIn().setBody("Also good");
-                            }
-                        });
+                        .process(exchange -> exchange.getIn().setBody("Also good"));
             }
         };
     }

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyFreemarkerTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyFreemarkerTest.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.ResolveEndpointFailedException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.support.ResourceHelper;
@@ -83,20 +82,17 @@ public class JettyFreemarkerTest extends CamelTestSupport {
         return new RouteBuilder() {
             public void configure() {
                 from("jetty:http://localhost:" + port + "/test")
-                        .process(new Processor() {
-                            @Override
-                            public void process(Exchange exchange) throws Exception {
-                                String name = exchange.getIn().getHeader("name", String.class);
-                                ObjectHelper.notNull(name, "name");
+                        .process(exchange -> {
+                            String name = exchange.getIn().getHeader("name", String.class);
+                            ObjectHelper.notNull(name, "name");
 
-                                name = "org/apache/camel/itest/jetty/" + name + ".ftl";
-                                InputStream is
-                                        = ResourceHelper.resolveMandatoryResourceAsInputStream(exchange.getContext(), name);
-                                String xml = exchange.getContext().getTypeConverter().convertTo(String.class, is);
+                            name = "org/apache/camel/itest/jetty/" + name + ".ftl";
+                            InputStream is
+                                    = ResourceHelper.resolveMandatoryResourceAsInputStream(exchange.getContext(), name);
+                            String xml = exchange.getContext().getTypeConverter().convertTo(String.class, is);
 
-                                exchange.getMessage().setBody(xml);
-                                exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "text/plain");
-                            }
+                            exchange.getMessage().setBody(xml);
+                            exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "text/plain");
                         });
             }
         };

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyJmsShutdownInProgressTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyJmsShutdownInProgressTest.java
@@ -60,14 +60,12 @@ public class JettyJmsShutdownInProgressTest {
         Future<String> reply2 = template.asyncRequestBody(URL, "Camel", String.class);
 
         // shutdown camel while in progress, wait 2 sec so the first req has been received in Camel route
-        Executors.newSingleThreadExecutor().execute(new Runnable() {
-            public void run() {
-                try {
-                    Thread.sleep(2000);
-                    JettyJmsShutdownInProgressTest.this.camelContext.stop();
-                } catch (Exception e) {
-                    // ignore
-                }
+        Executors.newSingleThreadExecutor().execute(() -> {
+            try {
+                Thread.sleep(2000);
+                JettyJmsShutdownInProgressTest.this.camelContext.stop();
+            } catch (Exception e) {
+                // ignore
             }
         });
 

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyJmsTwowayTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyJmsTwowayTest.java
@@ -18,7 +18,6 @@ package org.apache.camel.itest.jetty;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.itest.utils.extensions.JmsServiceExtension;
 import org.apache.camel.test.AvailablePortFinder;
@@ -52,12 +51,9 @@ public class JettyJmsTwowayTest {
     void testSendingRequest() {
         assertNotNull(camelContext, "The camelContext should not be null");
         ProducerTemplate template = camelContext.createProducerTemplate();
-        Exchange exchange = template.send(URL, new Processor() {
-            public void process(Exchange exchange) {
-                exchange.getIn().setBody("<hello>Willem</hello>");
-                exchange.getIn().setHeader("Operation", "greetMe");
-            }
-
+        Exchange exchange = template.send(URL, exchange1 -> {
+            exchange1.getIn().setBody("<hello>Willem</hello>");
+            exchange1.getIn().setHeader("Operation", "greetMe");
         });
         assertEquals("<response><hello>Willem</hello></response>", exchange.getMessage().getBody(String.class));
         template.stop();

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyRestRedirectTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyRestRedirectTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.itest.jetty;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.http.HttpComponent;
 import org.apache.camel.test.AvailablePortFinder;
@@ -53,12 +52,9 @@ public class JettyRestRedirectTest extends CamelTestSupport {
                         .post("/tag").to("direct:tag");
 
                 from("direct:profileLookup").transform().constant("Mock profile");
-                from("direct:tag").log("${headers}").process(new Processor() {
-                    @Override
-                    public void process(Exchange ex) {
-                        ex.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 303);
-                        ex.getMessage().setHeader("Location", "/metadata/profile/1");
-                    }
+                from("direct:tag").log("${headers}").process(ex -> {
+                    ex.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 303);
+                    ex.getMessage().setHeader("Location", "/metadata/profile/1");
                 }).log("${headers}").transform().constant("Redirecting...");
             }
         };

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettySimulateFailoverRoundRobinTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettySimulateFailoverRoundRobinTest.java
@@ -82,37 +82,25 @@ public class JettySimulateFailoverRoundRobinTest extends CamelTestSupport {
 
                 from(bad)
                         .to("mock:bad")
-                        .process(new Processor() {
-                            public void process(Exchange exchange) {
-                                exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 500);
-                                exchange.getIn().setBody("Something bad happened");
-                            }
+                        .process(exchange -> {
+                            exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 500);
+                            exchange.getIn().setBody("Something bad happened");
                         });
 
                 from(bad2)
                         .to("mock:bad2")
-                        .process(new Processor() {
-                            public void process(Exchange exchange) {
-                                exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
-                                exchange.getIn().setBody("Not found");
-                            }
+                        .process(exchange -> {
+                            exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
+                            exchange.getIn().setBody("Not found");
                         });
 
                 from(good)
                         .to("mock:good")
-                        .process(new Processor() {
-                            public void process(Exchange exchange) {
-                                exchange.getIn().setBody("Good");
-                            }
-                        });
+                        .process(exchange -> exchange.getIn().setBody("Good"));
 
                 from(good2)
                         .to("mock:good2")
-                        .process(new Processor() {
-                            public void process(Exchange exchange) {
-                                exchange.getIn().setBody("Also good");
-                            }
-                        });
+                        .process(exchange -> exchange.getIn().setBody("Also good"));
             }
         };
     }

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyVelocityTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyVelocityTest.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.ResolveEndpointFailedException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.support.ResourceHelper;
@@ -83,20 +82,17 @@ public class JettyVelocityTest extends CamelTestSupport {
         return new RouteBuilder() {
             public void configure() {
                 from("jetty:http://localhost:" + port + "/test")
-                        .process(new Processor() {
-                            @Override
-                            public void process(Exchange exchange) throws Exception {
-                                String name = exchange.getIn().getHeader("name", String.class);
-                                ObjectHelper.notNull(name, "name");
+                        .process(exchange -> {
+                            String name = exchange.getIn().getHeader("name", String.class);
+                            ObjectHelper.notNull(name, "name");
 
-                                name = "org/apache/camel/itest/jetty/" + name;
-                                InputStream is
-                                        = ResourceHelper.resolveMandatoryResourceAsInputStream(exchange.getContext(), name);
-                                String xml = exchange.getContext().getTypeConverter().convertTo(String.class, is);
+                            name = "org/apache/camel/itest/jetty/" + name;
+                            InputStream is
+                                    = ResourceHelper.resolveMandatoryResourceAsInputStream(exchange.getContext(), name);
+                            String xml = exchange.getContext().getTypeConverter().convertTo(String.class, is);
 
-                                exchange.getMessage().setBody(xml);
-                                exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "text/plain");
-                            }
+                            exchange.getMessage().setBody(xml);
+                            exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "text/plain");
                         });
             }
         };

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyXsltHttpTemplateTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyXsltHttpTemplateTest.java
@@ -37,11 +37,11 @@ public class JettyXsltHttpTemplateTest extends CamelTestSupport {
                 "<mail><subject>Hey</subject><body>Hello world!</body></mail>", String.class);
 
         assertNotNull(xml, "The transformed XML should not be null");
-        assertTrue(xml.indexOf("transformed") > -1);
+        assertTrue(xml.contains("transformed"));
         // the cheese tag is in the transform.xsl
-        assertTrue(xml.indexOf("cheese") > -1);
-        assertTrue(xml.indexOf("<subject>Hey</subject>") > -1);
-        assertTrue(xml.indexOf("<body>Hello world!</body>") > -1);
+        assertTrue(xml.contains("cheese"));
+        assertTrue(xml.contains("<subject>Hey</subject>"));
+        assertTrue(xml.contains("<body>Hello world!</body>"));
     }
 
     @Override

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyXsltTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jetty/JettyXsltTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.itest.jetty;
 import java.io.InputStream;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.ResolveEndpointFailedException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.support.ResourceHelper;
@@ -70,20 +69,17 @@ public class JettyXsltTest extends CamelTestSupport {
         return new RouteBuilder() {
             public void configure() {
                 from("jetty:http://localhost:" + port + "/test")
-                        .process(new Processor() {
-                            @Override
-                            public void process(Exchange exchange) throws Exception {
-                                String name = exchange.getIn().getHeader("name", String.class);
-                                ObjectHelper.notNull(name, "name");
+                        .process(exchange -> {
+                            String name = exchange.getIn().getHeader("name", String.class);
+                            ObjectHelper.notNull(name, "name");
 
-                                name = "org/apache/camel/itest/jetty/" + name;
-                                InputStream is
-                                        = ResourceHelper.resolveMandatoryResourceAsInputStream(exchange.getContext(), name);
-                                String xml = exchange.getContext().getTypeConverter().convertTo(String.class, is);
+                            name = "org/apache/camel/itest/jetty/" + name;
+                            InputStream is
+                                    = ResourceHelper.resolveMandatoryResourceAsInputStream(exchange.getContext(), name);
+                            String xml = exchange.getContext().getTypeConverter().convertTo(String.class, is);
 
-                                exchange.getMessage().setBody(xml);
-                                exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "text/xml");
-                            }
+                            exchange.getMessage().setBody(xml);
+                            exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "text/xml");
                         });
             }
         };

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jms/JmsConsumerShutdownTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jms/JmsConsumerShutdownTest.java
@@ -18,8 +18,6 @@ package org.apache.camel.itest.jms;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
-import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
@@ -62,11 +60,8 @@ public class JmsConsumerShutdownTest {
         end.setResultWaitTime(1000);
 
         // direct:dir route always fails
-        exception.whenAnyExchangeReceived(new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                throw new Exception("Kaboom!");
-            }
+        exception.whenAnyExchangeReceived(exchange -> {
+            throw new Exception("Kaboom!");
         });
 
         activemq.sendBody("jms:start", "Hello");
@@ -84,11 +79,8 @@ public class JmsConsumerShutdownTest {
         end.setResultWaitTime(1000);
 
         // direct:dir route always fails
-        exception.whenAnyExchangeReceived(new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                throw new Exception("Kaboom!");
-            }
+        exception.whenAnyExchangeReceived(exchange -> {
+            throw new Exception("Kaboom!");
         });
 
         seda.sendBody("seda:start", "Hello");

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jms/JmsHttpJmsTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jms/JmsHttpJmsTest.java
@@ -18,7 +18,6 @@ package org.apache.camel.itest.jms;
 
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.JmsComponent;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -51,22 +50,14 @@ public class JmsHttpJmsTest extends CamelTestSupport {
         template.sendBody("jms:in", "Hello World");
 
         Endpoint endpoint = context.getEndpoint("jms:out");
-        endpoint.createConsumer(new Processor() {
-            public void process(Exchange exchange) {
-                assertEquals("Bye World", exchange.getIn().getBody(String.class));
-            }
-        });
+        endpoint.createConsumer(exchange -> assertEquals("Bye World", exchange.getIn().getBody(String.class)));
 
         mock.assertIsSatisfied();
     }
 
     @Test
     void testResultReplyJms() throws Exception {
-        Exchange exchange = template.request("jms:reply?replyTo=bar", new Processor() {
-            public void process(Exchange exchange) {
-                exchange.getIn().setBody("Hello World");
-            }
-        });
+        Exchange exchange = template.request("jms:reply?replyTo=bar", exchange1 -> exchange1.getIn().setBody("Hello World"));
         assertEquals("Bye World", exchange.getMessage().getBody(String.class));
         assertTrue(exchange.getMessage().hasHeaders(), "Should have headers");
         assertEquals("ActiveMQQueue[bar]", exchange.getMessage().getHeader("JMSDestination", String.class));

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jms/JmsHttpPostIssueTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jms/JmsHttpPostIssueTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.itest.jms;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.JmsComponent;
@@ -72,16 +70,13 @@ public class JmsHttpPostIssueTest extends CamelTestSupport {
                         .to("http://localhost:" + port + "/myservice");
 
                 from("jetty:http://0.0.0.0:" + port + "/myservice")
-                        .process(new Processor() {
-                            @Override
-                            public void process(Exchange exchange) {
-                                String body = exchange.getIn().getBody(String.class);
-                                assertEquals("name=Hello World", body);
+                        .process(exchange -> {
+                            String body = exchange.getIn().getBody(String.class);
+                            assertEquals("name=Hello World", body);
 
-                                exchange.getMessage().setBody("OK");
-                                exchange.getMessage().setHeader(CONTENT_TYPE, "text/plain");
-                                exchange.getMessage().setHeader(HTTP_RESPONSE_CODE, 200);
-                            }
+                            exchange.getMessage().setBody("OK");
+                            exchange.getMessage().setHeader(CONTENT_TYPE, "text/plain");
+                            exchange.getMessage().setHeader(HTTP_RESPONSE_CODE, 200);
                         });
             }
         };

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jms/JmsHttpPostIssueWithMockTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jms/JmsHttpPostIssueWithMockTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.itest.jms;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.JmsComponent;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -76,16 +74,13 @@ public class JmsHttpPostIssueWithMockTest extends CamelTestSupport {
                         .to("mock:result");
 
                 from("jetty:http://0.0.0.0:" + port + "/myservice")
-                        .process(new Processor() {
-                            @Override
-                            public void process(Exchange exchange) {
-                                String body = exchange.getIn().getBody(String.class);
-                                assertEquals("name=Hello World", body);
+                        .process(exchange -> {
+                            String body = exchange.getIn().getBody(String.class);
+                            assertEquals("name=Hello World", body);
 
-                                exchange.getMessage().setBody("OK");
-                                exchange.getMessage().setHeader(CONTENT_TYPE, "text/plain");
-                                exchange.getMessage().setHeader(HTTP_RESPONSE_CODE, 200);
-                            }
+                            exchange.getMessage().setBody("OK");
+                            exchange.getMessage().setHeader(CONTENT_TYPE, "text/plain");
+                            exchange.getMessage().setHeader(HTTP_RESPONSE_CODE, 200);
                         });
             }
         };

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/jms/JmsResequencerTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/jms/JmsResequencerTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.apache.camel.Body;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
-import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.JmsComponent;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -51,14 +50,12 @@ public class JmsResequencerTest extends CamelTestSupport {
     public void sendBodyAndHeader(
             String endpointUri, final Object body, final String headerName,
             final Object headerValue) {
-        template.send(endpointUri, new Processor() {
-            public void process(Exchange exchange) {
-                Message in = exchange.getIn();
-                in.setBody(body);
-                in.setHeader(headerName, headerValue);
-                //in.setHeader("testCase", getName());
-                in.setHeader(Exchange.BEAN_METHOD_NAME, "execute");
-            }
+        template.send(endpointUri, exchange -> {
+            Message in = exchange.getIn();
+            in.setBody(body);
+            in.setHeader(headerName, headerValue);
+            //in.setHeader("testCase", getName());
+            in.setHeader(Exchange.BEAN_METHOD_NAME, "execute");
         });
     }
 
@@ -134,7 +131,7 @@ public class JmsResequencerTest extends CamelTestSupport {
         return "bean:" + beanName + "?method=execute";
     }
 
-    public class ReusableBean {
+    public static class ReusableBean {
         public String body;
         private String name;
 

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/nettyhttp/NettyHttpClientChunkedResponseTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/nettyhttp/NettyHttpClientChunkedResponseTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.itest.nettyhttp;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit5.CamelTestSupport;
@@ -44,13 +43,8 @@ public class NettyHttpClientChunkedResponseTest extends CamelTestSupport {
     }
 
     private void invokeService(int port, boolean checkChunkedHeader) {
-        Exchange out = template.request("netty-http:http://localhost:" + port + "/test", new Processor() {
-
-            @Override
-            public void process(Exchange exchange) {
-                exchange.getIn().setBody("Camel in chunks.");
-            }
-        });
+        Exchange out = template.request("netty-http:http://localhost:" + port + "/test",
+                exchange -> exchange.getIn().setBody("Camel in chunks."));
 
         assertNotNull(out);
         assertEquals("Bye Camel in chunks.", out.getMessage().getBody(String.class));

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/security/KeystorePasswordCallback.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/security/KeystorePasswordCallback.java
@@ -95,9 +95,7 @@ public class KeystorePasswordCallback implements CallbackHandler {
             Method getType = null;
             try {
                 getType = pc.getClass().getMethod("getPasswordType");
-            } catch (NoSuchMethodException ex) {
-                // keep looking
-            } catch (SecurityException ex) {
+            } catch (NoSuchMethodException | SecurityException ex) {
                 // keep looking
             }
             if (getType == null) {

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpWithOnExceptionAndNoTransactionErrorHandlerConfiguredRoute.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpWithOnExceptionAndNoTransactionErrorHandlerConfiguredRoute.java
@@ -17,8 +17,6 @@
 package org.apache.camel.itest.tx;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.Predicate;
-import org.apache.camel.Processor;
 import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.test.AvailablePortFinder;
 
@@ -35,11 +33,9 @@ public class JmsToHttpWithOnExceptionAndNoTransactionErrorHandlerConfiguredRoute
         port = AvailablePortFinder.getNextAvailable();
 
         // if its a 404 then regard it as handled
-        onException(HttpOperationFailedException.class).onWhen(new Predicate() {
-            public boolean matches(Exchange exchange) {
-                HttpOperationFailedException e = exchange.getException(HttpOperationFailedException.class);
-                return e != null && e.getStatusCode() == 404;
-            }
+        onException(HttpOperationFailedException.class).onWhen(exchange -> {
+            HttpOperationFailedException e = exchange.getException(HttpOperationFailedException.class);
+            return e != null && e.getStatusCode() == 404;
         }).handled(true).to("mock:404").transform(constant(noAccess));
 
         from("activemq:queue:JmsToHttpWithOnExceptionAndNoTransactionErrorHandlerConfiguredRoute")
@@ -64,30 +60,28 @@ public class JmsToHttpWithOnExceptionAndNoTransactionErrorHandlerConfiguredRoute
                 .end();
 
         // this is our http router
-        from("jetty:http://localhost:" + port + "/sender").process(new Processor() {
-            public void process(Exchange exchange) {
-                // first hit is always a error code 500 to force the caller to retry
-                if (counter++ < 1) {
-                    // simulate http error 500
-                    exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 500);
-                    exchange.getMessage().setBody("Damn some internal server error");
-                    return;
-                }
-
-                String user = exchange.getIn().getHeader("user", String.class);
-                if ("unknown".equals(user)) {
-                    // no page for a unknown user
-                    exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
-                    exchange.getMessage().setBody("Page does not exists");
-                    return;
-                } else if ("guest".equals(user)) {
-                    // not okay for guest user
-                    exchange.getMessage().setBody(nok);
-                    return;
-                }
-
-                exchange.getMessage().setBody(ok);
+        from("jetty:http://localhost:" + port + "/sender").process(exchange -> {
+            // first hit is always a error code 500 to force the caller to retry
+            if (counter++ < 1) {
+                // simulate http error 500
+                exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 500);
+                exchange.getMessage().setBody("Damn some internal server error");
+                return;
             }
+
+            String user = exchange.getIn().getHeader("user", String.class);
+            if ("unknown".equals(user)) {
+                // no page for a unknown user
+                exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
+                exchange.getMessage().setBody("Page does not exists");
+                return;
+            } else if ("guest".equals(user)) {
+                // not okay for guest user
+                exchange.getMessage().setBody(nok);
+                return;
+            }
+
+            exchange.getMessage().setBody(ok);
         });
     }
 

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpWithOnExceptionRoute.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpWithOnExceptionRoute.java
@@ -19,8 +19,6 @@ package org.apache.camel.itest.tx;
 import jakarta.annotation.Resource;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.Predicate;
-import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
@@ -53,11 +51,9 @@ public class JmsToHttpWithOnExceptionRoute extends RouteBuilder {
         errorHandler(transactionErrorHandler(required));
 
         // if its a 404 then regard it as handled
-        onException(HttpOperationFailedException.class).onWhen(new Predicate() {
-            public boolean matches(Exchange exchange) {
-                HttpOperationFailedException e = exchange.getException(HttpOperationFailedException.class);
-                return e != null && e.getStatusCode() == 404;
-            }
+        onException(HttpOperationFailedException.class).onWhen(exchange -> {
+            HttpOperationFailedException e = exchange.getException(HttpOperationFailedException.class);
+            return e != null && e.getStatusCode() == 404;
         }).handled(true).to("mock:JmsToHttpWithOnExceptionRoute404").transform(constant(noAccess));
 
         from("activemq:queue:JmsToHttpWithOnExceptionRoute")
@@ -82,30 +78,28 @@ public class JmsToHttpWithOnExceptionRoute extends RouteBuilder {
                 .end();
 
         // this is our http router
-        from("jetty:http://localhost:" + port + "/sender").process(new Processor() {
-            public void process(Exchange exchange) {
-                // first hit is always a error code 500 to force the caller to retry
-                if (counter++ < 1) {
-                    // simulate http error 500
-                    exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 500);
-                    exchange.getMessage().setBody("Damn some internal server error");
-                    return;
-                }
-
-                String user = exchange.getIn().getHeader("user", String.class);
-                if ("unknown".equals(user)) {
-                    // no page for a unknown user
-                    exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
-                    exchange.getMessage().setBody("Page does not exists");
-                    return;
-                } else if ("guest".equals(user)) {
-                    // not okay for guest user
-                    exchange.getMessage().setBody(nok);
-                    return;
-                }
-
-                exchange.getMessage().setBody(ok);
+        from("jetty:http://localhost:" + port + "/sender").process(exchange -> {
+            // first hit is always a error code 500 to force the caller to retry
+            if (counter++ < 1) {
+                // simulate http error 500
+                exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 500);
+                exchange.getMessage().setBody("Damn some internal server error");
+                return;
             }
+
+            String user = exchange.getIn().getHeader("user", String.class);
+            if ("unknown".equals(user)) {
+                // no page for a unknown user
+                exchange.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 404);
+                exchange.getMessage().setBody("Page does not exists");
+                return;
+            } else if ("guest".equals(user)) {
+                // not okay for guest user
+                exchange.getMessage().setBody(nok);
+                return;
+            }
+
+            exchange.getMessage().setBody(ok);
         });
     }
 

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpWithRollbackRoute.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/tx/JmsToHttpWithRollbackRoute.java
@@ -20,8 +20,6 @@ import jakarta.annotation.Resource;
 
 import org.apache.camel.Endpoint;
 import org.apache.camel.EndpointInject;
-import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
 import org.apache.camel.test.AvailablePortFinder;
@@ -76,13 +74,11 @@ public class JmsToHttpWithRollbackRoute extends RouteBuilder {
 
         // this is our http route that will fail the first 2 attempts
         // before it sends an ok response
-        from("jetty:http://localhost:" + port + "/sender").process(new Processor() {
-            public void process(Exchange exchange) {
-                if (counter++ < 2) {
-                    exchange.getMessage().setBody(nok);
-                } else {
-                    exchange.getMessage().setBody(ok);
-                }
+        from("jetty:http://localhost:" + port + "/sender").process(exchange -> {
+            if (counter++ < 2) {
+                exchange.getMessage().setBody(nok);
+            } else {
+                exchange.getMessage().setBody(ok);
             }
         });
     }


### PR DESCRIPTION
- avoid NPEs
- use lambdas when possible
- collapsed identical catch blocks
- simplified generics
- simplified string operations
- fixed incorrect assertions (swapped arguments)
- simplified assertions
- use static inner classes
- fixed C-style array declaration