### PR TITLE
CAMEL-20590: avoiding delay to execute timeout to Camel RabbitMQ (InOut)

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultTimeoutMap.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultTimeoutMap.java
@@ -84,7 +84,7 @@ public class DefaultTimeoutMap<K, V> extends ServiceSupport implements TimeoutMa
     public V get(K key) {
         TimeoutMapEntry<K, V> entry;
         // if no contains, the lock is not necessary
-        if(!map.containsKey(key)){
+        if (!map.containsKey(key)) {
             return null;
         }
         lock.lock();

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultTimeoutMap.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultTimeoutMap.java
@@ -101,10 +101,6 @@ public class DefaultTimeoutMap<K, V> extends ServiceSupport implements TimeoutMa
     }
 
 
-    public boolean containsKey(K key) {
-        return map.containsKey(key);
-    }
-
     @Override
     public V put(K key, V value, long timeoutMillis) {
         TimeoutMapEntry<K, V> entry = new TimeoutMapEntry<>(key, value, timeoutMillis);

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultTimeoutMap.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultTimeoutMap.java
@@ -83,6 +83,10 @@ public class DefaultTimeoutMap<K, V> extends ServiceSupport implements TimeoutMa
     @Override
     public V get(K key) {
         TimeoutMapEntry<K, V> entry;
+        // if no contains, the lock is not necessary
+        if(!map.containsKey(key)){
+            return null;
+        }
         lock.lock();
         try {
             entry = map.get(key);
@@ -94,6 +98,11 @@ public class DefaultTimeoutMap<K, V> extends ServiceSupport implements TimeoutMa
             lock.unlock();
         }
         return entry.getValue();
+    }
+
+
+    public boolean containsKey(K key) {
+        return map.containsKey(key);
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultTimeoutMap.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultTimeoutMap.java
@@ -100,7 +100,6 @@ public class DefaultTimeoutMap<K, V> extends ServiceSupport implements TimeoutMa
         return entry.getValue();
     }
 
-
     @Override
     public V put(K key, V value, long timeoutMillis) {
         TimeoutMapEntry<K, V> entry = new TimeoutMapEntry<>(key, value, timeoutMillis);


### PR DESCRIPTION
# Description

As described on the issue, the https://github.com/apache/camel/blob/camel-3.21.x/components/camel-rabbitmq/src/main/java/org/apache/camel/component/rabbitmq/reply/ReplyManagerSupport.java#L217 is executing the get excessively. This delay occurs because the ReplyHandler has already been removed by the RabbitMQReplyManagerTimeoutChecker. The contains avoid getting locked when the TimeoutMapEntry does not exist.

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

