### PR TITLE
CAMEL-20814: Publish buildinfo and provide a build container to improve release reproducibility.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This has a JDK and Maven we can use.
+FROM registry.access.redhat.com/ubi9/openjdk-11
+USER root
+
+#
+# the builder script will run this container under as your uid:guid so that the files it creates
+# in the host env are owned by you, lets make sure there is uid:guid to match in the container.
+RUN for i in $(seq 50 184); do echo "default$i:x:$i:$i:default:/home/default:/bin/bash" >> /etc/passwd; done; 
+RUN for i in $(seq 186 2000); do echo "default$i:x:$i:$i:default:/home/default:/bin/bash" >> /etc/passwd; done
+
+CMD ["/bin/bash"]
+WORKDIR /src

--- a/builder
+++ b/builder
@@ -1,0 +1,40 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+set -e
+
+# This script gives you a reproducible build enviroment, since the enviroment is containerizedL
+# Example usage: ./builder mvn clean install -Dquickly
+
+# We can't build on ARM since the following artifact does not exist:
+# org.apache.kudu:kudu-binary:jar:linux-aarch_64:1.17.0
+# So force the build to run on amd64
+PLATFORM_ARGS="--platform linux/amd64"
+
+docker build ${PLATFORM_ARGS} -t apache-camel-builder .
+
+# Run the builder container as the current user, and mount his home dirs
+# so that host .m2 repos can be reused and provide access to release gpg keys and such.
+docker run --rm -it \
+    ${PLATFORM_ARGS} \
+    --user "`id -u`:`id -g`" \
+    -v "`pwd`:/src" \
+    -v "${HOME}:/home/default" \
+    -v "${HOME}:${HOME}" \
+    apache-camel-builder $*

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
         <maven-bundle-plugin-version>5.1.9</maven-bundle-plugin-version>
         <maven-enforcer-plugin-version>3.0.0</maven-enforcer-plugin-version>
         <maven-dependency-plugin-version>3.4.0</maven-dependency-plugin-version>
+        <maven-artifact-plugin-version>3.5.1</maven-artifact-plugin-version>
 
         <!-- eclipse plugin need the jaxb in this pom.xml file -->
         <!-- Make sure to keep JAXB version up to date in parent/pom.xml in the bottom of the file -->
@@ -803,6 +804,23 @@
                             <outputName>${project.artifactId}-${project.version}-sbom</outputName>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-artifact-plugin</artifactId>
+                        <version>${maven-artifact-plugin-version}</version>
+                        <executions>
+                            <execution>
+                                <id>buildinfo</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>buildinfo</goal>
+                                </goals>
+                                <configuration>
+                                    <attach>true</attach>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -843,6 +861,8 @@
                                 <exclude>.mvn/**</exclude>
                                 <exclude>mvnw*</exclude>
                                 <exclude>**/META-INF/persistence*.xsd</exclude>
+                                <exclude>Dockerfile</exclude>
+                                <exclude>builder*</exclude>
                             </excludes>
                             <mapping>
                                 <java>SLASHSTAR_STYLE</java>


### PR DESCRIPTION
 Description

This is a back port of #14275 

This allows you to `./builder mvn install` on a unixish system with only docker installed to do a camel build.  This has the added benefit of using a consistent JDK/Maven version which should aid in build reproducibility.

# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
https://issues.apache.org/jira/browse/CAMEL-20814

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.
