### PR TITLE
Camel 16099: add throttle changes to migration guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4-migration-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4-migration-guide.adoc
@@ -171,7 +171,7 @@ To use attributes instead:
 Throttle now uses the number of concurrent requests as the throttling measure instead of the number of requests
 per period.
 
-Update throttle definitions using `maxRequestsPerPeriod` and optionally `timePeriodMillis`:
+Update throttle expressions configured with `maxRequestsPerPeriod` and remove any `timePeriodMillis` option:
 
 [source]
 ----

--- a/docs/user-manual/modules/ROOT/pages/camel-4-migration-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4-migration-guide.adoc
@@ -166,40 +166,6 @@ To use attributes instead:
 </circuitBreaker>
 ----
 
-== Throttle EIP
-
-Throttle now uses the number of concurrent requests as the throttling measure instead of the number of requests
-per period.
-
-Update throttle expressions configured with `maxRequestsPerPeriod` and remove any `timePeriodMillis` option:
-
-[source]
-----
-long maxRequestsPerPeriod = 100;
-from("seda:a")
-  .throttle(maxRequestsPerPeriod).timePeriodMillis(500)
-  .to("seda:b")
-
-// 1000 ms default time period
-from("seda:c")
-  .throttle(maxRequestsPerPeriod)
-  .to("seda:d")
-----
-
-To use `maxConcurrentRequests`:
-
-[source]
-----
-long maxConcurrentRequests = 30;
-from("seda:a")
-  .throttle(maxConcurrentRequests)
-  .to("seda:b")
-
-from("seda:c")
-  .throttle(maxConcurrentRequests)
-  .to("seda:d")
-----
-
 
 == XML DSL
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4-migration-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4-migration-guide.adoc
@@ -166,6 +166,40 @@ To use attributes instead:
 </circuitBreaker>
 ----
 
+== Throttle EIP
+
+Throttle now uses the number of concurrent requests as the throttling measure instead of the number of requests
+per period.
+
+Update throttle definitions using `maxRequestsPerPeriod` and optionally `timePeriodMillis`:
+
+[source]
+----
+long maxRequestsPerPeriod = 100;
+from("seda:a")
+  .throttle(maxRequestsPerPeriod).timePeriodMillis(500)
+  .to("seda:b")
+
+// 1000 ms default time period
+from("seda:c")
+  .throttle(maxRequestsPerPeriod)
+  .to("seda:d")
+----
+
+To use `maxConcurrentRequests`:
+
+[source]
+----
+long maxConcurrentRequests = 30;
+from("seda:a")
+  .throttle(maxConcurrentRequests)
+  .to("seda:b")
+
+from("seda:c")
+  .throttle(maxConcurrentRequests)
+  .to("seda:d")
+----
+
 
 == XML DSL
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_3.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_3.adoc
@@ -25,5 +25,34 @@ the behavior described in the documentation.
 Throttle now uses the number of concurrent requests as the throttling measure instead of the number of requests
 per period.
 
-The `throttle` parameter now specifies the maximum number of concurrent requests,
-and there is no longer support for the `timePeriodMillis` option.
+Update throttle expressions configured with `maxRequestsPerPeriod` to use `maxConcurrentRequests` instead,
+and remove any `timePeriodMillis` option.
+
+For example, update the following:
+
+[source]
+----
+long maxRequestsPerPeriod = 100L;
+from("seda:a")
+  .throttle(maxRequestsPerPeriod).timePeriodMillis(500)
+  .to("seda:b")
+
+// 1000 ms default time period
+from("seda:c")
+  .throttle(maxRequestsPerPeriod)
+  .to("seda:d")
+----
+
+to use `maxConcurrentRequests`:
+
+[source]
+----
+long maxConcurrentRequests = 30L;
+from("seda:a")
+  .throttle(maxConcurrentRequests)
+  .to("seda:b")
+
+from("seda:c")
+  .throttle(maxConcurrentRequests)
+  .to("seda:d")
+----


### PR DESCRIPTION

Added examples to the migration guide showing changes required to throttle EIP expressions now that throttle uses the number of concurrent requests as the throttling measure.
