### PR TITLE
tearDown overload inherits @AfterEach  instead of the declared @AfterAll

### DIFF
--- a/components/camel-azure/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BlobChangeFeedOperationsIT.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BlobChangeFeedOperationsIT.java
@@ -86,7 +86,7 @@ class BlobChangeFeedOperationsIT extends Base {
     }
 
     @AfterAll
-    public void tearDown() {
+    public void deleteClient() {
         containerClient.delete();
     }
 

--- a/components/camel-azure/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BlobConsumerIT.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BlobConsumerIT.java
@@ -218,11 +218,11 @@ class BlobConsumerIT extends Base {
     }
 
     @AfterAll
-    public void tearDown() {
+    public void deleteContainers() {
         // delete container
-        containerClient.delete();
-        batchContainerClient.delete();
-        prefixContainerClient.delete();
+        containerClient.deleteIfExists();
+        batchContainerClient.deleteIfExists();
+        prefixContainerClient.deleteIfExists();
     }
 
     @Override

--- a/components/camel-azure/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BlobOperationsIT.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BlobOperationsIT.java
@@ -86,7 +86,7 @@ class BlobOperationsIT extends Base {
     }
 
     @AfterAll
-    public void tearDown() {
+    public void deleteClient() {
         blobContainerClientWrapper.deleteContainer(null, null);
     }
 

--- a/components/camel-azure/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BlobProducerIT.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/BlobProducerIT.java
@@ -187,7 +187,7 @@ class BlobProducerIT extends Base {
     }
 
     @AfterAll
-    public void tearDown() {
+    public void deleteClient() {
         containerClient.delete();
     }
 


### PR DESCRIPTION
This is related to the following JUnit change https://github.com/junit-team/junit5/issues/3498