### PR TITLE
Fix command `camel jolokia` fails to attach JVM agent (4.4.x)

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-core/pom.xml
@@ -92,6 +92,7 @@
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-agent-jvm</artifactId>
             <version>${jolokia-version}</version>
+            <classifier>javaagent</classifier>
         </dependency>
         <!-- servlet for launching hawtio -->
         <dependency>


### PR DESCRIPTION
Backport #13585 to 4.4.x LTS. 4.0.x doesn't have the issue.