### PR TITLE
CAMEL-20218: On startup populate local cache synchronously

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/processor/idempotent/kafka/KafkaConsumerUtil.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/processor/idempotent/kafka/KafkaConsumerUtil.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.idempotent.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.camel.util.ObjectHelper;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
+
+public class KafkaConsumerUtil {
+
+    /**
+     * Tests whether the Kafka consumer reached the target offsets for all specified topic partitions.
+     *
+     * @param  consumer      Kafka consumer. It is expected to have some assignment to topic partitions.
+     * @param  targetOffsets Target offsets for topic partitions.
+     * @param  <K>           Key type.
+     * @param  <V>           Value type.
+     * @return               {@code true} if the consumer has reached the target offsets for all specified topic
+     *                       partitions.
+     */
+    public static <K, V> boolean isReachedOffsets(Consumer<K, V> consumer, Map<TopicPartition, Long> targetOffsets) {
+        if (ObjectHelper.isEmpty(targetOffsets)) {
+            throw new IllegalArgumentException("Target offsets must be non-empty");
+        }
+
+        Set<TopicPartition> partitions = consumer.assignment();
+
+        /* If some partition is missing in the targetOffsets map, then we do not check the offset for this partition. */
+        Map<TopicPartition, Long> extendedTargetOffsets = new HashMap<>(targetOffsets);
+        partitions.forEach(partition -> extendedTargetOffsets.putIfAbsent(partition, Long.MIN_VALUE));
+
+        return partitions.stream()
+                .allMatch(partition -> consumer.position(partition) >= extendedTargetOffsets.get(partition));
+    }
+
+}

