### PR TITLE
CAMEL-20389: fix incorrectly named Integration tests

### DIFF
--- a/components/camel-google/camel-google-calendar/src/test/java/org/apache/camel/component/google/calendar/stream/GoogleCalendarStreamConsumerIT.java
+++ b/components/camel-google/camel-google-calendar/src/test/java/org/apache/camel/component/google/calendar/stream/GoogleCalendarStreamConsumerIT.java
@@ -19,8 +19,11 @@ package org.apache.camel.component.google.calendar.stream;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
-public class GoogleCalendarStreamConsumerIntegrationTest extends AbstractGoogleCalendarStreamTestSupport {
+@EnabledIf(value = "org.apache.camel.component.google.calendar.AbstractGoogleCalendarTestSupport#hasCredentials",
+           disabledReason = "Google Calendar credentials were not provided")
+public class GoogleCalendarStreamConsumerIT extends AbstractGoogleCalendarStreamTestSupport {
 
     @Test
     public void testConsumePrefixedMessages() throws Exception {

--- a/components/camel-google/camel-google-mail/src/test/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumerIT.java
+++ b/components/camel-google/camel-google-mail/src/test/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumerIT.java
@@ -19,8 +19,11 @@ package org.apache.camel.component.google.mail.stream;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
-public class GoogleMailStreamConsumerIntegrationTest extends AbstractGoogleMailStreamTestSupport {
+@EnabledIf(value = "org.apache.camel.component.google.mail.AbstractGoogleMailTestSupport#hasCredentials",
+           disabledReason = "Google Mail credentials were not provided")
+public class GoogleMailStreamConsumerIT extends AbstractGoogleMailStreamTestSupport {
 
     @Test
     public void testConsumePrefixedMessages() throws Exception {

--- a/components/camel-google/camel-google-sheets/src/test/java/org/apache/camel/component/google/sheets/SheetsSpreadsheetsIT.java
+++ b/components/camel-google/camel-google-sheets/src/test/java/org/apache/camel/component/google/sheets/SheetsSpreadsheetsIT.java
@@ -32,6 +32,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +49,8 @@ public class SheetsSpreadsheetsIT {
     private static final String PATH_PREFIX
             = GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName();
 
-    public static class CreateTest extends AbstractGoogleSheetsTestSupport {
+    @Nested
+    class CreateIT extends AbstractGoogleSheetsTestSupport {
         private String title = "camel-sheets-" + new SecureRandom().nextInt(Integer.MAX_VALUE);
 
         @Test
@@ -85,7 +87,8 @@ public class SheetsSpreadsheetsIT {
         }
     }
 
-    public static class GetTest extends AbstractGoogleSheetsTestSupport {
+    @Nested
+    class GetIT extends AbstractGoogleSheetsTestSupport {
         private Spreadsheet testSheet = getSpreadsheet();
 
         @Test
@@ -115,7 +118,8 @@ public class SheetsSpreadsheetsIT {
         }
     }
 
-    public static class BatchUpdateTest extends AbstractGoogleSheetsTestSupport {
+    @Nested
+    class BatchUpdateIT extends AbstractGoogleSheetsTestSupport {
         private Spreadsheet testSheet = getSpreadsheet();
         private String updateTitle = "updated-" + testSheet.getProperties().getTitle();
 

--- a/components/camel-google/camel-google-sheets/src/test/java/org/apache/camel/component/google/sheets/SheetsSpreadsheetsValuesIT.java
+++ b/components/camel-google/camel-google-sheets/src/test/java/org/apache/camel/component/google/sheets/SheetsSpreadsheetsValuesIT.java
@@ -36,6 +36,7 @@ import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollecti
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
 import org.apache.camel.util.ObjectHelper;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +54,8 @@ public class SheetsSpreadsheetsValuesIT {
     private static final String PATH_PREFIX
             = GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName();
 
-    public static class GetTest extends AbstractGoogleSheetsTestSupport {
+    @Nested
+    class GetIT extends AbstractGoogleSheetsTestSupport {
         private Spreadsheet testSheet = getSpreadsheet();
 
         @Test
@@ -92,7 +94,8 @@ public class SheetsSpreadsheetsValuesIT {
         }
     }
 
-    public static class UpdateTest extends AbstractGoogleSheetsTestSupport {
+    @Nested
+    class UpdateIT extends AbstractGoogleSheetsTestSupport {
         private Spreadsheet testSheet = getSpreadsheet();
         private String range = "TEST_SHEET!A1:B2";
         private List<List<Object>> data = Arrays.asList(
@@ -153,7 +156,8 @@ public class SheetsSpreadsheetsValuesIT {
         }
     }
 
-    public static class AppendTest extends AbstractGoogleSheetsTestSupport {
+    @Nested
+    class AppendIT extends AbstractGoogleSheetsTestSupport {
         private Spreadsheet testSheet = getSpreadsheet();
         private List<List<Object>> data = Collections.singletonList(Arrays.asList("A10", "B10", "C10"));
         private String range = TEST_SHEET + "!A10";
@@ -211,7 +215,8 @@ public class SheetsSpreadsheetsValuesIT {
         }
     }
 
-    public static class ClearTest extends AbstractGoogleSheetsTestSupport {
+    @Nested
+    class ClearIT extends AbstractGoogleSheetsTestSupport {
         private Spreadsheet testSheet = getSpreadsheet();
 
         @Test

--- a/components/camel-google/camel-google-sheets/src/test/java/org/apache/camel/component/google/sheets/stream/SheetsStreamConsumerIT.java
+++ b/components/camel-google/camel-google-sheets/src/test/java/org/apache/camel/component/google/sheets/stream/SheetsStreamConsumerIT.java
@@ -32,6 +32,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.google.sheets.GoogleSheetsClientFactory;
 import org.apache.camel.component.google.sheets.MockGoogleSheetsClientFactory;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants.MAJOR_DIMENSION;
@@ -42,7 +43,7 @@ import static org.apache.camel.component.google.sheets.stream.GoogleSheetsStream
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SheetsStreamConsumerIntegrationTest {
+public class SheetsStreamConsumerIT {
 
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .setDefaultPropertyInclusion(
@@ -54,7 +55,8 @@ public class SheetsStreamConsumerIntegrationTest {
             Arrays.asList("a1", "b1"),
             Arrays.asList("a2", "b2"));
 
-    public static class ConsumeValueRangeTest extends AbstractGoogleSheetsStreamTestSupport {
+    @Nested
+    class ConsumeValueRangeIT extends AbstractGoogleSheetsStreamTestSupport {
         Spreadsheet testSheet = getSpreadsheet();
 
         @Test
@@ -105,7 +107,8 @@ public class SheetsStreamConsumerIntegrationTest {
         }
     }
 
-    public static class ConsumeValueRangeSplitResultsTest extends AbstractGoogleSheetsStreamTestSupport {
+    @Nested
+    class ConsumeValueRangeSplitResultsIT extends AbstractGoogleSheetsStreamTestSupport {
         Spreadsheet testSheet = getSpreadsheet();
 
         @Test


### PR DESCRIPTION
Fix a few integration tests that were named incorrectly - as I pointed on one of the comments on PR #12966. 

This only affects camel-google-calendar, camel-google-mail and camel-google-sheets.