### PR TITLE
CAMEL-20884 - Cache Index from jandex.idx defined in jar

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/SpiGeneratorMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/SpiGeneratorMojo.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.regex.Matcher;
@@ -48,6 +49,7 @@ import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.ClassInfo.NestingType;
 import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexReader;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
@@ -58,6 +60,7 @@ public class SpiGeneratorMojo extends AbstractGeneratorMojo {
 
     public static final DotName SERVICE_FACTORY = DotName.createSimple(ServiceFactory.class.getName());
     public static final DotName CONSTANT_PROVIDER = DotName.createSimple(ConstantProvider.class.getName());
+    private static final Map<String, Index> JANDEX_CACHE = new ConcurrentHashMap<>();
 
     @Parameter(defaultValue = "${project.build.outputDirectory}")
     protected File classesDirectory;
@@ -193,17 +196,22 @@ public class SpiGeneratorMojo extends AbstractGeneratorMojo {
     }
 
     private void addIndex(List<IndexView> indices, String cpe) throws IOException {
-        try (JarFile jf = new JarFile(cpe)) {
-            JarEntry indexEntry = jf.getJarEntry("META-INF/jandex.idx");
-            if (indexEntry != null) {
-                readIndexFromJandex(indices, jf, indexEntry);
-            } else {
-                createIndexFromClass(indices, jf);
+        Index index = JANDEX_CACHE.get(cpe);
+        if (index == null) {
+            try (JarFile jf = new JarFile(cpe)) {
+                JarEntry indexEntry = jf.getJarEntry("META-INF/jandex.idx");
+                if (indexEntry != null) {
+                    index = readIndexFromJandex(jf, indexEntry);
+                } else {
+                    index = createIndexFromClass(jf);
+                }
+                JANDEX_CACHE.put(cpe, index);
             }
         }
+        indices.add(index);
     }
 
-    private void createIndexFromClass(List<IndexView> indices, JarFile jf) throws IOException {
+    private Index createIndexFromClass(JarFile jf) throws IOException {
         final Indexer indexer = new Indexer();
 
         List<JarEntry> classes = jf.stream()
@@ -215,13 +223,12 @@ public class SpiGeneratorMojo extends AbstractGeneratorMojo {
                 indexer.index(is);
             }
         }
-
-        indices.add(indexer.complete());
+        return indexer.complete();
     }
 
-    private void readIndexFromJandex(List<IndexView> indices, JarFile jf, JarEntry indexEntry) throws IOException {
+    private Index readIndexFromJandex(JarFile jf, JarEntry indexEntry) throws IOException {
         try (InputStream is = jf.getInputStream(indexEntry)) {
-            indices.add(new IndexReader(is).read());
+            return new IndexReader(is).read();
         }
     }
 


### PR DESCRIPTION
Recreating in-memory the Java Object Index from the jandex.idx was done approximately 9 times per components. This action is relatively long. In fact, only a few different jars require this operation.

It was representing 25% of the time spent in camel classes when calling `mvn clean install -D quickly`

To give an order of magnitude, locally build time with timestamped went from 9'45" to 8'23" globally. The time spent in camel-package Maven plugin reported decreased from 54" to 39"

# Description

before:
![Screenshot from 2024-06-19 13-41-19](https://github.com/apache/camel/assets/1105127/e465b648-e2a5-4a40-b836-107cb670e0ff)

after:
![Screenshot from 2024-06-19 13-41-47](https://github.com/apache/camel/assets/1105127/553f246b-a872-4470-9383-877321f66a39)


# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

