### PR TITLE
[jbang-it] Fixes and improves Camel CLI tests

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/DevModeITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/DevModeITCase.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.dsl.jbang;
+package org.apache.camel.dsl.jbang.it;
 
 import java.io.IOException;
 import java.net.URI;
@@ -42,6 +42,7 @@ public class DevModeITCase extends JBangTestSupport {
         executeBackground(String.format("run %s/cheese.xml --dev", mountPoint()));
         checkLogContains("cheese", DEFAULT_MSG);
         final Path routeFile = Path.of(getDataFolder(), "cheese.xml");
+        makeTheFileWriteable(String.format("%s/cheese.xml", mountPoint()));
         Files.write(routeFile,
                 Files.readAllLines(routeFile).stream()
                         .map(line -> line.replace("${routeId}", "custom"))

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandITCase.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.dsl.jbang;
+package org.apache.camel.dsl.jbang.it;
 
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
@@ -27,10 +27,13 @@ import java.util.Date;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
 import org.apache.camel.dsl.jbang.it.support.JiraIssue;
+import org.apache.camel.test.infra.cli.common.CliProperties;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.Assume;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -138,6 +141,7 @@ public class RunCommandITCase extends JBangTestSupport {
 
     @ParameterizedTest
     @ValueSource(strings = { "4.0.0", "4.2.0" })
+    @DisabledIfSystemProperty(named = CliProperties.FORCE_RUN_VERSION, matches = ".+", disabledReason = "Due to CAMEL-20426")
     public void runSpecificVersionTest(String version) {
         initFileInDataFolder("cheese.xml");
         final String pid = executeBackground(String.format("run %s/cheese.xml --camel-version=%s", mountPoint(), version));
@@ -156,6 +160,7 @@ public class RunCommandITCase extends JBangTestSupport {
 
     @Test
     @EnabledOnOs(LINUX)
+    @DisabledIf(value = "java.awt.GraphicsEnvironment#isHeadless")
     public void runFromClipboardTest() throws IOException {
         Assume.assumeTrue(execInHost("command -v ssh").contains("ssh"));
         Assume.assumeTrue(execInHost("command -v sshpass").contains("sshpass"));

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandOnMqttITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandOnMqttITCase.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.dsl.jbang;
+package org.apache.camel.dsl.jbang.it;
 
 import java.io.IOException;
 

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/VersionCommandITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/VersionCommandITCase.java
@@ -14,25 +14,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.dsl.jbang;
+package org.apache.camel.dsl.jbang.it;
 
 import org.apache.camel.dsl.jbang.it.support.InVersion;
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.apache.camel.test.infra.cli.common.CliProperties;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 public class VersionCommandITCase extends JBangTestSupport {
 
     @Test
+    @DisabledIfSystemProperty(named = CliProperties.FORCE_RUN_VERSION, matches = ".+")
     public void versionCommandTest() {
         Assertions.assertThat(execute("version").trim())
                 .contains("Camel JBang version: " + version());
         execute("version set 3.20.2");
         Assertions.assertThat(execute("version").trim())
-                .hasLineCount(4)
                 .contains("Camel JBang version: " + version())
                 .contains("User configuration:")
                 .contains("camel-version = 3.20.2");
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = CliProperties.FORCE_RUN_VERSION, matches = ".+")
+    public void versionCommandTestWithCustomVersion() {
+        Assertions.assertThat(execute("version").trim())
+                .contains("User configuration:")
+                .contains("camel-version = " + version());
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -25,7 +25,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
 import java.time.Duration;
+import java.util.EnumSet;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -62,8 +64,9 @@ public abstract class JBangTestSupport {
 
     @BeforeEach
     protected void beforeEach(TestInfo testInfo) throws IOException {
-        Assertions.assertThat(DATA_FOLDER).as("%s need to be set", CliProperties.DATA_FOLDER).isNotNull();
+        Assertions.assertThat(DATA_FOLDER).as("%s need to be set", CliProperties.DATA_FOLDER).isNotBlank();
         containerDataFolder = Files.createDirectory(Paths.get(DATA_FOLDER, containerService.id())).toAbsolutePath().toString();
+        Files.setPosixFilePermissions(Paths.get(containerDataFolder), EnumSet.allOf(PosixFilePermission.class));
         logger.debug("running {}#{} using data folder {}", getClass().getName(), testInfo.getDisplayName(), getDataFolder());
     }
 
@@ -246,5 +249,9 @@ public abstract class JBangTestSupport {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    protected String makeTheFileWriteable(String containerPath) {
+        return containerService.executeGenericCommand("chmod 777 " + containerPath);
     }
 }

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JiraIssue.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JiraIssue.java
@@ -35,6 +35,9 @@ public @interface JiraIssue {
     class JiraIssueCondition implements ExecutionCondition {
         @Override
         public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+            if (context.getTestInstance().isEmpty()) {
+                return ConditionEvaluationResult.enabled("unable to verify version");
+            }
             final JBangTestSupport currTestClass = (JBangTestSupport) context.getTestInstance().get();
             if (currTestClass == null) {
                 return ConditionEvaluationResult.enabled("unable to verify version");

--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliLocalContainerService.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliLocalContainerService.java
@@ -104,9 +104,19 @@ public class CliLocalContainerService implements CliService, ContainerService<Cl
 
     @Override
     public String execute(String command) {
+        return executeGenericCommand(String.format("camel %s", command));
+    }
+
+    @Override
+    public String executeBackground(String command) {
+        return StringUtils.substringAfter(execute(command.concat(" --background")), "PID:").trim();
+    }
+
+    @Override
+    public String executeGenericCommand(String command) {
         try {
-            LOG.debug("executing camel {}", command);
-            Container.ExecResult execResult = container.execInContainer("/bin/bash", "-c", "camel ".concat(command));
+            LOG.debug("executing {}", command);
+            Container.ExecResult execResult = container.execInContainer("/bin/bash", "-c", command);
             if (execResult.getExitCode() != 0) {
                 Assertions.fail(String.format("command %s failed with output %s and error %s", command, execResult.getStdout(),
                         execResult.getStderr()));
@@ -120,11 +130,6 @@ public class CliLocalContainerService implements CliService, ContainerService<Cl
             Assertions.fail(String.format("command %s failed", command), e);
             throw new RuntimeException(e);
         }
-    }
-
-    @Override
-    public String executeBackground(String command) {
-        return StringUtils.substringAfter(execute(command.concat(" --background")), "PID:").trim();
     }
 
     @Override

--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliService.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliService.java
@@ -61,6 +61,8 @@ public interface CliService extends BeforeAllCallback, AfterAllCallback, BeforeE
 
     String executeBackground(String command);
 
+    String executeGenericCommand(String command);
+
     /**
      * Copy a file inside the container
      *


### PR DESCRIPTION
- Skip headless incompatible test, conditionally
- Run specific version test conditionally, due to CAMEL-20426
- Make the file writeble for external user in dev mode
- Add generic command execution in container
- Split version tests for custom setup
- Move JBang IT classes in correct package