### PR TITLE
Revert log4j to version 2.21.1 to match spring-boot-dependencies

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -306,7 +306,7 @@
         <libphonenumber-version>8.13.28</libphonenumber-version>
         <!-- virtual dependency only used by Eclipse m2e -->
         <lifecycle-mapping-version>1.0.0</lifecycle-mapping-version>
-        <log4j2-version>2.22.1</log4j2-version>
+        <log4j2-version>2.21.1</log4j2-version>
         <logback-version>1.4.14</logback-version>
         <lucene-version>9.9.1</lucene-version>
         <lightcouch-version>0.2.0</lightcouch-version>


### PR DESCRIPTION
I'd like to suggest reverting log4j to version 2.21.1 to match the version in spring-boot-dependencies 3.2.1.       It looks like the upgrades to 2.22.1 were done via dependabot

https://github.com/apache/camel/pull/12613
https://github.com/apache/camel/pull/12110

The camel-spring-boot itests are reporting library version mismatches with 2.22.1

[INFO] Running org.apache.camel.itest.springboot.CamelActivemqTest
WARN>>> Library version mismatch found.
Found mismatch for dependency org.apache.logging.log4j:log4j:
 - org.apache.logging.log4j:log4j-api:jar: --> [2.21.1, 2.22.1]
 - org.apache.logging.log4j:log4j-to-slf4j:jar: --> [2.21.1]
