### PR TITLE
Align camel-4.4.x branch with dependencies from spring-boot 3.2.7

### DIFF
--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfRecipientListTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfRecipientListTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.cxf;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.camel.EndpointInject;
 import org.apache.camel.component.cxf.common.message.CxfConstants;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -24,9 +27,6 @@ import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfRecipientListWithUrlParamsTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfRecipientListWithUrlParamsTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.cxf;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.camel.EndpointInject;
 import org.apache.camel.component.cxf.common.message.CxfConstants;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -24,9 +27,6 @@ import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathSplitSingleListOptionTest.java
+++ b/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathSplitSingleListOptionTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.jsonpath;
 
+import java.io.File;
+import java.util.Map;
+
 import com.jayway.jsonpath.Option;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
-
-import java.io.File;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/components/camel-knative/camel-knative-component/src/main/java/org/apache/camel/component/knative/KnativeConfiguration.java
+++ b/components/camel-knative/camel-knative-component/src/main/java/org/apache/camel/component/knative/KnativeConfiguration.java
@@ -16,15 +16,15 @@
  */
 package org.apache.camel.component.knative;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.cloudevents.CloudEvents;
 import org.apache.camel.component.knative.spi.KnativeEnvironment;
 import org.apache.camel.component.knative.spi.KnativeSinkBinding;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriParams;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @UriParams
 public class KnativeConfiguration implements Cloneable {

--- a/core/camel-core-engine/src/main/docs/modules/eips/nav.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/nav.adoc
@@ -80,7 +80,7 @@
 ** xref:routingSlip-eip.adoc[Routing Slip]
 ** xref:saga-eip.adoc[Saga]
 ** xref:sample-eip.adoc[Sample]
-** xref:scatter-gather.adoc[Scatter Gather]
+** xref:scatter-gather.adoc[Scatter-Gather]
 ** xref:script-eip.adoc[Script]
 ** xref:selective-consumer.adoc[Selective Consumer]
 ** xref:service-activator.adoc[Service Activator]

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -51,7 +51,7 @@
         <!-- dependency versions -->
         <activemq-version>5.18.3</activemq-version>
         <activemq-artemis-version>2.32.0</activemq-artemis-version>
-        <angus-mail-version>2.0.2</angus-mail-version>
+        <angus-mail-version>2.0.3</angus-mail-version>
         <apacheds-version>2.0.0.AM26</apacheds-version>
         <apache-drill-version>1.21.1</apache-drill-version>
         <apicurio-version>2.0.4</apicurio-version>
@@ -93,7 +93,7 @@
         <cometd-java-client-version>8.0.0.beta2</cometd-java-client-version>
         <cometd-java-server-version>8.0.0.beta2</cometd-java-server-version>
         <commons-beanutils-version>1.9.4</commons-beanutils-version>
-        <commons-codec-version>1.16.0</commons-codec-version>
+        <commons-codec-version>1.16.1</commons-codec-version>
         <commons-collections-version>3.2.2</commons-collections-version>
         <commons-collections4-version>4.4</commons-collections4-version>
         <commons-compress-version>1.26.0</commons-compress-version>
@@ -215,7 +215,7 @@
         <icu4j-version>74.2</icu4j-version>
         <ignite-version>2.16.0</ignite-version>
         <impsort-maven-plugin-version>1.9.0</impsort-maven-plugin-version>
-        <infinispan-version>14.0.24.Final</infinispan-version>
+        <infinispan-version>14.0.29.Final</infinispan-version>
         <influx-java-driver-version>2.24</influx-java-driver-version>
         <influx-client-java-driver-version>7.0.0</influx-client-java-driver-version>
         <irclib-version>1.10</irclib-version>
@@ -238,16 +238,16 @@
         <javassist-version>3.30.2-GA</javassist-version>
         <jakarta-el-api-version>5.0.1</jakarta-el-api-version>
         <jakarta-el-expressly-version>5.0.0</jakarta-el-expressly-version>
-        <jakarta-activation-version>2.1.2</jakarta-activation-version>
+        <jakarta-activation-version>2.1.3</jakarta-activation-version>
         <jakarta-annotation-api-version>2.1.1</jakarta-annotation-api-version>
         <jakarta-servlet-api-version>6.0.0</jakarta-servlet-api-version>
         <jakarta-enterprise-cdi-api-version>4.0.1</jakarta-enterprise-cdi-api-version>
         <jakarta-inject-version>2.0.1</jakarta-inject-version>
         <jakarta-xml-bind-api-version>4.0.1</jakarta-xml-bind-api-version>
-        <jakarta-xml-soap-api-version>3.0.1</jakarta-xml-soap-api-version>
-        <jakarta-xml-ws-api-version>4.0.1</jakarta-xml-ws-api-version>
+        <jakarta-xml-soap-api-version>3.0.2</jakarta-xml-soap-api-version>
+        <jakarta-xml-ws-api-version>4.0.2</jakarta-xml-ws-api-version>
         <glassfish-javax-json>1.1.4</glassfish-javax-json>
-        <glassfish-jaxb-runtime-version>4.0.4</glassfish-jaxb-runtime-version>
+        <glassfish-jaxb-runtime-version>4.0.5</glassfish-jaxb-runtime-version>
         <jaxb2-maven-plugin-version>3.1.0</jaxb2-maven-plugin-version>
         <jaxp-ri-version>1.4.5</jaxp-ri-version>
         <jboss-el-api_3.0_spec-version>2.0.0.Final</jboss-el-api_3.0_spec-version>
@@ -259,7 +259,7 @@
         <jcr-version>2.0</jcr-version>
         <jedis-client-version>5.1.0</jedis-client-version>
         <jetcd-version>0.7.7</jetcd-version>
-        <jetty-version>12.0.6</jetty-version>
+        <jetty-version>12.0.10</jetty-version>
         <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
         <jetty-runner-groupId>org.eclipse.jetty</jetty-runner-groupId>
         <jettison-version>1.5.4</jettison-version>
@@ -349,7 +349,7 @@
         <mock-javamail-version>1.9</mock-javamail-version>
         <mockwebserver-version>6.10.0</mockwebserver-version>
         <mockito-version>5.10.0</mockito-version>
-        <mongo-java-driver-version>4.11.1</mongo-java-driver-version>
+        <mongo-java-driver-version>4.11.2</mongo-java-driver-version>
         <mongo-hadoop-version>1.5.0</mongo-hadoop-version>
         <msal4j-version>1.14.2</msal4j-version>
         <mustache-java-version>0.9.11</mustache-java-version>
@@ -357,7 +357,7 @@
         <mybatis-version>3.5.15</mybatis-version>
         <narayana-version>5.13.1.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
-        <netty-version>4.1.110.Final</netty-version>
+        <netty-version>4.1.111.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.3.2</networknt-json-schema-validator-version>
         <nimbus-jose-jwt>9.37.3</nimbus-jose-jwt>
@@ -416,7 +416,7 @@
         <scala-datasonnet-version>2.13.12</scala-datasonnet-version>
         <shiro-version>1.13.0</shiro-version>
         <slack-api-model-version>1.38.1</slack-api-model-version>
-        <slf4j-api-version>2.0.12</slf4j-api-version>
+        <slf4j-api-version>2.0.13</slf4j-api-version>
         <slf4j-version>2.0.12</slf4j-version>
         <smack-version>4.3.5</smack-version>
         <smallrye-config-version>3.5.3</smallrye-config-version>
@@ -429,11 +429,11 @@
         <splunk-version>1.9.5_1</splunk-version>
         <spock-version>2.3-groovy-4.0</spock-version>
         <spring-batch-version>5.1.2</spring-batch-version>
-        <spring-data-redis-version>3.2.6</spring-data-redis-version>
-        <spring-ldap-version>3.2.3</spring-ldap-version>
+        <spring-data-redis-version>3.2.7</spring-data-redis-version>
+        <spring-ldap-version>3.2.4</spring-ldap-version>
         <spring-vault-core-version>3.1.1</spring-vault-core-version>
         <spring-version>6.1.10</spring-version>
-        <spring-rabbitmq-version>3.1.5</spring-rabbitmq-version>
+        <spring-rabbitmq-version>3.1.6</spring-rabbitmq-version>
         <spring-security-version>6.2.5</spring-security-version>
         <spring-ws-version>4.0.11</spring-ws-version>
         <sql-maven-plugin-version>1.5</sql-maven-plugin-version>


### PR DESCRIPTION
# Description

Align camel-4.4.x branch with dependencies in spring-boot-dependencies 3.2.7 to prevent dependency clashes

# Target

- [ x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
Not a large change

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes


