### PR TITLE
CAMEL-20724: camel-saxon - Fix xquery namespaces usage

### DIFF
--- a/components/camel-saxon/src/main/java/org/apache/camel/language/xquery/XQueryLanguage.java
+++ b/components/camel-saxon/src/main/java/org/apache/camel/language/xquery/XQueryLanguage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.language.xquery;
 
+import java.util.Map;
+
 import net.sf.saxon.Configuration;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Expression;
@@ -56,6 +58,10 @@ public class XQueryLanguage extends SingleInputTypedLanguageSupport implements P
         Class<?> clazz = property(Class.class, properties, 0, null);
         if (clazz != null) {
             builder.setResultType(clazz);
+        }
+        Map<String, String> ns = property(Map.class, properties, 2, null);
+        if (ns != null && !ns.isEmpty()) {
+            builder.setNamespaces(ns);
         }
         if (configuration != null) {
             builder.setConfiguration(configuration);

--- a/components/camel-saxon/src/test/java/org/apache/camel/builder/saxon/XQueryHeaderNameResultTypeAndNamespaceTest.java
+++ b/components/camel-saxon/src/test/java/org/apache/camel/builder/saxon/XQueryHeaderNameResultTypeAndNamespaceTest.java
@@ -32,6 +32,7 @@ public class XQueryHeaderNameResultTypeAndNamespaceTest extends CamelTestSupport
         MockEndpoint mock = getMockEndpoint("mock:55");
         mock.expectedBodiesReceived("body");
         mock.expectedHeaderReceived("cheeseDetails", "<number xmlns=\"http://acme.com/cheese\">55</number>");
+        mock.expectedHeaderReceived("numberExists", "true");
 
         template.sendBodyAndHeader("direct:in", "body", "cheeseDetails",
                 "<number xmlns=\"http://acme.com/cheese\">55</number>");
@@ -46,9 +47,11 @@ public class XQueryHeaderNameResultTypeAndNamespaceTest extends CamelTestSupport
                 Namespaces ns = new Namespaces("c", "http://acme.com/cheese");
                 var xq = expression().xquery().expression("/c:number = 55").namespaces(ns).resultType(Integer.class)
                         .source("header:cheeseDetails").end();
-
+                var xqExist = expression().xquery().expression("exists(/c:number)").namespaces(ns).resultType(String.class)
+                        .source("header:cheeseDetails").end();
                 from("direct:in").choice()
                         .when(xq)
+                            .setHeader("numberExists", xqExist)
                             .to("mock:55")
                         .otherwise()
                             .to("mock:other")

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/language/XQueryExpressionReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/language/XQueryExpressionReifier.java
@@ -48,9 +48,10 @@ public class XQueryExpressionReifier extends SingleInputTypedExpressionReifier<X
     }
 
     protected Object[] createProperties() {
-        Object[] properties = new Object[2];
+        Object[] properties = new Object[3];
         properties[0] = asResultType();
         properties[1] = parseString(definition.getSource());
+        properties[2] = definition.getNamespaces();
         return properties;
     }
 


### PR DESCRIPTION
# Description

Fixes xquery namespaces usage.
This is a regression starting from 4.4.0.
Should be also merged to 4.4.x, 4.5.x.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