--- a/components/camel-kafka/src/main/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepository.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepository.java
@@ -369,7 +369,6 @@ public class KafkaIdempotentRepository extends ServiceSupport implements Idempot
         Map<TopicPartition, Long> endOffsets = consumer.endOffsets(partitions);
         log.debug("Consuming records from partitions {} till end offsets {}", partitions, endOffsets);
         while (!KafkaConsumerUtil.isReachedOffsets(consumer, endOffsets)) {
-            // TODO Cache population timeout?
             ConsumerRecords<String, String> consumerRecords = consumer.poll(Duration.ofMillis(pollDurationMs));
             for (ConsumerRecord<String, String> consumerRecord : consumerRecords) {
                 addToCache(consumerRecord);

--- a/components/camel-kafka/src/test/java/org/apache/camel/processor/idempotent/kafka/KafkaConsumerUtilsTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/processor/idempotent/kafka/KafkaConsumerUtilsTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.idempotent.kafka;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.processor.idempotent.kafka.KafkaConsumerUtil.isReachedOffsets;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class KafkaConsumerUtilsTest {
+
+    @Test
+    public void testNotReachedOffsets() {
+        Map<TopicPartition, Long> targetOffsets = Map.of(
+                new TopicPartition("topic1", 0), 10L,
+                new TopicPartition("topic1", 1), 100L);
+
+        Consumer<String, String> consumer = mock(Consumer.class);
+        when(consumer.assignment())
+                .thenReturn(
+                        Set.of(
+                                new TopicPartition("topic1", 0),
+                                new TopicPartition("topic1", 1)));
+        when(consumer.position(new TopicPartition("topic1", 0)))
+                .thenReturn(9L);
+        when(consumer.position(new TopicPartition("topic1", 1)))
+                .thenReturn(99L);
+
+        boolean result = isReachedOffsets(consumer, targetOffsets);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testReachedOffsets() {
+        Map<TopicPartition, Long> targetOffsets = Map.of(
+                new TopicPartition("topic1", 0), 10L,
+                new TopicPartition("topic1", 1), 100L);
+
+        Consumer<String, String> consumer = mock(Consumer.class);
+        when(consumer.assignment())
+                .thenReturn(
+                        Set.of(
+                                new TopicPartition("topic1", 0),
+                                new TopicPartition("topic1", 1)));
+        when(consumer.position(new TopicPartition("topic1", 0)))
+                .thenReturn(10L);
+        when(consumer.position(new TopicPartition("topic1", 1)))
+                .thenReturn(100L);
+
+        boolean result = isReachedOffsets(consumer, targetOffsets);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testOverrunOffsets() {
+        Map<TopicPartition, Long> targetOffsets = Map.of(
+                new TopicPartition("topic1", 0), 10L,
+                new TopicPartition("topic1", 1), 100L);
+
+        Consumer<String, String> consumer = mock(Consumer.class);
+        when(consumer.assignment())
+                .thenReturn(
+                        Set.of(
+                                new TopicPartition("topic1", 0),
+                                new TopicPartition("topic1", 1)));
+        when(consumer.position(new TopicPartition("topic1", 0)))
+                .thenReturn(11L);
+        when(consumer.position(new TopicPartition("topic1", 1)))
+                .thenReturn(101L);
+
+        boolean result = isReachedOffsets(consumer, targetOffsets);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testReachedOffsetsForSomePartitions() {
+        Map<TopicPartition, Long> targetOffsets = Map.of(
+                new TopicPartition("topic1", 0), 10L,
+                new TopicPartition("topic1", 1), 100L);
+
+        Consumer<String, String> consumer = mock(Consumer.class);
+        when(consumer.assignment())
+                .thenReturn(
+                        Set.of(
+                                new TopicPartition("topic1", 0),
+                                new TopicPartition("topic1", 1)));
+        when(consumer.position(new TopicPartition("topic1", 0)))
+                .thenReturn(10L);
+        when(consumer.position(new TopicPartition("topic1", 1)))
+                .thenReturn(99L);
+
+        boolean result = isReachedOffsets(consumer, targetOffsets);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testNotReachedOffsetsSomeTargetOffsetsUnspecified() {
+        Map<TopicPartition, Long> targetOffsets = Map.of(
+                new TopicPartition("topic1", 0), 10L);
+
+        Consumer<String, String> consumer = mock(Consumer.class);
+        when(consumer.assignment())
+                .thenReturn(
+                        Set.of(
+                                new TopicPartition("topic1", 0),
+                                new TopicPartition("topic1", 1)));
+        when(consumer.position(new TopicPartition("topic1", 0)))
+                .thenReturn(9L);
+        when(consumer.position(new TopicPartition("topic1", 1)))
+                .thenReturn(99L);
+
+        boolean result = isReachedOffsets(consumer, targetOffsets);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testReachedOffsetsSomeTargetOffsetsUnspecified() {
+        Map<TopicPartition, Long> targetOffsets = Map.of(
+                new TopicPartition("topic1", 0), 10L);
+
+        Consumer<String, String> consumer = mock(Consumer.class);
+        when(consumer.assignment())
+                .thenReturn(
+                        Set.of(
+                                new TopicPartition("topic1", 0),
+                                new TopicPartition("topic1", 1)));
+        when(consumer.position(new TopicPartition("topic1", 0)))
+                .thenReturn(10L);
+        when(consumer.position(new TopicPartition("topic1", 1)))
+                .thenReturn(99L);
+
+        boolean result = isReachedOffsets(consumer, targetOffsets);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testTargetOffsetsEmpty() {
+        Map<TopicPartition, Long> targetOffsets = Collections.emptyMap();
+        Consumer<String, String> consumer = mock(Consumer.class);
+        assertThrows(IllegalArgumentException.class, () -> isReachedOffsets(consumer, targetOffsets));
+    }
+
+}

--- a/components/camel-kafka/src/test/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepositoryPersistenceIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/processor/idempotent/kafka/KafkaIdempotentRepositoryPersistenceIT.java
@@ -91,7 +91,6 @@ public class KafkaIdempotentRepositoryPersistenceIT extends BaseEmbeddedKafkaTes
     @Test
     @DisplayName("Checks that half of the messages pass and duplicates are blocked")
     public void testFirstPassFiltersAsExpected() {
-        await().until(() -> kafkaIdempotentRepository.isCacheReady());
         int count = 10;
         sendMessages(count);
 


### PR DESCRIPTION
# Description

Make sure that the local cache of KafkaIdempotentRepository has been fully initialized on application startup. This is needed to prevent duplicates from occurring after the application has restarted.

# Target

The main branch

# Tracking

https://issues.apache.org/jira/browse/CAMEL-20373

# Apache Camel coding standards and style

- [ v] I checked that each commit in the pull request has a meaningful subject line and body.

- [v ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

