### PR TITLE
Replace obsolete classname in the camel-netty document

### DIFF
--- a/components/camel-netty/src/main/docs/netty-component.adoc
+++ b/components/camel-netty/src/main/docs/netty-component.adoc
@@ -473,7 +473,7 @@ must be created and registered with the context via the context registry
 A custom pipeline factory must be constructed as follows
 
 * A Producer linked channel pipeline factory must extend the abstract
-class `ClientPipelineFactory`.
+class `ClientInitializerFactory`.
 * A Consumer linked channel pipeline factory must extend the abstract
 class `ServerInitializerFactory`.
 * The classes should override the initChannel() method in order to


### PR DESCRIPTION
# Description

This PR fixes an obsolete classname in the camel-netty document replaced in 00b64c8ad617e86de6be005f939f354d598bc92e.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

