### PR TITLE
CAMEL-20279 - provide retry attempts for known flaky container start during tests

### DIFF
--- a/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSLocalContainerService.java
+++ b/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSLocalContainerService.java
@@ -103,6 +103,7 @@ public abstract class AWSLocalContainerService implements AWSService, ContainerS
     @Override
     public void initialize() {
         LOG.debug("Trying to start the container");
+        container.withStartupAttempts(5);
         container.start();
 
         registerProperties();

--- a/test-infra/camel-test-infra-hashicorp-vault/src/test/java/org/apache/camel/test/infra/hashicorp/vault/services/HashicorpVaultLocalContainerService.java
+++ b/test-infra/camel-test-infra-hashicorp-vault/src/test/java/org/apache/camel/test/infra/hashicorp/vault/services/HashicorpVaultLocalContainerService.java
@@ -89,6 +89,7 @@ public class HashicorpVaultLocalContainerService implements HashicorpVaultServic
     @Override
     public void initialize() {
         LOG.info("Trying to start the Hashicorp Vault container");
+        container.withStartupAttempts(5);
         container.start();
 
         registerProperties();


### PR DESCRIPTION


# Description

Some containers are known to be flaky during startup, provide a "reasonable" retry number (5) attempts to workaround it and not affect the tests.

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

