### PR TITLE
CAMEL-20705: fix non-atomic operations on volatile fields on the ScheduledPollConsumer

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/impl/ScheduledPollConsumerBackoffTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/ScheduledPollConsumerBackoffTest.java
@@ -45,7 +45,7 @@ public class ScheduledPollConsumerBackoffTest extends ContextTestSupport {
         consumer.run();
         consumer.run();
         consumer.run();
-        assertEquals(2, commits);
+        assertEquals(3, commits);
         // and now we poll again
         consumer.run();
         consumer.run();
@@ -55,9 +55,9 @@ public class ScheduledPollConsumerBackoffTest extends ContextTestSupport {
         consumer.run();
         consumer.run();
         consumer.run();
-        assertEquals(4, commits);
+        assertEquals(6, commits);
         consumer.run();
-        assertEquals(5, commits);
+        assertEquals(6, commits);
 
         consumer.stop();
     }
@@ -78,7 +78,7 @@ public class ScheduledPollConsumerBackoffTest extends ContextTestSupport {
         consumer.run();
         consumer.run();
         consumer.run();
-        assertEquals(3, errors);
+        assertEquals(4, errors);
         // and now we poll again
         consumer.run();
         consumer.run();
@@ -89,7 +89,7 @@ public class ScheduledPollConsumerBackoffTest extends ContextTestSupport {
         consumer.run();
         consumer.run();
         consumer.run();
-        assertEquals(6, errors);
+        assertEquals(8, errors);
 
         consumer.stop();
     }


### PR DESCRIPTION
I'd like a review on this one. 

What's the problem here: ScheduledPollConsumer does non-atomic operations on volatile fields. For instance: 

```
backoffCounter++
```

That's a non-atomic operation because it does more than one operation (i.e.: fetch, add, update). So when multiple threads are watching for this value, there is a risk they may see corrupted values (as they may see the memory contents half-way in the operation). 

This changes the code to use `AtomicInteger` and `AtomicLong` instead. 

It also adjusts a test that seemed to wait for an specific number of cycles in the run loop (which is not clear to me why those numbers where chosen, hence the request for the review) . It should fix the flakiness on the test, but I left it isolated for now.