### PR TITLE
[CAMEL-20976] camel-jbang: Consolidate export dependencies

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
@@ -113,7 +113,7 @@ public class Export extends ExportBaseCommand {
         // copy properties from this to cmd
         cmd.files = this.files;
         cmd.repos = this.repos;
-        cmd.addDependencies(this.dependencies());
+        cmd.addDependencies(this.dependencies);
         cmd.runtime = this.runtime;
         cmd.gav = this.gav;
         cmd.mavenSettings = this.mavenSettings;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
@@ -113,7 +113,7 @@ public class Export extends ExportBaseCommand {
         // copy properties from this to cmd
         cmd.files = this.files;
         cmd.repos = this.repos;
-        cmd.dependencies = this.dependencies;
+        cmd.addDependencies(this.dependencies());
         cmd.runtime = this.runtime;
         cmd.gav = this.gav;
         cmd.mavenSettings = this.mavenSettings;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -32,15 +32,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Stack;
-import java.util.StringJoiner;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -161,8 +153,8 @@ public class Run extends CamelCommand {
     String profile = "dev";
 
     @Option(names = {
-            "--dep", "--deps" }, description = "Add additional dependencies (Use commas to separate multiple dependencies)")
-    String dependencies;
+            "--dep", "--deps" }, arity = "*", description = "Add additional dependencies")
+    private String[] _dependencies; // [TODO] make less protected when we ditch --deps
 
     @Option(names = { "--repos" },
             description = "Additional maven repositories for download on-demand (Use commas to separate multiple repositories)")
@@ -633,17 +625,8 @@ public class Run extends CamelCommand {
             // find source files
             files = RunHelper.scanMavenOrGradleProject();
             // include extra dependencies from pom.xml
-            List<String> deps = RunHelper.scanMavenDependenciesFromPom();
-            for (String d : deps) {
-                if (dependencies == null) {
-                    dependencies = "";
-                }
-                if (dependencies.isBlank()) {
-                    dependencies = d;
-                } else {
-                    dependencies += "," + d;
-                }
-            }
+            var pomDependencies = RunHelper.scanMavenDependenciesFromPom();
+            addDependencies(pomDependencies.toArray(new String[0]));
         }
 
         if (profile != null) {
@@ -825,15 +808,11 @@ public class Run extends CamelCommand {
         }
 
         // merge existing dependencies with --deps
-        String deps = RuntimeUtil.getDependencies(profileProperties);
-        if (deps.isBlank()) {
-            deps = dependencies != null ? dependencies : "";
-        } else if (dependencies != null && !dependencies.equals(deps)) {
-            deps += "," + dependencies;
-        }
-        if (!deps.isBlank()) {
-            main.addInitialProperty("camel.jbang.dependencies", deps);
-            writeSettings("camel.jbang.dependencies", deps);
+        addDependencies(RuntimeUtil.getDependenciesAsArray(profileProperties));
+        if (dependencies().length > 0) {
+            var joined = String.join(",", dependencies());
+            main.addInitialProperty("camel.jbang.dependencies", joined);
+            writeSettings("camel.jbang.dependencies", joined);
         }
 
         // if we have a specific camel version then make sure we really need to switch
@@ -877,6 +856,28 @@ public class Run extends CamelCommand {
         }
     }
 
+    // [TODO] Remove when we ditch --deps
+    // For backward compatibility, we expands comma separated --deps
+    // https://issues.apache.org/jira/browse/CAMEL-20976
+    String[] dependencies() {
+        if (_dependencies != null && _dependencies.length == 1) {
+            String[] toks = _dependencies[0].split(",");
+            _dependencies = Arrays.stream(toks).map(String::trim).toArray(String[]::new);
+        }
+        return _dependencies;
+    }
+
+    protected void addDependencies(String... deps) {
+        var depsList = new ArrayList<>(getDependenciesList());
+        depsList.addAll(Arrays.asList(deps));
+        _dependencies = depsList.toArray(new String[0]);
+    }
+
+    protected List<String> getDependenciesList() {
+        var depsArray = Optional.ofNullable(dependencies()).orElse(new String[0]);
+        return Arrays.asList(depsArray);
+    }
+
     protected int runQuarkus() throws Exception {
         // create temp run dir
         File runDir = new File(RUN_PLATFORM_DIR, Long.toString(System.currentTimeMillis()));
@@ -900,12 +901,8 @@ public class Run extends CamelCommand {
         if (eq.gav == null) {
             eq.gav = "org.example.project:jbang-run-dummy:1.0-SNAPSHOT";
         }
-        eq.dependencies = this.dependencies;
-        if (eq.dependencies == null) {
-            eq.dependencies = "camel:cli-connector";
-        } else {
-            eq.dependencies += ",camel:cli-connector";
-        }
+        eq.addDependencies(this.dependencies());
+        eq.addDependencies("camel:cli-connector");
         eq.fresh = this.fresh;
         eq.download = this.download;
         eq.quiet = true;
@@ -968,15 +965,11 @@ public class Run extends CamelCommand {
         if (eq.gav == null) {
             eq.gav = "org.example.project:jbang-run-dummy:1.0-SNAPSHOT";
         }
-        eq.dependencies = this.dependencies;
-        if (eq.dependencies == null) {
-            eq.dependencies = "camel:cli-connector";
-        } else {
-            eq.dependencies += ",camel:cli-connector";
-        }
+        eq.addDependencies(dependencies());
+        eq.addDependencies("camel:cli-connector");
         if (this.dev) {
             // hot-reload of spring-boot
-            eq.dependencies += ",mvn:org.springframework.boot:spring-boot-devtools";
+            eq.addDependencies("mvn:org.springframework.boot:spring-boot-devtools");
         }
         eq.fresh = this.fresh;
         eq.download = this.download;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeUtil.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeUtil.java
@@ -24,10 +24,7 @@ import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-import java.util.StringJoiner;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.camel.util.IOHelper;
@@ -184,6 +181,10 @@ public final class RuntimeUtil {
             deps = "";
         }
         return deps;
+    }
+
+    public static String[] getDependenciesAsArray(Properties properties) {
+        return getDependencies(properties).split(",");
     }
 
     public static String getPid() {


### PR DESCRIPTION
This PR build on top of https://github.com/apache/camel/pull/14789

It pays attention to not breaking the comma separated `--deps` option. You can now do ...

```
camel kubernetes export timer-log-route.yaml \
  --gav=examples:timer-log:1.0.0 \
  --deps=io.quarkus:quarkus-container-image-docker,io.quarkus:quarkus-minikube \
  --runtime=quarkus
```

or 

```
camel kubernetes export timer-log-route.yaml \
  --gav=examples:timer-log:1.0.0 \
  --dep=io.quarkus:quarkus-container-image-docker \
  --dep=io.quarkus:quarkus-minikube \
  --runtime=quarkus
```

The code would be a lot simpler when we got rid of `--deps`
Not sure whether we can do this any time soon.