### PR TITLE
(chores) camel-jms: fix misconfigured Artemis broker instance

### DIFF
--- a/components/camel-jms/src/test/resources/org/apache/camel/component/jms/integration/spring/tx/security/artemis-security.xml
+++ b/components/camel-jms/src/test/resources/org/apache/camel/component/jms/integration/spring/tx/security/artemis-security.xml
@@ -26,10 +26,18 @@
 		<bindings-directory>target/tx/data/bindings</bindings-directory>
 		<paging-directory>target/tx/data/paging</paging-directory>
 		<large-messages-directory>target/tx/data/large-messages</large-messages-directory>
+		<max-disk-usage>98</max-disk-usage>
+
 
 		<acceptors>
 			<acceptor name="in-vm">vm://999</acceptor>
 		</acceptors>
+
+		<address-settings>
+			<address-setting match="#">
+				<address-full-policy>FAIL</address-full-policy>
+			</address-setting>
+		</address-settings>
 
 		<security-settings>
 			<!-- any user can have full control of generic topics -->


### PR DESCRIPTION
The lack of address policy may cause the JMS tests to hang indefinitely if there is insufficient disk space available on the host running the tests