### PR TITLE
CAMEL-20379: Camel CLI infra, add maven repos config

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/README.adoc
+++ b/dsl/camel-jbang/camel-jbang-it/README.adoc
@@ -12,3 +12,10 @@ To run tests use the dedicated Maven profile `jbang-it-test` activated by the sa
 ----
 mvn verify -Djbang-it-test
 ----
+
+== Configuration
+
+Camel CLI infra configuration is defined in link:../../../test-infra/camel-test-infra-cli/README.adoc[README.adoc]
+
+- `jbang.it.assert.wait.timeout` : timeout in seconds for log assertions, default `60`
+

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -51,6 +51,9 @@ public abstract class JBangTestSupport {
 
     private static final String DATA_FOLDER = System.getProperty(CliProperties.DATA_FOLDER);
 
+    protected static final int ASSERTION_WAIT_SECONDS
+            = Integer.parseInt(System.getProperty("jbang.it.assert.wait.timeout", "60"));
+
     protected static final String DEFAULT_ROUTE_FOLDER = "/home/jbang";
 
     public static final String DEFAULT_MSG = "Hello Camel from";
@@ -138,7 +141,7 @@ public abstract class JBangTestSupport {
     }
 
     protected void checkLogContainsAllOf(String... contains) {
-        checkLogContainsAllOf(60, contains);
+        checkLogContainsAllOf(ASSERTION_WAIT_SECONDS, contains);
     }
 
     protected void checkLogContainsAllOf(int waitForSeconds, String... contains) {
@@ -149,11 +152,11 @@ public abstract class JBangTestSupport {
     }
 
     protected void checkLogContains(String contains) {
-        checkLogContains(contains, 60);
+        checkLogContains(contains, ASSERTION_WAIT_SECONDS);
     }
 
     protected void checkLogContains(String route, String contains) {
-        checkLogContains(route, contains, 60);
+        checkLogContains(route, contains, ASSERTION_WAIT_SECONDS);
     }
 
     protected void checkLogContains(String contains, int waitForSeconds) {
@@ -169,11 +172,11 @@ public abstract class JBangTestSupport {
     }
 
     protected void checkLogContainsPattern(String contains) {
-        checkLogContainsPattern(contains, 60);
+        checkLogContainsPattern(contains, ASSERTION_WAIT_SECONDS);
     }
 
     protected void checkLogContainsPattern(String route, String contains) {
-        checkLogContainsPattern(route, contains, 60);
+        checkLogContainsPattern(route, contains, ASSERTION_WAIT_SECONDS);
     }
 
     protected void checkLogContainsPattern(String contains, int waitForSeconds) {

--- a/test-infra/camel-test-infra-cli/README.adoc
+++ b/test-infra/camel-test-infra-cli/README.adoc
@@ -15,3 +15,6 @@ System variables are defined in link:{config-class}[CliProperties]
  - `cli.service.data.folder` : mandatory - path to local folder to bind as volume in the container
  - `cli.service.ssh.password` : ssh password set to access to the container via ssh, default `jbang`
  - `cli.service.execute.version` : version set just after container start, default is empty so the version is the one in the branch defined in `cli.service.version`
+ - `cli.service.mvn.repos` : comma separated list of custom Maven repositories, default empty
+ - `cli.service.extra.hosts` : comma separated host=ip pairs to add in the hosts file
+ - `cli.service.trusted.paths` : commas separated paths, relative to the host, of the files containing PEM trusted certificates

--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/common/CliProperties.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/common/CliProperties.java
@@ -26,6 +26,12 @@ public final class CliProperties {
 
     public static final String FORCE_RUN_VERSION = "cli.service.execute.version";
 
+    public static final String MVN_REPOS = "cli.service.mvn.repos";
+
+    public static final String EXTRA_HOSTS = "cli.service.extra.hosts";
+
+    public static final String TRUSTED_CERT_PATHS = "cli.service.trusted.paths";
+
     private CliProperties() {
     }
 }

--- a/test-infra/camel-test-infra-cli/src/test/resources/org/apache/camel/test/infra/cli/services/Dockerfile
+++ b/test-infra/camel-test-infra-cli/src/test/resources/org/apache/camel/test/infra/cli/services/Dockerfile
@@ -25,7 +25,7 @@ ARG SSH_PASSWORD=jbang
 
 #update os and install tools
 RUN dnf update -y \
-    && dnf install java-17-openjdk openssh-server xauth -y
+    && dnf install java-17-openjdk-devel openssh-server xauth -y
 
 RUN ssh-keygen -A
 
@@ -43,6 +43,8 @@ RUN usermod -a -G wheel jbang
 USER jbang
 ENV HOME=/home/jbang
 WORKDIR $HOME
+
+ENV JAVA_HOME=/usr/lib/jvm/java
 
 RUN curl -Ls https://sh.jbang.dev | bash -s - app setup \
     && source ~/.bashrc \

--- a/test-infra/camel-test-infra-cli/src/test/resources/org/apache/camel/test/infra/cli/services/entrypoint.sh
+++ b/test-infra/camel-test-infra-cli/src/test/resources/org/apache/camel/test/infra/cli/services/entrypoint.sh
@@ -16,6 +16,9 @@
 # limitations under the License.
 #
 
+#upated trusted certificates
+su - root -c "update-ca-trust"
+
 if [ "$KEEP_RUNNING" == "true" ]; then
     echo "keep container running"
     su - root -c "/usr/sbin/sshd -D"


### PR DESCRIPTION
It is possible to set external maven repositories, custom trusted certificates and set custom hosts file entries. Moreover the JBang downloaded JDK has been replaced by the system JDK 

