### PR TITLE
CAMEL-20158: enable camel-spring-xml throttle tests

### DIFF
--- a/components/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringThrottlerGroupingTest.java
+++ b/components/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringThrottlerGroupingTest.java
@@ -16,18 +16,41 @@
  */
 package org.apache.camel.spring.processor;
 
+import java.util.concurrent.Semaphore;
+
 import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
 import org.apache.camel.processor.ThrottlingGroupingTest;
-import org.junit.jupiter.api.Disabled;
 
 import static org.apache.camel.spring.processor.SpringTestHelper.createSpringCamelContext;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled("Disabled due to CAMEL-20158")
 public class SpringThrottlerGroupingTest extends ThrottlingGroupingTest {
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
         return createSpringCamelContext(this,
                 "org/apache/camel/spring/processor/ThrottlerGroupingTest.xml");
+    }
+
+    public static class IncrementProcessor implements Processor {
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            String key = (String) exchange.getMessage().getHeader("key");
+            assertTrue(
+                    semaphores.computeIfAbsent(key, k -> new Semaphore(
+                            exchange.getMessage().getHeader("throttleValue") == null
+                                    ? CONCURRENT_REQUESTS : (Integer) exchange.getMessage().getHeader("throttleValue")))
+                            .tryAcquire(),
+                    "too many requests for key " + key);
+        }
+    }
+
+    public static class DecrementProcessor implements Processor {
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            semaphores.get(exchange.getMessage().getHeader("key")).release();
+        }
     }
 }

--- a/components/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringThrottlerMethodCallTest.java
+++ b/components/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringThrottlerMethodCallTest.java
@@ -18,11 +18,9 @@ package org.apache.camel.spring.processor;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.processor.ThrottlerMethodCallTest;
-import org.junit.jupiter.api.Disabled;
 
 import static org.apache.camel.spring.processor.SpringTestHelper.createSpringCamelContext;
 
-@Disabled("Disabled due to CAMEL-20158")
 public class SpringThrottlerMethodCallTest extends ThrottlerMethodCallTest {
 
     @Override

--- a/components/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringThrottlerTest.java
+++ b/components/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringThrottlerTest.java
@@ -17,17 +17,39 @@
 package org.apache.camel.spring.processor;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
 import org.apache.camel.processor.ThrottlerTest;
-import org.junit.jupiter.api.Disabled;
 
 import static org.apache.camel.spring.processor.SpringTestHelper.createSpringCamelContext;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled("Disabled due to CAMEL-20158")
 public class SpringThrottlerTest extends ThrottlerTest {
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
         return createSpringCamelContext(this,
                 "org/apache/camel/spring/processor/throttler.xml");
+    }
+
+    public static class IncrementProcessor implements Processor {
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            assertTrue(semaphore.tryAcquire(), "too many requests");
+        }
+    }
+
+    public static class DecrementProcessor implements Processor {
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            semaphore.release();
+        }
+    }
+
+    public static class RuntimeExceptionProcessor implements Processor {
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            throw new RuntimeException();
+        }
     }
 }

--- a/components/camel-spring-xml/src/test/resources/org/apache/camel/spring/processor/ThrottlerGroupingTest.xml
+++ b/components/camel-spring-xml/src/test/resources/org/apache/camel/spring/processor/ThrottlerGroupingTest.xml
@@ -23,12 +23,15 @@
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
     ">
+  <bean id="incrementProcessor" class="org.apache.camel.spring.processor.SpringThrottlerGroupingTest$IncrementProcessor"/>
+  <bean id="decrementProcessor" class="org.apache.camel.spring.processor.SpringThrottlerGroupingTest$DecrementProcessor"/>
+
   <camelContext xmlns="http://camel.apache.org/schema/spring">
     <jmxAgent id="jmx" disabled="true"/>
     <errorHandler id="dlc" deadLetterUri="mock:dead" type="DeadLetterChannel"/>
     <route errorHandlerRef="dlc">
       <from uri="seda:a"/>
-      <throttle timePeriodMillis="1000">
+      <throttle>
         <header>max</header>
         <correlationExpression>
           <constant>1</constant>
@@ -40,7 +43,7 @@
     
     <route errorHandlerRef="dlc">
       <from uri="seda:b"/>
-      <throttle timePeriodMillis="1000">
+      <throttle>
         <header>max</header>
         <correlationExpression>
           <constant>2</constant>
@@ -52,7 +55,7 @@
     
     <route errorHandlerRef="dlc">
       <from uri="seda:c"/>
-      <throttle timePeriodMillis="1000">
+      <throttle>
         <header>max</header>
         <correlationExpression>
           <header>key</header>
