### PR TITLE
(chores) core: wait for I/O to reduce flakiness

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/TestSupport.java
+++ b/core/camel-core/src/test/java/org/apache/camel/TestSupport.java
@@ -102,7 +102,11 @@ public abstract class TestSupport {
     }
 
     protected Path testFile(String file) {
-        return testDirectory().resolve(file);
+        return testFile(testDirectory(), file);
+    }
+
+    protected static Path testFile(Path testDirectory, String file) {
+        return testDirectory.resolve(file);
     }
 
     protected Path testDirectory(String path) {

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOConvertBodyToTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOConvertBodyToTest.java
@@ -20,13 +20,16 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -57,12 +60,16 @@ class FileProducerCharsetUTFtoISOConvertBodyToTest extends ContextTestSupport {
         }
     }
 
-    @RepeatedTest(10)
+    @Test
     void testFileProducerCharsetUTFtoISOConvertBodyTo() throws Exception {
         assertTrue(oneExchangeDone.matchesWaitTime());
 
-        assertFileExists(testFile("output.txt"));
-        byte[] data = Files.readAllBytes(testFile("output.txt"));
+        final Path outputFile = testFile("output.txt");
+
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> assertFileExists(outputFile));
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(Files.size(outputFile) > 0));
+
+        byte[] data = Files.readAllBytes(outputFile);
 
         assertEquals(DATA, new String(data, StandardCharsets.ISO_8859_1));
     }


### PR DESCRIPTION
In slow systems, the interval between the exchange completion and the data being written to the disk may cause the test to read an empty file. This should give an extra time for that to happen.