### PR TITLE
CAMEL-19544 - remove Thread.sleep in sql component test

### DIFF
--- a/components/camel-sql/src/test/java/org/apache/camel/component/sql/SqlConsumerDeleteFailedTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/component/sql/SqlConsumerDeleteFailedTest.java
@@ -32,6 +32,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -80,11 +81,8 @@ public class SqlConsumerDeleteFailedTest extends CamelTestSupport {
         assertEquals(3, exchanges.get(1).getIn().getBody(Map.class).get("ID"));
         assertEquals("Linux", exchanges.get(1).getIn().getBody(Map.class).get("PROJECT"));
 
-        // give it a little tine to delete
-        Thread.sleep(500);
-
-        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject("select count(*) from projects", Integer.class),
-                "Should have deleted 2 rows");
+        await("Should have deleted 2 rows, keeping 1")
+                .until(() -> jdbcTemplate.queryForObject("select count(*) from projects", Integer.class) == 1);
         assertEquals("AMQ", jdbcTemplate.queryForObject("select PROJECT from projects where license = 'BAD'", String.class),
                 "Should be AMQ project that is BAD");
     }

--- a/components/camel-sql/src/test/java/org/apache/camel/component/sql/SqlConsumerDeleteTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/component/sql/SqlConsumerDeleteTest.java
@@ -31,6 +31,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -81,17 +82,8 @@ public class SqlConsumerDeleteTest extends CamelTestSupport {
         assertEquals(3, exchanges.get(2).getIn().getBody(Map.class).get("ID"));
         assertEquals("Linux", exchanges.get(2).getIn().getBody(Map.class).get("PROJECT"));
 
-        // some servers may be a bit slow for this
-        for (int i = 0; i < 5; i++) {
-            // give it a little time to delete
-            Thread.sleep(200);
-            int rows = jdbcTemplate.queryForObject("select count(*) from projects", Integer.class);
-            if (rows == 0) {
-                break;
-            }
-        }
-        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject("select count(*) from projects", Integer.class),
-                "Should have deleted all 3 rows");
+        await("Should have deleted all 3 rows")
+                .until(() -> jdbcTemplate.queryForObject("select count(*) from projects", Integer.class) == 0);
     }
 
     @Override

--- a/components/camel-sql/src/test/java/org/apache/camel/component/sql/SqlConsumerDeleteTransformTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/component/sql/SqlConsumerDeleteTransformTest.java
@@ -27,7 +27,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.awaitility.Awaitility.await;
 
 /**
  *
@@ -67,17 +67,8 @@ public class SqlConsumerDeleteTransformTest extends CamelTestSupport {
 
         MockEndpoint.assertIsSatisfied(context);
 
-        // some servers may be a bit slow for this
-        for (int i = 0; i < 5; i++) {
-            // give it a little time to delete
-            Thread.sleep(200);
-            int rows = jdbcTemplate.queryForObject("select count(*) from projects", Integer.class);
-            if (rows == 0) {
-                break;
-            }
-        }
-        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject("select count(*) from projects", Integer.class),
-                "Should have deleted all 3 rows");
+        await("Should have deleted all 3 rows")
+                .until(() -> jdbcTemplate.queryForObject("select count(*) from projects", Integer.class) == 0);
     }
 
     @Override


### PR DESCRIPTION
Gain 800ms locally but easier to read code

It remains several Thread.sleep but that are testing timeouts of the sql component or trying to simulate a little delay so I guess we need to keep them.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

