### PR TITLE
CAMEL-20551: camel-core - Avoid ignoring beans when using several repos

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/support/DefaultRegistryTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/DefaultRegistryTest.java
@@ -276,6 +276,19 @@ public class DefaultRegistryTest {
         assertSame(context, lookup.getCamelContext());
     }
 
+    @Test
+    public void testFindSingleByTypeWithMultipleRepositories() {
+        SimpleRegistry sr = new SimpleRegistry();
+        Animal myAnimal = new Animal();
+        sr.bind("myAnimal", myAnimal);
+        registry.addBeanRepository(sr);
+
+        // Retrieve from the first bean repository
+        assertNotNull(registry.findSingleByType(Animal.class));
+        // Retrieve from the second bean repository
+        assertNotNull(registry.findSingleByType(Company.class));
+    }
+
     private static class MyBean implements CamelContextAware {
 
         private CamelContext camelContext;

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultRegistry.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultRegistry.java
@@ -365,6 +365,9 @@ public class DefaultRegistry extends ServiceSupport implements Registry, LocalBe
         if (found == null && repositories != null) {
             for (BeanRepository r : repositories) {
                 found = r.findSingleByType(type);
+                if (found != null) {
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-20551

## Motivation

In case we have several bean repositories defined in the default registry and a bean is defined in one of the first bean repositories, the method findSingleByType won't return any result while we expect to retrieve a bean.

## Modifications:

* Avoid ignoring the result of `findSingleByType` on the first bean repositories