### PR TITLE
CAMEL-20794: AWS2 Kinesis producer supports sending batch

### DIFF
--- a/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Producer.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Producer.java
@@ -23,10 +23,21 @@ import org.apache.camel.util.ObjectHelper;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kinesis.model.PutRecordRequest;
 import software.amazon.awssdk.services.kinesis.model.PutRecordResponse;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsResponse;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class Kinesis2Producer extends DefaultProducer {
 
+    // Maximum number of records that can be sent in a single PutRecords request
+    private static final int MAX_BATCH_SIZE = 500;
+
     private KinesisConnection connection;
+
+    private List<PutRecordsRequestEntry> requestBatchBuffer = new ArrayList<>(MAX_BATCH_SIZE);
 
     public Kinesis2Producer(Kinesis2Endpoint endpoint) {
         super(endpoint);
@@ -47,9 +58,24 @@ public class Kinesis2Producer extends DefaultProducer {
 
     @Override
     public void process(Exchange exchange) throws Exception {
+        Boolean batchComplete = exchange.getProperty(Exchange.BATCH_COMPLETE, Boolean.class);
+        if (batchComplete == null) {
+            // if batchComplete is not set, then we are processing a single record
+            flushRequestBatchBuffer();
+            sendSingleRecord(exchange);
+            return;
+        }
+
+        addToRequestBatchBuffer(createRequestEntry(exchange));
+        if (batchComplete) {
+            flushRequestBatchBuffer();
+        }
+    }
+
+    private void sendSingleRecord(Exchange exchange) {
         PutRecordRequest request = createRequest(exchange);
         PutRecordResponse putRecordResult = connection.getClient(getEndpoint()).putRecord(request);
-        Message message = getMessageForResponse(exchange);
+        Message message = exchange.getMessage();
         message.setHeader(Kinesis2Constants.SEQUENCE_NUMBER, putRecordResult.sequenceNumber());
         message.setHeader(Kinesis2Constants.SHARD_ID, putRecordResult.shardId());
     }
@@ -62,15 +88,53 @@ public class Kinesis2Producer extends DefaultProducer {
         PutRecordRequest.Builder putRecordRequest = PutRecordRequest.builder();
         putRecordRequest.data(SdkBytes.fromByteArray(body));
         putRecordRequest.streamName(getEndpoint().getConfiguration().getStreamName());
+        ensurePartitionKeyNotNull(partitionKey);
         putRecordRequest.partitionKey(partitionKey.toString());
+
         if (sequenceNumber != null) {
             putRecordRequest.sequenceNumberForOrdering(sequenceNumber.toString());
         }
+
         return putRecordRequest.build();
     }
 
-    public static Message getMessageForResponse(final Exchange exchange) {
-        return exchange.getMessage();
+    private PutRecordsRequestEntry createRequestEntry(Exchange exchange) {
+        byte[] body = exchange.getIn().getBody(byte[].class);
+        Object partitionKey = exchange.getIn().getHeader(Kinesis2Constants.PARTITION_KEY);
+
+        PutRecordsRequestEntry.Builder putRecordsRequestEntry = PutRecordsRequestEntry.builder();
+        putRecordsRequestEntry.data(SdkBytes.fromByteArray(body));
+        ensurePartitionKeyNotNull(partitionKey);
+        putRecordsRequestEntry.partitionKey(partitionKey.toString());
+        return putRecordsRequestEntry.build();
+    }
+
+    private synchronized void addToRequestBatchBuffer(PutRecordsRequestEntry requestEntry) {
+        this.requestBatchBuffer.add(requestEntry);
+        if (this.requestBatchBuffer.size() >= MAX_BATCH_SIZE) {
+            flushRequestBatchBuffer();
+        }
+    }
+
+    private synchronized void flushRequestBatchBuffer() {
+        if (this.requestBatchBuffer.isEmpty()) {
+            return;
+        }
+
+        List<PutRecordsRequestEntry> requestBatchToSend = new ArrayList<>(this.requestBatchBuffer);
+        this.requestBatchBuffer = new ArrayList<>(MAX_BATCH_SIZE);
+
+        PutRecordsRequest putRecordsRequest = PutRecordsRequest.builder()
+                .streamName(getEndpoint().getConfiguration().getStreamName())
+                .records(requestBatchToSend)
+                .build();
+
+        PutRecordsResponse putRecordsResponse = connection.getClient(getEndpoint()).putRecords(putRecordsRequest);
+        int failedRecordCount = putRecordsResponse.failedRecordCount();
+        if (failedRecordCount > 0) {
+            throw new RuntimeException(
+                    "Failed to send records " + failedRecordCount + " of " + requestBatchToSend.size());
+        }
     }
 
     @Override
@@ -78,5 +142,11 @@ public class Kinesis2Producer extends DefaultProducer {
         super.doStart();
 
         ObjectHelper.notNull(connection, "connection", this);
+    }
+
+    private void ensurePartitionKeyNotNull(Object partitionKey) {
+        if (partitionKey == null) {
+            throw new IllegalArgumentException("Partition key must be specified");
+        }
     }
 }


### PR DESCRIPTION
# Description

Current kinesis producer can only send on record each time. It neither supports sending records in batch, nor supports async sending. Therefore, the throughput of kinesis producer is extremely low.

In this PR, kinesis producer added supporting for sending batch. This can significantly improve the throughput.

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

