### PR TITLE
CAMEL-20686 - changed file resources in tests to more unique & dynamic UUID

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerMoveExistingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerMoveExistingTest.java
@@ -119,7 +119,7 @@ public class FileProducerMoveExistingTest extends ContextTestSupport {
     }
 
     @Test
-    public void testExistingFileExistsTempFileNameMoRENAMED_TEST_FILE_NAMEath() throws Exception {
+    public void testExistingFileExistsTempFileNameMoveDynamicSubdirFullPath() throws Exception {
         final String subdirPrefix = generateRandomString(5);
         final String dynamicPath = "${file:parent}/" + subdirPrefix + "-${date:now:yyyyMMddHHmmssSSS}/${file:onlyname}";
         final String tempFilename = "tempFileName=${file:onlyname}.temp&";

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerMoveExistingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerMoveExistingTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Random;
+import java.util.UUID;
 
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.ContextTestSupport;
@@ -38,27 +39,31 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class FileProducerMoveExistingTest extends ContextTestSupport {
 
+    public static final String TEST_FILE_NAME = "hello." + UUID.randomUUID() + ".txt";
+    public static final String TEST_FILE_NAME_2 = "howdy." + UUID.randomUUID() + ".txt";
+    public static final String RENAMED_TEST_FILE_NAME = "renamed-" + TEST_FILE_NAME;
+
     @Test
     public void testExistingFileDoesNotExists() {
         template.sendBodyAndHeader(
                 fileUri("?fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}"), "Hello World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"));
-        assertFileNotExists(testFile("renamed-hello.txt"));
+        assertFileExists(testFile(TEST_FILE_NAME));
+        assertFileNotExists(testFile(RENAMED_TEST_FILE_NAME));
     }
 
     @Test
     public void testExistingFileExists() throws Exception {
         template.sendBodyAndHeader(
                 fileUri("?fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}"), "Hello World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
         template.sendBodyAndHeader(
                 fileUri("?fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}"), "Bye World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"), "Bye World");
-        assertFileExists(testFile("renamed-hello.txt"), "Hello World");
+        assertFileExists(testFile(TEST_FILE_NAME), "Bye World");
+        assertFileExists(testFile(RENAMED_TEST_FILE_NAME), "Hello World");
     }
 
     @Test
@@ -66,14 +71,14 @@ public class FileProducerMoveExistingTest extends ContextTestSupport {
         template.sendBodyAndHeader(
                 fileUri("?tempFileName=${file:onlyname}.temp&fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}"),
                 "Hello World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
         template.sendBodyAndHeader(
                 fileUri("?tempFileName=${file:onlyname}.temp&fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}"),
                 "Bye World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"), "Bye World");
-        assertFileExists(testFile("renamed-hello.txt"), "Hello World");
+        assertFileExists(testFile(TEST_FILE_NAME), "Bye World");
+        assertFileExists(testFile(RENAMED_TEST_FILE_NAME), "Hello World");
     }
 
     @Test
@@ -81,23 +86,23 @@ public class FileProducerMoveExistingTest extends ContextTestSupport {
         template.sendBodyAndHeader(
                 fileUri("?tempFileName=${file:onlyname}.temp&fileExist=Move&moveExisting=renamed"),
                 "Hello World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
         template.sendBodyAndHeader(
                 fileUri("?tempFileName=${file:onlyname}.temp&fileExist=Move&moveExisting=renamed"),
                 "Bye World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"), "Bye World");
-        assertFileExists(testFile("renamed/hello.txt"), "Hello World");
+        assertFileExists(testFile(TEST_FILE_NAME), "Bye World");
+        assertFileExists(testFile("renamed/" + TEST_FILE_NAME), "Hello World");
     }
 
     @Test
     public void testFailOnMoveExistingFileExistsEagerDeleteFalseTempFileName() throws Exception {
-        final String filename = "hello.txt";
+        final String filename = TEST_FILE_NAME;
 
         template.sendBodyAndHeader(fileUri("?tempFileName=${file:onlyname}.temp"), "First File",
                 Exchange.FILE_NAME,
-                "renamed-hello.txt");
+                RENAMED_TEST_FILE_NAME);
 
         template.sendBodyAndHeader(
                 fileUri("?tempFileName=${file:onlyname}.temp&fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}&eagerDeleteTargetFile=false"),
@@ -114,7 +119,7 @@ public class FileProducerMoveExistingTest extends ContextTestSupport {
     }
 
     @Test
-    public void testExistingFileExistsTempFileNameMoveDynamicSubdirFullPath() throws Exception {
+    public void testExistingFileExistsTempFileNameMoRENAMED_TEST_FILE_NAMEath() throws Exception {
         final String subdirPrefix = generateRandomString(5);
         final String dynamicPath = "${file:parent}/" + subdirPrefix + "-${date:now:yyyyMMddHHmmssSSS}/${file:onlyname}";
         final String tempFilename = "tempFileName=${file:onlyname}.temp&";
@@ -146,7 +151,7 @@ public class FileProducerMoveExistingTest extends ContextTestSupport {
     }
 
     private void testDynamicSubdir(String subdirPrefix, String dynamicPath, String tempFilename) throws IOException {
-        final String filename = "howdy.txt";
+        final String filename = TEST_FILE_NAME_2;
         final String fileContent = "Hello World";
         template.sendBodyAndHeader(fileUri("?" + tempFilename + "fileExist=Move&moveExisting=" + dynamicPath),
                 fileContent, Exchange.FILE_NAME, filename);
@@ -169,7 +174,7 @@ public class FileProducerMoveExistingTest extends ContextTestSupport {
     @Test
     public void testExistingFileExistsTempFileNameMoveSubDir() throws Exception {
 
-        final String filename = "howdy.txt";
+        final String filename = TEST_FILE_NAME_2;
         final String fileContent = "Hello World";
 
         template.sendBodyAndHeader(
@@ -187,7 +192,7 @@ public class FileProducerMoveExistingTest extends ContextTestSupport {
     @Test
     public void testExistingFileExistsTempFileNameRename() throws Exception {
 
-        final String filename = "howdy.txt";
+        final String filename = TEST_FILE_NAME_2;
         final String fileContent1 = "Hello World1";
         final String fileContent2 = "Hello World2";
 
@@ -212,51 +217,51 @@ public class FileProducerMoveExistingTest extends ContextTestSupport {
     @Test
     public void testExistingFileExistsMoveSubDir() throws Exception {
         template.sendBodyAndHeader(fileUri("?fileExist=Move&moveExisting=backup"), "Hello World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
         template.sendBodyAndHeader(fileUri("?fileExist=Move&moveExisting=backup"), "Bye World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"), "Bye World");
+        assertFileExists(testFile(TEST_FILE_NAME), "Bye World");
 
         // would move into subdirectory and keep existing name as is
-        assertFileExists(testFile("backup/hello.txt"), "Hello World");
+        assertFileExists(testFile("backup/" + TEST_FILE_NAME), "Hello World");
     }
 
     @Test
     public void testFailOnMoveExistingFileExistsEagerDeleteTrue() throws Exception {
-        template.sendBodyAndHeader(fileUri(), "Old file", Exchange.FILE_NAME, "renamed-hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Old file", Exchange.FILE_NAME, RENAMED_TEST_FILE_NAME);
 
         template.sendBodyAndHeader(
                 fileUri("?fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}&eagerDeleteTargetFile=true"),
                 "Hello World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
         // we should be okay as we will just delete any existing file
         template.sendBodyAndHeader(
                 fileUri("?fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}&eagerDeleteTargetFile=true"),
                 "Bye World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
 
         // we could write the new file so the old context should be there
-        assertFileExists(testFile("hello.txt"), "Bye World");
+        assertFileExists(testFile(TEST_FILE_NAME), "Bye World");
 
         // and the renamed file should be overridden
-        assertFileExists(testFile("renamed-hello.txt"), "Hello World");
+        assertFileExists(testFile(RENAMED_TEST_FILE_NAME), "Hello World");
     }
 
     @Test
     public void testFailOnMoveExistingFileExistsEagerDeleteFalse() throws Exception {
-        template.sendBodyAndHeader(fileUri(), "Old file", Exchange.FILE_NAME, "renamed-hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Old file", Exchange.FILE_NAME, RENAMED_TEST_FILE_NAME);
 
         template.sendBodyAndHeader(
                 fileUri("?fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}&eagerDeleteTargetFile=false"),
                 "Hello World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
 
         CamelExecutionException e = assertThrows(CamelExecutionException.class, () -> {
             template.sendBodyAndHeader(
                     fileUri("?fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}&eagerDeleteTargetFile=false"),
                     "Bye World",
-                    Exchange.FILE_NAME, "hello.txt");
+                    Exchange.FILE_NAME, TEST_FILE_NAME);
         }, "Should have thrown an exception");
 
         GenericFileOperationFailedException cause
@@ -265,10 +270,10 @@ public class FileProducerMoveExistingTest extends ContextTestSupport {
 
         // we could not write the new file so the previous context should be
         // there
-        assertFileExists(testFile("hello.txt"), "Hello World");
+        assertFileExists(testFile(TEST_FILE_NAME), "Hello World");
 
         // and the renamed file should be untouched
-        assertFileExists(testFile("renamed-hello.txt"), "Old file");
+        assertFileExists(testFile(RENAMED_TEST_FILE_NAME), "Old file");
     }
 
     private String generateRandomString(int targetStringLength) {

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerTempFileExistsIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerTempFileExistsIssueTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -26,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FileProducerTempFileExistsIssueTest extends ContextTestSupport {
+
+    public static final String TEST_FILE_NAME = "hello." + UUID.randomUUID() + ".txt";
 
     @Test
     public void testIllegalConfigurationPrefix() {
@@ -43,46 +47,48 @@ public class FileProducerTempFileExistsIssueTest extends ContextTestSupport {
 
     @Test
     public void testWriteUsingTempPrefixButFileExist() throws Exception {
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
-        template.sendBodyAndHeader(fileUri("?tempPrefix=foo"), "Bye World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
+        template.sendBodyAndHeader(fileUri("?tempPrefix=foo"), "Bye World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"), "Bye World");
+        assertFileExists(testFile(TEST_FILE_NAME), "Bye World");
     }
 
     @Test
     public void testWriteUsingTempPrefixButBothFileExist() throws Exception {
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "foohello.txt");
-        template.sendBodyAndHeader(fileUri("?tempPrefix=foo"), "Bye World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri("?tempPrefix=foo"), "Bye World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"), "Bye World");
+        assertFileExists(testFile(TEST_FILE_NAME), "Bye World");
     }
 
     @Test
     public void testWriteUsingTempPrefixButFileExistOverride() throws Exception {
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
-        template.sendBodyAndHeader(fileUri("?tempPrefix=foo&fileExist=Override"), "Bye World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
+        template.sendBodyAndHeader(fileUri("?tempPrefix=foo&fileExist=Override"), "Bye World", Exchange.FILE_NAME,
+                TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"), "Bye World");
+        assertFileExists(testFile(TEST_FILE_NAME), "Bye World");
     }
 
     @Test
     public void testWriteUsingTempPrefixButFileExistIgnore() throws Exception {
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
-        template.sendBodyAndHeader(fileUri("?tempPrefix=foo&fileExist=Ignore"), "Bye World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
+        template.sendBodyAndHeader(fileUri("?tempPrefix=foo&fileExist=Ignore"), "Bye World", Exchange.FILE_NAME,
+                TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"), "Hello World");
+        assertFileExists(testFile(TEST_FILE_NAME), "Hello World");
     }
 
     @Test
     public void testWriteUsingTempPrefixButFileExistFail() throws Exception {
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
         CamelExecutionException e = assertThrows(CamelExecutionException.class, () -> template
-                .sendBodyAndHeader(fileUri("?tempPrefix=foo&fileExist=Fail"), "Bye World", Exchange.FILE_NAME, "hello.txt"));
+                .sendBodyAndHeader(fileUri("?tempPrefix=foo&fileExist=Fail"), "Bye World", Exchange.FILE_NAME, TEST_FILE_NAME));
         GenericFileOperationFailedException cause = assertIsInstanceOf(GenericFileOperationFailedException.class, e.getCause());
         assertTrue(cause.getMessage().startsWith("File already exist"));
 
-        assertFileExists(testFile("hello.txt"), "Hello World");
+        assertFileExists(testFile(TEST_FILE_NAME), "Hello World");
     }
 
 }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerProducerDoneFileNameTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerProducerDoneFileNameTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.file;
 
 import java.util.Properties;
+import java.util.UUID;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelExecutionException;
@@ -33,6 +34,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for writing done files
  */
 public class FilerProducerDoneFileNameTest extends ContextTestSupport {
+
+    public static final String TEST_FILE_NAME_NOEXT = "hello." + UUID.randomUUID();
+    public static final String TEST_FILE_NAME = TEST_FILE_NAME_NOEXT + ".txt";
 
     private final Properties myProp = new Properties();
 
@@ -52,44 +56,45 @@ public class FilerProducerDoneFileNameTest extends ContextTestSupport {
 
     @Test
     public void testProducerConstantDoneFileName() {
-        template.sendBodyAndHeader(fileUri("?doneFileName=done"), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        String doneFileName = "xdone" + UUID.randomUUID();
+        template.sendBodyAndHeader(fileUri("?doneFileName=" + doneFileName), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"));
-        assertFileExists(testFile("done"));
+        assertFileExists(testFile(TEST_FILE_NAME));
+        assertFileExists(testFile(doneFileName));
     }
 
     @Test
     public void testProducerPrefixDoneFileName() {
         template.sendBodyAndHeader(fileUri("?doneFileName=done-${file:name}"), "Hello World", Exchange.FILE_NAME,
-                "hello.txt");
+                TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"));
-        assertFileExists(testFile("done-hello.txt"));
+        assertFileExists(testFile(TEST_FILE_NAME));
+        assertFileExists(testFile("done-" + TEST_FILE_NAME));
     }
 
     @Test
     public void testProducerExtDoneFileName() {
         template.sendBodyAndHeader(fileUri("?doneFileName=${file:name}.done"), "Hello World", Exchange.FILE_NAME,
-                "hello.txt");
+                TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"));
-        assertFileExists(testFile("hello.txt.done"));
+        assertFileExists(testFile(TEST_FILE_NAME));
+        assertFileExists(testFile(TEST_FILE_NAME + ".done"));
     }
 
     @Test
     public void testProducerReplaceExtDoneFileName() {
         template.sendBodyAndHeader(fileUri("?doneFileName=${file:name.noext}.done"), "Hello World",
-                Exchange.FILE_NAME, "hello.txt");
+                Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"));
-        assertFileExists(testFile("hello.done"));
+        assertFileExists(testFile(TEST_FILE_NAME));
+        assertFileExists(testFile(TEST_FILE_NAME_NOEXT + ".done"));
     }
 
     @Test
     public void testProducerInvalidDoneFileName() {
         CamelExecutionException e = assertThrows(CamelExecutionException.class,
                 () -> template.sendBodyAndHeader(fileUri("?doneFileName=${file:parent}/foo"), "Hello World", Exchange.FILE_NAME,
-                        "hello.txt"));
+                        TEST_FILE_NAME));
         ExpressionIllegalSyntaxException cause = assertIsInstanceOf(ExpressionIllegalSyntaxException.class, e.getCause());
         assertTrue(cause.getMessage().endsWith("Cannot resolve reminder: ${file:parent}/foo"), cause.getMessage());
     }
@@ -97,7 +102,7 @@ public class FilerProducerDoneFileNameTest extends ContextTestSupport {
     @Test
     public void testProducerEmptyDoneFileName() {
         CamelExecutionException e = assertThrows(CamelExecutionException.class,
-                () -> template.sendBodyAndHeader(fileUri("?doneFileName="), "Hello World", Exchange.FILE_NAME, "hello.txt"));
+                () -> template.sendBodyAndHeader(fileUri("?doneFileName="), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME));
         IllegalArgumentException cause = assertIsInstanceOf(IllegalArgumentException.class, e.getCause());
         assertTrue(cause.getMessage().startsWith("doneFileName must be specified and not empty"), cause.getMessage());
     }
@@ -107,10 +112,10 @@ public class FilerProducerDoneFileNameTest extends ContextTestSupport {
         myProp.put("myDir", testDirectory().toString());
 
         template.sendBodyAndHeader("file:{{myDir}}?doneFileName=done-${file:name}", "Hello World", Exchange.FILE_NAME,
-                "hello.txt");
+                TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"));
-        assertFileExists(testFile("done-hello.txt"));
+        assertFileExists(testFile(TEST_FILE_NAME));
+        assertFileExists(testFile("done-" + TEST_FILE_NAME));
     }
 
 }


### PR DESCRIPTION
# Description
Initial change set for CAMEL-20686
Changed three test files which had the maximum number of static filename usage (hello.txt etc.)
Appended `UUID `to make these more unique
```

- core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerMoveExistingTest.java
- core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerTempFileExistsIssueTest.java
- core/camel-core/src/test/java/org/apache/camel/component/file/FilerProducerDoneFileNameTest.java

```

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-20686) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

