### PR TITLE
CAMEL-19524: camel-infinispan: replace Thread.sleep in tests

### DIFF
--- a/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/cluster/InfinispanEmbeddedClusteredMasterTest.java
+++ b/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/cluster/InfinispanEmbeddedClusteredMasterTest.java
@@ -22,6 +22,9 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.infinispan.manager.DefaultCacheManager;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import java.util.concurrent.TimeUnit;
 
 public class InfinispanEmbeddedClusteredMasterTest extends AbstractInfinispanEmbeddedClusteredTest {
     @Override
@@ -50,8 +53,8 @@ public class InfinispanEmbeddedClusteredMasterTest extends AbstractInfinispanEmb
 
             // Start the context after some random time so the startup order
             // changes for each test.
-            Thread.sleep(ThreadLocalRandom.current().nextInt(500));
-            context.start();
+            Awaitility.await().pollDelay(ThreadLocalRandom.current().nextInt(500), TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> Assertions.assertDoesNotThrow(context::start));
 
             contextLatch.await();
         }

--- a/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/cluster/InfinispanEmbeddedClusteredRoutePolicyFactoryTest.java
+++ b/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/cluster/InfinispanEmbeddedClusteredRoutePolicyFactoryTest.java
@@ -23,6 +23,9 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.cluster.ClusteredRoutePolicyFactory;
 import org.infinispan.manager.DefaultCacheManager;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import java.util.concurrent.TimeUnit;
 
 public class InfinispanEmbeddedClusteredRoutePolicyFactoryTest extends AbstractInfinispanEmbeddedClusteredTest {
     @Override
@@ -52,8 +55,8 @@ public class InfinispanEmbeddedClusteredRoutePolicyFactoryTest extends AbstractI
 
             // Start the context after some random time so the startup order
             // changes for each test.
-            Thread.sleep(ThreadLocalRandom.current().nextInt(500));
-            context.start();
+            Awaitility.await().pollDelay(ThreadLocalRandom.current().nextInt(500), TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> Assertions.assertDoesNotThrow(context::start));
 
             contextLatch.await();
         }

--- a/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/cluster/InfinispanEmbeddedClusteredRoutePolicyTest.java
+++ b/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/cluster/InfinispanEmbeddedClusteredRoutePolicyTest.java
@@ -23,6 +23,9 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.cluster.ClusteredRoutePolicy;
 import org.infinispan.manager.DefaultCacheManager;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import java.util.concurrent.TimeUnit;
 
 public class InfinispanEmbeddedClusteredRoutePolicyTest extends AbstractInfinispanEmbeddedClusteredTest {
     @Override
@@ -52,8 +55,8 @@ public class InfinispanEmbeddedClusteredRoutePolicyTest extends AbstractInfinisp
 
             // Start the context after some random time so the startup order
             // changes for each test.
-            Thread.sleep(ThreadLocalRandom.current().nextInt(500));
-            context.start();
+            Awaitility.await().pollDelay(ThreadLocalRandom.current().nextInt(500), TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> Assertions.assertDoesNotThrow(context::start));
 
             contextLatch.await();
         }

--- a/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/cluster/AbstractInfinispanRemoteClusteredIT.java
+++ b/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/cluster/AbstractInfinispanRemoteClusteredIT.java
@@ -42,6 +42,8 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
 
 import static org.apache.camel.component.infinispan.remote.cluster.InfinispanRemoteClusteredTestSupport.createCache;
 import static org.apache.camel.component.infinispan.remote.cluster.InfinispanRemoteClusteredTestSupport.createConfiguration;
@@ -135,8 +137,8 @@ public class AbstractInfinispanRemoteClusteredIT {
 
             // Start the context after some random time so the startup order
             // changes for each test.
-            Thread.sleep(ThreadLocalRandom.current().nextInt(500));
-            context.start();
+            Awaitility.await().pollDelay(ThreadLocalRandom.current().nextInt(500), TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> Assertions.assertDoesNotThrow(context::start));
 
             contextLatch.await();
         } catch (Exception e) {


### PR DESCRIPTION
Issue Link: https://issues.apache.org/jira/browse/CAMEL-19524