### PR TITLE
(chores) camel-platform-http-vertx: simplify applying headers

### DIFF
--- a/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpSupport.java
+++ b/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpSupport.java
@@ -316,25 +316,26 @@ public final class VertxPlatformHttpSupport {
             HttpServerRequest request) {
         final MultiMap requestHeaders = request.headers();
         applyAuthHeaders(headersMap, exchange, headerFilterStrategy, requestHeaders);
-        for (String name : requestHeaders.names()) {
-            applyHeaders(headersMap, exchange, headerFilterStrategy, name, requestHeaders);
-        }
+        applyHeaders(headersMap, exchange, headerFilterStrategy, requestHeaders);
 
         // process uri parameters as headers
         final MultiMap pathParameters = ctx.queryParams();
         // continue if the map is not empty, otherwise there are no params
         if (!pathParameters.isEmpty()) {
-            for (String name : pathParameters.names()) {
-                applyHeaders(headersMap, exchange, headerFilterStrategy, name, pathParameters);
-            }
+            applyHeaders(headersMap, exchange, headerFilterStrategy, pathParameters);
         }
     }
 
     private static void applyHeaders(
-            Map<String, Object> headersMap, Exchange exchange, HeaderFilterStrategy headerFilterStrategy, String name,
+            Map<String, Object> headersMap, Exchange exchange, HeaderFilterStrategy headerFilterStrategy,
             MultiMap requestHeaders) {
-        // add the headers one by one, and use the header filter strategy
-        for (String value : requestHeaders.getAll(name)) {
+
+        final List<Map.Entry<String, String>> entries = requestHeaders.entries();
+        for (var entry : entries) {
+            final String name = entry.getKey();
+            final String value = entry.getValue();
+
+            // add the headers one by one, and use the header filter strategy
             if (!headerFilterStrategy.applyFilterToExternalHeaders(name, value, exchange)) {
                 appendHeader(headersMap, name, value);
             }

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpEngineTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpEngineTest.java
@@ -718,6 +718,36 @@ public class VertxPlatformHttpEngineTest {
     }
 
     @Test
+    public void responseMultipleHeaders() throws Exception {
+        final CamelContext context = createCamelContext();
+
+        try {
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("platform-http:/test")
+                            .setHeader("nonEmptyFromRoute", constant("nonEmptyFromRouteValue"))
+                            .setBody().simple("Hello World");
+                }
+            });
+
+            context.start();
+
+            RestAssured.given()
+                    .header("nonEmpty", "nonEmptyValue")
+                    .header("empty", "")
+                    .get("/test?duplicated=1&duplicated=2")
+                    .then()
+                    .statusCode(200)
+                    .body(equalTo("Hello World"))
+                    .header("nonEmpty", "nonEmptyValue")
+                    .header("nonEmptyFromRoute", "nonEmptyFromRouteValue");
+        } finally {
+            context.stop();
+        }
+    }
+
+    @Test
     public void testConsumerSuspended() throws Exception {
         final CamelContext context = createCamelContext();
 


### PR DESCRIPTION
Optimize the code by avoiding creating multiple Objects and iterating several times on the inner structures supporting the MultiMap.

Also adds a simple test that uses duplicated parameters when calling the service