### PR TITLE
Improve data type resolving in YAML Pipe loader

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/spi/TransformerResolver.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/TransformerResolver.java
@@ -20,6 +20,7 @@ package org.apache.camel.spi;
 import java.util.Locale;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.util.StringHelper;
 
 /**
  * Resolves data type transformers from given transformer key. This represents the opportunity to lazy load transformers
@@ -42,13 +43,17 @@ public interface TransformerResolver<K> {
 
     /**
      * Normalize transformer key to conform with factory finder resource path. Replaces all non supported characters
-     * such as slashes and colons to dashes.
+     * such as slashes and colons to dashes. Automatically removes the default scheme prefix as it should not be part of
+     * the resource path.
      *
      * @param  key the transformer key
      * @return     normalized String representation of the key
      */
     default String normalize(K key) {
-        return key.toString().replaceAll("[^A-Za-z0-9-]", "-").toLowerCase(Locale.US);
+        String keyString = key.toString();
+        keyString = StringHelper.after(keyString, DataType.DEFAULT_SCHEME + ":", keyString);
+
+        return StringHelper.sanitize(keyString).toLowerCase(Locale.US);
     }
 
 }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/transformer/ByteArrayDataTypeTransformerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/transformer/ByteArrayDataTypeTransformerTest.java
@@ -90,6 +90,12 @@ public class ByteArrayDataTypeTransformerTest {
         DefaultTransformerRegistry transformerRegistry = new DefaultTransformerRegistry(camelContext);
         Transformer transformer = transformerRegistry.resolveTransformer(new TransformerKey("application-octet-stream"));
         Assertions.assertNotNull(transformer);
+
+        transformer = transformerRegistry.resolveTransformer(new TransformerKey("application/octet-stream"));
+        Assertions.assertNotNull(transformer);
+
+        transformer = transformerRegistry.resolveTransformer(new TransformerKey("camel:application-octet-stream"));
+        Assertions.assertNotNull(transformer);
     }
 
     private static void assertBinaryBody(Exchange exchange, String key, String content) {

--- a/core/camel-core/src/test/java/org/apache/camel/processor/transformer/StringDataTypeTransformerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/transformer/StringDataTypeTransformerTest.java
@@ -78,6 +78,12 @@ public class StringDataTypeTransformerTest {
         DefaultTransformerRegistry dataTypeRegistry = new DefaultTransformerRegistry(camelContext);
         Transformer transformer = dataTypeRegistry.resolveTransformer(new TransformerKey("text-plain"));
         Assertions.assertNotNull(transformer);
+
+        transformer = dataTypeRegistry.resolveTransformer(new TransformerKey("text/plain"));
+        Assertions.assertNotNull(transformer);
+
+        transformer = dataTypeRegistry.resolveTransformer(new TransformerKey("camel:text-plain"));
+        Assertions.assertNotNull(transformer);
     }
 
     private static void assertStringBody(Exchange exchange, String key, String content) {

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/main/java/org/apache/camel/dsl/yaml/YamlRoutesBuilderLoader.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/main/java/org/apache/camel/dsl/yaml/YamlRoutesBuilderLoader.java
@@ -722,12 +722,12 @@ public class YamlRoutesBuilderLoader extends YamlRoutesBuilderLoaderSupport {
                 if (dataTypes != null) {
                     MappingNode in = asMappingNode(nodeAt(dataTypes, "/in"));
                     if (in != null) {
-                        route.inputType(extractTupleValue(in.getValue(), "format"));
+                        route.inputType(extractDataType(in));
                     }
 
                     MappingNode out = asMappingNode(nodeAt(dataTypes, "/out"));
                     if (out != null) {
-                        route.transform(new DataType(extractTupleValue(out.getValue(), "format")));
+                        route.transform(new DataType(extractDataType(out)));
                     }
                 }
 
@@ -770,12 +770,12 @@ public class YamlRoutesBuilderLoader extends YamlRoutesBuilderLoaderSupport {
                     if (dataTypes != null) {
                         MappingNode in = asMappingNode(nodeAt(dataTypes, "/in"));
                         if (in != null) {
-                            route.transform(new DataType(extractTupleValue(in.getValue(), "format")));
+                            route.transform(new DataType(extractDataType(in)));
                         }
 
                         MappingNode out = asMappingNode(nodeAt(dataTypes, "/out"));
                         if (out != null) {
-                            route.outputType(extractTupleValue(out.getValue(), "format"));
+                            route.outputType(extractDataType(out));
                         }
                     }
 
@@ -843,6 +843,24 @@ public class YamlRoutesBuilderLoader extends YamlRoutesBuilderLoaderSupport {
         }
 
         return answer;
+    }
+
+    /**
+     * Extracts the data type transformer name information form nodes dataTypes/in or dataTypes/out. When scheme is set
+     * construct the transformer name with a prefix like scheme:format. Otherwise, just use the given format as a data
+     * type transformer name.
+     *
+     * @param  node
+     * @return
+     */
+    private String extractDataType(MappingNode node) {
+        String scheme = extractTupleValue(node.getValue(), "scheme");
+        String format = extractTupleValue(node.getValue(), "format");
+        if (scheme != null) {
+            return scheme + ":" + format;
+        }
+
+        return format;
     }
 
     private String extractCamelEndpointUri(MappingNode node) {


### PR DESCRIPTION
# Description

- Support default data type prefix "camel:" when resolving transformers
- Support for optional "scheme" property in YAML DSL on dataTypes/in and dataTypes/out nodes

Enables users to reference data types in Pipes like this:

```yaml
dataTypes:
  out:
    scheme: aws2-s3
    format: application-cloudevents
```

Enables users to use the default data type scheme prefix

```yaml
dataTypes:
  out:
    scheme: camel
    format: text-plain
```

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes
