### PR TITLE
Fix getInOnlyTemplate in SpringRabbitMQProducer.java

### DIFF
--- a/components/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/SpringRabbitMQProducer.java
+++ b/components/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/SpringRabbitMQProducer.java
@@ -54,7 +54,7 @@ public class SpringRabbitMQProducer extends DefaultAsyncProducer {
     }
 
     public RabbitTemplate getInOnlyTemplate() {
-        if (inOutTemplate == null) {
+        if (inOnlyTemplate == null) {
             inOnlyTemplate = getEndpoint().createInOnlyTemplate();
         }
         return inOnlyTemplate;


### PR DESCRIPTION

# Description

getInOnlyTemplate is checking if inOutTemplate is null to determine whether or not it should initialize inOnlyTemplate.  It should check inOnlyTemplate.  This change fixes that.

# Target

- [ X ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ N/A ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [ X ] I checked that each commit in the pull request has a meaningful subject line and body.

- [ X ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes


