### PR TITLE
chore(docs): Add Kaoto and Hawtio to Catalog page

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-catalog.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-catalog.adoc
@@ -28,6 +28,8 @@ The following tools uses the catalog in their editor:
 - https://marketplace.eclipse.org/content/language-support-apache-camel[Camel tooling for Eclipse]
 - https://marketplace.visualstudio.com/items?itemName=redhat.vscode-apache-camel[Camel tooling for VS Code]
 - https://marketplace.visualstudio.com/items?itemName=camel-karavan.karavan[Camel Karavan for VS Code]
+- https://marketplace.visualstudio.com/items?itemName=redhat.vscode-kaoto[Kaoto for VS Code]
+- https://hawt.io/[Hawtio]
 
 The xref:camel-report-maven-plugin.adoc[Camel Maven validation] plugin uses the catalog during validation of all the
 Camel endpoints found while scanning the source code.
@@ -58,4 +60,3 @@ org
 Each directory contains files with the information. Every Camel component is included
 as JSON schema files in the components directory. For example, the Timer component
 is included in the file timer.json.
-


### PR DESCRIPTION
# Description
Add Kaoto and Hawtio links to the [Camel Catalog website](https://camel.apache.org/manual/camel-catalog.html)

# Target
- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Apache Camel coding standards and style
- [X] I checked that each commit in the pull request has a meaningful subject line and body.
- [X] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes
