### PR TITLE
CAMEL-20584: Revert "Bump mongo-java-driver-version from 4.11.1 to 5.0.0 (#13476)"

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -356,7 +356,7 @@
         <mock-javamail-version>1.9</mock-javamail-version>
         <mockwebserver-version>6.10.0</mockwebserver-version>
         <mockito-version>5.11.0</mockito-version>
-        <mongo-java-driver-version>5.0.0</mongo-java-driver-version>
+        <mongo-java-driver-version>4.11.1</mongo-java-driver-version>
         <mongo-hadoop-version>1.5.0</mongo-hadoop-version>
         <msal4j-version>1.14.3</msal4j-version>
         <mustache-java-version>0.9.11</mustache-java-version>


### PR DESCRIPTION
This reverts commit 6fe4706f1ff4051bebe109f6bdd28fd35d737f77.