### PR TITLE
Various code cleanups

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/ExtendedCamelContext.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExtendedCamelContext.java
@@ -441,7 +441,10 @@ public interface ExtendedCamelContext {
      * Danger!!! This will dispose the route model from the {@link CamelContext} which is used for lightweight mode.
      * This means afterwards no new routes can be dynamically added. Any operations on the
      * org.apache.camel.model.ModelCamelContext will return null or be a noop operation.
+     *
+     * @deprecated noop, do not use
      */
+    @Deprecated
     void disposeModel();
 
     /**

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
@@ -4085,6 +4085,7 @@ public abstract class AbstractCamelContext extends BaseService
 
     public abstract Processor createErrorHandler(Route route, Processor processor) throws Exception;
 
+    @Deprecated
     public abstract void disposeModel();
 
     public abstract String getTestExcludeRoutes();

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultCamelContextExtension.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultCamelContextExtension.java
@@ -950,7 +950,6 @@ class DefaultCamelContextExtension implements ExtendedCamelContext {
 
     @Override
     public void disposeModel() {
-        camelContext.disposeModel();
     }
 
     @Override

--- a/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -105,7 +105,7 @@ public class DefaultCamelContext extends SimpleCamelContext implements ModelCame
     private static final Logger LOG = LoggerFactory.getLogger(DefaultCamelContext.class);
     private static final UuidGenerator UUID = new SimpleUuidGenerator();
 
-    private Model model = new DefaultModel(this);
+    private final Model model = new DefaultModel(this);
 
     /**
      * Creates the {@link ModelCamelContext} using {@link org.apache.camel.support.DefaultRegistry} as registry.
@@ -229,12 +229,6 @@ public class DefaultCamelContext extends SimpleCamelContext implements ModelCame
             resolver.addFilter(new InvertingPackageScanFilter(new AssignableToPackageScanFilter(excludedClasses)));
         }
         return resolver;
-    }
-
-    @Override
-    public void disposeModel() {
-        LOG.debug("Disposing Model on CamelContext");
-        model = null;
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/component/AbstractApiEndpoint.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/component/AbstractApiEndpoint.java
@@ -74,7 +74,7 @@ public abstract class AbstractApiEndpoint<E extends ApiName, T>
     private List<ApiMethod> candidates;
 
     // cached Executor service
-    private ExecutorService executorService;
+    private volatile ExecutorService executorService;
 
     // cached property names and values
     private Set<String> endpointPropertyNames;
@@ -337,13 +337,14 @@ public abstract class AbstractApiEndpoint<E extends ApiName, T>
     }
 
     public final ExecutorService getExecutorService() {
-        if (this.executorService == null) {
-            // synchronize on class to avoid creating duplicate class level executors
-            synchronized (getClass()) {
-                this.executorService = getExecutorService(getClass(), getCamelContext(), getThreadProfileName());
+        if (executorService == null) {
+            synchronized (this) {
+                if (executorService == null) {
+                    executorService = getExecutorService(getClass(), getCamelContext(), getThreadProfileName());
+                }
             }
         }
-        return this.executorService;
+        return executorService;
     }
 
     /**

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/idempotent/MemoryIdempotentRepository.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/idempotent/MemoryIdempotentRepository.java
@@ -44,6 +44,7 @@ public class MemoryIdempotentRepository extends ServiceSupport implements Idempo
     private static final int MAX_CACHE_SIZE = 1000;
 
     private Map<String, Object> cache;
+    private final Object cacheAndStoreLock = new Object();
 
     @Metadata(description = "Maximum elements that can be stored in-memory", defaultValue = "" + MAX_CACHE_SIZE)
     private int cacheSize;
@@ -88,7 +89,7 @@ public class MemoryIdempotentRepository extends ServiceSupport implements Idempo
     @Override
     @ManagedOperation(description = "Adds the key to the store")
     public boolean add(String key) {
-        synchronized (cache) {
+        synchronized (cacheAndStoreLock) {
             if (cache.containsKey(key)) {
                 return false;
             } else {
@@ -101,7 +102,7 @@ public class MemoryIdempotentRepository extends ServiceSupport implements Idempo
     @Override
     @ManagedOperation(description = "Does the store contain the given key")
     public boolean contains(String key) {
-        synchronized (cache) {
+        synchronized (cacheAndStoreLock) {
             return cache.containsKey(key);
         }
     }
@@ -109,7 +110,7 @@ public class MemoryIdempotentRepository extends ServiceSupport implements Idempo
     @Override
     @ManagedOperation(description = "Remove the key from the store")
     public boolean remove(String key) {
-        synchronized (cache) {
+        synchronized (cacheAndStoreLock) {
             return cache.remove(key) != null;
         }
     }
@@ -123,7 +124,7 @@ public class MemoryIdempotentRepository extends ServiceSupport implements Idempo
     @Override
     @ManagedOperation(description = "Clear the store")
     public void clear() {
-        synchronized (cache) {
+        synchronized (cacheAndStoreLock) {
             cache.clear();
         }
     }

--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -50,6 +50,7 @@ public final class URISupport {
     // Match any key-value pair in the URI query string whose key contains
     // "passphrase" or "password" or secret key (case-insensitive).
     // First capture group is the key, second is the value.
+    @SuppressWarnings("RegExpUnnecessaryNonCapturingGroup")
     private static final Pattern ALL_SECRETS = Pattern.compile(
             "([?&][^=]*(?:" + SensitiveUtils.getSensitivePattern() + ")[^=]*)=(RAW(([{][^}]*[}])|([(][^)]*[)]))|[^&]*)",
             Pattern.CASE_INSENSITIVE);


### PR DESCRIPTION
- **Make model field final in DefaultCamelContext, deprecate the disposeModel method which was used with the lightweight mode**
- **Fix wrong synchronization pattern**
- **Do not synchronize on non final fields**
- **Remove unwanted warning for regex**
