### PR TITLE
Align versions to spring-boot 3.2.6

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -285,7 +285,7 @@
         <jsonassert-version>1.5.1</jsonassert-version>
         <json-path-version>2.9.0</json-path-version>
         <json-patch-version>1.13</json-patch-version>
-        <json-smart-version>2.5.0</json-smart-version>
+        <json-smart-version>2.5.1</json-smart-version>
         <jsonata-version>0.9.5</jsonata-version>
         <json-unit-version>3.2.4</json-unit-version>
         <jsoup-version>1.17.2</jsoup-version>
@@ -357,7 +357,7 @@
         <mybatis-version>3.5.15</mybatis-version>
         <narayana-version>5.13.1.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
-        <netty-version>4.1.106.Final</netty-version>
+        <netty-version>4.1.110.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.3.2</networknt-json-schema-validator-version>
         <nimbus-jose-jwt>9.37.3</nimbus-jose-jwt>
@@ -429,13 +429,13 @@
         <splunk-version>1.9.5_1</splunk-version>
         <spock-version>2.3-groovy-4.0</spock-version>
         <spring-batch-version>5.1.2</spring-batch-version>
-        <spring-data-redis-version>3.2.2</spring-data-redis-version>
+        <spring-data-redis-version>3.2.6</spring-data-redis-version>
         <spring-ldap-version>3.2.3</spring-ldap-version>
         <spring-vault-core-version>3.1.1</spring-vault-core-version>
         <spring-version>6.1.8</spring-version>
-        <spring-rabbitmq-version>3.1.1</spring-rabbitmq-version>
+        <spring-rabbitmq-version>3.1.5</spring-rabbitmq-version>
         <spring-security-version>6.2.4</spring-security-version>
-        <spring-ws-version>4.0.10</spring-ws-version>
+        <spring-ws-version>4.0.11</spring-ws-version>
         <sql-maven-plugin-version>1.5</sql-maven-plugin-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>
         <squareup-okio-version>1.17.5</squareup-okio-version>


### PR DESCRIPTION
# Description

camel-spring-boot 4.4.x is using spring-boot 3.2.6 https://github.com/apache/camel-spring-boot/blob/camel-spring-boot-4.4.x/pom.xml#L111 : align json-smart, netty, spring-data-redis, spring-rabbitmq, and spring-ws to the versions used in spring-boot 3.2.6 to avoid classpath issues in camel-spring-boot.

# Target

- [x ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

(not a large change)

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes


