### PR TITLE
Fix camel-vertx-websocket endpoint instantiation when connection to r…

### DIFF
--- a/components/camel-vertx/camel-vertx-websocket/src/main/java/org/apache/camel/component/vertx/websocket/VertxWebsocketComponent.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/main/java/org/apache/camel/component/vertx/websocket/VertxWebsocketComponent.java
@@ -76,6 +76,13 @@ public class VertxWebsocketComponent extends DefaultComponent implements SSLCont
             }
         }
 
+        VertxWebsocketConfiguration configuration = new VertxWebsocketConfiguration();
+        configuration.setAllowOriginHeader(isAllowOriginHeader());
+        configuration.setOriginHeaderUrl(getOriginHeaderUrl());
+
+        VertxWebsocketEndpoint endpoint = createEndpointInstance(uri, configuration);
+        setProperties(endpoint, parameters);
+
         URI endpointUri = new URI(UnsafeUriCharactersEncoder.encodeHttpURI(wsUri));
         URI websocketURI = URISupport.createRemainingURI(endpointUri, parameters);
 
@@ -102,13 +109,7 @@ public class VertxWebsocketComponent extends DefaultComponent implements SSLCont
                     websocketURI.getFragment());
         }
 
-        VertxWebsocketConfiguration configuration = new VertxWebsocketConfiguration();
         configuration.setWebsocketURI(websocketURI);
-        configuration.setAllowOriginHeader(isAllowOriginHeader());
-        configuration.setOriginHeaderUrl(getOriginHeaderUrl());
-
-        VertxWebsocketEndpoint endpoint = createEndpointInstance(uri, configuration);
-        setProperties(endpoint, parameters);
 
         if (configuration.getSslContextParameters() == null) {
             configuration.setSslContextParameters(retrieveGlobalSslContextParameters());

--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketEndpointConfigurationTest.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketEndpointConfigurationTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.vertx.websocket;
 
+import java.net.URI;
+
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServerOptions;
@@ -99,6 +101,17 @@ public class VertxWebsocketEndpointConfigurationTest extends VertxWebSocketTestS
         String originHeaderValue = headers.get(ORIGIN_HTTP_HEADER_NAME);
         assertNotNull(headers);
         assertEquals(originUrl, originHeaderValue);
+    }
+
+    @Test
+    void testPropertiesBinding() {
+        String testQueryParam = "testParam=hello";
+        String endpointParams = "consumeAsClient=true&maxReconnectAttempts=2";
+        VertxWebsocketEndpoint endpoint
+                = context.getEndpoint("vertx-websocket:foo.bar.com/test?" + endpointParams + "&" + testQueryParam,
+                        VertxWebsocketEndpoint.class);
+        URI websocketURI = endpoint.getConfiguration().getWebsocketURI();
+        assertEquals(testQueryParam, websocketURI.getQuery(), "Query parameters are not correctly set in the in websocketURI.");
     }
 
     @Override


### PR DESCRIPTION
…emote websocket server

# Description

While trying to migrate from `camel-ahc-ws` to `camel-vertx-websocket`, I encountered a problem with the `consumeAsClient` option. The remote server I was trying to interact with refused to upgrade to websocket because of invalid query parameters.

Previously, endpoint properties were set after configuring the `websocketURI`. As a result, when using the endpoint with `consumeAsClient` option, endpoint properties were passed as query param (`consumeAsClient` for example). Some APIs reject upgrade to websocket when unknown parameters are passed in the call. 

The purpose of this commit is to set endpoint properties before configuring `websocketURI`. So properties are binded and removed from the parameters map before configuring the `websocketURI`. 

This is inspired by the way `VertxHttpEndpoint` is instantiated.

I modified the endpoint instanciation and I added a test to verify that endpoint properties are correctly removed from the `websocketURI` query params.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

