### PR TITLE
CAMEL-20297 camel-seda: do not swallow interrupted exceptions (leftover)

### DIFF
--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaProducer.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaProducer.java
@@ -243,6 +243,7 @@ public class SedaProducer extends DefaultAsyncProducer {
             } catch (InterruptedException e) {
                 // ignore
                 LOG.debug("Offer interrupted, are we stopping? {}", isStopping() || isStopped());
+                Thread.currentThread().interrupt();
             }
         } else {
             queue.add(target);


### PR DESCRIPTION
Leftover from 1c73ce90679ab0cc5e5bdb36b4e221462af7ef56