### PR TITLE
CAMEL-20722 - ensure concurrent processing from multiple kafka partitions

### DIFF
--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorSeekIssueIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaBreakOnFirstErrorSeekIssueIT.java
@@ -31,6 +31,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.Uuid;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -59,8 +60,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class KafkaBreakOnFirstErrorSeekIssueIT extends BaseKafkaTestSupport {
 
-    public static final String ROUTE_ID = "breakOnFirstError-19894";
-    public static final String TOPIC = "breakOnFirstError-19894";
+    public static final String ROUTE_ID = "breakOnFirstError-19894" + Uuid.randomUuid().toString();
+    public static final String TOPIC = "breakOnFirstError-19894" + Uuid.randomUuid().toString();
     public static final int PARTITION_COUNT = 2;
     private static final Logger LOG = LoggerFactory.getLogger(KafkaBreakOnFirstErrorSeekIssueIT.class);
 
@@ -103,17 +104,20 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseKafkaTestSupport {
         }
         // clean all test topics
         kafkaAdminClient.deleteTopics(Collections.singletonList(TOPIC)).all();
+        // if more tests are added later, then also check DeleteTopicResult::all().isDone() to avoid concurrency issues
     }
 
     @Test
     void testCamel19894TestFix() throws Exception {
         to.reset();
-        // will consume the payloads from partition 0
-        // and will continually retry the payload with "6"
-        // Changed from 4 to 5 to ensure that at least something gets read from partition 1
+        // will consume the payloads from partition 0 & 1
+        // and will continually retry the payload with "7" and "3"
+        // 2 messages from partition 0 and 3 from partition 1 are read before exceptions are raised.
         to.expectedMessageCount(5);
 
-        to.expectedBodiesReceived("1", "2", "3", "4", "5"); // message 6 onwards will not be received because of exception + breakOnFirstError=true
+        to.expectedBodiesReceivedInAnyOrder("5", "6", "7", "1", "2");
+        // Messages 1, 2 are read in-order from partition 0,
+        // and 5, 6, 7 are read in-order from partition 1
 
         contextExtension.getContext().getRouteController().stopRoute(ROUTE_ID);
 
@@ -125,16 +129,10 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseKafkaTestSupport {
 
         contextExtension.getContext().getRouteController().startRoute(ROUTE_ID);
 
-        // let test run for awhile
-        Awaitility.await()
-                .timeout(180, TimeUnit.SECONDS)
-                .pollDelay(5, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertTrue(true));
-
-        // the replaying of the message with an error
-        // will prevent other paylods from being
+        // the replaying of the message 3 and 8 with an error
+        // will prevent other payloads from the same partition being
         // processed
-        to.assertIsSatisfied();
+        to.assertIsSatisfied(60000); //wait up to 60 sec (changed from a wait of fixed duration)
     }
 
     @Override
@@ -151,6 +149,8 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseKafkaTestSupport {
                      + "&allowManualCommit=true"
                      + "&breakOnFirstError=true"
                      + "&maxPollRecords=8"
+                     + "&consumersCount=" + (PARTITION_COUNT) // when one partition stops reading because of breakOnFirstError,
+                                                                                                                                                                                                                                                    //   ensure the other can still continues reading
                      + "&metadataMaxAgeMs=1000"
                      + "&pollTimeoutMs=1000"
                      + "&keyDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
@@ -173,7 +173,8 @@ class KafkaBreakOnFirstErrorSeekIssueIT extends BaseKafkaTestSupport {
     }
 
     private void ifIsFifthRecordThrowException(Exchange e) {
-        if (e.getMessage().getBody().equals("6")) { //this actually goes to partition 1, but due to breakOnFirstError=true, poller should only read till 5
+        if (e.getMessage().getBody().equals("8") || e.getMessage().getBody().equals("3")) {
+            //Message 3 from partition 0, and 8 from partition 1 will be retried indefinitely
             throw new RuntimeException("ERROR_TRIGGERED_BY_TEST");
         }
     }


### PR DESCRIPTION
Since this test is still flaky on **ppc64le**, made the below changes: 
-1) Add consumerCount > 1 in the poller
-2) Append random uuid to topic & route name for uniqueness 
-3) Remove fixed duration wait & replaced it with an "up to" duration in assertIsSatisfied(long millisec). 
_This further reduces a few seconds from test execution time._
-4) Ensure both partitions get read and asserted (even if the kafka poller stops reading from partition 0 due to breakOnFirstError, it will still read from partition 1).
(Some of the 'flakiness' could be reproduced locally by running the test repeatedly: because there is no guarantee which partition gets read by a Kafka consumer first. 
The only guarantee is: consumer should receive messages "from a particular partition" in the "same order in which they were produced".

Must create a blog post with a compilation of all changes, once this test is stable.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

