### PR TITLE
(chores) camel-file: avoid using a restricted directory

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerExpressionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerExpressionTest.java
@@ -73,11 +73,11 @@ public class FileProducerExpressionTest extends ContextTestSupport {
 
     @Test
     public void testProducerComplexByExpression() {
-        String expression = "../filelanguageinbox/myfile-${bean:myguidgenerator.guid}-${date:now:yyyyMMdd}.txt";
+        String expression = "target/filelanguageinbox/myfile-${bean:myguidgenerator.guid}-${date:now:yyyyMMdd}.txt";
         template.sendBody(fileUri("?jailStartingDirectory=false&fileName=" + expression), "Hello World");
 
         String date = new SimpleDateFormat("yyyyMMdd").format(new Date());
-        assertFileExists(testFile("../filelanguageinbox/myfile-123-" + date + ".txt"));
+        assertFileExists(testFile("target/filelanguageinbox/myfile-123-" + date + ".txt"));
     }
 
     @Test


### PR DESCRIPTION
Try to avoid using a path that may have different permissions, which tends to lead to failures in CI environments