### PR TITLE
Make incremental-build action generic

### DIFF
--- a/.github/actions/incremental-build/action.yaml
+++ b/.github/actions/incremental-build/action.yaml
@@ -31,16 +31,20 @@ inputs:
     description: 'Flag indicating whether the installation of mvnd should be skipped'
     required: false
     default: 'false'
+  github-repo:
+    description: 'The GitHub repository name (example, apache/camel)'
+    required: false
+    default: 'apache/camel'
 runs:
   using: "composite"
   steps:
     - id: install-mvnd
-      uses: ./.github/actions/install-mvnd
+      uses: apache/camel/.github/actions/install-mvnd
       with:
         dry-run: ${{ inputs.skip-mvnd-install }}
     - name: maven build
       shell: bash
-      run: ${{ github.action_path }}/incremental-build.sh ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd ${{ inputs.mode }} ${{ inputs.pr-id }}
+      run: ${{ github.action_path }}/incremental-build.sh ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd ${{ inputs.mode }} ${{ inputs.pr-id }} ${{ inputs.github-repo }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
     - name: archive logs


### PR DESCRIPTION
Make incremental-build action generic in order to be reused in camel-spring-boot repository