### PR TITLE
CAMEL-20763: camel-support Handle special characters in REST templates

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/RestConsumerContextPathMatcher.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/RestConsumerContextPathMatcher.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
  */
 public final class RestConsumerContextPathMatcher {
 
+    private static final Pattern CONSUMER_PATH_PARAMETER_PATTERN = Pattern.compile("([^{]*)(\\{.*?\\})([^{]*)");
     private static final Map<String, Pattern> PATH_PATTERN = new ConcurrentHashMap<>();
 
     private RestConsumerContextPathMatcher() {
@@ -242,9 +243,14 @@ public final class RestConsumerContextPathMatcher {
      * @param consumerPath a consumer path
      */
     public static void register(String consumerPath) {
+        // Remove hyphens and underscores from parameter names
+        // as these are not supported in regex named group names
+        String regex = prepareConsumerPathRegex(consumerPath);
+
         // Convert URI template to a regex pattern
-        String regex = consumerPath
+        regex = regex
                 .replace("/", "\\/")
+                .replace("-", "\\-")
                 .replace("{", "(?<")
                 .replace("}", ">[^\\/]+)");
 
@@ -392,6 +398,26 @@ public final class RestConsumerContextPathMatcher {
         Matcher matcher = pattern.matcher(requestPath);
 
         return matcher.matches();
+    }
+
+    /**
+     * Removes any hyphens or underscores from parameter names to create valid java regex named group names
+     *
+     * @param  consumerPath
+     * @return
+     */
+    private static String prepareConsumerPathRegex(String consumerPath) {
+        Matcher m = CONSUMER_PATH_PARAMETER_PATTERN.matcher(consumerPath);
+        StringBuilder regexBuilder = new StringBuilder();
+        while (m.find()) {
+            m.appendReplacement(regexBuilder, m.group(1) + m.group(2).replaceAll("[\\_\\-]", "") + m.group(3));
+        }
+        // No matches so return the original path
+        if (regexBuilder.isEmpty()) {
+            return consumerPath;
+        } else {
+            return regexBuilder.toString();
+        }
     }
 
 }


### PR DESCRIPTION
# Description

Ensure that any hypens or underscores in parameters in REST templates are removed before being parsed into a regular expression

The code will remove (using a regular expression match) any hyphens or underscores in REST template parameter names.  This is required as the parameter name are parsed into regular expression named groups which support only letters and numbers as group names.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

https://issues.apache.org/jira/browse/CAMEL-20763

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes
