### PR TITLE
CAMEL-20624: Fix bug in camel-http to avoid duplicate OAuth2 Authorization headers

### DIFF
--- a/components/camel-http/src/main/java/org/apache/camel/component/http/OAuth2ClientConfigurer.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/OAuth2ClientConfigurer.java
@@ -61,7 +61,7 @@ public class OAuth2ClientConfigurer implements HttpClientConfigurer {
 
                     if (response.getCode() == 200) {
                         String accessToken = ((JsonObject) Jsoner.deserialize(responseString)).getString("access_token");
-                        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+                        request.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
                     } else {
                         throw new HttpException(
                                 "Received error response from token request with Status Code: " + response.getCode());


### PR DESCRIPTION
# Description

Uses HttpRequest `setHeader` instead of `addHeader` to ensure that duplicate of "Authorization" header will not be created when using camel-http's OAuth2 support.  See: https://hc.apache.org/httpcomponents-core-5.1.x/current/httpcore5/apidocs/org/apache/hc/core5/http/HttpMessage.html#setHeader(org.apache.hc.core5.http.Header)

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

