### PR TITLE
CAMEL-20152: camel-jetty - Fix a file size threshold

### DIFF
--- a/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
+++ b/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
@@ -106,6 +106,10 @@ public abstract class JettyHttpComponent extends HttpCommonComponent
     private static final String JETTY_SSL_KEYSTORE = "org.eclipse.jetty.ssl.keystore";
     private static final String JETTY_SSL_KEYPASSWORD = "org.eclipse.jetty.ssl.keypassword";
     private static final String JETTY_SSL_PASSWORD = "org.eclipse.jetty.ssl.password";
+    /**
+     * The default value in bytes of the threshold beyond which the multipart files are written to disk to prevent OOME.
+     */
+    private static final int DEFAULT_FILE_SIZE_THRESHOLD = 10 * 1024 * 1024;
 
     protected String sslKeyPassword;
     protected String sslPassword;
@@ -1150,7 +1154,8 @@ public abstract class JettyHttpComponent extends HttpCommonComponent
 
         //must register the MultipartConfig to make jetty server multipart aware
         holder.getRegistration()
-                .setMultipartConfig(new MultipartConfigElement(file.getParentFile().getAbsolutePath(), -1, -1, 0));
+                .setMultipartConfig(new MultipartConfigElement(
+                        file.getParentFile().getAbsolutePath(), -1, -1, DEFAULT_FILE_SIZE_THRESHOLD));
 
         // use rest enabled resolver in case we use rest
         camelServlet.setServletResolveConsumerStrategy(new HttpRestServletResolveConsumerStrategy());


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-20152 for 4.0

## Motivation

In the case of multipart, the content is kept in memory which can lead to an OOME, it is due to the fact that the `fileSizeThreshold` is set to `0` by default which should mean that the content is stored on disk according to the Jakarta Javadoc but it is not what the Jetty code expects.

## Modifications:

* Set the default file size threshold to 10 MB by default