### PR TITLE
(chores) camel-zeebe: avoid polluting the build

### DIFF
--- a/components/camel-zeebe/pom.xml
+++ b/components/camel-zeebe/pom.xml
@@ -103,31 +103,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>zeebe-integration</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <zeebe.test.integration.enable>true</zeebe.test.integration.enable>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
Remove unnecessary profile to avoid polluting/over-complicating the build

Signed-off-by: Otavio R. Piske <angusyoung@gmail.com>