### PR TITLE
Make EndpointRegistry extends Map<NormalizedEndpointUri, Endpoint>

### DIFF
--- a/components/camel-rest/src/main/java/org/apache/camel/component/rest/DefaultRestRegistry.java
+++ b/components/camel-rest/src/main/java/org/apache/camel/component/rest/DefaultRestRegistry.java
@@ -33,7 +33,7 @@ import org.apache.camel.Service;
 import org.apache.camel.ServiceStatus;
 import org.apache.camel.StatefulService;
 import org.apache.camel.StaticService;
-import org.apache.camel.ValueHolder;
+import org.apache.camel.spi.NormalizedEndpointUri;
 import org.apache.camel.spi.RestConfiguration;
 import org.apache.camel.spi.RestRegistry;
 import org.apache.camel.support.LifecycleStrategySupport;
@@ -76,8 +76,8 @@ public class DefaultRestRegistry extends ServiceSupport implements StaticService
         if (apiProducer == null) {
             Endpoint restApiEndpoint = null;
             Endpoint restEndpoint = null;
-            for (Map.Entry<? extends ValueHolder<String>, Endpoint> entry : camelContext.getEndpointRegistry().entrySet()) {
-                String uri = entry.getKey().get();
+            for (Map.Entry<NormalizedEndpointUri, Endpoint> entry : camelContext.getEndpointRegistry().entrySet()) {
+                String uri = entry.getKey().getUri();
                 if (uri.startsWith("rest-api:")) {
                     restApiEndpoint = entry.getValue();
                     break;

--- a/components/camel-stub/src/main/java/org/apache/camel/component/stub/StubComponent.java
+++ b/components/camel-stub/src/main/java/org/apache/camel/component/stub/StubComponent.java
@@ -26,7 +26,6 @@ import org.apache.camel.component.seda.BlockingQueueFactory;
 import org.apache.camel.component.seda.SedaComponent;
 import org.apache.camel.spi.EndpointRegistry;
 import org.apache.camel.spi.Metadata;
-import org.apache.camel.spi.NormalizedEndpointUri;
 import org.apache.camel.support.EndpointHelper;
 import org.apache.camel.support.NormalizedUri;
 
@@ -112,7 +111,7 @@ public class StubComponent extends SedaComponent {
         super.doInit();
 
         if (shadow) {
-            final EndpointRegistry<NormalizedEndpointUri> registry = getCamelContext().getEndpointRegistry();
+            final EndpointRegistry registry = getCamelContext().getEndpointRegistry();
             getCamelContext().getCamelContextExtension().registerEndpointCallback((uri, endpoint) -> {
                 boolean match = shadowPattern == null || EndpointHelper.matchEndpoint(getCamelContext(), uri, shadowPattern);
                 if (match) {

--- a/components/camel-stub/src/main/java/org/apache/camel/component/stub/StubComponent.java
+++ b/components/camel-stub/src/main/java/org/apache/camel/component/stub/StubComponent.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.seda.BlockingQueueFactory;
 import org.apache.camel.component.seda.SedaComponent;
 import org.apache.camel.spi.EndpointRegistry;
 import org.apache.camel.spi.Metadata;
+import org.apache.camel.spi.NormalizedEndpointUri;
 import org.apache.camel.support.EndpointHelper;
 import org.apache.camel.support.NormalizedUri;
 
@@ -111,7 +112,7 @@ public class StubComponent extends SedaComponent {
         super.doInit();
 
         if (shadow) {
-            final EndpointRegistry registry = getCamelContext().getEndpointRegistry();
+            final EndpointRegistry<NormalizedEndpointUri> registry = getCamelContext().getEndpointRegistry();
             getCamelContext().getCamelContextExtension().registerEndpointCallback((uri, endpoint) -> {
                 boolean match = shadowPattern == null || EndpointHelper.matchEndpoint(getCamelContext(), uri, shadowPattern);
                 if (match) {

--- a/core/camel-api/src/main/java/org/apache/camel/CamelContext.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelContext.java
@@ -37,7 +37,6 @@ import org.apache.camel.spi.LifecycleStrategy;
 import org.apache.camel.spi.ManagementNameStrategy;
 import org.apache.camel.spi.ManagementStrategy;
 import org.apache.camel.spi.MessageHistoryFactory;
-import org.apache.camel.spi.NormalizedEndpointUri;
 import org.apache.camel.spi.PropertiesComponent;
 import org.apache.camel.spi.Registry;
 import org.apache.camel.spi.RestConfiguration;
@@ -396,7 +395,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
     /**
      * Gets the {@link org.apache.camel.spi.EndpointRegistry}
      */
-    EndpointRegistry<NormalizedEndpointUri> getEndpointRegistry();
+    EndpointRegistry getEndpointRegistry();
 
     /**
      * Resolves the given name to an {@link Endpoint} of the specified type. If the name has a singleton endpoint

--- a/core/camel-api/src/main/java/org/apache/camel/CamelContext.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelContext.java
@@ -37,6 +37,7 @@ import org.apache.camel.spi.LifecycleStrategy;
 import org.apache.camel.spi.ManagementNameStrategy;
 import org.apache.camel.spi.ManagementStrategy;
 import org.apache.camel.spi.MessageHistoryFactory;
+import org.apache.camel.spi.NormalizedEndpointUri;
 import org.apache.camel.spi.PropertiesComponent;
 import org.apache.camel.spi.Registry;
 import org.apache.camel.spi.RestConfiguration;
@@ -395,7 +396,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
     /**
      * Gets the {@link org.apache.camel.spi.EndpointRegistry}
      */
-    EndpointRegistry<? extends ValueHolder<String>> getEndpointRegistry();
+    EndpointRegistry<NormalizedEndpointUri> getEndpointRegistry();
 
     /**
      * Resolves the given name to an {@link Endpoint} of the specified type. If the name has a singleton endpoint

--- a/core/camel-api/src/main/java/org/apache/camel/spi/EndpointRegistry.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/EndpointRegistry.java
@@ -36,10 +36,8 @@ import org.apache.camel.StaticService;
  * <p/>
  * The dynamic cache stores the endpoints that are created and used ad-hoc, such as from custom Java code that creates
  * new endpoints etc. The dynamic cache has an upper limit, that by default is 1000 entries.
- *
- * @param <K> endpoint key
  */
-public interface EndpointRegistry<K> extends Map<K, Endpoint>, StaticService {
+public interface EndpointRegistry extends Map<NormalizedEndpointUri, Endpoint>, StaticService {
 
     /**
      * Number of endpoints in the static registry.

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
@@ -267,7 +267,7 @@ public abstract class AbstractCamelContext extends BaseService
     private Boolean autowiredEnabled = Boolean.TRUE;
     private Long delay;
     private Map<String, String> globalOptions = new HashMap<>();
-    private EndpointRegistry<NormalizedEndpointUri> endpoints;
+    private EndpointRegistry endpoints;
     private RuntimeEndpointRegistry runtimeEndpointRegistry;
     private ShutdownRoute shutdownRoute = ShutdownRoute.Default;
     private ShutdownRunningTask shutdownRunningTask = ShutdownRunningTask.CompleteCurrentTaskOnly;
@@ -612,7 +612,7 @@ public abstract class AbstractCamelContext extends BaseService
     }
 
     @Override
-    public EndpointRegistry<NormalizedEndpointUri> getEndpointRegistry() {
+    public EndpointRegistry getEndpointRegistry() {
         return endpoints;
     }
 
@@ -4060,7 +4060,7 @@ public abstract class AbstractCamelContext extends BaseService
 
     protected abstract RestRegistryFactory createRestRegistryFactory();
 
-    protected abstract EndpointRegistry<NormalizedEndpointUri> createEndpointRegistry(
+    protected abstract EndpointRegistry createEndpointRegistry(
             Map<NormalizedEndpointUri, Endpoint> endpoints);
 
     protected abstract TransformerRegistry<TransformerKey> createTransformerRegistry();

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
@@ -133,6 +133,7 @@ import org.apache.camel.spi.ModelToXMLDumper;
 import org.apache.camel.spi.ModelToYAMLDumper;
 import org.apache.camel.spi.ModelineFactory;
 import org.apache.camel.spi.NodeIdFactory;
+import org.apache.camel.spi.NormalizedEndpointUri;
 import org.apache.camel.spi.PackageScanClassResolver;
 import org.apache.camel.spi.PackageScanResourceResolver;
 import org.apache.camel.spi.PeriodTaskResolver;
@@ -266,7 +267,7 @@ public abstract class AbstractCamelContext extends BaseService
     private Boolean autowiredEnabled = Boolean.TRUE;
     private Long delay;
     private Map<String, String> globalOptions = new HashMap<>();
-    private EndpointRegistry<NormalizedUri> endpoints;
+    private EndpointRegistry<NormalizedEndpointUri> endpoints;
     private RuntimeEndpointRegistry runtimeEndpointRegistry;
     private ShutdownRoute shutdownRoute = ShutdownRoute.Default;
     private ShutdownRunningTask shutdownRunningTask = ShutdownRunningTask.CompleteCurrentTaskOnly;
@@ -611,7 +612,7 @@ public abstract class AbstractCamelContext extends BaseService
     }
 
     @Override
-    public EndpointRegistry<NormalizedUri> getEndpointRegistry() {
+    public EndpointRegistry<NormalizedEndpointUri> getEndpointRegistry() {
         return endpoints;
     }
 
@@ -648,8 +649,8 @@ public abstract class AbstractCamelContext extends BaseService
     @Override
     public void removeEndpoint(Endpoint endpoint) {
         Endpoint oldEndpoint = null;
-        NormalizedUri oldKey = null;
-        for (Map.Entry<NormalizedUri, Endpoint> entry : endpoints.entrySet()) {
+        NormalizedEndpointUri oldKey = null;
+        for (Map.Entry<NormalizedEndpointUri, Endpoint> entry : endpoints.entrySet()) {
             if (endpoint == entry.getValue()) {
                 oldKey = entry.getKey();
                 oldEndpoint = endpoint;
@@ -701,8 +702,8 @@ public abstract class AbstractCamelContext extends BaseService
 
     private void tryMatchingEndpoints(String uri, Collection<Endpoint> answer) {
         Endpoint oldEndpoint;
-        List<NormalizedUri> toRemove = new ArrayList<>();
-        for (Map.Entry<NormalizedUri, Endpoint> entry : endpoints.entrySet()) {
+        List<NormalizedEndpointUri> toRemove = new ArrayList<>();
+        for (Map.Entry<NormalizedEndpointUri, Endpoint> entry : endpoints.entrySet()) {
             oldEndpoint = entry.getValue();
             if (EndpointHelper.matchEndpoint(this, oldEndpoint.getEndpointUri(), uri)) {
                 try {
@@ -714,7 +715,7 @@ public abstract class AbstractCamelContext extends BaseService
                 toRemove.add(entry.getKey());
             }
         }
-        for (NormalizedUri key : toRemove) {
+        for (NormalizedEndpointUri key : toRemove) {
             endpoints.remove(key);
         }
     }
@@ -1389,14 +1390,11 @@ public abstract class AbstractCamelContext extends BaseService
 
     private String doLoadResource(String resourceName, String path, String resourceType) throws IOException {
         final ClassResolver resolver = getClassResolver();
-        InputStream inputStream = resolver.loadResourceAsStream(path);
-        LOG.debug("Loading {} JSON Schema for: {} using class resolver: {} -> {}", resourceType, resourceName, resolver,
-                inputStream);
-        if (inputStream != null) {
-            try {
+        try (InputStream inputStream = resolver.loadResourceAsStream(path)) {
+            LOG.debug("Loading {} JSON Schema for: {} using class resolver: {} -> {}", resourceType, resourceName, resolver,
+                    inputStream);
+            if (inputStream != null) {
                 return IOHelper.loadText(inputStream);
-            } finally {
-                IOHelper.close(inputStream);
             }
         }
         return null;
@@ -1495,11 +1493,7 @@ public abstract class AbstractCamelContext extends BaseService
     public String getPojoBeanParameterJsonSchema(String beanName) throws IOException {
         String name = sanitizeFileName(beanName) + ".json";
         String path = "META-INF/services/org/apache/camel/bean/" + name;
-        String inputStream = doLoadResource(beanName, path, "bean");
-        if (inputStream != null) {
-            return inputStream;
-        }
-        return null;
+        return doLoadResource(beanName, path, "bean");
     }
 
     // Helper methods
@@ -4066,7 +4060,8 @@ public abstract class AbstractCamelContext extends BaseService
 
     protected abstract RestRegistryFactory createRestRegistryFactory();
 
-    protected abstract EndpointRegistry<NormalizedUri> createEndpointRegistry(Map<NormalizedUri, Endpoint> endpoints);
+    protected abstract EndpointRegistry<NormalizedEndpointUri> createEndpointRegistry(
+            Map<NormalizedEndpointUri, Endpoint> endpoints);
 
     protected abstract TransformerRegistry<TransformerKey> createTransformerRegistry();
 

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultEndpointRegistry.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultEndpointRegistry.java
@@ -29,7 +29,7 @@ import org.apache.camel.support.NormalizedUri;
  * Default implementation of {@link org.apache.camel.spi.EndpointRegistry}
  */
 public class DefaultEndpointRegistry extends AbstractDynamicRegistry<NormalizedEndpointUri, Endpoint>
-        implements EndpointRegistry<NormalizedEndpointUri> {
+        implements EndpointRegistry {
 
     public DefaultEndpointRegistry(CamelContext context) {
         super(context, CamelContextHelper.getMaximumEndpointCacheSize(context));

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultEndpointRegistry.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultEndpointRegistry.java
@@ -21,20 +21,21 @@ import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.spi.EndpointRegistry;
+import org.apache.camel.spi.NormalizedEndpointUri;
 import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.NormalizedUri;
 
 /**
  * Default implementation of {@link org.apache.camel.spi.EndpointRegistry}
  */
-public class DefaultEndpointRegistry extends AbstractDynamicRegistry<NormalizedUri, Endpoint>
-        implements EndpointRegistry<NormalizedUri> {
+public class DefaultEndpointRegistry extends AbstractDynamicRegistry<NormalizedEndpointUri, Endpoint>
+        implements EndpointRegistry<NormalizedEndpointUri> {
 
     public DefaultEndpointRegistry(CamelContext context) {
         super(context, CamelContextHelper.getMaximumEndpointCacheSize(context));
     }
 
-    public DefaultEndpointRegistry(CamelContext context, Map<NormalizedUri, Endpoint> endpoints) {
+    public DefaultEndpointRegistry(CamelContext context, Map<NormalizedEndpointUri, Endpoint> endpoints) {
         this(context);
         if (!context.isStarted()) {
             // optimize to put all into the static map as we are not started

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/ProvisionalEndpointRegistry.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/ProvisionalEndpointRegistry.java
@@ -34,7 +34,7 @@ import org.apache.camel.support.LRUCacheFactory;
  * Camel faster while {@link LRUCacheFactory} is warming up etc.
  */
 class ProvisionalEndpointRegistry extends HashMap<NormalizedEndpointUri, Endpoint>
-        implements EndpointRegistry<NormalizedEndpointUri> {
+        implements EndpointRegistry {
 
     @Override
     public void start() {

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/ProvisionalEndpointRegistry.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/ProvisionalEndpointRegistry.java
@@ -26,14 +26,15 @@ import java.util.Map;
 
 import org.apache.camel.Endpoint;
 import org.apache.camel.spi.EndpointRegistry;
+import org.apache.camel.spi.NormalizedEndpointUri;
 import org.apache.camel.support.LRUCacheFactory;
-import org.apache.camel.support.NormalizedUri;
 
 /**
  * A provisional (temporary) {@link EndpointRegistry} that is only used during startup of Apache Camel to make starting
  * Camel faster while {@link LRUCacheFactory} is warming up etc.
  */
-class ProvisionalEndpointRegistry extends HashMap<NormalizedUri, Endpoint> implements EndpointRegistry<NormalizedUri> {
+class ProvisionalEndpointRegistry extends HashMap<NormalizedEndpointUri, Endpoint>
+        implements EndpointRegistry<NormalizedEndpointUri> {
 
     @Override
     public void start() {
@@ -118,7 +119,7 @@ class ProvisionalEndpointRegistry extends HashMap<NormalizedUri, Endpoint> imple
         boolean done = false;
         while (!done) {
             try {
-                for (Entry<NormalizedUri, Endpoint> entry : entrySet()) {
+                for (Entry<NormalizedEndpointUri, Endpoint> entry : entrySet()) {
                     String k = entry.getKey().toString();
                     answer.put(k, entry.getValue());
                 }

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/SimpleCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/SimpleCamelContext.java
@@ -67,6 +67,7 @@ import org.apache.camel.spi.ModelToXMLDumper;
 import org.apache.camel.spi.ModelToYAMLDumper;
 import org.apache.camel.spi.ModelineFactory;
 import org.apache.camel.spi.NodeIdFactory;
+import org.apache.camel.spi.NormalizedEndpointUri;
 import org.apache.camel.spi.PackageScanClassResolver;
 import org.apache.camel.spi.PackageScanResourceResolver;
 import org.apache.camel.spi.PeriodTaskResolver;
@@ -94,7 +95,6 @@ import org.apache.camel.spi.ValidatorRegistry;
 import org.apache.camel.spi.VariableRepositoryFactory;
 import org.apache.camel.support.DefaultRegistry;
 import org.apache.camel.support.DefaultUuidGenerator;
-import org.apache.camel.support.NormalizedUri;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.ResolverHelper;
 import org.slf4j.Logger;
@@ -669,7 +669,7 @@ public class SimpleCamelContext extends AbstractCamelContext {
     }
 
     @Override
-    protected EndpointRegistry<NormalizedUri> createEndpointRegistry(Map<NormalizedUri, Endpoint> endpoints) {
+    protected EndpointRegistry<NormalizedEndpointUri> createEndpointRegistry(Map<NormalizedEndpointUri, Endpoint> endpoints) {
         return new DefaultEndpointRegistry(getCamelContextReference(), endpoints);
     }
 

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/SimpleCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/SimpleCamelContext.java
@@ -669,7 +669,7 @@ public class SimpleCamelContext extends AbstractCamelContext {
     }
 
     @Override
-    protected EndpointRegistry<NormalizedEndpointUri> createEndpointRegistry(Map<NormalizedEndpointUri, Endpoint> endpoints) {
+    protected EndpointRegistry createEndpointRegistry(Map<NormalizedEndpointUri, Endpoint> endpoints) {
         return new DefaultEndpointRegistry(getCamelContextReference(), endpoints);
     }
 

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/EndpointDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/EndpointDevConsole.java
@@ -46,7 +46,7 @@ public class EndpointDevConsole extends AbstractDevConsole {
         if (runtimeReg != null) {
             stats = runtimeReg.getEndpointStatistics();
         }
-        EndpointRegistry<?> reg = getCamelContext().getEndpointRegistry();
+        EndpointRegistry reg = getCamelContext().getEndpointRegistry();
         sb.append(
                 String.format("    Endpoints: %s (static: %s dynamic: %s)\n", reg.size(), reg.staticSize(), reg.dynamicSize()));
         sb.append(String.format("    Maximum Cache Size: %s\n", reg.getMaximumCacheSize()));
@@ -83,7 +83,7 @@ public class EndpointDevConsole extends AbstractDevConsole {
         if (runtimeReg != null) {
             stats = runtimeReg.getEndpointStatistics();
         }
-        EndpointRegistry<?> reg = getCamelContext().getEndpointRegistry();
+        EndpointRegistry reg = getCamelContext().getEndpointRegistry();
         root.put("size", reg.size());
         root.put("staticSize", reg.staticSize());
         root.put("dynamicSize", reg.dynamicSize());

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultEndpointRegistryTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultEndpointRegistryTest.java
@@ -29,7 +29,6 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.engine.DefaultEndpointRegistry;
 import org.apache.camel.impl.engine.SimpleCamelContext;
 import org.apache.camel.spi.EndpointRegistry;
-import org.apache.camel.spi.NormalizedEndpointUri;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -154,7 +153,7 @@ public class DefaultEndpointRegistryTest {
         context.start();
 
         ProducerTemplate producerTemplate = context.createProducerTemplate();
-        EndpointRegistry<NormalizedEndpointUri> endpointRegistry = context.getEndpointRegistry();
+        EndpointRegistry endpointRegistry = context.getEndpointRegistry();
 
         int nThreads = 4;
         ExecutorService executorService = Executors.newFixedThreadPool(nThreads);

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultEndpointRegistryTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultEndpointRegistryTest.java
@@ -29,7 +29,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.engine.DefaultEndpointRegistry;
 import org.apache.camel.impl.engine.SimpleCamelContext;
 import org.apache.camel.spi.EndpointRegistry;
-import org.apache.camel.support.NormalizedUri;
+import org.apache.camel.spi.NormalizedEndpointUri;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -154,7 +154,7 @@ public class DefaultEndpointRegistryTest {
         context.start();
 
         ProducerTemplate producerTemplate = context.createProducerTemplate();
-        EndpointRegistry<NormalizedUri> endpointRegistry = context.getEndpointRegistry();
+        EndpointRegistry<NormalizedEndpointUri> endpointRegistry = context.getEndpointRegistry();
 
         int nThreads = 4;
         ExecutorService executorService = Executors.newFixedThreadPool(nThreads);

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultCamelContextTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultCamelContextTest.java
@@ -35,10 +35,10 @@ import org.apache.camel.component.direct.DirectComponent;
 import org.apache.camel.component.log.LogComponent;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spi.EndpointRegistry;
+import org.apache.camel.spi.NormalizedEndpointUri;
 import org.apache.camel.spi.UuidGenerator;
 import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.DefaultUuidGenerator;
-import org.apache.camel.support.NormalizedUri;
 import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.URISupport;
 import org.junit.jupiter.api.Test;
@@ -425,7 +425,7 @@ public class DefaultCamelContextTest extends TestSupport {
         });
         ctx.start();
 
-        EndpointRegistry<NormalizedUri> endpoints = ctx.getEndpointRegistry();
+        EndpointRegistry<NormalizedEndpointUri> endpoints = ctx.getEndpointRegistry();
         Map<String, RouteService> routeServices = ctx.getRouteServices();
         Set<Endpoint> routeEndpoints = routeServices.get("rawRoute").gatherEndpoints();
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultCamelContextTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultCamelContextTest.java
@@ -35,7 +35,6 @@ import org.apache.camel.component.direct.DirectComponent;
 import org.apache.camel.component.log.LogComponent;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spi.EndpointRegistry;
-import org.apache.camel.spi.NormalizedEndpointUri;
 import org.apache.camel.spi.UuidGenerator;
 import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.DefaultUuidGenerator;
@@ -425,7 +424,7 @@ public class DefaultCamelContextTest extends TestSupport {
         });
         ctx.start();
 
-        EndpointRegistry<NormalizedEndpointUri> endpoints = ctx.getEndpointRegistry();
+        EndpointRegistry endpoints = ctx.getEndpointRegistry();
         Map<String, RouteService> routeServices = ctx.getRouteServices();
         Set<Endpoint> routeEndpoints = routeServices.get("rawRoute").gatherEndpoints();
 

--- a/core/camel-management/src/main/java/org/apache/camel/management/JmxManagementLifecycleStrategy.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/JmxManagementLifecycleStrategy.java
@@ -545,7 +545,7 @@ public class JmxManagementLifecycleStrategy extends ServiceSupport implements Li
             answer = new ManagedProducerCache(context, (ProducerCache) service);
         } else if (service instanceof ExchangeFactoryManager) {
             answer = new ManagedExchangeFactoryManager(context, (ExchangeFactoryManager) service);
-        } else if (service instanceof EndpointRegistry<?> endpointRegistry) {
+        } else if (service instanceof EndpointRegistry endpointRegistry) {
             answer = new ManagedEndpointRegistry(context, endpointRegistry);
         } else if (service instanceof BeanIntrospection) {
             answer = new ManagedBeanIntrospection(context, (BeanIntrospection) service);

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedEndpointRegistry.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedEndpointRegistry.java
@@ -36,10 +36,10 @@ import org.apache.camel.util.URISupport;
 
 @ManagedResource(description = "Managed EndpointRegistry")
 public class ManagedEndpointRegistry extends ManagedService implements ManagedEndpointRegistryMBean {
-    private final EndpointRegistry<?> endpointRegistry;
+    private final EndpointRegistry endpointRegistry;
     private boolean sanitize;
 
-    public ManagedEndpointRegistry(CamelContext context, EndpointRegistry<?> endpointRegistry) {
+    public ManagedEndpointRegistry(CamelContext context, EndpointRegistry endpointRegistry) {
         super(context, endpointRegistry);
         this.endpointRegistry = endpointRegistry;
     }
@@ -50,7 +50,7 @@ public class ManagedEndpointRegistry extends ManagedService implements ManagedEn
         sanitize = strategy.getManagementAgent().getMask() != null ? strategy.getManagementAgent().getMask() : false;
     }
 
-    public EndpointRegistry<?> getEndpointRegistry() {
+    public EndpointRegistry getEndpointRegistry() {
         return endpointRegistry;
     }
 

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedRuntimeEndpointRegistry.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedRuntimeEndpointRegistry.java
@@ -96,7 +96,7 @@ public class ManagedRuntimeEndpointRegistry extends ManagedService implements Ma
         try {
             TabularData answer = new TabularDataSupport(CamelOpenMBeanTypes.listRuntimeEndpointsTabularType());
 
-            EndpointRegistry<?> staticRegistry = getContext().getEndpointRegistry();
+            EndpointRegistry staticRegistry = getContext().getEndpointRegistry();
             int index = 0;
 
             for (RuntimeEndpointRegistry.Statistic stat : registry.getEndpointStatistics()) {


### PR DESCRIPTION
Change the `CamelContext.getEndpointRegistry()` to return an `EndpointRegistry<NormalizedEndpointUri>` instead of an `EndpointRegistry<? extends ValueHolder<String>>`.  

This is a small incompatible change.