### PR TITLE
CAMEL-20722: Changed base class for KafkaBreakOnFirstErrorSeekIssueIT

### DIFF
--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorSeekIssueIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorSeekIssueIT.java
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
              architectures = { "amd64", "aarch64" },
              disabledReason = "This test does not run reliably on some platforms")
 
-class KafkaBreakOnFirstErrorSeekIssueIT extends BaseExclusiveKafkaTestSupport {
+class KafkaBreakOnFirstErrorSeekIssueIT extends BaseKafkaTestSupport {
 
     public static final String ROUTE_ID = "breakOnFirstError-19894";
     public static final String TOPIC = "breakOnFirstError-19894";


### PR DESCRIPTION
# Description
Changed base class for KafkaBreakOnFirstErrorSeekIssueIT
- `BaseKafkaTestSupport` calls `KafkaServiceFactory.createSingletonService` whereas the previous one called `createService()`
- The `NoSuchElementException `occurs at `KafkaService.beforeAll(KafkaService.java:47)` even though the actual test case succeeds consistently. With the new base class, this method is avoided altogether
- Other Kafka integration tests that call `BaseKafkaTestSupport `,  and don't show the `NoSuchElementException `

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [CAMEL-20722](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

