### PR TITLE
CAMEL-20399: String to short type conversion fails

### DIFF
--- a/core/camel-base/src/generated/java/org/apache/camel/converter/CamelBaseBulkConverterLoader.java
+++ b/core/camel-base/src/generated/java/org/apache/camel/converter/CamelBaseBulkConverterLoader.java
@@ -297,7 +297,7 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             if (value instanceof byte[]) {
                 return org.apache.camel.converter.ObjectConverter.toNumber((byte[]) value, exchange);
             }
-        } else if (to == java.lang.Short.class) {
+        } else if (to == java.lang.Short.class || to == short.class) {
             if (value instanceof java.lang.Number) {
                 Object obj = org.apache.camel.converter.ObjectConverter.toShort((java.lang.Number) value);
                 if (obj == null) {
@@ -845,7 +845,7 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             if (from == byte[].class) {
                 return this;
             }
-        } else if (to == java.lang.Short.class) {
+        } else if (to == java.lang.Short.class || to == short.class) {
             if (from == java.lang.Number.class) {
                 return this;
             }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/converter/TypeConvertersTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/converter/TypeConvertersTest.java
@@ -45,4 +45,16 @@ public class TypeConvertersTest extends ContextTestSupport {
         assertEquals("en", iso);
     }
 
+    @Test
+    public void testStringToPrimitiveTypes() throws Exception {
+        assertEquals(Short.parseShort("1"), context.getTypeConverter().mandatoryConvertTo(short.class, "1"));
+        assertEquals(Integer.parseInt("1"), context.getTypeConverter().mandatoryConvertTo(int.class, "1"));
+        assertEquals(Long.parseLong("1"), context.getTypeConverter().mandatoryConvertTo(long.class, "1"));
+
+        assertEquals(Float.parseFloat("1.1"), context.getTypeConverter().mandatoryConvertTo(float.class, "1.1"));
+        assertEquals(Double.parseDouble("1.1"), context.getTypeConverter().mandatoryConvertTo(double.class, "1.1"));
+
+        assertEquals("a".charAt(0), context.getTypeConverter().mandatoryConvertTo(char.class, "a"));
+        assertEquals(Boolean.parseBoolean("true"), context.getTypeConverter().mandatoryConvertTo(boolean.class, "true"));
+    }
 }

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/TypeConverterLoaderGeneratorMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/TypeConverterLoaderGeneratorMojo.java
@@ -471,6 +471,8 @@ public class TypeConverterLoaderGeneratorMojo extends AbstractGeneratorMojo {
                 return "int";
             } else if ("java.lang.Long".equals(to)) {
                 return "long";
+            } else if ("java.lang.Short".equals(to)) {
+                return "short";
             } else if ("java.lang.Character".equals(to)) {
                 return "char";
             } else if ("java.lang.Boolean".equals(to)) {


### PR DESCRIPTION
# Description
String to short type conversion fails with:

`NoTypeConversionAvailable No type converter available to convert from type: java.lang.String to the required type: short`

to reproduce it just test:

`assertEquals(Short.parseShort("1"), context.getTypeConverter().mandatoryConvertTo(short.class, "1"));`


<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

