### PR TITLE
CAMEL-19522: camel-http replace Thread.sleep in tests

### DIFF
--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpConcurrentTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpConcurrentTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.http;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HttpConcurrentTest extends BaseHttpTest {
@@ -48,11 +50,7 @@ public class HttpConcurrentTest extends BaseHttpTest {
                 .setConnectionReuseStrategy(getConnectionReuseStrategy()).setResponseFactory(getHttpResponseFactory())
                 .setSslContext(getSSLContext())
                 .register("/", (request, response, context) -> {
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        // ignore
-                    }
+                    await().atMost(Duration.ofMillis(1000)).until(()->true);
                     response.setCode(HttpStatus.SC_OK);
                     response.setEntity(new StringEntity(Integer.toString(counter.incrementAndGet())));
                 }).create();

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpProducerRestartTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpProducerRestartTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.http;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HttpProducerRestartTest extends BaseHttpTest {
@@ -86,7 +88,8 @@ public class HttpProducerRestartTest extends BaseHttpTest {
         context.getRouteController().stopRoute("foo");
 
         // a little delay before starting again
-        Thread.sleep(1000);
+        await().atMost(Duration.ofMillis(1000)).until(()->true);
+
 
         context.getRouteController().startRoute("foo");
         out = template.requestBody("direct:start", "Hello World", String.class);

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpsTwoComponentsSslContextParametersGetTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpsTwoComponentsSslContextParametersGetTest.java
@@ -27,6 +27,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class HttpsTwoComponentsSslContextParametersGetTest extends BaseHttpsTest {
@@ -99,7 +102,8 @@ public class HttpsTwoComponentsSslContextParametersGetTest extends BaseHttpsTest
         context.start();
 
         // should be able to startup
-        Thread.sleep(500);
+        await().atMost(Duration.ofMillis(500)).until(()->true);
+
 
         context.stop();
     }

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/handler/DelayValidationHandler.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/handler/DelayValidationHandler.java
@@ -17,11 +17,14 @@
 package org.apache.camel.component.http.handler;
 
 import java.io.IOException;
+import java.time.Duration;
 
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.protocol.HttpContext;
+
+import static org.awaitility.Awaitility.await;
 
 public class DelayValidationHandler extends BasicValidationHandler {
 
@@ -38,11 +41,7 @@ public class DelayValidationHandler extends BasicValidationHandler {
             final ClassicHttpRequest request, final ClassicHttpResponse response,
             final HttpContext context)
             throws HttpException, IOException {
-        try {
-            Thread.sleep(delay);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
+        await().atMost(Duration.ofMillis(delay)).until(()->true);
 
         super.handle(request, response, context);
     }


### PR DESCRIPTION
Replaced occurences of Thread.sleep() with Awaitility. Also checked camel-http-common but it had no occurences