### PR TITLE
(chores) ci: redirect outputs in script

### DIFF
--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -61,13 +61,13 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: maven build
-        run: ./etc/scripts/regen.sh > build-${{ matrix.java }}.log 2>&1
+        run: ./etc/scripts/regen.sh
       - name: archive logs
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: build.log
-          path: build-${{ matrix.java }}.log
+          name: build-${{ matrix.java }}.log
+          path: build.log
       - name: Fail if there are uncommitted changes
         shell: bash
         run: |

--- a/etc/scripts/regen.sh
+++ b/etc/scripts/regen.sh
@@ -24,6 +24,6 @@ git clean -fdx
 rm -Rf **/src/generated/
 
 # Regenerate everything
-./mvnw --batch-mode -Pregen -DskipTests install
+./mvnw --batch-mode -Pregen -DskipTests install >> build.log 2>&1
 # One additional pass to get the info for the 'others' jars
-./mvnw --batch-mode install -f catalog/camel-catalog
+./mvnw --batch-mode install -f catalog/camel-catalog >> build.log 2>&1


### PR DESCRIPTION
## Motivation

The redirection of standard outputs is not supported by GitHub jobs so we don't get the log of builds.

## Modifications:

* Move the redirection of the standard outputs in the build script