### PR TITLE
Updated pom to skip build on Windows running on ARM

### DIFF
--- a/components/camel-salesforce/pom.xml
+++ b/components/camel-salesforce/pom.xml
@@ -32,12 +32,6 @@
     <name>Camel :: Salesforce :: Parent</name>
     <description>Camel Salesforce parent</description>
 
-    <modules>
-        <module>camel-salesforce-component</module>
-        <module>camel-salesforce-codegen</module>
-        <module>camel-salesforce-maven-plugin</module>
-    </modules>
-    
     <properties>
         <salesforce.component.root>${project.basedir}</salesforce.component.root>
 
@@ -50,4 +44,33 @@
         <skipITs>true</skipITs>
     </properties>
 
+    <profiles>
+        <!-- there is no gRPC library available for Windows on ARM so we need to skip building the Salesforce component -->
+        <profile>
+            <id>win-arm</id>
+            <activation>
+                <os>
+                    <arch>aarch64</arch>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <modules>
+                <module>camel-salesforce-maven-plugin</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>not-win-arm</id>
+            <activation>
+                <os>
+                    <arch>!aarch64</arch>
+                    <family>!windows</family>
+                </os>
+            </activation>
+            <modules>
+                <module>camel-salesforce-component</module>
+                <module>camel-salesforce-codegen</module>
+                <module>camel-salesforce-maven-plugin</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
# Description

The `camel-salesforce` component cannot build on Windows running on ARM because there is no gRPC library available. In order to build successfully on Windows/ARM, this PR disables the build on that environment.

In general, adding profiles is discouraged, but since there is no way to disable a module via properties, adding profiles to the `camel-salesforce` parent pom was the only way to make this work.

# Target

- [ x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [ x] I checked that each commit in the pull request has a meaningful subject line and body.

- [ x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

`mvn clean install -DskipTests` fails on Windows/ARM due to an error when building the documentation. That error probably requires a separate JIRA issue.


