### PR TITLE
(chores) camel-test-infra-arangodb: update ArangoDB container to the latest version

### DIFF
--- a/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDbContainer.java
+++ b/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDbContainer.java
@@ -24,7 +24,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public class ArangoDbContainer extends GenericContainer {
     public static final Integer PORT_DEFAULT = 8529;
-    public static final String ARANGO_IMAGE = "arangodb:3.10.9";
+    public static final String ARANGO_IMAGE = "arangodb:3.11.5";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ArangoDbContainer.class);
     private static final String CONTAINER_NAME = "arango";


### PR DESCRIPTION
Updates the container to 3.11.5