### PR TITLE
camel-knative-http: Avoid Nullpointer on KnativeHttpProducer/Consumer factory

### DIFF
--- a/components/camel-knative/camel-knative-http/src/main/java/org/apache/camel/component/knative/http/KnativeHttpConsumerFactory.java
+++ b/components/camel-knative/camel-knative-http/src/main/java/org/apache/camel/component/knative/http/KnativeHttpConsumerFactory.java
@@ -53,6 +53,13 @@ public class KnativeHttpConsumerFactory extends ServiceSupport implements CamelC
     }
 
     @Override
+    protected void doInit() throws Exception {
+        if (router == null) {
+            router = KnativeHttpSupport.lookupRouter(camelContext);
+        }
+    }
+
+    @Override
     public Consumer createConsumer(
             Endpoint endpoint, KnativeTransportConfiguration config, KnativeResource service, Processor processor) {
         Objects.requireNonNull(this.router, "router");

--- a/components/camel-knative/camel-knative-http/src/main/java/org/apache/camel/component/knative/http/KnativeHttpProducerFactory.java
+++ b/components/camel-knative/camel-knative-http/src/main/java/org/apache/camel/component/knative/http/KnativeHttpProducerFactory.java
@@ -62,6 +62,13 @@ public class KnativeHttpProducerFactory extends ServiceSupport implements CamelC
     }
 
     @Override
+    protected void doInit() throws Exception {
+        if (vertx == null) {
+            vertx = KnativeHttpSupport.lookupVertxInstance(camelContext);
+        }
+    }
+
+    @Override
     public Producer createProducer(Endpoint endpoint, KnativeTransportConfiguration config, KnativeResource service) {
         Objects.requireNonNull(this.vertx, "vertx");
 

--- a/components/camel-knative/camel-knative-http/src/main/java/org/apache/camel/component/knative/http/KnativeHttpSupport.java
+++ b/components/camel-knative/camel-knative-http/src/main/java/org/apache/camel/component/knative/http/KnativeHttpSupport.java
@@ -22,12 +22,19 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
 
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.Router;
+import org.apache.camel.CamelContext;
 import org.apache.camel.Message;
 import org.apache.camel.component.cloudevents.CloudEvent;
 import org.apache.camel.component.knative.spi.KnativeResource;
+import org.apache.camel.support.CamelContextHelper;
 
 public final class KnativeHttpSupport {
+    private static final String PLATFORM_HTTP_ROUTER_NAME = "platform-http-router";
+
     private KnativeHttpSupport() {
     }
 
@@ -95,4 +102,46 @@ public final class KnativeHttpSupport {
         }
     }
 
+    /**
+     * Retrieve router from given CamelContext or create new instance.
+     *
+     * @param  camelContext the current context.
+     * @return              router
+     */
+    public static Router lookupRouter(CamelContext camelContext) {
+        Router router = CamelContextHelper.findSingleByType(camelContext, Router.class);
+        if (router != null) {
+            return router;
+        }
+
+        router = CamelContextHelper.lookup(
+                camelContext,
+                PLATFORM_HTTP_ROUTER_NAME,
+                Router.class);
+        if (router != null) {
+            return router;
+        }
+
+        return Router.router(lookupVertxInstance(camelContext));
+    }
+
+    /**
+     * Retrieve Vert.x instance from given CamelContext or create new instance.
+     *
+     * @param  camelContext the current context.
+     * @return              vertx instance
+     */
+    public static Vertx lookupVertxInstance(CamelContext camelContext) {
+        Vertx vertx = CamelContextHelper.findSingleByType(camelContext, Vertx.class);
+        if (vertx != null) {
+            return vertx;
+        }
+
+        VertxOptions options = CamelContextHelper.findSingleByType(camelContext, VertxOptions.class);
+        if (options == null) {
+            options = new VertxOptions();
+        }
+
+        return Vertx.vertx(options);
+    }
 }


### PR DESCRIPTION
# Description

- Lookup router and vertx instance when not explicitly set on the factory
- Avoids Nullpointer exception when for instance running the Knative component with Camel JBang

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

