### PR TITLE
CAMEL-20403: Support Knative Broker reference in Pipe YAML

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/support/YamlTestSupport.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/support/YamlTestSupport.groovy
@@ -18,7 +18,8 @@ package org.apache.camel.dsl.yaml.support
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.JsonSchemaFactory
+import com.networknt.schema.SchemaValidatorsConfig
 import com.networknt.schema.SpecVersionDetector
 import groovy.util.logging.Slf4j
 import org.apache.camel.CamelContext
@@ -40,9 +41,14 @@ import java.nio.charset.StandardCharsets
 @Slf4j
 class YamlTestSupport extends Specification implements HasCamelContext {
     static def MAPPER = new ObjectMapper(new YAMLFactory())
-    static def SCHEMA_NODE = MAPPER.readTree(ResourceHelper.getResourceAsStream('/schema/camelYamlDsl.json'));
-    static def FACTORY = JsonSchemaFactory.getInstance(SpecVersionDetector.detect(SCHEMA_NODE));
-    static def SCHEMA = FACTORY.getSchema(SCHEMA_NODE);
+    static def SCHEMA_NODE = MAPPER.readTree(ResourceHelper.getResourceAsStream('/schema/camelYamlDsl.json'))
+    static def FACTORY = JsonSchemaFactory.getInstance(SpecVersionDetector.detect(SCHEMA_NODE))
+    static def SCHEMA_VALIDATORS_CONFIG = {
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig()
+        config.setLocale(Locale.ENGLISH)
+        return config
+    }()
+    static def SCHEMA = FACTORY.getSchema(SCHEMA_NODE, SCHEMA_VALIDATORS_CONFIG)
 
     @AutoCleanup
     def context = new DefaultCamelContext()


### PR DESCRIPTION
# Description

- Pipes may reference a Knative broker as a source/sink. 
- Properly configure the Knative component endpoint URI (knative:event/my-event-type?kind=Broker&name=default) on the resulting route definition when the Pipe uses a Knative broker reference

Example Pipe:
```yaml
apiVersion: camel.apache.org/v1
kind: Pipe
metadata:
  name: timer-event-source                  
spec:
  source:
    ref:
      kind: Kamelet
      apiVersion: camel.apache.org/v1
      name: timer-source
    properties:
      message: "Hello world!"
  sink:
    ref:
      kind: Broker
      apiVersion: eventing.knative.dev/v1
      name: foo-broker
    properties:
      type: org.apache.camel.event.foo
```

- Make sure to always use Locale.ENGLISH when performing schema validation in YAML DSL unit tests (avoids assertion errors due to internationalized error messages when tests are run on a machine with different default Locale set e.g. GERMAN)

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking

- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

Fixes CAMEL-20403

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes
