### PR TITLE
camel-cdi remove deprecated fireEvent method

### DIFF
--- a/components/camel-cdi/src/main/java/org/apache/camel/cdi/CdiCamelExtension.java
+++ b/components/camel-cdi/src/main/java/org/apache/camel/cdi/CdiCamelExtension.java
@@ -412,7 +412,7 @@ public class CdiCamelExtension implements Extension {
 
     private void afterDeploymentValidation(@Observes AfterDeploymentValidation adv, BeanManager manager) {
         // Send event for Camel CDI configuration
-        manager.fireEvent(configuration);
+        manager.getEvent().fire(configuration);
         configuration.unmodifiable();
 
         Collection<CamelContext> contexts = new ArrayList<>();

--- a/components/camel-cdi/src/main/java/org/apache/camel/cdi/CdiEventNotifier.java
+++ b/components/camel-cdi/src/main/java/org/apache/camel/cdi/CdiEventNotifier.java
@@ -56,9 +56,9 @@ final class CdiEventNotifier extends EventNotifierSupport {
             List<Annotation> annotations = new ArrayList<>();
             Collections.addAll(annotations, qualifiers);
             annotations.add(NamedLiteral.of(id));
-            manager.fireEvent(event, annotations.toArray(new Annotation[0]));
+            manager.getEvent().select(annotations.toArray(new Annotation[0])).fire(event);
         } else {
-            manager.fireEvent(event, qualifiers);
+            manager.getEvent().select(qualifiers).fire(event);
         }
     }
 


### PR DESCRIPTION
- remove deprecated BeanManager.fireEvent
- this will allow the library to be used in also with cdi api 4 after transforming it with eclipse transformer.

# Description
fireEvent method was removed in cdi api 4 version. This means the camel-cdi library cannot be used in jakarta app servers even after transforming it using eclipse transformer tool.  
<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

