### PR TITLE
CAMEL-20814: Publish buildinfo and provide a build container to improve release reproducibility.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This has a JDK and Maven we can use.
+FROM registry.access.redhat.com/ubi9/openjdk-21
+USER root
+
+#
+# the builder script will run this container under as your uid:guid so that the files it creates
+# in the host env are owned by you, lets make sure there is uid:guid to match in the container.
+RUN for i in $(seq 50 184); do echo "default$i:x:$i:$i:default:/home/default:/bin/bash" >> /etc/passwd; done; 
+RUN for i in $(seq 186 2000); do echo "default$i:x:$i:$i:default:/home/default:/bin/bash" >> /etc/passwd; done
+
+CMD ["/bin/bash"]
+WORKDIR /src

--- a/builder
+++ b/builder
@@ -1,0 +1,34 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+set -e
+
+# This script gives you a reproducible build enviroment, since the enviroment is containerizedL
+# Example usage: ./builder mvn clean install -Dquickly
+
+docker build . -t apache-camel-builder
+
+# Run the builder container as the current user, and mount his home dirs
+# so that host .m2 repos can be reused and provide access to release gpg keys and such.
+docker run --rm -it \
+    --user "`id -u`:`id -g`" \
+    -v "`pwd`:/src" \
+    -v "${HOME}:/home/default" \
+    -v "${HOME}:${HOME}" \
+    apache-camel-builder $*

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
         <maven-remote-resources-plugin-version>3.2.0</maven-remote-resources-plugin-version>
         <maven-surefire-plugin-version>3.2.5</maven-surefire-plugin-version>
         <versions-maven-plugin-version>2.16.2</versions-maven-plugin-version>
+        <maven-artifact-plugin-version>3.5.1</maven-artifact-plugin-version>
 
         <camel.javadoc.offline>false</camel.javadoc.offline>
 
@@ -213,6 +214,24 @@
                 <configuration>
                     <outputDirectory>target</outputDirectory>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-artifact-plugin</artifactId>
+                <version>${maven-artifact-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>buildinfo</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>buildinfo</goal>
+                        </goals>
+                        <configuration>
+                            <attach>true</attach>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
 
@@ -327,6 +346,8 @@
                                     <exclude>camel-sbom/*.xml</exclude>
                                     <exclude>doap.rdf</exclude>
                                     <exclude>mvnw*</exclude>
+                                    <exclude>Dockerfile</exclude>
+                                    <exclude>builder*</exclude>
                                 </excludes>
                             </licenseSet>
                         </licenseSets>


### PR DESCRIPTION
 Description

This allows you to `./builder mvn install` on a unixish system with only docker installed to do a camel build.  This has the added benefit of using a consistent JDK/Maven version which should aid in build reproducibility.

# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
https://issues.apache.org/jira/browse/CAMEL-20814

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.
