### PR TITLE
CAMEL-20732: fix parsing primitive array types in RestDefinition

### DIFF
--- a/core/camel-core-model/pom.xml
+++ b/core/camel-core-model/pom.xml
@@ -67,6 +67,13 @@
             <artifactId>camel-util</artifactId>
         </dependency>
 
+        <!-- testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/rest/RestDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/rest/RestDefinition.java
@@ -908,23 +908,17 @@ public class RestDefinition extends OptionalIdentifiedDefinition<RestDefinition>
         //
         // The VerbDefinition::setType and VerbDefinition::setOutType require
         // the class to be expressed as canonical with an optional [] to mark
-        // the type is an array but this i wrong as the canonical name can not
+        // the type is an array but this is wrong as the canonical name can not
         // be dynamically be loaded by the classloader thus this workaround
         // that for nested classes generates a class name that does not respect
         // any JLS convention.
-        //
-        // TODO: this probably need to be revisited
 
         String type;
 
-        if (!classType.isPrimitive()) {
-            if (classType.isArray()) {
-                type = StringHelper.between(classType.getName(), "[L", ";") + "[]";
-            } else {
-                type = classType.getName();
-            }
+        if (classType.isArray()) {
+            type = classType.getComponentType().getName() + "[]";
         } else {
-            type = classType.getCanonicalName();
+            type = classType.getName();
         }
 
         return type;

--- a/core/camel-core-model/src/test/java/org/apache/camel/model/rest/RestDefinitionTest.java
+++ b/core/camel-core-model/src/test/java/org/apache/camel/model/rest/RestDefinitionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.model.rest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RestDefinitionTest {
+
+    @Test
+    void typeClassTest() {
+        RestDefinition rest = new RestDefinition().get();
+        VerbDefinition verb = rest.getVerbs().get(0);
+
+        // Plain classes
+        rest.outType(String.class);
+        assertEquals(String.class, verb.getOutTypeClass());
+        assertEquals("java.lang.String", verb.getOutType());
+
+        rest.outType(RestDefinitionTest.class);
+        assertEquals(RestDefinitionTest.class, verb.getOutTypeClass());
+        assertEquals("org.apache.camel.model.rest.RestDefinitionTest", rest.getVerbs().get(0).getOutType());
+
+        // Nested classes (CAMEL-15199)
+        rest.outType(TestType.class);
+        assertEquals(TestType.class, verb.getOutTypeClass());
+        assertEquals("org.apache.camel.model.rest.RestDefinitionTest$TestType", rest.getVerbs().get(0).getOutType());
+
+        // Primitives
+        rest.outType(int.class);
+        assertEquals(int.class, verb.getOutTypeClass());
+        assertEquals("int", verb.getOutType());
+
+        // Object array
+        rest.outType(String[].class);
+        assertEquals(String[].class, verb.getOutTypeClass());
+        assertEquals("java.lang.String[]", verb.getOutType());
+
+        // Nested object array
+        rest.outType(TestType[].class);
+        assertEquals(TestType[].class, verb.getOutTypeClass());
+        assertEquals("org.apache.camel.model.rest.RestDefinitionTest$TestType[]", rest.getVerbs().get(0).getOutType());
+
+        // Primitive array (CAMEL-20732)
+        rest.outType(byte[].class);
+        assertEquals(byte[].class, verb.getOutTypeClass());
+        assertEquals("byte[]", verb.getOutType());
+    }
+
+    private static class TestType {
+        // empty class for testing nested types
+    }
+}


### PR DESCRIPTION
# Description

Generation of string representation for arrays relies on getName() as a workaround to properly support nested classes. However, this results in "null[]" for array of primitives.

```java
package my.example;

public class MyRoutes extends org.apache.camel.builder.RouteBuilder {
    @Override
    public void configure() throws Exception {
        rest()
            .get("/test")
                .outType(byte[].class)  // <-- this is the problematic argument
                .produces("application/octet-stream")
                .route()
                    .log("test me");
    }
} 
```

The problem is that `asTypeName(byte[].class)` returns `"null[]"` before this fix, because `byte[].class.getName()` equals `"[B"` and the logic is looking for `"[L...;"` only.

Rework (and simplify) the logic and introduce a unit test, so we can handle such types properly again.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

