### PR TITLE
Fix HTML route coverage report generation on Windows machines

### DIFF
--- a/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
+++ b/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/RouteCoverageMojo.java
@@ -374,7 +374,7 @@ public class RouteCoverageMojo extends AbstractMojo {
             String out = processor.generateReport(project, xmlPath, htmlPath);
             getLog().info(out);
         } catch (Exception e) {
-            getLog().warn("Error generating HTML route coverage reports " + e.getMessage());
+            getLog().warn("Error generating HTML route coverage reports due " + e.getMessage());
         }
     }
 

--- a/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/htmlxlsx/process/CoverageResultsProcessor.java
+++ b/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/htmlxlsx/process/CoverageResultsProcessor.java
@@ -72,7 +72,7 @@ public class CoverageResultsProcessor {
 
         parseAllTestResults(xmlPath);
 
-        if (testResults.size() > 0) {
+        if (!testResults.isEmpty()) {
 
             gatherBestRouteCoverages();
 

--- a/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/htmlxlsx/process/FileUtil.java
+++ b/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/htmlxlsx/process/FileUtil.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 
 public class FileUtil {
@@ -100,6 +101,6 @@ public class FileUtil {
 
     public String readFileFromClassPath(String path) throws IOException {
 
-        return IOUtils.resourceToString(path, Charset.defaultCharset(), FileUtil.class.getClassLoader());
+        return IOUtils.resourceToString(FilenameUtils.separatorsToUnix(path), Charset.defaultCharset(), FileUtil.class.getClassLoader());
     }
 }


### PR DESCRIPTION
# Description

Fix HTML route coverage report generation on Windows machines

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

