### PR TITLE
[CAMEL-20577] Avoid rest routes dupes

### DIFF
--- a/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBean.java
+++ b/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/AbstractCamelContextFactoryBean.java
@@ -538,7 +538,7 @@ public abstract class AbstractCamelContextFactoryBean<T extends ModelCamelContex
             }
 
             // add each rest as route
-            for (RestDefinition rest : getContext().getRestDefinitions()) {
+            for (RestDefinition rest : getRests()) {
                 rest.asRouteDefinition(getContext()).forEach(r -> getRoutes().add(r));
             }
 


### PR DESCRIPTION
In the case of a Camel Spring Boot application that defines rest routes in camel-xml-io-dsl, rest routes in java dsl, and rest routes spring beans xml, the rest routes are loaded twice in the context and the application cannot start.

I noticed that rests defined in camel-xml-io-dsl and java route configuration are loaded first, together, without issues, but when the rests defined in the spring beans xml are loaded into the camel context, the getContext().getRestDefinitions() contains both the rests defined in the spring beans xml and the rests defined via java or camel-xml, this is why they are loaded twice, getRests() contains only rests defined in the beans xml dsl.

I'm opening the PR in draft, I'd like to execute more tests.