### PR TITLE
fix(camel-salesforce): bump cometd-java-client-version to 8.0.0.beta2 [CAMEL-20588]

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -90,7 +90,7 @@
         <chicocy-version>0.0.7</chicocy-version>
         <chunk-templates-version>3.6.2</chunk-templates-version>
         <classgraph-version>4.8.165</classgraph-version>
-        <cometd-java-client-version>8.0.0.beta1</cometd-java-client-version>
+        <cometd-java-client-version>8.0.0.beta2</cometd-java-client-version>
         <cometd-java-server-version>8.0.0.beta2</cometd-java-server-version>
         <commons-beanutils-version>1.9.4</commons-beanutils-version>
         <commons-codec-version>1.16.0</commons-codec-version>


### PR DESCRIPTION
# Description
The Set-Cookie "Expires" cookie attribute is being incorrectly parsed by the version `8.0.0.beta1` `cometd-java-client-http-jetty` library. This results in the request headers growing indefinitely, eventually leading to a "java.lang.IllegalArgumentException: Request header too large" exception being thrown by Salesforce auth servers. This issue seems to have been resolved in `8.0.0.beta2` by this PR: https://github.com/cometd/cometd/pull/1631

This issue resides in the `JettyHttpClientTransport`  class which is called from the  `SubscriptionHelper`, and stems from the use of the `HttpField.getValueList` method, which uses the `QuotedCSV` class that extends `QuotedCSVParser`. Unfortunately, `QuotedCSVParser` does not appropriately handle the "Expires" cookie attribute, and splits the [RFC6265](https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-examples) compliant Expires date string incorrectly.

Given the following [RFC6265](https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-examples) compliant cookie, 
`Set-Cookie: CookieConsentPolicy=0:1; path=/; expires=Wed, 19-Mar-2025 00:18:54 GMT; Max-Age=31536000; secure`
the call to `HttpField.getValueList` will result in the cookie string being split into:
- `CookieConsentPolicy=0:1; path=/; expires=Wed`
- `19-Mar-2025 00:18:54 GMT; Max-Age=31536000; secure`

`JettyHttpClientTransport` is called from `SubscriptionHelper`, see:
```
public class JettyHttpClientTransport extends AbstractHttpClientTransport {
...
  @Override
  public boolean onHeader(Response response, HttpField field) {
      if (response.getStatus() == HttpStatus.OK_200) {
          HttpHeader header = field.getHeader();
          if (header == HttpHeader.SET_COOKIE || header == HttpHeader.SET_COOKIE2) {
              // We do not allow cookies to be handled by HttpClient, since one
              // HttpClient instance is shared by multiple BayeuxClient instances.
              // Instead, we store the cookies in the BayeuxClient instance.
              Map<String, List<String>> cookies = Map.of(field.getName(), field.getValueList());
              storeCookies(cookieURI, cookies);
              return false;
          }
      }
      return true;
  }
```

# Target
- camel-4.4.x

# Tracking
- https://issues.apache.org/jira/browse/CAMEL-20588

# Apache Camel coding standards and style
- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes.

