### PR TITLE
Update Jenkinsfile.jdk17

### DIFF
--- a/Jenkinsfile.jdk17
+++ b/Jenkinsfile.jdk17
@@ -91,7 +91,7 @@ pipeline {
             emailext(
                 subject: '${DEFAULT_SUBJECT}',
                 body: '${DEFAULT_CONTENT}',
-                recipientProviders: [[$class: 'CulpritsRecipientProvider']]
+                recipientProviders: [[$class: 'DevelopersRecipientProvider']]
             )
         }
     }


### PR DESCRIPTION
to not include people that never contributed to camel, but receive jenkins build failure mails now.

I never contributed directly to Camel. but receive mails from Jenkins.
