### PR TITLE
Updated dependency coordinates for artifacts moved elsewhere

### DIFF
--- a/components/camel-bonita/pom.xml
+++ b/components/camel-bonita/pom.xml
@@ -70,7 +70,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <version>${wiremock-version}</version>
             <scope>test</scope>

--- a/components/camel-debezium/camel-debezium-mysql/pom.xml
+++ b/components/camel-debezium/camel-debezium-mysql/pom.xml
@@ -45,15 +45,15 @@
             <version>${debezium-version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>mysql</groupId>
-                    <artifactId>mysql-connector-java</artifactId>
+                    <groupId>com.mysql</groupId>
+                    <artifactId>mysql-connector-j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <version>${debezium-mysql-connector-version}</version>
             <scope>provided</scope>
         </dependency>

--- a/components/camel-debezium/camel-debezium-mysql/src/main/docs/debezium-mysql-component.adoc
+++ b/components/camel-debezium/camel-debezium-mysql/src/main/docs/debezium-mysql-component.adoc
@@ -51,13 +51,13 @@ debezium-mysql:name[?options]
 
 [NOTE]
 ====
-Due to licensing issues, you will need to add the dependency for `mysql-connector-java` if you are using MySQL connector, add the following to your POM file:
+Due to licensing issues, you will need to add the dependency for `mysql-connector-j` if you are using MySQL connector, add the following to your POM file:
 
 [source,xml]
 ----
 <dependency>
-    <groupId>mysql</groupId>
-    <artifactId>mysql-connector-java</artifactId>
+    <groupId>com.mysql</groupId>
+    <artifactId>mysql-connector-j</artifactId>
     <version>8.0.15</version>
 </dependency>
 ----

--- a/components/camel-ftp/pom.xml
+++ b/components/camel-ftp/pom.xml
@@ -101,7 +101,7 @@
 
         <!-- for testing sftp through http proxy -->
         <dependency>
-            <groupId>xyz.rogfam</groupId>
+            <groupId>io.github.littleproxy</groupId>
             <artifactId>littleproxy</artifactId>
             <version>${littleproxy-version}</version>
             <scope>test</scope>

--- a/components/camel-oaipmh/pom.xml
+++ b/components/camel-oaipmh/pom.xml
@@ -61,7 +61,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <version>${wiremock-version}</version>
             <scope>test</scope>

--- a/components/camel-openstack/pom.xml
+++ b/components/camel-openstack/pom.xml
@@ -78,7 +78,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <version>${wiremock-version}</version>
             <scope>test</scope>

--- a/components/camel-platform-http-vertx/pom.xml
+++ b/components/camel-platform-http-vertx/pom.xml
@@ -107,7 +107,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <version>${wiremock-version}</version>
             <scope>test</scope>

--- a/components/camel-pubnub/pom.xml
+++ b/components/camel-pubnub/pom.xml
@@ -77,7 +77,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <version>${wiremock-version}</version>
             <scope>test</scope>

--- a/components/camel-rest-openapi/pom.xml
+++ b/components/camel-rest-openapi/pom.xml
@@ -133,7 +133,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <!-- TODO: needs code changes to update -->
             <version>3.0.1</version>

--- a/components/camel-salesforce/camel-salesforce-maven-plugin/pom.xml
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/pom.xml
@@ -162,7 +162,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>xyz.rogfam</groupId>
+            <groupId>io.github.littleproxy</groupId>
             <artifactId>littleproxy</artifactId>
             <version>${littleproxy-version}</version>
             <scope>test</scope>

--- a/components/camel-thymeleaf/pom.xml
+++ b/components/camel-thymeleaf/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <version>${wiremock-version}</version>
             <scope>test</scope>

--- a/components/camel-xchange/pom.xml
+++ b/components/camel-xchange/pom.xml
@@ -63,7 +63,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <version>${wiremock-version}</version>
             <scope>test</scope>

--- a/dsl/camel-kamelet-main/src/main/resources/camel-main-known-dependencies.properties
+++ b/dsl/camel-kamelet-main/src/main/resources/camel-main-known-dependencies.properties
@@ -17,7 +17,7 @@
 
 com.amazon.redshift.jdbc.Driver = com.amazon.redshift:redshift-jdbc42:2.1.0.26
 com.microsoft.sqlserver.jdbc.SQLServerDriver = com.microsoft.sqlserver:mssql-jdbc:11.2.3.jre17
-com.mysql.cj.jdbc.Driver = mysql:mysql-connector-java:8.0.33
+com.mysql.cj.jdbc.Driver = com.mysql:mysql-connector-j:8.0.33
 net.sf.saxon.xpath.XPathFactoryImpl = camel:saxon
 org.springframework.amqp.rabbit.connection.CachingConnectionFactory = camel:spring-rabbitmq
 org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory = org.apache.activemq:artemis-jakarta-client-all:2.33.0


### PR DESCRIPTION
# Description

The following artefact moved:

```
mysql:mysql-connector-java -> com.mysql:mysql-connector-j 
xyz.rogfam:littleproxy -> io.github.littleproxy:littleproxy 
com.github.tomakehurst:wiremock -> org.wiremock:wiremock
```

Updated the dependencies coordinates accordingly, kept same versions

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

