### PR TITLE
CAMEL-20614: deep-copy output processors during instantiation of a route template

### DIFF
--- a/components/camel-kamelet/src/test/java/org/apache/camel/component/kamelet/KameletMultiThreadedTest.java
+++ b/components/camel-kamelet/src/test/java/org/apache/camel/component/kamelet/KameletMultiThreadedTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.kamelet;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.component.kamelet.Kamelet.templateToRoute;
+
+public class KameletMultiThreadedTest extends CamelTestSupport {
+
+    @Test
+    public void createSameKameletTwiceInParallel_KameletConsumerNotAvailableExceptionThrown() throws InterruptedException {
+        var latch = new CountDownLatch(2);
+        context.addRouteTemplateDefinitionConverter("*", (in, parameters) -> {
+            try {
+                return templateToRoute(in, parameters);
+            } finally {
+                latch.countDown();
+                latch.await();
+            }
+        });
+        getMockEndpoint("mock:foo").expectedMessageCount(2);
+
+        template.sendBody("seda:route", null);
+        template.requestBody("seda:route", ((Object) null));
+
+        MockEndpoint.assertIsSatisfied(context);
+    }
+
+    // **********************************************
+    //
+    // test set-up
+    //
+    // **********************************************
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("seda:route?concurrentConsumers=2")
+                        .toD("kamelet:-");
+
+                routeTemplate("-"). // This is a workaround for "*" to be iterated before templateId at org.apache.camel.impl.DefaultModel#addRouteFromTemplate (line 460)
+                        from("kamelet:source")
+                        .to("mock:foo");
+            }
+        };
+    }
+}

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/CopyableProcessorDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/CopyableProcessorDefinition.java
@@ -16,23 +16,10 @@
  */
 package org.apache.camel.model;
 
-import java.util.Collections;
-import java.util.List;
-
 /**
- * Base class for definitions which does not support outputs.
+ * This interface is used to copy {@link ProcessorDefinition ProcessorDefinitions} during instantiation of a route
+ * template.
  */
-public abstract class NoOutputDefinition<Type extends ProcessorDefinition<Type>> extends ProcessorDefinition<Type> {
-
-    @Override
-    public List<ProcessorDefinition<?>> getOutputs() {
-        return Collections.emptyList();
-    }
-
-    public NoOutputDefinition() {
-    }
-
-    NoOutputDefinition(NoOutputDefinition source) {
-        super(source);
-    }
+interface CopyableProcessorDefinition {
+    ProcessorDefinition<?> copy();
 }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/FromDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/FromDefinition.java
@@ -66,6 +66,22 @@ public class FromDefinition extends OptionalIdentifiedDefinition<FromDefinition>
         setEndpointConsumerBuilder(endpointConsumerBuilder);
     }
 
