### PR TITLE
CAMEL-20257: convert AbstractContext to the clock API

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/BrowsableQueueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/BrowsableQueueTest.java
@@ -29,11 +29,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Isolated("Needs greater isolation due to CAMEL-20269")
 public class BrowsableQueueTest extends AbstractJMSTest {
     @Order(2)
     @RegisterExtension

--- a/core/camel-api/src/main/java/org/apache/camel/CamelContext.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelContext.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.camel.clock.EventClock;
 import org.apache.camel.spi.CamelContextNameStrategy;
 import org.apache.camel.spi.ClassResolver;
 import org.apache.camel.spi.DataFormat;
@@ -165,6 +166,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
      *
      * @return the uptime in days/hours/minutes
      */
+    @Deprecated
     String getUptime();
 
     /**
@@ -172,12 +174,20 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
      *
      * @return the uptime in millis seconds
      */
+    @Deprecated
     long getUptimeMillis();
 
     /**
      * Gets the date and time Camel was started up.
      */
+    @Deprecated
     Date getStartDate();
+
+    /**
+     * Gets a clock instance that keeps track of time for relevant CamelContext events
+     * @return A clock instance
+     */
+    EventClock<ContextEvents> getClock();
 
     // Service Methods
     //-----------------------------------------------------------------------

--- a/core/camel-api/src/main/java/org/apache/camel/ContextEvents.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ContextEvents.java
@@ -14,29 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.support;
 
-import java.util.concurrent.TimeUnit;
-
-import org.apache.camel.clock.Clock;
+package org.apache.camel;
 
 /**
- * A clock that increases monotonically (i.e.: does not go back in time)
+ * Context events that can be traced by an {@link org.apache.camel.clock.EventClock}
  */
-public final class MonotonicClock implements Clock {
-    private final long createdNano;
-
-    public MonotonicClock() {
-        this.createdNano = System.nanoTime();
-    }
-
-    @Override
-    public long elapsed() {
-        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - createdNano);
-    }
-
-    @Override
-    public long getCreated() {
-        return System.currentTimeMillis() - elapsed();
-    }
+public enum ContextEvents {
+    /**
+     * Start event
+     */
+    START
 }

--- a/core/camel-api/src/main/java/org/apache/camel/Exchange.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Exchange.java
@@ -18,6 +18,7 @@ package org.apache.camel;
 
 import java.util.Map;
 
+import org.apache.camel.clock.Clock;
 import org.apache.camel.spi.UnitOfWork;
 import org.apache.camel.spi.annotations.ConstantProvider;
 

--- a/core/camel-api/src/main/java/org/apache/camel/clock/Clock.java
+++ b/core/camel-api/src/main/java/org/apache/camel/clock/Clock.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel;
+package org.apache.camel.clock;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -22,19 +22,19 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 
 /**
- * A clock used to track the lifetime of an exchange
+ * A clock abstraction used to track pass of time
  */
 public interface Clock {
 
     /**
-     * The elapsed time since the creation of the exchange
+     * The elapsed time since the creation of the clock
      *
      * @return The elapsed time, in milliseconds, since the creation of the exchange
      */
     long elapsed();
 
     /**
-     * The point in time the exchange was created
+     * The point in time the clock was created
      *
      * @return The point in time, in milliseconds, the exchange was created.
      * @see    System#currentTimeMillis()

--- a/core/camel-api/src/main/java/org/apache/camel/clock/ContextClock.java
+++ b/core/camel-api/src/main/java/org/apache/camel/clock/ContextClock.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.clock;
+
+import java.util.Date;
+import java.util.EnumMap;
+
+import org.apache.camel.ContextEvents;
+
+/**
+ * An event clock that tracks the pass of time for different types of context-related events (see {@link ContextEvents})
+ */
+public final class ContextClock implements EventClock<ContextEvents> {
+    private EnumMap<ContextEvents, Clock> events = new EnumMap<>(ContextEvents.class);
+
+    @Override
+    public long elapsed() {
+        return 0;
+    }
+
+    @Override
+    public long getCreated() {
+        return 0;
+    }
+
+    @Override
+    public void add(ContextEvents event, Clock clock) {
+        events.put(event, clock);
+    }
+
+    @Override
+    public Clock get(ContextEvents event) {
+        return events.get(event);
+    }
+
+    /**
+     * Get the elapsed time for the event
+     * @param event the event to get the elapsed time
+     * @param defaultValue the default value to provide if the event is not being tracked
+     * @return The elapsed time or the default value if the event is not being tracked
+     */
+    public long elapsed(ContextEvents event, long defaultValue) {
+        Clock clock = events.get(event);
+        if (clock == null) {
+            return defaultValue;
+        }
+
+        return clock.elapsed();
+    }
+
+    /**
+     * Get the time for the event as a Date object
+     * @param event the event to get the elapsed time
+     * @param defaultValue the default value to provide if the event is not being tracked
+     * @return The Date object representing the creation date or the default value if the event is not being tracked
+     */
+    public Date asDate(ContextEvents event, Date defaultValue) {
+        Clock clock = events.get(event);
+        if (clock == null) {
+            return defaultValue;
+        }
+
+        return clock.asDate();
+    }
+}

--- a/core/camel-api/src/main/java/org/apache/camel/clock/EventClock.java
+++ b/core/camel-api/src/main/java/org/apache/camel/clock/EventClock.java
@@ -14,29 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.support;
 
-import java.util.concurrent.TimeUnit;
-
-import org.apache.camel.clock.Clock;
+package org.apache.camel.clock;
 
 /**
- * A clock that increases monotonically (i.e.: does not go back in time)
+ * A specialized clock that tracks the pass of time for one or more types of events
+ * @param <T> The event type as an Enum
  */
-public final class MonotonicClock implements Clock {
-    private final long createdNano;
+public interface EventClock<T extends Enum<T>> extends Clock {
 
-    public MonotonicClock() {
-        this.createdNano = System.nanoTime();
-    }
+    /**
+     * Add the event to be tracked
+     * @param event the event to track
+     * @param clock the clock associated with the event
+     */
+    void add(T event, Clock clock);
 
-    @Override
-    public long elapsed() {
-        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - createdNano);
-    }
-
-    @Override
-    public long getCreated() {
-        return System.currentTimeMillis() - elapsed();
-    }
+    /**
+     * Get the clock for the event
+     * @param event the event to get the clock for
+     * @return the clock instance or null if not set
+     */
+    Clock get(T event);
 }

--- a/core/camel-core/src/test/java/org/apache/camel/support/AbstractExchangeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/AbstractExchangeTest.java
@@ -17,8 +17,8 @@
 package org.apache.camel.support;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.Clock;
 import org.apache.camel.Exchange;
+import org.apache.camel.clock.Clock;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spi.DataType;
 import org.apache.camel.spi.DataTypeAware;

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultExchange.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultExchange.java
@@ -20,11 +20,11 @@ import java.util.EnumMap;
 import java.util.Map;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.Clock;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.ExchangePropertyKey;
+import org.apache.camel.clock.Clock;
 
 /**
  * The default and only implementation of {@link Exchange}.

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultPooledExchange.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultPooledExchange.java
@@ -19,12 +19,12 @@ package org.apache.camel.support;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.Clock;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.Message;
 import org.apache.camel.PooledExchange;
+import org.apache.camel.clock.Clock;
 
 /**
  * The default and only implementation of {@link PooledExchange}.

--- a/core/camel-support/src/main/java/org/apache/camel/support/ResetableClock.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/ResetableClock.java
@@ -18,7 +18,7 @@ package org.apache.camel.support;
 
 import java.util.concurrent.TimeUnit;
 
-import org.apache.camel.Clock;
+import org.apache.camel.clock.Clock;
 
 /**
  * A clock that can be reset.
@@ -27,12 +27,12 @@ public final class ResetableClock implements Clock {
     private long created;
     private long createdNano;
 
-    ResetableClock(Clock clock) {
+    public ResetableClock(Clock clock) {
         this.created = clock.getCreated();
         this.createdNano = System.nanoTime();
     }
 
-    ResetableClock() {
+    public ResetableClock() {
         this.created = System.currentTimeMillis();
         this.createdNano = System.nanoTime();
     }


### PR DESCRIPTION
This also makes the clock API more generic and usable for other use cases besides tracking exchanges