### PR TITLE
chore(camel-jbang): Use printer API for command log output

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-core/pom.xml
@@ -39,6 +39,8 @@
         <label>jbang</label>
         <supportLevel>Preview</supportLevel>
         <camel-prepare-component>false</camel-prepare-component>
+
+        <camel.surefire.reuseForks>false</camel.surefire.reuseForks>
     </properties>
 
     <dependencies>

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelCommand.java
@@ -40,7 +40,6 @@ public abstract class CamelCommand implements Callable<Integer> {
     CommandLine.Model.CommandSpec spec;
 
     private final CamelJBangMain main;
-    private File camelDir;
 
     @CommandLine.Option(names = { "-h", "--help" }, usageHelp = true, description = "Display the help and sub-commands")
     private boolean helpRequested = false;
@@ -96,38 +95,23 @@ public abstract class CamelCommand implements Callable<Integer> {
     public abstract Integer doCall() throws Exception;
 
     public File getStatusFile(String pid) {
-        if (camelDir == null) {
-            camelDir = new File(System.getProperty("user.home"), ".camel");
-        }
-        return new File(camelDir, pid + "-status.json");
+        return new File(CommandLineHelper.getCamelDir(), pid + "-status.json");
     }
 
     public File getActionFile(String pid) {
-        if (camelDir == null) {
-            camelDir = new File(System.getProperty("user.home"), ".camel");
-        }
-        return new File(camelDir, pid + "-action.json");
+        return new File(CommandLineHelper.getCamelDir(), pid + "-action.json");
     }
 
     public File getOutputFile(String pid) {
-        if (camelDir == null) {
-            camelDir = new File(System.getProperty("user.home"), ".camel");
-        }
-        return new File(camelDir, pid + "-output.json");
+        return new File(CommandLineHelper.getCamelDir(), pid + "-output.json");
     }
 
     public File getTraceFile(String pid) {
-        if (camelDir == null) {
-            camelDir = new File(System.getProperty("user.home"), ".camel");
-        }
-        return new File(camelDir, pid + "-trace.json");
+        return new File(CommandLineHelper.getCamelDir(), pid + "-trace.json");
     }
 
     public File getDebugFile(String pid) {
-        if (camelDir == null) {
-            camelDir = new File(System.getProperty("user.home"), ".camel");
-        }
-        return new File(camelDir, pid + "-debug.json");
+        return new File(CommandLineHelper.getCamelDir(), pid + "-debug.json");
     }
 
     protected Printer printer() {
@@ -147,8 +131,8 @@ public abstract class CamelCommand implements Callable<Integer> {
             }
         });
         if (!lines.isEmpty()) {
-            System.out.println(header);
-            lines.forEach(System.out::println);
+            printer().println(header);
+            lines.forEach(printer()::println);
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CodeRestGenerator.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CodeRestGenerator.java
@@ -82,7 +82,7 @@ public class CodeRestGenerator extends CamelCommand {
             }
             if (text != null) {
                 if (output == null) {
-                    System.out.println(text);
+                    printer().println(text);
                 } else {
                     Files.write(Paths.get(output), text.getBytes());
                 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Debug.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Debug.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.camel.dsl.jbang.core.commands.action.MessageTableHelper;
 import org.apache.camel.dsl.jbang.core.common.CamelCommandHelper;
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.main.KameletMain;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
@@ -209,11 +210,11 @@ public class Debug extends Run {
             } else if (exit == -1) {
                 // maybe failed on startup, so dump log buffer
                 for (String line : logBuffer) {
-                    System.out.println(line);
+                    printer().println(line);
                 }
                 // and any error
                 String text = IOHelper.loadText(spawnError);
-                System.out.println(text);
+                printer().println(text);
                 return -1;
             }
         } while (exit == 0 && !quit.get());
@@ -254,7 +255,7 @@ public class Debug extends Run {
         this.spawnOutput = p.getInputStream();
         this.spawnError = p.getErrorStream();
         this.spawnPid = p.pid();
-        System.out.println("Debugging Camel integration: " + name + " with PID: " + p.pid());
+        printer().println("Debugging Camel integration: " + name + " with PID: " + p.pid());
         return 0;
     }
 
@@ -337,7 +338,7 @@ public class Debug extends Run {
                 if (arr != null) {
 
                     if (arr.size() > 1) {
-                        System.out.println(
+                        printer().println(
                                 "WARN: Multiple suspended breakpoints is not supported (You can use --breakpoint option to specify a starting breakpoint)");
                         return;
                     }
@@ -426,7 +427,7 @@ public class Debug extends Run {
             // okay there is some updates to the screen, so redraw
             clearScreen();
             // top header
-            System.out.println(buffer.toString());
+            printer().println(buffer.toString());
             // suspended breakpoints
             for (SuspendedRow row : rows) {
                 printSourceAndHistory(row);
@@ -461,9 +462,9 @@ public class Debug extends Run {
                 if (loggingColor) {
                     AnsiConsole.out().println(Ansi.ansi().a(Ansi.Attribute.INTENSITY_BOLD).a(msg).reset());
                 } else {
-                    System.out.println(msg);
+                    printer().println(msg);
                 }
-                System.out.println();
+                printer().println();
             }
         }
     }
@@ -586,7 +587,7 @@ public class Debug extends Run {
                 h = h.substring(0, 90);
             }
             String line = c + "    " + h;
-            System.out.println(line);
+            printer().println(line);
         }
     }
 
@@ -602,9 +603,9 @@ public class Debug extends Run {
             if (loggingColor) {
                 AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(Ansi.Attribute.INTENSITY_FAINT).a(ts).reset());
             } else {
-                System.out.print(ts);
+                printer().print(ts);
             }
-            System.out.print("  ");
+            printer().print("  ");
         }
         // pid
         String p = String.format("%5.5s", row.pid);
@@ -612,8 +613,8 @@ public class Debug extends Run {
             AnsiConsole.out().print(Ansi.ansi().fgMagenta().a(p).reset());
             AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(Ansi.Attribute.INTENSITY_FAINT).a(" --- ").reset());
         } else {
-            System.out.print(p);
-            System.out.print(" --- ");
+            printer().print(p);
+            printer().print(" --- ");
         }
         // thread name
         String tn = row.threadName;
@@ -624,9 +625,9 @@ public class Debug extends Run {
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(Ansi.Attribute.INTENSITY_FAINT).a(tn).reset());
         } else {
-            System.out.print(tn);
+            printer().print(tn);
         }
-        System.out.print(" ");
+        printer().print(" ");
         // node ids or source location
         String ids;
         if (source) {
@@ -641,31 +642,31 @@ public class Debug extends Run {
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgCyan().a(ids).reset());
         } else {
-            System.out.print(ids);
+            printer().print(ids);
         }
-        System.out.print(" : ");
+        printer().print(" : ");
         // uuid
         String u = String.format("%5.5s", row.uid);
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgMagenta().a(u).reset());
         } else {
-            System.out.print(u);
+            printer().print(u);
         }
-        System.out.print(" - ");
+        printer().print(" - ");
         // status
-        System.out.print(getStatus(row));
+        printer().print(getStatus(row));
         // elapsed
         String e = getElapsed(row);
         if (e != null) {
             if (loggingColor) {
                 AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(" (" + e + ")").reset());
             } else {
-                System.out.print("(" + e + ")");
+                printer().print("(" + e + ")");
             }
         }
