### PR TITLE
Make component-test runnable only by organization members

### DIFF
--- a/.github/actions/component-test/action.yaml
+++ b/.github/actions/component-test/action.yaml
@@ -30,11 +30,15 @@ inputs:
   comment-body:
     description: 'Body of the comment to process'
     required: true
+  author-association:
+    description: 'The comment author's association with the organization'
+    required: true
 runs:
   using: "composite"
   steps:
     - id: install-mvnd
       uses: ./.github/actions/install-mvnd
+      if: ${{ inputs.author-association == 'MEMBER' }}
     - name: maven build
       shell: bash
       run: ${{ github.action_path }}/component-test.sh
@@ -43,12 +47,14 @@ runs:
         COMMENT_BODY: ${{ inputs.comment-body }}
         FAST_BUILD: "true"
         LOG_FILE: build.log
+      if: ${{ inputs.author-association == 'MEMBER' }}
     - name: archive logs
       uses: actions/upload-artifact@v3
       if: always()
       with:
         name: build.log
         path: build.log
+      if: ${{ inputs.author-association == 'MEMBER' }}
     - name: maven test
       shell: bash
       run: ${{ github.action_path }}/component-test.sh
@@ -57,14 +63,16 @@ runs:
         COMMENT_BODY: ${{ inputs.comment-body }}
         FAST_BUILD: "false"
         LOG_FILE: tests.log
+      if: ${{ inputs.author-association == 'MEMBER' }}
     - name: archive logs
       uses: actions/upload-artifact@v3
       if: always()
       with:
         name: tests.log
         path: tests.log
+      if: ${{ inputs.author-association == 'MEMBER' }}
     - name: Success comment
-      if: success()
+      if: success() && ${{ inputs.author-association == 'MEMBER' }}
       uses: ./.github/actions/create-or-update-comment
       with:
         comment-id: ${{ inputs.comment-id }}
@@ -74,7 +82,7 @@ runs:
 
           **Result** :white_check_mark: The tests passed successfully
     - name: Failure comment
-      if: failure()
+      if: failure() && ${{ inputs.author-association == 'MEMBER' }}
       uses: ./.github/actions/create-or-update-comment
       with:
         comment-id: ${{ inputs.comment-id }}

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -68,3 +68,4 @@ jobs:
           pr-id: ${{ github.event.issue.number }}
           comment-id: ${{ github.event.comment.id }}
           comment-body: ${{ github.event.comment.body }}
+          author-association: ${{ github.event.comment.author_association }}


### PR DESCRIPTION
# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

