### PR TITLE
CAMEL-20895: camel-djl - The image classification predictors should not round the resulted probabilities

### DIFF
--- a/components/camel-ai/camel-djl/src/main/docs/djl-component.adoc
+++ b/components/camel-ai/camel-djl/src/main/docs/djl-component.adoc
@@ -55,23 +55,26 @@ The following table contains supported models in the model zoo:
 
 [width="100%",cols="1,3,5,3,5,5",options="header"]
 |===
-| CV | Image  Classification | Resnet image classification | `cv/image_classification` | `ai.djl.zoo:resnet:0.0.1` | {layers=50, flavor=v1, dataset=cifar10}
-| CV | Image  Classification | MLP image classification | `cv/image_classification` | `ai.djl.zoo:mlp:0.0.2` | {dataset=mnist}
-| CV | Image  Classification | MLP image classification | `cv/image_classification` | `ai.djl.mxnet:mlp:0.0.1` | {dataset=mnist}
-| CV | Image  Classification | Resnet image classification | `cv/image_classification` | `ai.djl.mxnet:resnet:0.0.1` | {layers=18, flavor=v1, dataset=imagenet}
-| CV | Image  Classification | Resnet image classification | `cv/image_classification` | `ai.djl.mxnet:resnet:0.0.1` | {layers=50, flavor=v2, dataset=imagenet}
-| CV | Image  Classification | Resnet image classification | `cv/image_classification` | `ai.djl.mxnet:resnet:0.0.1` | {layers=152, flavor=v1d, dataset=imagenet}
-| CV | Image  Classification | Resnet image classification | `cv/image_classification` | `ai.djl.mxnet:resnet:0.0.1` | {layers=50, flavor=v1, dataset=cifar10}
-| CV | Image  Classification | Resnext image classification | `cv/image_classification` | `ai.djl.mxnet:resnext:0.0.1` | {layers=101, flavor=64x4d, dataset=imagenet}
-| CV | Image  Classification | Senet image classification | `cv/image_classification` | `ai.djl.mxnet:senet:0.0.1` | {layers=154, dataset=imagenet}
-| CV | Image  Classification | Senet and Resnext image classification | `cv/image_classification` | `ai.djl.mxnet:se_resnext:0.0.1` | {layers=101, flavor=32x4d, dataset=imagenet}
-| CV | Image  Classification | Senet and Resnext image classification | `cv/image_classification` | `ai.djl.mxnet:se_resnext:0.0.1` | {layers=101, flavor=64x4d, dataset=imagenet}
-| CV | Image  Classification | Squeezenet image classification | `cv/image_classification` | `ai.djl.mxnet:squeezenet:0.0.1` | {flavor=1.0, dataset=imagenet}
-| CV | Object  Detection | Single Shot Detection for Object Detection | `cv/object_detection` | `ai.djl.zoo:ssd:0.0.1` | {flavor=tiny, dataset=pikachu}
-| CV | Object  Detection | Single-shot object detection | `cv/object_detection` | `ai.djl.mxnet:ssd:0.0.1` | {size=512, backbone=resnet50, flavor=v1, dataset=voc}
-| CV | Object  Detection | Single-shot object detection | `cv/object_detection` | `ai.djl.mxnet:ssd:0.0.1` | {size=512, backbone=vgg16, flavor=atrous, dataset=coco}
-| CV | Object  Detection | Single-shot object detection | `cv/object_detection` | `ai.djl.mxnet:ssd:0.0.1` | {size=512, backbone=mobilenet1.0, dataset=voc}
-| CV | Object  Detection | Single-shot object detection | `cv/object_detection` | `ai.djl.mxnet:ssd:0.0.1` | {size=300, backbone=vgg16, flavor=atrous, dataset=voc}
+| Category | Application | Model family | Application path | Artifact ID | Options
+
+| CV | Image Classification | MLP | `cv/image_classification` | `ai.djl.zoo:mlp:0.0.2` | {dataset=mnist}
+| CV | Image Classification | MLP | `cv/image_classification` | `ai.djl.mxnet:mlp:0.0.1` | {dataset=mnist}
+| CV | Image Classification | Resnet | `cv/image_classification` | `ai.djl.zoo:resnet:0.0.1` | {layers=50, flavor=v1, dataset=cifar10}
+| CV | Image Classification | Resnet | `cv/image_classification` | `ai.djl.mxnet:resnet:0.0.1` | {layers=18, flavor=v1, dataset=imagenet}
+| CV | Image Classification | Resnet | `cv/image_classification` | `ai.djl.mxnet:resnet:0.0.1` | {layers=50, flavor=v2, dataset=imagenet}
+| CV | Image Classification | Resnet | `cv/image_classification` | `ai.djl.mxnet:resnet:0.0.1` | {layers=152, flavor=v1d, dataset=imagenet}
+| CV | Image Classification | Resnet | `cv/image_classification` | `ai.djl.mxnet:resnet:0.0.1` | {layers=50, flavor=v1, dataset=cifar10}
+| CV | Image Classification | Resnext | `cv/image_classification` | `ai.djl.mxnet:resnext:0.0.1` | {layers=101, flavor=64x4d, dataset=imagenet}
+| CV | Image Classification | Senet | `cv/image_classification` | `ai.djl.mxnet:senet:0.0.1` | {layers=154, dataset=imagenet}
+| CV | Image Classification | SeResnext | `cv/image_classification` | `ai.djl.mxnet:se_resnext:0.0.1` | {layers=101, flavor=32x4d, dataset=imagenet}
+| CV | Image Classification | SeResnext | `cv/image_classification` | `ai.djl.mxnet:se_resnext:0.0.1` | {layers=101, flavor=64x4d, dataset=imagenet}
+| CV | Image Classification | Squeezenet | `cv/image_classification` | `ai.djl.mxnet:squeezenet:0.0.1` | {flavor=1.0, dataset=imagenet}
+
+| CV | Object Detection | SSD | `cv/object_detection` | `ai.djl.zoo:ssd:0.0.1` | {flavor=tiny, dataset=pikachu}
+| CV | Object Detection | SSD | `cv/object_detection` | `ai.djl.mxnet:ssd:0.0.1` | {size=512, backbone=resnet50, flavor=v1, dataset=voc}
+| CV | Object Detection | SSD | `cv/object_detection` | `ai.djl.mxnet:ssd:0.0.1` | {size=512, backbone=vgg16, flavor=atrous, dataset=coco}
+| CV | Object Detection | SSD | `cv/object_detection` | `ai.djl.mxnet:ssd:0.0.1` | {size=512, backbone=mobilenet1.0, dataset=voc}
+| CV | Object Detection | SSD | `cv/object_detection` | `ai.djl.mxnet:ssd:0.0.1` | {size=300, backbone=vgg16, flavor=atrous, dataset=voc}
 |===
 
 
