### PR TITLE
CAMEL-20794: AWS2 Kinesis producer supports sending batch

### DIFF
--- a/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Producer.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Producer.java
@@ -16,6 +16,11 @@
  */
 package org.apache.camel.component.aws2.kinesis;
 
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.support.DefaultProducer;
@@ -26,11 +31,6 @@ import software.amazon.awssdk.services.kinesis.model.PutRecordResponse;
 import software.amazon.awssdk.services.kinesis.model.PutRecordsRequest;
 import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
 import software.amazon.awssdk.services.kinesis.model.PutRecordsResponse;
-
-import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 
 public class Kinesis2Producer extends DefaultProducer {
 
@@ -80,7 +80,8 @@ public class Kinesis2Producer extends DefaultProducer {
         PutRecordsResponse putRecordsResponse = connection.getClient(getEndpoint()).putRecords(putRecordsRequest);
         if (putRecordsResponse.failedRecordCount() > 0) {
             throw new RuntimeException(
-                    "Failed to send records " + putRecordsResponse.failedRecordCount() + " of " + putRecordsResponse.records().size());
+                    "Failed to send records " + putRecordsResponse.failedRecordCount() + " of "
+                                       + putRecordsResponse.records().size());
         }
     }
 
@@ -97,7 +98,8 @@ public class Kinesis2Producer extends DefaultProducer {
             } else if (record instanceof String str) {
                 sdkBytes = SdkBytes.fromUtf8String(str);
             } else {
-                throw new IllegalArgumentException("Record type not supported. Must be byte[], ByteBuffer, InputStream or UTF-8 String");
+                throw new IllegalArgumentException(
+                        "Record type not supported. Must be byte[], ByteBuffer, InputStream or UTF-8 String");
             }
 
             PutRecordsRequestEntry putRecordsRequestEntry = PutRecordsRequestEntry.builder()


### PR DESCRIPTION
# Description

Current kinesis producer can only send on record each time. It neither supports sending records in batch, nor supports async sending. Therefore, the throughput of kinesis producer is extremely low.

In this PR, kinesis producer added supporting for sending batch. This can significantly improve the throughput.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

