### PR TITLE
(chores) camel-cxf: code cleanup

### DIFF
--- a/components/camel-cxf/camel-cxf-common/src/main/java/org/apache/camel/component/cxf/common/CxfPayload.java
+++ b/components/camel-cxf/camel-cxf-common/src/main/java/org/apache/camel/component/cxf/common/CxfPayload.java
@@ -38,7 +38,7 @@ import org.apache.cxf.staxutils.StaxUtils;
 public class CxfPayload<T> {
 
     private List<Source> body;
-    private List<T> headers;
+    private final List<T> headers;
     private Map<String, String> nsMap;
 
     public CxfPayload(List<T> headers, List<Source> body, Map<String, String> nsMap) {

--- a/components/camel-cxf/camel-cxf-common/src/main/java/org/apache/camel/component/cxf/converter/CxfConverter.java
+++ b/components/camel-cxf/camel-cxf-common/src/main/java/org/apache/camel/component/cxf/converter/CxfConverter.java
@@ -138,36 +138,41 @@ public final class CxfConverter {
             }
 
             // try to turn the first array element into the object that we want
-            for (Object embedded : list) {
-                if (embedded != null) {
-                    if (type.isInstance(embedded)) {
-                        return type.cast(embedded);
-                    } else {
-                        TypeConverter tc = registry.lookup(type, embedded.getClass());
-                        if (tc == null) {
-                            // maybe one of its interface fits
-                            for (Class<?> clazz : embedded.getClass().getInterfaces()) {
-                                tc = registry.lookup(type, clazz);
-                                if (tc != null) {
-                                    break;
-                                }
-                            }
-                        }
-                        if (tc != null) {
-                            Object result = tc.convertTo(type, exchange, embedded);
-                            if (result != null) {
-                                return (T) result;
-                            }
-                            // there is no suitable result will be return
-                            break;
-                        }
-                    }
-                }
-            }
-            // return void to indicate its not possible to convert at this time
-            return (T) MISS_VALUE;
+            return tryCoerceFirstArrayElement(type, exchange, registry, list);
         }
 
         return null;
+    }
+
+    public static <T> T tryCoerceFirstArrayElement(
+            Class<T> type, Exchange exchange, TypeConverterRegistry registry, MessageContentsList list) {
+        for (Object embedded : list) {
+            if (embedded != null) {
+                if (type.isInstance(embedded)) {
+                    return type.cast(embedded);
+                } else {
+                    TypeConverter tc = registry.lookup(type, embedded.getClass());
+                    if (tc == null) {
+                        // maybe one of its interfaces fits
+                        for (Class<?> clazz : embedded.getClass().getInterfaces()) {
+                            tc = registry.lookup(type, clazz);
+                            if (tc != null) {
+                                break;
+                            }
+                        }
+                    }
+                    if (tc != null) {
+                        Object result = tc.convertTo(type, exchange, embedded);
+                        if (result != null) {
+                            return (T) result;
+                        }
+                        // there is no suitable result will be return
+                        break;
+                    }
+                }
+            }
+        }
+        // return void to indicate its not possible to convert at this time
+        return (T) MISS_VALUE;
     }
 }