@@ -63,40 +66,37 @@
     </route>
     
     <route errorHandlerRef="dlc">
-      <from uri="seda:ga"/>
-      <!-- throttle 3 messages per 1 sec -->
-      <throttle timePeriodMillis="1000">
-        <constant>3</constant>
-        <correlationExpression>
-          <header>key</header>
-        </correlationExpression>
-      </throttle>
-      <to uri="log:gresult"/>
-      <to uri="mock:gresult"/>
-    </route>
-    
-    <route errorHandlerRef="dlc">
       <from uri="direct:ga"/>
-      <!-- throttle 5 messages per 0.5 sec -->
-      <throttle timePeriodMillis="500">
-        <constant>5</constant>
+      <!-- throttle max of 5 concurrent messages -->
+      <throttle>
+        <constant>2</constant>
         <correlationExpression>
           <header>key</header>
         </correlationExpression>
       </throttle>
+      <process ref="incrementProcessor"/>
+      <delay>
+        <constant>100</constant>
+      </delay>
+      <process ref="decrementProcessor"/>
       <to uri="log:gresult"/>
       <to uri="mock:gresult"/>
     </route>
     
     <route errorHandlerRef="dlc">
       <from uri="direct:gexpressionHeader"/>
-      <throttle timePeriodMillis="500">
-        <!-- use a header to determine how many messages to throttle per 0.5 sec -->
+      <throttle>
+        <!-- use a header to determine the max number of concurrent requests to set on the throttle-->
         <header>throttleValue</header>
         <correlationExpression>
           <header>key</header>
         </correlationExpression>
       </throttle>
+      <process ref="incrementProcessor"/>
+      <delay>
+        <constant>100</constant>
+      </delay>
+      <process ref="decrementProcessor"/>
       <to uri="log:gresult"/>
       <to uri="mock:gresult"/>
     </route>

--- a/components/camel-spring-xml/src/test/resources/org/apache/camel/spring/processor/ThrottlerMethodCallTest.xml
+++ b/components/camel-spring-xml/src/test/resources/org/apache/camel/spring/processor/ThrottlerMethodCallTest.xml
@@ -31,9 +31,9 @@
 
     <route>
       <from uri="direct:expressionMethod"/>
-      <throttle timePeriodMillis="100">
-        <!-- use a java  bean method call to determine how many messages to throttle per 0.1 sec -->
-        <method ref="myBean" method="getMessagesPerInterval"/>
+      <throttle>
+        <!-- use a java bean method call to determine the max number of concurrent messages to set on the throttle -->
+        <method ref="myBean" method="getConcurrentMessages"/>
       </throttle>
       <to uri="mock:result"/>
     </route>

--- a/components/camel-spring-xml/src/test/resources/org/apache/camel/spring/processor/throttler.xml
+++ b/components/camel-spring-xml/src/test/resources/org/apache/camel/spring/processor/throttler.xml
@@ -23,9 +23,13 @@
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
     ">
+  <bean id="runtimeExceptionProcessor" class="org.apache.camel.spring.processor.SpringThrottlerTest$RuntimeExceptionProcessor"/>
+  <bean id="incrementProcessor" class="org.apache.camel.spring.processor.SpringThrottlerTest$IncrementProcessor"/>
+  <bean id="decrementProcessor" class="org.apache.camel.spring.processor.SpringThrottlerTest$DecrementProcessor"/>
 
   <camelContext xmlns="http://camel.apache.org/schema/spring">
     <jmxAgent id="jmx" disabled="true"/>
+    <errorHandler type="DeadLetterChannel" id="myDLC" deadLetterUri="mock:error"/>
     <onException>
       <exception>org.apache.camel.processor.ThrottlerRejectedExecutionException</exception>
       <handled>
@@ -34,43 +38,47 @@
       <to uri="mock:error"/>
     </onException>
 
-    <!-- START SNIPPET: example -->
-    <route>
-      <from uri="seda:a"/>
-      <!-- throttle 3 messages per 1 sec -->
-      <throttle timePeriodMillis="1000">
-        <constant>3</constant>
-      </throttle>
-      <to uri="log:result"/>
-      <to uri="mock:result"/>
-    </route>
-    <!-- END SNIPPET: example -->
-
     <route>
       <from uri="direct:a"/>
-      <!-- throttle 5 messages per 0.5 sec -->
-      <throttle timePeriodMillis="500">
-        <constant>5</constant>
+      <!-- throttle max of 2 concurrent messages -->
+      <throttle>
+        <constant>2</constant>
       </throttle>
+      <process ref="incrementProcessor"/>
+      <delay>
+        <constant>100</constant>
+      </delay>
+      <process ref="decrementProcessor"/>
       <to uri="log:result"/>
       <to uri="mock:result"/>
     </route>
 
     <route>
       <from uri="direct:expressionConstant"/>
