### PR TITLE
Refactor camel jbang dependency list to not depend on the export command

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
@@ -17,11 +17,9 @@
 package org.apache.camel.dsl.jbang.core.commands;
 
 import java.io.File;
-import java.util.Comparator;
 import java.util.Properties;
 
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
-import org.apache.camel.tooling.maven.MavenGav;
 import org.apache.camel.util.CamelCaseOrderedProperties;
 import picocli.CommandLine.Command;
 
@@ -127,57 +125,4 @@ public class Export extends ExportBaseCommand {
         // run export
         return cmd.export();
     }
-
-    public Comparator<MavenGav> mavenGavComparator() {
-        return new Comparator<MavenGav>() {
-            @Override
-            public int compare(MavenGav o1, MavenGav o2) {
-                int r1 = rankGroupId(o1);
-                int r2 = rankGroupId(o2);
-
-                if (r1 > r2) {
-                    return -1;
-                } else if (r2 > r1) {
-                    return 1;
-                } else {
-                    return o1.toString().compareTo(o2.toString());
-                }
-            }
-
-            int rankGroupId(MavenGav o1) {
-                String g1 = o1.getGroupId();
-                if ("org.springframework.boot".equals(g1)) {
-                    return 30;
-                } else if ("io.quarkus".equals(g1)) {
-                    return 30;
-                } else if ("org.apache.camel.quarkus".equals(g1)) {
-                    String a1 = o1.getArtifactId();
-                    // main/core/engine first
-                    if ("camel-quarkus-core".equals(a1)) {
-                        return 21;
-                    }
-                    return 20;
-                } else if ("org.apache.camel.springboot".equals(g1)) {
-                    String a1 = o1.getArtifactId();
-                    // main/core/engine first
-                    if ("camel-spring-boot-engine-starter".equals(a1)) {
-                        return 21;
-                    }
-                    return 20;
-                } else if ("org.apache.camel".equals(g1)) {
-                    String a1 = o1.getArtifactId();
-                    // main/core/engine first
-                    if ("camel-main".equals(a1)) {
-                        return 11;
-                    }
-                    return 10;
-                } else if ("org.apache.camel.kamelets".equals(g1)) {
-                    return 5;
-                } else {
-                    return 0;
-                }
-            }
-        };
-    }
-
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
+import org.apache.camel.dsl.jbang.core.common.MavenGavComparator;
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
 import org.apache.camel.tooling.maven.MavenGav;
 import org.apache.camel.util.CamelCaseOrderedProperties;
@@ -196,7 +197,7 @@ class ExportCamelMain extends Export {
         }
 
         // sort artifacts
-        gavs.sort(mavenGavComparator());
+        gavs.sort(new MavenGavComparator());
 
         StringBuilder sb = new StringBuilder();
         for (MavenGav gav : gavs) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.dsl.jbang.core.common.CatalogLoader;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
+import org.apache.camel.dsl.jbang.core.common.MavenGavComparator;
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
 import org.apache.camel.tooling.maven.MavenGav;
 import org.apache.camel.tooling.model.ArtifactModel;
@@ -293,7 +294,7 @@ class ExportQuarkus extends Export {
         }
 
         // sort artifacts
