### PR TITLE
Avoid NPE on Camel Tests

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
@@ -75,7 +75,7 @@ Configures batch-processing resequence eip.
     <xs:annotation>
       <xs:documentation xml:lang="en">
 <![CDATA[
-Calls a Java bean
+Define custom beans that can be used in your Camel routes and in general.
 ]]>
       </xs:documentation>
     </xs:annotation>
@@ -3973,50 +3973,10 @@ Enables random backoff. Default value: false
     <xs:complexContent>
       <xs:extension base="tns:noOutputDefinition">
         <xs:sequence/>
-        <xs:attribute name="ref" type="xs:string">
-          <xs:annotation>
-            <xs:documentation xml:lang="en">
-<![CDATA[
-Sets a reference to an existing bean to use, which is looked up from the registry.
-]]>
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="method" type="xs:string">
-          <xs:annotation>
-            <xs:documentation xml:lang="en">
-<![CDATA[
-Sets the method name on the bean to use.
-]]>
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="beanType" type="xs:string">
-          <xs:annotation>
-            <xs:documentation xml:lang="en">
-<![CDATA[
-Sets the class name (fully qualified) of the bean to use.
-]]>
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="scope" type="xs:string">
-          <xs:annotation>
-            <xs:documentation xml:lang="en">
-<![CDATA[
-Scope of bean. When using singleton scope (default) the bean is created or looked up only once and reused for the
-lifetime of the endpoint. The bean should be thread-safe in case concurrent threads is calling the bean at the same
-time. When using request scope the bean is created or looked up once per request (exchange). This can be used if you
-want to store state on a bean while processing a request and you want to call the same bean instance multiple times
-while processing the request. The bean does not have to be thread-safe as the instance is only called from the same
-request. When using prototype scope, then the bean will be looked up or created per call. However in case of lookup then
-this is delegated to the bean registry such as Spring or CDI (if in use), which depends on their configuration can act
-as either singleton or prototype scope. So when using prototype scope then this depends on the bean registry
-implementation. Default value: Singleton
-]]>
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
+        <xs:attribute name="ref" type="xs:string"/>
+        <xs:attribute name="method" type="xs:string"/>
+        <xs:attribute name="beanType" type="xs:string"/>
+        <xs:attribute name="scope" type="xs:string"/>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
@@ -75,7 +75,7 @@ Configures batch-processing resequence eip.
     <xs:annotation>
       <xs:documentation xml:lang="en">
 <![CDATA[
-Define custom beans that can be used in your Camel routes and in general.
+Calls a Java bean
 ]]>
       </xs:documentation>
     </xs:annotation>
@@ -3973,10 +3973,50 @@ Enables random backoff. Default value: false
     <xs:complexContent>
       <xs:extension base="tns:noOutputDefinition">
         <xs:sequence/>
-        <xs:attribute name="ref" type="xs:string"/>
-        <xs:attribute name="method" type="xs:string"/>
-        <xs:attribute name="beanType" type="xs:string"/>
-        <xs:attribute name="scope" type="xs:string"/>
+        <xs:attribute name="ref" type="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+<![CDATA[
+Sets a reference to an existing bean to use, which is looked up from the registry.
+]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="method" type="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+<![CDATA[
+Sets the method name on the bean to use.
+]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="beanType" type="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+<![CDATA[
+Sets the class name (fully qualified) of the bean to use.
+]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="scope" type="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+<![CDATA[
+Scope of bean. When using singleton scope (default) the bean is created or looked up only once and reused for the
+lifetime of the endpoint. The bean should be thread-safe in case concurrent threads is calling the bean at the same
+time. When using request scope the bean is created or looked up once per request (exchange). This can be used if you
+want to store state on a bean while processing a request and you want to call the same bean instance multiple times
+while processing the request. The bean does not have to be thread-safe as the instance is only called from the same
+request. When using prototype scope, then the bean will be looked up or created per call. However in case of lookup then
+this is delegated to the bean registry such as Spring or CDI (if in use), which depends on their configuration can act
+as either singleton or prototype scope. So when using prototype scope then this depends on the bean registry
+implementation. Default value: Singleton
+]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -150,7 +150,7 @@ public abstract class CamelTestSupport extends AbstractTestSupport
     }
 
     @Override
