### PR TITLE
Saxon 'getStructuredVersionNumber' has no parameter: https://www.saxo…

### DIFF
--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/XmlConverter.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/XmlConverter.java
@@ -1122,7 +1122,7 @@ public class XmlConverter {
     private int[] retrieveSaxonVersion(ClassLoader loader) {
         try {
             final Class<?> versionClass = loader.loadClass("net.sf.saxon.Version");
-            final Method method = versionClass.getDeclaredMethod("getStructuredVersionNumber", int[].class);
+            final Method method = versionClass.getDeclaredMethod("getStructuredVersionNumber");
             final Object result = method.invoke(null);
             return (int[]) result;
         } catch (ClassNotFoundException e) {

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/support/builder/xml/XMLConverterHelper.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/support/builder/xml/XMLConverterHelper.java
@@ -253,7 +253,7 @@ public class XMLConverterHelper {
     private int[] retrieveSaxonVersion(ClassLoader loader) {
         try {
             final Class<?> versionClass = loader.loadClass("net.sf.saxon.Version");
-            final Method method = versionClass.getDeclaredMethod("getStructuredVersionNumber", int[].class);
+            final Method method = versionClass.getDeclaredMethod("getStructuredVersionNumber");
             final Object result = method.invoke(null);
             return (int[]) result;
         } catch (ClassNotFoundException e) {


### PR DESCRIPTION
# Description

A while ago I did a fix for a new saxon version. As of camel 4.3.0 we started to get the following warning:

> Method getStructuredVersionNumber not available on net.sf.saxon.Version!

It became clear to me that I did something very bad with it, this should fix it. The [method](https://www.saxonica.com/html/documentation12/javadoc/net/sf/saxon/Version.html#getStructuredVersionNumber()) itself has no parameter, so it should be findable without anything else.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