-        gavs.sort(mavenGavComparator());
+        gavs.sort(new MavenGavComparator());
 
         StringBuilder sb = new StringBuilder();
         for (MavenGav gav : gavs) {
@@ -394,7 +395,7 @@ class ExportQuarkus extends Export {
         }
 
         // sort artifacts
-        gavs.sort(mavenGavComparator());
+        gavs.sort(new MavenGavComparator());
 
         StringBuilder sb = new StringBuilder();
         for (MavenGav gav : gavs) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.dsl.jbang.core.common.CatalogLoader;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
+import org.apache.camel.dsl.jbang.core.common.MavenGavComparator;
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
 import org.apache.camel.tooling.maven.MavenGav;
 import org.apache.camel.tooling.model.ArtifactModel;
@@ -233,7 +234,7 @@ class ExportSpringBoot extends Export {
         }
 
         // sort artifacts
-        gavs.sort(mavenGavComparator());
+        gavs.sort(new MavenGavComparator());
 
         StringBuilder sb = new StringBuilder();
         for (MavenGav gav : gavs) {
@@ -330,7 +331,7 @@ class ExportSpringBoot extends Export {
         }
 
         // sort artifacts
-        gavs.sort(mavenGavComparator());
+        gavs.sort(new MavenGavComparator());
 
         StringBuilder sb = new StringBuilder();
         for (MavenGav gav : gavs) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/MavenGavComparator.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/MavenGavComparator.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.common;
+
+import java.util.Comparator;
+
+import org.apache.camel.tooling.maven.MavenGav;
+
+public class MavenGavComparator implements Comparator<MavenGav> {
+
+    @Override
+    public int compare(MavenGav o1, MavenGav o2) {
+        int r1 = rankGroupId(o1);
+        int r2 = rankGroupId(o2);
+
+        if (r1 > r2) {
+            return -1;
+        } else if (r2 > r1) {
+            return 1;
+        } else {
+            return o1.toString().compareTo(o2.toString());
+        }
+    }
+
+    int rankGroupId(MavenGav o1) {
+        String g1 = o1.getGroupId();
+        if ("org.springframework.boot".equals(g1)) {
+            return 30;
+        } else if ("io.quarkus".equals(g1)) {
+            return 30;
+        } else if ("org.apache.camel.quarkus".equals(g1)) {
+            String a1 = o1.getArtifactId();
+            // main/core/engine first
+            if ("camel-quarkus-core".equals(a1)) {
+                return 21;
+            }
+            return 20;
+        } else if ("org.apache.camel.springboot".equals(g1)) {
+            String a1 = o1.getArtifactId();
+            // main/core/engine first
+            if ("camel-spring-boot-engine-starter".equals(a1)) {
+                return 21;
+            }
+            return 20;
+        } else if ("org.apache.camel".equals(g1)) {
+            String a1 = o1.getArtifactId();
+            // main/core/engine first
+            if ("camel-main".equals(a1)) {
+                return 11;
+            }
+            return 10;
+        } else if ("org.apache.camel.kamelets".equals(g1)) {
+            return 5;
+        } else {
+            return 0;
+        }
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/DependencyListTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/DependencyListTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dsl.jbang.core.commands;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DependencyListTest extends CamelCommandBaseTest {
+
+    @Test
+    public void calculateDependencies() throws Exception {
+        UserConfigHelper.createUserConfig("");
+
+        DependencyList command = createCommand();
+        Path javaFile = Path.of("src/test/resources/Sample.java");
+        Assertions.assertTrue(javaFile.toFile().exists(), "The src/test/resources/Sample.java was not found.");
+        command.filePaths = new Path[] { javaFile };
+        command.output = "gav";
+        command.doCall();
+
+        String[] deps = new String[] {
+                "org.apache.camel:camel-aws2-s3", "org.apache.camel:camel-caffeine", "org.apache.camel:camel-dropbox",
+                "org.apache.camel:camel-jacksonxml", "org.apache.camel:camel-kafka", "org.apache.camel:camel-kamelet",
+                "org.apache.camel:camel-mongodb", "org.apache.camel:camel-rest", "org.apache.camel:camel-telegram",
+                "org.apache.camel:camel-zipfile" };
+        List<String> lines = printer.getLines();
+        int depsFound = 0;
+        for (int i = 0; i < lines.size(); i++) {
+            for (String dep : deps) {
+                if (lines.get(i).contains(dep)) {
+                    depsFound++;
+                    break;
+                }
+            }
+        }
+        Assertions.assertEquals(deps.length, depsFound, "The expected dependencies were not calculated correctly.");
+    }
+
+    @Test
+    public void calculateDependenciesOutputJBang() throws Exception {
+        UserConfigHelper.createUserConfig("");
+
+        DependencyList command = createCommand();
+        Path javaFile = Path.of("src/test/resources/sample.yaml");
+        Assertions.assertTrue(javaFile.toFile().exists(), "The src/test/resources/sample.yaml was not found.");
+        command.filePaths = new Path[] { javaFile };
+        command.output = "jbang";
+        command.doCall();
+
+        String[] deps = new String[] {
+                "//DEPS org.apache.camel:camel-bom:",
+                "//DEPS org.apache.camel:camel-caffeine",
+                "//DEPS org.apache.camel:camel-http",
+                "//DEPS org.apache.camel:camel-jackson",
+                "//DEPS org.apache.camel:camel-jsonpath",
+                "//DEPS org.apache.camel:camel-kamelet",
+                "//DEPS org.apache.camel:camel-log",
+                "//DEPS org.apache.camel:camel-rest",
+                "//DEPS org.apache.camel:camel-timer",
+                "//DEPS org.apache.camel:camel-yaml-dsl" };
+
+        List<String> lines = printer.getLines();
+        int depsFound = 0;
+        for (int i = 0; i < lines.size(); i++) {
+            for (String dep : deps) {
+                if (lines.get(i).contains(dep)) {
+                    depsFound++;
+                    break;
+                }
+            }
+        }
+        Assertions.assertEquals(deps.length, depsFound,
+                "The expected dependencies were not calculated correctly when output=jbang.");
+    }
+
+    @Test
+    public void calculateDependenciesOutputMaven() throws Exception {
+        UserConfigHelper.createUserConfig("");
+
+        DependencyList command = createCommand();
+        Path javaFile = Path.of("src/test/resources/sample.yaml");
+        Assertions.assertTrue(javaFile.toFile().exists(), "The src/test/resources/sample.yaml was not found.");
+        command.filePaths = new Path[] { javaFile };
+        command.output = "maven";
+        command.doCall();
+
+        String[] deps = new String[] {
+                "camel-caffeine",
+                "camel-http",
+                "camel-jackson",
+                "camel-jsonpath",
+                "camel-kamelet",
+                "camel-log",
+                "camel-rest",
+                "camel-timer",
+                "camel-yaml-dsl" };
+
+        List<String> lines = printer.getLines();
+        int depsFound = 0;
+        for (int i = 0; i < lines.size(); i++) {
+            if (lines.get(i).contains("<artifactId>")) {
+                for (String dep : deps) {
+                    if (lines.get(i).contains(dep)) {
+                        depsFound++;
+                        break;
+                    }
+                }
+            }
+        }
+        Assertions.assertEquals(deps.length, depsFound,
+                "The expected dependencies were not calculated correctly when output=maven.");
+    }
+
+    private DependencyList createCommand() {
+        return new DependencyList(new CamelJBangMain().withPrinter(printer));
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/resources/Sample.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/resources/Sample.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.lang.Exception;
+import java.lang.Override;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+
+// this is a sample file to be load by the DependencyList test
+public class Sample extends RouteBuilder {
+
+    String s = "random";
+
+    @Override
+    public void configure() throws Exception {
+        String params = "random_string";
+        from("telegram:" + params)
+            .setHeader("test",simple("${in.header.fileName}"))
+            .pollEnrich()
+                .simple("aws2-s3://data?fileName=${in.header.fileName}&deleteAfterRead=false")
+                .unmarshal().jacksonXml()
+                .to("mongodb:test")
+            .end()
+            .unmarshal().zipFile()
+            .to("dropbox:random")
+            .to("mongodb:test")
+            .toD("caffeine-cache:" + s)
+            .to("kafka:test")
+            ;
+    }
+}
+

--- a/dsl/camel-jbang/camel-jbang-core/src/test/resources/sample.yaml
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/resources/sample.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# camel-k: language=yaml property=period=20000 property=lookAhead=120
+
+- from:
+    uri: "timer:sample"
+    parameters:
+      period: "{{period}}"
+    steps:
+    - setHeader:
+        name: CamelCaffeineAction
+        constant: GET
+    - toD: "caffeine-cache:cache-${routeId}?key=lastUpdate"
+    - toD: "https://sample"
+    - unmarshal:
+        json: {}
+    - toD: "caffeine-cache:cache-${routeId}?key=lastUpdate"
+    - split:
+        jsonpath: "$.features[*]"
+        steps:
+          - marshal:
+              json: {}
+          - to: "log:info"
+


### PR DESCRIPTION
The intention is two-fold, first to have the `dependency list` not have to depend on the Export sub-command. Second the calculate dependencies functionality will be used in an upcoming update of camel-k camel-jbang plugin to calculate the dependencies of the `IntegrationRun` sub-command.

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)