-    public void afterAll(ExtensionContext context) {\
+    public void afterAll(ExtensionContext context) {
         if (contextManager != null) {
             // It may be null in some occasion, such as when failing to initialize the context
             contextManager.stop();

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -151,8 +151,9 @@ public abstract class CamelTestSupport extends AbstractTestSupport
     }
 
     @Override
-    public void afterAll(ExtensionContext context) {
-        if (Objects.nonNull(contextManager)) {
+    public void afterAll(ExtensionContext context) {\
+        if (contextManager != null) {
+            // It may be null in some occasion, such as when failing to initialize the context
             contextManager.stop();
         }
     }
@@ -341,7 +342,6 @@ public abstract class CamelTestSupport extends AbstractTestSupport
     @Deprecated(since = "4.7.0")
     protected void stopCamelContext() throws Exception {
         contextManager.stopCamelContext();
-
     }
 
     @Deprecated(since = "4.7.0")

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -152,7 +152,7 @@ public abstract class CamelTestSupport extends AbstractTestSupport
 
     @Override
     public void afterAll(ExtensionContext context) {
-        if(Objects.nonNull(contextManager)) {
+        if (Objects.nonNull(contextManager)) {
             contextManager.stop();
         }
     }

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -17,7 +17,6 @@
 package org.apache.camel.test.junit5;
 
 import java.util.Map;
-import java.util.Objects;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/CamelTestSupport.java
@@ -119,15 +119,7 @@ public abstract class CamelTestSupport extends AbstractTestSupport
 
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
-        if (contextManager == null) {
-            LOG.trace("Creating a transient context manager for {}", context.getDisplayName());
-            contextManager = contextManagerFactory.createContextManager(ContextManagerFactory.Type.BEFORE_EACH,
-                    testConfigurationBuilder, camelContextConfiguration);
-        }
-
         currentTestName = context.getDisplayName();
-        ExtensionContext.Store globalStore = context.getStore(ExtensionContext.Namespace.GLOBAL);
-        contextManager.setGlobalStore(globalStore);
     }
 
     @Override
@@ -143,6 +135,12 @@ public abstract class CamelTestSupport extends AbstractTestSupport
             LOG.trace("Creating a legacy context manager for {}", context.getDisplayName());
             testConfigurationBuilder.withCreateCamelContextPerClass(perClassPresent);
             contextManager = contextManagerFactory.createContextManager(ContextManagerFactory.Type.BEFORE_ALL,
+                    testConfigurationBuilder, camelContextConfiguration);
+        }
+
+        if (contextManager == null) {
+            LOG.trace("Creating a transient context manager for {}", context.getDisplayName());
+            contextManager = contextManagerFactory.createContextManager(ContextManagerFactory.Type.BEFORE_EACH,
                     testConfigurationBuilder, camelContextConfiguration);
         }
 


### PR DESCRIPTION
# Description

Affects camel-test component. Related to https://issues.apache.org/jira/browse/CAMEL-20838

Fixes errors like:
```
java.lang.NullPointerException: Cannot invoke "org.apache.camel.test.junit5.CamelContextManager.setGlobalStore(org.junit.jupiter.api.extension.ExtensionContext$Store)" because "this.contextManager" is null
        at org.apache.camel.test.junit5.CamelTestSupport.beforeAll(CamelTestSupport.java:148)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
        Suppressed: java.lang.NullPointerException: Cannot invoke "org.apache.camel.test.junit5.CamelContextManager.stop()" because "this.contextManager" is null
                at org.apache.camel.test.junit5.CamelTestSupport.afterAll(CamelTestSupport.java:153)
                ... 1 more
```
when running camel tests.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
https://issues.apache.org/jira/browse/CAMEL-20838
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