@@ -80,35 +83,6 @@ The following table contains supported models in the model zoo:
 Because DJL is deep learning framework-agnostic, you don't have to make a choice between frameworks when creating your projects.
 You can switch frameworks at any point.
 To ensure the best performance, DJL also provides automatic CPU/GPU choice based on hardware configuration.
-
-=== MxNet engine
-
-You can pull the MXNet engine from the central Maven repository by including the following dependency:
-
-[source,xml]
-----
-<dependency>
-    <groupId>ai.djl.mxnet</groupId>
-    <artifactId>mxnet-engine</artifactId>
-    <version>x.x.x</version>
-    <scope>runtime</scope>
-</dependency>
-----
-
-DJL offers an automatic option that will download the jars the first time you run DJL.
-It will automatically determine the appropriate jars for your system based on the platform and GPU support.
-
-[source,xml]
-----
-    <dependency>
-      <groupId>ai.djl.mxnet</groupId>
-      <artifactId>mxnet-native-auto</artifactId>
-      <version>1.8.0</version>
-      <scope>runtime</scope>
-    </dependency>
-----
-
-More information about https://docs.djl.ai/engines/mxnet/index.html[MxNet engine installation]
 
 === PyTorch engine
 
@@ -124,24 +98,14 @@ You can pull the PyTorch engine from the central Maven repository by including t
 </dependency>
 ----
 
-DJL offers an automatic option that will download the jars the first time you run DJL.
+By default, DJL will download the PyTorch native libraries into https://docs.djl.ai/docs/development/cache_management.html[cache folder] the first time you run DJL.
 It will automatically determine the appropriate jars for your system based on the platform and GPU support.
-
-[source,xml]
-----
-    <dependency>
-      <groupId>ai.djl.pytorch</groupId>
-      <artifactId>pytorch-native-auto</artifactId>
-      <version>1.9.1</version>
-      <scope>runtime</scope>
-    </dependency>
-----
 
 More information about https://docs.djl.ai/engines/pytorch/index.html[PyTorch engine installation]
 
-=== Tensorflow engine
+=== TensorFlow engine
 
-You can pull the Tensorflow engine from the central Maven repository by including the following dependency:
+You can pull the TensorFlow engine from the central Maven repository by including the following dependency:
 
 [source,xml]
 ----
@@ -153,20 +117,29 @@ You can pull the Tensorflow engine from the central Maven repository by includin
 </dependency>
 ----
 
-DJL offers an automatic option that will download the jars the first time you run DJL.
+By default, DJL will download the TensorFlow native libraries into https://docs.djl.ai/docs/development/cache_management.html[cache folder] the first time you run DJL.
 It will automatically determine the appropriate jars for your system based on the platform and GPU support.
+
+More information about https://docs.djl.ai/engines/tensorflow/index.html[TensorFlow engine installation]
+
+=== MXNet engine
+
+You can pull the MXNet engine from the central Maven repository by including the following dependency:
 
 [source,xml]
 ----
