### PR TITLE
CAMEL-19997: camel-smb - Update first version

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/smb.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/smb.json
@@ -5,7 +5,7 @@
     "title": "SMB",
     "description": "Receive files from SMB (Server Message Block) shares.",
     "deprecated": false,
-    "firstVersion": "4.3.0-SNAPSHOT",
+    "firstVersion": "4.3.0",
     "label": "file",
     "javaType": "org.apache.camel.component.smb.SmbComponent",
     "supportLevel": "Preview",

--- a/components/camel-smb/pom.xml
+++ b/components/camel-smb/pom.xml
@@ -47,18 +47,6 @@
       <artifactId>smbj</artifactId>
       <version>${smbj-version}</version>
     </dependency>
-    
-    <!-- logging -->
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <!-- testing -->
     <dependency>
@@ -72,6 +60,7 @@
       <artifactId>camel-test-infra-smb</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/components/camel-smb/src/generated/resources/org/apache/camel/component/smb/smb.json
+++ b/components/camel-smb/src/generated/resources/org/apache/camel/component/smb/smb.json
@@ -5,7 +5,7 @@
     "title": "SMB",
     "description": "Receive files from SMB (Server Message Block) shares.",
     "deprecated": false,
-    "firstVersion": "4.3.0-SNAPSHOT",
+    "firstVersion": "4.3.0",
     "label": "file",
     "javaType": "org.apache.camel.component.smb.SmbComponent",
     "supportLevel": "Preview",

--- a/components/camel-smb/src/main/docs/smb-component.adoc
+++ b/components/camel-smb/src/main/docs/smb-component.adoc
@@ -3,7 +3,7 @@
 :shortname: smb
 :artifactid: camel-smb
 :description: Receive files from SMB (Server Message Block) shares.
-:since: 4.3.0-SNAPSHOT
+:since: 4.3
 :supportlevel: Preview
 :tabs-sync-option:
 :component-header: Only consumer is supported

--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbConfiguration.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbConfiguration.java
@@ -43,11 +43,12 @@ public class SmbConfiguration {
     @UriParam(defaultValue = "*.txt", description = "The search pattern used to list the files")
     private String searchPattern;
 
-    @UriParam(label = "advanced", description = "An optional SMB I/O bean to use to setup the file access attributes when reading/writing a file")
+    @UriParam(label = "advanced",
+              description = "An optional SMB I/O bean to use to setup the file access attributes when reading/writing a file")
     private SmbIOBean smbIoBean = new SmbReadBean();
 
     @UriParam(label = "advanced,consumer", description = "A pluggable repository org.apache.camel.spi.IdempotentRepository "
-                                                + "which by default use MemoryIdempotentRepository if none is specified.")
+                                                         + "which by default use MemoryIdempotentRepository if none is specified.")
     protected IdempotentRepository idempotentRepository
             = MemoryIdempotentRepository.memoryIdempotentRepository(DEFAULT_IDEMPOTENT_CACHE_SIZE);
 

--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbEndpoint.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbEndpoint.java
@@ -29,7 +29,7 @@ import org.apache.camel.support.ScheduledPollEndpoint;
 /**
  * Receive files from SMB (Server Message Block) shares.
  */
-@UriEndpoint(firstVersion = "4.3.0-SNAPSHOT", scheme = "smb", title = "SMB", syntax = "smb:hostname:port/shareName",
+@UriEndpoint(firstVersion = "4.3.0", scheme = "smb", title = "SMB", syntax = "smb:hostname:port/shareName",
              consumerOnly = true,
              category = { Category.FILE })
 public class SmbEndpoint extends ScheduledPollEndpoint {


### PR DESCRIPTION
## Motivation

The first version of the SMB component is set to a snapshot version instead of a final version.

## Modifications:

* Change the first version to 4.3
* Remove the logging dependencies as they are inherited from the direct parent pom file
* Set the scope of `camel-test-infra-smb` to `test`