### PR TITLE
CAMEL-20225: use the clock API when possible for exchange duration calculations

### DIFF
--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedBacklogDebugger.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedBacklogDebugger.java
@@ -394,7 +394,7 @@ public class ManagedBacklogDebugger implements ManagedBacklogDebuggerMBean {
                             + "]";
                 }
 
-                long elapsed = TimeUtils.elapsedMillisSince(suspendedExchange.getClock().getCreated());
+                long elapsed = suspendedExchange.getClock().elapsed();
 
                 messageHistoryBuilder
                         .append("    <messageHistoryEntry")

--- a/core/camel-support/src/main/java/org/apache/camel/support/MonotonicClock.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/MonotonicClock.java
@@ -17,18 +17,22 @@
 
 package org.apache.camel.support;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.Clock;
 
 public class MonotonicClock implements Clock {
     private final long created;
+    private final long createdNano;
 
     MonotonicClock() {
         this.created = System.currentTimeMillis();
+        this.createdNano = System.nanoTime();
     }
 
     @Override
     public long elapsed() {
-        return System.currentTimeMillis() - created;
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - createdNano);
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/ResetableClock.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/ResetableClock.java
@@ -17,22 +17,27 @@
 
 package org.apache.camel.support;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.Clock;
 
 public final class ResetableClock implements Clock {
     private long created;
+    private long createdNano;
 
     ResetableClock(Clock clock) {
         this.created = clock.getCreated();
+        this.createdNano = System.nanoTime();
     }
 
     ResetableClock() {
         this.created = System.currentTimeMillis();
+        this.createdNano = System.nanoTime();
     }
 
     @Override
     public long elapsed() {
-        return System.currentTimeMillis() - created;
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - createdNano);
     }
 
     @Override
@@ -45,6 +50,7 @@ public final class ResetableClock implements Clock {
      */
     public void reset() {
         this.created = System.currentTimeMillis();
+        this.createdNano = System.nanoTime();
     }
 
     /**
@@ -53,5 +59,6 @@ public final class ResetableClock implements Clock {
      */
     void unset() {
         this.created = 0;
+        this.createdNano = 0;
     }
 }

--- a/core/camel-util/src/main/java/org/apache/camel/util/TimeUtils.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/TimeUtils.java
@@ -254,9 +254,11 @@ public final class TimeUtils {
     /**
      * Elapsed time using milliseconds since epoch.
      *
-     * @param  start the timestamp in milliseconds since epoch
-     * @return       the elapsed time in milliseconds
+     * @param      start the timestamp in milliseconds since epoch
+     * @return           the elapsed time in milliseconds
+     * @deprecated       Use the Clock API when possible
      */
+    @Deprecated(since = "4.4.0")
     public static long elapsedMillisSince(long start) {
         return System.currentTimeMillis() - start;
     }


### PR DESCRIPTION
This brings a few additional improvements:
1. Use a monotonic clock for calculating duration
2. Consolidate more code into the `elapsed` method 
3. Deprecate ad-hoc duration calculations 