### PR TITLE
Making several configuration ehtods for TestSupport public

### DIFF
--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelContextConfiguration.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelContextConfiguration.java
@@ -33,7 +33,7 @@ import org.apache.camel.support.EndpointHelper;
 /**
  * Configures a context for test execution
  */
-public final class CamelContextConfiguration {
+public class CamelContextConfiguration {
     @FunctionalInterface
     public interface CamelContextSupplier {
         CamelContext createCamelContext() throws Exception;
@@ -228,7 +228,7 @@ public final class CamelContextConfiguration {
      *
      * @param camelContextSupplier A supplier for the Camel context
      */
-    CamelContextConfiguration withCamelContextSupplier(
+    protected CamelContextConfiguration withCamelContextSupplier(
             CamelContextSupplier camelContextSupplier) {
         this.camelContextSupplier = camelContextSupplier;
         return this;
@@ -285,7 +285,7 @@ public final class CamelContextConfiguration {
     /**
      * A supplier that classes can use to create a {@link RouteBuilder} to define the routes for testing
      */
-    CamelContextConfiguration withRoutesSupplier(
+    protected CamelContextConfiguration withRoutesSupplier(
             RoutesSupplier routesSupplier) {
         this.routesSupplier = routesSupplier;
         return this;
@@ -314,7 +314,7 @@ public final class CamelContextConfiguration {
      *
      * @param postProcessor the post-test processor to use
      */
-    CamelContextConfiguration withPostProcessor(
+    protected CamelContextConfiguration withPostProcessor(
             PostProcessor postProcessor) {
         this.postProcessor = postProcessor;
         return this;

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/TestExecutionConfiguration.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/TestExecutionConfiguration.java
@@ -106,7 +106,7 @@ public class TestExecutionConfiguration {
      * @return <tt>true</tt> if you use advice with in your unit tests.
      */
     @Deprecated(since = "4.7.0")
-    TestExecutionConfiguration withUseAdviceWith(boolean useAdviceWith) {
+    protected TestExecutionConfiguration withUseAdviceWith(boolean useAdviceWith) {
         this.useAdviceWith = useAdviceWith;
         return this;
     }
@@ -129,7 +129,7 @@ public class TestExecutionConfiguration {
      * @return     <tt>true</tt> per class, <tt>false</tt> per test.
      */
     @Deprecated(since = "4.7.0")
-    TestExecutionConfiguration withCreateCamelContextPerClass(boolean createCamelContextPerClass) {
+    protected TestExecutionConfiguration withCreateCamelContextPerClass(boolean createCamelContextPerClass) {
         this.createCamelContextPerClass = createCamelContextPerClass;
         return this;
     }


### PR DESCRIPTION
Follows https://issues.apache.org/jira/browse/CAMEL-20843

I tried to use the `AbstractTestSupport` in CQ project. I found that I was missing access to several configuration methods. This PR adds `public` to all of them.


# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

