### PR TITLE
(chores) camel-test-infra-fhir: update HAPI container to the latest version

### DIFF
--- a/test-infra/camel-test-infra-fhir/src/test/java/org/apache/camel/test/infra/fhir/services/FhirLocalContainerService.java
+++ b/test-infra/camel-test-infra-fhir/src/test/java/org/apache/camel/test/infra/fhir/services/FhirLocalContainerService.java
@@ -27,7 +27,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public class FhirLocalContainerService implements FhirService, ContainerService<GenericContainer> {
     // needs https://github.com/hapifhir/hapi-fhir-jpaserver-starter/commit/54120f374eea5084634830d34c99a9137b22a310
-    public static final String CONTAINER_IMAGE = "hapiproject/hapi:v6.6.0";
+    public static final String CONTAINER_IMAGE = "hapiproject/hapi:v6.8.3";
     public static final String CONTAINER_NAME = "fhir";
 
     private static final Logger LOG = LoggerFactory.getLogger(FhirLocalContainerService.class);


### PR DESCRIPTION
Updates the container to 6.8.3