### PR TITLE
CAMEL-20507: camel-core - Add enums to expression builders

### DIFF
--- a/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathSplitSingleListOptionTest.java
+++ b/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathSplitSingleListOptionTest.java
@@ -19,9 +19,9 @@ package org.apache.camel.jsonpath;
 import java.io.File;
 import java.util.Map;
 
-import com.jayway.jsonpath.Option;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.model.language.JsonPathExpression;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +38,8 @@ public class JsonPathSplitSingleListOptionTest extends CamelTestSupport {
             public void configure() {
                 // use option to force returning a list even for a single element selected
                 var jsonpath
-                        = expression().jsonpath().option(Option.ALWAYS_RETURN_LIST.name()).expression("$.store.book[0]").end();
+                        = expression().jsonpath().option(JsonPathExpression.Option.ALWAYS_RETURN_LIST)
+                                .expression("$.store.book[0]").end();
 
                 from("direct:start")
                         .split(jsonpath)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/language/JsonPathExpression.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/language/JsonPathExpression.java
@@ -16,6 +16,10 @@
  */
 package org.apache.camel.model.language;
 
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
@@ -241,9 +245,29 @@ public class JsonPathExpression extends SingleInputTypedExpressionDefinition {
             return this;
         }
 
+        /**
+         * To configure additional options on JSONPath.
+         */
+        public Builder option(Option... options) {
+            this.option = Arrays.stream(options).map(Objects::toString).collect(Collectors.joining(","));
+            return this;
+        }
+
         @Override
         public JsonPathExpression end() {
             return new JsonPathExpression(this);
         }
+    }
+
+    /**
+     * {@code Option} defines the possible json path options that can be used.
+     */
+    @XmlTransient
+    public enum Option {
+        DEFAULT_PATH_LEAF_TO_NULL,
+        ALWAYS_RETURN_LIST,
+        AS_PATH_LIST,
+        SUPPRESS_EXCEPTIONS,
+        REQUIRE_PROPERTIES;
     }
 }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/language/MethodCallExpression.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/language/MethodCallExpression.java
@@ -295,6 +295,24 @@ public class MethodCallExpression extends TypedExpressionDefinition {
         }
 
         /**
+         * Scope of bean.
+         *
+         * When using singleton scope (default) the bean is created or looked up only once and reused for the lifetime
+         * of the endpoint. The bean should be thread-safe in case concurrent threads is calling the bean at the same
+         * time. When using request scope the bean is created or looked up once per request (exchange). This can be used
+         * if you want to store state on a bean while processing a request and you want to call the same bean instance
+         * multiple times while processing the request. The bean does not have to be thread-safe as the instance is only
+         * called from the same request. When using prototype scope, then the bean will be looked up or created per
+         * call. However in case of lookup then this is delegated to the bean registry such as Spring or CDI (if in
+         * use), which depends on their configuration can act as either singleton or prototype scope. So when using
+         * prototype scope then this depends on the bean registry implementation.
+         */
+        public Builder scope(Scope scope) {
+            this.scope = scope == null ? null : scope.value;
+            return this;
+        }
+
+        /**
          * Whether to validate the bean has the configured method.
          */
         public Builder validate(String validate) {
@@ -313,6 +331,22 @@ public class MethodCallExpression extends TypedExpressionDefinition {
         @Override
         public MethodCallExpression end() {
             return new MethodCallExpression(this);
+        }
+    }
+
+    /**
+     * {@code Scope} defines the possible bean scopes that can be used.
+     */
+    @XmlTransient
+    public enum Scope {
+        SINGLETON("Singleton"),
+        REQUEST("Request"),
+        PROTOTYPE("Prototype");
+
+        private final String value;
+
+        Scope(String value) {
+            this.value = value;
         }
     }
 }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/language/XMLTokenizerExpression.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/language/XMLTokenizerExpression.java
@@ -114,6 +114,14 @@ public class XMLTokenizerExpression extends NamespaceAwareExpression {
         }
 
         /**
+         * The extraction mode.
+         */
+        public Builder mode(Mode mode) {
+            this.mode = mode == null ? null : mode.value;
+            return this;
+        }
+
+        /**
          * To group N parts together
          */
         public Builder group(String group) {
@@ -132,6 +140,23 @@ public class XMLTokenizerExpression extends NamespaceAwareExpression {
         @Override
         public XMLTokenizerExpression end() {
             return new XMLTokenizerExpression(this);
+        }
+    }
+
+    /**
+     * {@code Mode} defines the possible extraction modes that can be used.
+     */
+    @XmlTransient
+    public enum Mode {
+        INJECTING_CONTEXTUAL_NAMESPACE_BINDINGS("i"),
+        WRAPPING_EXTRACTED_TOKEN("w"),
+        UNWRAPPING_EXTRACTED_TOKEN("u"),
+        EXTRACTING_TEXT_CONTENT("t");
+
+        private final String value;
+
+        Mode(String value) {
+            this.value = value;
         }
     }
 }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/language/XPathExpression.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/language/XPathExpression.java
@@ -265,8 +265,18 @@ public class XPathExpression extends NamespaceAwareExpression {
          * <p/>
          * The default result type is NodeSet
          */
-        public Builder resultQName(String resultTypeName) {
+        public Builder resultQName(String resultQName) {
             this.resultQName = resultQName;
+            return this;
+        }
+
+        /**
+         * Sets the class name of the result type (type from output)
+         * <p/>
+         * The default result type is NodeSet
+         */
+        public Builder resultQName(ResultQName resultQName) {
+            this.resultQName = resultQName == null ? null : resultQName.name();
             return this;
         }
 
@@ -376,5 +386,17 @@ public class XPathExpression extends NamespaceAwareExpression {
         public XPathExpression end() {
             return new XPathExpression(this);
         }
+    }
+
+    /**
+     * {@code ResultQName} defines the possible class name of the result types that can be used.
+     */
+    @XmlTransient
+    public enum ResultQName {
+        NUMBER,
+        STRING,
+        BOOLEAN,
+        NODESET,
+        NODE
     }
 }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-20507

## Motivation

The expression builders that have fields whose possible values are limited, only support String as type of argument while we could expect to use an enumeration instead.

## Modifications:

* Adds an enum to all expression classes where a field has only limited possible values
* Uses the internal enum in an existing test case to ensure that it works as expected
* Fixes the setter of `resultQName` in the builder of `XPathExpression`