--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CamelResourceProvider.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CamelResourceProvider.java
@@ -24,7 +24,7 @@ import org.apache.cxf.message.Message;
 
 public class CamelResourceProvider implements ResourceProvider {
     // Using the dynamical proxy to provide the instance of client to invoke
-    private Class<?> clazz;
+    private final Class<?> clazz;
     private ResourceProvider provider;
 
     public CamelResourceProvider(Class<?> clazz) {

--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsEndpoint.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsEndpoint.java
@@ -374,28 +374,40 @@ public class CxfRsEndpoint extends DefaultEndpoint implements HeaderFilterStrate
         }
 
         if (getProperties() != null) {
-            if (factory.getProperties() != null) {
-                // add to existing properties
-                factory.getProperties().putAll(getProperties());
-            } else {
-                factory.setProperties(getProperties());
-            }
-            LOG.debug("JAXRS FactoryBean: {} added properties: {}", factory, getProperties());
+            setupProperties(factory);
         }
 
         if (isLoggingFeatureEnabled()) {
-            LoggingFeature loggingFeature = new LoggingFeature();
-            if (getLoggingSizeLimit() >= -1) {
-                loggingFeature.setLimit(getLoggingSizeLimit());
-            }
-            factory.getFeatures().add(loggingFeature);
+            setupLoggingFeature(factory);
         }
         if (this.isSkipFaultLogging()) {
-            if (factory.getProperties() == null) {
-                factory.setProperties(new HashMap<>());
-            }
-            factory.getProperties().put(FaultListener.class.getName(), new NullFaultListener());
+            setupSkipFaultLogging(factory);
         }
+    }
+
+    private void setupProperties(AbstractJAXRSFactoryBean factory) {
+        if (factory.getProperties() != null) {
+            // add to existing properties
+            factory.getProperties().putAll(getProperties());
+        } else {
+            factory.setProperties(getProperties());
+        }
+        LOG.debug("JAXRS FactoryBean: {} added properties: {}", factory, getProperties());
+    }
+
+    private void setupLoggingFeature(AbstractJAXRSFactoryBean factory) {
+        LoggingFeature loggingFeature = new LoggingFeature();
+        if (getLoggingSizeLimit() >= -1) {
+            loggingFeature.setLimit(getLoggingSizeLimit());
+        }
+        factory.getFeatures().add(loggingFeature);
+    }
+
+    private static void setupSkipFaultLogging(AbstractJAXRSFactoryBean factory) {
+        if (factory.getProperties() == null) {
+            factory.setProperties(new HashMap<>());
+        }
+        factory.getProperties().put(FaultListener.class.getName(), new NullFaultListener());
     }
 
     protected JAXRSServerFactoryBean newJAXRSServerFactoryBean() {

--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/DataFormatProvider.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/DataFormatProvider.java
@@ -37,7 +37,7 @@ import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 
 public class DataFormatProvider<T> implements MessageBodyWriter<T>, MessageBodyReader<T> {
 
-    private Map<String, DataFormat> formats = new HashMap<>();
+    private final Map<String, DataFormat> formats = new HashMap<>();
 
     @Override
     public boolean isReadable(Class<?> cls, Type type, Annotation[] anns, MediaType mt) {

--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/DefaultCxfRsBinding.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/DefaultCxfRsBinding.java
@@ -89,51 +89,59 @@ public class DefaultCxfRsBinding implements CxfRsBinding, HeaderFilterStrategyAw
 
         Object o = response.getBody();
         if (!(o instanceof Response)) {
-            //not a JAX-RS Response object, we need to set the headers from the Camel values
-
-            if (response.getHeader(CxfConstants.PROTOCOL_HEADERS) != null) {
-                Map<String, Object> headers
-                        = CastUtils.cast((Map<?, ?>) response.getHeader(CxfConstants.PROTOCOL_HEADERS));
-                if (!ObjectHelper.isEmpty(cxfExchange) && !ObjectHelper.isEmpty(cxfExchange.getOutMessage())) {
-                    cxfExchange.getOutMessage().putIfAbsent(CxfConstants.PROTOCOL_HEADERS,
-                            new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
-                }
-                final Map<String, List<String>> cxfHeaders = CastUtils
-                        .cast((Map<?, ?>) cxfExchange.getOutMessage().get(CxfConstants.PROTOCOL_HEADERS));
-
-                for (Map.Entry<String, Object> ent : headers.entrySet()) {
-                    List<String> v;
-                    if (ent.getValue() instanceof List) {
-                        v = CastUtils.cast((List<?>) ent.getValue());
-                    } else {
-                        v = Arrays.asList(ent.getValue().toString());
-                    }
-                    cxfHeaders.put(ent.getKey(), v);
-                }
-            }
-
-            if (response.getHeader(CxfConstants.HTTP_RESPONSE_CODE) != null
-                    && !cxfExchange.containsKey(org.apache.cxf.message.Message.RESPONSE_CODE)) {
-                cxfExchange.put(org.apache.cxf.message.Message.RESPONSE_CODE,
-                        response.getHeader(CxfConstants.HTTP_RESPONSE_CODE, Integer.class));
-            }
-            if (response.getHeader(CxfConstants.CONTENT_TYPE) != null
-                    && !cxfExchange.containsKey(org.apache.cxf.message.Message.CONTENT_TYPE)) {
-                if (!ObjectHelper.isEmpty(cxfExchange) && !ObjectHelper.isEmpty(cxfExchange.getOutMessage())) {
-                    cxfExchange.getOutMessage().putIfAbsent(CxfConstants.PROTOCOL_HEADERS,
-                            new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
-                }
-                final Map<String, List<String>> cxfHeaders = CastUtils
-                        .cast((Map<?, ?>) cxfExchange.getOutMessage().get(CxfConstants.PROTOCOL_HEADERS));
-
-                if (!cxfHeaders.containsKey(CxfConstants.CONTENT_TYPE)) {
-                    List<String> a = Arrays.asList((String) response.getHeader(CxfConstants.CONTENT_TYPE));
-                    cxfHeaders.put(CxfConstants.CONTENT_TYPE, a);
-                    cxfExchange.getOutMessage().put(CxfConstants.CONTENT_TYPE, response.getHeader(CxfConstants.CONTENT_TYPE));
-                }
-            }
+            populateViaResponse(cxfExchange, response);
         }
         return o;
+    }
+
+    private static void populateViaResponse(org.apache.cxf.message.Exchange cxfExchange, Message response) {
+        //not a JAX-RS Response object, we need to set the headers from the Camel values
+
+        if (response.getHeader(CxfConstants.PROTOCOL_HEADERS) != null) {
+            setProtocolHeaders(cxfExchange, response);
+        }
+
+        if (response.getHeader(CxfConstants.HTTP_RESPONSE_CODE) != null
+                && !cxfExchange.containsKey(org.apache.cxf.message.Message.RESPONSE_CODE)) {
+            cxfExchange.put(org.apache.cxf.message.Message.RESPONSE_CODE,
+                    response.getHeader(CxfConstants.HTTP_RESPONSE_CODE, Integer.class));
+        }
+        if (response.getHeader(CxfConstants.CONTENT_TYPE) != null
+                && !cxfExchange.containsKey(org.apache.cxf.message.Message.CONTENT_TYPE)) {
+            if (!ObjectHelper.isEmpty(cxfExchange) && !ObjectHelper.isEmpty(cxfExchange.getOutMessage())) {
+                cxfExchange.getOutMessage().putIfAbsent(CxfConstants.PROTOCOL_HEADERS,
+                        new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+            }
+            final Map<String, List<String>> cxfHeaders = CastUtils
+                    .cast((Map<?, ?>) cxfExchange.getOutMessage().get(CxfConstants.PROTOCOL_HEADERS));
+
+            if (!cxfHeaders.containsKey(CxfConstants.CONTENT_TYPE)) {
+                List<String> a = Arrays.asList((String) response.getHeader(CxfConstants.CONTENT_TYPE));
+                cxfHeaders.put(CxfConstants.CONTENT_TYPE, a);
+                cxfExchange.getOutMessage().put(CxfConstants.CONTENT_TYPE, response.getHeader(CxfConstants.CONTENT_TYPE));
+            }
+        }
+    }
+
+    private static void setProtocolHeaders(org.apache.cxf.message.Exchange cxfExchange, Message response) {
+        Map<String, Object> headers
+                = CastUtils.cast((Map<?, ?>) response.getHeader(CxfConstants.PROTOCOL_HEADERS));
+        if (!ObjectHelper.isEmpty(cxfExchange) && !ObjectHelper.isEmpty(cxfExchange.getOutMessage())) {
+            cxfExchange.getOutMessage().putIfAbsent(CxfConstants.PROTOCOL_HEADERS,
+                    new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+        }
+        final Map<String, List<String>> cxfHeaders = CastUtils
+                .cast((Map<?, ?>) cxfExchange.getOutMessage().get(CxfConstants.PROTOCOL_HEADERS));
+
+        for (Map.Entry<String, Object> ent : headers.entrySet()) {
+            List<String> v;
+            if (ent.getValue() instanceof List) {
+                v = CastUtils.cast((List<?>) ent.getValue());
+            } else {
+                v = Arrays.asList(ent.getValue().toString());
+            }
+            cxfHeaders.put(ent.getKey(), v);
+        }
     }
 
     @Override

--- a/components/camel-cxf/camel-cxf-rest/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsStreamCacheTest.java
+++ b/components/camel-cxf/camel-cxf-rest/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsStreamCacheTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.cxf.jaxrs;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.cxf.common.CXFTestSupport;
@@ -61,7 +63,7 @@ public class CxfRsStreamCacheTest extends CamelTestSupport {
                         .process(exchange -> {
                             // respond with OK
                             CachedOutputStream cos = new CachedOutputStream(exchange);
-                            cos.write(RESPONSE.getBytes("UTF-8"));
+                            cos.write(RESPONSE.getBytes(StandardCharsets.UTF_8));
                             cos.close();
                             exchange.getMessage().setBody(cos.newStreamCache());
 

--- a/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/feature/AbstractDataFormatFeature.java
+++ b/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/feature/AbstractDataFormatFeature.java
@@ -50,26 +50,38 @@ public abstract class AbstractDataFormatFeature extends AbstractFeature {
     protected void removeInterceptorWhichIsOutThePhases(
             List<Interceptor<? extends Message>> interceptors, String[] phaseNames, Set<String> needToBeKept) {
         for (Interceptor<? extends Message> i : interceptors) {
-            boolean outside = false;
-            if (i instanceof PhaseInterceptor) {
-                PhaseInterceptor<? extends Message> p = (PhaseInterceptor<? extends Message>) i;
-                for (String phaseName : phaseNames) {
-                    if (p.getPhase().equals(phaseName)) {
-                        outside = true;
-                        break;
-                    }
-                }
-                if (!outside) {
-                    // To support the old API
-                    if (needToBeKept == null) {
-                        getLogger().info("removing the interceptor {}", p);
-                        interceptors.remove(p);
-                    } else if (!needToBeKept.contains(p.getClass().getName())) {
-                        getLogger().info("removing the interceptor {}", p);
-                        interceptors.remove(p);
-                    }
+            tryRemove(interceptors, phaseNames, needToBeKept, i);
+        }
+    }
+
+    private void tryRemove(
+            List<Interceptor<? extends Message>> interceptors, String[] phaseNames, Set<String> needToBeKept,
+            Interceptor<? extends Message> i) {
+        boolean outside = false;
+        if (i instanceof PhaseInterceptor) {
+            PhaseInterceptor<? extends Message> p = (PhaseInterceptor<? extends Message>) i;
+            for (String phaseName : phaseNames) {
+                if (p.getPhase().equals(phaseName)) {
+                    outside = true;
+                    break;
                 }
             }
+            if (!outside) {
+                doRemove(interceptors, needToBeKept, p);
+            }
+        }
+    }
+
+    private void doRemove(
+            List<Interceptor<? extends Message>> interceptors, Set<String> needToBeKept,
+            PhaseInterceptor<? extends Message> p) {
+        // To support the old API
+        if (needToBeKept == null) {
+            getLogger().info("removing the interceptor {}", p);
+            interceptors.remove(p);
+        } else if (!needToBeKept.contains(p.getClass().getName())) {
+            getLogger().info("removing the interceptor {}", p);
+            interceptors.remove(p);
         }
     }
 

--- a/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfConsumerStreamCacheTest.java
+++ b/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfConsumerStreamCacheTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.cxf.jaxws;
 
+import java.nio.charset.StandardCharsets;
+
 import org.w3c.dom.Node;
 
 import org.apache.camel.Exchange;
@@ -68,7 +70,7 @@ public class CxfConsumerStreamCacheTest extends CamelTestSupport {
                         Node node = in.getBody(Node.class);
                         assertNotNull(node);
                         CachedOutputStream cos = new CachedOutputStream(exchange);
-                        cos.write(RESPONSE.getBytes("UTF-8"));
+                        cos.write(RESPONSE.getBytes(StandardCharsets.UTF_8));
                         cos.close();
                         exchange.getMessage().setBody(cos.newStreamCache());
 

--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfDispatchMessageTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfDispatchMessageTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.cxf;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.w3c.dom.Document;
 
@@ -87,7 +88,7 @@ public class CxfDispatchMessageTest extends CxfDispatchTestSupport {
         String payloadstr = String.format(form, name);
         InputStream message = null;
         try {
-            message = new ByteArrayInputStream(payloadstr.getBytes("utf-8"));
+            message = new ByteArrayInputStream(payloadstr.getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {
             // ignore and let it fail
         }

--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfDispatchPayloadTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfDispatchPayloadTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.cxf;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -93,7 +94,7 @@ public class CxfDispatchPayloadTest extends CxfDispatchTestSupport {
         CxfPayload<T> payload = null;
         try {
             Document doc = getDocumentBuilderFactory().newDocumentBuilder()
-                    .parse(new ByteArrayInputStream(payloadstr.getBytes("utf-8")));
+                    .parse(new ByteArrayInputStream(payloadstr.getBytes(StandardCharsets.UTF_8)));
             payload = CxfPayloadConverter.documentToCxfPayload(doc, exchange);
         } catch (Exception e) {
             // ignore and let it fail

--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/mtom/CxfJavaMtomProducerPayloadTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/mtom/CxfJavaMtomProducerPayloadTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.cxf.mtom;
 
 import java.awt.Image;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import jakarta.xml.ws.Holder;
@@ -44,7 +45,7 @@ public class CxfJavaMtomProducerPayloadTest extends CxfMtomConsumerTest {
             return;
         }
 
-        final Holder<byte[]> photo = new Holder<>("RequestFromCXF".getBytes("UTF-8"));
+        final Holder<byte[]> photo = new Holder<>("RequestFromCXF".getBytes(StandardCharsets.UTF_8));
         final Holder<Image> image = new Holder<>(getImage("/java.jpg"));
 
         Exchange exchange = context.createProducerTemplate().send(MTOM_ENDPOINT_URI_MTOM_ENABLE, new Processor() {
@@ -66,7 +67,7 @@ public class CxfJavaMtomProducerPayloadTest extends CxfMtomConsumerTest {
         final Holder<byte[]> responsePhoto = (Holder<byte[]>) parameter.get(1);
         assertNotNull(responsePhoto.value, "The photo should not be null");
         assertEquals("ResponseFromCamel",
-                new String(responsePhoto.value, "UTF-8"), "Should get the right response");
+                new String(responsePhoto.value, StandardCharsets.UTF_8), "Should get the right response");
 
         final Holder<Image> responseImage = (Holder<Image>) parameter.get(2);
         assertNotNull(responseImage.value, "We should get the image here");

--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomConsumerTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomConsumerTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.cxf.mtom;
 
 import java.awt.Image;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import jakarta.xml.ws.BindingProvider;
@@ -74,8 +75,8 @@ public class CxfMtomConsumerTest extends CamelTestSupport {
                         Holder<byte[]> photo = (Holder<byte[]>) parameter.get(0);
                         assertNotNull(photo.value, "The photo should not be null");
                         assertEquals("RequestFromCXF",
-                                new String(photo.value, "UTF-8"), "Should get the right request");
-                        photo.value = "ResponseFromCamel".getBytes("UTF-8");
+                                new String(photo.value, StandardCharsets.UTF_8), "Should get the right request");
+                        photo.value = "ResponseFromCamel".getBytes(StandardCharsets.UTF_8);
                         Holder<Image> image = (Holder<Image>) parameter.get(1);
                         assertNotNull(image.value, "We should get the image here");
                         // set the holder message back
@@ -114,7 +115,7 @@ public class CxfMtomConsumerTest extends CamelTestSupport {
             return;
         }
 
-        Holder<byte[]> photo = new Holder<>("RequestFromCXF".getBytes("UTF-8"));
+        Holder<byte[]> photo = new Holder<>("RequestFromCXF".getBytes(StandardCharsets.UTF_8));
         Holder<Image> image = new Holder<>(getImage("/java.jpg"));
 
         Hello port = getPort();
@@ -124,7 +125,7 @@ public class CxfMtomConsumerTest extends CamelTestSupport {
 
         port.detail(photo, image);
 
-        assertEquals("ResponseFromCamel", new String(photo.value, "UTF-8"));
+        assertEquals("ResponseFromCamel", new String(photo.value, StandardCharsets.UTF_8));
         assertNotNull(image.value);
 
     }

--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomProducerPayloadModeTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomProducerPayloadModeTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.cxf.mtom;
 import java.awt.image.BufferedImage;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -157,7 +158,7 @@ public class CxfMtomProducerPayloadModeTest {
 
     // CXF encoding the XOP reference since 3.0.1
     private String decodingReference(String reference) throws UnsupportedEncodingException {
-        return java.net.URLDecoder.decode(reference, "UTF-8");
+        return java.net.URLDecoder.decode(reference, StandardCharsets.UTF_8);
     }
 
     protected boolean isMtomEnabled() {

--- a/components/camel-cxf/camel-cxf-spring-transport/src/test/java/org/apache/camel/component/cxf/transport/CamelDestinationTest.java
+++ b/components/camel-cxf/camel-cxf-spring-transport/src/test/java/org/apache/camel/component/cxf/transport/CamelDestinationTest.java
@@ -153,7 +153,7 @@ public class CamelDestinationTest extends CamelTransportTestSupport {
 
     private void verifyReceivedMessage(Message inMessage, String content) throws IOException {
         InputStream bis = inMessage.getContent(InputStream.class);
-        byte bytes[] = new byte[bis.available()];
+        byte[] bytes = new byte[bis.available()];
         bis.read(bytes);
         String reponse = new String(bytes);
         assertEquals(content, reponse, "The reponse date should be equals");

--- a/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/CamelConduit.java
+++ b/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/CamelConduit.java
@@ -44,12 +44,12 @@ public class CamelConduit extends AbstractConduit implements Configurable {
     private static final java.util.logging.Logger JUL_LOG = LogUtils.getL7dLogger(CamelConduit.class);
 
     private CamelContext camelContext;
-    private EndpointInfo endpointInfo;
+    private final EndpointInfo endpointInfo;
     private String targetCamelEndpointUri;
-    private Producer producer;
+    private final Producer producer;
     private ProducerTemplate camelTemplate;
-    private Bus bus;
-    private HeaderFilterStrategy headerFilterStrategy;
+    private final Bus bus;
+    private final HeaderFilterStrategy headerFilterStrategy;
 
     public CamelConduit(CamelContext context, Bus b, EndpointInfo endpointInfo) {
         this(context, b, endpointInfo, null);

--- a/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/CamelDestination.java
+++ b/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/CamelDestination.java
@@ -62,7 +62,7 @@ public class CamelDestination extends AbstractDestination implements Configurabl
     String camelDestinationUri;
 
     private Endpoint destinationEndpoint;
-    private HeaderFilterStrategy headerFilterStrategy;
+    private final HeaderFilterStrategy headerFilterStrategy;
     private boolean checkException;
 
     public CamelDestination(CamelContext camelContext, Bus bus, ConduitInitiator ci, EndpointInfo info) {
@@ -270,7 +270,7 @@ public class CamelDestination extends AbstractDestination implements Configurabl
      * Receives a response from CXF and forwards it to the camel route the request came in from
      */
     private class CamelOutputStream extends CachedOutputStream {
-        private Message outMessage;
+        private final Message outMessage;
 
         CamelOutputStream(Message m) {
             outMessage = m;

--- a/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/CamelOutputStream.java
+++ b/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/CamelOutputStream.java
@@ -45,10 +45,10 @@ class CamelOutputStream extends CachedOutputStream {
      */
     private final Message outMessage;
     private boolean isOneWay;
-    private String targetCamelEndpointUri;
-    private Producer producer;
-    private HeaderFilterStrategy headerFilterStrategy;
-    private MessageObserver observer;
+    private final String targetCamelEndpointUri;
+    private final Producer producer;
+    private final HeaderFilterStrategy headerFilterStrategy;
+    private final MessageObserver observer;
     private boolean hasLoggedAsyncWarning;
 
     CamelOutputStream(String targetCamelEndpointUri, Producer producer,

--- a/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/CamelTransportFactory.java
+++ b/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/CamelTransportFactory.java
@@ -165,26 +165,34 @@ public class CamelTransportFactory extends AbstractTransportFactory
         }
         DestinationFactoryManager dfm = bus.getExtension(DestinationFactoryManager.class);
         if (null != dfm && getTransportIds() != null) {
-            for (String ns : getTransportIds()) {
-                try {
-                    if (dfm.getDestinationFactory(ns) == this) {
-                        dfm.deregisterDestinationFactory(ns);
-                    }
-                } catch (BusException e) {
-                    //ignore
-                }
-            }
+            unregisterDestinationFactories(dfm);
         }
         ConduitInitiatorManager cim = bus.getExtension(ConduitInitiatorManager.class);
         if (cim != null && getTransportIds() != null) {
-            for (String ns : getTransportIds()) {
-                try {
-                    if (cim.getConduitInitiator(ns) == this) {
-                        cim.deregisterConduitInitiator(ns);
-                    }
-                } catch (BusException e) {
-                    //ignore
+            unregisterConduitInitiators(cim);
+        }
+    }
+
+    private void unregisterConduitInitiators(ConduitInitiatorManager cim) {
+        for (String ns : getTransportIds()) {
+            try {
+                if (cim.getConduitInitiator(ns) == this) {
+                    cim.deregisterConduitInitiator(ns);
                 }
+            } catch (BusException e) {
+                //ignore
+            }
+        }
+    }
+
+    private void unregisterDestinationFactories(DestinationFactoryManager dfm) {
+        for (String ns : getTransportIds()) {
+            try {
+                if (dfm.getDestinationFactory(ns) == this) {
+                    dfm.deregisterDestinationFactory(ns);
+                }
+            } catch (BusException e) {
+                //ignore
             }
         }
     }

--- a/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/header/CxfHeaderFilterStrategy.java
+++ b/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/header/CxfHeaderFilterStrategy.java
@@ -130,7 +130,7 @@ public class CxfHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
             messageHeaderfilter.filter(direction, (List<Header>) value);
         } catch (Exception t) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Failed to cast value to Header<List> due to {}", t.toString(), t);
+                LOG.debug("Failed to cast value to Header<List> due to {}", t.getMessage(), t);
             }
         }
 


### PR DESCRIPTION
- break large and complex methods
- use final when possible
- use Java-style array declaration
- use charset constants
- fix logging