### PR TITLE
CAMEL-20659: include contentTransferEncoding on parsed Report

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/DispositionNotificationMultipartReportEntity.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/DispositionNotificationMultipartReportEntity.java
@@ -31,10 +31,11 @@ import org.apache.hc.core5.http.HttpResponse;
 
 public class DispositionNotificationMultipartReportEntity extends MultipartReportEntity {
 
-    protected DispositionNotificationMultipartReportEntity(String boundary, boolean isMainBody) {
+    protected DispositionNotificationMultipartReportEntity(String boundary, String contentTransferEncoding,
+                                                           boolean isMainBody) {
         super(ContentType.parse(AS2MimeType.MULTIPART_REPORT + ";"
                                 + "report-type=disposition-notification; boundary=\"" + boundary + "\""),
-              null, isMainBody, boundary);
+              contentTransferEncoding, isMainBody, boundary);
     }
 
     public DispositionNotificationMultipartReportEntity(ClassicHttpRequest request,

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/EntityParser.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/EntityParser.java
@@ -642,7 +642,7 @@ public final class EntityParser {
             inbuffer.setCharsetDecoder(charsetDecoder);
 
             DispositionNotificationMultipartReportEntity dispositionNotificationMultipartReportEntity
-                    = new DispositionNotificationMultipartReportEntity(boundary, false);
+                    = new DispositionNotificationMultipartReportEntity(boundary, contentTransferEncoding, false);
 
             // Skip Preamble and Start Boundary line
             skipPreambleAndStartBoundary(inbuffer, is, boundary);

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/entity/EntityParserTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/entity/EntityParserTest.java
@@ -111,7 +111,7 @@ public class EntityParserTest {
                                                                          + "\r\n"
                                                                          + "------=_Part_56_1672293592.1028122454656--\r\n";
 
-    // version of the MDN report without any folded body parts that would be unfolded when the entity is parsed
+    // version of the Disposition Notification Report without any folded body parts that would be unfolded when the entity is parsed
     // modifying the report
     public static final String DISPOSITION_NOTIFICATION_REPORT_CONTENT_UNFOLDED = "\r\n"
                                                                                   + "------=_Part_56_1672293592.1028122454656\r\n"
@@ -262,7 +262,7 @@ public class EntityParserTest {
                 "Unexpected type for second body part");
     }
 
-    // verify that parsing the MDN has made no alteration to the entity's body part fields
+    // verify that parsing the Disposition Notification Report has made no alteration to the entity's body part fields
     @Test
     public void messageDispositionNotificationReportBodyContentTest() throws Exception {
 
@@ -270,12 +270,15 @@ public class EntityParserTest {
                 = createMdnEntity(DISPOSITION_NOTIFICATION_REPORT_CONTENT_UNFOLDED,
                         DISPOSITION_NOTIFICATION_REPORT_CONTENT_BOUNDARY);
 
+        String expectedContent = String.format("%s\r\n%s\r\n%s",
+                new BasicHeader(AS2Header.CONTENT_TYPE, REPORT_CONTENT_TYPE_VALUE),
+                new BasicHeader(AS2Header.CONTENT_TRANSFER_ENCODING, DISPOSITION_NOTIFICATION_REPORT_CONTENT_TRANSFER_ENCODING),
+                DISPOSITION_NOTIFICATION_REPORT_CONTENT_UNFOLDED);
+
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         dispositionNotificationMultipartReportEntity.writeTo(out);
-        assertEquals(out.toString(DISPOSITION_NOTIFICATION_CONTENT_CHARSET_NAME),
-                new BasicHeader(AS2Header.CONTENT_TYPE, ContentType.parse(REPORT_CONTENT_TYPE_VALUE))
-                                                                                  + "\r\n"
-                                                                                  + DISPOSITION_NOTIFICATION_REPORT_CONTENT_UNFOLDED);
+
+        assertEquals(expectedContent, out.toString(DISPOSITION_NOTIFICATION_CONTENT_CHARSET_NAME));
     }
 
     @Test


### PR DESCRIPTION
# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

The `contentTransferEncoding` needs to be included in the DispositionNotificationMultipartReportEntity constructor when parsing the entity body.  Previously this was set via a 'setter' but with the upgrade to Apache HTTP client v5 it was changed to an attribute that must be set via the constructor: https://github.com/apache/camel/blob/camel-4.4.x/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/EntityParser.java#L713

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

