### PR TITLE
Fix multicast iterator to be lazy again

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
@@ -313,7 +313,7 @@ public class MulticastProcessor extends AsyncProcessorSupport
             pairs = createProcessorExchangePairs(exchange);
             if (pairs instanceof Collection) {
                 pairs = ((Collection<ProcessorExchangePair>) pairs)
-                            .stream().filter(Objects::nonNull).toList();
+                        .stream().filter(Objects::nonNull).toList();
                 size = ((Collection<ProcessorExchangePair>) pairs).size();
             }
         } catch (Exception e) {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/Splitter.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/Splitter.java
@@ -295,7 +295,7 @@ public class Splitter extends MulticastProcessor implements AsyncProcessor, Trac
     protected void updateNewExchange(Exchange exchange, int index, Iterable<ProcessorExchangePair> allPairs, boolean hasNext) {
         exchange.setProperty(ExchangePropertyKey.SPLIT_INDEX, index);
         if (allPairs instanceof Collection) {
-            // non streaming mode, so we know the total size already
+            // non-streaming mode, so we know the total size already
             exchange.setProperty(ExchangePropertyKey.SPLIT_SIZE, ((Collection<?>) allPairs).size());
         }
         if (hasNext) {

--- a/core/camel-core/src/test/java/org/apache/camel/issues/SplitterParallelWithIteratorThrowingExceptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/SplitterParallelWithIteratorThrowingExceptionTest.java
@@ -49,7 +49,7 @@ public class SplitterParallelWithIteratorThrowingExceptionTest extends ContextTe
 
     @Test
     public void testIteratorThrowExceptionOnSecond() throws Exception {
-        getMockEndpoint("mock:line").expectedMessageCount(0);
+        getMockEndpoint("mock:line").expectedMessageCount(1);
         getMockEndpoint("mock:end").expectedMessageCount(0);
 
         try {
@@ -65,7 +65,7 @@ public class SplitterParallelWithIteratorThrowingExceptionTest extends ContextTe
 
     @Test
     public void testIteratorThrowExceptionOnThird() throws Exception {
-        getMockEndpoint("mock:line").expectedMessageCount(1);
+        getMockEndpoint("mock:line").expectedMessageCount(2);
         getMockEndpoint("mock:end").expectedMessageCount(0);
 
         try {


### PR DESCRIPTION
If the last element of the iterable is null, the last message will not contain the final informations such as splitter-size, multicast-complete
