### PR TITLE
CAMEL-20722 - changes to address flakiness observed on CI

### DIFF
--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorOffUsingKafkaManualCommitIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorOffUsingKafkaManualCommitIT.java
@@ -100,7 +100,7 @@ class KafkaBreakOnFirstErrorOffUsingKafkaManualCommitIT extends BaseKafkaTestSup
         contextExtension.getContext().getRouteController().startRoute(ROUTE_ID);
 
         Awaitility.await()
-                .atMost(10, TimeUnit.SECONDS) // changed to 10 sec for CAMEL-20722
+                .atMost(30, TimeUnit.SECONDS) // changed to 30 sec for CAMEL-20722
                 .until(() -> to.getExchanges().size() > 3);
 
         to.assertIsSatisfied(3000);

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorReleaseResourcesIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorReleaseResourcesIT.java
@@ -51,8 +51,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
              disabledReason = "This test does not run reliably on some platforms")
 class KafkaBreakOnFirstErrorReleaseResourcesIT extends BaseKafkaTestSupport {
 
-    public static final String ROUTE_ID = "breakOnFirstError-20563";
-    public static final String TOPIC = "breakOnFirstError-20563";
+    public static final String ROUTE_ID = "breakOnFirstError-20563" + Thread.currentThread().hashCode(); //CAMEL-20722 - added for similar reason as CAMEL-20686:
+    public static final String TOPIC = "breakOnFirstError-20563" + Thread.currentThread().hashCode(); //CAMEL-20722 - added for similar reason as CAMEL-20686:
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaBreakOnFirstErrorReleaseResourcesIT.class);
     private static final int CONSUMER_COUNT = 3;
@@ -106,7 +106,7 @@ class KafkaBreakOnFirstErrorReleaseResourcesIT extends BaseKafkaTestSupport {
 
         // let test run for awhile
         Awaitility.await()
-                .timeout(10, TimeUnit.SECONDS)
+                .timeout(30, TimeUnit.SECONDS)  // changed to 30 sec for CAMEL-20722
                 .pollDelay(8, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertTrue(true));
 

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingSyncCommitManagerIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorWithBatchUsingSyncCommitManagerIT.java
@@ -98,7 +98,7 @@ class KafkaBreakOnFirstErrorWithBatchUsingSyncCommitManagerIT extends BaseKafkaT
         contextExtension.getContext().getRouteController().startRoute(ROUTE_ID);
 
         Awaitility.await()
-                .atMost(10, TimeUnit.SECONDS)   // changed to 10 sec for CAMEL-20722
+                .atMost(30, TimeUnit.SECONDS)   // changed to 30 sec for CAMEL-20722
                 .until(() -> errorPayloads.size() > 3);
 
         to.assertIsSatisfied();


### PR DESCRIPTION
Changes to address flakiness:
- most likely cause is resource crunch on CI causing some tests to time out.
- more unique test-specific topic names approach might be needed later (after observation)

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [CAMEL-20722](https://issues.apache.org/jira/browse/CAMEL-20722) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