+    FromDefinition copy() {
+        FromDefinition copy = new FromDefinition();
+        copy.parent = this.parent;
+        copy.endpoint = this.endpoint;
+        copy.endpointConsumerBuilder = this.endpointConsumerBuilder;
+        copy.uri = this.uri;
+        copy.variableReceive = this.variableReceive;
+        copy.setCamelContext(this.getCamelContext());
+        copy.setId(this.getId());
+        copy.setCustomId(this.getCustomId());
+        copy.setDescription(this.getDescription());
+        copy.setLineNumber(this.getLineNumber());
+        copy.setLocation(this.getLocation());
+        return copy;
+    }
+
     @Override
     public String toString() {
         return "From[" + getLabel() + "]";

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/NoOutputDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/NoOutputDefinition.java
@@ -32,7 +32,7 @@ public abstract class NoOutputDefinition<Type extends ProcessorDefinition<Type>>
     public NoOutputDefinition() {
     }
 
-    NoOutputDefinition(NoOutputDefinition source) {
+    protected NoOutputDefinition(NoOutputDefinition source) {
         super(source);
     }
 }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/OptionalIdentifiedDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/OptionalIdentifiedDefinition.java
@@ -48,7 +48,7 @@ public abstract class OptionalIdentifiedDefinition<T extends OptionalIdentifiedD
     public OptionalIdentifiedDefinition() {
     }
 
-    OptionalIdentifiedDefinition(OptionalIdentifiedDefinition source) {
+    protected OptionalIdentifiedDefinition(OptionalIdentifiedDefinition source) {
         this.camelContext = source.camelContext;
         this.id = source.id;
         this.customId = source.customId;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/OptionalIdentifiedDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/OptionalIdentifiedDefinition.java
@@ -45,6 +45,18 @@ public abstract class OptionalIdentifiedDefinition<T extends OptionalIdentifiedD
     private int lineNumber = -1;
     private String location;
 
+    public OptionalIdentifiedDefinition() {
+    }
+
+    OptionalIdentifiedDefinition(OptionalIdentifiedDefinition source) {
+        this.camelContext = source.camelContext;
+        this.id = source.id;
+        this.customId = source.customId;
+        this.description = source.description;
+        this.lineNumber = source.lineNumber;
+        this.location = source.location;
+    }
+
     @Override
     public CamelContext getCamelContext() {
         return camelContext;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ProcessorDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ProcessorDefinition.java
@@ -102,6 +102,17 @@ public abstract class ProcessorDefinition<Type extends ProcessorDefinition<Type>
         index = COUNTER.getAndIncrement();
     }
 
+    ProcessorDefinition(ProcessorDefinition source) {
+        super(source);
+        this.disabled = source.disabled;
+        this.inheritErrorHandler = source.inheritErrorHandler;
+        this.blocks.addAll(source.blocks);
+        this.parent = source.parent;
+        this.routeConfiguration = source.routeConfiguration;
+        this.interceptStrategies.addAll(source.interceptStrategies);
+        this.index = source.index;
+    }
+
     private static <T extends ExpressionNode> ExpressionClause<T> createAndSetExpression(T result) {
         ExpressionClause<T> clause = new ExpressionClause<>(result);
         result.setExpression(clause);

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ProcessorDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ProcessorDefinition.java
@@ -102,7 +102,7 @@ public abstract class ProcessorDefinition<Type extends ProcessorDefinition<Type>
         index = COUNTER.getAndIncrement();
     }
 
-    ProcessorDefinition(ProcessorDefinition source) {
+    protected ProcessorDefinition(ProcessorDefinition source) {
         super(source);
         this.disabled = source.disabled;
         this.inheritErrorHandler = source.inheritErrorHandler;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/RouteTemplateDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/RouteTemplateDefinition.java
@@ -16,7 +16,12 @@
  */
 package org.apache.camel.model;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNullElse;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -36,6 +41,10 @@ import org.apache.camel.spi.AsEndpointUri;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.Resource;
 import org.apache.camel.spi.ResourceAware;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNullElse;
 
 /**
  * Defines a route template (parameterized routes)
@@ -415,10 +424,10 @@ public class RouteTemplateDefinition extends OptionalIdentifiedDefinition<RouteT
         copy.setLogMask(route.getLogMask());
         copy.setMessageHistory(route.getMessageHistory());
         copy.setOutputType(route.getOutputType());
-        copy.setOutputs(route.getOutputs());
-        copy.setRoutePolicies(route.getRoutePolicies());
+        copy.setOutputs(copy(route.getOutputs()));
+        copy.setRoutePolicies(new ArrayList<>(requireNonNullElse(route.getRoutePolicies(), emptyList())));
         copy.setRoutePolicyRef(route.getRoutePolicyRef());
-        copy.setRouteProperties(route.getRouteProperties());
+        copy.setRouteProperties(new ArrayList<>(requireNonNullElse(route.getRouteProperties(), emptyList())));
         copy.setShutdownRoute(route.getShutdownRoute());
         copy.setShutdownRunningTask(route.getShutdownRunningTask());
         copy.setStartupOrder(route.getStartupOrder());
@@ -432,6 +441,19 @@ public class RouteTemplateDefinition extends OptionalIdentifiedDefinition<RouteT
         }
         copy.setPrecondition(route.getPrecondition());
         copy.setRouteConfigurationId(route.getRouteConfigurationId());
+        copy.setTemplateParameters(new HashMap<>(requireNonNullElse(route.getTemplateParameters(), emptyMap())));
+        return copy;
+    }
+
+    private List<ProcessorDefinition<?>> copy(List<ProcessorDefinition<?>> outputs) {
+        var copy = new ArrayList<ProcessorDefinition<?>>();
+        for (var definition : outputs) {
+            if (definition instanceof CopyableProcessorDefinition copyable) {
+                copy.add(copyable.copy());
+            } else {
+                copy.add(definition);
+            }
+        }
         return copy;
     }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/RouteTemplateDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/RouteTemplateDefinition.java
@@ -42,10 +42,6 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.Resource;
 import org.apache.camel.spi.ResourceAware;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
-import static java.util.Objects.requireNonNullElse;
-
 /**
  * Defines a route template (parameterized routes)
  */
@@ -426,9 +422,9 @@ public class RouteTemplateDefinition extends OptionalIdentifiedDefinition<RouteT
         copy.setMessageHistory(route.getMessageHistory());
         copy.setOutputType(route.getOutputType());
         copy.setOutputs(copy(route.getOutputs()));
-        copy.setRoutePolicies(new ArrayList<>(requireNonNullElse(route.getRoutePolicies(), emptyList())));
+        copy.setRoutePolicies(shallowCopy(route.getRoutePolicies()));
         copy.setRoutePolicyRef(route.getRoutePolicyRef());
-        copy.setRouteProperties(new ArrayList<>(requireNonNullElse(route.getRouteProperties(), emptyList())));
+        copy.setRouteProperties(shallowCopy(route.getRouteProperties()));
         copy.setShutdownRoute(route.getShutdownRoute());
         copy.setShutdownRunningTask(route.getShutdownRunningTask());
         copy.setStartupOrder(route.getStartupOrder());
@@ -442,8 +438,16 @@ public class RouteTemplateDefinition extends OptionalIdentifiedDefinition<RouteT
         }
         copy.setPrecondition(route.getPrecondition());
         copy.setRouteConfigurationId(route.getRouteConfigurationId());
-        copy.setTemplateParameters(new HashMap<>(requireNonNullElse(route.getTemplateParameters(), emptyMap())));
+        copy.setTemplateParameters(shallowCopy(route.getTemplateParameters()));
         return copy;
+    }
+
+    private <T> List<T> shallowCopy(List<T> list) {
+        return (list != null) ? new ArrayList<>(list) : null;
+    }
+
+    private <K, V> Map<K, V> shallowCopy(Map<K, V> map) {
+        return (map != null) ? new HashMap<>(map) : null;
     }
 
     private List<ProcessorDefinition<?>> copy(List<ProcessorDefinition<?>> outputs) {

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/RouteTemplateDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/RouteTemplateDefinition.java
@@ -419,7 +419,8 @@ public class RouteTemplateDefinition extends OptionalIdentifiedDefinition<RouteT
         copy.setDelayer(route.getDelayer());
         copy.setGroup(route.getGroup());
         copy.setInheritErrorHandler(route.isInheritErrorHandler());
-        copy.setInput(route.getInput());
+        // make a defensive copy of the input as input can be adviced during testing or other changes
+        copy.setInput(route.getInput().copy());
         copy.setInputType(route.getInputType());
         copy.setLogMask(route.getLogMask());
         copy.setMessageHistory(route.getMessageHistory());

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/SendDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/SendDefinition.java
@@ -51,6 +51,14 @@ public abstract class SendDefinition<Type extends ProcessorDefinition<Type>> ext
         this.uri = uri;
     }
 
+    SendDefinition(SendDefinition source) {
+        super(source);
+        this.endpointUriToString = source.endpointUriToString;
+        this.endpoint = source.endpoint;
+        this.endpointProducerBuilder = source.endpointProducerBuilder;
+        this.uri = source.uri;
+    }
+
     @Override
     public String getEndpointUri() {
         if (endpointProducerBuilder != null) {

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/SendDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/SendDefinition.java
@@ -51,7 +51,7 @@ public abstract class SendDefinition<Type extends ProcessorDefinition<Type>> ext
         this.uri = uri;
     }
 
-    SendDefinition(SendDefinition source) {
+    protected SendDefinition(SendDefinition source) {
         super(source);
         this.endpointUriToString = source.endpointUriToString;
         this.endpoint = source.endpoint;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ToDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ToDefinition.java
@@ -76,7 +76,7 @@ public class ToDefinition extends SendDefinition<ToDefinition> implements Copyab
         this.pattern = pattern.name();
     }
 
-    ToDefinition(ToDefinition source) {
+    protected ToDefinition(ToDefinition source) {
         super(source);
         this.variableSend = source.variableSend;
         this.variableReceive = source.variableReceive;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ToDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ToDefinition.java
@@ -33,7 +33,7 @@ import org.apache.camel.spi.Metadata;
 @Metadata(label = "eip,routing")
 @XmlRootElement(name = "to")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class ToDefinition extends SendDefinition<ToDefinition> {
+public class ToDefinition extends SendDefinition<ToDefinition> implements CopyableProcessorDefinition {
 
     @XmlAttribute
     private String variableSend;
@@ -74,6 +74,13 @@ public class ToDefinition extends SendDefinition<ToDefinition> {
     public ToDefinition(EndpointProducerBuilder endpoint, ExchangePattern pattern) {
         this(endpoint);
         this.pattern = pattern.name();
+    }
+
+    ToDefinition(ToDefinition source) {
+        super(source);
+        this.variableSend = source.variableSend;
+        this.variableReceive = source.variableReceive;
+        this.pattern = source.pattern;
     }
 
     @Override
@@ -127,5 +134,9 @@ public class ToDefinition extends SendDefinition<ToDefinition> {
      */
     public void setVariableReceive(String variableReceive) {
         this.variableReceive = variableReceive;
+    }
+
+    public ToDefinition copy() {
+        return new ToDefinition(this);
     }
 }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ToDynamicDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ToDynamicDefinition.java
@@ -69,7 +69,7 @@ public class ToDynamicDefinition extends NoOutputDefinition<ToDynamicDefinition>
         this.uri = uri;
     }
 
-    ToDynamicDefinition(ToDynamicDefinition source) {
+    protected ToDynamicDefinition(ToDynamicDefinition source) {
         super(source);
         this.endpointProducerBuilder = source.endpointProducerBuilder;
         this.uri = source.uri;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ToDynamicDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ToDynamicDefinition.java
@@ -34,7 +34,7 @@ import org.apache.camel.spi.Metadata;
 @Metadata(label = "eip,routing")
 @XmlRootElement(name = "toD")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class ToDynamicDefinition extends NoOutputDefinition<ToDynamicDefinition> {
+public class ToDynamicDefinition extends NoOutputDefinition<ToDynamicDefinition> implements CopyableProcessorDefinition {
 
     @XmlTransient
     protected EndpointProducerBuilder endpointProducerBuilder;
@@ -67,6 +67,19 @@ public class ToDynamicDefinition extends NoOutputDefinition<ToDynamicDefinition>
 
     public ToDynamicDefinition(String uri) {
         this.uri = uri;
+    }
+
+    ToDynamicDefinition(ToDynamicDefinition source) {
+        super(source);
+        this.endpointProducerBuilder = source.endpointProducerBuilder;
+        this.uri = source.uri;
+        this.variableSend = source.variableSend;
+        this.variableReceive = source.variableReceive;
+        this.pattern = source.pattern;
+        this.cacheSize = source.cacheSize;
+        this.ignoreInvalidEndpoint = source.ignoreInvalidEndpoint;
+        this.allowOptimisedComponents = source.allowOptimisedComponents;
+        this.autoStartComponents = source.autoStartComponents;
     }
 
     @Override
@@ -314,5 +327,9 @@ public class ToDynamicDefinition extends NoOutputDefinition<ToDynamicDefinition>
 
     public void setAutoStartComponents(String autoStartComponents) {
         this.autoStartComponents = autoStartComponents;
+    }
+
+    public ToDynamicDefinition copy() {
+        return new ToDynamicDefinition(this);
     }
 }

--- a/core/camel-core/src/test/java/org/apache/camel/model/RouteTemplateDefinitionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/model/RouteTemplateDefinitionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.model;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.support.RoutePolicySupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class RouteTemplateDefinitionTest {
+
+    @Test
+    void testDeepCopyMutableProperties() {
+        RouteDefinition route = new RouteDefinition();
+        route.setTemplateParameters(Map.of("parameter", "parameterValue"));
+        route.setRouteProperties(List.of(new PropertyDefinition("property", "propertyValue")));
+        route.setRoutePolicies(List.of(new RoutePolicySupport() {
+        }));
+        route.setInput(new FromDefinition("direct://fromEndpoint"));
+        route.setOutputs(List.of(new ToDefinition("direct://toEndpoint"), new SetHeaderDefinition("header", "headerValue")));
+        RouteTemplateDefinition routeTemplate = new RouteTemplateDefinition();
+        routeTemplate.setRoute(route);
+
+        RouteDefinition routeCopy = routeTemplate.asRouteDefinition();
+
+        assertNotSame(route.getTemplateParameters(), routeCopy.getTemplateParameters());
+        assertEquals(route.getTemplateParameters(), routeCopy.getTemplateParameters());
+        assertNotSame(route.getRouteProperties(), routeCopy.getRouteProperties());
+        assertEquals(route.getRouteProperties(), routeCopy.getRouteProperties());
+        assertNotSame(route.getRoutePolicies(), routeCopy.getRoutePolicies());
+        assertEquals(route.getRoutePolicies(), routeCopy.getRoutePolicies());
+        assertNotSame(route.getInput(), routeCopy.getInput());
+        assertEquals(route.getInput().getUri(), routeCopy.getInput().getUri());
+        assertNotSame(route.getOutputs(), routeCopy.getOutputs());
+        assertEquals(2, routeCopy.getOutputs().size());
+        assertNotSame(route.getOutputs().get(0), routeCopy.getOutputs().get(0));
+        assertInstanceOf(ToDefinition.class, route.getOutputs().get(0));
+        assertInstanceOf(ToDefinition.class, routeCopy.getOutputs().get(0));
+        assertEquals(((ToDefinition) route.getOutputs().get(0)).getUri(),
+                ((ToDefinition) routeCopy.getOutputs().get(0)).getUri());
+        assertSame(route.getOutputs().get(1), routeCopy.getOutputs().get(1));
+    }
+}


### PR DESCRIPTION
CAMEL-20614: deep-copy output processors during instantiation of a route template

# Description

When multiple threads try to instantiate and send an exchange to the same kamelet in parallel, org.apache.camel.component.kamelet.KameletConsumerNotAvailableException may be thrown because the underlying RouteTemplateDefinition is shallow-copied and changes to the RouteDefinition are reflected in the RouteTemplateDefinition.

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

