### PR TITLE
CAMEL-20699: Fix Azure ServiceBus consumer broker property propagation

### DIFF
--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
@@ -189,7 +189,7 @@ public class ServiceBusConsumer extends DefaultConsumer {
 
         // propagate headers
         final HeaderFilterStrategy headerFilterStrategy = getConfiguration().getHeaderFilterStrategy();
-        message.setHeaders(receivedMessage.getApplicationProperties().entrySet().stream()
+        message.getHeaders().putAll(receivedMessage.getApplicationProperties().entrySet().stream()
                 .filter(entry -> !headerFilterStrategy.applyFilterToExternalHeaders(entry.getKey(), entry.getValue(), exchange))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
 


### PR DESCRIPTION
# Description

Fix propagation of Azure ServiceBus broker properties to the Camel Exchange.

Discovered whilst developing new integration tests for #13862.

Backport of #13872.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes