### PR TITLE
CAMEL-20785: split responsibilities from the test support class

### DIFF
--- a/catalog/camel-route-parser/src/test/java/org/apache/camel/parser/java/MyRouteDuplicateIdTest.java
+++ b/catalog/camel-route-parser/src/test/java/org/apache/camel/parser/java/MyRouteDuplicateIdTest.java
@@ -22,16 +22,17 @@ import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class MyRouteDuplicateIdTest extends CamelTestSupport {
 
-    @Override
-    protected void startCamelContext() throws Exception {
-        // do not start context automatically
+    MyRouteDuplicateIdTest() {
+        testConfiguration().withAutoStartContext(false);
     }
 
     @Test
     void testFoo() {
+        assumeFalse(context.isStarted(), "This test cannot run with the context already started");
         assertThrows(FailedToStartRouteException.class, () -> context.start());
     }
 

--- a/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfConsumerPayloadXPathTest.java
+++ b/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfConsumerPayloadXPathTest.java
@@ -206,7 +206,7 @@ public class CxfConsumerPayloadXPathTest extends CamelTestSupport {
     }
 
     private void simpleTest(int repeat, BaseRouteBuilder builder) throws Exception {
-        setUseRouteBuilder(false);
+        testConfiguration().withUseRouteBuilder(false);
         context.addRoutes(builder);
         startCamelContext();
 

--- a/components/camel-cxf/camel-cxf-spring-rest/pom.xml
+++ b/components/camel-cxf/camel-cxf-spring-rest/pom.xml
@@ -36,6 +36,7 @@
         <firstVersion>3.18.0</firstVersion>
         <camel.surefire.fork.vmargs>--add-opens java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED --add-opens java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED --add-opens java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</camel.surefire.fork.vmargs>
         <camel.surefire.forkTimeout>300</camel.surefire.forkTimeout>
+        <camel.surefire.reuseForks>false</camel.surefire.reuseForks>
     </properties>
 
     <dependencies>

--- a/components/camel-cxf/camel-cxf-spring-rest/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsConsumerTest.java
+++ b/components/camel-cxf/camel-cxf-spring-rest/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsConsumerTest.java
@@ -37,7 +37,7 @@ import org.apache.camel.LoggingLevel;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
-import org.apache.camel.builder.LegacyNoErrorHandlerBuilder;
+import org.apache.camel.builder.NoErrorHandlerBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.cxf.common.CXFTestSupport;
 import org.apache.camel.component.cxf.common.message.CxfConstants;
@@ -92,7 +92,7 @@ public class CxfRsConsumerTest extends CamelTestSupport {
         final Processor testProcessor3 = new TestProcessor3();
         return new RouteBuilder() {
             public void configure() {
-                errorHandler(new LegacyNoErrorHandlerBuilder());
+                errorHandler(new NoErrorHandlerBuilder());
                 from(CXF_RS_ENDPOINT_URI).process(testProcessor);
                 from(CXF_RS_ENDPOINT_URI2).process(testProcessor);
                 from(CXF_RS_ENDPOINT_URI3).process(testProcessor);

--- a/components/camel-cxf/camel-cxf-spring-rest/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsSpringConsumerTest.java
+++ b/components/camel-cxf/camel-cxf-spring-rest/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsSpringConsumerTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.component.cxf.jaxrs;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.apache.camel.builder.LegacyNoErrorHandlerBuilder;
+import org.apache.camel.builder.NoErrorHandlerBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.cxf.common.CXFTestSupport;
 import org.apache.camel.component.cxf.jaxrs.testbean.CustomException;
@@ -55,7 +55,7 @@ public class CxfRsSpringConsumerTest extends CamelSpringTestSupport {
         };
         return new RouteBuilder() {
             public void configure() {
-                errorHandler(new LegacyNoErrorHandlerBuilder());
+                errorHandler(new NoErrorHandlerBuilder());
                 from("cxfrs://bean://rsServer").process(testProcessor);
                 from("cxfrs://bean://rsServer2").process(testProcessor);
                 from("cxfrs://bean://rsServerInvoke?performInvocation=true").process(responseProcessor);

--- a/components/camel-cxf/camel-cxf-spring-soap/pom.xml
+++ b/components/camel-cxf/camel-cxf-spring-soap/pom.xml
@@ -36,6 +36,7 @@
         <firstVersion>3.18.0</firstVersion>
         <camel.surefire.fork.vmargs>--add-opens java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED --add-opens java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED --add-opens java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</camel.surefire.fork.vmargs>
         <camel.surefire.forkTimeout>300</camel.surefire.forkTimeout>
+        <camel.surefire.reuseForks>false</camel.surefire.reuseForks>
     </properties>
 
     <dependencies>

--- a/components/camel-ehcache/src/test/java/org/apache/camel/component/ehcache/EhcacheConfigurationTest.java
+++ b/components/camel-ehcache/src/test/java/org/apache/camel/component/ehcache/EhcacheConfigurationTest.java
@@ -72,7 +72,7 @@ public class EhcacheConfigurationTest extends CamelTestSupport {
     // *****************************
 
     @Test
-    void testConfiguration() throws Exception {
+    void testComponentConfiguration() throws Exception {
         Cache<String, String> globalConfigCache
                 = globalConfig.getManager().getCache("globalConfig", String.class, String.class);
         Cache<String, String> customConfigCache

--- a/components/camel-fhir/camel-fhir-component/src/test/java/org/apache/camel/component/fhir/FhirConfigurationIT.java
+++ b/components/camel-fhir/camel-fhir-component/src/test/java/org/apache/camel/component/fhir/FhirConfigurationIT.java
@@ -87,7 +87,7 @@ public class FhirConfigurationIT extends AbstractFhirTestSupport {
     }
 
     @Test
-    public void testConfiguration() {
+    public void testComponentConfiguration() {
         FhirEndpoint endpoint = getMandatoryEndpoint(TEST_URI, FhirEndpoint.class);
         GenericClient client = (GenericClient) endpoint.getClient();
         FhirConfiguration configuration = endpoint.getConfiguration();

--- a/components/camel-google/camel-google-calendar/src/test/java/org/apache/camel/component/google/calendar/CalendarConfigurationTest.java
+++ b/components/camel-google/camel-google-calendar/src/test/java/org/apache/camel/component/google/calendar/CalendarConfigurationTest.java
@@ -60,7 +60,7 @@ public class CalendarConfigurationTest extends AbstractGoogleCalendarTestSupport
     }
 
     @Test
-    public void testConfiguration() {
+    public void testComponentConfiguration() {
         GoogleCalendarEndpoint endpoint = getMandatoryEndpoint(TEST_URI, GoogleCalendarEndpoint.class);
         GoogleCalendarConfiguration configuration = endpoint.getConfiguration();
         assertNotNull(configuration);

--- a/components/camel-google/camel-google-drive/src/test/java/org/apache/camel/component/google/drive/DriveConfigurationTest.java
+++ b/components/camel-google/camel-google-drive/src/test/java/org/apache/camel/component/google/drive/DriveConfigurationTest.java
@@ -51,7 +51,7 @@ public class DriveConfigurationTest extends AbstractGoogleDriveTestSupport {
     }
 
     @Test
-    public void testConfiguration() {
+    public void testComponentConfiguration() {
         GoogleDriveEndpoint endpoint = getMandatoryEndpoint(TEST_URI, GoogleDriveEndpoint.class);
         GoogleDriveConfiguration configuration = endpoint.getConfiguration();
         assertNotNull(configuration);

--- a/components/camel-google/camel-google-mail/src/test/java/org/apache/camel/component/google/mail/GmailConfigurationTest.java
+++ b/components/camel-google/camel-google-mail/src/test/java/org/apache/camel/component/google/mail/GmailConfigurationTest.java
@@ -53,7 +53,7 @@ public class GmailConfigurationTest extends AbstractGoogleMailTestSupport {
     }
 
     @Test
-    public void testConfiguration() {
+    public void testComponentConfiguration() {
         GoogleMailEndpoint endpoint = getMandatoryEndpoint(TEST_URI, GoogleMailEndpoint.class);
         GoogleMailConfiguration configuration = endpoint.getConfiguration();
         assertNotNull(configuration);

--- a/components/camel-google/camel-google-sheets/src/test/java/org/apache/camel/component/google/sheets/SheetsConfigurationTest.java
+++ b/components/camel-google/camel-google-sheets/src/test/java/org/apache/camel/component/google/sheets/SheetsConfigurationTest.java
@@ -46,7 +46,7 @@ public class SheetsConfigurationTest extends CamelTestSupport {
     }
 
     @Test
-    public void testConfiguration() {
+    public void testComponentConfiguration() {
         GoogleSheetsEndpoint endpoint = getMandatoryEndpoint(TEST_URI, GoogleSheetsEndpoint.class);
         GoogleSheetsConfiguration configuration = endpoint.getConfiguration();
         assertNotNull(configuration);

--- a/components/camel-jaxb/src/test/java/org/apache/camel/jaxb/CamelJaxbNoNamespaceSchemaLocationSpringTest.java
+++ b/components/camel-jaxb/src/test/java/org/apache/camel/jaxb/CamelJaxbNoNamespaceSchemaLocationSpringTest.java
@@ -26,7 +26,7 @@ public class CamelJaxbNoNamespaceSchemaLocationSpringTest extends CamelJaxbNoNam
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
-        setUseRouteBuilder(false);
+        testConfiguration().withUseRouteBuilder(false);
         final AbstractXmlApplicationContext applicationContext
                 = new ClassPathXmlApplicationContext("org/apache/camel/jaxb/CamelJaxbNoNamespaceSchemaLocationTest.xml");
         setCamelContextService(new Service() {

--- a/components/camel-jaxb/src/test/java/org/apache/camel/jaxb/CamelJaxbSpringTest.java
+++ b/components/camel-jaxb/src/test/java/org/apache/camel/jaxb/CamelJaxbSpringTest.java
@@ -26,7 +26,7 @@ public class CamelJaxbSpringTest extends CamelJaxbTest {
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
-        setUseRouteBuilder(false);
+        testConfiguration().withUseRouteBuilder(false);
         final AbstractXmlApplicationContext applicationContext
                 = new ClassPathXmlApplicationContext("org/apache/camel/jaxb/CamelJaxbTest.xml");
         setCamelContextService(new Service() {

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAClientTest.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAClientTest.java
@@ -32,7 +32,7 @@ import org.mockito.Mockito;
 public class LRAClientTest extends CamelTestSupport {
 
     public LRAClientTest() {
-        setUseRouteBuilder(false);
+        testConfiguration().withUseRouteBuilder(false);
     }
 
     @DisplayName("Tests whether LRAClient is using a default HttpClient")

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRASagaCoordinatorTest.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRASagaCoordinatorTest.java
@@ -53,7 +53,7 @@ public class LRASagaCoordinatorTest extends CamelTestSupport {
     }
 
     public LRASagaCoordinatorTest() {
-        setUseRouteBuilder(false);
+        testConfiguration().withUseRouteBuilder(false);
     }
 
     @DisplayName("Tests whether no sagaService is causing exception")

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRASagaServiceTest.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRASagaServiceTest.java
@@ -29,7 +29,7 @@ import org.mockito.Mockito;
 public class LRASagaServiceTest extends CamelTestSupport {
 
     public LRASagaServiceTest() {
-        setUseRouteBuilder(false);
+        testConfiguration().withUseRouteBuilder(false);
     }
 
     @DisplayName("Tests whether doStart() is creating a LRAClient")

--- a/components/camel-microprofile/camel-microprofile-fault-tolerance/src/test/java/org/apache/camel/component/microprofile/faulttolerance/FaultToleranceTimeoutTest.java
+++ b/components/camel-microprofile/camel-microprofile-fault-tolerance/src/test/java/org/apache/camel/component/microprofile/faulttolerance/FaultToleranceTimeoutTest.java
@@ -73,6 +73,7 @@ public class FaultToleranceTimeoutTest extends CamelTestSupport {
             @Override
             public void configure() {
                 from("direct:start")
+                        .routeId("start")
                         .circuitBreaker()
                         // enable and use 2 second timeout
                         .faultToleranceConfiguration().timeoutEnabled(true).timeoutDuration(2000).end()
@@ -83,11 +84,13 @@ public class FaultToleranceTimeoutTest extends CamelTestSupport {
                         .log("After FaultTolerance ${body}");
 
                 from("direct:fast")
+                        .routeId("fast")
                         // this is a fast route and takes 1 second to respond
                         .log("Fast processing start: ${threadName}").delay(1000).transform().constant("Fast response")
                         .log("Fast processing end: ${threadName}");
 
                 from("direct:slow")
+                        .routeId("slow")
                         // this is a slow route and takes 3 second to respond
                         .log("Slow processing start: ${threadName}").delay(3000).transform().constant("Slow response")
                         .log("Slow processing end: ${threadName}");

--- a/components/camel-olingo4/camel-olingo4-component/src/test/java/org/apache/camel/component/olingo4/Olingo4ComponentConsumerTest.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/test/java/org/apache/camel/component/olingo4/Olingo4ComponentConsumerTest.java
@@ -47,7 +47,7 @@ public class Olingo4ComponentConsumerTest extends AbstractOlingo4TestSupport {
     private static final String AIRPORTS = "Airports";
 
     public Olingo4ComponentConsumerTest() {
-        setUseRouteBuilder(false);
+        testConfiguration().withUseRouteBuilder(false);
     }
 
     private void addRouteAndStartContext(RouteBuilder builder) throws Exception {

--- a/components/camel-quickfix/src/test/java/org/apache/camel/component/quickfixj/QuickfixjConfigurationTest.java
+++ b/components/camel-quickfix/src/test/java/org/apache/camel/component/quickfixj/QuickfixjConfigurationTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class QuickfixjConfigurationTest {
 
     @Test
-    public void testConfiguration() throws Exception {
+    public void testComponentConfiguration() throws Exception {
         QuickfixjConfiguration factory = new QuickfixjConfiguration();
 
         Map<Object, Object> defaultSettings = new HashMap<>();

--- a/components/camel-saxon/src/test/java/org/apache/camel/component/xquery/XQueryComponentConfigurationTest.java
+++ b/components/camel-saxon/src/test/java/org/apache/camel/component/xquery/XQueryComponentConfigurationTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class XQueryComponentConfigurationTest extends CamelSpringTestSupport {
 
     @Test
-    public void testConfiguration() {
+    public void testComponentConfiguration() {
         XQueryComponent component = context.getComponent("xquery", XQueryComponent.class);
         XQueryEndpoint endpoint
                 = context.getEndpoint("xquery:org/apache/camel/component/xquery/transform.xquery", XQueryEndpoint.class);

--- a/components/camel-saxon/src/test/java/org/apache/camel/component/xquery/XQueryEndpointConfigurationTest.java
+++ b/components/camel-saxon/src/test/java/org/apache/camel/component/xquery/XQueryEndpointConfigurationTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class XQueryEndpointConfigurationTest extends CamelSpringTestSupport {
     @Test
-    public void testConfiguration() {
+    public void testComponentConfiguration() {
         Configuration configuration = context.getRegistry().lookupByNameAndType("saxon-configuration", Configuration.class);
         Map<String, Object> properties = context.getRegistry().lookupByNameAndType("saxon-properties", Map.class);
         XQueryComponent component = context.getComponent("xquery", XQueryComponent.class);

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelContextConfiguration.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelContextConfiguration.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.test.junit5;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.Service;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.Breakpoint;
+import org.apache.camel.spi.PropertiesComponent;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.support.EndpointHelper;
+
+/**
+ * Configures a context for test execution
+ */
+public final class CamelContextConfiguration {
+    @FunctionalInterface
+    public interface CamelContextSupplier {
+        CamelContext createCamelContext() throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface RegistryBinder {
+        void bindToRegistry(Registry registry) throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface RoutesSupplier {
+        RoutesBuilder[] createRouteBuilders() throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface PostProcessor {
+        void postSetup() throws Exception;
+    }
+
+    private String routeFilterIncludePattern;
+    private String routeFilterExcludePattern;
+    private Registry registry;
+    private Breakpoint breakpoint;
+    private String mockEndpoints;
+    private String mockEndpointsAndSkip;
+    private Properties useOverridePropertiesWithPropertiesComponent;
+    private Boolean ignoreMissingLocationWithPropertiesComponent;
+
+    private CamelContextSupplier camelContextSupplier;
+    private RegistryBinder registryBinder;
+    private Service camelContextService;
+
+    private int shutdownTimeout = 10;
+
+    private RoutesSupplier routesSupplier;
+    private final Map<String, String> fromEndpoints = new HashMap<>();
+    private PostProcessor postProcessor;
+
+    public String routeFilterIncludePattern() {
+        return routeFilterIncludePattern;
+    }
+
+    /**
+     * Used for filtering routes matching the given pattern, which follows the following rules:
+     * <p>
+     * - Match by route id - Match by route input endpoint uri
+     * <p>
+     * The matching is using exact match, by wildcard and regular expression.
+     * <p>
+     * For example, to only include routes which start with foo in their route id's, use: include=foo&#42; And to
+     * exclude routes which start from JMS endpoints, use: exclude=jms:&#42;
+     * <p>
+     * Multiple patterns can be separated by comma, for example, to exclude both foo and bar routes, use:
+     * exclude=foo&#42;,bar&#42;
+     * <p>
+     * Exclude takes precedence over include.
+     */
+    public CamelContextConfiguration withRouteFilterIncludePattern(String routeFilterIncludePattern) {
+        this.routeFilterIncludePattern = routeFilterIncludePattern;
+        return this;
+    }
+
+    public String routeFilterExcludePattern() {
+        return routeFilterExcludePattern;
+    }
+
+    /**
+     * Used for filtering routes matching the given pattern, which follows the following rules:
+     * <p>
+     * - Match by route id - Match by route input endpoint uri
+     * <p>
+     * The matching is using exact match, by wildcard and regular expression.
+     * <p>
+     * For example, to only include routes which starts with foo in their route id's, use: include=foo&#42; And to
+     * exclude routes which start from JMS endpoints, use: exclude=jms:&#42;
+     * <p>
+     * Multiple patterns can be separated by comma, for example, to exclude both foo and bar routes, use:
+     * exclude=foo&#42;,bar&#42;
+     * <p>
+     * Exclude takes precedence over include.
+     */
+    public CamelContextConfiguration withRouteFilterExcludePattern(String routeFilterExcludePattern) {
+        this.routeFilterExcludePattern = routeFilterExcludePattern;
+        return this;
+    }
+
+    public Registry registry() {
+        return registry;
+    }
+
+    /**
+     * Sets a custom {@link Registry}.
+     * <p>
+     * However, if you need to bind beans to the registry, then this is possible already with the bind method on registry,
+     * and there is no need to use this method.
+     */
+    public CamelContextConfiguration withRegistry(Registry registry) {
+        this.registry = registry;
+        return this;
+    }
+
+    public boolean useDebugger() {
+        return this.breakpoint != null;
+    }
+
+    public Breakpoint breakpoint() {
+        return breakpoint;
+    }
+
+    /**
+     * Provides a debug breakpoint to be executed before and/or after entering processors
+     *
+     * @param breakpoint a new debug breakpoint
+     */
+    public CamelContextConfiguration withBreakpoint(DebugBreakpoint breakpoint) {
+        this.breakpoint = breakpoint;
+        return this;
+    }
+
+    public String mockEndpoints() {
+        return mockEndpoints;
+    }
+
+    /**
+     * Enables auto mocking endpoints based on the pattern.
+     * <p/>
+     * Use <tt>*</tt> to mock all endpoints.
+     *
+     * @see EndpointHelper#matchEndpoint(CamelContext, String, String)
+     */
+    public CamelContextConfiguration withMockEndpoints(String mockEndpoints) {
+        this.mockEndpoints = mockEndpoints;
+        return this;
+    }
+
+    public String mockEndpointsAndSkip() {
+        return mockEndpointsAndSkip;
+    }
+
+    /**
+     * Enables auto mocking endpoints based on the pattern, and <b>skip</b> sending to original endpoint.
+     * <p/>
+     * Use <tt>*</tt> to mock all endpoints.
+     *
+     * @see EndpointHelper#matchEndpoint(CamelContext, String, String)
+     */
+    public CamelContextConfiguration withMockEndpointsAndSkip(String mockEndpointsAndSkip) {
+        this.mockEndpointsAndSkip = mockEndpointsAndSkip;
+        return this;
+    }
+
+    public Properties useOverridePropertiesWithPropertiesComponent() {
+        return useOverridePropertiesWithPropertiesComponent;
+    }
+
+    /**
+     * To include and override properties with the Camel {@link PropertiesComponent}.
+     *
+     * @param useOverridePropertiesWithPropertiesComponent additional properties to add/override.
+     */
+    public CamelContextConfiguration withUseOverridePropertiesWithPropertiesComponent(
+            Properties useOverridePropertiesWithPropertiesComponent) {
+        this.useOverridePropertiesWithPropertiesComponent = useOverridePropertiesWithPropertiesComponent;
+        return this;
+    }
+
+    public Boolean ignoreMissingLocationWithPropertiesComponent() {
+        return ignoreMissingLocationWithPropertiesComponent;
+    }
+
+    /**
+     * Whether to ignore missing locations with the {@link PropertiesComponent}. For example, when unit testing, you may
+     * want to ignore locations that are not available in the environment used for testing.
+     *
+     * @param ignoreMissingLocationWithPropertiesComponent Use <tt>true</tt> to ignore, <tt>false</tt> to not ignore, and
+     *                                                    <tt>null</tt> to leave it
+     *                                                    as configured on the {@link PropertiesComponent}
+     */
+    public CamelContextConfiguration withIgnoreMissingLocationWithPropertiesComponent(
+            Boolean ignoreMissingLocationWithPropertiesComponent) {
+        this.ignoreMissingLocationWithPropertiesComponent = ignoreMissingLocationWithPropertiesComponent;
+        return this;
+    }
+
+    public CamelContextSupplier camelContextSupplier() {
+        return camelContextSupplier;
+    }
+
+    /**
+     * To set a supplier for the CamelContext
+     * @param camelContextSupplier A supplier for the Camel context
+     */
+    CamelContextConfiguration withCamelContextSupplier(
+            CamelContextSupplier camelContextSupplier) {
+        this.camelContextSupplier = camelContextSupplier;
+        return this;
+    }
+
+    public RegistryBinder registryBinder() {
+        return registryBinder;
+    }
+
+
+    /**
+     * A supplier to create a custom {@link Registry}.
+     * <p>
+     * Do not use it for binding beans to the registry.
+     */
+    public CamelContextConfiguration withRegistryBinder(
+            RegistryBinder registryBinder) {
+        this.registryBinder = registryBinder;
+        return this;
+    }
+
+    public int shutdownTimeout() {
+        return shutdownTimeout;
+    }
+
+    /**
+     * Sets the timeout to use when shutting down (unit in seconds).
+     * <p/>
+     * By default, it uses 10 seconds.
+     *
+     * @param shutdownTimeout the timeout to use
+     */
+    public CamelContextConfiguration withShutdownTimeout(int shutdownTimeout) {
+        this.shutdownTimeout = shutdownTimeout;
+        return this;
+    }
+
+    public Service camelContextService() {
+        return camelContextService;
+    }
+
+    /**
+     * Allows a service to be registered a separate lifecycle service to start and stop the context; such as for Spring
+     * when the ApplicationContext is started and stopped, rather than directly stopping the CamelContext
+     */
+    public CamelContextConfiguration withCamelContextService(Service camelContextService) {
+        this.camelContextService = camelContextService;
+        return this;
+    }
+
+    public RoutesSupplier routesSupplier() {
+        return routesSupplier;
+    }
+
+    /**
+     * A supplier that classes can use to create a {@link RouteBuilder} to define the routes for testing
+     */
+    CamelContextConfiguration withRoutesSupplier(
+            RoutesSupplier routesSupplier) {
+        this.routesSupplier = routesSupplier;
+        return this;
+    }
+
+    public Map<String, String> fromEndpoints() {
+        return fromEndpoints;
+    }
+
+    /**
+     * To replace from routes with a different one
+     * @param routeId
+     * @param fromEndpoint
+     */
+    void replaceRouteFromWith(String routeId, String fromEndpoint) {
+        fromEndpoints.put(routeId, fromEndpoint);
+    }
+
+    public PostProcessor postProcessor() {
+        return postProcessor;
+    }
+
+    /**
+     * Set set a custom post-test processor
+     * @param postProcessor the post-test processor to use
+     */
+    CamelContextConfiguration withPostProcessor(
+            PostProcessor postProcessor) {
+        this.postProcessor = postProcessor;
+        return this;
+    }
+}

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelContextManager.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelContextManager.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.test.junit5;
+
+import org.apache.camel.ConsumerTemplate;
+import org.apache.camel.FluentProducerTemplate;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.Service;
+import org.apache.camel.model.ModelCamelContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * A ContextManager is used to manage the lifecycle of a {@link org.apache.camel.CamelContext} during test execution
+ */
+public interface CamelContextManager {
+
+    /**
+     * Creates a new CamelContext
+     * @param test the test instance requesting the next context
+     * @throws Exception if unable to create the context
+     */
+    void createCamelContext(Object test) throws Exception;
+
+    /**
+     * A callback method to be executed before starting the context
+     * @param test
+     * @throws Exception
+     */
+    void beforeContextStart(Object test) throws Exception;
+
+    /**
+     * Gets the reference to the CamelContext instance
+     * @return the CamelContext instance
+     */
+    ModelCamelContext context();
+
+    /**
+     * Gets the reference to the producer template created during initialization
+     * @return the producer template instance
+     */
+    ProducerTemplate template();
+
+    /**
+     * Gets the reference to the fluent producer template created during initialization
+     * @return the fluent producer template instance
+     */
+    FluentProducerTemplate fluentTemplate();
+
+    /**
+     * Gets the reference to the consumer template created during initialization
+     * @return the consumer template instance
+     */
+    ConsumerTemplate consumer();
+
+    /**
+     * When a separate service is used to manage the context lifecycle, this returns the reference to that service
+     * @return the reference to the context lifecycle service
+     */
+    @Deprecated(since = "4.7.0")
+    Service camelContextService();
+
+    /**
+     * Starts the context
+     * @throws Exception if unable to start the context for any reason
+     */
+    void startCamelContext() throws Exception;
+
+    /**
+     * Stops the context
+     */
+    void stopCamelContext();
+
+    /**
+     * Stops the templates
+     */
+    void stopTemplates();
+
+    /**
+     * Fully stops the manager
+     */
+    void stop();
+
+    /**
+     * Sets the JUnit's data context that may be used to provide additional information for some tests
+     * @param globalStore JUnit's data context instance
+     */
+    void setGlobalStore(ExtensionContext.Store globalStore);
+}

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -16,10 +16,8 @@
  */
 package org.apache.camel.test.junit5;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
@@ -44,7 +42,6 @@ import org.apache.camel.spi.Language;
 import org.apache.camel.spi.PropertiesComponent;
 import org.apache.camel.spi.Registry;
 import org.apache.camel.support.EndpointHelper;
-import org.apache.camel.support.PluginHelper;
 import org.apache.camel.test.junit5.util.CamelContextTestHelper;
 import org.apache.camel.test.junit5.util.ExtensionHelper;
 import org.apache.camel.test.junit5.util.RouteCoverageDumperExtension;
@@ -64,7 +61,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.camel.test.junit5.TestSupport.isCamelDebugPresent;
 import static org.apache.camel.test.junit5.util.ExtensionHelper.normalizeUri;
 import static org.apache.camel.test.junit5.util.ExtensionHelper.testStartHeader;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -84,29 +80,44 @@ public abstract class CamelTestSupport
     public static final String ROUTE_COVERAGE_ENABLED = "CamelTestRouteCoverage";
 
     private static final Logger LOG = LoggerFactory.getLogger(CamelTestSupport.class);
-    private static final ThreadLocal<ModelCamelContext> THREAD_CAMEL_CONTEXT = new ThreadLocal<>();
-    private static final ThreadLocal<ProducerTemplate> THREAD_TEMPLATE = new ThreadLocal<>();
-    private static final ThreadLocal<FluentProducerTemplate> THREAD_FLUENT_TEMPLATE = new ThreadLocal<>();
-    private static final ThreadLocal<ConsumerTemplate> THREAD_CONSUMER = new ThreadLocal<>();
-    private static final ThreadLocal<Service> THREAD_SERVICE = new ThreadLocal<>();
 
-    protected Properties extra;
     protected volatile ModelCamelContext context;
     protected volatile ProducerTemplate template;
     protected volatile FluentProducerTemplate fluentTemplate;
     protected volatile ConsumerTemplate consumer;
-    protected volatile Service camelContextService;
     @RegisterExtension
     protected CamelTestSupport camelTestSupportExtension = this;
-    private boolean useRouteBuilder = true;
     private final StopWatch watch = new StopWatch();
-    private final Map<String, String> fromEndpoints = new HashMap<>();
-    private static final ThreadLocal<AtomicInteger> TESTS = new ThreadLocal<>();
-    private static final ThreadLocal<CamelTestSupport> INSTANCE = new ThreadLocal<>();
     private String currentTestName;
-    private boolean isCreateCamelContextPerClass = false;
 
-    private ExtensionContext.Store globalStore;
+    private final TestExecutionConfiguration testConfigurationBuilder;
+    private final CamelContextConfiguration camelContextConfiguration;
+
+    private CamelContextManager contextManager;
+
+    protected CamelTestSupport() {
+         testConfigurationBuilder = new TestExecutionConfiguration();
+         testConfigurationBuilder.withJMX(useJmx())
+                 .withUseRouteBuilder(isUseRouteBuilder())
+                 .withUseAdviceWith(isUseAdviceWith())
+                 .withDumpRouteCoverage(isDumpRouteCoverage());
+
+
+         camelContextConfiguration = new CamelContextConfiguration();
+
+         camelContextConfiguration
+                 .withCamelContextSupplier(this::createCamelContext)
+                 .withRegistryBinder(this::bindToRegistry)
+                 .withPostProcessor(this::postProcessTest)
+                 .withRoutesSupplier(this::createRouteBuilders)
+                 .withUseOverridePropertiesWithPropertiesComponent(useOverridePropertiesWithPropertiesComponent())
+                 .withRouteFilterExcludePattern(getRouteFilterExcludePattern())
+                 .withRouteFilterIncludePattern(getRouteFilterIncludePattern())
+                 .withMockEndpoints(isMockEndpoints())
+                 .withMockEndpointsAndSkip(isMockEndpointsAndSkip());
+
+        contextManager = new LegacyCamelContextManager(testConfigurationBuilder, camelContextConfiguration);
+    }
 
     @Override
     public void afterTestExecution(ExtensionContext context) throws Exception {
@@ -126,7 +137,8 @@ public abstract class CamelTestSupport
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
         currentTestName = context.getDisplayName();
-        globalStore = context.getStore(ExtensionContext.Namespace.GLOBAL);
+        ExtensionContext.Store globalStore = context.getStore(ExtensionContext.Namespace.GLOBAL);
+        contextManager.setGlobalStore(globalStore);
     }
 
     @Override
@@ -136,34 +148,33 @@ public abstract class CamelTestSupport
 
     @Override
     public void beforeAll(ExtensionContext context) {
-        isCreateCamelContextPerClass
-                = context.getTestInstanceLifecycle().filter(lc -> lc.equals(Lifecycle.PER_CLASS)).isPresent();
+        final boolean perClassPresent = context.getTestInstanceLifecycle().filter(lc -> lc.equals(Lifecycle.PER_CLASS)).isPresent();
+        testConfigurationBuilder.withCreateCamelContextPerClass(perClassPresent);
+
+        ExtensionContext.Store globalStore = context.getStore(ExtensionContext.Namespace.GLOBAL);
+        contextManager.setGlobalStore(globalStore);
     }
 
     @Override
     public void afterAll(ExtensionContext context) {
-        CamelTestSupport support = INSTANCE.get();
-        if (support != null && support.isCreateCamelContextPerClass) {
-            try {
-                support.tearDownCreateCamelContextPerClass();
-            } catch (Exception e) {
-                // ignore
-            }
-        }
+        contextManager.stop();
     }
 
     /**
      * Use the RouteBuilder or not
      *
+     * @deprecated Use the accessors from {@link #testConfiguration()} method
      * @return <tt>true</tt> then {@link CamelContext} will be auto started, <tt>false</tt> then {@link CamelContext}
      *         will <b>not</b> be auto started (you will have to start it manually)
      */
+    @Deprecated(since = "4.7.0")
     public boolean isUseRouteBuilder() {
-        return useRouteBuilder;
+        return testConfigurationBuilder.useRouteBuilder();
     }
 
+    @Deprecated(since = "4.7.0")
     public void setUseRouteBuilder(boolean useRouteBuilder) {
-        this.useRouteBuilder = useRouteBuilder;
+        testConfigurationBuilder.withUseRouteBuilder(useRouteBuilder);
     }
 
     /**
@@ -175,9 +186,11 @@ public abstract class CamelTestSupport
      * You can also turn on route coverage globally via setting JVM system property
      * <tt>CamelTestRouteCoverage=true</tt>.
      *
+     * @deprecated Use the accessors from {@link #testConfiguration()} method
      * @return <tt>true</tt> to write route coverage status in an xml file in the <tt>target/camel-route-coverage</tt>
      *         directory after the test has finished.
      */
+    @Deprecated(since = "4.7.0")
     public boolean isDumpRouteCoverage() {
         return false;
     }
@@ -191,10 +204,12 @@ public abstract class CamelTestSupport
      * <b>Important:</b> Its important to start {@link CamelContext} manually from the unit test after you are done
      * doing all the advice with.
      *
+     * @deprecated Use the accessors from {@link #testConfiguration()} method
      * @return <tt>true</tt> if you use advice with in your unit tests.
      */
+    @Deprecated(since = "4.7.0")
     public boolean isUseAdviceWith() {
-        return false;
+        return testConfigurationBuilder.isUseAdviceWith();
     }
 
     /**
@@ -209,10 +224,12 @@ public abstract class CamelTestSupport
      * Setting up {@link CamelContext} uses the {@link #doPreSetup()}, {@link #doSetUp()}, and {@link #doPostSetup()}
      * methods in that given order.
      *
+     * @deprecated Use the accessors from {@link #testConfiguration()} method
      * @return <tt>true</tt> per class, <tt>false</tt> per test.
      */
+    @Deprecated(since = "4.7.0")
     protected final boolean isCreateCamelContextPerClass() {
-        return isCreateCamelContextPerClass;
+        return testConfigurationBuilder.isCreateCamelContextPerClass();
     }
 
     /**
@@ -221,9 +238,11 @@ public abstract class CamelTestSupport
      * Return <tt>*</tt> to mock all endpoints.
      *
      * @see EndpointHelper#matchEndpoint(CamelContext, String, String)
+     * @deprecated Use the accessors from {@link #camelContextConfiguration()} method
      */
+    @Deprecated(since = "4.7.0")
     public String isMockEndpoints() {
-        return null;
+        return camelContextConfiguration().mockEndpoints();
     }
 
     /**
@@ -232,13 +251,22 @@ public abstract class CamelTestSupport
      * Return <tt>*</tt> to mock all endpoints.
      *
      * @see EndpointHelper#matchEndpoint(CamelContext, String, String)
+     * @deprecated Use the accessors from {@link #camelContextConfiguration()} method
      */
+    @Deprecated(since = "4.7.0")
     public String isMockEndpointsAndSkip() {
-        return null;
+        return camelContextConfiguration().mockEndpointsAndSkip();
     }
 
+    /**
+     * To replace from routes
+     * @param routeId
+     * @param fromEndpoint
+     * @deprecated Use the accessors from {@link #camelContextConfiguration()} method
+     */
+    @Deprecated(since = "4.7.0")
     public void replaceRouteFromWith(String routeId, String fromEndpoint) {
-        fromEndpoints.put(routeId, fromEndpoint);
+        camelContextConfiguration.replaceRouteFromWith(routeId, fromEndpoint);
     }
 
     /**
@@ -256,8 +284,9 @@ public abstract class CamelTestSupport
      * <p>
      * Exclude takes precedence over include.
      */
+    @Deprecated(since = "4.7.0")
     public String getRouteFilterIncludePattern() {
-        return null;
+        return camelContextConfiguration.routeFilterIncludePattern();
     }
 
     /**
@@ -275,8 +304,9 @@ public abstract class CamelTestSupport
      * <p>
      * Exclude takes precedence over include.
      */
+    @Deprecated(since = "4.7.0")
     public String getRouteFilterExcludePattern() {
-        return null;
+        return camelContextConfiguration.routeFilterExcludePattern();
     }
 
     /**
@@ -290,21 +320,40 @@ public abstract class CamelTestSupport
      * Override to enable debugger
      * <p/>
      * Is default <tt>false</tt>
+     * @deprecated Use the accessors from {@link #testConfiguration()} method
      */
+    @Deprecated(since = "4.7.0")
     public boolean isUseDebugger() {
-        return false;
+        return camelContextConfiguration.useDebugger();
     }
 
+    @Deprecated(since = "4.7.0")
     public Service getCamelContextService() {
-        return camelContextService;
+        return camelContextConfiguration.camelContextService();
     }
 
+    @Deprecated(since = "4.7.0")
     public Service camelContextService() {
-        return camelContextService;
+        return camelContextConfiguration.camelContextService();
     }
 
+    /**
+     * Gets a reference to the CamelContext. Must not be used during test setup.
+     *
+     * @return A reference to the CamelContext
+     */
     public CamelContext context() {
         return context;
+    }
+
+    /**
+     * Sets the CamelContext. Used by the manager to override tests that try to access the context
+     * during setup. DO NOT USE.
+     * @param context
+     */
+    @Deprecated(since = "4.7.0")
+    public void setContext(ModelCamelContext context) {
+        this.context = context;
     }
 
     public ProducerTemplate template() {
@@ -324,8 +373,7 @@ public abstract class CamelTestSupport
      * when the ApplicationContext is started and stopped, rather than directly stopping the CamelContext
      */
     public void setCamelContextService(Service service) {
-        camelContextService = service;
-        THREAD_SERVICE.set(camelContextService);
+        camelContextConfiguration.withCamelContextService(service);
     }
 
     @BeforeEach
@@ -334,41 +382,16 @@ public abstract class CamelTestSupport
 
         unsupportedCheck();
 
-        if (isCreateCamelContextPerClass) {
-            createCamelContextPerClass();
-        } else {
-            // test is per test so always setup
-            initialize();
-        }
+        setupResources();
+        doPreSetup();
+
+        contextManager.createCamelContext(this);
+        context = contextManager.context();
+
+        doPostSetup();
 
         // only start timing after all the setup
         watch.restart();
-    }
-
-    private void createCamelContextPerClass() throws Exception {
-        INSTANCE.set(this);
-        AtomicInteger v = TESTS.get();
-        if (v == null) {
-            v = new AtomicInteger();
-            TESTS.set(v);
-        }
-        if (v.getAndIncrement() == 0) {
-            LOG.debug("Setup CamelContext before running first test");
-            // test is per class, so only setup once (the first time)
-            initialize();
-        } else {
-            LOG.debug("Reset between test methods");
-            // and in between tests we must do IoC and reset mocks
-            postProcessTest();
-            MockEndpoint.resetMocks(context);
-        }
-    }
-
-    private void initialize() throws Exception {
-        setupResources();
-        doPreSetup();
-        doSetUp();
-        doPostSetup();
     }
 
     /**
@@ -423,102 +446,9 @@ public abstract class CamelTestSupport
 
     @Deprecated(since = "4.7.0")
     protected final void doSetUp() throws Exception {
-        LOG.debug("setUp test");
-        // jmx is enabled if we have configured to use it, if dump route coverage is enabled (it requires JMX) or if
-        // the component camel-debug is in the classpath
-        if (useJmx() || isRouteCoverageEnabled() || isCamelDebugPresent()) {
-            enableJMX();
-        } else {
-            disableJMX();
-        }
-
-        context = (ModelCamelContext) createCamelContext();
-        THREAD_CAMEL_CONTEXT.set(context);
-
-        assert context != null : "No context found!";
-
-        // add custom beans
-        bindToRegistry(context.getRegistry());
-
-        // reduce default shutdown timeout to avoid waiting for 300 seconds
-        context.getShutdownStrategy().setTimeout(getShutdownTimeout());
-
-        // set debugger if enabled
-        if (isUseDebugger()) {
-            CamelContextTestHelper.setupDebugger(context, createBreakpoint());
-        }
-
-        setupTemplates();
-
-        // enable auto mocking if enabled
-        CamelContextTestHelper.enableAutoMocking(context, isMockEndpoints(), isMockEndpointsAndSkip());
-
-        // configure properties component (mandatory for testing)
-        configurePropertiesComponent();
-
-        configureIncludeExcludePatterns();
-
-        // prepare for in-between tests
-        postProcessTest();
-
-        if (isUseRouteBuilder()) {
-            setupRoutes();
-
-            tryStartCamelContext();
-        } else {
-            CamelContextTestHelper.replaceFromEndpoints(context, fromEndpoints);
-            LOG.debug("Using route builder from the created context: {}", context);
-        }
-        LOG.debug("Routing Rules are: {}", context.getRoutes());
+        throw new UnsupportedOperationException("Do not use the doSetUp method");
     }
 
-    private void setupTemplates() {
-        template = context.createProducerTemplate();
-        template.start();
-        fluentTemplate = context.createFluentProducerTemplate();
-        fluentTemplate.start();
-        consumer = context.createConsumerTemplate();
-        consumer.start();
-
-        THREAD_TEMPLATE.set(template);
-        THREAD_FLUENT_TEMPLATE.set(fluentTemplate);
-        THREAD_CONSUMER.set(consumer);
-    }
-
-    private void setupRoutes() throws Exception {
-        RoutesBuilder[] builders = createRouteBuilders();
-
-        CamelContextTestHelper.setupRoutes(context, builders);
-
-        CamelContextTestHelper.replaceFromEndpoints(context, fromEndpoints);
-    }
-
-    private void tryStartCamelContext() throws Exception {
-        boolean skip = Boolean.parseBoolean(System.getProperty("skipStartingCamelContext"));
-        if (skip) {
-            LOG.info("Skipping starting CamelContext as system property skipStartingCamelContext is set to be true.");
-        } else if (isUseAdviceWith()) {
-            LOG.info("Skipping starting CamelContext as isUseAdviceWith is set to true.");
-        } else {
-            startCamelContext();
-        }
-    }
-
-    private void configureIncludeExcludePatterns() {
-        final String include = getRouteFilterIncludePattern();
-        final String exclude = getRouteFilterExcludePattern();
-
-        CamelContextTestHelper.configureIncludeExcludePatterns(context, include, exclude);
-    }
-
-    private void configurePropertiesComponent() {
-        if (extra == null) {
-            extra = useOverridePropertiesWithPropertiesComponent();
-        }
-
-        Boolean ignore = ignoreMissingLocationWithPropertiesComponent();
-        CamelContextTestHelper.configurePropertiesComponent(context, extra, new JunitPropertiesSource(globalStore), ignore);
-    }
 
     private boolean isRouteCoverageEnabled() {
         return Boolean.parseBoolean(System.getProperty(ROUTE_COVERAGE_ENABLED, "false")) || isDumpRouteCoverage();
@@ -534,26 +464,18 @@ public abstract class CamelTestSupport
             ExtensionHelper.testEndFooter(getClass(), currentTestName, time);
         }
 
-        if (isCreateCamelContextPerClass) {
+        if (testConfigurationBuilder.isCreateCamelContextPerClass()) {
             // will tear down test specially in afterAll callback
             return;
         }
 
         LOG.debug("tearDown()");
-        doStopTemplates(consumer, template, fluentTemplate);
-        doStopCamelContext(context, camelContextService);
+
+        contextManager.stop();
+
         doPostTearDown();
         cleanupResources();
 
-    }
-
-    void tearDownCreateCamelContextPerClass() throws Exception {
-        LOG.debug("tearDownCreateCamelContextPerClass()");
-        TESTS.remove();
-        doStopTemplates(THREAD_CONSUMER.get(), THREAD_TEMPLATE.get(), THREAD_FLUENT_TEMPLATE.get());
-        doStopCamelContext(THREAD_CAMEL_CONTEXT.get(), THREAD_SERVICE.get());
-        doPostTearDown();
-        cleanupResources();
     }
 
     /**
@@ -584,45 +506,50 @@ public abstract class CamelTestSupport
      * @return the timeout to use
      */
     protected int getShutdownTimeout() {
-        return 10;
+        return camelContextConfiguration.shutdownTimeout();
     }
 
     /**
      * Whether JMX should be used during testing.
      *
+     * @deprecated Use the methods {@link #testConfiguration()} to enable, disable or check JMX state.
      * @return <tt>false</tt> by default.
      */
+    @Deprecated(since = "4.7.0")
     protected boolean useJmx() {
-        return false;
+        return testConfigurationBuilder.isJmxEnabled();
     }
 
     /**
      * Override this method to include and override properties with the Camel {@link PropertiesComponent}.
      *
+     * @deprecated Use the accessors from {@link #camelContextConfiguration()} method
      * @return additional properties to add/override.
      */
+    @Deprecated(since = "4.7.0")
     protected Properties useOverridePropertiesWithPropertiesComponent() {
-        return null;
+        return camelContextConfiguration.useOverridePropertiesWithPropertiesComponent();
     }
 
     /**
      * Whether to ignore missing locations with the {@link PropertiesComponent}. For example when unit testing you may
      * want to ignore locations that are not available in the environment used for testing.
      *
+     * @deprecated Use the accessors from {@link #camelContextConfiguration()} method
      * @return <tt>true</tt> to ignore, <tt>false</tt> to not ignore, and <tt>null</tt> to leave as configured on the
      *         {@link PropertiesComponent}
      */
+    @Deprecated(since = "4.7.0")
     protected Boolean ignoreMissingLocationWithPropertiesComponent() {
-        return null;
+        return camelContextConfiguration.ignoreMissingLocationWithPropertiesComponent();
     }
 
+    @Deprecated(since = "4.7.0")
     protected void postProcessTest() throws Exception {
-        context = THREAD_CAMEL_CONTEXT.get();
-        template = THREAD_TEMPLATE.get();
-        fluentTemplate = THREAD_FLUENT_TEMPLATE.get();
-        consumer = THREAD_CONSUMER.get();
-        camelContextService = THREAD_SERVICE.get();
-        applyCamelPostProcessor();
+        context = contextManager.context();
+        template = contextManager.template();
+        fluentTemplate = contextManager.fluentTemplate();
+        consumer = contextManager.consumer();
     }
 
     /**
@@ -631,16 +558,9 @@ public abstract class CamelTestSupport
      * Derived classes using IoC / DI frameworks may wish to turn this into a NoOp such as for CDI we would just use CDI
      * to inject this
      */
+    @Deprecated(since = "4.7.0")
     protected void applyCamelPostProcessor() throws Exception {
-        // use the bean post processor if the test class is not dependency
-        // injected already by Spring Framework
-        boolean spring = ExtensionHelper.hasClassAnnotation(getClass(), "org.springframework.context.annotation.ComponentScan");
-        if (!spring) {
-            PluginHelper.getBeanPostProcessor(context).postProcessBeforeInitialization(this,
-                    getClass().getName());
-            PluginHelper.getBeanPostProcessor(context).postProcessAfterInitialization(this,
-                    getClass().getName());
-        }
+
     }
 
     /**
@@ -652,49 +572,12 @@ public abstract class CamelTestSupport
     }
 
     protected void stopCamelContext() throws Exception {
-        doStopCamelContext(context, camelContextService);
-    }
+        contextManager.stopCamelContext();
 
-    protected void doStopCamelContext(CamelContext context, Service camelContextService) {
-        if (camelContextService != null) {
-            if (camelContextService == THREAD_SERVICE.get()) {
-                THREAD_SERVICE.remove();
-            }
-            camelContextService.stop();
-        } else {
-            if (context != null) {
-                if (context == THREAD_CAMEL_CONTEXT.get()) {
-                    THREAD_CAMEL_CONTEXT.remove();
-                }
-                context.stop();
-            }
-        }
-    }
-
-    private static void doStopTemplates(
-            ConsumerTemplate consumer, ProducerTemplate template, FluentProducerTemplate fluentTemplate) {
-        if (consumer != null) {
-            if (consumer == THREAD_CONSUMER.get()) {
-                THREAD_CONSUMER.remove();
-            }
-            consumer.stop();
-        }
-        if (template != null) {
-            if (template == THREAD_TEMPLATE.get()) {
-                THREAD_TEMPLATE.remove();
-            }
-            template.stop();
-        }
-        if (fluentTemplate != null) {
-            if (fluentTemplate == THREAD_FLUENT_TEMPLATE.get()) {
-                THREAD_FLUENT_TEMPLATE.remove();
-            }
-            fluentTemplate.stop();
-        }
     }
 
     protected void startCamelContext() throws Exception {
-        CamelContextTestHelper.startCamelContextOrService(context, camelContextService);
+        contextManager.startCamelContext();
     }
 
     protected CamelContext createCamelContext() throws Exception {
@@ -702,7 +585,7 @@ public abstract class CamelTestSupport
     }
 
     /**
-     * Allows to bind custom beans to the Camel {@link Registry}.
+     * Allows binding custom beans to the Camel {@link Registry}.
      */
     protected void bindToRegistry(Registry registry) throws Exception {
         // noop
@@ -736,7 +619,9 @@ public abstract class CamelTestSupport
      * to define the routes for testing
      *
      * @see #createRouteBuilder()
+     * @deprecated This method will be made private. Do not use
      */
+    @Deprecated(since = "4.7.0")
     protected RoutesBuilder[] createRouteBuilders() throws Exception {
         return new RoutesBuilder[] { createRouteBuilder() };
     }
@@ -746,7 +631,9 @@ public abstract class CamelTestSupport
      *
      * @param  uri the Camel <a href="">URI</a> to use to create or resolve an endpoint
      * @return     the endpoint
+     * @deprecated Use the methods from {@link TestSupport}
      */
+    @Deprecated(since = "4.7.0")
     protected final Endpoint resolveMandatoryEndpoint(String uri) {
         return TestSupport.resolveMandatoryEndpoint(context, uri);
     }
@@ -756,7 +643,9 @@ public abstract class CamelTestSupport
      *
      * @param  uri the Camel <a href="">URI</a> to use to create or resolve an endpoint
      * @return     the endpoint
+     * @deprecated Use the methods from {@link TestSupport}
      */
+    @Deprecated(since = "4.7.0")
     protected final <T extends Endpoint> T resolveMandatoryEndpoint(String uri, Class<T> endpointType) {
         return TestSupport.resolveMandatoryEndpoint(context, uri, endpointType);
     }
@@ -873,12 +762,19 @@ public abstract class CamelTestSupport
     /**
      * Asserts that the language name can be resolved
      */
+    @Deprecated(since = "4.7.0")
     protected final Language assertResolveLanguage(String languageName) {
         Language language = context.resolveLanguage(languageName);
         assertNotNull(language, "Nog language found for name: " + languageName);
         return language;
     }
 
+    /**
+     * Asserts the validity of the context
+     * @deprecated Use JUnit's assertions if needed
+     * @param context
+     */
+    @Deprecated(since = "4.7.0")
     protected final void assertValidContext(CamelContext context) {
         assertNotNull(context, "No context found!");
     }
@@ -897,22 +793,27 @@ public abstract class CamelTestSupport
 
     /**
      * Disables the JMX agent. Must be called before the {@link #setUp()} method.
+     * @deprecated Use the methods {@link #testConfiguration()} to enable, disable or check JMX state.
      */
+    @Deprecated(since = "4.7.0")
     protected void disableJMX() {
-        DefaultCamelContext.setDisableJmx(true);
+        testConfigurationBuilder.withDisableJMX();
     }
 
     /**
      * Enables the JMX agent. Must be called before the {@link #setUp()} method.
+     *
+     * @deprecated Use the methods {@link #testConfiguration()} to enable, disable or check JMX state.
      */
+    @Deprecated(since = "4.7.0")
     protected void enableJMX() {
-        DefaultCamelContext.setDisableJmx(false);
+        testConfigurationBuilder.withEnableJMX();
     }
 
     /**
      * Single step debugs and Camel invokes this method before entering the given processor. This method is NOOP.
      *
-     * @deprecated Use {@link #createBreakpoint} and return a new instance of {@link DebugBreakpoint}
+     * @deprecated Use {@link #camelContextConfiguration()} to set an instance of {@link DebugBreakpoint}
      */
     @Deprecated(since = "4.7.0")
     protected void debugBefore(
@@ -922,7 +823,7 @@ public abstract class CamelTestSupport
     /**
      * Single step debugs and Camel invokes this method after processing the given processor. This method is NOOP.
      *
-     * @deprecated Use {@link #createBreakpoint} and return a new instance of {@link DebugBreakpoint}
+     * @deprecated Use {@link #camelContextConfiguration()} to set an instance of {@link DebugBreakpoint}
      */
     @Deprecated(since = "4.7.0")
     protected void debugAfter(
@@ -931,11 +832,20 @@ public abstract class CamelTestSupport
     }
 
     /**
-     * Provides a debug breakpoint to be executed before and/or after entering processors
-     *
-     * @return a new debug breakpoint
+     * Gets the {@link TestExecutionConfiguration} test execution configuration instance for the test
+     * @return the configuration instance for the test
      */
-    protected DebugBreakpoint createBreakpoint() {
-        return null;
+    public final TestExecutionConfiguration testConfiguration() {
+        return testConfigurationBuilder;
     }
+
+    /**
+     * Gets the {@link CamelContextConfiguration} for the test
+     * @return the camel context configuration
+     */
+    public final CamelContextConfiguration camelContextConfiguration() {
+        return camelContextConfiguration;
+    }
+
+
 }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/LegacyCamelContextManager.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/LegacyCamelContextManager.java
@@ -1,0 +1,352 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.test.junit5;
+
+import java.lang.reflect.Method;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ConsumerTemplate;
+import org.apache.camel.FluentProducerTemplate;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.Service;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.model.ModelCamelContext;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit5.util.CamelContextTestHelper;
+import org.apache.camel.test.junit5.util.ExtensionHelper;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.camel.test.junit5.TestSupport.isCamelDebugPresent;
+
+/**
+ * A {@link CamelContext} test lifecycle manager based on the behavior that was built in {@link CamelTestSupport} up to
+ * Camel 4.7.0
+ */
+public class LegacyCamelContextManager implements CamelContextManager {
+    private static final Logger LOG = LoggerFactory.getLogger(LegacyCamelContextManager.class);
+
+    private static final ThreadLocal<LegacyCamelContextManager> INSTANCE = new ThreadLocal<>();
+    private static final ThreadLocal<AtomicInteger> TESTS = new ThreadLocal<>();
+    private static final ThreadLocal<ModelCamelContext> THREAD_CAMEL_CONTEXT = new ThreadLocal<>();
+    private static final ThreadLocal<ProducerTemplate> THREAD_TEMPLATE = new ThreadLocal<>();
+    private static final ThreadLocal<FluentProducerTemplate> THREAD_FLUENT_TEMPLATE = new ThreadLocal<>();
+    private static final ThreadLocal<ConsumerTemplate> THREAD_CONSUMER = new ThreadLocal<>();
+    private static final ThreadLocal<Service> THREAD_SERVICE = new ThreadLocal<>();
+
+    private final TestExecutionConfiguration testConfigurationBuilder;
+    private final CamelContextConfiguration camelContextConfiguration;
+    private ModelCamelContext context;
+
+    protected volatile ProducerTemplate template;
+    protected volatile FluentProducerTemplate fluentTemplate;
+    protected volatile ConsumerTemplate consumer;
+    private Properties extra;
+    private ExtensionContext.Store globalStore;
+
+    public LegacyCamelContextManager(TestExecutionConfiguration testConfigurationBuilder,
+            CamelContextConfiguration camelContextConfiguration) {
+        this.testConfigurationBuilder = testConfigurationBuilder;
+        this.camelContextConfiguration = camelContextConfiguration;
+
+        final Service service = camelContextConfiguration.camelContextService();
+        if (service != null) {
+            THREAD_SERVICE.set(service);
+        }
+    }
+
+    @Override
+    public void createCamelContext(Object test) throws Exception {
+        if (testConfigurationBuilder.isCreateCamelContextPerClass()) {
+            createCamelContextPerClass(test);
+        } else {
+            initialize(test);
+        }
+    }
+
+    @Override
+    public void beforeContextStart(Object test) throws Exception {
+        context = THREAD_CAMEL_CONTEXT.get();
+        template = THREAD_TEMPLATE.get();
+        fluentTemplate = THREAD_FLUENT_TEMPLATE.get();
+        consumer = THREAD_CONSUMER.get();
+
+        applyCamelPostProcessor(test);
+        camelContextConfiguration.postProcessor().postSetup();
+    }
+
+    private void createCamelContextPerClass(Object test) throws Exception {
+        INSTANCE.set(this);
+        AtomicInteger v = TESTS.get();
+        if (v == null) {
+            v = new AtomicInteger();
+            TESTS.set(v);
+        }
+        if (v.getAndIncrement() == 0) {
+            LOG.debug("Setup CamelContext before running first test");
+            // test is per class, so only setup once (the first time)
+            initialize(test);
+        } else {
+            LOG.debug("Reset between test methods");
+            // and in between tests we must do IoC and reset mocks
+            beforeContextStart(test);
+            MockEndpoint.resetMocks(context);
+        }
+    }
+
+    private void initialize(Object test) throws Exception {
+        LOG.debug("Initializing a new CamelContext");
+
+        // jmx is enabled if we have configured to use it, if dump route coverage is enabled (it requires JMX) or if
+        // the component camel-debug is in the classpath
+        if (testConfigurationBuilder.isJmxEnabled() || testConfigurationBuilder.isRouteCoverageEnabled() || isCamelDebugPresent()) {
+            enableJMX();
+        } else {
+            disableJMX();
+        }
+
+        context = (ModelCamelContext) camelContextConfiguration.camelContextSupplier().createCamelContext();
+        THREAD_CAMEL_CONTEXT.set(context);
+
+        // TODO: fixme (some tests try to access the context before it's set on the test)
+        final Method setContextMethod = test.getClass().getMethod("setContext", ModelCamelContext.class);
+        setContextMethod.invoke(test, context);
+
+        assert context != null : "No context found!";
+
+        // add custom beans
+        camelContextConfiguration.registryBinder().bindToRegistry(context.getRegistry());
+
+        // reduce default shutdown timeout to avoid waiting for 300 seconds
+        context.getShutdownStrategy().setTimeout(camelContextConfiguration.shutdownTimeout());
+
+        // set debugger if enabled
+        if (camelContextConfiguration.useDebugger()) {
+            CamelContextTestHelper.setupDebugger(context, camelContextConfiguration.breakpoint());
+        }
+
+        setupTemplates();
+
+        // enable auto mocking if enabled
+        final String mockPattern = camelContextConfiguration.mockEndpoints();
+        final String mockAndSkipPattern = camelContextConfiguration.mockEndpointsAndSkip();
+        CamelContextTestHelper.enableAutoMocking(context, mockPattern, mockAndSkipPattern);
+
+        // configure properties component (mandatory for testing)
+        configurePropertiesComponent();
+
+        configureIncludeExcludePatterns();
+
+        // prepare for in-between tests
+        beforeContextStart(test);
+
+        if (testConfigurationBuilder.useRouteBuilder()) {
+            setupRoutes();
+
+            tryStartCamelContext();
+        } else {
+            CamelContextTestHelper.replaceFromEndpoints(context, camelContextConfiguration.fromEndpoints());
+            LOG.debug("Using route builder from the created context: {}", context);
+        }
+        LOG.debug("Routing Rules are: {}", context.getRoutes());
+    }
+
+    private void setupTemplates() {
+        template = context.createProducerTemplate();
+        template.start();
+        fluentTemplate = context.createFluentProducerTemplate();
+        fluentTemplate.start();
+        consumer = context.createConsumerTemplate();
+        consumer.start();
+
+        THREAD_TEMPLATE.set(template);
+        THREAD_FLUENT_TEMPLATE.set(fluentTemplate);
+        THREAD_CONSUMER.set(consumer);
+    }
+
+    private void configureIncludeExcludePatterns() {
+        final String include = camelContextConfiguration.routeFilterIncludePattern();
+        final String exclude = camelContextConfiguration.routeFilterExcludePattern();
+
+        CamelContextTestHelper.configureIncludeExcludePatterns(context, include, exclude);
+    }
+
+    private void configurePropertiesComponent() {
+        if (extra == null) {
+            extra = camelContextConfiguration.useOverridePropertiesWithPropertiesComponent();
+        }
+
+        Boolean ignore = camelContextConfiguration.ignoreMissingLocationWithPropertiesComponent();
+        CamelContextTestHelper.configurePropertiesComponent(context, extra, new JunitPropertiesSource(globalStore), ignore);
+    }
+
+
+    private void setupRoutes() throws Exception {
+        RoutesBuilder[] builders = camelContextConfiguration.routesSupplier().createRouteBuilders();
+
+        CamelContextTestHelper.setupRoutes(context, builders);
+
+        CamelContextTestHelper.replaceFromEndpoints(context, camelContextConfiguration.fromEndpoints());
+    }
+
+    private void tryStartCamelContext() throws Exception {
+        boolean skip = CamelContextTestHelper.isSkipAutoStartContext(testConfigurationBuilder);
+        if (skip) {
+            LOG.info("Skipping starting CamelContext as system property skipStartingCamelContext is set to be true or auto start context is false.");
+        } else if (testConfigurationBuilder.isUseAdviceWith()) {
+            LOG.info("Skipping starting CamelContext as isUseAdviceWith is set to true.");
+        } else {
+            CamelContextTestHelper.startCamelContextOrService(context, camelContextConfiguration.camelContextService());
+        }
+    }
+
+    /**
+     * Disables the JMX agent.
+     */
+    protected void disableJMX() {
+        DefaultCamelContext.setDisableJmx(true);
+    }
+
+    /**
+     * Enables the JMX agent.
+     */
+    protected void enableJMX() {
+        DefaultCamelContext.setDisableJmx(false);
+    }
+
+    @Override
+    public ModelCamelContext context() {
+        return context;
+    }
+
+    @Override
+    public ProducerTemplate template() {
+        return template;
+    }
+
+    @Override
+    public FluentProducerTemplate fluentTemplate() {
+        return fluentTemplate;
+    }
+
+    @Override
+    public ConsumerTemplate consumer() {
+        return consumer;
+    }
+
+    @Override
+    public Service camelContextService() {
+        return THREAD_SERVICE.get();
+    }
+
+    @Override
+    public void startCamelContext() throws Exception {
+        CamelContextTestHelper.startCamelContextOrService(context, camelContextConfiguration.camelContextService());
+    }
+
+    @Override
+    public void stopCamelContext() {
+        doStopCamelContext(context, camelContextConfiguration.camelContextService());
+    }
+
+    @Override
+    public void stop() {
+        LegacyCamelContextManager support = INSTANCE.get();
+        if (support != null && testConfigurationBuilder.isCreateCamelContextPerClass()) {
+            try {
+                support.tearDownCreateCamelContextPerClass();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+
+        doStopCamelContext(THREAD_CAMEL_CONTEXT.get(), THREAD_SERVICE.get());
+    }
+
+    @Override
+    public void stopTemplates() {
+        doStopTemplates(THREAD_CONSUMER.get(), THREAD_TEMPLATE.get(), THREAD_FLUENT_TEMPLATE.get());
+    }
+
+    void tearDownCreateCamelContextPerClass() {
+        LOG.debug("tearDownCreateCamelContextPerClass()");
+        TESTS.remove();
+        stopTemplates();
+        doStopCamelContext(THREAD_CAMEL_CONTEXT.get(), THREAD_SERVICE.get());
+    }
+
+    private static void doStopTemplates(
+            ConsumerTemplate consumer, ProducerTemplate template, FluentProducerTemplate fluentTemplate) {
+        if (consumer != null) {
+            if (consumer == THREAD_CONSUMER.get()) {
+                THREAD_CONSUMER.remove();
+            }
+            consumer.stop();
+        }
+        if (template != null) {
+            if (template == THREAD_TEMPLATE.get()) {
+                THREAD_TEMPLATE.remove();
+            }
+            template.stop();
+        }
+        if (fluentTemplate != null) {
+            if (fluentTemplate == THREAD_FLUENT_TEMPLATE.get()) {
+                THREAD_FLUENT_TEMPLATE.remove();
+            }
+            fluentTemplate.stop();
+        }
+    }
+
+    protected void doStopCamelContext(CamelContext context, Service camelContextService) {
+        if (camelContextService != null) {
+            if (camelContextService == THREAD_SERVICE.get()) {
+                THREAD_SERVICE.remove();
+            }
+            camelContextService.stop();
+        } else {
+            if (context != null) {
+                if (context == THREAD_CAMEL_CONTEXT.get()) {
+                    THREAD_CAMEL_CONTEXT.remove();
+                }
+                context.stop();
+            }
+        }
+    }
+
+    protected void applyCamelPostProcessor(Object test) throws Exception {
+        // use the bean post processor if the test class is not dependency
+        // injected already by Spring Framework
+        boolean spring = ExtensionHelper.hasClassAnnotation(test.getClass(), "org.springframework.context.annotation.ComponentScan");
+        if (!spring) {
+            PluginHelper.getBeanPostProcessor(context).postProcessBeforeInitialization(test,
+                    test.getClass().getName());
+            PluginHelper.getBeanPostProcessor(context).postProcessAfterInitialization(test,
+                    test.getClass().getName());
+        }
+    }
+
+    @Override
+    public void setGlobalStore(ExtensionContext.Store globalStore) {
+        this.globalStore = globalStore;
+    }
+}

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/TestExecutionConfiguration.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/TestExecutionConfiguration.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.test.junit5;
+
+import org.apache.camel.CamelContext;
+
+/**
+ * This configuration class allows tweaking how the test itself configured and enable/disable features that affect its
+ * execution environment.
+ */
+public class TestExecutionConfiguration {
+    private boolean jmx;
+    private boolean dumpRouteCoverage = false;
+    private boolean useAdviceWith = false;
+    private boolean createCamelContextPerClass = false;
+    private boolean useRouteBuilder = true;
+    private boolean autoStartContext = true;
+
+    public boolean isJmxEnabled() {
+        return jmx;
+    }
+
+    /**
+     * Enables the JMX agent. Must be called before the setUp method.
+     */
+    public TestExecutionConfiguration withEnableJMX() {
+        return withJMX(true);
+    }
+
+    /**
+     * Disables the JMX agent. Must be called before the setUp method.
+     */
+    public TestExecutionConfiguration withDisableJMX() {
+        return withJMX(false);
+    }
+
+    public TestExecutionConfiguration withJMX(boolean enableJMX) {
+        this.jmx = enableJMX;
+        return this;
+    }
+
+    public boolean isDumpRouteCoverage() {
+        return dumpRouteCoverage;
+    }
+
+    /**
+     * Whether to dump route coverage stats at the end of the test.
+     * <p/>
+     * This allows tooling or manual inspection of the stats, so you can generate a route trace diagram of which EIPs
+     * have been in use and which have not. Similar concepts as a code coverage report.
+     * <p/>
+     * You can also turn on route coverage globally via setting JVM system property
+     * <tt>CamelTestRouteCoverage=true</tt>.
+     *
+     * @param dumpRouteCoverage <tt>true</tt> to write route coverage status in an xml file in the <tt>target/camel-route-coverage</tt>
+     *                          directory after the test has finished.
+     */
+    public TestExecutionConfiguration withDumpRouteCoverage(boolean dumpRouteCoverage) {
+        this.dumpRouteCoverage = dumpRouteCoverage;
+        return this;
+    }
+
+    public boolean isRouteCoverageEnabled() {
+        return Boolean.parseBoolean(
+                System.getProperty(CamelTestSupport.ROUTE_COVERAGE_ENABLED, "false")) || isDumpRouteCoverage();
+    }
+
+    public boolean isUseAdviceWith() {
+        return useAdviceWith;
+    }
+
+    /**
+     * Set when using <a href="http://camel.apache.org/advicewith.html">advice with</a> and return <tt>true</tt>.
+     * This helps to know that advice with is to be used, and {@link CamelContext} will not be started before the advice with
+     * takes place. This helps by ensuring the advice with has been property setup before the {@link CamelContext} is
+     * started
+     * <p/>
+     * <b>Important:</b> It's important to start {@link CamelContext} manually from the unit test after you are done
+     * doing all the advice with.
+     *
+     * @return <tt>true</tt> if you use advice with in your unit tests.
+     */
+    @Deprecated(since = "4.7.0")
+    TestExecutionConfiguration withUseAdviceWith(boolean useAdviceWith) {
+        this.useAdviceWith = useAdviceWith;
+        return this;
+    }
+
+    public boolean isCreateCamelContextPerClass() {
+        return createCamelContextPerClass;
+    }
+
+    /**
+     * Tells whether {@link CamelContext} should be setup per test or per class.
+     * <p/>
+     * By default, it will be setup/teardown per test method. This method returns <code>true</code> when the camel test
+     * class is annotated with @TestInstance(TestInstance.Lifecycle.PER_CLASS).
+     * <p/>
+     * <b>Important:</b> Use this with care as the {@link CamelContext} will carry over state from previous tests, such
+     * as endpoints, components etc. So you cannot use this in all your tests.
+     * <p/>
+     *
+     * @deprecated Do not use
+     * @return <tt>true</tt> per class, <tt>false</tt> per test.
+     */
+    @Deprecated(since = "4.7.0")
+    TestExecutionConfiguration withCreateCamelContextPerClass(boolean createCamelContextPerClass) {
+        this.createCamelContextPerClass = createCamelContextPerClass;
+        return this;
+    }
+
+    public boolean useRouteBuilder() {
+        return useRouteBuilder;
+    }
+
+    /**
+     * Whether to use the RouteBuilder or not
+     *
+     * @return <tt>true</tt> then {@link CamelContext} will be auto started, <tt>false</tt> then {@link CamelContext}
+     *         will <b>not</b> be auto started (you will have to start it manually)
+     */
+    public TestExecutionConfiguration withUseRouteBuilder(boolean useRouteBuilder) {
+        this.useRouteBuilder = useRouteBuilder;
+        return this;
+    }
+
+    public boolean autoStartContext() {
+        return autoStartContext;
+    }
+
+    /**
+     * Sets to auto-start the context of not.
+     * @param autoStartContext
+     * @deprecated Do not use
+     */
+    @Deprecated(since = "4.7.0")
+    public TestExecutionConfiguration withAutoStartContext(boolean autoStartContext) {
+        this.autoStartContext = autoStartContext;
+        return this;
+    }
+}

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/util/CamelContextTestHelper.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/util/CamelContextTestHelper.java
@@ -38,6 +38,7 @@ import org.apache.camel.spi.Breakpoint;
 import org.apache.camel.spi.PropertiesComponent;
 import org.apache.camel.spi.PropertiesSource;
 import org.apache.camel.spi.Registry;
+import org.apache.camel.test.junit5.TestExecutionConfiguration;
 import org.apache.camel.test.junit5.TestSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -229,5 +230,10 @@ public final class CamelContextTestHelper {
                 }
             });
         }
+    }
+
+
+    public static boolean isSkipAutoStartContext(TestExecutionConfiguration configuration) {
+        return Boolean.parseBoolean(System.getProperty("skipStartingCamelContext")) || !configuration.autoStartContext();
     }
 }

--- a/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/CamelTestSupportOneContextForAllTest.java
+++ b/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/CamelTestSupportOneContextForAllTest.java
@@ -21,7 +21,6 @@ import org.apache.camel.EndpointInject;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.RoutesBuilder;
-import org.apache.camel.Service;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -29,7 +28,9 @@ import org.apache.camel.spi.Registry;
 import org.apache.camel.support.DefaultRegistry;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CamelTestSupportOneContextForAllTest extends CamelTestSupport {
 
     private static final CamelContext CUSTOM_CONTEXT;
@@ -47,11 +48,6 @@ class CamelTestSupportOneContextForAllTest extends CamelTestSupport {
     @Override
     protected CamelContext createCamelContext() throws Exception {
         return CUSTOM_CONTEXT;
-    }
-
-    @Override
-    protected void doStopCamelContext(CamelContext context, Service camelContextService) {
-        //don't stop
     }
 
     @Test

--- a/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/DebugJUnit5Test.java
+++ b/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/DebugJUnit5Test.java
@@ -20,24 +20,24 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.test.junit5.DebugBreakpoint;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DebugJUnit5Test extends CamelTestSupport {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DebugJUnit5Test.class);
+    private TestDebugBreakpoint testDebugBreakpoint;
 
-    // START SNIPPET: e1
     @Override
-    public boolean isUseDebugger() {
-        // must enable debugger
-        return true;
+    public void doPreSetup() throws Exception {
+        super.doPreSetup();
+
+        camelContextConfiguration()
+                .withBreakpoint(createBreakpoint());
     }
-    // END SNIPPET: e1
 
     protected DebugBreakpoint createBreakpoint() {
-        return new TestDebugBreakpoint();
+        testDebugBreakpoint = new TestDebugBreakpoint();
+        return testDebugBreakpoint;
     }
 
     @Test
@@ -51,6 +51,8 @@ public class DebugJUnit5Test extends CamelTestSupport {
 
         // assert mocks
         MockEndpoint.assertIsSatisfied(context);
+        Assertions.assertTrue(testDebugBreakpoint.isDebugAfterCalled());
+        Assertions.assertTrue(testDebugBreakpoint.isDebugBeforeCalled());
     }
 
     @Test
@@ -65,6 +67,8 @@ public class DebugJUnit5Test extends CamelTestSupport {
 
         // assert mocks
         MockEndpoint.assertIsSatisfied(context);
+        Assertions.assertTrue(testDebugBreakpoint.isDebugAfterCalled());
+        Assertions.assertTrue(testDebugBreakpoint.isDebugBeforeCalled());
     }
 
     // START SNIPPET: e2

--- a/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/DebugNoLazyTypeConverterTest.java
+++ b/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/DebugNoLazyTypeConverterTest.java
@@ -20,25 +20,25 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.test.junit5.DebugBreakpoint;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DebugNoLazyTypeConverterTest extends CamelTestSupport {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DebugNoLazyTypeConverterTest.class);
+    private TestDebugBreakpoint testDebugBreakpoint;
 
-    // START SNIPPET: e1
     @Override
-    public boolean isUseDebugger() {
-        // must enable debugger
-        return true;
+    public void doPreSetup() throws Exception {
+        super.doPreSetup();
+
+        camelContextConfiguration()
+                .withBreakpoint(createBreakpoint());
     }
 
     protected DebugBreakpoint createBreakpoint() {
-        return new TestDebugBreakpoint();
+        testDebugBreakpoint = new TestDebugBreakpoint();
+        return testDebugBreakpoint;
     }
-    // END SNIPPET: e1
 
     @Test
     public void testDebugger() throws Exception {
@@ -51,6 +51,9 @@ public class DebugNoLazyTypeConverterTest extends CamelTestSupport {
 
         // assert mocks
         MockEndpoint.assertIsSatisfied(context);
+
+        Assertions.assertTrue(testDebugBreakpoint.isDebugAfterCalled());
+        Assertions.assertTrue(testDebugBreakpoint.isDebugBeforeCalled());
     }
 
     @Test
@@ -65,6 +68,9 @@ public class DebugNoLazyTypeConverterTest extends CamelTestSupport {
 
         // assert mocks
         MockEndpoint.assertIsSatisfied(context);
+
+        Assertions.assertTrue(testDebugBreakpoint.isDebugAfterCalled());
+        Assertions.assertTrue(testDebugBreakpoint.isDebugBeforeCalled());
     }
 
     // START SNIPPET: e2

--- a/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/DebugTest.java
+++ b/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/DebugTest.java
@@ -20,25 +20,25 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.test.junit5.DebugBreakpoint;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DebugTest extends CamelTestSupport {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DebugTest.class);
+    private TestDebugBreakpoint testDebugBreakpoint;
 
-    // START SNIPPET: e1
     @Override
-    public boolean isUseDebugger() {
-        // must enable debugger
-        return true;
+    public void doPreSetup() throws Exception {
+        super.doPreSetup();
+
+        camelContextConfiguration()
+                .withBreakpoint(createBreakpoint());
     }
 
     protected DebugBreakpoint createBreakpoint() {
-        return new TestDebugBreakpoint();
+        testDebugBreakpoint = new TestDebugBreakpoint();
+        return testDebugBreakpoint;
     }
-    // END SNIPPET: e1
 
     @Test
     public void testDebugger() throws Exception {
@@ -51,6 +51,9 @@ public class DebugTest extends CamelTestSupport {
 
         // assert mocks
         MockEndpoint.assertIsSatisfied(context);
+
+        Assertions.assertTrue(testDebugBreakpoint.isDebugAfterCalled());
+        Assertions.assertTrue(testDebugBreakpoint.isDebugBeforeCalled());
     }
 
     @Test
@@ -65,6 +68,9 @@ public class DebugTest extends CamelTestSupport {
 
         // assert mocks
         MockEndpoint.assertIsSatisfied(context);
+
+        Assertions.assertTrue(testDebugBreakpoint.isDebugAfterCalled());
+        Assertions.assertTrue(testDebugBreakpoint.isDebugBeforeCalled());
     }
 
     // START SNIPPET: e2

--- a/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/TestDebugBreakpoint.java
+++ b/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/TestDebugBreakpoint.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 
 public class TestDebugBreakpoint extends DebugBreakpoint {
     private static final Logger LOG = LoggerFactory.getLogger(TestDebugBreakpoint.class);
+    private boolean debugBeforeCalled = false;
+    private boolean debugAfterCalled = false;
 
     @Override
     protected void debugBefore(
@@ -35,6 +37,7 @@ public class TestDebugBreakpoint extends DebugBreakpoint {
         // from your Java editor you can add a breakpoint in the code line
         // below
         LOG.info("Before {} with body {}", definition, exchange.getIn().getBody());
+        debugBeforeCalled = true;
     }
 
     @Override
@@ -42,5 +45,14 @@ public class TestDebugBreakpoint extends DebugBreakpoint {
             Exchange exchange, Processor processor, ProcessorDefinition<?> definition, String id, String label,
             long timeTaken) {
 
+        debugAfterCalled = true;
+    }
+
+    public boolean isDebugBeforeCalled() {
+        return debugBeforeCalled;
+    }
+
+    public boolean isDebugAfterCalled() {
+        return debugAfterCalled;
     }
 }

--- a/components/camel-test/camel-test-main-junit5/src/main/java/org/apache/camel/test/main/junit5/CamelMainTestSupport.java
+++ b/components/camel-test/camel-test-main-junit5/src/main/java/org/apache/camel/test/main/junit5/CamelMainTestSupport.java
@@ -142,14 +142,14 @@ public abstract class CamelMainTestSupport extends CamelTestSupport {
         }
         configure(main.configure());
         main.setPropertyPlaceholderLocations(getPropertyPlaceholderLocations());
-        main.setOverrideProperties(useOverridePropertiesWithPropertiesComponent());
+        main.setOverrideProperties(camelContextConfiguration().useOverridePropertiesWithPropertiesComponent());
         main.init(context);
         return context;
     }
 
     @Override
-    protected void applyCamelPostProcessor() throws Exception {
-        super.applyCamelPostProcessor();
+    protected void postProcessTest() throws Exception {
+        super.postProcessTest();
         bindToRegistryAfterInjections(context.getRegistry());
     }
 

--- a/components/camel-test/camel-test-spring-junit5/src/test/java/org/apache/camel/test/patterns/DebugSpringTest.java
+++ b/components/camel-test/camel-test-spring-junit5/src/test/java/org/apache/camel/test/patterns/DebugSpringTest.java
@@ -36,10 +36,13 @@ public class DebugSpringTest extends CamelSpringTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(DebugSpringTest.class);
     private boolean debugged;
 
+
     @Override
-    public boolean isUseDebugger() {
-        // must enable debugger
-        return true;
+    public void doPreSetup() throws Exception {
+        super.doPreSetup();
+
+        camelContextConfiguration()
+                .withBreakpoint(createBreakpoint());
     }
 
     protected DebugBreakpoint createBreakpoint() {

--- a/components/camel-xslt-saxon/src/test/java/org/apache/camel/component/xslt/SaxonXsltComponentConfigurationTest.java
+++ b/components/camel-xslt-saxon/src/test/java/org/apache/camel/component/xslt/SaxonXsltComponentConfigurationTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SaxonXsltComponentConfigurationTest extends CamelSpringTestSupport {
     @Test
-    public void testConfiguration() {
+    public void testComponentConfiguration() {
         XsltSaxonComponent component = context.getComponent("xslt-saxon", XsltSaxonComponent.class);
         XsltSaxonEndpoint endpoint
                 = context.getEndpoint("xslt-saxon:org/apache/camel/component/xslt/transform.xsl", XsltSaxonEndpoint.class);

--- a/components/camel-xslt-saxon/src/test/java/org/apache/camel/component/xslt/SaxonXsltEndpointConfigurationTest.java
+++ b/components/camel-xslt-saxon/src/test/java/org/apache/camel/component/xslt/SaxonXsltEndpointConfigurationTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SaxonXsltEndpointConfigurationTest extends CamelSpringTestSupport {
     @Test
-    public void testConfiguration() {
+    public void testComponentConfiguration() {
         Configuration configuration = context.getRegistry().lookupByNameAndType("saxon-configuration", Configuration.class);
         Map<?, ?> properties = context.getRegistry().lookupByNameAndType("saxon-properties", Map.class);
         XsltSaxonComponent component = context.getComponent("xslt-saxon", XsltSaxonComponent.class);

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_7.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_7.adoc
@@ -130,6 +130,12 @@ You can now use the following syntax:
 
 Where engine will be the Hashicorp Vault Engine to be used. This means you'll be able to use multiple engines at the same time. More details at CAMEL-20775 issue.
 
+=== camel-test
+
+As part of CAMEL-20785, we have started to rework the `CamelTestSupport` class. At this point, it should be highly compatible with
+previous versions, as we are laying down the foundations for greater cleanups in the future. However, several methods have been
+marked as deprecated. Users of this class are advised to look at the deprecation notices and adjust the code accordingly.
+
 === Camel Spring Boot
 
 ==== camel-debug-starter


### PR DESCRIPTION
This change moves the management of the CamelContext lifecycle to a separate class with a more well-defined responsibility scope.

It also splits the test configuration and the context configuration from the test class itself.

It also includes a few cleanups and fixes for tests. And, also, mark some methods as deprecated.