### PR TITLE
CAMEL-20699, CAMEL-20691: Fix Azure ServiceBus header propagation

### DIFF
--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConfiguration.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConfiguration.java
@@ -31,7 +31,6 @@ import com.azure.messaging.servicebus.models.ServiceBusReceiveMode;
 import com.azure.messaging.servicebus.models.SubQueue;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spi.*;
-import org.apache.camel.support.DefaultHeaderFilterStrategy;
 
 import static org.apache.camel.component.azure.servicebus.CredentialType.CONNECTION_STRING;
 
@@ -59,7 +58,7 @@ public class ServiceBusConfiguration implements Cloneable, HeaderFilterStrategyA
     private AmqpTransportType amqpTransportType = AmqpTransportType.AMQP;
     @UriParam(label = "common",
               description = "To use a custom HeaderFilterStrategy to filter Service Bus application properties to and from Camel message headers.")
-    private HeaderFilterStrategy headerFilterStrategy = new DefaultHeaderFilterStrategy();
+    private HeaderFilterStrategy headerFilterStrategy = new ServiceBusHeaderFilterStrategy();
     @UriParam(label = "consumer", defaultValue = "receiveMessages")
     private ServiceBusConsumerOperationDefinition consumerOperation = ServiceBusConsumerOperationDefinition.receiveMessages;
     @UriParam(label = "consumer")

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
@@ -189,7 +189,7 @@ public class ServiceBusConsumer extends DefaultConsumer {
 
         // propagate headers
         final HeaderFilterStrategy headerFilterStrategy = getConfiguration().getHeaderFilterStrategy();
-        message.setHeaders(receivedMessage.getApplicationProperties().entrySet().stream()
+        message.getHeaders().putAll(receivedMessage.getApplicationProperties().entrySet().stream()
                 .filter(entry -> !headerFilterStrategy.applyFilterToExternalHeaders(entry.getKey(), entry.getValue(), exchange))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
 

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusHeaderFilterStrategy.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusHeaderFilterStrategy.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.azure.servicebus;
+
+import org.apache.camel.support.DefaultHeaderFilterStrategy;
+
+public class ServiceBusHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
+    public ServiceBusHeaderFilterStrategy() {
+        super();
+        initialise();
+    }
+
+    private void initialise() {
+        setOutFilterStartsWith("Camel", "camel", "org.apache.camel.");
+        setInFilterStartsWith("Camel", "camel", "org.apache.camel.");
+    }
+}


### PR DESCRIPTION
# Description

Fix propagation of Azure ServiceBus broker properties to the Camel Exchange.

Discovered whilst developing new integration tests for #13862.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes