### PR TITLE
CAMEL-20335: component-test - Exclude target folders

### DIFF
--- a/.github/actions/component-test/component-test.sh
+++ b/.github/actions/component-test/component-test.sh
@@ -39,7 +39,7 @@ function main() {
       componentPath="components/camel-${component}"
     fi
     if [[ -d "${componentPath}" ]] ; then
-      pl="$pl$(find "${componentPath}" -name pom.xml -not -path "*/src/it/*" -exec dirname {} \; | sort | tr -s "\n" ",")"
+      pl="$pl$(find "${componentPath}" -name pom.xml -not -path "*/src/it/*" -not -path "*/target/*" -exec dirname {} \; | sort | tr -s "\n" ",")"
     fi
   done
   len=${#pl}


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-20335

## Motivation

The GitHub Action `component-test` doesn't work as expected with components like `camel-spring-xml` because it tries to build projects in the target folder.

## Modifications:

* Exclude the target folders when trying to autodetect the root of sub-projects.