### PR TITLE
CAMEL-20852: Fix CamelCatalogTest

### DIFF
--- a/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
+++ b/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
@@ -1632,7 +1632,7 @@ public class CamelCatalogTest {
         assertEquals(Kind.bean, model.getKind());
         assertEquals("ZipAggregationStrategy", model.getName());
         assertEquals("org.apache.camel.processor.aggregate.zipfile.ZipAggregationStrategy", model.getJavaType());
-        assertEquals(6, model.getOptions().size());
+        assertEquals(7, model.getOptions().size());
     }
 
 }


### PR DESCRIPTION
## Motivation

The build is failing because of the test CamelCatalogTest since the addition of an option within the context of CAMEL-20852

## Modifications:

* Adapt the test consequently