### PR TITLE
Revert "(chores) camel-core: added the ability to provide a cause to ObjectHelper.notNull"

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/util/ObjectHelperTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/util/ObjectHelperTest.java
@@ -39,7 +39,6 @@ import org.w3c.dom.NodeList;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
-import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.TypeConverter;
 import org.apache.camel.component.bean.MyOtherFooBean;
 import org.apache.camel.component.bean.MyOtherFooBean.AbstractClassSize;
@@ -58,7 +57,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -1000,33 +998,21 @@ public class ObjectHelperTest {
 
         Long actual2 = org.apache.camel.util.ObjectHelper.notNull(expected, "expected", "holder");
         assertSame(expected, actual2, "Didn't get the same object back!");
-    }
 
-    @Test
-    void testNotNullWithNull() {
-        final IllegalArgumentException holderLessException = Assertions.assertThrows(IllegalArgumentException.class,
-                () -> org.apache.camel.util.ObjectHelper.notNull(null, "expectedObject"), "Should have thrown exception");
-        assertEquals("expectedObject must be specified", holderLessException.getMessage());
-    }
+        Long expected2 = null;
+        try {
+            org.apache.camel.util.ObjectHelper.notNull(expected2, "expected2");
+            fail("Should have thrown exception");
+        } catch (IllegalArgumentException iae) {
+            assertEquals("expected2 must be specified", iae.getMessage());
+        }
 
-    @Test
-    void testNotNullWithHolder() {
-        final IllegalArgumentException exWithHolder = Assertions.assertThrows(IllegalArgumentException.class,
-                () -> org.apache.camel.util.ObjectHelper.notNull(null, "expectedObject", "holder"),
-                "Should have thrown exception due to holder being null");
-        assertEquals("expectedObject must be specified on: holder", exWithHolder.getMessage());
-    }
-
-    @Test
-    void testNotNullWithCause() {
-        final IllegalArgumentException exWithCause = Assertions.assertThrows(IllegalArgumentException.class,
-                () -> org.apache.camel.util.ObjectHelper.notNull(null, "expectedObject", () -> new RuntimeCamelException("exception cause")),
-                "Should have thrown exception due to holder being null");
-        assertEquals("expectedObject must be specified", exWithCause.getMessage());
-
-        final RuntimeCamelException runtimeCamelException =
-                assertInstanceOf(RuntimeCamelException.class, exWithCause.getCause());
-        assertEquals("exception cause", runtimeCamelException.getMessage(), "Cause should have been retained");
+        try {
+            org.apache.camel.util.ObjectHelper.notNull(expected2, "expected2", "holder");
+            fail("Should have thrown exception");
+        } catch (IllegalArgumentException iae) {
+            assertEquals("expected2 must be specified on: holder", iae.getMessage());
+        }
     }
 
     @Test

--- a/core/camel-util/src/main/java/org/apache/camel/util/ObjectHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/ObjectHelper.java
@@ -157,23 +157,6 @@ public final class ObjectHelper {
     }
 
     /**
-     * Asserts whether the value is <b>not</b> <tt>null</tt>
-     *
-     * @param  value                    the value to test
-     * @param  name                     the key that resolved the value
-     * @param  exceptionSupplier        a supplier for a custom exception to be added as the cause and provide contextual information
-     * @return                          the passed {@code value} as is
-     * @throws IllegalArgumentException is thrown if assertion fails
-     */
-    public static <T> T notNull(T value, String name, Supplier<? extends Exception> exceptionSupplier) {
-        if (value == null) {
-            throw new IllegalArgumentException(name + " must be specified", exceptionSupplier.get());
-        }
-
-        return value;
-    }
-
-    /**
      * Asserts that the given {@code value} is neither {@code null} nor an emptyString.
      *
      * @param  value                    the value to test


### PR DESCRIPTION
This reverts commit c7b8f0c6fea02ffd5194c7abd33b92c9c8dc6f3c.

This was a mistake. Let's revert it to avoid confusion.