### PR TITLE
CAMEL-20608 - Improve Docker image for JBang

### DIFF
--- a/dsl/camel-jbang/camel-jbang-container/Dockerfile
+++ b/dsl/camel-jbang/camel-jbang-container/Dockerfile
@@ -15,9 +15,21 @@
 # limitations under the License.
 #
 
-FROM docker.io/jbangdev/jbang-action
+FROM docker.io/eclipse-temurin:21-jdk
+
+ENV JBANG_VERSION=0.116.0
+# /!\ Camel version must be changed in the entrypoint line too
+ENV CAMEL_VERSION=4.6.0 
+
+RUN wget -c https://github.com/jbangdev/jbang/releases/download/v$JBANG_VERSION/jbang.tar -O - | tar xv && \
+    chmod +x jbang/bin/jbang
+ENV PATH="${PATH}:/jbang/bin"
+ENV JBANG_PATH=/jbang/bin
 
 RUN jbang trust add https://github.com/apache/camel
+
+# used to initiliaze dependencies in the docker image
+RUN jbang -Dcamel.jbang.version=$CAMEL_VERSION camel@apache/camel version
     
-ENTRYPOINT [ "jbang",  "-Dcamel.jbang.version=4.6.0", "camel@apache/camel"]
+ENTRYPOINT [ "jbang", "-Dcamel.jbang.version=4.6.0", "camel@apache/camel"]
 


### PR DESCRIPTION
- Use specific image instead of jbang-action image which was initially designed for GitHub actions which is not actively maintained as jabg-action is no more the recommended way
- Upgrade from JDK 11 to JDK 21
- Upgrade to JBang 0.116.0
- Added a line to warm up the dependencies which is drastically reduce the time to execute the docker image

# Description

The `version` call is now almost instant versus 2'30" for me with 4.6.0 as it was downloading a valid JDK (17) and downloading dependencies 

Remaining issues specific to this PR:
* empty JBang version line is printed when calleing the `version`
* the Dockerfile is repeating the Camel version at 2 places (not found how to use an env/variable in the entrypoint

Important issues impacting previous versions too:
* with `run` the file is not found (an be tried by following https://camel.apache.org/manual/camel-jbang.html#_container_image  `docker run apache/camel-jbang:4.6.0 run example.yaml`
```
java.io.FileNotFoundException: demo.yaml (No such file or directory)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:216)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:111)
	at org.apache.camel.dsl.jbang.core.commands.Run.knownFile(Run.java:1272)
	at org.apache.camel.dsl.jbang.core.commands.Run.run(Run.java:596)
	at org.apache.camel.dsl.jbang.core.commands.Run.doCall(Run.java:297)
	at org.apache.camel.dsl.jbang.core.commands.CamelCommand.call(CamelCommand.java:71)
	at org.apache.camel.dsl.jbang.core.commands.CamelCommand.call(CamelCommand.java:37)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
	at picocli.CommandLine.execute(CommandLine.java:2170)
	at org.apache.camel.dsl.jbang.core.commands.CamelJBangMain.run(CamelJBangMain.java:151)
	at org.apache.camel.dsl.jbang.core.commands.CamelJBangMain.run(CamelJBangMain.java:58)
	at main.CamelJBang.main(CamelJBang.java:36)
``` 
we need to mount the volume such as: `docker run -v ~/git/camel3/dsl/camel-jbang/camel-jbang-container:/integration camel-jbang run /integration/demo.yaml` I guess there is no other choice than improving the documentation
--> Created https://github.com/apache/camel/pull/14410
* with `init`, the file is created in the container and so not usable by the end user. I guess there is the same mount volume trick to provide
* Kamelet version used is the latest version online and not the one corresponding the Camel version

Potential other improvement: install Camel K JBang plugin

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

