### PR TITLE
Use the correct camel spring boot starter for camel export

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/spring-boot-pom.tmpl
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/spring-boot-pom.tmpl
@@ -54,7 +54,7 @@
 
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-spring-boot-engine-starter</artifactId>
+            <artifactId>camel-spring-boot-starter</artifactId>
         </dependency>
 {{ .CamelDependencies }}
 


### PR DESCRIPTION
When an exported application is delpoyed on OCP via jkube, camel-spring-boot-engine-starter is not enough, camel-spring-boot-starter is needed