### PR TITLE
CAMEL-20121 reconnect SMPP session after receiving Unbound

### DIFF
--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppConsumer.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppConsumer.java
@@ -75,10 +75,11 @@ public class SmppConsumer extends DefaultConsumer {
                 configuration.getSessionStateListener().onStateChange(newState, oldState, source);
             }
 
-            if (newState.equals(SessionState.CLOSED)) {
-                LOG.warn("Lost connection to: {} - trying to reconnect...", getEndpoint().getConnectionString());
+            if (newState.equals(SessionState.UNBOUND) || newState.equals(SessionState.CLOSED)) {
+                LOG.warn(newState.equals(SessionState.UNBOUND)
+                        ? "Session to {} was unbound - trying to reconnect" : "Lost connection to: {} - trying to reconnect...",
+                        getEndpoint().getConnectionString());
                 closeSession();
-
                 reconnect(configuration.getInitialReconnectDelay());
             }
         };

--- a/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppProducer.java
+++ b/components/camel-smpp/src/main/java/org/apache/camel/component/smpp/SmppProducer.java
@@ -71,8 +71,10 @@ public class SmppProducer extends DefaultProducer {
                 configuration.getSessionStateListener().onStateChange(newState, oldState, source);
             }
 
-            if (newState.equals(SessionState.CLOSED)) {
-                LOG.warn("Lost connection to: {} - trying to reconnect...", getEndpoint().getConnectionString());
+            if (newState.equals(SessionState.UNBOUND) || newState.equals(SessionState.CLOSED)) {
+                LOG.warn(newState.equals(SessionState.UNBOUND)
+                        ? "Session to {} was unbound - trying to reconnect" : "Lost connection to: {} - trying to reconnect...",
+                        getEndpoint().getConnectionString());
                 closeSession();
                 reconnect(configuration.getInitialReconnectDelay());
             }

--- a/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppProducerTest.java
+++ b/components/camel-smpp/src/test/java/org/apache/camel/component/smpp/SmppProducerTest.java
@@ -16,20 +16,34 @@
  */
 package org.apache.camel.component.smpp;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 import org.apache.camel.Exchange;
+import org.apache.camel.support.task.BackgroundTask;
+import org.apache.camel.support.task.budget.Budgets;
+import org.apache.camel.util.ReflectionHelper;
 import org.jsmpp.bean.BindType;
 import org.jsmpp.bean.InterfaceVersion;
 import org.jsmpp.bean.NumberingPlanIndicator;
 import org.jsmpp.bean.TypeOfNumber;
+import org.jsmpp.extra.SessionState;
 import org.jsmpp.session.BindParameter;
 import org.jsmpp.session.SMPPSession;
 import org.jsmpp.session.SessionStateListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.MockedStatic;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -125,5 +139,38 @@ public class SmppProducerTest {
     public void getterShouldReturnTheSetValues() {
         assertSame(endpoint, producer.getEndpoint());
         assertSame(configuration, producer.getConfiguration());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SessionState.class, names = { "UNBOUND", "CLOSED" })
+    public void internalSessionStateListenerShouldCloseSessionAndReconnect(SessionState sessionState) throws Exception {
+        try (MockedStatic<SmppUtils> smppUtilsMock = mockStatic(SmppUtils.class)) {
+            ScheduledExecutorService reconnectService = (ScheduledExecutorService) ReflectionHelper
+                    .getField(SmppProducer.class.getDeclaredField("reconnectService"), producer);
+            SessionStateListener sessionStateListener = (SessionStateListener) ReflectionHelper
+                    .getField(SmppProducer.class.getDeclaredField("internalSessionStateListener"), producer);
+            when(endpoint.getConnectionString())
+                    .thenReturn("smpp://smppclient@localhost:2775");
+            BindParameter expectedBindParameters = new BindParameter(
+                    BindType.BIND_TX,
+                    "smppclient",
+                    "password",
+                    "cp",
+                    TypeOfNumber.UNKNOWN,
+                    NumberingPlanIndicator.UNKNOWN,
+                    "",
+                    InterfaceVersion.IF_50);
+            when(session.connectAndBind("localhost", Integer.valueOf(2775), expectedBindParameters))
+                    .thenReturn("1");
+            when(endpoint.isSingleton()).thenReturn(true);
+            smppUtilsMock.when(() -> SmppUtils.newReconnectTask(any(), anyString(), anyLong(), anyLong(), anyInt()))
+                    .thenReturn(new BackgroundTask.BackgroundTaskBuilder().withScheduledExecutor(reconnectService)
+                            .withBudget(Budgets.timeBudget().build()).build());
+
+            producer.doStart();
+
+            sessionStateListener.onStateChange(SessionState.CLOSED, SessionState.BOUND_TX, null);
+            verify(session).unbindAndClose();
+        }
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -277,7 +277,7 @@
         <jose4j-version>0.9.3</jose4j-version>
         <johnzon-version>2.0.0</johnzon-version>
         <jslt-version>0.1.14</jslt-version>
-        <jsmpp-version>3.0.0</jsmpp-version>
+        <jsmpp-version>3.0.1</jsmpp-version>
         <jsch-version>0.2.16</jsch-version>
         <javax-json-api-version>1.1.4</javax-json-api-version>
         <jsonassert-version>1.5.1</jsonassert-version>


### PR DESCRIPTION
# Description
The SMPP peer I am using Camel against sends an Unbind after an inactivity period of 60 seconds on the connection. This means that the logical connection has been terminated and (as I understand the SMPP spec) the peer that received the Unbind is supposed to terminate the connection as the session cannot be recovered.

SmppProducer/SmppConsumer don't react on this event and trying to send a SMS after receiving the Unbind ends up in exceptions (`org.apache.camel.component.smpp.SmppException: java.io.IOException: Cannot submitShortMessage while session 0f46dc52 in state UNBOUND`)

This PR adds code to catch the UNBOUND event in both SmppProducer/SmppConsumer and also closes the previous test gap of the internalSessionStateListener being uncovered in tests.

# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

