### PR TITLE
CAMEL-20614: deep-copy enrich and poll-enrich processors during instantiation of a route template

### DIFF
--- a/core/camel-core-model/src/main/java/org/apache/camel/model/Copyable.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/Copyable.java
@@ -20,6 +20,6 @@ package org.apache.camel.model;
  * This interface is used to copy {@link ProcessorDefinition ProcessorDefinitions} during instantiation of a route
  * template.
  */
-interface CopyableProcessorDefinition {
+interface Copyable {
     ProcessorDefinition<?> copy();
 }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/EnrichDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/EnrichDefinition.java
@@ -34,7 +34,8 @@ import org.apache.camel.spi.Metadata;
 @Metadata(label = "eip,transformation")
 @XmlRootElement(name = "enrich")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class EnrichDefinition extends ExpressionNode implements AggregationStrategyAwareDefinition<EnrichDefinition> {
+public class EnrichDefinition extends ExpressionNode
+        implements AggregationStrategyAwareDefinition<EnrichDefinition>, CopyableProcessorDefinition {
 
     @XmlTransient
     private AggregationStrategy aggregationStrategyBean;
@@ -72,11 +73,26 @@ public class EnrichDefinition extends ExpressionNode implements AggregationStrat
     private String autoStartComponents;
 
     public EnrichDefinition() {
-        this(null);
+        this((AggregationStrategy) null);
     }
 
     public EnrichDefinition(AggregationStrategy aggregationStrategy) {
         this.aggregationStrategyBean = aggregationStrategy;
+    }
+
+    protected EnrichDefinition(EnrichDefinition source) {
+        this.aggregationStrategyBean = source.aggregationStrategyBean;
+        this.variableSend = source.variableSend;
+        this.variableReceive = source.variableReceive;
+        this.aggregationStrategy = source.aggregationStrategy;
+        this.aggregationStrategyMethodName = source.aggregationStrategyMethodName;
+        this.aggregationStrategyMethodAllowNull = source.aggregationStrategyMethodAllowNull;
+        this.aggregateOnException = source.aggregateOnException;
+        this.shareUnitOfWork = source.shareUnitOfWork;
+        this.cacheSize = source.cacheSize;
+        this.ignoreInvalidEndpoint = source.ignoreInvalidEndpoint;
+        this.allowOptimisedComponents = source.allowOptimisedComponents;
+        this.autoStartComponents = source.autoStartComponents;
     }
 
     @Override
@@ -378,5 +394,10 @@ public class EnrichDefinition extends ExpressionNode implements AggregationStrat
 
     public void setAutoStartComponents(String autoStartComponents) {
         this.autoStartComponents = autoStartComponents;
+    }
+
+    @Override
+    public EnrichDefinition copy() {
+        return new EnrichDefinition(this);
     }
 }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/EnrichDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/EnrichDefinition.java
@@ -35,7 +35,7 @@ import org.apache.camel.spi.Metadata;
 @XmlRootElement(name = "enrich")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class EnrichDefinition extends ExpressionNode
-        implements AggregationStrategyAwareDefinition<EnrichDefinition>, CopyableProcessorDefinition {
+        implements AggregationStrategyAwareDefinition<EnrichDefinition>, Copyable {
 
     @XmlTransient
     private AggregationStrategy aggregationStrategyBean;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ExpressionNode.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ExpressionNode.java
@@ -58,6 +58,11 @@ public abstract class ExpressionNode extends ProcessorDefinition<ExpressionNode>
         setPredicate(predicate);
     }
 
+    protected ExpressionNode(ExpressionNode source) {
+        super(source);
+        this.expression = source.expression;
+    }
+
     public ExpressionDefinition getExpression() {
         return expression;
     }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/PollEnrichDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/PollEnrichDefinition.java
@@ -35,7 +35,7 @@ import org.apache.camel.spi.Metadata;
 @XmlRootElement(name = "pollEnrich")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class PollEnrichDefinition extends ExpressionNode
-        implements AggregationStrategyAwareDefinition<PollEnrichDefinition>, CopyableProcessorDefinition {
+        implements AggregationStrategyAwareDefinition<PollEnrichDefinition>, Copyable {
 
     @XmlTransient
     private AggregationStrategy aggregationStrategyBean;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/PollEnrichDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/PollEnrichDefinition.java
@@ -34,7 +34,8 @@ import org.apache.camel.spi.Metadata;
 @Metadata(label = "eip,transformation")
 @XmlRootElement(name = "pollEnrich")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class PollEnrichDefinition extends ExpressionNode implements AggregationStrategyAwareDefinition<PollEnrichDefinition> {
+public class PollEnrichDefinition extends ExpressionNode
+        implements AggregationStrategyAwareDefinition<PollEnrichDefinition>, CopyableProcessorDefinition {
 
     @XmlTransient
     private AggregationStrategy aggregationStrategyBean;
@@ -72,6 +73,20 @@ public class PollEnrichDefinition extends ExpressionNode implements AggregationS
     public PollEnrichDefinition(AggregationStrategy aggregationStrategy, long timeout) {
         this.aggregationStrategyBean = aggregationStrategy;
         this.timeout = Long.toString(timeout);
+    }
+
+    protected PollEnrichDefinition(PollEnrichDefinition source) {
+        super(source);
+        this.aggregationStrategyBean = source.aggregationStrategyBean;
+        this.variableReceive = source.variableReceive;
+        this.aggregationStrategy = source.aggregationStrategy;
+        this.aggregationStrategyMethodName = source.aggregationStrategyMethodName;
+        this.aggregationStrategyMethodAllowNull = source.aggregationStrategyMethodAllowNull;
+        this.aggregateOnException = source.aggregateOnException;
+        this.timeout = source.timeout;
+        this.cacheSize = source.cacheSize;
+        this.ignoreInvalidEndpoint = source.ignoreInvalidEndpoint;
+        this.autoStartComponents = source.autoStartComponents;
     }
 
     @Override
@@ -357,5 +372,10 @@ public class PollEnrichDefinition extends ExpressionNode implements AggregationS
 
     public void setAutoStartComponents(String autoStartComponents) {
         this.autoStartComponents = autoStartComponents;
+    }
+
+    @Override
+    public PollEnrichDefinition copy() {
+        return new PollEnrichDefinition(this);
     }
 }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/RouteTemplateDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/RouteTemplateDefinition.java
@@ -450,8 +450,8 @@ public class RouteTemplateDefinition extends OptionalIdentifiedDefinition<RouteT
     private List<ProcessorDefinition<?>> copy(List<ProcessorDefinition<?>> outputs) {
         var copy = new ArrayList<ProcessorDefinition<?>>();
         for (var definition : outputs) {
-            if (definition instanceof CopyableProcessorDefinition copyable) {
-                copy.add(copyable.copy());
+            if (definition instanceof Copyable copyableDefinition) {
+                copy.add(copyableDefinition.copy());
             } else {
                 copy.add(definition);
             }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ToDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ToDefinition.java
@@ -33,7 +33,7 @@ import org.apache.camel.spi.Metadata;
 @Metadata(label = "eip,routing")
 @XmlRootElement(name = "to")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class ToDefinition extends SendDefinition<ToDefinition> implements CopyableProcessorDefinition {
+public class ToDefinition extends SendDefinition<ToDefinition> implements Copyable {
 
     @XmlAttribute
     private String variableSend;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ToDynamicDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ToDynamicDefinition.java
@@ -34,7 +34,7 @@ import org.apache.camel.spi.Metadata;
 @Metadata(label = "eip,routing")
 @XmlRootElement(name = "toD")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class ToDynamicDefinition extends NoOutputDefinition<ToDynamicDefinition> implements CopyableProcessorDefinition {
+public class ToDynamicDefinition extends NoOutputDefinition<ToDynamicDefinition> implements Copyable {
 
     @XmlTransient
     protected EndpointProducerBuilder endpointProducerBuilder;

--- a/core/camel-core/src/test/java/org/apache/camel/model/RouteTemplateDefinitionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/model/RouteTemplateDefinitionTest.java
@@ -34,10 +34,13 @@ class RouteTemplateDefinitionTest {
         RouteDefinition route = new RouteDefinition();
         route.setTemplateParameters(Map.of("parameter", "parameterValue"));
         route.setRouteProperties(List.of(new PropertyDefinition("property", "propertyValue")));
-        route.setRoutePolicies(List.of(new RoutePolicySupport() {
-        }));
+        route.setRoutePolicies(List.of(new RoutePolicySupport() {}));
         route.setInput(new FromDefinition("direct://fromEndpoint"));
-        route.setOutputs(List.of(new ToDefinition("direct://toEndpoint"), new SetHeaderDefinition("header", "headerValue")));
+        route.setOutputs(List.of(
+            new ToDefinition("direct://toEndpoint"),
+            new SetHeaderDefinition("header", "headerValue"),
+            new EnrichDefinition(),
+            new PollEnrichDefinition()));
         RouteTemplateDefinition routeTemplate = new RouteTemplateDefinition();
         routeTemplate.setRoute(route);
 

--- a/core/camel-core/src/test/java/org/apache/camel/model/RouteTemplateDefinitionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/model/RouteTemplateDefinitionTest.java
@@ -61,7 +61,8 @@ class RouteTemplateDefinitionTest {
         assertSame(route.getOutputs().get(1), routeCopy.getOutputs().get(3));
     }
 
-    private static final class CopyableProcessDefinition extends ProcessorDefinition<CopyableProcessDefinition> implements Copyable {
+    private static final class CopyableProcessDefinition extends ProcessorDefinition<CopyableProcessDefinition>
+            implements Copyable {
 
         public CopyableProcessDefinition() {
             setId(randomUUID().toString());

--- a/core/camel-core/src/test/java/org/apache/camel/model/RouteTemplateDefinitionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/model/RouteTemplateDefinitionTest.java
@@ -58,7 +58,7 @@ class RouteTemplateDefinitionTest {
         assertInstanceOf(CopyableProcessDefinition.class, routeCopy.getOutputs().get(0));
         assertNotSame(route.getOutputs().get(0), routeCopy.getOutputs().get(0));
         assertEquals(route.getOutputs().get(0).getId(), routeCopy.getOutputs().get(0).getId());
-        assertSame(route.getOutputs().get(1), routeCopy.getOutputs().get(3));
+        assertSame(route.getOutputs().get(1), routeCopy.getOutputs().get(1));
     }
 
     private static final class CopyableProcessDefinition extends ProcessorDefinition<CopyableProcessDefinition>


### PR DESCRIPTION
CAMEL-20614: deep-copy enrich and poll-enrich processors during instantiation of a route template

# Description

This pull request updates Enrich and PollEnrich to be deep-copied during instantiation of a route template as requested in the [comment](https://github.com/apache/camel/pull/13823#issuecomment-2063654951).

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

