### PR TITLE
CAMEL-20686 restored overwrites from previous commit + replace deprecated method call

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeAlterFileNameHeaderIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeAlterFileNameHeaderIssueTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.file;
 
 import java.nio.file.Files;
+import java.util.UUID;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -31,6 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  */
 public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport {
+    public static final String TEST_FILE_NAME = "hello." + UUID.randomUUID() + ".txt";
+    public static final String TEST_FILE_NAME_BYE = "bye." + UUID.randomUUID() + ".txt";
 
     @Override
     public boolean isUseRouteBuilder() {
@@ -52,7 +55,7 @@ public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport 
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Hello World");
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
         oneExchangeDone.matchesWaitTime();
@@ -62,7 +65,7 @@ public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport 
         // the original file should have been deleted, as the file consumer
         // should be resilient against
         // end users deleting headers
-        assertFalse(Files.exists(testFile("hello.txt")), "File should been deleted");
+        assertFalse(Files.exists(testFile(TEST_FILE_NAME)), "File should been deleted");
     }
 
     @Test
@@ -72,16 +75,16 @@ public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport 
             public void configure() {
                 from(fileUri() + "?initialDelay=0&delay=10&delete=true")
                         // change file header
-                        .setHeader(Exchange.FILE_NAME, constant("bye.txt")).to("mock:result");
+                        .setHeader(Exchange.FILE_NAME, constant(TEST_FILE_NAME_BYE)).to("mock:result");
             }
         });
         context.start();
 
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Hello World");
-        mock.expectedHeaderReceived(Exchange.FILE_NAME, "bye.txt");
+        mock.expectedHeaderReceived(Exchange.FILE_NAME, TEST_FILE_NAME_BYE);
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
         oneExchangeDone.matchesWaitTime();
@@ -89,7 +92,7 @@ public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport 
         // the original file should have been deleted, as the file consumer
         // should be resilient against
         // end users changing headers
-        assertFalse(Files.exists(testFile("hello.txt")), "File should been deleted");
+        assertFalse(Files.exists(testFile(TEST_FILE_NAME)), "File should been deleted");
     }
 
     @Test
@@ -107,7 +110,7 @@ public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport 
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Hello World");
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
         oneExchangeDone.matchesWaitTime();
@@ -117,7 +120,7 @@ public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport 
         // the original file should have been moved, as the file consumer should
         // be resilient against
         // end users deleting headers
-        assertTrue(Files.exists(testFile(".camel/hello.txt")), "File should been moved");
+        assertTrue(Files.exists(testFile(".camel/" + TEST_FILE_NAME)), "File should been moved");
     }
 
     @Test
@@ -127,16 +130,16 @@ public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport 
             public void configure() {
                 from(fileUri() + "?initialDelay=0&delay=10")
                         // change file header
-                        .setHeader(Exchange.FILE_NAME, constant("bye.txt")).to("mock:result");
+                        .setHeader(Exchange.FILE_NAME, constant(TEST_FILE_NAME_BYE)).to("mock:result");
             }
         });
         context.start();
 
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Hello World");
-        mock.expectedHeaderReceived(Exchange.FILE_NAME, "bye.txt");
+        mock.expectedHeaderReceived(Exchange.FILE_NAME, TEST_FILE_NAME_BYE);
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
         oneExchangeDone.matchesWaitTime();
@@ -144,7 +147,7 @@ public class FileConsumeAlterFileNameHeaderIssueTest extends ContextTestSupport 
         // the original file should have been moved, as the file consumer should
         // be resilient against
         // end users changing headers
