### PR TITLE
[mongodb] Select right container image on find-operation test

### DIFF
--- a/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/integration/MongoDbFindOperationIT.java
+++ b/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/integration/MongoDbFindOperationIT.java
@@ -32,6 +32,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mongodb.MongoDbComponent;
 import org.apache.camel.component.mongodb.MongoDbConstants;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.test.infra.mongodb.common.MongoDBProperties;
 import org.apache.camel.test.infra.mongodb.services.MongoDBLocalContainerService;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.util.IOHelper;
@@ -62,6 +63,8 @@ public class MongoDbFindOperationIT extends CamelTestSupport {
     protected static String dbName = "test";
     protected static String testCollectionName;
 
+    private static String mongoDbContainer;
+
     private static MongoClient mongo;
     private static MongoDatabase db;
     private static MongoCollection<Document> testCollection;
@@ -70,7 +73,9 @@ public class MongoDbFindOperationIT extends CamelTestSupport {
 
         // This one requires Mongo 4.4. This is related to
         // "CAMEL-15604 support allowDiskUse for MongoDB find operations"
-        service = new MongoDBLocalContainerService("mongo:4.4");
+        mongoDbContainer = System.getProperty(MongoDBProperties.MONGODB_CONTAINER, "mongo:4.4");
+
+        service = new MongoDBLocalContainerService(mongoDbContainer);
 
         service.getContainer()
                 .waitingFor(Wait.forListeningPort())


### PR DESCRIPTION
# Description

Due to [CAMEL-15604] we need to make use of Mongo container 4.4 version. BTW, minor versions (i.e. 4.4.6) should be used as multi-arch image (_x86, ppc64le, s390x_). Forcing the 4.4 version pull from docker hub, makes the test _MongoDbFindOperationIT_ fail

# Target

- [main] 