### PR TITLE
(chores) ci: start checking PRs with Java 21

### DIFF
--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17' ]
+        java: [ '17', '21' ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/push-build-main.yml
+++ b/.github/workflows/push-build-main.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17' ]
+        java: [ '17', '21' ]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
As Java 21 becomes more common, I think we should start checking the PRs with it. It would help us catch issues earlier.