-        System.out.println();
-        System.out.println(getDataAsTable(row));
-        System.out.println();
+        printer().println();
+        printer().println(getDataAsTable(row));
+        printer().println();
     }
 
     private static String locationAndLine(String loc, int line) {
@@ -680,10 +681,9 @@ public class Debug extends Run {
 
     private void handleHangup() {
         if (spawnPid > 0) {
-            File dir = new File(System.getProperty("user.home"), ".camel");
-            File pidFile = new File(dir, Long.toString(spawnPid));
+            File pidFile = new File(CommandLineHelper.getCamelDir(), Long.toString(spawnPid));
             if (pidFile.exists()) {
-                System.out.println("Shutting down Camel integration (PID: " + spawnPid + ")");
+                printer().println("Shutting down Camel integration (PID: " + spawnPid + ")");
                 FileUtil.deleteFile(pidFile);
             }
         }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyList.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyList.java
@@ -28,6 +28,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
 import org.apache.camel.dsl.jbang.core.common.XmlHelper;
 import org.apache.camel.tooling.maven.MavenGav;
@@ -39,7 +40,7 @@ import picocli.CommandLine;
                      description = "Displays all Camel dependencies required to run")
 public class DependencyList extends Export {
 
-    protected static final String EXPORT_DIR = ".camel-jbang/export";
+    protected static final String EXPORT_DIR = CommandLineHelper.CAMEL_JBANG_WORK_DIR + "/export";
 
     @CommandLine.Option(names = { "--output" }, description = "Output format (gav, maven, jbang)", defaultValue = "gav")
     protected String output;
@@ -159,22 +160,22 @@ public class DependencyList extends Export {
 
     protected void outputGav(MavenGav gav, int index, int total) {
         if ("gav".equals(output)) {
-            System.out.println(gav);
+            printer().println(String.valueOf(gav));
         } else if ("maven".equals(output)) {
-            System.out.println("<dependency>");
-            System.out.printf("    <groupId>%s</groupId>%n", gav.getGroupId());
-            System.out.printf("    <artifactId>%s</artifactId>%n", gav.getArtifactId());
-            System.out.printf("    <version>%s</version>%n", gav.getVersion());
-            System.out.println("</dependency>");
+            printer().println("<dependency>");
+            printer().printf("    <groupId>%s</groupId>%n", gav.getGroupId());
+            printer().printf("    <artifactId>%s</artifactId>%n", gav.getArtifactId());
+            printer().printf("    <version>%s</version>%n", gav.getVersion());
+            printer().println("</dependency>");
         } else if ("jbang".equals(output)) {
             if (index == 0) {
-                System.out.println("//DEPS org.apache.camel:camel-bom:" + gav.getVersion() + "@pom");
+                printer().println("//DEPS org.apache.camel:camel-bom:" + gav.getVersion() + "@pom");
             }
             if (gav.getGroupId().equals("org.apache.camel")) {
                 // jbang has version in @pom so we should remove this
                 gav.setVersion(null);
             }
-            System.out.println("//DEPS " + gav);
+            printer().println("//DEPS " + gav);
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -46,6 +46,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.camel.catalog.DefaultCamelCatalog;
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.dsl.jbang.core.common.RuntimeCompletionCandidates;
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
 import org.apache.camel.dsl.jbang.core.common.VersionHelper;
@@ -62,7 +63,7 @@ import picocli.CommandLine;
 
 abstract class ExportBaseCommand extends CamelCommand {
 
-    protected static final String BUILD_DIR = ".camel-jbang/work";
+    protected static final String BUILD_DIR = CommandLineHelper.CAMEL_JBANG_WORK_DIR + "/work";
 
     protected static final String[] SETTINGS_PROP_SOURCE_KEYS = new String[] {
             "camel.main.routesIncludePattern",

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
 import org.apache.camel.tooling.maven.MavenGav;
 import org.apache.camel.util.CamelCaseOrderedProperties;
@@ -57,11 +58,11 @@ class ExportCamelMain extends Export {
         File profile = new File(getProfile() + ".properties");
 
         // the settings file has information what to export
-        File settings = new File(Run.WORK_DIR + "/" + Run.RUN_SETTINGS_FILE);
+        File settings = new File(CommandLineHelper.getWorkDir(), Run.RUN_SETTINGS_FILE);
         if (fresh || files != null || !settings.exists()) {
             // allow to automatic build
             if (!quiet && fresh) {
-                System.out.println("Generating fresh run data");
+                printer().println("Generating fresh run data");
             }
             int silent = runSilently(ignoreLoadingError);
             if (silent != 0) {
@@ -69,12 +70,12 @@ class ExportCamelMain extends Export {
             }
         } else {
             if (!quiet) {
-                System.out.println("Reusing existing run data");
+                printer().println("Reusing existing run data");
             }
         }
 
         if (!quiet) {
-            System.out.println("Exporting as Camel Main project to: " + exportDir);
+            printer().println("Exporting as Camel Main project to: " + exportDir);
         }
 
         // use a temporary work dir

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.dsl.jbang.core.common.CatalogLoader;
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
 import org.apache.camel.tooling.maven.MavenGav;
 import org.apache.camel.tooling.model.ArtifactModel;
@@ -60,11 +61,11 @@ class ExportQuarkus extends Export {
         File profile = new File(getProfile() + ".properties");
 
         // the settings file has information what to export
-        File settings = new File(Run.WORK_DIR + "/" + Run.RUN_SETTINGS_FILE);
+        File settings = new File(CommandLineHelper.getWorkDir(), Run.RUN_SETTINGS_FILE);
         if (fresh || files != null || !settings.exists()) {
             // allow to automatic build
             if (!quiet) {
-                System.out.println("Generating fresh run data");
+                printer().println("Generating fresh run data");
             }
             int silent = runSilently(ignoreLoadingError);
             if (silent != 0) {
@@ -72,12 +73,12 @@ class ExportQuarkus extends Export {
             }
         } else {
             if (!quiet) {
-                System.out.println("Reusing existing run data");
+                printer().println("Reusing existing run data");
             }
         }
 
         if (!quiet) {
-            System.out.println("Exporting as Quarkus project to: " + exportDir);
+            printer().println("Exporting as Quarkus project to: " + exportDir);
         }
 
         // use a temporary work dir
@@ -196,7 +197,7 @@ class ExportQuarkus extends Export {
         if (s.contains(":")) {
             s = StringHelper.after(s, ":");
         }
-        s = s.replace(".camel-jbang/", "");
+        s = s.replace(CommandLineHelper.CAMEL_JBANG_WORK_DIR + "/", "");
         return s;
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.dsl.jbang.core.common.CatalogLoader;
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
 import org.apache.camel.tooling.maven.MavenGav;
 import org.apache.camel.tooling.model.ArtifactModel;
@@ -61,11 +62,11 @@ class ExportSpringBoot extends Export {
         File profile = new File(getProfile() + ".properties");
 
         // the settings file has information what to export
-        File settings = new File(Run.WORK_DIR + "/" + Run.RUN_SETTINGS_FILE);
+        File settings = new File(CommandLineHelper.getWorkDir(), Run.RUN_SETTINGS_FILE);
         if (fresh || files != null || !settings.exists()) {
             // allow to automatic build
             if (!quiet) {
-                System.out.println("Generating fresh run data");
+                printer().println("Generating fresh run data");
             }
             int silent = runSilently(ignoreLoadingError);
             if (silent != 0) {
@@ -73,12 +74,12 @@ class ExportSpringBoot extends Export {
             }
         } else {
             if (!quiet) {
-                System.out.println("Reusing existing run data");
+                printer().println("Reusing existing run data");
             }
         }
 
         if (!quiet) {
-            System.out.println("Exporting as Spring Boot project to: " + exportDir);
+            printer().println("Exporting as Spring Boot project to: " + exportDir);
         }
 
         // use a temporary work dir

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Init.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Init.java
@@ -25,6 +25,7 @@ import java.util.StringJoiner;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.dsl.jbang.core.commands.catalog.KameletCatalogHelper;
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.dsl.jbang.core.common.ResourceDoesNotExist;
 import org.apache.camel.dsl.jbang.core.common.VersionHelper;
 import org.apache.camel.github.GistResourceResolver;
@@ -38,7 +39,6 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import static org.apache.camel.dsl.jbang.core.commands.Run.WORK_DIR;
 import static org.apache.camel.dsl.jbang.core.common.GistHelper.fetchGistUrls;
 import static org.apache.camel.dsl.jbang.core.common.GitHubHelper.asGithubSingleUrl;
 import static org.apache.camel.dsl.jbang.core.common.GitHubHelper.fetchGithubUrls;
@@ -99,7 +99,7 @@ public class Init extends CamelCommand {
         }
 
         if (fromKamelet != null && !"kamelet.yaml".equals(ext)) {
-            System.out.println("When extending from an existing Kamelet then file must have extension .kamelet.yaml");
+            printer().println("When extending from an existing Kamelet then file must have extension .kamelet.yaml");
             return 1;
         }
 
@@ -129,9 +129,9 @@ public class Init extends CamelCommand {
         }
         if (is == null) {
             if (fromKamelet != null) {
-                System.out.println("Error: Existing Kamelet does not exist: " + fromKamelet);
+                printer().println("Error: Existing Kamelet does not exist: " + fromKamelet);
             } else {
-                System.out.println("Error: Unsupported file type: " + ext);
+                printer().println("Error: Unsupported file type: " + ext);
             }
             return 1;
         }
@@ -170,7 +170,7 @@ public class Init extends CamelCommand {
     }
 
     private void createWorkingDirectoryIfAbsent() {
-        File work = new File(WORK_DIR);
+        File work = CommandLineHelper.getWorkDir();
         if (!work.exists()) {
             work.mkdirs();
         }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/SBOMGenerator.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/SBOMGenerator.java
@@ -21,6 +21,7 @@ import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
 import org.apache.camel.util.CamelCaseOrderedProperties;
 import org.apache.camel.util.FileUtil;
@@ -30,7 +31,7 @@ import picocli.CommandLine;
                      description = "Generate a CycloneDX or SPDX SBOM for a specific project")
 public class SBOMGenerator extends Export {
 
-    protected static final String EXPORT_DIR = ".camel-jbang/export";
+    protected static final String EXPORT_DIR = CommandLineHelper.CAMEL_JBANG_WORK_DIR + "/export";
 
     protected static final String CYCLONEDX_FORMAT = "cyclonedx";
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/TransformRoute.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/TransformRoute.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.main.KameletMain;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StopWatch;
@@ -70,7 +71,7 @@ public class TransformRoute extends CamelCommand {
         String dump = output;
         // if no output then we want to print to console, so we need to write to a hidden file, and dump that file afterwards
         if (output == null) {
-            dump = Run.WORK_DIR + "/transform-output." + format;
+            dump = CommandLineHelper.CAMEL_JBANG_WORK_DIR + "/transform-output." + format;
         }
         final String target = dump;
 
@@ -102,7 +103,7 @@ public class TransformRoute extends CamelCommand {
             // load target file and print to console
             dump = waitForDumpFile(new File(target));
             if (dump != null) {
-                System.out.println(dump);
+                printer().println(dump);
             }
         }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelLogAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelLogAction.java
@@ -38,6 +38,7 @@ import java.util.regex.Pattern;
 
 import org.apache.camel.catalog.impl.TimePatternConverter;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.dsl.jbang.core.common.ProcessHelper;
 import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.StringHelper;
@@ -157,7 +158,7 @@ public class CamelLogAction extends ActionBaseCommand {
             do {
                 if (rows.isEmpty()) {
                     if (waitMessage) {
-                        System.out.println("Waiting for logs ...");
+                        printer().println("Waiting for logs ...");
                         waitMessage = false;
                     }
                     Thread.sleep(500);
@@ -366,8 +367,8 @@ public class CamelLogAction extends ActionBaseCommand {
             line = unescapeAnsi(line);
             if (name != null) {
                 String n = String.format("%-" + nameMaxWidth + "s", name);
-                System.out.print(n);
-                System.out.print("| ");
+                printer().print(n);
+                printer().print("| ");
             }
         }
         if (find != null || grep != null) {
@@ -388,14 +389,13 @@ public class CamelLogAction extends ActionBaseCommand {
         if (loggingColor) {
             AnsiConsole.out().println(line);
         } else {
-            System.out.println(line);
+            printer().println(line);
         }
     }
 
     private static File logFile(String pid) {
-        File dir = new File(System.getProperty("user.home"), ".camel");
         String name = pid + ".log";
-        return new File(dir, name);
+        return new File(CommandLineHelper.getCamelDir(), name);
     }
 
     private void tailLogFiles(Map<Long, Row> rows, int tail, Date limit) throws Exception {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteDumpAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteDumpAction.java
@@ -88,8 +88,8 @@ public class CamelRouteDumpAction extends ActionBaseCommand {
         if (pids.isEmpty()) {
             return 0;
         } else if (pids.size() > 1) {
-            System.out.println("Name or pid " + name + " matches " + pids.size()
-                               + " running Camel integrations. Specify a name or PID that matches exactly one.");
+            printer().println("Name or pid " + name + " matches " + pids.size()
+                              + " running Camel integrations. Specify a name or PID that matches exactly one.");
             return 0;
         }
 
@@ -154,7 +154,7 @@ public class CamelRouteDumpAction extends ActionBaseCommand {
                 }
             }
         } else {
-            System.out.println("Response from running Camel with PID " + pid + " not received within 5 seconds");
+            printer().println("Response from running Camel with PID " + pid + " not received within 5 seconds");
             return 1;
         }
 
@@ -190,21 +190,21 @@ public class CamelRouteDumpAction extends ActionBaseCommand {
 
     protected void printSource(List<Row> rows) {
         for (Row row : rows) {
-            System.out.println();
+            printer().println();
             if (!raw) {
-                System.out.printf("Source: %s%n", row.location);
-                System.out.println("--------------------------------------------------------------------------------");
+                printer().printf("Source: %s%n", row.location);
+                printer().println("--------------------------------------------------------------------------------");
             }
             for (int i = 0; i < row.code.size(); i++) {
                 Code code = row.code.get(i);
                 String c = Jsoner.unescape(code.code);
                 if (raw) {
-                    System.out.printf("%s%n", c);
+                    printer().printf("%s%n", c);
                 } else {
-                    System.out.printf("%4d: %s%n", code.line, c);
+                    printer().printf("%4d: %s%n", code.line, c);
                 }
             }
-            System.out.println();
+            printer().println();
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSendAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSendAction.java
@@ -103,8 +103,8 @@ public class CamelSendAction extends ActionBaseCommand {
         if (pids.isEmpty()) {
             return 0;
         } else if (pids.size() > 1) {
-            System.out.println("Name or pid " + name + " matches " + pids.size()
-                               + " running Camel integrations. Specify a name or PID that matches exactly one.");
+            printer().println("Name or pid " + name + " matches " + pids.size()
+                              + " running Camel integrations. Specify a name or PID that matches exactly one.");
             return 0;
         }
 
@@ -125,7 +125,7 @@ public class CamelSendAction extends ActionBaseCommand {
             for (String h : headers) {
                 JsonObject jo = new JsonObject();
                 if (!h.contains("=")) {
-                    System.out.println("Header must be in key=value format, was: " + h);
+                    printer().println("Header must be in key=value format, was: " + h);
                     return 0;
                 }
                 jo.put("key", StringHelper.before(h, "="));
@@ -174,7 +174,7 @@ public class CamelSendAction extends ActionBaseCommand {
                     tableHelper.setLoggingColor(loggingColor);
                     tableHelper.setShowExchangeProperties(showExchangeProperties);
                     String table = tableHelper.getDataAsTable(exchangeId, mep, jo, message, cause);
-                    System.out.println(table);
+                    printer().println(table);
                 }
             }
         }
@@ -192,17 +192,17 @@ public class CamelSendAction extends ActionBaseCommand {
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(Ansi.Attribute.INTENSITY_FAINT).a(ts).reset());
         } else {
-            System.out.print(ts);
+            printer().print(ts);
         }
         // pid
-        System.out.print("  ");
+        printer().print("  ");
         String p = String.format("%5.5s", this.pid);
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgMagenta().a(p).reset());
             AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(Ansi.Attribute.INTENSITY_FAINT).a(" --- ").reset());
         } else {
-            System.out.print(p);
-            System.out.print(" --- ");
+            printer().print(p);
+            printer().print(" --- ");
         }
         // endpoint
         String ids = jo.getString("endpoint");
@@ -213,19 +213,19 @@ public class CamelSendAction extends ActionBaseCommand {
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgCyan().a(ids).reset());
         } else {
-            System.out.print(ids);
+            printer().print(ids);
         }
-        System.out.print(" : ");
+        printer().print(" : ");
         // status
-        System.out.print(getStatus(jo));
+        printer().print(getStatus(jo));
         // elapsed
         String e = TimeUtils.printDuration(jo.getLong("elapsed"), true);
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(" (" + e + ")").reset());
         } else {
-            System.out.print("(" + e + ")");
+            printer().print("(" + e + ")");
         }
-        System.out.println();
+        printer().println();
     }
 
     private String getStatus(JsonObject r) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSourceAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSourceAction.java
@@ -64,8 +64,8 @@ public class CamelSourceAction extends ActionBaseCommand {
         if (pids.isEmpty()) {
             return 0;
         } else if (pids.size() > 1) {
-            System.out.println("Name or pid " + name + " matches " + pids.size()
-                               + " running Camel integrations. Specify a name or PID that matches exactly one.");
+            printer().println("Name or pid " + name + " matches " + pids.size()
+                              + " running Camel integrations. Specify a name or PID that matches exactly one.");
             return 0;
         }
 
@@ -128,7 +128,7 @@ public class CamelSourceAction extends ActionBaseCommand {
                 }
             }
         } else {
-            System.out.println("Response from running Camel with PID " + pid + " not received within 5 seconds");
+            printer().println("Response from running Camel with PID " + pid + " not received within 5 seconds");
             return 1;
         }
 
@@ -162,15 +162,15 @@ public class CamelSourceAction extends ActionBaseCommand {
 
     protected void printSource(List<Row> rows) {
         for (Row row : rows) {
-            System.out.println();
-            System.out.printf("Source: %s%n", row.location);
-            System.out.println("--------------------------------------------------------------------------------");
+            printer().println();
+            printer().printf("Source: %s%n", row.location);
+            printer().println("--------------------------------------------------------------------------------");
             for (int i = 0; i < row.code.size(); i++) {
                 Code code = row.code.get(i);
                 String c = Jsoner.unescape(code.code);
-                System.out.printf("%4d: %s%n", code.line, c);
+                printer().printf("%4d: %s%n", code.line, c);
             }
-            System.out.println();
+            printer().println();
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSourceTop.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSourceTop.java
@@ -60,8 +60,8 @@ public class CamelSourceTop extends ActionWatchCommand {
         if (pids.isEmpty()) {
             return 0;
         } else if (pids.size() > 1) {
-            System.out.println("Name or pid " + name + " matches " + pids.size()
-                               + " running Camel integrations. Specify a name or PID that matches exactly one.");
+            printer().println("Name or pid " + name + " matches " + pids.size()
+                              + " running Camel integrations. Specify a name or PID that matches exactly one.");
             return 0;
         }
 
@@ -133,7 +133,7 @@ public class CamelSourceTop extends ActionWatchCommand {
                 }
             }
         } else {
-            System.out.println("Response from running Camel with PID " + pid + " not received within 5 seconds");
+            printer().println("Response from running Camel with PID " + pid + " not received within 5 seconds");
             return 1;
         }
 
@@ -155,16 +155,16 @@ public class CamelSourceTop extends ActionWatchCommand {
 
     protected void printSource(List<Row> rows) {
         for (Row row : rows) {
-            System.out.printf("Route: %s\tSource: %s Total: %s Mean: %s Max: %s Min: %s Last: %s%n", row.routeId, row.location,
+            printer().printf("Route: %s\tSource: %s Total: %s Mean: %s Max: %s Min: %s Last: %s%n", row.routeId, row.location,
                     row.total, row.mean != null ? row.mean : "", row.max,
                     row.min, row.last != null ? row.last : "");
             for (int i = 0; i < row.code.size(); i++) {
                 Code code = row.code.get(i);
                 String c = Jsoner.unescape(code.code);
                 String arrow = code.match ? "-->" : "   ";
-                System.out.printf("%4d: %s %s%n", code.line, arrow, c);
+                printer().printf("%4d: %s %s%n", code.line, arrow, c);
             }
-            System.out.println();
+            printer().println();
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelStartupRecorderAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelStartupRecorderAction.java
@@ -62,8 +62,8 @@ public class CamelStartupRecorderAction extends ActionWatchCommand {
         if (pids.isEmpty()) {
             return 0;
         } else if (pids.size() > 1) {
-            System.out.println("Name or pid " + name + " matches " + pids.size()
-                               + " running Camel integrations. Specify a name or PID that matches exactly one.");
+            printer().println("Name or pid " + name + " matches " + pids.size()
+                              + " running Camel integrations. Specify a name or PID that matches exactly one.");
             return 0;
         }
 
@@ -103,7 +103,7 @@ public class CamelStartupRecorderAction extends ActionWatchCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("DURATION").dataAlign(HorizontalAlign.RIGHT).with(this::getDuration),
                     new Column().header("TYPE").dataAlign(HorizontalAlign.LEFT).with(r -> r.type),
                     new Column().header("STEP (END)").dataAlign(HorizontalAlign.LEFT)

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelStubAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelStubAction.java
@@ -140,8 +140,8 @@ public class CamelStubAction extends ActionWatchCommand {
         if (pids.isEmpty()) {
             return 0;
         } else if (pids.size() > 1) {
-            System.out.println("Name or pid " + name + " matches " + pids.size()
-                               + " running Camel integrations. Specify a name or PID that matches exactly one.");
+            printer().println("Name or pid " + name + " matches " + pids.size()
+                              + " running Camel integrations. Specify a name or PID that matches exactly one.");
             return 0;
         }
 
@@ -219,7 +219,7 @@ public class CamelStubAction extends ActionWatchCommand {
                 }
             }
         } else {
-            System.out.println("Response from running Camel with PID " + pid + " not received within 5 seconds");
+            printer().println("Response from running Camel with PID " + pid + " not received within 5 seconds");
             return 1;
         }
 
@@ -272,7 +272,7 @@ public class CamelStubAction extends ActionWatchCommand {
     protected void printStub(List<Row> rows) {
         if (browse) {
             for (Row row : rows) {
-                System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, List.of(row), Arrays.asList(
+                printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, List.of(row), Arrays.asList(
                         new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> "" + r.pid),
                         new Column().header("NAME").dataAlign(HorizontalAlign.LEFT)
                                 .maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
@@ -308,7 +308,7 @@ public class CamelStubAction extends ActionWatchCommand {
                                 }
 
                                 if (!compact && first) {
-                                    System.out.println();
+                                    printer().println();
                                 }
                                 for (String line : lines) {
                                     if (find != null) {
@@ -321,11 +321,11 @@ public class CamelStubAction extends ActionWatchCommand {
                                             line = line.replaceAll("(?i)" + g, findAnsi);
                                         }
                                     }
-                                    System.out.print(" ");
-                                    System.out.println(line);
+                                    printer().print(" ");
+                                    printer().println(line);
                                 }
                                 if (!compact) {
-                                    System.out.println();
+                                    printer().println();
                                 }
                                 first = false;
                             }
@@ -334,7 +334,7 @@ public class CamelStubAction extends ActionWatchCommand {
                 }
             }
         } else {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> "" + r.pid),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                             .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelThreadDump.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelThreadDump.java
@@ -86,8 +86,8 @@ public class CamelThreadDump extends ActionWatchCommand {
         if (pids.isEmpty()) {
             return 0;
         } else if (pids.size() > 1) {
-            System.out.println("Name or pid " + name + " matches " + pids.size()
-                               + " running Camel integrations. Specify a name or PID that matches exactly one.");
+            printer().println("Name or pid " + name + " matches " + pids.size()
+                              + " running Camel integrations. Specify a name or PID that matches exactly one.");
             return 0;
         }
 
@@ -138,7 +138,7 @@ public class CamelThreadDump extends ActionWatchCommand {
                 rows.add(row);
             }
         } else {
-            System.out.println("Response from running Camel with PID " + pid + " not received within 5 seconds");
+            printer().println("Response from running Camel with PID " + pid + " not received within 5 seconds");
             return 1;
         }
 
@@ -151,7 +151,7 @@ public class CamelThreadDump extends ActionWatchCommand {
         if (!rows.isEmpty()) {
             int total = jo.getInteger("threadCount");
             int peak = jo.getInteger("peakThreadCount");
-            System.out.printf("PID: %s\tThreads: %d\tPeak: %d\t\tDisplay: %d/%d\n", pid, total, peak, rows.size(), total);
+            printer().printf("PID: %s\tThreads: %d\tPeak: %d\t\tDisplay: %d/%d\n", pid, total, peak, rows.size(), total);
 
             if (depth == 1) {
                 singleTable(rows);
@@ -167,7 +167,7 @@ public class CamelThreadDump extends ActionWatchCommand {
     }
 
     protected void singleTable(List<Row> rows) {
-        System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+        printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                 new Column().header("ID").headerAlign(HorizontalAlign.CENTER).with(r -> Long.toString(r.id)),
                 new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(60, OverflowBehaviour.ELLIPSIS_RIGHT)
                         .with(r -> r.name),
@@ -180,7 +180,7 @@ public class CamelThreadDump extends ActionWatchCommand {
 
     protected void tableAndStackTrace(List<Row> rows) {
         for (Row row : rows) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, List.of(row), Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, List.of(row), Arrays.asList(
                     new Column().header("ID").headerAlign(HorizontalAlign.CENTER).with(r -> Long.toString(r.id)),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(60, OverflowBehaviour.ELLIPSIS_RIGHT)
                             .with(r -> r.name),
@@ -188,7 +188,7 @@ public class CamelThreadDump extends ActionWatchCommand {
                     new Column().header("BLOCK").with(this::getBlocked),
                     new Column().header("WAIT").with(this::getWaited))));
             for (int i = 0; i < depth && i < row.stackTrace.size(); i++) {
-                System.out.println("\t" + row.stackTrace.get(i));
+                printer().println("\t" + row.stackTrace.get(i));
             }
         }
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelTraceAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelTraceAction.java
@@ -238,7 +238,7 @@ public class CamelTraceAction extends ActionBaseCommand {
             do {
                 if (pids.isEmpty()) {
                     if (waitMessage) {
-                        System.out.println("Waiting for traces ...");
+                        printer().println("Waiting for traces ...");
                         waitMessage = false;
                     }
                     Thread.sleep(500);
@@ -592,7 +592,7 @@ public class CamelTraceAction extends ActionBaseCommand {
             } else {
                 nameWithPrefix = String.format("%-" + nameMaxWidth + "s", name) + "| ";
             }
-            System.out.print(nameWithPrefix);
+            printer().print(nameWithPrefix);
         }
         if (timestamp) {
             String ts;
@@ -605,9 +605,9 @@ public class CamelTraceAction extends ActionBaseCommand {
             if (loggingColor) {
                 AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(Ansi.Attribute.INTENSITY_FAINT).a(ts).reset());
             } else {
-                System.out.print(ts);
+                printer().print(ts);
             }
-            System.out.print("  ");
+            printer().print("  ");
         }
         // pid
         String p = String.format("%5.5s", row.pid);
@@ -615,8 +615,8 @@ public class CamelTraceAction extends ActionBaseCommand {
             AnsiConsole.out().print(Ansi.ansi().fgMagenta().a(p).reset());
             AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(Ansi.Attribute.INTENSITY_FAINT).a(" --- ").reset());
         } else {
-            System.out.print(p);
-            System.out.print(" --- ");
+            printer().print(p);
+            printer().print(" --- ");
         }
         // thread name
         String tn = row.threadName;
@@ -627,9 +627,9 @@ public class CamelTraceAction extends ActionBaseCommand {
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(Ansi.Attribute.INTENSITY_FAINT).a(tn).reset());
         } else {
-            System.out.print(tn);
+            printer().print(tn);
         }
-        System.out.print(" ");
+        printer().print(" ");
         // node ids or source location
         String ids;
         if (source) {
@@ -644,32 +644,32 @@ public class CamelTraceAction extends ActionBaseCommand {
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgCyan().a(ids).reset());
         } else {
-            System.out.print(ids);
+            printer().print(ids);
         }
-        System.out.print(" : ");
+        printer().print(" : ");
         // uuid
         String u = String.format("%5.5s", row.uid);
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgMagenta().a(u).reset());
         } else {
-            System.out.print(u);
+            printer().print(u);
         }
-        System.out.print(" - ");
+        printer().print(" - ");
         // status
-        System.out.print(getStatus(row));
+        printer().print(getStatus(row));
         // elapsed
         String e = getElapsed(row);
         if (e != null) {
             if (loggingColor) {
                 AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(" (" + e + ")").reset());
             } else {
-                System.out.print("(" + e + ")");
+                printer().print("(" + e + ")");
             }
         }
         // trace message
         String[] lines = data.split(System.lineSeparator());
         if (lines.length > 0) {
-            System.out.println();
+            printer().println();
             for (String line : lines) {
                 if (find != null) {
                     for (String f : find) {
@@ -682,17 +682,17 @@ public class CamelTraceAction extends ActionBaseCommand {
                     }
                 }
                 if (nameWithPrefix != null) {
-                    System.out.print(nameWithPrefix);
+                    printer().print(nameWithPrefix);
                 }
-                System.out.print(" ");
-                System.out.println(line);
+                printer().print(" ");
+                printer().println(line);
             }
             if (!compact) {
                 if (nameWithPrefix != null) {
-                    System.out.println(nameWithPrefix);
+                    printer().println(nameWithPrefix);
                 } else {
                     // empty line
-                    System.out.println();
+                    printer().println();
                 }
             }
         }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/LoggerAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/LoggerAction.java
@@ -130,7 +130,7 @@ public class LoggerAction extends ActionBaseCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT)
                             .maxWidth(40, OverflowBehaviour.ELLIPSIS_RIGHT)

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/RouteControllerAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/RouteControllerAction.java
@@ -89,8 +89,8 @@ public class RouteControllerAction extends ActionWatchCommand {
         if (pids.isEmpty()) {
             return 0;
         } else if (pids.size() > 1) {
-            System.out.println("Name or pid " + name + " matches " + pids.size()
-                               + " running Camel integrations. Specify a name or PID that matches exactly one.");
+            printer().println("Name or pid " + name + " matches " + pids.size()
+                              + " running Camel integrations. Specify a name or PID that matches exactly one.");
             return 0;
         }
 
@@ -151,7 +151,7 @@ public class RouteControllerAction extends ActionWatchCommand {
                 rows.add(row);
             }
         } else {
-            System.out.println("Response from running Camel with PID " + pid + " not received within 5 seconds");
+            printer().println("Response from running Camel with PID " + pid + " not received within 5 seconds");
             return 1;
         }
 
@@ -164,30 +164,30 @@ public class RouteControllerAction extends ActionWatchCommand {
         if (!rows.isEmpty()) {
             if (supervising) {
                 if (header) {
-                    System.out.println("Supervising Route Controller");
-                    System.out.printf("\tInitial Starting Routes: %b%n", jo.getBoolean("startingRoutes"));
-                    System.out.printf("\tUnhealthy Routes: %b%n", jo.getBoolean("unhealthyRoutes"));
-                    System.out.printf("\tRoutes Total: %s%n", jo.getInteger("totalRoutes"));
-                    System.out.printf("\tRoutes Started: %d%n", jo.getInteger("startedRoutes"));
-                    System.out.printf("\tRoutes Restarting: %d%n", jo.getInteger("restartingRoutes"));
-                    System.out.printf("\tRoutes Exhausted: %d%n", jo.getInteger("exhaustedRoutes"));
-                    System.out.printf("\tInitial Delay: %d%n", jo.getInteger("initialDelay"));
-                    System.out.printf("\tBackoff Delay: %d%n", jo.getInteger("backoffDelay"));
-                    System.out.printf("\tBackoff Max Delay: %d%n", jo.getInteger("backoffMaxDelay"));
-                    System.out.printf("\tBackoff Max Elapsed Time: %d%n", jo.getInteger("backoffMaxElapsedTime"));
-                    System.out.printf("\tBackoff Max Attempts: %d%n", jo.getInteger("backoffMaxAttempts"));
-                    System.out.printf("\tThread Pool Size: %d%n", jo.getInteger("threadPoolSize"));
-                    System.out.printf("\tUnhealthy On Restarting: %b%n", jo.getBoolean("unhealthyOnRestarting"));
-                    System.out.printf("\tUnhealthy On Exhaust: %b%n", jo.getBoolean("unhealthyOnExhausted"));
-                    System.out.println("\n");
+                    printer().println("Supervising Route Controller");
+                    printer().printf("\tInitial Starting Routes: %b%n", jo.getBoolean("startingRoutes"));
+                    printer().printf("\tUnhealthy Routes: %b%n", jo.getBoolean("unhealthyRoutes"));
+                    printer().printf("\tRoutes Total: %s%n", jo.getInteger("totalRoutes"));
+                    printer().printf("\tRoutes Started: %d%n", jo.getInteger("startedRoutes"));
+                    printer().printf("\tRoutes Restarting: %d%n", jo.getInteger("restartingRoutes"));
+                    printer().printf("\tRoutes Exhausted: %d%n", jo.getInteger("exhaustedRoutes"));
+                    printer().printf("\tInitial Delay: %d%n", jo.getInteger("initialDelay"));
+                    printer().printf("\tBackoff Delay: %d%n", jo.getInteger("backoffDelay"));
+                    printer().printf("\tBackoff Max Delay: %d%n", jo.getInteger("backoffMaxDelay"));
+                    printer().printf("\tBackoff Max Elapsed Time: %d%n", jo.getInteger("backoffMaxElapsedTime"));
+                    printer().printf("\tBackoff Max Attempts: %d%n", jo.getInteger("backoffMaxAttempts"));
+                    printer().printf("\tThread Pool Size: %d%n", jo.getInteger("threadPoolSize"));
+                    printer().printf("\tUnhealthy On Restarting: %b%n", jo.getBoolean("unhealthyOnRestarting"));
+                    printer().printf("\tUnhealthy On Exhaust: %b%n", jo.getBoolean("unhealthyOnExhausted"));
+                    printer().println("\n");
                 }
                 dumpTable(rows, true);
             } else {
                 if (header) {
-                    System.out.println("Default Route Controller");
-                    System.out.printf("\tStarting Routes: %b%n", jo.getBoolean("startingRoutes"));
-                    System.out.printf("\tRoutes Total: %s%n", jo.getInteger("totalRoutes"));
-                    System.out.println("\n");
+                    printer().println("Default Route Controller");
+                    printer().printf("\tStarting Routes: %b%n", jo.getBoolean("startingRoutes"));
+                    printer().printf("\tRoutes Total: %s%n", jo.getInteger("totalRoutes"));
+                    printer().println("\n");
                 }
                 dumpTable(rows, false);
             }
@@ -200,7 +200,7 @@ public class RouteControllerAction extends ActionWatchCommand {
     }
 
     protected void dumpTable(List<Row> rows, boolean supervised) {
-        System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+        printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                 new Column().header("ID").dataAlign(HorizontalAlign.LEFT).maxWidth(25, OverflowBehaviour.ELLIPSIS_RIGHT)
                         .with(r -> r.routeId),
                 new Column().header("URI").dataAlign(HorizontalAlign.LEFT).maxWidth(60, OverflowBehaviour.ELLIPSIS_RIGHT)
@@ -218,10 +218,10 @@ public class RouteControllerAction extends ActionWatchCommand {
             rows = rows.stream().filter(r -> r.error != null && !r.error.isEmpty()).collect(Collectors.toList());
             if (!rows.isEmpty()) {
                 for (Row row : rows) {
-                    System.out.println("\n");
-                    System.out.println(StringHelper.fillChars('-', 120));
-                    System.out.println(StringHelper.padString(1, 55) + "STACK-TRACE");
-                    System.out.println(StringHelper.fillChars('-', 120));
+                    printer().println("\n");
+                    printer().println(StringHelper.fillChars('-', 120));
+                    printer().println(StringHelper.padString(1, 55) + "STACK-TRACE");
+                    printer().println(StringHelper.fillChars('-', 120));
                     StringBuilder sb = new StringBuilder();
                     sb.append(String.format("\tID: %s%n", row.routeId));
                     sb.append(String.format("\tURI: %s%n", row.uri));
@@ -229,7 +229,7 @@ public class RouteControllerAction extends ActionWatchCommand {
                     for (int i = 0; i < depth && i < row.stackTrace.size(); i++) {
                         sb.append(String.format("\t%s%n", row.stackTrace.get(i)));
                     }
-                    System.out.println(sb);
+                    printer().println(String.valueOf(sb));
                 }
             }
         }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/TransformMessageAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/TransformMessageAction.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.commands.Run;
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.dsl.jbang.core.common.VersionHelper;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
@@ -175,8 +176,7 @@ public class TransformMessageAction extends ActionWatchCommand {
                 File outputFile = getOutputFile(Long.toString(pid));
                 FileUtil.deleteFile(outputFile);
                 // stop running camel as we are done
-                File dir = new File(System.getProperty("user.home"), ".camel");
-                File pidFile = new File(dir, Long.toString(pid));
+                File pidFile = new File(CommandLineHelper.getCamelDir(), Long.toString(pid));
                 if (pidFile.exists()) {
                     FileUtil.deleteFile(pidFile);
                 }
@@ -215,7 +215,7 @@ public class TransformMessageAction extends ActionWatchCommand {
             for (String h : headers) {
                 JsonObject jo = new JsonObject();
                 if (!h.contains("=")) {
-                    System.out.println("Header must be in key=value format, was: " + h);
+                    printer().println("Header must be in key=value format, was: " + h);
                     return 0;
                 }
                 jo.put("key", StringHelper.before(h, "="));
@@ -229,7 +229,7 @@ public class TransformMessageAction extends ActionWatchCommand {
             for (String h : options) {
                 JsonObject jo = new JsonObject();
                 if (!h.contains("=")) {
-                    System.out.println("Option must be in key=value format, was: " + h);
+                    printer().println("Option must be in key=value format, was: " + h);
                     return 0;
                 }
                 jo.put("key", StringHelper.before(h, "="));
@@ -281,7 +281,7 @@ public class TransformMessageAction extends ActionWatchCommand {
                     tableHelper.setLoggingColor(loggingColor);
                     tableHelper.setShowExchangeProperties(showExchangeProperties);
                     String table = tableHelper.getDataAsTable(exchangeId, "InOut", null, message, cause);
-                    System.out.println(table);
+                    printer().println(table);
                 }
             }
         }
@@ -299,28 +299,28 @@ public class TransformMessageAction extends ActionWatchCommand {
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(Ansi.Attribute.INTENSITY_FAINT).a(ts).reset());
         } else {
-            System.out.print(ts);
+            printer().print(ts);
         }
         // pid
-        System.out.print("  ");
+        printer().print("  ");
         String p = String.format("%5.5s", this.pid);
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgMagenta().a(p).reset());
             AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(Ansi.Attribute.INTENSITY_FAINT).a(" --- ").reset());
         } else {
-            System.out.print(p);
-            System.out.print(" --- ");
+            printer().print(p);
+            printer().print(" --- ");
         }
         // status
-        System.out.print(getStatus(jo));
+        printer().print(getStatus(jo));
         // elapsed
         String e = TimeUtils.printDuration(jo.getLong("elapsed"), true);
         if (loggingColor) {
             AnsiConsole.out().print(Ansi.ansi().fgBrightDefault().a(" (" + e + ")").reset());
         } else {
-            System.out.print("(" + e + ")");
+            printer().print("(" + e + ")");
         }
-        System.out.println();
+        printer().println();
     }
 
     private String getStatus(JsonObject r) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogBaseCommand.java
@@ -135,14 +135,14 @@ public abstract class CatalogBaseCommand extends CamelCommand {
 
         if (!rows.isEmpty()) {
             if (jsonOutput) {
-                System.out.println(
+                printer().println(
                         Jsoner.serialize(
                                 rows.stream().map(row -> Map.of(
                                         "name", row.name,
                                         "level", row.level,
                                         "native", row.nativeSupported)).collect(Collectors.toList())));
             } else {
-                System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+                printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                         new Column().header("NAME").visible(!gav).dataAlign(HorizontalAlign.LEFT).maxWidth(30)
                                 .with(r -> r.name),
                         new Column().header("ARTIFACT-ID").visible(gav).dataAlign(HorizontalAlign.LEFT).with(this::shortGav),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogDoc.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogDoc.java
@@ -175,9 +175,9 @@ public class CatalogDoc extends CamelCommand {
             }
             if (suggestions != null) {
                 String type = kamelet ? "kamelet" : "component";
-                System.out.printf("Camel %s: %s not found. Did you mean? %s%n", type, name, String.join(", ", suggestions));
+                printer().printf("Camel %s: %s not found. Did you mean? %s%n", type, name, String.join(", ", suggestions));
             } else {
-                System.out.println("Camel resource: " + name + " not found");
+                printer().println("Camel resource: " + name + " not found");
             }
         } else {
             List<String> suggestions = null;
@@ -193,9 +193,9 @@ public class CatalogDoc extends CamelCommand {
                 suggestions = SuggestSimilarHelper.didYouMean(catalog.findOtherNames(), name);
             }
             if (suggestions != null) {
-                System.out.printf("Camel %s: %s not found. Did you mean? %s%n", prefix, name, String.join(", ", suggestions));
+                printer().printf("Camel %s: %s not found. Did you mean? %s%n", prefix, name, String.join(", ", suggestions));
             } else {
-                System.out.printf("Camel %s: %s not found.%n", prefix, name);
+                printer().printf("Camel %s: %s not found.%n", prefix, name);
             }
         }
         return 1;
@@ -211,50 +211,50 @@ public class CatalogDoc extends CamelCommand {
         }
         if (url) {
             if (link != null) {
-                System.out.println(link);
+                printer().println(link);
             }
             return;
         }
 
-        System.out.printf("Kamelet Name: %s%n", km.name);
-        System.out.printf("Kamelet Type: %s%n", km.type);
-        System.out.println("Support Level: " + km.supportLevel);
-        System.out.println("");
-        System.out.printf("%s%n", km.description);
-        System.out.println("");
+        printer().printf("Kamelet Name: %s%n", km.name);
+        printer().printf("Kamelet Type: %s%n", km.type);
+        printer().println("Support Level: " + km.supportLevel);
+        printer().println("");
+        printer().printf("%s%n", km.description);
+        printer().println("");
         if (km.dependencies != null && !km.dependencies.isEmpty()) {
-            System.out.println("");
+            printer().println("");
             for (String dep : km.dependencies) {
                 MavenGav gav = MavenGav.parseGav(dep);
                 if ("camel-core".equals(gav.getArtifactId())) {
                     // camel-core is implied so skip
                     continue;
                 }
-                System.out.println("    <dependency>");
-                System.out.println("        <groupId>" + gav.getGroupId() + "</groupId>");
-                System.out.println("        <artifactId>" + gav.getArtifactId() + "</artifactId>");
+                printer().println("    <dependency>");
+                printer().println("        <groupId>" + gav.getGroupId() + "</groupId>");
+                printer().println("        <artifactId>" + gav.getArtifactId() + "</artifactId>");
                 String v = gav.getVersion();
                 if (v == null && "org.apache.camel".equals(gav.getGroupId())) {
                     v = catalog.getCatalogVersion();
                 }
                 if (v != null) {
-                    System.out.println("        <version>" + v + "</version>");
+                    printer().println("        <version>" + v + "</version>");
                 }
-                System.out.println("    </dependency>");
+                printer().println("    </dependency>");
             }
-            System.out.println("");
+            printer().println("");
         }
         if (km.properties != null && !km.properties.isEmpty()) {
             var filtered = filterKameletOptions(filter, km.properties.values());
             int total1 = km.properties.size();
             var total2 = filtered.size();
             if (total1 == total2) {
-                System.out.printf("The %s kamelet supports (total: %s) options, which are listed below.%n%n", km.name, total1);
+                printer().printf("The %s kamelet supports (total: %s) options, which are listed below.%n%n", km.name, total1);
             } else {
-                System.out.printf("The %s kamelet supports (total: %s match-filter: %s) options, which are listed below.%n%n",
+                printer().printf("The %s kamelet supports (total: %s match-filter: %s) options, which are listed below.%n%n",
                         km.name, total1, total2);
             }
-            System.out.println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, filtered, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, filtered, Arrays.asList(
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).minWidth(20)
                             .maxWidth(35, OverflowBehaviour.NEWLINE)
                             .with(r -> r.name),
@@ -266,12 +266,12 @@ public class CatalogDoc extends CamelCommand {
                             .with(r -> r.type),
                     new Column().header("EXAMPLE").dataAlign(HorizontalAlign.LEFT).maxWidth(40, OverflowBehaviour.NEWLINE)
                             .with(r -> r.example))));
-            System.out.println("");
+            printer().println("");
         }
 
         if (link != null) {
-            System.out.println(link);
-            System.out.println("");
+            printer().println(link);
+            printer().println("");
         }
     }
 
@@ -285,25 +285,25 @@ public class CatalogDoc extends CamelCommand {
         }
         if (url) {
             if (link != null) {
-                System.out.println(link);
+                printer().println(link);
             }
             return;
         }
 
-        System.out.printf("Name: %s%n", "main");
-        System.out.printf("Since: %s%n", "3.0");
-        System.out.println("");
-        System.out.printf("%s%n",
+        printer().printf("Name: %s%n", "main");
+        printer().printf("Since: %s%n", "3.0");
+        printer().println("");
+        printer().printf("%s%n",
                 "This module is used for running Camel standalone via a main class extended from camel-main.");
-        System.out.println("");
-        System.out.println("    <dependency>");
-        System.out.println("        <groupId>" + "org.apache.camel" + "</groupId>");
-        System.out.println("        <artifactId>" + "camel.main" + "</artifactId>");
-        System.out.println("        <version>" + catalog.getCatalogVersion() + "</version>");
-        System.out.println("    </dependency>");
-        System.out.println("");
+        printer().println("");
+        printer().println("    <dependency>");
+        printer().println("        <groupId>" + "org.apache.camel" + "</groupId>");
+        printer().println("        <artifactId>" + "camel.main" + "</artifactId>");
+        printer().println("        <version>" + catalog.getCatalogVersion() + "</version>");
+        printer().println("    </dependency>");
+        printer().println("");
 
-        System.out.printf("%s%n%n%n",
+        printer().printf("%s%n%n%n",
                 "When running Camel via camel-main you can configure Camel in the application.properties file");
 
         for (MainModel.MainGroupModel g : mm.getGroups()) {
@@ -313,11 +313,11 @@ public class CatalogDoc extends CamelCommand {
             var total2 = filtered.size();
             if (total2 > 0) {
                 if (total1 == total2) {
-                    System.out.printf("%s (total: %s):%n", g.getDescription(), total1);
+                    printer().printf("%s (total: %s):%n", g.getDescription(), total1);
                 } else {
-                    System.out.printf("%s options (total: %s match-filter: %s):%n", g.getDescription(), total1, total2);
+                    printer().printf("%s options (total: %s match-filter: %s):%n", g.getDescription(), total1, total2);
                 }
-                System.out.println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, filtered, Arrays.asList(
+                printer().println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, filtered, Arrays.asList(
                         new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).minWidth(20)
                                 .maxWidth(40, OverflowBehaviour.NEWLINE)
                                 .with(this::getName),
@@ -328,14 +328,14 @@ public class CatalogDoc extends CamelCommand {
                                 .with(r -> r.getShortDefaultValue(25)),
                         new Column().header("TYPE").dataAlign(HorizontalAlign.LEFT).maxWidth(25, OverflowBehaviour.NEWLINE)
                                 .with(BaseOptionModel::getShortJavaType))));
-                System.out.println("");
-                System.out.println("");
+                printer().println("");
+                printer().println("");
             }
         }
 
         if (link != null) {
-            System.out.println(link);
-            System.out.println("");
+            printer().println(link);
+            printer().println("");
         }
     }
 
@@ -349,43 +349,43 @@ public class CatalogDoc extends CamelCommand {
         }
         if (url) {
             if (link != null) {
-                System.out.println(link);
+                printer().println(link);
             }
             return;
         }
 
         if (cm.isDeprecated()) {
-            System.out.printf("Component Name: %s (deprecated)%n", cm.getName());
+            printer().printf("Component Name: %s (deprecated)%n", cm.getName());
         } else {
-            System.out.printf("Component Name: %s%n", cm.getName());
+            printer().printf("Component Name: %s%n", cm.getName());
         }
-        System.out.printf("Since: %s%n", fixQuarkusSince(cm.getFirstVersionShort()));
-        System.out.println("");
+        printer().printf("Since: %s%n", fixQuarkusSince(cm.getFirstVersionShort()));
+        printer().println("");
         if (cm.isProducerOnly()) {
-            System.out.println("Only producer is supported");
+            printer().println("Only producer is supported");
         } else if (cm.isConsumerOnly()) {
-            System.out.println("Only consumer is supported");
+            printer().println("Only consumer is supported");
         } else {
-            System.out.println("Both producer and consumer are supported");
+            printer().println("Both producer and consumer are supported");
         }
 
-        System.out.println("");
-        System.out.printf("%s%n", cm.getDescription());
-        System.out.println("");
-        System.out.println("    <dependency>");
-        System.out.println("        <groupId>" + cm.getGroupId() + "</groupId>");
-        System.out.println("        <artifactId>" + cm.getArtifactId() + "</artifactId>");
-        System.out.println("        <version>" + cm.getVersion() + "</version>");
-        System.out.println("    </dependency>");
-        System.out.println("");
-        System.out.printf("The %s endpoint is configured using URI syntax:%n", cm.getName());
-        System.out.println("");
-        System.out.printf("    %s%n", cm.getSyntax());
-        System.out.println("");
-        System.out.println("with the following path and query parameters:");
-        System.out.println("");
-        System.out.printf("Path parameters (%s):%n", cm.getEndpointPathOptions().size());
-        System.out.println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, cm.getEndpointPathOptions(), Arrays.asList(
+        printer().println("");
+        printer().printf("%s%n", cm.getDescription());
+        printer().println("");
+        printer().println("    <dependency>");
+        printer().println("        <groupId>" + cm.getGroupId() + "</groupId>");
+        printer().println("        <artifactId>" + cm.getArtifactId() + "</artifactId>");
+        printer().println("        <version>" + cm.getVersion() + "</version>");
+        printer().println("    </dependency>");
+        printer().println("");
+        printer().printf("The %s endpoint is configured using URI syntax:%n", cm.getName());
+        printer().println("");
+        printer().printf("    %s%n", cm.getSyntax());
+        printer().println("");
+        printer().println("with the following path and query parameters:");
+        printer().println("");
+        printer().printf("Path parameters (%s):%n", cm.getEndpointPathOptions().size());
+        printer().println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, cm.getEndpointPathOptions(), Arrays.asList(
                 new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).minWidth(20).maxWidth(35, OverflowBehaviour.NEWLINE)
                         .with(this::getName),
                 new Column().header("DESCRIPTION").dataAlign(HorizontalAlign.LEFT).maxWidth(80, OverflowBehaviour.NEWLINE)
@@ -394,16 +394,16 @@ public class CatalogDoc extends CamelCommand {
                         .with(r -> r.getShortDefaultValue(25)),
                 new Column().header("TYPE").dataAlign(HorizontalAlign.LEFT).maxWidth(25, OverflowBehaviour.NEWLINE)
                         .with(BaseOptionModel::getShortJavaType))));
-        System.out.println("");
+        printer().println("");
         var filtered = filter(filter, cm.getEndpointParameterOptions());
         var total1 = cm.getEndpointParameterOptions().size();
         var total2 = filtered.size();
         if (total1 == total2) {
-            System.out.printf("Query parameters (total: %s):%n", total1);
+            printer().printf("Query parameters (total: %s):%n", total1);
         } else {
-            System.out.printf("Query parameters (total: %s match-filter: %s):%n", total1, total2);
+            printer().printf("Query parameters (total: %s match-filter: %s):%n", total1, total2);
         }
-        System.out.println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, filtered, Arrays.asList(
+        printer().println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, filtered, Arrays.asList(
                 new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).minWidth(20).maxWidth(35, OverflowBehaviour.NEWLINE)
                         .with(this::getName),
                 new Column().header("DESCRIPTION").dataAlign(HorizontalAlign.LEFT).maxWidth(80, OverflowBehaviour.NEWLINE)
@@ -412,12 +412,12 @@ public class CatalogDoc extends CamelCommand {
                         .with(r -> r.getShortDefaultValue(25)),
                 new Column().header("TYPE").dataAlign(HorizontalAlign.LEFT).maxWidth(25, OverflowBehaviour.NEWLINE)
                         .with(BaseOptionModel::getShortJavaType))));
-        System.out.println("");
+        printer().println("");
 
         if (headers && !cm.getEndpointHeaders().isEmpty()) {
-            System.out.printf("The %s component supports (total: %s) message headers, which are listed below.%n%n",
+            printer().printf("The %s component supports (total: %s) message headers, which are listed below.%n%n",
                     cm.getName(), cm.getEndpointHeaders().size());
-            System.out.println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, cm.getEndpointHeaders(), Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, cm.getEndpointHeaders(), Arrays.asList(
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).minWidth(20)
                             .maxWidth(35, OverflowBehaviour.NEWLINE)
                             .with(this::getName),
@@ -427,12 +427,12 @@ public class CatalogDoc extends CamelCommand {
                             .with(r -> r.getShortDefaultValue(25)),
                     new Column().header("TYPE").dataAlign(HorizontalAlign.LEFT).maxWidth(25, OverflowBehaviour.NEWLINE)
                             .with(BaseOptionModel::getShortJavaType))));
-            System.out.println("");
+            printer().println("");
         }
 
         if (link != null) {
-            System.out.println(link);
-            System.out.println("");
+            printer().println(link);
+            printer().println("");
         }
     }
 
@@ -446,37 +446,37 @@ public class CatalogDoc extends CamelCommand {
         }
         if (url) {
             if (link != null) {
-                System.out.println(link);
+                printer().println(link);
             }
             return;
         }
 
         if (dm.isDeprecated()) {
-            System.out.printf("Dataformat Name: %s (deprecated)%n", dm.getName());
+            printer().printf("Dataformat Name: %s (deprecated)%n", dm.getName());
         } else {
-            System.out.printf("Dataformat Name: %s%n", dm.getName());
+            printer().printf("Dataformat Name: %s%n", dm.getName());
         }
-        System.out.printf("Since: %s%n", fixQuarkusSince(dm.getFirstVersionShort()));
-        System.out.println("");
-        System.out.printf("%s%n", dm.getDescription());
-        System.out.println("");
-        System.out.println("    <dependency>");
-        System.out.println("        <groupId>" + dm.getGroupId() + "</groupId>");
-        System.out.println("        <artifactId>" + dm.getArtifactId() + "</artifactId>");
-        System.out.println("        <version>" + dm.getVersion() + "</version>");
-        System.out.println("    </dependency>");
-        System.out.println("");
+        printer().printf("Since: %s%n", fixQuarkusSince(dm.getFirstVersionShort()));
+        printer().println("");
+        printer().printf("%s%n", dm.getDescription());
+        printer().println("");
+        printer().println("    <dependency>");
+        printer().println("        <groupId>" + dm.getGroupId() + "</groupId>");
+        printer().println("        <artifactId>" + dm.getArtifactId() + "</artifactId>");
+        printer().println("        <version>" + dm.getVersion() + "</version>");
+        printer().println("    </dependency>");
+        printer().println("");
         var filtered = filter(filter, dm.getOptions());
         var total1 = dm.getOptions().size();
         var total2 = filtered.size();
         if (total1 == total2) {
-            System.out.printf("The %s dataformat supports (total: %s) options, which are listed below.%n%n", dm.getName(),
+            printer().printf("The %s dataformat supports (total: %s) options, which are listed below.%n%n", dm.getName(),
                     total1);
         } else {
-            System.out.printf("The %s dataformat supports (total: %s match-filter: %s) options, which are listed below.%n%n",
+            printer().printf("The %s dataformat supports (total: %s match-filter: %s) options, which are listed below.%n%n",
                     dm.getName(), total1, total2);
         }
-        System.out.println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, filtered, Arrays.asList(
+        printer().println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, filtered, Arrays.asList(
                 new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).minWidth(20).maxWidth(35, OverflowBehaviour.NEWLINE)
                         .with(this::getName),
                 new Column().header("DESCRIPTION").dataAlign(HorizontalAlign.LEFT).maxWidth(80, OverflowBehaviour.NEWLINE)
@@ -485,11 +485,11 @@ public class CatalogDoc extends CamelCommand {
                         .with(r -> r.getShortDefaultValue(25)),
                 new Column().header("TYPE").dataAlign(HorizontalAlign.LEFT).maxWidth(25, OverflowBehaviour.NEWLINE)
                         .with(BaseOptionModel::getShortJavaType))));
-        System.out.println("");
+        printer().println("");
 
         if (link != null) {
-            System.out.println(link);
-            System.out.println("");
+            printer().println(link);
+            printer().println("");
         }
     }
 
@@ -503,37 +503,37 @@ public class CatalogDoc extends CamelCommand {
         }
         if (url) {
             if (link != null) {
-                System.out.println(link);
+                printer().println(link);
             }
             return;
         }
 
         if (lm.isDeprecated()) {
-            System.out.printf("Language Name: %s (deprecated)%n", lm.getName());
+            printer().printf("Language Name: %s (deprecated)%n", lm.getName());
         } else {
-            System.out.printf("Language Name: %s%n", lm.getName());
+            printer().printf("Language Name: %s%n", lm.getName());
         }
-        System.out.printf("Since: %s%n", fixQuarkusSince(lm.getFirstVersionShort()));
-        System.out.println("");
-        System.out.printf("%s%n", lm.getDescription());
-        System.out.println("");
-        System.out.println("    <dependency>");
-        System.out.println("        <groupId>" + lm.getGroupId() + "</groupId>");
-        System.out.println("        <artifactId>" + lm.getArtifactId() + "</artifactId>");
-        System.out.println("        <version>" + lm.getVersion() + "</version>");
-        System.out.println("    </dependency>");
-        System.out.println("");
+        printer().printf("Since: %s%n", fixQuarkusSince(lm.getFirstVersionShort()));
+        printer().println("");
+        printer().printf("%s%n", lm.getDescription());
+        printer().println("");
+        printer().println("    <dependency>");
+        printer().println("        <groupId>" + lm.getGroupId() + "</groupId>");
+        printer().println("        <artifactId>" + lm.getArtifactId() + "</artifactId>");
+        printer().println("        <version>" + lm.getVersion() + "</version>");
+        printer().println("    </dependency>");
+        printer().println("");
         var filtered = filter(filter, lm.getOptions());
         var total1 = lm.getOptions().size();
         var total2 = filtered.size();
         if (total1 == total2) {
-            System.out.printf("The %s language supports (total: %s) options, which are listed below.%n%n", lm.getName(),
+            printer().printf("The %s language supports (total: %s) options, which are listed below.%n%n", lm.getName(),
                     total1);
         } else {
-            System.out.printf("The %s language supports (total: %s match-filter: %s) options, which are listed below.%n%n",
+            printer().printf("The %s language supports (total: %s match-filter: %s) options, which are listed below.%n%n",
                     lm.getName(), total1, total2);
         }
-        System.out.println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, filtered, Arrays.asList(
+        printer().println(AsciiTable.getTable(AsciiTable.FANCY_ASCII, filtered, Arrays.asList(
                 new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).minWidth(20).maxWidth(35, OverflowBehaviour.NEWLINE)
                         .with(this::getName),
                 new Column().header("DESCRIPTION").dataAlign(HorizontalAlign.LEFT).maxWidth(80, OverflowBehaviour.NEWLINE)
@@ -542,11 +542,11 @@ public class CatalogDoc extends CamelCommand {
                         .with(r -> r.getShortDefaultValue(25)),
                 new Column().header("TYPE").dataAlign(HorizontalAlign.LEFT).maxWidth(25, OverflowBehaviour.NEWLINE)
                         .with(BaseOptionModel::getShortJavaType))));
-        System.out.println("");
+        printer().println("");
 
         if (link != null) {
-            System.out.println(link);
-            System.out.println("");
+            printer().println(link);
+            printer().println("");
         }
     }
 
@@ -560,30 +560,30 @@ public class CatalogDoc extends CamelCommand {
         }
         if (url) {
             if (link != null) {
-                System.out.println(link);
+                printer().println(link);
             }
             return;
         }
 
         if (om.isDeprecated()) {
-            System.out.printf("Miscellaneous Name: %s (deprecated)%n", om.getName());
+            printer().printf("Miscellaneous Name: %s (deprecated)%n", om.getName());
         } else {
-            System.out.printf("Miscellaneous Name: %s%n", om.getName());
+            printer().printf("Miscellaneous Name: %s%n", om.getName());
         }
-        System.out.printf("Since: %s%n", fixQuarkusSince(om.getFirstVersionShort()));
-        System.out.println("");
-        System.out.printf("%s%n", om.getDescription());
-        System.out.println("");
-        System.out.println("    <dependency>");
-        System.out.println("        <groupId>" + om.getGroupId() + "</groupId>");
-        System.out.println("        <artifactId>" + om.getArtifactId() + "</artifactId>");
-        System.out.println("        <version>" + om.getVersion() + "</version>");
-        System.out.println("    </dependency>");
-        System.out.println("");
+        printer().printf("Since: %s%n", fixQuarkusSince(om.getFirstVersionShort()));
+        printer().println("");
+        printer().printf("%s%n", om.getDescription());
+        printer().println("");
+        printer().println("    <dependency>");
+        printer().println("        <groupId>" + om.getGroupId() + "</groupId>");
+        printer().println("        <artifactId>" + om.getArtifactId() + "</artifactId>");
+        printer().println("        <version>" + om.getVersion() + "</version>");
+        printer().println("    </dependency>");
+        printer().println("");
 
         if (link != null) {
-            System.out.println(link);
-            System.out.println("");
+            printer().println(link);
+            printer().println("");
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogKamelet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogKamelet.java
@@ -105,7 +105,7 @@ public class CatalogKamelet extends CamelCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).with(r -> r.name),
                     new Column().header("TYPE").dataAlign(HorizontalAlign.LEFT).minWidth(10).with(r -> r.type),
                     new Column().header("LEVEL").dataAlign(HorizontalAlign.LEFT).minWidth(12).with(r -> r.supportLevel),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigGet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigGet.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.dsl.jbang.core.commands.config;
 
+import java.util.Optional;
+
 import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
@@ -26,7 +28,7 @@ import picocli.CommandLine;
 public class ConfigGet extends CamelCommand {
 
     @CommandLine.Parameters(description = "Configuration key", arity = "1")
-    private String key;
+    String key;
 
     public ConfigGet(CamelJBangMain main) {
         super(main);
@@ -35,10 +37,11 @@ public class ConfigGet extends CamelCommand {
     @Override
     public Integer doCall() throws Exception {
         CommandLineHelper.loadProperties(properties -> {
-            if (properties.containsKey(key)) {
-                System.out.println(properties.getProperty(key));
+            Optional<Object> maybeProperty = Optional.ofNullable(properties.get(key));
+            if (maybeProperty.isPresent()) {
+                printer().println(String.valueOf(maybeProperty.get()));
             } else {
-                System.out.println(key + " key not found");
+                printer().println(key + " key not found");
             }
         });
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigSet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigSet.java
@@ -27,7 +27,7 @@ import picocli.CommandLine;
 public class ConfigSet extends CamelCommand {
 
     @CommandLine.Parameters(description = "Configuration parameter (ex. key=value)", arity = "1")
-    private String configuration;
+    String configuration;
 
     public ConfigSet(CamelJBangMain main) {
         super(main);
@@ -38,7 +38,7 @@ public class ConfigSet extends CamelCommand {
         CommandLineHelper.createPropertyFile();
 
         if (configuration.split("=").length == 1) {
-            System.out.println("Configuration parameter not in key=value format");
+            printer().println("Configuration parameter not in key=value format");
             return 1;
         }
 
@@ -46,7 +46,7 @@ public class ConfigSet extends CamelCommand {
             String key = StringHelper.before(configuration, "=").trim();
             String value = StringHelper.after(configuration, "=").trim();
             properties.put(key, value);
-            CommandLineHelper.storeProperties(properties);
+            CommandLineHelper.storeProperties(properties, printer());
         });
 
         return 0;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnset.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnset.java
@@ -26,7 +26,7 @@ import picocli.CommandLine;
 public class ConfigUnset extends CamelCommand {
 
     @CommandLine.Parameters(description = "Configuration key", arity = "1")
-    private String key;
+    String key;
 
     public ConfigUnset(CamelJBangMain main) {
         super(main);
@@ -36,7 +36,7 @@ public class ConfigUnset extends CamelCommand {
     public Integer doCall() throws Exception {
         CommandLineHelper.loadProperties(properties -> {
             properties.remove(key);
-            CommandLineHelper.storeProperties(properties);
+            CommandLineHelper.storeProperties(properties, printer());
         });
 
         return 0;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelContextStatus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelContextStatus.java
@@ -141,7 +141,7 @@ public class CamelContextStatus extends ProcessWatchCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                             .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelContextTop.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelContextTop.java
@@ -144,7 +144,7 @@ public class CamelContextTop extends ProcessWatchCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                             .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelCount.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelCount.java
@@ -93,7 +93,7 @@ public class CamelCount extends ProcessWatchCommand {
 
         if (!total && !fail) {
             if (!rows.isEmpty()) {
-                System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+                printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                         new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                         new Column().header("NAME").dataAlign(HorizontalAlign.LEFT)
                                 .maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
@@ -125,7 +125,7 @@ public class CamelCount extends ProcessWatchCommand {
                     index++;
                 }
             }
-            System.out.println(builder);
+            printer().println(String.valueOf(builder));
         }
 
         return 0;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelProcessorStatus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelProcessorStatus.java
@@ -227,7 +227,7 @@ public class CamelProcessorStatus extends ProcessWatchCommand {
     }
 
     protected void printTable(List<Row> rows) {
-        System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+        printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                 new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(this::getPid),
                 new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                         .with(this::getName),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelRouteStatus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelRouteStatus.java
@@ -179,7 +179,7 @@ public class CamelRouteStatus extends ProcessWatchCommand {
     }
 
     protected void printTable(List<Row> rows) {
-        System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+        printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                 new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                 new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                         .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelRouteTop.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelRouteTop.java
@@ -36,7 +36,7 @@ public class CamelRouteTop extends CamelRouteStatus {
 
     @Override
     protected void printTable(List<Row> rows) {
-        System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+        printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                 new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                 new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                         .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/Jolokia.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/Jolokia.java
@@ -48,8 +48,8 @@ public class Jolokia extends ProcessBaseCommand {
         if (pids.isEmpty()) {
             return 0;
         } else if (pids.size() > 1) {
-            System.out.println("Name or pid " + name + " matches " + pids.size()
-                               + " running Camel integrations. Specify a name or PID that matches exactly one.");
+            printer().println("Name or pid " + name + " matches " + pids.size()
+                              + " running Camel integrations. Specify a name or PID that matches exactly one.");
             return 0;
         }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListBlocked.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListBlocked.java
@@ -94,7 +94,7 @@ public class ListBlocked extends ProcessWatchCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                             .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListCircuitBreaker.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListCircuitBreaker.java
@@ -132,7 +132,7 @@ public class ListCircuitBreaker extends ProcessWatchCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                             .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListConsumer.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListConsumer.java
@@ -166,7 +166,7 @@ public class ListConsumer extends ProcessWatchCommand {
     }
 
     protected void printTable(List<Row> rows) {
-        System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+        printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                 new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                 new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                         .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListEndpoint.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListEndpoint.java
@@ -160,7 +160,7 @@ public class ListEndpoint extends ProcessWatchCommand {
     }
 
     protected void printTable(List<Row> rows) {
-        System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+        printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                 new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                 new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                         .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListEvent.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListEvent.java
@@ -90,7 +90,7 @@ public class ListEvent extends ProcessWatchCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                             .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListHealth.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListHealth.java
@@ -194,7 +194,7 @@ public class ListHealth extends ProcessWatchCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT)
                             .maxWidth(40, OverflowBehaviour.ELLIPSIS_RIGHT)
@@ -222,10 +222,10 @@ public class ListHealth extends ProcessWatchCommand {
                     = rows.stream().filter(r -> r.stackTrace != null && !r.stackTrace.isEmpty()).collect(Collectors.toList());
             if (!traces.isEmpty()) {
                 for (Row row : traces) {
-                    System.out.println("\n");
-                    System.out.println(StringHelper.fillChars('-', 120));
-                    System.out.println(StringHelper.padString(1, 55) + "STACK-TRACE");
-                    System.out.println(StringHelper.fillChars('-', 120));
+                    printer().println("\n");
+                    printer().println(StringHelper.fillChars('-', 120));
+                    printer().println(StringHelper.padString(1, 55) + "STACK-TRACE");
+                    printer().println(StringHelper.fillChars('-', 120));
                     StringBuilder sb = new StringBuilder();
                     sb.append(String.format("\tPID: %s%n", row.pid));
                     sb.append(String.format("\tNAME: %s%n", row.name));
@@ -244,7 +244,7 @@ public class ListHealth extends ProcessWatchCommand {
                     for (int i = 0; i < depth && i < row.stackTrace.size(); i++) {
                         sb.append(String.format("\t%s%n", row.stackTrace.get(i)));
                     }
-                    System.out.println(sb);
+                    printer().println(sb.toString());
                 }
             }
         }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListInflight.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListInflight.java
@@ -96,7 +96,7 @@ public class ListInflight extends ProcessWatchCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                             .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListMetric.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListMetric.java
@@ -198,7 +198,7 @@ public class ListMetric extends ProcessWatchCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                             .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListProcess.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListProcess.java
@@ -87,9 +87,9 @@ public class ListProcess extends ProcessWatchCommand {
 
         if (!rows.isEmpty()) {
             if (pid) {
-                rows.forEach(r -> System.out.println(r.pid));
+                rows.forEach(r -> printer().println(r.pid));
             } else {
-                System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+                printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                         new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                         new Column().header("NAME").dataAlign(HorizontalAlign.LEFT)
                                 .maxWidth(40, OverflowBehaviour.ELLIPSIS_RIGHT)

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListService.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListService.java
@@ -101,7 +101,7 @@ public class ListService extends ProcessWatchCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(30, OverflowBehaviour.ELLIPSIS_RIGHT)
                             .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListVault.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListVault.java
@@ -139,7 +139,7 @@ public class ListVault extends ProcessWatchCommand {
         rows.sort(this::sortRow);
 
         if (!rows.isEmpty()) {
-            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+            printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                     new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
                     new Column().header("NAME").dataAlign(HorizontalAlign.LEFT).maxWidth(40, OverflowBehaviour.ELLIPSIS_RIGHT)
                             .with(r -> r.name),

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/StopProcess.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/StopProcess.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.util.List;
 
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.util.FileUtil;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -45,17 +46,16 @@ public class StopProcess extends ProcessBaseCommand {
 
         // stop by deleting the pid file
         for (Long pid : pids) {
-            File dir = new File(System.getProperty("user.home"), ".camel");
-            File pidFile = new File(dir, Long.toString(pid));
+            File pidFile = new File(CommandLineHelper.getCamelDir(), Long.toString(pid));
             if (pidFile.exists()) {
-                System.out.println("Shutting down Camel integration (PID: " + pid + ")");
+                printer().println("Shutting down Camel integration (PID: " + pid + ")");
                 FileUtil.deleteFile(pidFile);
             }
         }
         for (Long pid : pids) {
             if (kill) {
                 ProcessHandle.of(pid).ifPresent(ph -> {
-                    System.out.println("Killing Camel integration (PID: " + pid + ")");
+                    printer().println("Killing Camel integration (PID: " + pid + ")");
                     ph.destroyForcibly();
                 });
             }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionGet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionGet.java
@@ -35,12 +35,12 @@ public class VersionGet extends CamelCommand {
     public Integer doCall() throws Exception {
         String jv = VersionHelper.getJBangVersion();
         if (jv != null) {
-            System.out.println("JBang version: " + jv);
+            printer().println("JBang version: " + jv);
         }
 
         CamelCatalog catalog = new DefaultCamelCatalog();
         String v = catalog.getCatalogVersion();
-        System.out.println("Camel JBang version: " + v);
+        printer().println("Camel JBang version: " + v);
 
         CommandLineHelper.loadProperties(properties -> {
             String uv = properties.getProperty("camel-version");
@@ -48,18 +48,18 @@ public class VersionGet extends CamelCommand {
             String repos = properties.getProperty("repos");
             String runtime = properties.getProperty("runtime");
             if (uv != null || repos != null || runtime != null) {
-                System.out.println("User configuration:");
+                printer().println("User configuration:");
                 if (uv != null) {
-                    System.out.println("    camel-version = " + uv);
+                    printer().println("    camel-version = " + uv);
                 }
                 if (kv != null) {
-                    System.out.println("    kamelets-version = " + uv);
+                    printer().println("    kamelets-version = " + kv);
                 }
                 if (runtime != null) {
-                    System.out.println("    runtime = " + runtime);
+                    printer().println("    runtime = " + runtime);
                 }
                 if (repos != null) {
-                    System.out.println("    repos = " + repos);
+                    printer().println("    repos = " + repos);
                 }
             }
         });

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionList.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionList.java
@@ -133,7 +133,7 @@ public class VersionList extends CamelCommand {
             main.stop();
         } catch (Exception e) {
             e.printStackTrace();
-            System.out.println("Error downloading available Camel versions");
+            printer().println("Error downloading available Camel versions");
             return 1;
         }
 
@@ -173,7 +173,7 @@ public class VersionList extends CamelCommand {
         rows.sort(this::sortRow);
 
         // camel-quarkus is not LTS and have its own release schedule
-        System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+        printer().println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
                 new Column().header("CAMEL VERSION")
                         .headerAlign(HorizontalAlign.CENTER).dataAlign(HorizontalAlign.CENTER).with(r -> r.coreVersion),
                 new Column().header("QUARKUS").visible("quarkus".equalsIgnoreCase(runtime))

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionSet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionSet.java
@@ -62,7 +62,7 @@ public class VersionSet extends CamelCommand {
                     properties.put("runtime", runtime);
                 }
             }
-            CommandLineHelper.storeProperties(properties);
+            CommandLineHelper.storeProperties(properties, printer());
         });
 
         return 0;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/VersionHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/VersionHelper.java
@@ -29,7 +29,7 @@ public final class VersionHelper {
 
     public static String getJBangVersion() {
         try {
-            File file = new File(System.getProperty("user.home"), ".jbang/cache/version.txt");
+            File file = new File(CommandLineHelper.getHomeDir(), ".jbang/cache/version.txt");
             if (file.exists() && file.isFile()) {
                 FileInputStream fis = new FileInputStream(file);
                 String text = IOHelper.loadText(fis);

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/CamelCommandBaseTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/CamelCommandBaseTest.java
@@ -15,33 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.camel.dsl.jbang.core.common;
+package org.apache.camel.dsl.jbang.core.commands;
 
-/**
- * Printer interface used by commands to write output to given print stream. By default, uses System out print stream,
- * but unit tests for instance may use a different print stream.
- */
-public interface Printer {
+import org.junit.jupiter.api.BeforeEach;
 
-    default void println() {
-        System.out.println();
+public class CamelCommandBaseTest {
+
+    protected StringPrinter printer;
+
+    @BeforeEach
+    public void setup() {
+        printer = new StringPrinter();
     }
 
-    default void println(String line) {
-        System.out.println(line);
-    }
-
-    default void print(String output) {
-        System.out.print(output);
-    }
-
-    default void printf(String format, Object... args) {
-        System.out.printf(format, args);
-    }
-
-    /**
-     * Default printer uses System out print stream.
-     */
-    class SystemOutPrinter implements Printer {
-    }
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/StringPrinter.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/StringPrinter.java
@@ -31,8 +31,18 @@ public class StringPrinter implements Printer {
     private final StringWriter writer = new StringWriter();
 
     @Override
+    public void println() {
+        writer.write(System.lineSeparator());
+    }
+
+    @Override
     public void println(String line) {
-        writer.write(line + "\n");
+        printf("%s%n", line);
+    }
+
+    @Override
+    public void print(String output) {
+        writer.write(output);
     }
 
     @Override

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/UserConfigHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/UserConfigHelper.java
@@ -14,29 +14,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.dsl.jbang.core.commands.config;
 
-import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
-import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+package org.apache.camel.dsl.jbang.core.commands;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "list", description = "Displays user configuration", sortOptions = false)
-public class ConfigList extends CamelCommand {
+public final class UserConfigHelper {
 
-    public ConfigList(CamelJBangMain main) {
-        super(main);
+    private UserConfigHelper() {
+        // prevent instantiation of utility class
     }
 
-    @Override
-    public Integer doCall() throws Exception {
-        CommandLineHelper
-                .loadProperties(p -> {
-                    for (String k : p.stringPropertyNames()) {
-                        String v = p.getProperty(k);
-                        printer().printf("%s = %s%n", k, v);
-                    }
-                });
-        return 0;
+    public static void createUserConfig(String content) throws IOException {
+        CommandLineHelper.useHomeDir("target");
+        Path userConfigDir = Paths.get("target");
+        if (!userConfigDir.toFile().exists()) {
+            userConfigDir.toFile().mkdirs();
+        }
+
+        Files.writeString(userConfigDir.resolve(CommandLineHelper.USER_CONFIG), content,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING);
     }
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigGetTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigGetTest.java
@@ -14,29 +14,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.camel.dsl.jbang.core.commands.config;
 
-import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
+import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTest;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
-import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
-import picocli.CommandLine;
+import org.apache.camel.dsl.jbang.core.commands.UserConfigHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-@CommandLine.Command(name = "list", description = "Displays user configuration", sortOptions = false)
-public class ConfigList extends CamelCommand {
+class ConfigGetTest extends CamelCommandBaseTest {
 
-    public ConfigList(CamelJBangMain main) {
-        super(main);
+    @Test
+    public void shouldGetConfig() throws Exception {
+        UserConfigHelper.createUserConfig("foo=bar");
+
+        ConfigGet command = new ConfigGet(new CamelJBangMain().withPrinter(printer));
+        command.key = "foo";
+        command.doCall();
+
+        Assertions.assertEquals("bar", printer.getOutput());
     }
 
-    @Override
-    public Integer doCall() throws Exception {
-        CommandLineHelper
-                .loadProperties(p -> {
-                    for (String k : p.stringPropertyNames()) {
-                        String v = p.getProperty(k);
-                        printer().printf("%s = %s%n", k, v);
-                    }
-                });
-        return 0;
+    @Test
+    public void shouldHandleConfigGetKeyNotFound() throws Exception {
+        UserConfigHelper.createUserConfig("");
+
+        ConfigGet command = new ConfigGet(new CamelJBangMain().withPrinter(printer));
+        command.key = "foo";
+        command.doCall();
+
+        Assertions.assertEquals("foo key not found", printer.getOutput());
     }
+
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigListTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigListTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dsl.jbang.core.commands.config;
+
+import java.util.List;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTest;
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.UserConfigHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ConfigListTest extends CamelCommandBaseTest {
+
+    @Test
+    public void shouldHandleEmptyConfig() throws Exception {
+        UserConfigHelper.createUserConfig("");
+
+        ConfigList command = new ConfigList(new CamelJBangMain().withPrinter(printer));
+        command.doCall();
+
+        Assertions.assertEquals("", printer.getOutput());
+    }
+
+    @Test
+    public void shouldListUserConfig() throws Exception {
+        UserConfigHelper.createUserConfig("""
+                camel-version=latest
+                kamelets-version=greatest
+                foo=bar
+                """);
+
+        ConfigList command = new ConfigList(new CamelJBangMain().withPrinter(printer));
+        command.doCall();
+
+        List<String> lines = printer.getLines();
+        Assertions.assertEquals(3, lines.size());
+        Assertions.assertEquals("camel-version = latest", lines.get(0));
+        Assertions.assertEquals("kamelets-version = greatest", lines.get(1));
+        Assertions.assertEquals("foo = bar", lines.get(2));
+    }
+
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigSetTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigSetTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dsl.jbang.core.commands.config;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTest;
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.UserConfigHelper;
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ConfigSetTest extends CamelCommandBaseTest {
+
+    @Test
+    public void shouldSetConfig() throws Exception {
+        UserConfigHelper.createUserConfig("");
+
+        ConfigSet command = new ConfigSet(new CamelJBangMain().withPrinter(printer));
+        command.configuration = "foo=bar";
+        command.doCall();
+
+        Assertions.assertEquals("", printer.getOutput());
+
+        CommandLineHelper.loadProperties(properties -> {
+            Assertions.assertEquals(1, properties.size());
+            Assertions.assertEquals("bar", properties.get("foo"));
+        });
+    }
+
+    @Test
+    public void shouldOverwriteConfig() throws Exception {
+        UserConfigHelper.createUserConfig("foo=bar");
+
+        ConfigSet command = new ConfigSet(new CamelJBangMain().withPrinter(printer));
+        command.configuration = "foo=baz";
+        command.doCall();
+
+        Assertions.assertEquals("", printer.getOutput());
+
+        CommandLineHelper.loadProperties(properties -> {
+            Assertions.assertEquals(1, properties.size());
+            Assertions.assertEquals("baz", properties.get("foo"));
+        });
+    }
+
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnsetTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnsetTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dsl.jbang.core.commands.config;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTest;
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.UserConfigHelper;
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ConfigUnsetTest extends CamelCommandBaseTest {
+
+    @Test
+    public void shouldUnsetConfig() throws Exception {
+        UserConfigHelper.createUserConfig("""
+                camel-version=latest
+                foo=bar
+                kamelets-version=greatest
+                """);
+
+        ConfigUnset command = new ConfigUnset(new CamelJBangMain().withPrinter(printer));
+        command.key = "foo";
+        command.doCall();
+
+        Assertions.assertEquals("", printer.getOutput());
+
+        CommandLineHelper.loadProperties(properties -> {
+            Assertions.assertEquals(2, properties.size());
+            Assertions.assertEquals("latest", properties.get("camel-version"));
+            Assertions.assertEquals("greatest", properties.get("kamelets-version"));
+        });
+    }
+
+    @Test
+    public void shouldHandleMissingKeyToUnset() throws Exception {
+        UserConfigHelper.createUserConfig("""
+                camel-version=latest
+                kamelets-version=greatest
+                """);
+
+        ConfigUnset command = new ConfigUnset(new CamelJBangMain().withPrinter(printer));
+        command.key = "foo";
+        command.doCall();
+
+        Assertions.assertEquals("", printer.getOutput());
+
+        CommandLineHelper.loadProperties(properties -> {
+            Assertions.assertEquals(2, properties.size());
+            Assertions.assertEquals("latest", properties.get("camel-version"));
+            Assertions.assertEquals("greatest", properties.get("kamelets-version"));
+        });
+    }
+
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/version/VersionGetTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/version/VersionGetTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dsl.jbang.core.commands.version;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTest;
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.UserConfigHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class VersionGetTest extends CamelCommandBaseTest {
+
+    @Test
+    public void shouldPrintVersions() throws Exception {
+        UserConfigHelper.createUserConfig("");
+        createJBangVersionFile("0.100");
+
+        VersionGet command = createCommand();
+        command.doCall();
+
+        List<String> lines = printer.getLines();
+        Assertions.assertEquals("JBang version: 0.100", lines.get(0));
+        Assertions.assertTrue(lines.get(1).startsWith("Camel JBang version:"));
+    }
+
+    @Test
+    public void shouldPrintUserProperties() throws Exception {
+        UserConfigHelper.createUserConfig("""
+                camel-version=latest
+                foo=bar
+                kamelets-version=greatest
+                """);
+        createJBangVersionFile("0.101");
+
+        VersionGet command = createCommand();
+        command.doCall();
+
+        List<String> lines = printer.getLines();
+        Assertions.assertEquals(5, lines.size());
+        Assertions.assertEquals("JBang version: 0.101", lines.get(0));
+        Assertions.assertTrue(lines.get(1).startsWith("Camel JBang version:"));
+        Assertions.assertEquals("User configuration:", lines.get(2));
+        Assertions.assertEquals("camel-version = latest", lines.get(3));
+        Assertions.assertEquals("kamelets-version = greatest", lines.get(4));
+    }
+
+    private void createJBangVersionFile(String version) throws IOException {
+        Path jBangDir = Paths.get("target", ".jbang", "cache");
+        if (!jBangDir.toFile().exists()) {
+            jBangDir.toFile().mkdirs();
+        }
+
+        Files.writeString(jBangDir.resolve("version.txt"), version,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    private VersionGet createCommand() {
+        return new VersionGet(new CamelJBangMain().withPrinter(printer));
+    }
+
+}


### PR DESCRIPTION

# Description

- Enables unit testing of command output by using String printer instead of System.out
- Added unit tests for config commands
- Added unit tests for version commands

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking

- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes