### PR TITLE
Update camel-salesforce to use a newer protobuf-maven-plugin for gRPC

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/README.md
+++ b/components/camel-salesforce/camel-salesforce-component/README.md
@@ -5,6 +5,10 @@ There is a companion maven plugin [camel-salesforce-plugin](https://github.com/a
 
 ## Developing the Camel Salesforce component
 
+### Building on Windows/ARM
+
+**Note:** There is no `protoc` compiler available for Windows on ARM, so this component will fail to build in that environment. An issue has been raised against the `protobuf` project to request an executable for Windows on ARM. https://github.com/protocolbuffers/protobuf/issues/16877
+
 ### Running the integration tests
 
 **Note:** These instructions are only for running integration tests, they use permissions and IP restrictions that should be reconsidered for production use. 

--- a/components/camel-salesforce/camel-salesforce-component/pom.xml
+++ b/components/camel-salesforce/camel-salesforce-component/pom.xml
@@ -34,6 +34,9 @@
 
     <properties>
         <salesforce.component.root>..</salesforce.component.root>
+        <grpc.version>1.62.2</grpc.version>
+        <protobuf.version>3.21.5</protobuf.version>
+        <protobuf-maven-plugin.version>2.1.1</protobuf-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -256,19 +259,27 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.xolstice.maven.plugins</groupId>
+                <groupId>io.github.ascopes</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>${protobuf-maven-plugin-version}</version>
+                <version>${protobuf-maven-plugin.version}</version>
+
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:${protobuf-version}:exe:${os.detected.classifier}</protocArtifact>
-                    <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc-version}:exe:${os.detected.classifier}</pluginArtifact>
+                    <protocVersion>${protobuf.version}</protocVersion>
+                    <sourceDirectories>
+                        <sourceDirectory>src/main/proto</sourceDirectory>
+                    </sourceDirectories>
+                    <binaryMavenPlugins>
+                        <binaryMavenPlugin>
+                            <groupId>io.grpc</groupId>
+                            <artifactId>protoc-gen-grpc-java</artifactId>
+                            <version>${grpc.version}</version>
+                        </binaryMavenPlugin>
+                    </binaryMavenPlugins>
                 </configuration>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>compile</goal>
-                            <goal>compile-custom</goal>
+                            <goal>generate</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -283,7 +294,7 @@
                             <target>
                                 <replace token= "@javax.annotation.Generated"
                                          value="@jakarta.annotation.Generated"
-                                         dir="target/generated-sources/protobuf/grpc-java">
+                                         dir="target/generated-sources/protobuf">
                                     <include name="**/*.java"/>
                                 </replace>
                             </target>


### PR DESCRIPTION
# Description

The https://www.xolstice.org/protobuf-maven-plugin is not maintained anymore and the last release is from 2018.

We can use https://github.com/ascopes/protobuf-maven-plugin instead

# Target

- [X ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [ X] I checked that each commit in the pull request has a meaningful subject line and body.

- [ X] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes


