### PR TITLE
CAMEL-20823 Filter out folders when listing files

### DIFF
--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbConsumer.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbConsumer.java
@@ -64,7 +64,7 @@ public class SmbConsumer extends ScheduledPollConsumer {
                 IdempotentRepository repository = configuration.getIdempotentRepository();
 
                 for (FileIdBothDirectoryInformation f : share.list(configuration.getPath(), configuration.getSearchPattern())) {
-                    if (f.getFileName().equals(".") || f.getFileName().equals("..")) {
+                    if (f.getFileName().equals(".") || f.getFileName().equals("..") || share.folderExists(f.getFileName())) {
                         continue;
                     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-20823

From my read of the code, I think the intention is to only list files in the poll of the consumer?    If it is preferable to list both files and folders, we could have a separate if path here which handles Directory dir = share.openDirectory() at 

https://github.com/apache/camel/blob/main/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbConsumer.java#L75

Getting an exception now if the share has directories in it.