-      <throttle timePeriodMillis="500">
-        <constant>5</constant>
+      <throttle>
+        <constant>2</constant>
       </throttle>
+      <process ref="incrementProcessor"/>
+      <delay>
+        <constant>100</constant>
+      </delay>
+      <process ref="decrementProcessor"/>
+      <to uri="log:result"/>
       <to uri="mock:result"/>
     </route>
 
     <!-- START SNIPPET: e2 -->
     <route>
       <from uri="direct:expressionHeader"/>
-      <throttle timePeriodMillis="500">
-        <!-- use a header to determine how many messages to throttle per 0.5 sec -->
+      <throttle>
+        <!-- use a header to determine the max number of current messages -->
         <header>throttleValue</header>
       </throttle>
+      <process ref="incrementProcessor"/>
+      <delay>
+        <constant>100</constant>
+      </delay>
+      <process ref="decrementProcessor"/>
       <to uri="log:result"/>
       <to uri="mock:result"/>
     </route>
@@ -78,19 +86,39 @@
 
     <route>
       <from uri="direct:start"/>
-      <!-- throttle 2 messages per 1 sec -->
-      <throttle timePeriodMillis="1000" rejectExecution="true">
+      <!-- throttle max of 2 concurrent messages -->
+      <throttle rejectExecution="true">
         <constant>2</constant>
       </throttle>
+      <delay>
+        <constant>1000</constant>
+      </delay>
       <to uri="log:result"/>
       <to uri="mock:result"/>
     </route>
 
     <route>
-      <from uri="direct:highThrottleRate"/>
-      <throttle timePeriodMillis="500">
-        <constant>10000</constant>
+      <from uri="direct:fifo"/>
+      <!-- throttle max of 1 concurrent request -->
+      <throttle>
+        <constant>1</constant>
       </throttle>
+      <delay>
+        <constant>100</constant>
+      </delay>
+      <to uri="mock:result"/>
+    </route>
+
+    <route errorHandlerRef="myDLC">
+      <from uri="direct:release"/>
+      <!-- throttle max of 1 concurrent request -->
+      <throttle>
+        <constant>1</constant>
+      </throttle>
+      <delay>
+        <constant>100</constant>
+      </delay>
+      <process ref="runtimeExceptionProcessor"/>
       <to uri="mock:result"/>
     </route>
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerMethodCallTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerMethodCallTest.java
@@ -23,12 +23,9 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spi.Registry;
-import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledOnOs(OS.WINDOWS)
 public class ThrottlerMethodCallTest extends ContextTestSupport {
@@ -42,7 +39,7 @@ public class ThrottlerMethodCallTest extends ContextTestSupport {
         return jndi;
     }
 
-    public long getMessagesPerInterval() {
+    public long getConcurrentMessages() {
         return 3;
     }
 
@@ -53,20 +50,12 @@ public class ThrottlerMethodCallTest extends ContextTestSupport {
 
         ExecutorService executor = Executors.newFixedThreadPool(messageCount);
 
-        StopWatch watch = new StopWatch();
         for (int i = 0; i < messageCount; i++) {
-            executor.execute(new Runnable() {
-                public void run() {
-                    template.sendBody("direct:expressionMethod", "<message>payload</message>");
-                }
-            });
+            executor.execute(() -> template.sendBody("direct:expressionMethod", "<message>payload</message>"));
         }
 
         // let's wait for the exchanges to arrive
         resultEndpoint.assertIsSatisfied();
-
-        // should take a little time
-        assertTrue(watch.taken() > 100);
 
         executor.shutdownNow();
     }
@@ -75,7 +64,7 @@ public class ThrottlerMethodCallTest extends ContextTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from("direct:expressionMethod").throttle(method("myBean", "getMessagesPerInterval")).delay(INTERVAL)
+                from("direct:expressionMethod").throttle(method("myBean", "getConcurrentMessages")).delay(INTERVAL)
                         .to("log:result", "mock:result");
             }
         };

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerTest.java
@@ -38,7 +38,7 @@ public class ThrottlerTest extends ContextTestSupport {
     private static final int INTERVAL = 500;
     private static final int MESSAGE_COUNT = 9;
     private static final int CONCURRENT_REQUESTS = 2;
-    private Semaphore semaphore;
+    protected static Semaphore semaphore;
 
     @Test
     public void testSendLotsOfMessagesWithRejectExecution() throws Exception {


### PR DESCRIPTION
Updated camel-spring-xml throttle tests to use max number of concurrent requests instead of requests per time period as per changes to the throttle eip.