### PR TITLE
(chores) minor code cleanups

### DIFF
--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/JavaJoorClassLoader.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/JavaJoorClassLoader.java
@@ -91,8 +91,8 @@ public class JavaJoorClassLoader extends ClassLoader {
                 fos.write(byteCode);
                 IOHelper.close(fos);
             } catch (Exception e) {
-                LOG.warn("Error writing compiled class: " + name + " as bytecode to file: " + target + " due to "
-                         + e.getMessage() + ". This exception is ignored.");
+                LOG.warn("Error writing compiled class: {} as bytecode to file: {} due to {}. This exception is ignored.",
+                        name, target, e.getMessage());
             }
         }
     }

--- a/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/jolokia/JolokiaHttpRequestHandlerSupport.java
+++ b/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/jolokia/JolokiaHttpRequestHandlerSupport.java
@@ -58,7 +58,7 @@ public class JolokiaHttpRequestHandlerSupport extends ServiceSupport implements 
         serviceManager.addService(new JolokiaSerializer());
         serviceManager.addService(new LocalRequestHandler(1));
 
-        LOG.info("Creating JolokiaHttpRequestHandlerSupport with restrictor " + restrictor);
+        LOG.info("Creating JolokiaHttpRequestHandlerSupport with restrictor {}", restrictor);
     }
 
     @Override

--- a/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/RestOpenApiValidationException.java
+++ b/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/RestOpenApiValidationException.java
@@ -31,7 +31,7 @@ public class RestOpenApiValidationException extends Exception {
 
     @Override
     public String getMessage() {
-        return "Detected %d REST OpenAPI validation errors:\n%s"
+        return "Detected %d REST OpenAPI validation errors:%n%s"
                 .formatted(validationErrors.size(), String.join("\n", validationErrors));
     }
 }

--- a/components/camel-ssh/src/main/java/org/apache/camel/component/ssh/SshUtils.java
+++ b/components/camel-ssh/src/main/java/org/apache/camel/component/ssh/SshUtils.java
@@ -57,7 +57,7 @@ public class SshUtils {
             Class<S> type,
             Collection<NamedFactory<S>> factories, String[] names) {
         List<NamedFactory<S>> list = new ArrayList<>();
-        LOGGER.trace("List of available " + type.getSimpleName().toLowerCase() + "algorithms : {}",
+        LOGGER.trace("List of available {} algorithms : {}", type.getSimpleName().toLowerCase(),
                 factories.stream().map(NamedResource::getName).collect(joining(",")));
         for (String name : names) {
             name = name.trim();
@@ -70,8 +70,7 @@ public class SshUtils {
                 }
             }
             if (!found) {
-                LOGGER.warn("Configured " + type.getSimpleName().toLowerCase()
-                            + " '" + name + "' not available");
+                LOGGER.warn("Configured {} '{}' not available", type.getSimpleName().toLowerCase(), name);
             }
         }
         return list;
@@ -93,7 +92,7 @@ public class SshUtils {
                 }
             }
             if (!found) {
-                LOGGER.warn("Configured KeyExchangeFactory '" + name + "' not available");
+                LOGGER.warn("Configured KeyExchangeFactory '{}' not available", name);
             }
         }
         return list;

--- a/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultDumpRoutesStrategy.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultDumpRoutesStrategy.java
@@ -591,7 +591,7 @@ public class DefaultDumpRoutesStrategy extends ServiceSupport implements DumpRou
             loc = extractLocationName(resource.getLocation());
         }
         if (loc != null) {
-            sbLog.append(String.format("\nSource: %s%n%s%n%s%n", loc, DIVIDER, dump));
+            sbLog.append(String.format("%nSource: %s%n%s%n%s%n", loc, DIVIDER, dump));
         } else {
             sbLog.append(String.format("%n%n%s%n", dump));
         }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -1000,27 +1000,27 @@ public class Run extends CamelCommand {
 
         // use custom distribution of camel
         StringBuilder sb = new StringBuilder();
-        sb.append(String.format("//DEPS org.apache.camel:camel-bom:%s@pom\n", camelVersion));
-        sb.append(String.format("//DEPS org.apache.camel:camel-core:%s\n", camelVersion));
-        sb.append(String.format("//DEPS org.apache.camel:camel-core-engine:%s\n", camelVersion));
-        sb.append(String.format("//DEPS org.apache.camel:camel-main:%s\n", camelVersion));
-        sb.append(String.format("//DEPS org.apache.camel:camel-java-joor-dsl:%s\n", camelVersion));
-        sb.append(String.format("//DEPS org.apache.camel:camel-kamelet:%s\n", camelVersion));
+        sb.append(String.format("//DEPS org.apache.camel:camel-bom:%s@pom%n", camelVersion));
+        sb.append(String.format("//DEPS org.apache.camel:camel-core:%s%n", camelVersion));
+        sb.append(String.format("//DEPS org.apache.camel:camel-core-engine:%s%n", camelVersion));
+        sb.append(String.format("//DEPS org.apache.camel:camel-main:%s%n", camelVersion));
+        sb.append(String.format("//DEPS org.apache.camel:camel-java-joor-dsl:%s%n", camelVersion));
+        sb.append(String.format("//DEPS org.apache.camel:camel-kamelet:%s%n", camelVersion));
         content = content.replaceFirst("\\{\\{ \\.CamelDependencies }}", sb.toString());
 
         // use apache distribution of camel-jbang
         String v = camelVersion.substring(0, camelVersion.lastIndexOf('.'));
         sb = new StringBuilder();
-        sb.append(String.format("//DEPS org.apache.camel:camel-jbang-core:%s\n", v));
-        sb.append(String.format("//DEPS org.apache.camel:camel-kamelet-main:%s\n", v));
-        sb.append(String.format("//DEPS org.apache.camel:camel-resourceresolver-github:%s\n", v));
+        sb.append(String.format("//DEPS org.apache.camel:camel-jbang-core:%s%n", v));
+        sb.append(String.format("//DEPS org.apache.camel:camel-kamelet-main:%s%n", v));
+        sb.append(String.format("//DEPS org.apache.camel:camel-resourceresolver-github:%s%n", v));
         if (VersionHelper.isGE(v, "3.19.0")) {
-            sb.append(String.format("//DEPS org.apache.camel:camel-cli-connector:%s\n", v));
+            sb.append(String.format("//DEPS org.apache.camel:camel-cli-connector:%s%n", v));
         }
         content = content.replaceFirst("\\{\\{ \\.CamelJBangDependencies }}", sb.toString());
 
         sb = new StringBuilder();
-        sb.append(String.format("//DEPS org.apache.camel.kamelets:camel-kamelets:%s\n", kameletsVersion));
+        sb.append(String.format("//DEPS org.apache.camel.kamelets:camel-kamelets:%s%n", kameletsVersion));
         content = content.replaceFirst("\\{\\{ \\.CamelKameletsDependencies }}", sb.toString());
 
         String fn = CommandLineHelper.CAMEL_JBANG_WORK_DIR + "/CustomCamelJBang.java";


### PR DESCRIPTION
- Use platform-specific new line characters
- Use format-specifiers instead of concatenating strings