### PR TITLE
hazelcast-seda: Nested transactions are not allowed!

### DIFF
--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/seda/HazelcastSedaConsumer.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/seda/HazelcastSedaConsumer.java
@@ -127,6 +127,10 @@ public class HazelcastSedaConsumer extends DefaultConsumer implements Runnable {
                             transactionCtx.rollbackTransaction();
                         }
                     }
+                } else {
+                    if (transactionCtx != null) {
+                        transactionCtx.commitTransaction();
+                    }
                 }
             } catch (InterruptedException e) {
                 if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
# Description

If **transacted** is enabled for a **hazelcast-seda** queue, the transaction never gets committed if body is _null_. This is often the case when polling from an empty queue. This leads to "Camel Exception cause:  java.lang.IllegalStateException: Nested transactions are not allowed!". We found this issue as our Hazelcast txBackupLogs consumed a large amount of memory.

# Target
Camel 4. 

Older versions are also affected. It would be nice to merge down to Camel 3 LTS versions.