### PR TITLE
Upgrades to match versions in 2.7.18 spring-boot-dependencies

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -507,17 +507,17 @@
         <spark-version>3.3.1</spark-version>
         <splunk-version>1.9.0_1</splunk-version>
         <spock-version>2.1-groovy-3.0</spock-version>
-        <spring-batch-version>4.3.9</spring-batch-version>
+        <spring-batch-version>4.3.10</spring-batch-version>
         <spring-data-redis-version>2.6.2</spring-data-redis-version>
         <spring-integration-version>5.5.19</spring-integration-version>
         <spring-ldap-version>2.4.1</spring-ldap-version>
         <spring-vault-core-version>2.3.3</spring-vault-core-version>
         <spring-version-range>[5,6)</spring-version-range>
         <spring-version>${spring5-version}</spring-version>
-        <spring5-version>5.3.30</spring5-version>
+        <spring5-version>5.3.31</spring5-version>
         <spring-rabbitmq-version>2.4.8</spring-rabbitmq-version>
         <spring-security-version>5.8.8</spring-security-version>
-        <spring-ws-version>3.1.7</spring-ws-version>
+        <spring-ws-version>3.1.8</spring-ws-version>
         <sql-maven-plugin-version>1.5</sql-maven-plugin-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>
         <squareup-okio-version>1.17.2</squareup-okio-version>


### PR DESCRIPTION
Upgrade spring-* versions to match the versions in 2.7.18 spring-boot-dependencies