-        assertTrue(Files.exists(testFile(".camel/hello.txt")), "File should been moved");
+        assertTrue(Files.exists(testFile(".camel/" + TEST_FILE_NAME)), "File should been moved");
     }
 
 }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProduceOverruleTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProduceOverruleTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.file;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -29,15 +30,18 @@ import org.junit.jupiter.api.Test;
  * Unit test to verify the overrule filename header
  */
 public class FileProduceOverruleTest extends ContextTestSupport {
+    public static final String TEST_FILE_NAME = "hello." + UUID.randomUUID() + ".txt";
+    public static final String TEST_FILE_NAME_OVERRULE = "overrule." + UUID.randomUUID() + ".txt";
+    public static final String TEST_FILE_NAME_RULED = "ruled." + UUID.randomUUID() + ".txt";
 
     @Test
     public void testNoOverrule() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
-        mock.expectedHeaderReceived(Exchange.FILE_NAME, "hello.txt");
-        mock.expectedFileExists(testFile("hello.txt"), "Hello World");
+        mock.expectedHeaderReceived(Exchange.FILE_NAME, TEST_FILE_NAME);
+        mock.expectedFileExists(testFile(TEST_FILE_NAME), "Hello World");
 
-        template.sendBodyAndHeader("direct:start", "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader("direct:start", "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
     }
@@ -47,9 +51,9 @@ public class FileProduceOverruleTest extends ContextTestSupport {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
         mock.message(0).header(Exchange.FILE_NAME).isNull();
-        mock.expectedFileExists(testFile("overrule.txt"), "Hello World");
+        mock.expectedFileExists(testFile(TEST_FILE_NAME_OVERRULE), "Hello World");
 
-        template.sendBodyAndHeader("direct:start", "Hello World", Exchange.OVERRULE_FILE_NAME, "overrule.txt");
+        template.sendBodyAndHeader("direct:start", "Hello World", Exchange.OVERRULE_FILE_NAME, TEST_FILE_NAME_OVERRULE);
 
         assertMockEndpointsSatisfied();
     }
@@ -58,14 +62,14 @@ public class FileProduceOverruleTest extends ContextTestSupport {
     public void testBoth() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
-        mock.expectedHeaderReceived(Exchange.FILE_NAME, "hello.txt");
+        mock.expectedHeaderReceived(Exchange.FILE_NAME, TEST_FILE_NAME);
         mock.message(0).header(Exchange.OVERRULE_FILE_NAME).isNull();
-        mock.expectedFileExists(testFile("ruled.txt"), "Hello World");
+        mock.expectedFileExists(testFile(TEST_FILE_NAME_RULED), "Hello World");
 
         Map<String, Object> map = new HashMap<>();
-        map.put(Exchange.FILE_NAME, "hello.txt");
+        map.put(Exchange.FILE_NAME, TEST_FILE_NAME);
         // this header should overrule the endpoint configuration
-        map.put(Exchange.OVERRULE_FILE_NAME, "ruled.txt");
+        map.put(Exchange.OVERRULE_FILE_NAME, TEST_FILE_NAME_RULED);
 
         template.sendBodyAndHeaders("direct:start", "Hello World", map);
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerAllowNullBodyFileAlreadyExistsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerAllowNullBodyFileAlreadyExistsTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -28,13 +30,15 @@ import org.junit.jupiter.api.Test;
  */
 public class FileProducerAllowNullBodyFileAlreadyExistsTest extends ContextTestSupport {
 
+    public static final String TEST_FILE_NAME = "hello." + UUID.randomUUID() + ".txt";
+
     @Test
     public void testFileExistAppendAllowNullBody() throws Exception {
-        template.sendBodyAndHeader(fileUri(), "Hello world", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello world", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         MockEndpoint mock = getMockEndpoint("mock:appendTypeAppendResult");
         mock.expectedMessageCount(1);
-        mock.expectedFileExists(testFile("hello.txt"), "Hello world");
+        mock.expectedFileExists(testFile(TEST_FILE_NAME), "Hello world");
 
         template.sendBody("direct:appendTypeAppend", null);
 
@@ -43,11 +47,11 @@ public class FileProducerAllowNullBodyFileAlreadyExistsTest extends ContextTestS
 
     @Test
     public void testFileExistOverrideAllowNullBody() throws Exception {
-        template.sendBodyAndHeader(fileUri(), "Hello world", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello world", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         MockEndpoint mock = getMockEndpoint("mock:appendTypeOverrideResult");
         mock.expectedMessageCount(1);
-        mock.expectedFileExists(testFile("hello.txt"), "");
+        mock.expectedFileExists(testFile(TEST_FILE_NAME), "");
 
         template.sendBody("direct:appendTypeOverride", null);
 
@@ -58,11 +62,11 @@ public class FileProducerAllowNullBodyFileAlreadyExistsTest extends ContextTestS
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from("direct:appendTypeAppend").setHeader(Exchange.FILE_NAME, constant("hello.txt"))
+                from("direct:appendTypeAppend").setHeader(Exchange.FILE_NAME, constant(TEST_FILE_NAME))
                         .to(fileUri("?allowNullBody=true&fileExist=Append"))
                         .to("mock:appendTypeAppendResult");
 
-                from("direct:appendTypeOverride").setHeader(Exchange.FILE_NAME, constant("hello.txt"))
+                from("direct:appendTypeOverride").setHeader(Exchange.FILE_NAME, constant(TEST_FILE_NAME))
                         .to(fileUri("?allowNullBody=true&fileExist=Override"))
                         .to("mock:appendTypeOverrideResult");
             }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerMoveExistingStrategyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerMoveExistingStrategyTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.file;
 
 import java.io.File;
+import java.util.UUID;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -33,6 +34,8 @@ import org.slf4j.LoggerFactory;
  */
 public class FileProducerMoveExistingStrategyTest extends ContextTestSupport {
 
+    public static final String TEST_FILE_NAME_NOEXT = "hello." + UUID.randomUUID();
+    public static final String TEST_FILE_NAME = TEST_FILE_NAME_NOEXT + ".txt";
     private final MyStrategy myStrategy = new MyStrategy();
 
     @Override
@@ -46,19 +49,19 @@ public class FileProducerMoveExistingStrategyTest extends ContextTestSupport {
     public void testExistingFileExists() throws Exception {
         template.sendBodyAndHeader(
                 fileUri("?fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}&moveExistingFileStrategy=#myStrategy"),
-                "Hello World", Exchange.FILE_NAME, "hello.txt");
+                "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
         template.sendBodyAndHeader(
                 fileUri("?fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}&moveExistingFileStrategy=#myStrategy"),
-                "Bye Existing World 1", Exchange.FILE_NAME, "hello.txt");
+                "Bye Existing World 1", Exchange.FILE_NAME, TEST_FILE_NAME);
         template.sendBodyAndHeader(
                 fileUri("?fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}&moveExistingFileStrategy=#myStrategy"),
-                "Bye Existing World 2", Exchange.FILE_NAME, "hello.txt");
+                "Bye Existing World 2", Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        assertFileExists(testFile("hello.txt"), "Bye Existing World 2");
+        assertFileExists(testFile(TEST_FILE_NAME), "Bye Existing World 2");
 
-        assertFileExists(testFile("renamed-hello2.txt"), "Bye Existing World 1");
+        assertFileExists(testFile("renamed-" + TEST_FILE_NAME_NOEXT + "2.txt"), "Bye Existing World 1");
 
-        assertFileExists(testFile("renamed-hello1.txt"), "Hello World");
+        assertFileExists(testFile("renamed-" + TEST_FILE_NAME_NOEXT + "1.txt"), "Hello World");
     }
 
     private static class MyStrategy implements FileMoveExistingStrategy {

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/GenericFileConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/GenericFileConverterTest.java
@@ -171,7 +171,6 @@ public class GenericFileConverterTest extends ContextTestSupport {
             public void configure() {
 
                 from(fileUri("?initialDelay=0&delay=10"))
-                        .noStreamCaching()
                         .convertBodyTo(InputStream.class).process(new Processor() {
                             @Override
                             public void process(Exchange exchange) {

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/GenericFileConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/GenericFileConverterTest.java
@@ -171,6 +171,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
             public void configure() {
 
                 from(fileUri("?initialDelay=0&delay=10"))
+                        .streamCache(Boolean.toString(false))
                         .convertBodyTo(InputStream.class).process(new Processor() {
                             @Override
                             public void process(Exchange exchange) {

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/GenericFileConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/GenericFileConverterTest.java
@@ -20,6 +20,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.util.UUID;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -30,6 +31,8 @@ import org.apache.camel.converter.stream.InputStreamCache;
 import org.junit.jupiter.api.Test;
 
 public class GenericFileConverterTest extends ContextTestSupport {
+
+    public static final String TEST_FILE_NAME = "hello." + UUID.randomUUID() + ".txt";
 
     @Override
     public boolean isUseRouteBuilder() {
@@ -50,7 +53,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
         mock.expectedMessageCount(1);
         mock.message(0).body().isInstanceOf(File.class);
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
     }
@@ -70,7 +73,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
         mock.message(0).body().isInstanceOf(String.class);
         mock.message(0).body().isEqualTo("Hello World");
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
     }
@@ -90,7 +93,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
         mock.message(0).body().isInstanceOf(byte[].class);
         mock.message(0).body(String.class).isEqualTo("Hello World");
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
     }
@@ -110,7 +113,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
         mock.message(0).body().isInstanceOf(Serializable.class);
         mock.message(0).body(String.class).isEqualTo("Hello World");
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
     }
@@ -130,7 +133,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
         mock.message(0).body().isInstanceOf(InputStream.class);
         mock.message(0).body(String.class).isEqualTo("Hello World");
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
     }
@@ -156,7 +159,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
         mock.message(0).body().isInstanceOf(InputStreamCache.class);
         mock.message(0).body(String.class).isEqualTo("Hello World");
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
     }
@@ -187,7 +190,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
         mock.message(0).body().isInstanceOf(BufferedInputStream.class);
         mock.message(0).body(String.class).isEqualTo("Hello World");
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
     }

--- a/core/camel-core/src/test/java/org/apache/camel/converter/IOConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/converter/IOConverterTest.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
+import java.util.UUID;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -51,6 +52,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Test case for {@link IOConverter}
  */
 public class IOConverterTest extends ContextTestSupport {
+
+    public static final String TEST_FILE_NAME = "hello." + UUID.randomUUID() + ".txt";
 
     private static final byte[] TESTDATA = "My test data".getBytes();
 
@@ -76,8 +79,8 @@ public class IOConverterTest extends ContextTestSupport {
 
     @Test
     public void testToOutputStreamFile() throws Exception {
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
-        File file = testFile("hello.txt").toFile();
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
+        File file = testFile(TEST_FILE_NAME).toFile();
 
         OutputStream os = IOConverter.toOutputStream(file);
         assertIsInstanceOf(BufferedOutputStream.class, os);
@@ -86,8 +89,8 @@ public class IOConverterTest extends ContextTestSupport {
 
     @Test
     public void testToWriterFile() throws Exception {
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
-        File file = testFile("hello.txt").toFile();
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
+        File file = testFile(TEST_FILE_NAME).toFile();
 
         Writer writer = IOConverter.toWriter(file, null);
         assertIsInstanceOf(BufferedWriter.class, writer);
@@ -149,8 +152,8 @@ public class IOConverterTest extends ContextTestSupport {
 
     @Test
     public void testToByteArrayFile() throws Exception {
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
-        File file = testFile("hello.txt").toFile();
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
+        File file = testFile(TEST_FILE_NAME).toFile();
 
         byte[] data = IOConverter.toByteArray(file);
         assertNotNull(data);


### PR DESCRIPTION
# Description
CAMEL-20686 
- Restored overwrites from previous commit
- `GenericFileConverterTest` : Replace deprecated method call (existing issue flagged on sonar) 

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue CAMEL-20686](https://issues.apache.org/jira/browse/CAMEL-20686) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

