### PR TITLE
[CAMEL-20498] Fix bug with camel-http HTTP OAuth2 Authorization header

### DIFF
--- a/components/camel-http/src/main/java/org/apache/camel/component/http/OAuth2ClientConfigurer.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/OAuth2ClientConfigurer.java
@@ -61,7 +61,7 @@ public class OAuth2ClientConfigurer implements HttpClientConfigurer {
 
                     if (response.getCode() == 200) {
                         String accessToken = ((JsonObject) Jsoner.deserialize(responseString)).getString("access_token");
-                        request.addHeader(HttpHeaders.AUTHORIZATION, accessToken);
+                        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
                     } else {
                         throw new HttpException(
                                 "Received error response from token request with Status Code: " + response.getCode());

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpOAuth2AuthenticationTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpOAuth2AuthenticationTest.java
@@ -42,7 +42,7 @@ public class HttpOAuth2AuthenticationTest extends BaseHttpTest {
     @Override
     public void setUp() throws Exception {
         Map<String, String> expectedHeaders = new HashMap<>();
-        expectedHeaders.put("Authorization", FAKE_TOKEN);
+        expectedHeaders.put("Authorization", "Bearer " + FAKE_TOKEN);
 
         localServer = ServerBootstrap.bootstrap().setHttpProcessor(getBasicHttpProcessor())
                 .setConnectionReuseStrategy(getConnectionReuseStrategy()).setResponseFactory(getHttpResponseFactory())


### PR DESCRIPTION
# Description

Fixes bug as described in https://issues.apache.org/jira/browse/CAMEL-20498

> When using the OAuth2 support for camel-http, it is not adding the prefix text "Bearer " before the access token in the Authorization header as per the OAuth2 specification: https://datatracker.ietf.org/doc/html/rfc6750#section-2.1


# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

