### PR TITLE
Update Jenkinsfile.ppc64le

### DIFF
--- a/Jenkinsfile.ppc64le
+++ b/Jenkinsfile.ppc64le
@@ -93,7 +93,7 @@ pipeline {
             emailext(
                 subject: '${DEFAULT_SUBJECT}',
                 body: '${DEFAULT_CONTENT}',
-                recipientProviders: [[$class: 'CulpritsRecipientProvider']]
+                recipientProviders: [[$class: 'DevelopersRecipientProvider']]
             )
         }
     }


### PR DESCRIPTION
to not include people that never contributed to camel, but receive jenkins build failure mails now.

I never contributed directly to Camel. but receive mails from Jenkins. 