### PR TITLE
CAMEL-20124: camel-netty - Fix ChannelHandlerFactories' usage of unsharable ByteArrayDecoder

### DIFF
--- a/components/camel-netty/src/main/java/org/apache/camel/component/netty/ChannelHandlerFactories.java
+++ b/components/camel-netty/src/main/java/org/apache/camel/component/netty/ChannelHandlerFactories.java
@@ -107,7 +107,12 @@ public final class ChannelHandlerFactories {
         if ("udp".equals(protocol)) {
             return new ShareableChannelHandlerFactory(new DatagramPacketByteArrayDecoder());
         } else {
-            return new ShareableChannelHandlerFactory(new ByteArrayDecoder());
+            return new DefaultChannelHandlerFactory() {
+                @Override
+                public ChannelHandler newChannelHandler() {
+                    return new ByteArrayDecoder();
+                }
+            };
         }
     }
 

--- a/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyBinaryProxyTest.java
+++ b/components/camel-netty/src/test/java/org/apache/camel/component/netty/NettyBinaryProxyTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty;
+
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.support.DefaultRegistry;
+import org.apache.camel.test.AvailablePortFinder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class NettyBinaryProxyTest extends BaseNettyTest {
+
+    @RegisterExtension
+    protected static AvailablePortFinder.Port port2 = AvailablePortFinder.find();
+
+    @BindToRegistry("bytesDecoder")
+    private final ChannelHandlerFactory bytesDecoder = ChannelHandlerFactories.newByteArrayDecoder("tcp");
+
+    @BindToRegistry("bytesEncoder")
+    private final ChannelHandlerFactory bytesEncoder = ChannelHandlerFactories.newByteArrayEncoder("tcp");
+
+    @Test
+    public void testNettyBinaryProxy() throws Exception {
+        getMockEndpoint("mock:before").expectedBodiesReceived("Camel".getBytes());
+        getMockEndpoint("mock:proxy").expectedBodiesReceived("Camel".getBytes());
+        getMockEndpoint("mock:after").expectedBodiesReceived("Camel".getBytes());
+
+        byte[] body = template.requestBody(
+                "netty:tcp://localhost:%s?sync=true&disconnect=true&decoders=#bytesDecoder&encoders=#bytesEncoder"
+                        .formatted(port.getPort()),
+                "Camel".getBytes(), byte[].class);
+        assertArrayEquals("Camel".getBytes(), body);
+
+        MockEndpoint.assertIsSatisfied(context);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                DefaultRegistry registry = (DefaultRegistry) getContext().getRegistry();
+                registry.bind("bytesDecoder", ChannelHandlerFactories.newByteArrayDecoder("tcp"));
+                registry.bind("bytesEncoder", ChannelHandlerFactories.newByteArrayEncoder("tcp"));
+
+                fromF("netty:tcp://0.0.0.0:%s?sync=true&disconnect=true&decoders=#bytesDecoder&encoders=#bytesEncoder",
+                        port.getPort())
+                        .to("mock:before")
+                        .toF("netty:tcp://localhost:%s?sync=true&disconnect=true&decoders=#bytesDecoder&encoders=#bytesEncoder",
+                                port2.getPort())
+                        .to("mock:after");
+
+                fromF("netty:tcp://0.0.0.0:%s?sync=true&disconnect=true&decoders=#bytesDecoder&encoders=#bytesEncoder",
+                        port2.getPort())
+                        .to("mock:proxy");
+            }
+        };
+    }
+}


### PR DESCRIPTION
# Description

Currently, using `ByteArrayDecoder` got through `ChannelHandlerFactories.newByteArrayDecoder()` twice or more in the same route causes Netty error indicating unsharable decoder reuse. This PR fixes this problem in accordance with the following document: https://camel.apache.org/components/4.0.x/netty-component.html#_using_non_shareable_encoders_or_decoders

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

