### PR TITLE
CAMEL-20278: upgrade wildfly-elytron to 2.x

### DIFF
--- a/components/camel-elytron/pom.xml
+++ b/components/camel-elytron/pom.xml
@@ -73,14 +73,14 @@
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>${javax-json-api-version}</version>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>${jakarta-json-api-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>${glassfish-javax-json}</version>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <version>${parson-version}</version>
         </dependency>
 
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -373,6 +373,7 @@
         <optaplanner-version>9.44.0.Final</optaplanner-version>
         <os-maven-plugin-version>1.7.1</os-maven-plugin-version>
         <paho-version>1.2.5</paho-version>
+        <parson-version>1.1.5</parson-version>
         <parquet-common-version>1.13.1</parquet-common-version>
         <parquet-avro-version>1.13.1</parquet-avro-version>
         <pdfbox-version>3.0.1</pdfbox-version>
@@ -458,7 +459,7 @@
         <vysper-version>0.7</vysper-version>
         <web3j-version>5.0.0</web3j-version>
         <web3j-quorum-version>4.10.0</web3j-quorum-version>
-        <wildfly-elytron>1.20.4.Final</wildfly-elytron>
+        <wildfly-elytron>2.2.2.Final</wildfly-elytron>
         <wiremock-version>3.0.1</wiremock-version>
         <woodstox-version>4.4.1</woodstox-version>
         <woodstox-core-version>6.6.0</woodstox-core-version>


### PR DESCRIPTION
# Description

Wildfly-elytron 2.2.x has migrated from the deprecated javax.json to jakarta.json:

https://github.com/wildfly-security/wildfly-elytron/blame/2.2.x/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java#L30

Camel uses jakarta.json v2.1.3, and `parson` is the default provider:  

https://github.com/jakartaee/jsonp-api/blob/2.1.3/api/src/main/java/jakarta/json/spi/JsonProvider.java#L79.

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

