### PR TITLE
[WIP] Improve the documentation for httpHeaders parameter.

### DIFF
--- a/components/camel-stream/src/main/java/org/apache/camel/component/stream/StreamEndpoint.java
+++ b/components/camel-stream/src/main/java/org/apache/camel/component/stream/StreamEndpoint.java
@@ -145,8 +145,8 @@ public class StreamEndpoint extends DefaultEndpoint {
 
     /**
      * When using stream:http format, this option specifies optional http headers, such as Accept: application/json.
-     * Multiple headers can be separated by comma. The format of headers should be {@code HEADER=VALUE}. An example
-     * might look like {@code Accept=application/json,Content-Type=text/plain}
+     * Multiple headers can be separated by comma. The format of headers should be "HEADER=VALUE". An example
+     * might look like "Accept=application/json,Content-Type=text/plain"
      */
     public void setHttpHeaders(String httpHeaders) {
         this.httpHeaders = httpHeaders;

--- a/components/camel-stream/src/main/java/org/apache/camel/component/stream/StreamEndpoint.java
+++ b/components/camel-stream/src/main/java/org/apache/camel/component/stream/StreamEndpoint.java
@@ -145,7 +145,8 @@ public class StreamEndpoint extends DefaultEndpoint {
 
     /**
      * When using stream:http format, this option specifies optional http headers, such as Accept: application/json.
-     * Multiple headers can be separated by comma.
+     * Multiple headers can be separated by comma. The format of headers should be {@code HEADER=VALUE}. An example
+     * might look like {@code Accept=application/json,Content-Type=text/plain}
      */
     public void setHttpHeaders(String httpHeaders) {
         this.httpHeaders = httpHeaders;


### PR DESCRIPTION
# Description

The documentation for the `httpHeaders` parameter of the `stream` component is ambiguous about how to format the parameter. It appears from the documentation that one would use `HEADER: VALUE`; but the code requires using `HEADER=VALUE`

# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

Having issues getting this to run as there are other modules preventing the build.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

