### PR TITLE
CAMEL-20714 Added public no-arg constructor for SourceCache

### DIFF
--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/util/xml/SourceCache.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/util/xml/SourceCache.java
@@ -40,6 +40,10 @@ public final class SourceCache extends StringSource implements StreamCache {
         this.length = data.length();
     }
 
+    public SourceCache() {
+        throw new IllegalStateException();
+    }
+
     @Override
     public void reset() {
         // do nothing here


### PR DESCRIPTION
CAMEL-20714 Added public no-arg constructor for SourceCache
It throws an exception since I can't set a proper value to 
private final int length;