### PR TITLE
Javadoc typo

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/ValidationException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ValidationException.java
@@ -18,7 +18,7 @@ package org.apache.camel;
 
 /**
  * The base class for any validation exception, such as
- * {@link org.apache.camel.processor.validation.SchemaValidationException} so that it is easy to treat all validation
+ * {@link org.apache.camel.support.processor.validation.SchemaValidationException} so that it is easy to treat all validation
  * errors in a similar way irrespective of the particular validation technology used.
  */
 public class ValidationException extends CamelExchangeException {


### PR DESCRIPTION
# Description

Fix a typo on `ValidationException` javadoc

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

Building locally with `Apache Maven 4.0.0-alpha-9` gives the following error:
```
[INFO] Scanning for projects...
[INFO] Loaded 7 groupId for remote repository atlassian
[ERROR] Some problems were encountered while processing the POMs
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project org.apache.camel:camel-report-maven-plugin:4.4.0-SNAPSHOT (~/work/camel/catalog/camel-report-maven-plugin/pom.xml) has 1 error
[ERROR]     'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.camel:camel-catalog-common:jar -> version ${project.version} vs 4.4.0-SNAPSHOT @ line 232, column 9
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the '-e' switch
[ERROR] Re-run Maven using the '-X' switch to enable verbose output
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
```
