### PR TITLE
pg-replication-slot FIX: Calling super.doStart() after initializing the consumer to avoid poll() being called before the Consumer is initialized

### DIFF
--- a/components/camel-pg-replication-slot/src/main/java/org/apache/camel/component/pg/replication/slot/PgReplicationSlotConsumer.java
+++ b/components/camel-pg-replication-slot/src/main/java/org/apache/camel/component/pg/replication/slot/PgReplicationSlotConsumer.java
@@ -62,14 +62,14 @@ public class PgReplicationSlotConsumer extends ScheduledPollConsumer {
 
     @Override
     protected void doStart() throws Exception {
-        super.doStart();
-
         this.connect();
 
         if (this.scheduledExecutor == null) {
             this.scheduledExecutor = this.getEndpoint().getCamelContext().getExecutorServiceManager()
                     .newSingleThreadScheduledExecutor(this, "PgReplicationStatusUpdateSender");
         }
+
+        super.doStart();
     }
 
     @Override


### PR DESCRIPTION
# Description

Calling `super.doStart()` before initializing the consumer might cause `poll()` being called before the consumer is ready. This can happen if `connect()` takes relatively long time.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

