### PR TITLE
[CAMEL-20975] camel-jbang: Derive image group from project groupId

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationExport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationExport.java
@@ -44,8 +44,11 @@ public class IntegrationExport extends KubernetesExport {
 
     public IntegrationExport(CamelJBangMain main, RuntimeType runtime, String[] files, String exportDir, String imageGroup,
                              boolean quiet) {
-        super(main, runtime, files, exportDir, quiet);
+        super(main, files);
+        this.runtime = runtime;
         this.imageGroup = imageGroup;
+        this.exportDir = exportDir;
+        this.quiet = quiet;
     }
 
     @Override


### PR DESCRIPTION
This PR build on top of https://github.com/apache/camel/pull/14789, it ...

* derives the image group from the gav, if not explicitly set
* prepares for runtimes other than quarkus (e.g. spring-boot)
* sets quarkus.container-image.build=true by default

