### PR TITLE
chore: Specify a suffix for GitHub Actions upload artifact

### DIFF
--- a/.github/actions/component-test/action.yaml
+++ b/.github/actions/component-test/action.yaml
@@ -30,6 +30,10 @@ inputs:
   comment-body:
     description: 'Body of the comment to process'
     required: true
+  artifact-upload-suffix:
+    description: 'Suffix for artifacts stored'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -48,7 +52,7 @@ runs:
       if: always()
       with:
         name: build.log
-        path: build.log
+        path: build-${{ artifact-upload-suffix }}.log
     - name: maven test
       shell: bash
       run: ${{ github.action_path }}/component-test.sh
@@ -61,7 +65,7 @@ runs:
       uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: tests.log
+        name: tests-${{ artifact-upload-suffix }}.log
         path: tests.log
     - name: Success comment
       if: success() 

--- a/.github/actions/incremental-build/action.yaml
+++ b/.github/actions/incremental-build/action.yaml
@@ -35,6 +35,10 @@ inputs:
     description: 'The GitHub repository name (example, apache/camel)'
     required: false
     default: 'apache/camel'
+  artifact-upload-suffix:
+    description: 'Suffix for artifacts stored'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -51,5 +55,5 @@ runs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: incremental-${{ inputs.mode }}.log
-        path: incremental-${{ inputs.mode }}.log
+        name: incremental-${{ inputs.mode }}-${{ artifact-upload-suffix }}.log
+        path: incremental-${{ inputs.mode }}-${{ artifact-upload-suffix }}.log

--- a/.github/actions/quick-test/action.yaml
+++ b/.github/actions/quick-test/action.yaml
@@ -27,6 +27,10 @@ inputs:
   github-token: # id of input
     description: 'Github hub token'
     required: true
+  artifact-upload-suffix:
+    description: 'Suffix for artifacts stored'
+    required: false
+    default: ''
 outputs:
   result:
     description: "Quick test result"
@@ -53,5 +57,5 @@ runs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: test-logs
+        name: test-logs-${{ artifact-upload-suffix }}
         path: automated-build-log/**/*

--- a/.github/workflows/pr-build-camel-3.yml
+++ b/.github/workflows/pr-build-camel-3.yml
@@ -103,3 +103,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           start-commit: ${{ github.event.pull_request.base.sha }}
           end-commit: ${{ github.event.after }}
+          artifact-upload-suffix: java-${{ matrix.java }}

--- a/.github/workflows/pr-build-camel-40x.yml
+++ b/.github/workflows/pr-build-camel-40x.yml
@@ -72,3 +72,4 @@ jobs:
           pr-id: ${{ github.event.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-mvnd-install: 'true'
+          artifact-upload-suffix: java-${{ matrix.java }}

--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -79,3 +79,4 @@ jobs:
           pr-id: ${{ github.event.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-mvnd-install: 'true'
+          artifact-upload-suffix: java-${{ matrix.java }}

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -68,3 +68,4 @@ jobs:
           pr-id: ${{ github.event.issue.number }}
           comment-id: ${{ github.event.comment.id }}
           comment-body: ${{ github.event.comment.body }}
+          artifact-upload-suffix: java-${{ matrix.java }}


### PR DESCRIPTION
it is mandatory to not override artifact since v4. To avoid clash, passing specific suffix for matrix jobs

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

