### PR TITLE
github links are handled later on

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -1294,6 +1294,11 @@ public class Run extends CamelCommand {
     }
 
     private boolean skipFile(String name) {
+        if (name.startsWith("github:") || name.startsWith("https://github.com/")
+                || name.startsWith("https://gist.github.com/")) {
+            return false;
+        }
+
         // flatten file
         name = FileUtil.stripPath(name);
 


### PR DESCRIPTION
avoid file name analysis if the name is a github link, there are some duplicated lines for github links checks.