### PR TITLE
(chores) camel-paho-mqtt5: disable tests on s390x

### DIFF
--- a/components/camel-paho-mqtt5/pom.xml
+++ b/components/camel-paho-mqtt5/pom.xml
@@ -33,6 +33,7 @@
     <description>Camel Eclipse Paho support for MQTT v5</description>
 
     <properties>
+        <skipITs.s390x>true</skipITs.s390x>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
There are no mosquitto containers for this platform