### PR TITLE
CAMEL-20387: tracing-headers should be case insensitive

### DIFF
--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/ExtractAdapter.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/ExtractAdapter.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 public interface ExtractAdapter {
-    Iterator<Map.Entry<String, String>> iterator();
+    Iterator<Map.Entry<String, Object>> iterator();
 
     Object get(String key);
 

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/propagation/CamelHeadersExtractAdapter.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/propagation/CamelHeadersExtractAdapter.java
@@ -16,15 +16,15 @@
  */
 package org.apache.camel.tracing.propagation;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.camel.tracing.ExtractAdapter;
+import org.apache.camel.util.CaseInsensitiveMap;
 
 public final class CamelHeadersExtractAdapter implements ExtractAdapter {
-    private final Map<String, String> map = new HashMap<>();
+    private final Map<String, Object> map = new CaseInsensitiveMap();
 
     public CamelHeadersExtractAdapter(final Map<String, Object> map) {
         // Extract string valued map entries
@@ -33,7 +33,7 @@ public final class CamelHeadersExtractAdapter implements ExtractAdapter {
     }
 
     @Override
-    public Iterator<Map.Entry<String, String>> iterator() {
+    public Iterator<Map.Entry<String, Object>> iterator() {
         return map.entrySet().iterator();
     }
 

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/propagation/CamelMessagingHeadersExtractAdapter.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/propagation/CamelMessagingHeadersExtractAdapter.java
@@ -17,16 +17,16 @@
 package org.apache.camel.tracing.propagation;
 
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.camel.tracing.ExtractAdapter;
+import org.apache.camel.util.CaseInsensitiveMap;
 
 public final class CamelMessagingHeadersExtractAdapter implements ExtractAdapter {
 
-    private final Map<String, String> map = new HashMap<>();
+    private final Map<String, Object> map = new CaseInsensitiveMap();
     private final boolean jmsEncoding;
 
     public CamelMessagingHeadersExtractAdapter(final Map<String, Object> map, boolean jmsEncoding) {
@@ -42,7 +42,7 @@ public final class CamelMessagingHeadersExtractAdapter implements ExtractAdapter
     }
 
     @Override
-    public Iterator<Map.Entry<String, String>> iterator() {
+    public Iterator<Map.Entry<String, Object>> iterator() {
         return map.entrySet().iterator();
     }
 

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/propagation/CamelMessagingHeadersExtractAdapterTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/propagation/CamelMessagingHeadersExtractAdapterTest.java
@@ -39,7 +39,7 @@ public class CamelMessagingHeadersExtractAdapterTest {
     @Test
     public void noProperties() {
         CamelMessagingHeadersExtractAdapter adapter = new CamelMessagingHeadersExtractAdapter(map, true);
-        Iterator<Map.Entry<String, String>> iterator = adapter.iterator();
+        Iterator<Map.Entry<String, Object>> iterator = adapter.iterator();
         assertFalse(iterator.hasNext());
     }
 
@@ -47,8 +47,8 @@ public class CamelMessagingHeadersExtractAdapterTest {
     public void oneProperty() {
         map.put("key", "value");
         CamelMessagingHeadersExtractAdapter adapter = new CamelMessagingHeadersExtractAdapter(map, true);
-        Iterator<Map.Entry<String, String>> iterator = adapter.iterator();
-        Map.Entry<String, String> entry = iterator.next();
+        Iterator<Map.Entry<String, Object>> iterator = adapter.iterator();
+        Map.Entry<String, Object> entry = iterator.next();
         assertEquals("key", entry.getKey());
         assertEquals("value", entry.getValue());
     }
@@ -57,8 +57,8 @@ public class CamelMessagingHeadersExtractAdapterTest {
     public void propertyWithDash() {
         map.put(JMS_DASH + "key" + JMS_DASH + "1" + JMS_DASH, "value1");
         CamelMessagingHeadersExtractAdapter adapter = new CamelMessagingHeadersExtractAdapter(map, true);
-        Iterator<Map.Entry<String, String>> iterator = adapter.iterator();
-        Map.Entry<String, String> entry = iterator.next();
+        Iterator<Map.Entry<String, Object>> iterator = adapter.iterator();
+        Map.Entry<String, Object> entry = iterator.next();
         assertEquals("-key-1-", entry.getKey());
         assertEquals("value1", entry.getValue());
     }
@@ -67,8 +67,15 @@ public class CamelMessagingHeadersExtractAdapterTest {
     public void propertyWithoutDashEncoding() {
         map.put(JMS_DASH + "key" + JMS_DASH + "1" + JMS_DASH, "value1");
         CamelMessagingHeadersExtractAdapter adapter = new CamelMessagingHeadersExtractAdapter(map, false);
-        Iterator<Map.Entry<String, String>> iterator = adapter.iterator();
-        Map.Entry<String, String> entry = iterator.next();
+        Iterator<Map.Entry<String, Object>> iterator = adapter.iterator();
+        Map.Entry<String, Object> entry = iterator.next();
         assertEquals(JMS_DASH + "key" + JMS_DASH + "1" + JMS_DASH, entry.getKey());
+    }
+
+    @Test
+    public void keyWithDifferentCase() {
+        map.put("key", "value");
+        CamelMessagingHeadersExtractAdapter adapter = new CamelMessagingHeadersExtractAdapter(map, true);
+        assertEquals("value", adapter.get("KeY"));
     }
 }


### PR DESCRIPTION
# Description

See https://camel.zulipchat.com/#narrow/stream/257298-camel/topic/Micrometer.20Observation

When a camel-application is called with tracing-headers (http-request) that are not exactly in the same case as the implementation of the propagation demands (eg "X-B3-TraceId" / "traceparent") - then the implementation can not find these header values.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

