### PR TITLE
[BACKPORT-4.4.x] CAMEL-20568: Set error handler on route level in YAML DSL (#13489)

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/main/java/org/apache/camel/dsl/yaml/deserializers/CustomResolver.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/main/java/org/apache/camel/dsl/yaml/deserializers/CustomResolver.java
@@ -87,6 +87,8 @@ public class CustomResolver implements YamlDeserializerResolver {
             case "beans":
                 return beansDeserializer;
             case "errorHandler":
+                return new ErrorHandlerDeserializer();
+            case "org.apache.camel.ErrorHandlerFactory":
                 return new ErrorHandlerBuilderDeserializer();
             case "org.apache.camel.model.ProcessorDefinition":
                 return new ProcessorDefinitionDeserializer();

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/main/java/org/apache/camel/dsl/yaml/deserializers/RouteDefinitionDeserializer.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-deserializers/src/main/java/org/apache/camel/dsl/yaml/deserializers/RouteDefinitionDeserializer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.dsl.yaml.deserializers;
 
+import org.apache.camel.ErrorHandlerFactory;
 import org.apache.camel.dsl.yaml.common.YamlDeserializationContext;
 import org.apache.camel.dsl.yaml.common.YamlDeserializerBase;
 import org.apache.camel.dsl.yaml.common.YamlDeserializerResolver;
@@ -50,6 +51,8 @@ import org.snakeyaml.engine.v2.nodes.NodeTuple;
                   @YamlProperty(name = "messageHistory", type = "boolean"),
                   @YamlProperty(name = "logMask", type = "boolean"),
                   @YamlProperty(name = "trace", type = "boolean"),
+                  @YamlProperty(name = "errorHandlerRef", type = "string"),
+                  @YamlProperty(name = "errorHandler", type = "object:org.apache.camel.ErrorHandlerFactory"),
                   @YamlProperty(name = "shutdownRoute", type = "enum:Default,Defer",
                                 defaultValue = "Default",
                                 description = "To control how to shut down the route."),
@@ -127,6 +130,12 @@ public class RouteDefinitionDeserializer extends YamlDeserializerBase<RouteDefin
                     break;
                 case "trace":
                     target.setTrace(asText(val));
+                    break;
+                case "errorHandlerRef":
+                    target.setErrorHandlerRef(asText(val));
+                    break;
+                case "errorHandler":
+                    target.setErrorHandlerFactory(asType(val, ErrorHandlerFactory.class));
                     break;
                 case "inputType":
                     target.setInputType(asType(val, InputTypeDefinition.class));

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
@@ -207,6 +207,85 @@
           }
         }
       },
+      "org.apache.camel.ErrorHandlerFactory" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "deadLetterChannel" ],
+            "properties" : {
+              "deadLetterChannel" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.DeadLetterChannelDefinition"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "deadLetterChannel" ]
+              }, {
+                "required" : [ "defaultErrorHandler" ]
+              }, {
+                "required" : [ "jtaTransactionErrorHandler" ]
+              }, {
+                "required" : [ "noErrorHandler" ]
+              }, {
+                "required" : [ "refErrorHandler" ]
+              }, {
+                "required" : [ "springTransactionErrorHandler" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "defaultErrorHandler" ],
+            "properties" : {
+              "defaultErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.DefaultErrorHandlerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jtaTransactionErrorHandler" ],
+            "properties" : {
+              "jtaTransactionErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.JtaTransactionErrorHandlerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "noErrorHandler" ],
+            "properties" : {
+              "noErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.NoErrorHandlerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "refErrorHandler" ],
+            "properties" : {
+              "refErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.RefErrorHandlerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "springTransactionErrorHandler" ],
+            "properties" : {
+              "springTransactionErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.SpringTransactionErrorHandlerDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "deadLetterChannel" : { },
+          "defaultErrorHandler" : { },
+          "jtaTransactionErrorHandler" : { },
+          "noErrorHandler" : { },
+          "refErrorHandler" : { },
+          "springTransactionErrorHandler" : { }
+        }
+      },
       "org.apache.camel.dsl.yaml.deserializers.BeansDeserializer" : {
         "type" : "array",
         "additionalProperties" : false,
@@ -214,7 +293,7 @@
           "$ref" : "#/items/definitions/org.apache.camel.model.app.RegistryBeanDefinition"
         }
       },
-      "org.apache.camel.dsl.yaml.deserializers.ErrorHandlerBuilderDeserializer" : {
+      "org.apache.camel.dsl.yaml.deserializers.ErrorHandlerDeserializer" : {
         "type" : "object",
         "additionalProperties" : false,
         "anyOf" : [ {
@@ -5092,6 +5171,12 @@
             "type" : "boolean"
           },
           "description" : {
+            "type" : "string"
+          },
+          "errorHandler" : {
+            "$ref" : "#/items/definitions/org.apache.camel.ErrorHandlerFactory"
+          },
+          "errorHandlerRef" : {
             "type" : "string"
           },
           "from" : {
@@ -16206,7 +16291,7 @@
         "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.BeansDeserializer"
       },
       "errorHandler" : {
-        "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.ErrorHandlerBuilderDeserializer"
+        "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.ErrorHandlerDeserializer"
       },
       "from" : {
         "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.RouteFromDefinitionDeserializer"


### PR DESCRIPTION
Allow to set error handler on route level in Camel YAML DSL

(cherry picked from commit c0228d4f12c6a34859e69337bd0017a855fe195c)

