### PR TITLE
Update Jenkinsfile.deploy

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -78,7 +78,7 @@ pipeline {
             emailext(
                 subject: '${DEFAULT_SUBJECT}',
                 body: '${DEFAULT_CONTENT}',
-                recipientProviders: [[$class: 'CulpritsRecipientProvider']]
+                recipientProviders: [[$class: 'DevelopersRecipientProvider']]
             )
         }
     }


### PR DESCRIPTION
to not include people that never contributed to camel, but receive jenkins build failure mails now.

I missed one more Jenkinsfile and just received a failure notice from ASF-Jenkins.

Thanks