### PR TITLE
CAMEL-20158: await executor termination after shutdown

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlingGroupingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ThrottlingGroupingTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @Isolated
 public class ThrottlingGroupingTest extends ContextTestSupport {
@@ -109,8 +110,7 @@ public class ThrottlingGroupingTest extends ContextTestSupport {
                 receivingEndpoint.assertIsSatisfied();
             }
         } finally {
-            executor.awaitTermination(1000, TimeUnit.MILLISECONDS);
-            executor.shutdownNow();
+            shutdownAndAwait(executor);
         }
     }
 
@@ -123,8 +123,7 @@ public class ThrottlingGroupingTest extends ContextTestSupport {
         try {
             sendMessagesWithHeaderExpression(executor, resultEndpoint, CONCURRENT_REQUESTS, MESSAGE_COUNT);
         } finally {
-            executor.awaitTermination(1000, TimeUnit.MILLISECONDS);
-            executor.shutdownNow();
+            shutdownAndAwait(executor);
         }
     }
 
@@ -150,6 +149,16 @@ public class ThrottlingGroupingTest extends ContextTestSupport {
 
         // let's wait for the exchanges to arrive
         resultEndpoint.assertIsSatisfied();
+    }
+
+    private void shutdownAndAwait(final ExecutorService executorService) {
+        executorService.shutdown();
+        try {
+            assertTrue(executorService.awaitTermination(10, TimeUnit.SECONDS),
+                    "Test ExecutorService shutdown is not expected to take longer than 10 seconds.");
+        } catch (InterruptedException e) {
+            fail("Test ExecutorService shutdown is not expected to be interrupted.");
+        }
     }
 
     @Override


### PR DESCRIPTION
Shutdown the executor cleanly so that it doesn't produce any warnings due to thread interruption.

# Target
- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style
- [x] I checked that each commit in the pull request has a meaningful subject line and body.

