### PR TITLE
CAMEL-20832: Add camel-openapi-validator to parent pom

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -295,6 +295,7 @@
         <module>camel-stitch</module>
         <module>camel-swift</module>
         <module>camel-openapi-java</module>
+        <module>camel-openapi-validator</module>
         <module>camel-opensearch</module>
         <module>camel-optaplanner</module>
         <module>camel-syslog</module>


### PR DESCRIPTION
## Motivation

The build fails due to a missing snapshot corresponding to the new added component camel-openapi-validator

## Modifications

* Add the component to the parent pom to ensure that it is built