### PR TITLE
Upgrade XMLSecurity to version 4.0.0

### DIFF
--- a/components/camel-xmlsecurity/src/test/java/org/apache/camel/component/xmlsecurity/XmlSignatureTest.java
+++ b/components/camel-xmlsecurity/src/test/java/org/apache/camel/component/xmlsecurity/XmlSignatureTest.java
@@ -232,17 +232,6 @@ public class XmlSignatureTest extends CamelTestSupport {
             }
         }, new RouteBuilder() {
             public void configure() {
-                // START SNIPPET: transforms XSLT,XPath - secure Validation
-                // disabled
-                from("direct:transformsXsltXPathSecureValDisabled")
-                        .to("xmlsecurity-sign:transformsXsltXPathSecureValDisabled?keyAccessor=#accessor&transformMethods=#transformsXsltXPath",
-                                "xmlsecurity-verify:transformsXsltXPathSecureValDisabled?keySelector=#selector&secureValidation=false")
-                        .to("mock:result");
-                // END SNIPPET: transforms XSLT,XPath - secure Validation
-                // disabled
-            }
-        }, new RouteBuilder() {
-            public void configure() {
                 // START SNIPPET: cryptocontextprops
                 onException(XmlSignatureException.class).handled(false).to("mock:exception");
                 from("direct:cryptocontextprops")
@@ -557,13 +546,6 @@ public class XmlSignatureTest extends CamelTestSupport {
         sendBody("direct:transformsXsltXPath", payload);
         MockEndpoint.assertIsSatisfied(context);
         checkThrownException(mock, XmlSignatureException.class, null);
-    }
-
-    @Test
-    public void testSetTransformMethodXsltXpathInRouteDefinitionSecValDisabled() throws Exception {
-        setupMock();
-        sendBody("direct:transformsXsltXPathSecureValDisabled", payload);
-        MockEndpoint.assertIsSatisfied(context);
     }
 
     @Test

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -469,7 +469,7 @@
         <xml-apis-version>1.4.01</xml-apis-version>
         <xml-apis-ext-version>1.3.04</xml-apis-ext-version>
         <xml-resolver-version>1.2</xml-resolver-version>
-        <xmlsec-version>2.2.6</xmlsec-version>
+        <xmlsec-version>4.0.0</xmlsec-version>
         <xmlunit-version>2.9.1</xmlunit-version>
         <xpp3-version>1.1.4c</xpp3-version>
         <yasson-version>3.0.3</yasson-version>


### PR DESCRIPTION
# Description

The removed test was useless because now secureValidation is enabled by default.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

