### PR TITLE
CAMEL-18017: return body part fields copied from parsed MDN entity to avoid corruption

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/AS2MessageDispositionNotificationEntity.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/AS2MessageDispositionNotificationEntity.java
@@ -66,6 +66,7 @@ public class AS2MessageDispositionNotificationEntity extends MimeEntity {
     private String[] warningFields;
     private Map<String, String> extensionFields = new HashMap<>();
     private ReceivedContentMic receivedContentMic;
+    private String parsedBodyPartFields;
 
     public AS2MessageDispositionNotificationEntity(ClassicHttpRequest request,
                                                    HttpResponse response,
@@ -119,7 +120,8 @@ public class AS2MessageDispositionNotificationEntity extends MimeEntity {
                                                    String[] errorFields,
                                                    String[] warningFields,
                                                    Map<String, String> extensionFields,
-                                                   ReceivedContentMic receivedContentMic) {
+                                                   ReceivedContentMic receivedContentMic,
+                                                   String parsedBodyPartFields) {
         super(ContentType.create(AS2MimeType.MESSAGE_DISPOSITION_NOTIFICATION), null);
         this.reportingUA = reportingUA;
         this.mtnName = mtnName;
@@ -133,6 +135,7 @@ public class AS2MessageDispositionNotificationEntity extends MimeEntity {
         this.warningFields = warningFields;
         this.extensionFields = extensionFields;
         this.receivedContentMic = receivedContentMic;
+        this.parsedBodyPartFields = parsedBodyPartFields;
     }
 
     public String getReportingUA() {
@@ -197,6 +200,16 @@ public class AS2MessageDispositionNotificationEntity extends MimeEntity {
                 canonicalOutstream.writeln(); // ensure empty line between
                                              // headers and body; RFC2046 -
                                              // 5.1.1
+            }
+
+            if (parsedBodyPartFields != null) {
+                // The 'writeTo' method is used when verifying the signature of the received MDN, and any alteration
+                // to the body part fields would mean that the signature would fail verification. Therefor return
+                // the fields parsed from the MDN entity if available so that the specific field
+                // ordering/formatting is maintained otherwise fall back to recreating each header, e.g. 'Reporting-UA',
+                // in the order prescribed in this method.
+                canonicalOutstream.writeln(parsedBodyPartFields);
+                return;
             }
 
             if (reportingUA != null) {

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/DispositionNotificationContentUtils.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/util/DispositionNotificationContentUtils.java
@@ -131,6 +131,7 @@ public final class DispositionNotificationContentUtils {
 
     private static final char PARAM_DELIMITER = ',';
     private static final char ELEM_DELIMITER = ';';
+    private static final int DEFAULT_BUFFER_SIZE = 8 * 1024;
 
     private static final BitSet TOKEN_DELIMS = TokenParser.INIT_BITSET(PARAM_DELIMITER, ELEM_DELIMITER);
 
@@ -152,9 +153,15 @@ public final class DispositionNotificationContentUtils {
         List<String> warnings = new ArrayList<>();
         Map<String, String> extensionFields = new HashMap<>();
         ReceivedContentMic receivedContentMic = null;
+        CharArrayBuffer bodyPartFields = new CharArrayBuffer(DEFAULT_BUFFER_SIZE);
 
         for (int i = 0; i < dispositionNotificationFields.size(); i++) {
             final CharArrayBuffer fieldLine = dispositionNotificationFields.get(i);
+            bodyPartFields.append(fieldLine);
+            if (i < dispositionNotificationFields.size() - 1) {
+                bodyPartFields.append('\r');
+                bodyPartFields.append('\n');
+            }
             final Field field = parseDispositionField(fieldLine);
             switch (field.getName().toLowerCase()) {
                 case REPORTING_UA: {
@@ -250,7 +257,8 @@ public final class DispositionNotificationContentUtils {
                 errors.toArray(new String[0]),
                 warnings.toArray(new String[0]),
                 extensionFields,
-                receivedContentMic);
+                receivedContentMic,
+                bodyPartFields.toString());
     }
 
     public static Field parseDispositionField(CharArrayBuffer fieldLine) throws ParseException {

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/entity/EntityParserTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/entity/EntityParserTest.java
@@ -111,7 +111,8 @@ public class EntityParserTest {
                                                                          + "\r\n"
                                                                          + "------=_Part_56_1672293592.1028122454656--\r\n";
 
-    // version of MDN without report any folded body parts, which are unfolded when the entity is parsed
+    // version of the MDN report without any folded body parts that would be unfolded when the entity is parsed
+    // modifying the report
     public static final String DISPOSITION_NOTIFICATION_REPORT_CONTENT_UNFOLDED = "\r\n"
                                                                                   + "------=_Part_56_1672293592.1028122454656\r\n"
                                                                                   + "Content-Type: text/plain\r\n"


### PR DESCRIPTION
# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

The body part fields of a parsed MDN are written out to an output stream when a signature needs to be verified.  Any (ordering/formatting) changes introduced when the entity is parsed and written mean that the signature verification will fail.  One approach is to write out a direct copy of the body part fields of the received entity instead of trying to parse and recreate each field.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

