### PR TITLE
CamelTestSupport: removal of wrong annotation + addition of method for @Override

### DIFF
--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -343,7 +343,7 @@ public abstract class CamelTestSupport
     public void setUp() throws Exception {
         testStartHeader(getClass(), currentTestName);
 
-        ExtensionHelper.hasUnsupported(getClass());
+        assertUnsupported();
 
         if (isCreateCamelContextPerClass()) {
             createCamelContextPerClass();
@@ -357,6 +357,10 @@ public abstract class CamelTestSupport
 
         // only start timing after all the setup
         watch.restart();
+    }
+
+    protected void assertUnsupported() {
+        ExtensionHelper.hasUnsupported(getClass());
     }
 
     private void createCamelContextPerClass() throws Exception {

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/util/ExtensionHelper.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/util/ExtensionHelper.java
@@ -29,7 +29,6 @@ public final class ExtensionHelper {
     public static final String SEPARATOR = "*".repeat(80);
     private static final String SPRING_BOOT_TEST = "org.springframework.boot.test.context.SpringBootTest";
     private static final String QUARKUS_TEST = "io.quarkus.test.junit.QuarkusTest";
-    private static final String CAMEL_QUARKUS_TEST = "org.apache.camel.quarkus.test.CamelQuarkusTest";
 
     private static void throwUnsupportedClassException(String name) {
         switch (name) {
@@ -37,10 +36,8 @@ public final class ExtensionHelper {
                 throw new RuntimeException(
                         "Spring Boot detected: The CamelTestSupport/CamelSpringTestSupport class is not intended for Camel testing with Spring Boot.");
             case QUARKUS_TEST:
-            case CAMEL_QUARKUS_TEST: {
                 throw new RuntimeException(
                         "Quarkus detected: The CamelTestSupport/CamelSpringTestSupport class is not intended for Camel testing with Quarkus.");
-            }
         }
 
         throw new RuntimeException(
@@ -48,8 +45,7 @@ public final class ExtensionHelper {
     }
 
     public static boolean hasUnsupported(Class<?> clazz) {
-        hasClassAnnotation(clazz, ExtensionHelper::throwUnsupportedClassException, SPRING_BOOT_TEST, QUARKUS_TEST,
-                CAMEL_QUARKUS_TEST);
+        hasClassAnnotation(clazz, ExtensionHelper::throwUnsupportedClassException, SPRING_BOOT_TEST, QUARKUS_TEST);
         return true;
     }
 


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-20784

I remoced the annotation (`CamelQuarkusTest`) which does not exist and I moved the validation into a protected method. Child class is able to override the behavior if needed.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

