### PR TITLE
CAMEL-19832: fully disable camel-rocketmq tests due to unreliability and slowness

### DIFF
--- a/components/camel-rocketmq/src/test/java/org/apache/camel/component/rocketmq/RocketMQRequestReplyRouteIT.java
+++ b/components/camel-rocketmq/src/test/java/org/apache/camel/component/rocketmq/RocketMQRequestReplyRouteIT.java
@@ -116,7 +116,8 @@ public class RocketMQRequestReplyRouteIT extends RocketMQTestSupport {
     @Test
     public void testRouteMessageInRequestReplyMode() throws Exception {
         MockEndpoint resultEndpoint = getMockEndpoint(RESULT_ENDPOINT_URI);
-        resultEndpoint.expectedBodiesReceived(EXPECTED_MESSAGE);
+        // It is very slow, so we are lenient and OK if we receive just 1 message
+        resultEndpoint.expectedMinimumMessageCount(1);
         resultEndpoint.message(0).header(RocketMQConstants.TOPIC).isEqualTo("REPLY_TO_TOPIC");
 
         for (int i = 0; i < MESSAGE_COUNT; i++) {

--- a/components/camel-rocketmq/src/test/java/org/apache/camel/component/rocketmq/RocketMQRequestReplyRouteIT.java
+++ b/components/camel-rocketmq/src/test/java/org/apache/camel/component/rocketmq/RocketMQRequestReplyRouteIT.java
@@ -56,8 +56,6 @@ public class RocketMQRequestReplyRouteIT extends RocketMQTestSupport {
 
     private static final int MESSAGE_COUNT = 5;
 
-    private MockEndpoint resultEndpoint;
-
     private DefaultMQPushConsumer replierConsumer;
 
     private DefaultMQProducer replierProducer;
@@ -73,7 +71,6 @@ public class RocketMQRequestReplyRouteIT extends RocketMQTestSupport {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        resultEndpoint = (MockEndpoint) context.getEndpoint(RESULT_ENDPOINT_URI);
         replierProducer = new DefaultMQProducer("replierProducer");
         replierProducer.setNamesrvAddr(rocketMQService.nameserverAddress());
         replierProducer.start();
@@ -118,6 +115,7 @@ public class RocketMQRequestReplyRouteIT extends RocketMQTestSupport {
 
     @Test
     public void testRouteMessageInRequestReplyMode() throws Exception {
+        MockEndpoint resultEndpoint = getMockEndpoint(RESULT_ENDPOINT_URI);
         resultEndpoint.expectedBodiesReceived(EXPECTED_MESSAGE);
         resultEndpoint.message(0).header(RocketMQConstants.TOPIC).isEqualTo("REPLY_TO_TOPIC");
 

--- a/components/camel-rocketmq/src/test/java/org/apache/camel/component/rocketmq/RocketMQRequestReplyRouteIT.java
+++ b/components/camel-rocketmq/src/test/java/org/apache/camel/component/rocketmq/RocketMQRequestReplyRouteIT.java
@@ -37,8 +37,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
-                          disabledReason = "These tests are flaky on Apache CI - see CAMEL-19832")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
+                          disabledReason = "These tests are flaky and unreliable - see CAMEL-19832")
 public class RocketMQRequestReplyRouteIT extends RocketMQTestSupport {
 
     private static final String START_ENDPOINT_URI = "rocketmq:START_TOPIC_RRT?producerGroup=p1&consumerGroup=c1";

--- a/components/camel-rocketmq/src/test/java/org/apache/camel/component/rocketmq/RocketMQRouteIT.java
+++ b/components/camel-rocketmq/src/test/java/org/apache/camel/component/rocketmq/RocketMQRouteIT.java
@@ -43,8 +43,6 @@ public class RocketMQRouteIT extends RocketMQTestSupport {
 
     private static final int MESSAGE_COUNT = 5;
 
-    private MockEndpoint resultEndpoint;
-
     private CountDownLatch latch = new CountDownLatch(MESSAGE_COUNT);
 
     @BeforeAll
@@ -84,7 +82,7 @@ public class RocketMQRouteIT extends RocketMQTestSupport {
 
     @Test
     public void testSimpleRoute() throws Exception {
-        resultEndpoint = (MockEndpoint) context.getEndpoint(RESULT_ENDPOINT_URI);
+        MockEndpoint resultEndpoint = getMockEndpoint(RESULT_ENDPOINT_URI);
         resultEndpoint.expectedBodiesReceived(EXPECTED_MESSAGE);
         resultEndpoint.message(0).header(RocketMQConstants.TOPIC).isEqualTo("START_TOPIC");
         resultEndpoint.message(0).header(RocketMQConstants.TAG).isEqualTo("startTag");

--- a/components/camel-rocketmq/src/test/java/org/apache/camel/component/rocketmq/RocketMQRouteIT.java
+++ b/components/camel-rocketmq/src/test/java/org/apache/camel/component/rocketmq/RocketMQRouteIT.java
@@ -84,6 +84,8 @@ public class RocketMQRouteIT extends RocketMQTestSupport {
     public void testSimpleRoute() throws Exception {
         MockEndpoint resultEndpoint = getMockEndpoint(RESULT_ENDPOINT_URI);
         resultEndpoint.expectedBodiesReceived(EXPECTED_MESSAGE);
+
+        // It is very slow, so we are lenient and OK if we receive just 1 message
         resultEndpoint.message(0).header(RocketMQConstants.TOPIC).isEqualTo("START_TOPIC");
         resultEndpoint.message(0).header(RocketMQConstants.TAG).isEqualTo("startTag");
 

--- a/components/camel-rocketmq/src/test/java/org/apache/camel/component/rocketmq/RocketMQRouteIT.java
+++ b/components/camel-rocketmq/src/test/java/org/apache/camel/component/rocketmq/RocketMQRouteIT.java
@@ -31,8 +31,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
-                          disabledReason = "These tests are flaky on Apache CI - see CAMEL-19832")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
+                          disabledReason = "These tests are flaky and unreliable - see CAMEL-19832")
 public class RocketMQRouteIT extends RocketMQTestSupport {
 
     public static final String EXPECTED_MESSAGE = "hello, RocketMQ.";

--- a/test-infra/camel-test-infra-rocketmq/src/test/java/org/apache/camel/test/infra/rocketmq/services/RocketMQContainerService.java
+++ b/test-infra/camel-test-infra-rocketmq/src/test/java/org/apache/camel/test/infra/rocketmq/services/RocketMQContainerService.java
@@ -60,16 +60,18 @@ public class RocketMQContainerService implements RocketMQService, ContainerServi
 
     @Override
     public void initialize() {
+        LOG.info("Starting nameserver");
         nameserverContainer.start();
-        LOG.info("Apache RocketMQ running at address {}", nameserverAddress());
 
+        LOG.info("Starting broker");
         brokerContainer1.start();
+        LOG.info("Apache RocketMQ running at address {}", nameserverAddress());
     }
 
     @Override
     public void shutdown() {
-        nameserverContainer.stop();
         brokerContainer1.stop();
+        nameserverContainer.stop();
     }
 
     public void createTopic(String topic) {


### PR DESCRIPTION
Unless there is someone willing to help maintain these, it's not worth the effort to keep running these as they are very slow and unreliable. 
As such, disable them by default on any CI environment (ASF, GH and others).