### PR TITLE
Revert "Upgrade protobuf 4.27.1"

### DIFF
--- a/components/camel-protobuf/pom.xml
+++ b/components/camel-protobuf/pom.xml
@@ -74,9 +74,9 @@
               If the platform doesn't support, the protobuf test code generation, their
               assembly and launch will be skipped
               Supported platforms are:
-              - Linux: x86_32, x86_64, aarch_64, ppcle_64 & s390_64
-              - Windows: x86_32 & x86_64
-              - OSX: x86_64 & aarch_64
+              - Linux (x86 32 and 64-bit)
+              - Windows (x86 32 and 64-bit)
+              - OSX (x86 32 and 64-bit)
             -->
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
@@ -91,7 +91,7 @@
                         <configuration>
                             <scripts>
                                 <script><![CDATA[
-                  project.properties['skipTests']=project.properties['os.detected.classifier'].matches('^(linux-(x86_(32|64)|aarch_64|ppcle_64|s390_64)|windows-x86_(32|64)|osx-(x86_64|aarch_64))$') ? 'false' : 'true';
+                  project.properties['skipTests']=project.properties['os.detected.classifier'].matches('^.*?(linux|windows|osx)-x86.*$') ? 'false' : 'true';
                 ]]></script>
                             </scripts>
                         </configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -403,7 +403,7 @@
         <pooled-jms-version>3.1.6</pooled-jms-version>
         <properties-maven-plugin-version>1.2.1</properties-maven-plugin-version>
         <proto-google-common-protos-version>2.22.0</proto-google-common-protos-version>
-        <protobuf-version>4.27.1</protobuf-version>
+        <protobuf-version>3.25.3</protobuf-version>
         <protobuf-maven-plugin-version>0.6.1</protobuf-maven-plugin-version>
         <protonpack-version>1.8</protonpack-version>
         <protostream-version>5.0.5.Final</protostream-version>


### PR DESCRIPTION
Reverts apache/camel#14496

[ERROR] /home/oscerd/workspace/apache-camel/camel/components/camel-qdrant/src/main/java/org/apache/camel/component/qdrant/QdrantConverter.java:[64,45] cannot access com.google.protobuf.GeneratedMessageV3
[ERROR]   class file for com.google.protobuf.GeneratedMessageV3 not found
[ERROR] /home/oscerd/workspace/apache-camel/camel/components/camel-qdrant/src/main/java/org/apache/camel/component/qdrant/QdrantConverter.java:[62,37] cannot access com.google.protobuf.GeneratedMessageV3
[ERROR]   class file for com.google.protobuf.GeneratedMessageV3 not found
[ERROR] /home/oscerd/workspace/apache-camel/camel/components/camel-qdrant/src/main/java/org/apache/camel/component/qdrant/QdrantConverter.java:[65,33] cannot access com.google.protobuf.GeneratedMessageV3.Builder
[ERROR]   class file for com.google.protobuf.GeneratedMessageV3$Builder not found
