### PR TITLE
CAMEL-20158: wait till tasks finish before shutting down executors

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlerTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
@@ -55,6 +56,7 @@ public class ThrottlerTest extends ContextTestSupport {
             }
             assertMockEndpointsSatisfied();
         } finally {
+            executor.awaitTermination(1000, TimeUnit.MILLISECONDS);
             executor.shutdownNow();
         }
     }
@@ -82,6 +84,7 @@ public class ThrottlerTest extends ContextTestSupport {
         try {
             sendMessagesWithHeaderExpression(executor, resultEndpoint, CONCURRENT_REQUESTS, MESSAGE_COUNT);
         } finally {
+            executor.awaitTermination(1000, TimeUnit.MILLISECONDS);
             executor.shutdownNow();
         }
     }
@@ -111,6 +114,7 @@ public class ThrottlerTest extends ContextTestSupport {
             resultEndpoint.reset();
             sendMessagesWithHeaderExpression(executor, resultEndpoint, 4, MESSAGE_COUNT);
         } finally {
+            executor.awaitTermination(1000, TimeUnit.MILLISECONDS);
             executor.shutdownNow();
         }
     }
@@ -152,6 +156,7 @@ public class ThrottlerTest extends ContextTestSupport {
                 receivingEndpoint.assertIsSatisfied();
             }
         } finally {
+            executor.awaitTermination(1000, TimeUnit.MILLISECONDS);
             executor.shutdownNow();
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlingGroupingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlingGroupingTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
@@ -108,6 +109,7 @@ public class ThrottlingGroupingTest extends ContextTestSupport {
                 receivingEndpoint.assertIsSatisfied();
             }
         } finally {
+            executor.awaitTermination(1000, TimeUnit.MILLISECONDS);
             executor.shutdownNow();
         }
     }
@@ -121,6 +123,7 @@ public class ThrottlingGroupingTest extends ContextTestSupport {
         try {
             sendMessagesWithHeaderExpression(executor, resultEndpoint, CONCURRENT_REQUESTS, MESSAGE_COUNT);
         } finally {
+            executor.awaitTermination(1000, TimeUnit.MILLISECONDS);
             executor.shutdownNow();
         }
     }


### PR DESCRIPTION
In throttle tests, wait until tasks have completed before shutting down executors to avoid producing warning messages in the logs due to thread interruption.

