### PR TITLE
Update Jenkinsfile.jdk21

### DIFF
--- a/Jenkinsfile.jdk21
+++ b/Jenkinsfile.jdk21
@@ -92,7 +92,7 @@ pipeline {
             emailext(
                 subject: '${DEFAULT_SUBJECT}',
                 body: '${DEFAULT_CONTENT}',
-                recipientProviders: [[$class: 'CulpritsRecipientProvider']]
+                recipientProviders: [[$class: 'DevelopersRecipientProvider']]
             )
         }
     }


### PR DESCRIPTION
to not include people that never contributed to camel, but receive jenkins build failure mails now.

I never contributed directly to Camel. but receive mails from Jenkins. 