### PR TITLE
Update maven-release-plugin to 3.1.0 again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,7 @@
         <maven-enforcer-plugin-version>3.5.0</maven-enforcer-plugin-version>
         <maven-invoker-plugin-version>3.7.0</maven-invoker-plugin-version>
         <maven-javadoc-plugin-version>3.7.0</maven-javadoc-plugin-version>
-        <!-- downgraded to release plugin from 3.1.0 to 3.0.1 because of problem releasing 4.7.0 -->
-        <maven-release-plugin-version>3.0.1</maven-release-plugin-version>
+        <maven-release-plugin-version>3.1.0</maven-release-plugin-version>
         <maven-remote-resources-plugin-version>3.2.0</maven-remote-resources-plugin-version>
         <maven-surefire-plugin-version>3.3.0</maven-surefire-plugin-version>
         <versions-maven-plugin-version>2.17.0</versions-maven-plugin-version>


### PR DESCRIPTION
After successfully building the 4.7.0 release with maven-release-plugin 3.1.0, let's bump the version on `main` again.