### PR TITLE
CAMEL-20227: avoid calling the consumer test unless Kafka consumer has been paused

### DIFF
--- a/components/camel-kafka/src/main/docs/kafka-component.adoc
+++ b/components/camel-kafka/src/main/docs/kafka-component.adoc
@@ -439,8 +439,10 @@ from("kafka:topic")
 
 In this example, consuming messages can pause (by calling the Kafka's Consumer pause method) if the result from `canContinue` is false.
 
-The pausable EIP is meant to be used as a support mechanism when there is an exception somewhere in the route that prevents the exchange from being processed. More specifically,
+IMPORTANT: The pausable EIP is meant to be used as a support mechanism when *there is an exception* somewhere in the route that prevents the exchange from being processed. More specifically,
 the check called by the `pausable` EIP should be used to test for transient conditions preventing the exchange from being processed.
+
+NOTE: most users should prefer using the xref:manual::route-policy.adoc[RoutePolicy], which offers better control of the route.
 
 == Kafka Headers propagation
 

--- a/core/camel-api/src/main/java/org/apache/camel/resume/ConsumerListener.java
+++ b/core/camel-api/src/main/java/org/apache/camel/resume/ConsumerListener.java
@@ -35,10 +35,10 @@ public interface ConsumerListener<C, P> {
     void setResumableCheck(Predicate<?> afterConsumeEval);
 
     /**
-     * This is an event that runs after data consumption.
+     * This is an event that runs after data consumption if and only if the consumer has been paused.
      *
      * @param  consumePayload the resume payload if any
-     * @return                true if the consumer should processing or false otherwise.
+     * @return                true if the consumer should continue processing or false otherwise.
      */
     boolean afterConsume(C consumePayload);
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ProcessorDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ProcessorDefinition.java
@@ -4080,7 +4080,8 @@ public abstract class ProcessorDefinition<Type extends ProcessorDefinition<Type>
 
     /**
      * This enables pausable consumers, which allows the consumer to pause work until a certain condition allows it to
-     * resume operation
+     * resume operation. Please note that the check method is called only if the consumer has been paused due to an
+     * error on the routh.
      *
      * @param  consumerListener the consumer listener to use for consumer events
      * @return                  the builder
@@ -4095,7 +4096,8 @@ public abstract class ProcessorDefinition<Type extends ProcessorDefinition<Type>
 
     /**
      * This enables pausable consumers, which allows the consumer to pause work until a certain condition allows it to
-     * resume operation
+     * resume operation. Please note that the check method is called only if the consumer has been paused due to an
+     * error on the routh.
      *
      * @param  consumerListenerRef the resume strategy
      * @return                     the builder
@@ -4110,7 +4112,8 @@ public abstract class ProcessorDefinition<Type extends ProcessorDefinition<Type>
 
     /**
      * This enables pausable consumers, which allows the consumer to pause work until a certain condition allows it to
-     * resume operation
+     * resume operation. Please note that the check method is called only if the consumer has been paused due to an
+     * error on the routh.
      *
      * @param  consumerListenerRef the resume strategy
      * @return                     the builder


### PR DESCRIPTION
Hey @davsclaus, this is more or less what I was thinking about in my comment on https://github.com/apache/camel/pull/14745#issuecomment-2212350669. 

I'm wondering if we should add a log on to inform that we are not calling the `afterConsumeEval.test(null)` because it has not been paused (I have not done so yet, as I think it would flood the log with those messages, because it would be called after every `poll`).