### PR TITLE
camel-jbang: Use additional properties during export to add Maven POM properties

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelCommand.java
@@ -119,20 +119,22 @@ public abstract class CamelCommand implements Callable<Integer> {
     }
 
     protected void printConfigurationValues(String header) {
-        final Properties configProperties = new Properties();
-        CommandLineHelper.loadProperties(configProperties::putAll);
-        List<String> lines = new ArrayList<>();
-        spec.options().forEach(opt -> {
-            if (Arrays.stream(opt.names()).anyMatch(name ->
-            // name starts with --
-            configProperties.containsKey(name.substring(2)))) {
-                lines.add(String.format("    %s=%s",
-                        opt.longestName(), opt.getValue().toString()));
+        if (spec != null) {
+            final Properties configProperties = new Properties();
+            CommandLineHelper.loadProperties(configProperties::putAll);
+            List<String> lines = new ArrayList<>();
+            spec.options().forEach(opt -> {
+                if (Arrays.stream(opt.names()).anyMatch(name ->
+                // name starts with --
+                configProperties.containsKey(name.substring(2)))) {
+                    lines.add(String.format("    %s=%s",
+                            opt.longestName(), opt.getValue().toString()));
+                }
+            });
+            if (!lines.isEmpty()) {
+                printer().println(header);
+                lines.forEach(printer()::println);
             }
-        });
-        if (!lines.isEmpty()) {
-            printer().println(header);
-            lines.forEach(printer()::println);
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.camel.catalog.CamelCatalog;
@@ -371,6 +373,19 @@ class ExportQuarkus extends Export {
         context = context.replaceAll("\\{\\{ \\.QuarkusVersion }}", quarkusVersion);
         context = context.replaceFirst("\\{\\{ \\.JavaVersion }}", javaVersion);
         context = context.replaceFirst("\\{\\{ \\.CamelVersion }}", camelVersion);
+
+        if (additionalProperties != null) {
+            String properties = Arrays.stream(additionalProperties.split(","))
+                    .map(property -> {
+                        String[] keyValueProperty = property.split("=");
+                        return String.format("        <%s>%s</%s>", keyValueProperty[0], keyValueProperty[1],
+                                keyValueProperty[0]);
+                    })
+                    .collect(Collectors.joining(System.lineSeparator()));
+            context = context.replaceFirst(Pattern.quote("{{ .AdditionalProperties }}"), Matcher.quoteReplacement(properties));
+        } else {
+            context = context.replaceFirst(Pattern.quote("{{ .AdditionalProperties }}"), "");
+        }
 
         if (repos == null || repos.isEmpty()) {
             context = context.replaceFirst("\\{\\{ \\.MavenRepositories }}", "");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
@@ -189,14 +189,13 @@ class ExportSpringBoot extends Export {
             String properties = Arrays.stream(additionalProperties.split(","))
                     .map(property -> {
                         String[] keyValueProperty = property.split("=");
-                        return String.format("\t\t<%s>%s</%s>", keyValueProperty[0], keyValueProperty[1],
+                        return String.format("        <%s>%s</%s>", keyValueProperty[0], keyValueProperty[1],
                                 keyValueProperty[0]);
                     })
-                    .map(property -> property + System.lineSeparator())
-                    .collect(Collectors.joining());
-            context = context.replaceFirst("\\{\\{ \\.AdditionalProperties }}", properties);
+                    .collect(Collectors.joining(System.lineSeparator()));
+            context = context.replaceFirst(Pattern.quote("{{ .AdditionalProperties }}"), Matcher.quoteReplacement(properties));
         } else {
-            context = context.replaceFirst("\\{\\{ \\.AdditionalProperties }}", "");
+            context = context.replaceFirst(Pattern.quote("{{ .AdditionalProperties }}"), "");
         }
 
         // Convert jkube properties to maven properties

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/main-pom.tmpl
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/main-pom.tmpl
@@ -10,6 +10,7 @@
     <properties>
         <java.version>{{ .JavaVersion }}</java.version>
 {{ .CamelKubernetesProperties }}
+{{ .AdditionalProperties }}
     </properties>
 
     <dependencyManagement>

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/quarkus-pom.tmpl
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/quarkus-pom.tmpl
@@ -17,6 +17,7 @@
         <quarkus.platform.group-id>{{ .QuarkusGroupId }}</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>{{ .QuarkusArtifactId }}</quarkus.platform.artifact-id>
         <quarkus.platform.version>{{ .QuarkusVersion }}</quarkus.platform.version>
+{{ .AdditionalProperties }}
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
     </properties>

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/spring-boot-pom.tmpl
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/spring-boot-pom.tmpl
@@ -17,6 +17,7 @@
     <properties>
         <java.version>{{ .JavaVersion }}</java.version>
 {{ .jkubeProperties }}
+{{ .AdditionalProperties }}
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
# Description

Camel JBang export seemed to not use `--additional-properties` export option in default Maven POM templates.

- Maven POM templates support setting of additional properties during export
- Properties get added to the Maven POM properties section
- Support it in Quarkus, Spring Boot and Camel Main export

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

