### PR TITLE
CAMEL-20680 - fix root cause of slow publish to partition 1 + CAMEL-20722 re-enable

### DIFF
--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorSeekIssueIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorSeekIssueIT.java
@@ -28,6 +28,7 @@ import org.apache.camel.component.kafka.MockConsumerInterceptor;
 import org.apache.camel.component.kafka.integration.common.KafkaAdminUtil;
 import org.apache.camel.component.kafka.testutil.CamelKafkaUtil;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.awaitility.Awaitility;
@@ -37,12 +38,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -55,13 +56,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnabledOnOs(value = { OS.LINUX, OS.MAC, OS.FREEBSD, OS.OPENBSD, OS.WINDOWS },
              architectures = { "amd64", "aarch64" },
              disabledReason = "This test does not run reliably on some platforms")
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
-                          disabledReason = "CAMEL-20722: Too unreliable on most of the CI environments")
+
 class KafkaBreakOnFirstErrorSeekIssueIT extends BaseExclusiveKafkaTestSupport {
 
     public static final String ROUTE_ID = "breakOnFirstError-19894";
     public static final String TOPIC = "breakOnFirstError-19894";
-
+    public static final int PARTITION_COUNT = 2;
     private static final Logger LOG = LoggerFactory.getLogger(KafkaBreakOnFirstErrorSeekIssueIT.class);
 
     @EndpointInject("mock:result")
@@ -75,12 +75,19 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseExclusiveKafkaTestSupport {
             kafkaAdminClient = KafkaAdminUtil.createAdminClient(service);
         }
 
-        // create the topic w/ 2 partitions
-        final NewTopic mytopic = new NewTopic(TOPIC, 2, (short) 1);
-        kafkaAdminClient.createTopics(Collections.singleton(mytopic));
+        // create the topic w/ more than 1 partitions
+        final NewTopic mytopic = new NewTopic(TOPIC, PARTITION_COUNT, (short) 1);
+	    CreateTopicsResult r = kafkaAdminClient.createTopics(Collections.singleton(mytopic));
+	    
+	    // This wait is necessary to ensure that required number of partitions are actually created
+	    Awaitility.await()
+	        .timeout(20, TimeUnit.SECONDS)
+	        .pollDelay(5, TimeUnit.SECONDS)
+	        .untilAsserted(() -> assertTrue(r.numPartitions(TOPIC).isDone())); 	    
+
     }
 
-    @BeforeEach
+   @BeforeEach
     public void init() {
 
         // setup the producer
@@ -98,15 +105,23 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseExclusiveKafkaTestSupport {
         kafkaAdminClient.deleteTopics(Collections.singletonList(TOPIC)).all();
     }
 
+  
+   
     @Test
     void testCamel19894TestFix() throws Exception {
         to.reset();
         // will consume the payloads from partition 0
-        // and will continually retry the payload with "5"
-        to.expectedMessageCount(4);
-        to.expectedBodiesReceived("1", "2", "3", "4");
+        // and will continually retry the payload with "6"
+        // Changed from 4 to 5 to ensure that at least something gets read from partition 1 
+        to.expectedMessageCount(5); 
+        
+        to.expectedBodiesReceived("1", "2", "3", "4", "5"); // message 6 onwards will not be received because of exception + breakOnFirstError=true       													
+        								
+        contextExtension.getContext().getRouteController().stopRoute(ROUTE_ID);     
 
-        contextExtension.getContext().getRouteController().stopRoute(ROUTE_ID);
+        assertEquals(PARTITION_COUNT,  producer.partitionsFor(TOPIC).size());  
+        //Test relies on multiple partitions but expects the poller to stop reading after the errored message
+        // Increase the delay in setupTopic if this assert fails too frequently 
 
         this.publishMessagesToKafka();
 
@@ -126,6 +141,7 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseExclusiveKafkaTestSupport {
 
     @Override
     protected RouteBuilder createRouteBuilder() {
+    	
         return new RouteBuilder() {
 
             @Override
@@ -159,7 +175,7 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseExclusiveKafkaTestSupport {
     }
 
     private void ifIsFifthRecordThrowException(Exchange e) {
-        if (e.getMessage().getBody().equals("5")) {
+        if (e.getMessage().getBody().equals("6")) { //this actually goes to partition 1, but due to breakOnFirstError=true, poller should only read till 5
             throw new RuntimeException("ERROR_TRIGGERED_BY_TEST");
         }
     }
@@ -167,11 +183,19 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseExclusiveKafkaTestSupport {
     private void publishMessagesToKafka() {
         final List<String> producedRecordsPartition1 = List.of("5", "6", "7", "8", "9", "10", "11");
         final List<String> producedRecordsPartition0 = List.of("1", "2", "3", "4");
+       
 
         producedRecordsPartition0.forEach(v -> {
             ProducerRecord<String, String> data = new ProducerRecord<>(TOPIC, 0, "k0", v); //CAMEL-20680: kept explicit partition 0, added key.
             producer.send(data);
         });
+            
+        producedRecordsPartition1.forEach(v -> {
+            ProducerRecord<String, String> data = new ProducerRecord<>(TOPIC, 1, "k1", v);
+            producer.send(data); 
+        });  //CAMEL-20680: restored loop that publishes to partition1, but with reduced execution time
+		// See changes in setupTopic() and testCamel19894TestFix just before publishMessagesToKafka().
+		// This loop is required by the original fix for CAMEL-19894    
 
     }
 


### PR DESCRIPTION
CAMEL-20680 - fixed root cause of slow publish to partition 1. 
- Added a wait in `setupTopics ()` to ensure that required number of partitions are actually created
- Restored the loop in  `publishMessagesToKafka()` that publishes to partition 1
- Change the position of errored record from 5 to 6 _(to ensure that something is actually read from partition 1 as well)_
After these, the test continues to execute in under 45 sec even after adding back the loop that sends to partition 1  _(the long delay in `publishMessagesToKafka` when CAMEL-20680  was created was because partition 1 was being used before it was even created!)_

CAMEL-20722 - re-enabled test for CI, as the symptom from build 96 **might** go away as a side effect of this

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

