### PR TITLE
CAMEL-20613: set AbstractCamelContext#endpointStrategies to ConcurrentHashSet

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
@@ -207,7 +207,7 @@ public abstract class AbstractCamelContext extends BaseService
 
     private final DefaultCamelContextExtension camelContextExtension = new DefaultCamelContextExtension(this);
     private final AtomicInteger endpointKeyCounter = new AtomicInteger();
-    private final List<EndpointStrategy> endpointStrategies = new ArrayList<>();
+    private final Set<EndpointStrategy> endpointStrategies = ConcurrentHashMap.newKeySet();
     private final GlobalEndpointConfiguration globalEndpointConfiguration = new DefaultGlobalEndpointConfiguration();
     private final Map<String, Component> components = new ConcurrentHashMap<>();
     private final Set<Route> routes = new LinkedHashSet<>();
@@ -4159,7 +4159,7 @@ public abstract class AbstractCamelContext extends BaseService
         return camelContextExtension.getRegistry();
     }
 
-    List<EndpointStrategy> getEndpointStrategies() {
+    Set<EndpointStrategy> getEndpointStrategies() {
         return endpointStrategies;
     }
 

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultCamelContextExtension.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultCamelContextExtension.java
@@ -269,15 +269,17 @@ class DefaultCamelContextExtension implements ExtendedCamelContext {
 
     @Override
     public void registerEndpointCallback(EndpointStrategy strategy) {
-        if (!camelContext.getEndpointStrategies().contains(strategy)) {
-            // let it be invoked for already registered endpoints so it can
-            // catch-up.
-            camelContext.getEndpointStrategies().add(strategy);
+        // let it be invoked for already registered endpoints so it can
+        // catch-up.
+        if (camelContext.getEndpointStrategies().add(strategy)) {
             for (Endpoint endpoint : camelContext.getEndpoints()) {
-                Endpoint newEndpoint = strategy.registerEndpoint(endpoint.getEndpointUri(), endpoint);
+                Endpoint newEndpoint = strategy.registerEndpoint(endpoint.getEndpointUri(),
+                        endpoint);
                 if (newEndpoint != null) {
                     // put will replace existing endpoint with the new endpoint
-                    camelContext.getEndpointRegistry().put(camelContext.getEndpointKey(endpoint.getEndpointUri()), newEndpoint);
+                    camelContext.getEndpointRegistry()
+                            .put(camelContext.getEndpointKey(endpoint.getEndpointUri()),
+                                    newEndpoint);
                 }
             }
         }


### PR DESCRIPTION
CAMEL-20613: set AbstractCamelContext#endpointStrategies to ConcurrentHashSet to prevent ConcurrentModificationException

# Description

If a thread iterates over the list of strategies while another thread adds a new strategy, ConcurrentModificationException is thrown. To fix this issue, AbstractCamelContext#endpointStrategies can be set to a thread-safe collection.

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

