### PR TITLE
CAMEL-20123: Externalize container info in camel-test-infra

### DIFF
--- a/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBLocalContainerService.java
+++ b/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBLocalContainerService.java
@@ -17,6 +17,7 @@
 package org.apache.camel.test.infra.arangodb.services;
 
 import org.apache.camel.test.infra.arangodb.common.ArangoDBProperties;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.slf4j.Logger;
@@ -28,7 +29,7 @@ public class ArangoDBLocalContainerService implements ArangoDBService, Container
     private final ArangoDbContainer container;
 
     public ArangoDBLocalContainerService() {
-        this(System.getProperty(ArangoDBProperties.ARANGODB_CONTAINER, ArangoDbContainer.ARANGO_IMAGE));
+        this(LocalPropertyResolver.getProperty(ArangoDBLocalContainerService.class, ArangoDBProperties.ARANGODB_CONTAINER));
     }
 
     public ArangoDBLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDbContainer.java
+++ b/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDbContainer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.test.infra.arangodb.services;
 
+import org.apache.camel.test.infra.arangodb.common.ArangoDBProperties;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -24,14 +26,13 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public class ArangoDbContainer extends GenericContainer {
     public static final Integer PORT_DEFAULT = 8529;
-    public static final String ARANGO_IMAGE = "arangodb:3.11.5";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ArangoDbContainer.class);
     private static final String CONTAINER_NAME = "arango";
     private static final String ARANGO_NO_AUTH = "ARANGO_NO_AUTH";
 
     public ArangoDbContainer() {
-        this(ARANGO_IMAGE);
+        this(LocalPropertyResolver.getProperty(ArangoDbContainer.class, ArangoDBProperties.ARANGODB_CONTAINER));
     }
 
     public ArangoDbContainer(String containerName) {

--- a/test-infra/camel-test-infra-arangodb/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-arangodb/src/test/resources/container.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+## tested against 2.1.2, 2.2.0 & 2.3.1
+arangodb.container=arangodb:3.11.5

--- a/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSContainer.java
+++ b/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSContainer.java
@@ -17,18 +17,19 @@
 
 package org.apache.camel.test.infra.aws2.services;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
 import org.apache.camel.test.infra.aws.common.AWSProperties;
 import org.apache.camel.test.infra.aws2.common.TestAWSCredentialsProvider;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 /*
  The reason we are not using LocalStack containers here is because they bundle AWS SDK v1. They would
@@ -36,14 +37,14 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
  behave as in runtime.
  */
 public class AWSContainer extends GenericContainer<AWSContainer> {
-
-    public static final String LOCALSTACK_CONTAINER = "localstack/localstack:3.0.0";
-
+    
     private static final Logger LOG = LoggerFactory.getLogger(AWSLocalContainerService.class);
     private static final int SERVICE_PORT = 4566;
 
     public AWSContainer() {
-        this(System.getProperty(AWSProperties.AWS_CONTAINER, LOCALSTACK_CONTAINER));
+        this(LocalPropertyResolver.getProperty(
+                AWSContainer.class,
+                AWSProperties.AWS_CONTAINER));
     }
 
     public AWSContainer(String imageName) {

--- a/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSLocalContainerService.java
+++ b/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSLocalContainerService.java
@@ -17,24 +17,25 @@
 
 package org.apache.camel.test.infra.aws2.services;
 
-import java.net.URI;
-import java.util.Properties;
-
 import org.apache.camel.test.infra.aws.common.AWSConfigs;
 import org.apache.camel.test.infra.aws.common.AWSProperties;
 import org.apache.camel.test.infra.aws.common.services.AWSService;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.regions.Region;
 
+import java.net.URI;
+import java.util.Properties;
+
 public abstract class AWSLocalContainerService implements AWSService, ContainerService<AWSContainer> {
     private static final Logger LOG = LoggerFactory.getLogger(AWSLocalContainerService.class);
     private final AWSContainer container;
 
     public AWSLocalContainerService(Service... services) {
-        this(System.getProperty(AWSProperties.AWS_CONTAINER, AWSContainer.LOCALSTACK_CONTAINER), services);
+        this(LocalPropertyResolver.getProperty(AWSContainer.class, AWSProperties.AWS_CONTAINER), services);
     }
 
     public AWSLocalContainerService(AWSContainer container) {

--- a/test-infra/camel-test-infra-aws-v2/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-aws-v2/src/test/resources/container.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+## tested against 2.1.2, 2.2.0 & 2.3.1
+aws.container=localstack/localstack:2.3.2

--- a/test-infra/camel-test-infra-azure-common/src/test/java/org/apache/camel/test/infra/azure/common/services/AzureStorageService.java
+++ b/test-infra/camel-test-infra-azure-common/src/test/java/org/apache/camel/test/infra/azure/common/services/AzureStorageService.java
@@ -19,6 +19,7 @@ package org.apache.camel.test.infra.azure.common.services;
 
 import org.apache.camel.test.infra.azure.common.AzureConfigs;
 import org.apache.camel.test.infra.azure.common.AzureProperties;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +29,7 @@ public abstract class AzureStorageService implements AzureService, ContainerServ
     private final AzuriteContainer container;
 
     public AzureStorageService() {
-        this(System.getProperty(AzureProperties.AZURE_CONTAINER, AzuriteContainer.IMAGE_NAME));
+        this(LocalPropertyResolver.getProperty(AzureStorageService.class, AzureProperties.AZURE_CONTAINER));
     }
 
     public AzureStorageService(String imageName) {

--- a/test-infra/camel-test-infra-azure-common/src/test/java/org/apache/camel/test/infra/azure/common/services/AzuriteContainer.java
+++ b/test-infra/camel-test-infra-azure-common/src/test/java/org/apache/camel/test/infra/azure/common/services/AzuriteContainer.java
@@ -18,6 +18,8 @@
 package org.apache.camel.test.infra.azure.common.services;
 
 import org.apache.camel.test.infra.azure.common.AzureCredentialsHolder;
+import org.apache.camel.test.infra.azure.common.AzureProperties;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
@@ -26,10 +28,10 @@ public class AzuriteContainer extends GenericContainer<AzuriteContainer> {
     public static final String DEFAULT_ACCOUNT_KEY
             = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
 
-    public static final String IMAGE_NAME = "mcr.microsoft.com/azure-storage/azurite:3.27.0";
-
     public AzuriteContainer() {
-        this(IMAGE_NAME);
+        LocalPropertyResolver.getProperty(
+                AzuriteContainer.class,
+                AzureProperties.AZURE_CONTAINER);
     }
 
     public AzuriteContainer(String containerName) {

--- a/test-infra/camel-test-infra-azure-common/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-azure-common/src/test/resources/container.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+## tested against 2.1.2, 2.2.0 & 2.3.1
+azure.container=mcr.microsoft.com/azure-storage/azurite:3.27.0

--- a/test-infra/camel-test-infra-cassandra/src/test/java/org/apache/camel/test/infra/cassandra/services/CassandraLocalContainerService.java
+++ b/test-infra/camel-test-infra-cassandra/src/test/java/org/apache/camel/test/infra/cassandra/services/CassandraLocalContainerService.java
@@ -17,6 +17,7 @@
 package org.apache.camel.test.infra.cassandra.services;
 
 import org.apache.camel.test.infra.cassandra.common.CassandraProperties;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,12 +28,13 @@ import org.testcontainers.containers.CassandraContainer;
  */
 public class CassandraLocalContainerService implements CassandraService, ContainerService<CassandraContainer> {
     private static final Logger LOG = LoggerFactory.getLogger(CassandraLocalContainerService.class);
-    private static final String IMAGE_NAME = "cassandra:4.1.3";
 
     private final CassandraContainer container;
 
     public CassandraLocalContainerService() {
-        this(System.getProperty(CassandraProperties.CASSANDRA_CONTAINER, IMAGE_NAME));
+        this(LocalPropertyResolver.getProperty(
+                CassandraLocalContainerService.class,
+                CassandraProperties.CASSANDRA_CONTAINER));
     }
 
     public CassandraLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-cassandra/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-cassandra/src/test/resources/container.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+## tested against 2.1.2, 2.2.0 & 2.3.1
+cassandra.container=cassandra:4.1.3

--- a/test-infra/camel-test-infra-chatscript/src/test/java/org/apache/camel/test/infra/chatscript/common/ChatScriptProperties.java
+++ b/test-infra/camel-test-infra-chatscript/src/test/java/org/apache/camel/test/infra/chatscript/common/ChatScriptProperties.java
@@ -19,6 +19,7 @@ package org.apache.camel.test.infra.chatscript.common;
 
 public final class ChatScriptProperties {
     public static final String CHATSCRIPT_ADDRESS = "chatscript.address";
+    public static final String CHATSCRIPT_CONTAINER = "chatscript.container";
 
     private ChatScriptProperties() {
 

--- a/test-infra/camel-test-infra-chatscript/src/test/java/org/apache/camel/test/infra/chatscript/services/ChatScriptLocalContainerService.java
+++ b/test-infra/camel-test-infra-chatscript/src/test/java/org/apache/camel/test/infra/chatscript/services/ChatScriptLocalContainerService.java
@@ -17,6 +17,7 @@
 package org.apache.camel.test.infra.chatscript.services;
 
 import org.apache.camel.test.infra.chatscript.common.ChatScriptProperties;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,12 +25,13 @@ import org.testcontainers.containers.GenericContainer;
 
 public class ChatScriptLocalContainerService implements ChatScriptService, ContainerService<GenericContainer> {
     private static final Logger LOG = LoggerFactory.getLogger(ChatScriptLocalContainerService.class);
-    private static final String DEFAULT_CHATSCRIPT_CONTAINER = "claytantor/chatscript-docker:latest";
     private static final int SERVICE_PORT = 1024;
     private GenericContainer container;
 
     public ChatScriptLocalContainerService() {
-        String containerName = System.getProperty("chatscript.container", DEFAULT_CHATSCRIPT_CONTAINER);
+        String containerName = LocalPropertyResolver.getProperty(
+                ChatScriptLocalContainerService.class,
+                ChatScriptProperties.CHATSCRIPT_CONTAINER);
 
         container = new GenericContainer<>(containerName)
                 .withExposedPorts(SERVICE_PORT)

--- a/test-infra/camel-test-infra-chatscript/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-chatscript/src/test/resources/container.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+## tested against 2.1.2, 2.2.0 & 2.3.1
+chatscript.container=claytantor/chatscript-docker:latest

--- a/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/LocalPropertyResolver.java
+++ b/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/LocalPropertyResolver.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.infra.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class LocalPropertyResolver {
+
+    public static final String CONTAINER_PROPERTIES_FILE_NAME = "container.properties";
+
+    public static String getProperty(Class clazz, String propertyName) {
+        return System.getProperty(propertyName, getPropertyFromContainersPropertiesFile(clazz, propertyName));
+    }
+
+    private static String getPropertyFromContainersPropertiesFile(Class clazz, String propertyName) {
+        ClassLoader classLoader = clazz.getClassLoader();
+        if (classLoader == null)
+            throw new RuntimeException(
+                    "Error when trying to read file " + CONTAINER_PROPERTIES_FILE_NAME
+                                       + ": classLoader is null for class " + clazz.getCanonicalName());
+
+        Properties properties = new Properties();
+
+        try (InputStream inputStream = classLoader.getResourceAsStream(CONTAINER_PROPERTIES_FILE_NAME)) {
+            properties.load(inputStream);
+        } catch (IOException e) {
+            String errorMessage = "Error when reading file " + CONTAINER_PROPERTIES_FILE_NAME
+                                  + " for class " + clazz.getCanonicalName();
+            throw new RuntimeException(errorMessage, e);
+        }
+
+        return properties.getProperty(propertyName);
+    }
+
+}

--- a/test-infra/camel-test-infra-consul/src/test/java/org/apache/camel/test/infra/consul/services/ConsulLocalContainerService.java
+++ b/test-infra/camel-test-infra-consul/src/test/java/org/apache/camel/test/infra/consul/services/ConsulLocalContainerService.java
@@ -17,6 +17,7 @@
 package org.apache.camel.test.infra.consul.services;
 
 import com.orbitz.consul.Consul;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.consul.common.ConsulProperties;
 import org.slf4j.Logger;
@@ -25,7 +26,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 public class ConsulLocalContainerService implements ConsulService, ContainerService<GenericContainer> {
-    public static final String CONTAINER_IMAGE = "consul:1.15.4";
     public static final String CONTAINER_NAME = "consul";
 
     private static final Logger LOG = LoggerFactory.getLogger(ConsulLocalContainerService.class);
@@ -33,7 +33,9 @@ public class ConsulLocalContainerService implements ConsulService, ContainerServ
     private final GenericContainer container;
 
     public ConsulLocalContainerService() {
-        this(System.getProperty("consul.container", CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(
+                ConsulLocalContainerService.class,
+                ConsulProperties.CONSUL_CONTAINER));
     }
 
     public ConsulLocalContainerService(String containerName) {

--- a/test-infra/camel-test-infra-consul/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-consul/src/test/resources/container.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+## tested against 2.1.2, 2.2.0 & 2.3.1
+consul.container=consul:1.15.4

--- a/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseLocalContainerService.java
+++ b/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseLocalContainerService.java
@@ -17,6 +17,7 @@
 
 package org.apache.camel.test.infra.couchbase.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.couchbase.common.CouchbaseProperties;
 import org.slf4j.Logger;
@@ -25,7 +26,6 @@ import org.testcontainers.couchbase.CouchbaseContainer;
 
 public class CouchbaseLocalContainerService implements CouchbaseService, ContainerService<CouchbaseContainer> {
     // Please check CAMEL-19228 before upgrading
-    public static final String IMAGE_NAME = "couchbase/server:7.2.3";
 
     /*
      * Couchbase container uses a dynamic port for the KV service. The configuration
@@ -58,7 +58,9 @@ public class CouchbaseLocalContainerService implements CouchbaseService, Contain
     private final CouchbaseContainer container;
 
     public CouchbaseLocalContainerService() {
-        this(System.getProperty(CouchbaseProperties.COUCHBASE_CONTAINER, IMAGE_NAME));
+        this(LocalPropertyResolver.getProperty(
+                CouchbaseLocalContainerService.class,
+                CouchbaseProperties.COUCHBASE_CONTAINER));
     }
 
     public CouchbaseLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-couchbase/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-couchbase/src/test/resources/container.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+## tested against 2.1.2, 2.2.0 & 2.3.1
+couchbase.container=couchbase/server:7.2.3

--- a/test-infra/camel-test-infra-couchdb/src/test/java/org/apache/camel/test/infra/couchdb/services/CouchDbLocalContainerService.java
+++ b/test-infra/camel-test-infra-couchdb/src/test/java/org/apache/camel/test/infra/couchdb/services/CouchDbLocalContainerService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.test.infra.couchdb.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.couchdb.common.CouchDbProperties;
 import org.slf4j.Logger;
@@ -25,7 +26,6 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 public class CouchDbLocalContainerService implements CouchDbService, ContainerService<GenericContainer> {
-    public static final String CONTAINER_IMAGE = "couchdb:2.3.1"; // tested against 2.1.2, 2.2.0 & 2.3.1
     public static final String CONTAINER_NAME = "couchdb";
 
     private static final Logger LOG = LoggerFactory.getLogger(CouchDbLocalContainerService.class);
@@ -33,7 +33,9 @@ public class CouchDbLocalContainerService implements CouchDbService, ContainerSe
     private final GenericContainer container;
 
     public CouchDbLocalContainerService() {
-        this(System.getProperty(CouchDbProperties.COUCHDB_CONTAINER, CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(
+                CouchDbLocalContainerService.class,
+                CouchDbProperties.COUCHDB_CONTAINER));
     }
 
     public CouchDbLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-couchdb/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-couchdb/src/test/resources/container.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+## tested against 2.1.2, 2.2.0 & 2.3.1
+couchdb.container=couchdb:2.3.1

--- a/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchLocalContainerService.java
+++ b/test-infra/camel-test-infra-elasticsearch/src/test/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchLocalContainerService.java
@@ -17,15 +17,7 @@
 
 package org.apache.camel.test.infra.elasticsearch.services;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.Objects;
-import java.util.Optional;
-
-import javax.net.ssl.SSLContext;
-
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.elasticsearch.common.ElasticSearchProperties;
@@ -34,8 +26,15 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
 public class ElasticSearchLocalContainerService implements ElasticSearchService, ContainerService<ElasticsearchContainer> {
-    public static final String DEFAULT_ELASTIC_SEARCH_CONTAINER = "docker.elastic.co/elasticsearch/elasticsearch:8.10.4";
     private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchLocalContainerService.class);
     private static final int ELASTIC_SEARCH_PORT = 9200;
     private static final String USER_NAME = "elastic";
@@ -45,7 +44,9 @@ public class ElasticSearchLocalContainerService implements ElasticSearchService,
     private final ElasticsearchContainer container;
 
     public ElasticSearchLocalContainerService() {
-        this(System.getProperty(ElasticSearchProperties.ELASTIC_SEARCH_CONTAINER, DEFAULT_ELASTIC_SEARCH_CONTAINER));
+        this(LocalPropertyResolver.getProperty(
+                ElasticSearchLocalContainerService.class,
+                ElasticSearchProperties.ELASTIC_SEARCH_CONTAINER));
     }
 
     public ElasticSearchLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-elasticsearch/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-elasticsearch/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+elasticsearch.container=docker.elastic.co/elasticsearch/elasticsearch:8.10.4

--- a/test-infra/camel-test-infra-etcd3/src/test/java/org/apache/camel/test/infra/etcd3/services/Etcd3LocalContainerService.java
+++ b/test-infra/camel-test-infra-etcd3/src/test/java/org/apache/camel/test/infra/etcd3/services/Etcd3LocalContainerService.java
@@ -16,18 +16,18 @@
  */
 package org.apache.camel.test.infra.etcd3.services;
 
-import java.util.List;
-import java.util.UUID;
-
 import io.etcd.jetcd.launcher.EtcdContainer;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.etcd3.common.Etcd3Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.util.List;
+import java.util.UUID;
+
 public class Etcd3LocalContainerService implements Etcd3Service, ContainerService<EtcdContainer> {
-    public static final String CONTAINER_IMAGE = "gcr.io/etcd-development/etcd:v3.5.10";
     public static final String CONTAINER_NAME = "etcd";
     public static final int ETCD_CLIENT_PORT = 2379;
     public static final int ETCD_PEER_PORT = 2380;
@@ -37,7 +37,9 @@ public class Etcd3LocalContainerService implements Etcd3Service, ContainerServic
     private final EtcdContainer container;
 
     public Etcd3LocalContainerService() {
-        this(System.getProperty(Etcd3Properties.ETCD_CONTAINER, CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(
+                Etcd3LocalContainerService.class,
+                Etcd3Properties.ETCD_CONTAINER));
     }
 
     public Etcd3LocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-etcd3/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-etcd3/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+etcd.container=gcr.io/etcd-development/etcd:v3.5.10

--- a/test-infra/camel-test-infra-fhir/src/test/java/org/apache/camel/test/infra/fhir/services/FhirLocalContainerService.java
+++ b/test-infra/camel-test-infra-fhir/src/test/java/org/apache/camel/test/infra/fhir/services/FhirLocalContainerService.java
@@ -16,8 +16,7 @@
  */
 package org.apache.camel.test.infra.fhir.services;
 
-import java.time.Duration;
-
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.fhir.common.FhirProperties;
 import org.slf4j.Logger;
@@ -25,9 +24,10 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.time.Duration;
+
 public class FhirLocalContainerService implements FhirService, ContainerService<GenericContainer> {
     // needs https://github.com/hapifhir/hapi-fhir-jpaserver-starter/commit/54120f374eea5084634830d34c99a9137b22a310
-    public static final String CONTAINER_IMAGE = "hapiproject/hapi:v6.8.3";
     public static final String CONTAINER_NAME = "fhir";
 
     private static final Logger LOG = LoggerFactory.getLogger(FhirLocalContainerService.class);
@@ -35,7 +35,9 @@ public class FhirLocalContainerService implements FhirService, ContainerService<
     private final GenericContainer container;
 
     public FhirLocalContainerService() {
-        this(System.getProperty(FhirProperties.FHIR_CONTAINER, CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(
+                FhirLocalContainerService.class,
+                FhirProperties.FHIR_CONTAINER));
     }
 
     public FhirLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-fhir/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-fhir/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+fhir.container=hapiproject/hapi:v6.8.3

--- a/test-infra/camel-test-infra-google-pubsub/src/test/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubLocalContainerService.java
+++ b/test-infra/camel-test-infra-google-pubsub/src/test/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubLocalContainerService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.test.infra.google.pubsub.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.google.pubsub.common.GooglePubSubProperties;
 import org.slf4j.Logger;
@@ -24,7 +25,6 @@ import org.testcontainers.containers.PubSubEmulatorContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class GooglePubSubLocalContainerService implements GooglePubSubService, ContainerService<PubSubEmulatorContainer> {
-    public static final String IMAGE_NAME = "gcr.io/google.com/cloudsdktool/cloud-sdk:emulators";
 
     public static final String PROJECT_ID;
     private static final Logger LOG = LoggerFactory.getLogger(GooglePubSubLocalContainerService.class);
@@ -37,7 +37,9 @@ public class GooglePubSubLocalContainerService implements GooglePubSubService, C
     private final PubSubEmulatorContainer container;
 
     public GooglePubSubLocalContainerService() {
-        this(System.getProperty(GooglePubSubProperties.PUBSUB_CONTAINER, IMAGE_NAME));
+        this(LocalPropertyResolver.getProperty(
+                GooglePubSubLocalContainerService.class,
+                GooglePubSubProperties.PUBSUB_CONTAINER));
     }
 
     public GooglePubSubLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-google-pubsub/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-google-pubsub/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+google.pubsub.container=gcr.io/google.com/cloudsdktool/cloud-sdk:emulators

--- a/test-infra/camel-test-infra-hashicorp-vault/src/test/java/org/apache/camel/test/infra/hashicorp/vault/services/HashicorpVaultLocalContainerService.java
+++ b/test-infra/camel-test-infra-hashicorp-vault/src/test/java/org/apache/camel/test/infra/hashicorp/vault/services/HashicorpVaultLocalContainerService.java
@@ -1,4 +1,4 @@
-/*
+    /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,19 +16,19 @@
  */
 package org.apache.camel.test.infra.hashicorp.vault.services;
 
-import java.util.function.Consumer;
+    import org.apache.camel.test.infra.common.LocalPropertyResolver;
+    import org.apache.camel.test.infra.common.services.ContainerService;
+    import org.apache.camel.test.infra.hashicorp.vault.common.HashicorpVaultProperties;
+    import org.slf4j.Logger;
+    import org.slf4j.LoggerFactory;
+    import org.testcontainers.containers.GenericContainer;
+    import org.testcontainers.containers.output.OutputFrame;
+    import org.testcontainers.containers.output.Slf4jLogConsumer;
+    import org.testcontainers.containers.wait.strategy.Wait;
 
-import org.apache.camel.test.infra.common.services.ContainerService;
-import org.apache.camel.test.infra.hashicorp.vault.common.HashicorpVaultProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.OutputFrame;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.Wait;
+    import java.util.function.Consumer;
 
 public class HashicorpVaultLocalContainerService implements HashicorpVaultService, ContainerService<GenericContainer<?>> {
-    public static final String CONTAINER_IMAGE = "hashicorp/vault:1.15.2";
     public static final String CONTAINER_NAME = "hashicorp-vault";
     private static final String DEFAULT_TOKEN = "myToken";
 
@@ -37,7 +37,9 @@ public class HashicorpVaultLocalContainerService implements HashicorpVaultServic
     private final GenericContainer container;
 
     public HashicorpVaultLocalContainerService() {
-        this(System.getProperty(HashicorpVaultProperties.HASHICORP_VAULT_CONTAINER, CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(
+                HashicorpVaultLocalContainerService.class,
+                HashicorpVaultProperties.HASHICORP_VAULT_CONTAINER));
     }
 
     public HashicorpVaultLocalContainerService(String containerImage) {

--- a/test-infra/camel-test-infra-hashicorp-vault/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-hashicorp-vault/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+hashicorp.vault.container=hashicorp/vault:1.15.2

--- a/test-infra/camel-test-infra-infinispan/src/test/java/org/apache/camel/test/infra/infinispan/services/InfinispanLocalContainerService.java
+++ b/test-infra/camel-test-infra-infinispan/src/test/java/org/apache/camel/test/infra/infinispan/services/InfinispanLocalContainerService.java
@@ -16,8 +16,7 @@
  */
 package org.apache.camel.test.infra.infinispan.services;
 
-import java.util.function.Consumer;
-
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.infinispan.common.InfinispanProperties;
 import org.slf4j.Logger;
@@ -28,8 +27,9 @@ import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.util.function.Consumer;
+
 public class InfinispanLocalContainerService implements InfinispanService, ContainerService<GenericContainer<?>> {
-    public static final String CONTAINER_IMAGE = "quay.io/infinispan/server:14.0.21.Final";
     public static final String CONTAINER_NAME = "infinispan";
     private static final String DEFAULT_USERNAME = "admin";
     private static final String DEFAULT_PASSWORD = "password";
@@ -40,7 +40,9 @@ public class InfinispanLocalContainerService implements InfinispanService, Conta
     private final boolean isNetworkHost;
 
     public InfinispanLocalContainerService() {
-        this(System.getProperty(InfinispanProperties.INFINISPAN_CONTAINER, CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(
+                InfinispanLocalContainerService.class,
+                InfinispanProperties.INFINISPAN_CONTAINER));
     }
 
     public InfinispanLocalContainerService(String containerImage) {

--- a/test-infra/camel-test-infra-infinispan/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-infinispan/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+infinispan.container=quay.io/infinispan/server:14.0.20.Final

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/common/KafkaProperties.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/common/KafkaProperties.java
@@ -21,6 +21,10 @@ public final class KafkaProperties {
     public static final String KAFKA_BOOTSTRAP_SERVERS = "kafka.bootstrap.servers";
     public static final String KAFKA_ZOOKEEPER_ADDRESS = "kafka.zookeeper.address";
     public static final String KAFKA_CONTAINER = "kafka.container";
+    public static final String KAFKA3_CONTAINER = "kafka3.container";
+    public static final String KAFKA2_CONTAINER = "kafka2.container";
+    public static final String REDPANDA_CONTAINER = "itest.redpanda.container.image";
+    public static final String STRIMZI_CONTAINER = "itest.strimzi.container.image";
 
     private KafkaProperties() {
 

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalAuthKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalAuthKafkaService.java
@@ -31,7 +31,9 @@ public class ContainerLocalAuthKafkaService implements KafkaService, ContainerSe
 
     public static class TransientAuthenticatedKafkaContainer extends KafkaContainer {
         public TransientAuthenticatedKafkaContainer(String jaasConfigFile) {
-            super(DockerImageName.parse(System.getProperty("kafka.container", ContainerLocalKafkaService.KAFKA3_IMAGE_NAME))
+            super(DockerImageName.parse(System.getProperty(
+                    KafkaProperties.KAFKA_CONTAINER,
+                            ContainerLocalKafkaService.KAFKA3_IMAGE_NAME))
                     .asCompatibleSubstituteFor(ContainerLocalKafkaService.KAFKA3_IMAGE_NAME));
 
             withEmbeddedZookeeper();

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
@@ -17,6 +17,7 @@
 
 package org.apache.camel.test.infra.kafka.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.kafka.common.KafkaProperties;
 import org.slf4j.Logger;
@@ -25,8 +26,12 @@ import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class ContainerLocalKafkaService implements KafkaService, ContainerService<KafkaContainer> {
-    public static final String KAFKA3_IMAGE_NAME = "confluentinc/cp-kafka:7.4.0";
-    public static final String KAFKA2_IMAGE_NAME = "confluentinc/cp-kafka:5.5.12";
+    public static final String KAFKA3_IMAGE_NAME = LocalPropertyResolver.getProperty(
+            ContainerLocalKafkaService.class,
+            KafkaProperties.KAFKA3_CONTAINER);
+    public static final String KAFKA2_IMAGE_NAME = LocalPropertyResolver.getProperty(
+            ContainerLocalKafkaService.class,
+            KafkaProperties.KAFKA2_CONTAINER);
 
     private static final Logger LOG = LoggerFactory.getLogger(ContainerLocalKafkaService.class);
     private final KafkaContainer kafka;
@@ -40,7 +45,7 @@ public class ContainerLocalKafkaService implements KafkaService, ContainerServic
     }
 
     protected KafkaContainer initContainer() {
-        return new KafkaContainer(DockerImageName.parse(System.getProperty("kafka.container", KAFKA3_IMAGE_NAME)))
+        return new KafkaContainer(DockerImageName.parse(System.getProperty(KafkaProperties.KAFKA_CONTAINER, KAFKA3_IMAGE_NAME)))
                 .withEmbeddedZookeeper();
     }
 
@@ -74,7 +79,7 @@ public class ContainerLocalKafkaService implements KafkaService, ContainerServic
     public static ContainerLocalKafkaService kafka2Container() {
         KafkaContainer container
                 = new KafkaContainer(
-                        DockerImageName.parse(System.getProperty("kafka.container", KAFKA2_IMAGE_NAME))
+                        DockerImageName.parse(System.getProperty(KafkaProperties.KAFKA_CONTAINER, KAFKA2_IMAGE_NAME))
                                 .asCompatibleSubstituteFor(ContainerLocalKafkaService.KAFKA2_IMAGE_NAME));
         container = container.withEmbeddedZookeeper();
 
@@ -84,7 +89,7 @@ public class ContainerLocalKafkaService implements KafkaService, ContainerServic
     public static ContainerLocalKafkaService kafka3Container() {
         KafkaContainer container
                 = new KafkaContainer(
-                        DockerImageName.parse(System.getProperty("kafka.container", KAFKA3_IMAGE_NAME))
+                        DockerImageName.parse(System.getProperty(KafkaProperties.KAFKA_CONTAINER, KAFKA3_IMAGE_NAME))
                                 .asCompatibleSubstituteFor(ContainerLocalKafkaService.KAFKA3_IMAGE_NAME));
         container = container.withEmbeddedZookeeper();
 

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/RedpandaTransactionsEnabledContainer.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/RedpandaTransactionsEnabledContainer.java
@@ -17,14 +17,15 @@
 package org.apache.camel.test.infra.kafka.services;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.kafka.common.KafkaProperties;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.redpanda.RedpandaContainer;
 
 public class RedpandaTransactionsEnabledContainer extends RedpandaContainer {
-
-    public static final String DEFAULT_REDPANDA_CONTAINER = "docker.redpanda.com/vectorized/redpanda:v23.1.1";
-    public static final String REDPANDA_CONTAINER
-            = System.getProperty("itest.redpanda.container.image", DEFAULT_REDPANDA_CONTAINER);
+    public static final String REDPANDA_CONTAINER = LocalPropertyResolver.getProperty(
+            RedpandaTransactionsEnabledContainer.class,
+            KafkaProperties.REDPANDA_CONTAINER);
     public static final int REDPANDA_PORT = 9092;
 
     public RedpandaTransactionsEnabledContainer(String image) {

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/StrimziContainer.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/StrimziContainer.java
@@ -18,14 +18,16 @@
 package org.apache.camel.test.infra.kafka.services;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.kafka.common.KafkaProperties;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 public class StrimziContainer extends GenericContainer<StrimziContainer> {
-    public static final String DEFAULT_STRIMZI_CONTAINER = "quay.io/strimzi/kafka:latest-kafka-3.5.1";
-    static final String STRIMZI_CONTAINER
-            = System.getProperty("itest.strimzi.container.image", DEFAULT_STRIMZI_CONTAINER);
+    static final String STRIMZI_CONTAINER = LocalPropertyResolver.getProperty(
+            StrimziContainer.class,
+            KafkaProperties.STRIMZI_CONTAINER);
     private static final int KAFKA_PORT = 9092;
 
     public StrimziContainer(Network network, String name, String zookeeperInstanceName) {

--- a/test-infra/camel-test-infra-kafka/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-kafka/src/test/resources/container.properties
@@ -1,0 +1,20 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+kafka3.container=confluentinc/cp-kafka:7.4.0
+kafka2.container=confluentinc/cp-kafka:5.5.12
+itest.redpanda.container.image=docker.redpanda.com/vectorized/redpanda:v23.1.1
+itest.strimzi.container.image=quay.io/strimzi/kafka:latest-kafka-3.5.1

--- a/test-infra/camel-test-infra-microprofile-lra/src/test/java/org/apache/camel/test/infra/microprofile/lra/services/MicroprofileLRALocalContainerService.java
+++ b/test-infra/camel-test-infra-microprofile-lra/src/test/java/org/apache/camel/test/infra/microprofile/lra/services/MicroprofileLRALocalContainerService.java
@@ -17,6 +17,7 @@
 package org.apache.camel.test.infra.microprofile.lra.services;
 
 import com.github.dockerjava.api.model.Network;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.microprofile.lra.common.MicroprofileLRAProperties;
 import org.slf4j.Logger;
@@ -26,7 +27,6 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 public class MicroprofileLRALocalContainerService implements MicroprofileLRAService, ContainerService<GenericContainer> {
-    public static final String CONTAINER_IMAGE = "quay.io/jbosstm/lra-coordinator:5.13.1.Final-2.16.6.Final";
     public static final String CONTAINER_NAME = "microprofile-lra";
 
     private static final Logger LOG = LoggerFactory.getLogger(MicroprofileLRALocalContainerService.class);
@@ -34,7 +34,9 @@ public class MicroprofileLRALocalContainerService implements MicroprofileLRAServ
     private final GenericContainer container;
 
     public MicroprofileLRALocalContainerService() {
-        this(System.getProperty(MicroprofileLRAProperties.MICROPROFILE_LRA_CONTAINER, CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(
+                MicroprofileLRALocalContainerService.class,
+                MicroprofileLRAProperties.MICROPROFILE_LRA_CONTAINER));
     }
 
     public MicroprofileLRALocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-microprofile-lra/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-microprofile-lra/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+microprofile.lra.container=quay.io/jbosstm/lra-coordinator:5.13.1.Final-2.16.6.Final

--- a/test-infra/camel-test-infra-minio/src/test/java/org/apache/camel/test/infra/minio/services/MinioLocalContainerService.java
+++ b/test-infra/camel-test-infra-minio/src/test/java/org/apache/camel/test/infra/minio/services/MinioLocalContainerService.java
@@ -16,8 +16,7 @@
  */
 package org.apache.camel.test.infra.minio.services;
 
-import java.time.Duration;
-
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.minio.common.MinioProperties;
 import org.slf4j.Logger;
@@ -25,8 +24,9 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 
+import java.time.Duration;
+
 public class MinioLocalContainerService implements MinioService, ContainerService<GenericContainer> {
-    public static final String CONTAINER_IMAGE = "minio/minio:latest";
     public static final String CONTAINER_NAME = "minio";
     private static final String ACCESS_KEY;
     private static final String SECRET_KEY;
@@ -42,7 +42,7 @@ public class MinioLocalContainerService implements MinioService, ContainerServic
     private final GenericContainer container;
 
     public MinioLocalContainerService() {
-        this(System.getProperty(MinioProperties.MINIO_CONTAINER, CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(MinioLocalContainerService.class, MinioProperties.MINIO_CONTAINER));
     }
 
     public MinioLocalContainerService(String containerName) {

--- a/test-infra/camel-test-infra-minio/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-minio/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+minio.container=minio/minio:latest

--- a/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBLocalContainerService.java
+++ b/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBLocalContainerService.java
@@ -17,6 +17,7 @@
 
 package org.apache.camel.test.infra.mongodb.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.mongodb.common.MongoDBProperties;
 import org.slf4j.Logger;
@@ -29,7 +30,7 @@ public class MongoDBLocalContainerService implements MongoDBService, ContainerSe
     private final MongoDBContainer container;
 
     public MongoDBLocalContainerService() {
-        this(System.getProperty(MongoDBProperties.MONGODB_CONTAINER));
+        this(LocalPropertyResolver.getProperty(MongoDBLocalContainerService.class, MongoDBProperties.MONGODB_CONTAINER));
     }
 
     public MongoDBLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-mongodb/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-mongodb/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+mongodb.container=mongo:7.0.4-jammy

--- a/test-infra/camel-test-infra-mosquitto/src/test/java/org/apache/camel/test/infra/mosquitto/services/MosquittoLocalContainerService.java
+++ b/test-infra/camel-test-infra-mosquitto/src/test/java/org/apache/camel/test/infra/mosquitto/services/MosquittoLocalContainerService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.test.infra.mosquitto.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.mosquitto.common.MosquittoProperties;
 import org.slf4j.Logger;
@@ -26,7 +27,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 public class MosquittoLocalContainerService implements MosquittoService, ContainerService<GenericContainer> {
-    public static final String CONTAINER_IMAGE = "eclipse-mosquitto:2.0.18";
     public static final String CONTAINER_NAME = "mosquitto";
     public static final int CONTAINER_PORT = 1883;
 
@@ -35,11 +35,13 @@ public class MosquittoLocalContainerService implements MosquittoService, Contain
     private final GenericContainer container;
 
     public MosquittoLocalContainerService() {
-        this(CONTAINER_IMAGE);
+        this(LocalPropertyResolver.getProperty(MosquittoLocalContainerService.class, MosquittoProperties.MOSQUITTO_CONTAINER));
     }
 
     public MosquittoLocalContainerService(int port) {
-        String imageName = System.getProperty(MosquittoProperties.MOSQUITTO_CONTAINER, CONTAINER_IMAGE);
+        String imageName = LocalPropertyResolver.getProperty(
+                MosquittoLocalContainerService.class,
+                MosquittoProperties.MOSQUITTO_CONTAINER);
 
         container = initContainer(imageName, port);
     }

--- a/test-infra/camel-test-infra-mosquitto/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-mosquitto/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+mosquitto.container=eclipse-mosquitto:2.0.18

--- a/test-infra/camel-test-infra-nats/src/test/java/org/apache/camel/test/infra/nats/services/NatsLocalContainerService.java
+++ b/test-infra/camel-test-infra-nats/src/test/java/org/apache/camel/test/infra/nats/services/NatsLocalContainerService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.test.infra.nats.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.nats.common.NatsProperties;
 import org.slf4j.Logger;
@@ -24,7 +25,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 public class NatsLocalContainerService implements NatsService, ContainerService<GenericContainer> {
-    public static final String CONTAINER_IMAGE = "nats:2.10.5";
     public static final String CONTAINER_NAME = "nats";
     private static final int PORT = 4222;
 
@@ -32,7 +32,7 @@ public class NatsLocalContainerService implements NatsService, ContainerService<
     private final GenericContainer container;
 
     public NatsLocalContainerService() {
-        this(System.getProperty(NatsProperties.NATS_CONTAINER, CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(NatsLocalContainerService.class, NatsProperties.NATS_CONTAINER));
     }
 
     public NatsLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-nats/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-nats/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+nats.container=nats:2.10.5

--- a/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/OpenldapLocalContainerService.java
+++ b/test-infra/camel-test-infra-openldap/src/test/java/org/apache/camel/test/infra/openldap/services/OpenldapLocalContainerService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.test.infra.openldap.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.openldap.common.OpenldapProperties;
 import org.slf4j.Logger;
@@ -24,7 +25,8 @@ import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 
 public class OpenldapLocalContainerService implements OpenldapService, ContainerService<GenericContainer> {
-    public static final String CONTAINER_IMAGE = "osixia/openldap:1.5.0";
+
+    public static final String OPENLDAP_CONTAINER_PROPERTY = "openldap.container";
     public static final String CONTAINER_NAME = "openldap";
     public static final int CONTAINER_PORT_LDAP = 389;
     public static final int CONTAINER_PORT_LDAP_OVER_SSL = 636;
@@ -34,11 +36,13 @@ public class OpenldapLocalContainerService implements OpenldapService, Container
     private final GenericContainer container;
 
     public OpenldapLocalContainerService() {
-        this(CONTAINER_IMAGE);
+        this(LocalPropertyResolver.getProperty(OpenldapLocalContainerService.class, OPENLDAP_CONTAINER_PROPERTY));
     }
 
     public OpenldapLocalContainerService(int port, int sslPort) {
-        String imageName = System.getProperty(OpenldapProperties.OPENLDAP_CONTAINER, CONTAINER_IMAGE);
+        String imageName = System.getProperty(
+                OpenldapProperties.OPENLDAP_CONTAINER,
+                LocalPropertyResolver.getProperty(OpenldapLocalContainerService.class, OPENLDAP_CONTAINER_PROPERTY));
 
         container = initContainer(imageName, port, sslPort);
     }

--- a/test-infra/camel-test-infra-openldap/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-openldap/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+openldap.container=osixia/openldap:1.5.0

--- a/test-infra/camel-test-infra-opensearch/src/test/java/org/apache/camel/test/infra/opensearch/services/OpenSearchLocalContainerService.java
+++ b/test-infra/camel-test-infra-opensearch/src/test/java/org/apache/camel/test/infra/opensearch/services/OpenSearchLocalContainerService.java
@@ -17,8 +17,7 @@
 
 package org.apache.camel.test.infra.opensearch.services;
 
-import java.time.Duration;
-
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.opensearch.common.OpenSearchProperties;
@@ -28,8 +27,9 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
+import java.time.Duration;
+
 public class OpenSearchLocalContainerService implements OpenSearchService, ContainerService<OpensearchContainer> {
-    public static final String DEFAULT_OPEN_SEARCH_CONTAINER = "opensearchproject/opensearch:2.11.0";
     private static final Logger LOG = LoggerFactory.getLogger(OpenSearchLocalContainerService.class);
     private static final int OPEN_SEARCH_PORT = 9200;
     private static final String USER_NAME = "admin";
@@ -37,7 +37,7 @@ public class OpenSearchLocalContainerService implements OpenSearchService, Conta
     private final OpensearchContainer container;
 
     public OpenSearchLocalContainerService() {
-        this(System.getProperty(OpenSearchProperties.OPEN_SEARCH_CONTAINER, DEFAULT_OPEN_SEARCH_CONTAINER));
+        this(LocalPropertyResolver.getProperty(OpenSearchLocalContainerService.class, OpenSearchProperties.OPEN_SEARCH_CONTAINER));
     }
 
     public OpenSearchLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-opensearch/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-opensearch/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+opensearch.container=opensearchproject/opensearch:2.11.0

--- a/test-infra/camel-test-infra-postgres/src/test/java/org/apache/camel/test/infra/postgres/services/PostgresLocalContainerService.java
+++ b/test-infra/camel-test-infra-postgres/src/test/java/org/apache/camel/test/infra/postgres/services/PostgresLocalContainerService.java
@@ -24,11 +24,12 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 public class PostgresLocalContainerService implements PostgresService, ContainerService<PostgreSQLContainer> {
+    public static final String DEFAULT_POSTGRES_CONTAINER = LocalPropertyResolver.getProperty(PostgresLocalContainerService.class, PostgresProperties.POSTGRES_CONTAINER);
     private static final Logger LOG = LoggerFactory.getLogger(PostgresLocalContainerService.class);
     private final PostgreSQLContainer container;
 
     public PostgresLocalContainerService() {
-        this(LocalPropertyResolver.getProperty(PostgresLocalContainerService.class, PostgresProperties.POSTGRES_CONTAINER));
+        this(DEFAULT_POSTGRES_CONTAINER);
     }
 
     public PostgresLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-postgres/src/test/java/org/apache/camel/test/infra/postgres/services/PostgresLocalContainerService.java
+++ b/test-infra/camel-test-infra-postgres/src/test/java/org/apache/camel/test/infra/postgres/services/PostgresLocalContainerService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.test.infra.postgres.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.postgres.common.PostgresProperties;
 import org.slf4j.Logger;
@@ -23,12 +24,11 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 public class PostgresLocalContainerService implements PostgresService, ContainerService<PostgreSQLContainer> {
-    public static final String DEFAULT_POSTGRES_CONTAINER = "postgres:13.13";
     private static final Logger LOG = LoggerFactory.getLogger(PostgresLocalContainerService.class);
     private final PostgreSQLContainer container;
 
     public PostgresLocalContainerService() {
-        this(System.getProperty(PostgresProperties.POSTGRES_CONTAINER, DEFAULT_POSTGRES_CONTAINER));
+        this(LocalPropertyResolver.getProperty(PostgresLocalContainerService.class, PostgresProperties.POSTGRES_CONTAINER));
     }
 
     public PostgresLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-postgres/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-postgres/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+postgres.container=postgres:13.13

--- a/test-infra/camel-test-infra-pulsar/src/test/java/org/apache/camel/test/infra/pulsar/services/PulsarLocalContainerService.java
+++ b/test-infra/camel-test-infra-pulsar/src/test/java/org/apache/camel/test/infra/pulsar/services/PulsarLocalContainerService.java
@@ -16,8 +16,7 @@
  */
 package org.apache.camel.test.infra.pulsar.services;
 
-import java.time.Duration;
-
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.pulsar.common.PulsarProperties;
 import org.slf4j.Logger;
@@ -25,15 +24,16 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.time.Duration;
+
 public class PulsarLocalContainerService implements PulsarService, ContainerService<PulsarContainer> {
-    public static final String CONTAINER_IMAGE = "apachepulsar/pulsar:3.1.1";
 
     private static final Logger LOG = LoggerFactory.getLogger(PulsarLocalContainerService.class);
 
     private final PulsarContainer container;
 
     public PulsarLocalContainerService() {
-        this(System.getProperty(PulsarProperties.PULSAR_CONTAINER, CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(PulsarLocalContainerService.class, PulsarProperties.PULSAR_CONTAINER));
     }
 
     public PulsarLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-pulsar/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-pulsar/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+pulsar.container=apachepulsar/pulsar:3.1.1

--- a/test-infra/camel-test-infra-rabbitmq/src/test/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQLocalContainerService.java
+++ b/test-infra/camel-test-infra-rabbitmq/src/test/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQLocalContainerService.java
@@ -17,6 +17,7 @@
 
 package org.apache.camel.test.infra.rabbitmq.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.rabbitmq.common.RabbitMQProperties;
 import org.slf4j.Logger;
@@ -24,13 +25,12 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.RabbitMQContainer;
 
 public class RabbitMQLocalContainerService implements RabbitMQService, ContainerService<RabbitMQContainer> {
-    public static final String RABBITMQ_CONTAINER_IMAGE = "rabbitmq:3.12-management";
     private static final Logger LOG = LoggerFactory.getLogger(RabbitMQLocalContainerService.class);
 
     private final RabbitMQContainer container;
 
     public RabbitMQLocalContainerService() {
-        this(System.getProperty(RabbitMQProperties.RABBITMQ_CONTAINER, RABBITMQ_CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(RabbitMQLocalContainerService.class, RabbitMQProperties.RABBITMQ_CONTAINER));
     }
 
     public RabbitMQLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-rabbitmq/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-rabbitmq/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+rabbitmq.container=rabbitmq:3.12-management

--- a/test-infra/camel-test-infra-redis/src/test/java/org/apache/camel/test/infra/redis/services/RedisLocalContainerService.java
+++ b/test-infra/camel-test-infra-redis/src/test/java/org/apache/camel/test/infra/redis/services/RedisLocalContainerService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.test.infra.redis.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.redis.common.RedisProperties;
 import org.slf4j.Logger;
@@ -25,7 +26,6 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 public class RedisLocalContainerService implements RedisService, ContainerService<GenericContainer> {
-    public static final String CONTAINER_IMAGE = "redis:6.2.14";
     public static final String CONTAINER_NAME = "redis";
 
     private static final Logger LOG = LoggerFactory.getLogger(RedisLocalContainerService.class);
@@ -33,7 +33,7 @@ public class RedisLocalContainerService implements RedisService, ContainerServic
     private final GenericContainer container;
 
     public RedisLocalContainerService() {
-        this(System.getProperty(RedisProperties.REDIS_CONTAINER, CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(RedisLocalContainerService.class, RedisProperties.REDIS_CONTAINER));
     }
 
     public RedisLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-redis/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-redis/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+redis.container=redis:6.2.14

--- a/test-infra/camel-test-infra-rocketmq/src/test/java/org/apache/camel/test/infra/rocketmq/services/RocketMQContainer.java
+++ b/test-infra/camel-test-infra-rocketmq/src/test/java/org/apache/camel/test/infra/rocketmq/services/RocketMQContainer.java
@@ -16,9 +16,7 @@
  */
 package org.apache.camel.test.infra.rocketmq.services;
 
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.rocketmq.common.RocketMQProperties;
 import org.awaitility.Awaitility;
@@ -27,12 +25,17 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.Network;
 
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
 public class RocketMQContainer implements RocketMQService, ContainerService<RocketMQNameserverContainer> {
     private static final Logger LOG = LoggerFactory.getLogger(RocketMQContainer.class);
-    public static final String ROCKETMQ_VERSION = System.getProperty(RocketMQProperties.ROCKETMQ_VERSION_PROPERTY,
-            "5.1.4");
-    public static final String ROCKETMQ_IMAGE = System.getProperty(RocketMQProperties.ROCKETMQ_IMAGE_PROPERTY,
-            "apache/rocketmq:" + ROCKETMQ_VERSION);
+    public static final String ROCKETMQ_VERSION = LocalPropertyResolver.getProperty(
+            RocketMQContainer.class,
+            RocketMQProperties.ROCKETMQ_VERSION_PROPERTY);
+    public static final String ROCKETMQ_IMAGE = LocalPropertyResolver.getProperty(
+            RocketMQContainer.class,
+            RocketMQProperties.ROCKETMQ_IMAGE_PROPERTY) + ":" + ROCKETMQ_VERSION;
 
     private final RocketMQNameserverContainer nameserverContainer;
     private final RocketMQBrokerContainer brokerContainer1;

--- a/test-infra/camel-test-infra-rocketmq/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-rocketmq/src/test/resources/container.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+itest.rocketmq.container.image=apache/rocketmq
+itest.rocketmq.container.image.version=5.1.3

--- a/test-infra/camel-test-infra-xmpp/src/test/java/org/apache/camel/test/infra/xmpp/services/XmppLocalContainerService.java
+++ b/test-infra/camel-test-infra-xmpp/src/test/java/org/apache/camel/test/infra/xmpp/services/XmppLocalContainerService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.test.infra.xmpp.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.xmpp.common.XmppProperties;
 import org.slf4j.Logger;
@@ -27,7 +28,7 @@ public class XmppLocalContainerService implements XmppService, ContainerService<
     private XmppServerContainer container;
 
     public XmppLocalContainerService() {
-        this(System.getProperty(XmppProperties.XMPP_CONTAINER, XmppServerContainer.VYSPER_IMAGE));
+        this(LocalPropertyResolver.getProperty(XmppServerContainer.class, XmppProperties.XMPP_CONTAINER));
     }
 
     public XmppLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-xmpp/src/test/java/org/apache/camel/test/infra/xmpp/services/XmppServerContainer.java
+++ b/test-infra/camel-test-infra-xmpp/src/test/java/org/apache/camel/test/infra/xmpp/services/XmppServerContainer.java
@@ -16,10 +16,7 @@
  */
 package org.apache.camel.test.infra.xmpp.services;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.xmpp.common.XmppProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,15 +24,18 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
 public class XmppServerContainer extends GenericContainer {
-    public static final String VYSPER_IMAGE = "5mattho/vysper-wrapper:0.3";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(XmppServerContainer.class);
     private static final String CONTAINER_NAME = "vysper-wrapper";
     private static final Integer PORT_REST = 8080;
 
     public XmppServerContainer() {
-        super(VYSPER_IMAGE);
+        super(LocalPropertyResolver.getProperty(XmppServerContainer.class, XmppProperties.XMPP_CONTAINER));
         setWaitStrategy(Wait.forListeningPort());
         withExposedPorts(XmppProperties.PORT_DEFAULT, PORT_REST);
         withNetworkAliases(CONTAINER_NAME);

--- a/test-infra/camel-test-infra-xmpp/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-xmpp/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+xmpp.container=5mattho/vysper-wrapper:0.3

--- a/test-infra/camel-test-infra-zookeeper/src/test/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperContainer.java
+++ b/test-infra/camel-test-infra-zookeeper/src/test/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperContainer.java
@@ -23,7 +23,6 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 public class ZooKeeperContainer extends GenericContainer {
-    public static final String CONTAINER_IMAGE = "zookeeper:3.9";
     public static final String CONTAINER_NAME = "zookeeper";
     public static final int CLIENT_PORT = 2181;
 

--- a/test-infra/camel-test-infra-zookeeper/src/test/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperLocalContainerService.java
+++ b/test-infra/camel-test-infra-zookeeper/src/test/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperLocalContainerService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.test.infra.zookeeper.services;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.zookeeper.common.ZooKeeperProperties;
 import org.slf4j.Logger;
@@ -27,7 +28,7 @@ public class ZooKeeperLocalContainerService implements ZooKeeperService, Contain
     private final ZooKeeperContainer container;
 
     public ZooKeeperLocalContainerService() {
-        this(System.getProperty(ZooKeeperProperties.ZOOKEEPER_CONTAINER, ZooKeeperContainer.CONTAINER_IMAGE));
+        this(LocalPropertyResolver.getProperty(ZooKeeperLocalContainerService.class, ZooKeeperProperties.ZOOKEEPER_CONTAINER));
     }
 
     public ZooKeeperLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-zookeeper/src/test/resources/container.properties
+++ b/test-infra/camel-test-infra-zookeeper/src/test/resources/container.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+zookeeper.container=zookeeper:3.9


### PR DESCRIPTION
# Description
The file 'containers.properties' is added for each test-infra module that uses docker image and does not build its own docker image. File contains image names that are used in test-infra.
Loading image name from file from file is done by org.apache.camel.test.infra.common.LocalPropertyResolver

# Tracking
https://issues.apache.org/jira/browse/CAMEL-20123