-    <dependency>
-      <groupId>ai.djl.tensorflow</groupId>
-      <artifactId>tensorflow-native-auto</artifactId>
-      <version>2.4.1</version>
-      <scope>runtime</scope>
-    </dependency>
+<dependency>
+    <groupId>ai.djl.mxnet</groupId>
+    <artifactId>mxnet-engine</artifactId>
+    <version>x.x.x</version>
+    <scope>runtime</scope>
+</dependency>
 ----
 
-More information about https://docs.djl.ai/engines/tensorflow/index.html[Tensorflow engine installation]
+By default, DJL will download the Apache MXNet native libraries into https://docs.djl.ai/docs/development/cache_management.html[cache folder] the first time you run DJL.
+It will automatically determine the appropriate jars for your system based on the platform and GPU support.
+
+More information about https://docs.djl.ai/engines/mxnet/index.html[MXNet engine installation]
 
 
 
@@ -177,6 +150,7 @@ More information about https://docs.djl.ai/engines/tensorflow/index.html[Tensorf
 [source,java]
 ----
 from("file:/data/mnist/0/10.png")
+    .convertBodyTo(byte[].class)
     .to("djl:cv/image_classification?artifactId=ai.djl.mxnet:mlp:0.0.1");
 ----
 
@@ -184,6 +158,7 @@ from("file:/data/mnist/0/10.png")
 [source,java]
 ----
 from("file:/data/mnist/0/10.png")
+    .convertBodyTo(byte[].class)
     .to("djl:cv/image_classification?artifactId=ai.djl.mxnet:mlp:0.0.1");
 ----
 
@@ -207,6 +182,7 @@ context.getRegistry().bind("MyModel", model);
 context.getRegistry().bind("MyTranslator", translator);
 
 from("file:/data/mnist/0/10.png")
+    .convertBodyTo(byte[].class)
     .to("djl:cv/image_classification?model=MyModel&translator=MyTranslator");
 ----
 

--- a/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/ZooObjectDetectionPredictor.java
+++ b/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/ZooObjectDetectionPredictor.java
@@ -70,8 +70,7 @@ public class ZooObjectDetectionPredictor extends AbstractPredictor {
 
     public DetectedObjects classify(Image image) {
         try (Predictor<Image, DetectedObjects> predictor = model.newPredictor()) {
-            DetectedObjects detectedObjects = predictor.predict(image);
-            return detectedObjects;
+            return predictor.predict(image);
         } catch (TranslateException e) {
             throw new RuntimeCamelException("Could not process input or output", e);
         }

--- a/components/camel-ai/camel-djl/src/test/java/org/apache/camel/component/djl/ImageClassificationTest.java
+++ b/components/camel-ai/camel-djl/src/test/java/org/apache/camel/component/djl/ImageClassificationTest.java
@@ -20,9 +20,16 @@ package org.apache.camel.component.djl;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ImageClassificationTest extends CamelTestSupport {
+
+    @BeforeAll
+    public static void setupDefaultEngine() {
+        // Since Apache MXNet is discontinued, prefer PyTorch as the default engine
+        System.setProperty("ai.djl.default_engine", "PyTorch");
+    }
 
     @Test
     void testDJL() throws Exception {
@@ -37,8 +44,8 @@ public class ImageClassificationTest extends CamelTestSupport {
             public void configure() {
                 from("file:src/test/resources/data/mnist?recursive=true&noop=true")
                         .convertBodyTo(byte[].class)
-                        .to("djl:cv/image_classification?artifactId=ai.djl.mxnet:mobilenet:0.0.3")
-                        .log("${header.CamelFileName} = ${body}")
+                        .to("djl:cv/image_classification?artifactId=ai.djl.zoo:mlp:0.0.3")
+                        .log("${header.CamelFileName} = ${body.best.className}")
                         .to("mock:result");
             }
         };

--- a/components/camel-ai/camel-djl/src/test/java/org/apache/camel/component/djl/ObjectDetectionTest.java
+++ b/components/camel-ai/camel-djl/src/test/java/org/apache/camel/component/djl/ObjectDetectionTest.java
@@ -20,9 +20,16 @@ package org.apache.camel.component.djl;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ObjectDetectionTest extends CamelTestSupport {
+
+    @BeforeAll
+    public static void setupDefaultEngine() {
+        // Since Apache MXNet is discontinued, prefer PyTorch as the default engine
+        System.setProperty("ai.djl.default_engine", "PyTorch");
+    }
 
     @Test
     void testDJL() throws Exception {
@@ -37,7 +44,7 @@ public class ObjectDetectionTest extends CamelTestSupport {
             public void configure() {
                 from("file:src/test/resources/data/detect?recursive=true&noop=true")
                         .convertBodyTo(byte[].class)
-                        .to("djl:cv/object_detection?artifactId=ai.djl.mxnet:ssd:0.0.2")
+                        .to("djl:cv/object_detection?artifactId=ai.djl.pytorch:ssd:0.0.1")
                         .log("${header.CamelFileName} = ${body}")
                         .to("mock:result");
             }


### PR DESCRIPTION
# Description

https://issues.apache.org/jira/browse/CAMEL-20895

The predictors should return the Classifications provided from DJL as-is for the responses.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

