### PR TITLE
Fix examples links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The up to date list is available online at the Camel website:
 Apache Camel comes with many examples.
 The up to date list is available online at GitHub:
 
-* Examples: <https://github.com/apache/camel-examples/tree/main/examples#welcome-to-the-apache-camel-examples>
+* Examples: <https://github.com/apache/camel-examples/tree/main#welcome-to-the-apache-camel-examples>
 
 ## Getting Started
 
@@ -54,7 +54,7 @@ To help you get started, try the following links:
 
 The beginner examples are another powerful alternative pathway for getting started with Apache Camel.
 
-* Examples: <https://github.com/apache/camel-examples/tree/main/examples#welcome-to-the-apache-camel-examples>
+* Examples: <https://github.com/apache/camel-examples/tree/main#welcome-to-the-apache-camel-examples>
 
 **Building**
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/change-data-capture.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/change-data-capture.adoc
@@ -13,4 +13,4 @@ components that works with different databases such as MySQL, Postgres, and Mong
 
 == Example
 
-See the https://github.com/apache/camel-examples/tree/main/examples/debezium[Camel Debezium Example] for more details.
+See the https://github.com/apache/camel-examples/tree/main/debezium[Camel Debezium Example] for more details.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/kamelet-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/kamelet-eip.adoc
@@ -109,4 +109,4 @@ The implementation of the Kamelet EIP is located in the `camel-kamelet` JAR, so 
 
 == See Also
 
-See the example https://github.com/apache/camel-examples/tree/main/examples/kamelet[camel-example-kamelet].
+See the example https://github.com/apache/camel-examples/tree/main/kamelet[camel-example-kamelet].

--- a/docs/user-manual/modules/ROOT/pages/bean-integration.adoc
+++ b/docs/user-manual/modules/ROOT/pages/bean-integration.adoc
@@ -43,7 +43,7 @@ See more details at:
 
 *Example*
 
-See the https://github.com/apache/camel-examples/tree/main/examples/pojo-messaging[POJO Messaging Example]
+See the https://github.com/apache/camel-examples/tree/main/pojo-messaging[POJO Messaging Example]
 for how to use the annotations for routing and messaging.
 
 == Using @PropertyInject

--- a/docs/user-manual/modules/ROOT/pages/health-check.adoc
+++ b/docs/user-manual/modules/ROOT/pages/health-check.adoc
@@ -311,6 +311,6 @@ Camel will then use these custom component health checks when it performs *route
 
 There are examples for Camel at:
 
-- Camel Standalone: https://github.com/apache/camel-examples/tree/main/examples/main-health[main-health]
+- Camel Standalone: https://github.com/apache/camel-examples/tree/main/main-health[main-health]
 - Camel Spring Boot: https://github.com/apache/camel-spring-boot-examples/tree/main/health-checks[health-checks]
 - Camel Quarkus: https://github.com/apache/camel-quarkus-examples/tree/main/health[health]

--- a/docs/user-manual/modules/ROOT/pages/route-configuration.adoc
+++ b/docs/user-manual/modules/ROOT/pages/route-configuration.adoc
@@ -402,6 +402,6 @@ And in YAML DSL:
 
 See these examples:
 
-- https://github.com/apache/camel-examples/tree/main/examples/routes-configuration[camel-examples/examples/routes-configuration]
+- https://github.com/apache/camel-examples/tree/main/routes-configuration[camel-examples/examples/routes-configuration]
 - https://github.com/apache/camel-spring-boot-examples/tree/main/routes-configuration[camel-spring-boot-examples/routes-configuration/]
 

--- a/docs/user-manual/modules/ROOT/pages/route-reload.adoc
+++ b/docs/user-manual/modules/ROOT/pages/route-reload.adoc
@@ -80,5 +80,5 @@ See related xref:context-reload.adoc[].
 
 See the following examples that comes with live reloading enabled:
 
-- https://github.com/apache/camel-examples/tree/main/examples/main-xml[camel-examples/examples/main-xml]
-- https://github.com/apache/camel-examples/tree/main/examples/main-yaml[camel-examples/examples/main-yaml]
+- https://github.com/apache/camel-examples/tree/main/main-xml[camel-examples/examples/main-xml]
+- https://github.com/apache/camel-examples/tree/main/main-yaml[camel-examples/examples/main-yaml]

--- a/dsl/camel-kamelet-main/src/main/docs/kamelet-main.adoc
+++ b/dsl/camel-kamelet-main/src/main/docs/kamelet-main.adoc
@@ -48,4 +48,4 @@ For example a Camel route can be _coded_ in YAML which uses the Earthquake Kamel
 In this use-case the earthquake kamelet will be downloaded from github, and as well its required dependencies.
 
 You can find an example with this at
-https://github.com/apache/camel-examples/tree/main/examples/kamelet-main[kamelet-main].
+https://github.com/apache/camel-examples/tree/main/kamelet-main[kamelet-main].


### PR DESCRIPTION
# Description

Since https://github.com/apache/camel-examples/pull/129 some links are broken in docs.


