### PR TITLE
CAMEL-20708 added volatile keyword for double locking in JiraEndpoint

### DIFF
--- a/components/camel-jira/src/main/java/org/apache/camel/component/jira/JiraEndpoint.java
+++ b/components/camel-jira/src/main/java/org/apache/camel/component/jira/JiraEndpoint.java
@@ -95,7 +95,7 @@ public class JiraEndpoint extends DefaultEndpoint {
     @UriParam
     private JiraConfiguration configuration;
 
-    private transient JiraRestClient client;
+    private transient volatile JiraRestClient client;
 
     public JiraEndpoint(String uri, JiraComponent component, JiraConfiguration configuration) {
         super(uri, component);


### PR DESCRIPTION
CAMEL-20708 added volatile keyword for double locking in JiraEndpoint