### PR TITLE
CAMEL-20981: Fix ceOverrides option with YAML DSL

### DIFF
--- a/components/camel-knative/camel-knative-component/src/main/java/org/apache/camel/component/knative/ce/AbstractCloudEventProcessor.java
+++ b/components/camel-knative/camel-knative-component/src/main/java/org/apache/camel/component/knative/ce/AbstractCloudEventProcessor.java
@@ -29,6 +29,7 @@ import org.apache.camel.cloudevents.CloudEvent;
 import org.apache.camel.component.knative.KnativeEndpoint;
 import org.apache.camel.component.knative.spi.Knative;
 import org.apache.camel.component.knative.spi.KnativeResource;
+import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +126,11 @@ abstract class AbstractCloudEventProcessor implements CloudEventProcessor {
                 return DateTimeFormatter.ISO_INSTANT.format(created);
             });
 
-            headers.putAll(service.getCeOverrides());
+            for (Map.Entry<String, String> ceOverride : service.getCeOverrides().entrySet()) {
+                // when using keys in YAML DSL camelCase is being used by default -convert to dash due to CloudEvents spec
+                headers.put(StringHelper.camelCaseToDash(ceOverride.getKey()),
+                        exchange.getContext().resolvePropertyPlaceholders(ceOverride.getValue()));
+            }
         };
     }
 

--- a/components/camel-knative/camel-knative-component/src/test/resources/environment.json
+++ b/components/camel-knative/camel-knative-component/src/test/resources/environment.json
@@ -43,6 +43,22 @@
     },
     {
       "type": "event",
+      "name": "example-broker-1",
+      "url": "http://broker-example/default/example-broker-1",
+      "metadata": {
+        "camel.endpoint.kind": "sink",
+        "knative.apiVersion": "eventing.knative.dev/v1",
+        "knative.kind": "Broker",
+        "knative.name": "example-broker-1"
+      },
+      "ceOverrides": {
+        "ce-type": "custom-type",
+        "ce-source": "custom-source",
+        "ce-subject": "custom-subject"
+      }
+    },
+    {
+      "type": "event",
       "name": "evt1",
       "path": "/events/evt1",
       "metadata": {

--- a/components/camel-knative/camel-knative-component/src/test/resources/environment_classic.json
+++ b/components/camel-knative/camel-knative-component/src/test/resources/environment_classic.json
@@ -43,6 +43,22 @@
     },
     {
       "type": "event",
+      "name": "example-broker-1",
+      "url": "http://broker-example/default/example-broker-1",
+      "metadata": {
+        "camel.endpoint.kind": "sink",
+        "knative.apiVersion": "eventing.knative.dev/v1",
+        "knative.kind": "Broker",
+        "knative.name": "example-broker-1"
+      },
+      "ceOverrides": {
+        "ce-type": "custom-type",
+        "ce-source": "custom-source",
+        "ce-subject": "custom-subject"
+      }
+    },
+    {
+      "type": "event",
       "name": "evt1",
       "path": "/events/evt1",
       "metadata": {

--- a/components/camel-knative/camel-knative-http/src/test/java/org/apache/camel/component/knative/http/KnativeHttpTest.java
+++ b/components/camel-knative/camel-knative-http/src/test/java/org/apache/camel/component/knative/http/KnativeHttpTest.java
@@ -44,6 +44,7 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1480,6 +1481,51 @@ public class KnativeHttpTest {
 
     @ParameterizedTest
     @EnumSource(CloudEvents.class)
+    void testHeadersOverrideFromEnvPropertyPlaceholder(CloudEvent ce) throws Exception {
+        final KnativeHttpServer server = new KnativeHttpServer(context);
+        final String typeHeaderKey = httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_TYPE);
+        final String typeHeaderVal = UUID.randomUUID().toString();
+        final String sourceHeaderKey = httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_SOURCE);
+        final String sourceHeaderVal = UUID.randomUUID().toString();
+
+        configureKnativeComponent(
+                context,
+                ce,
+                endpoint(
+                        Knative.EndpointKind.sink,
+                        "ep",
+                        String.format("http://%s:%d", server.getHost(), server.getPort()),
+                        Map.of(
+                                Knative.KNATIVE_CLOUD_EVENT_TYPE, "org.apache.camel.event",
+                                Knative.CONTENT_TYPE, "text/plain",
+                                Knative.KNATIVE_CE_OVERRIDE_PREFIX + typeHeaderKey,
+                                "{{someProperty:%s}}".formatted(typeHeaderVal),
+                                Knative.KNATIVE_CE_OVERRIDE_PREFIX + sourceHeaderKey,
+                                "{{someProperty:%s}}".formatted(sourceHeaderVal))));
+
+        RouteBuilder.addRoutes(context, b -> {
+            b.from("direct:start")
+                    .to("knative:endpoint/ep");
+        });
+
+        context.start();
+        try {
+            server.start();
+            template.sendBody("direct:start", "");
+
+            HttpServerRequest request = server.poll(30, TimeUnit.SECONDS);
+            assertThat(request.getHeader(httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_VERSION))).isEqualTo(ce.version());
+            assertThat(request.getHeader(httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_TYPE))).isEqualTo(typeHeaderVal);
+            assertThat(request.getHeader(httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_ID))).isNotNull();
+            assertThat(request.getHeader(httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_SOURCE))).isEqualTo(sourceHeaderVal);
+            assertThat(request.getHeader(Exchange.CONTENT_TYPE)).isEqualTo("text/plain");
+        } finally {
+            server.stop();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(CloudEvents.class)
     void testHeadersOverrideFromURI(CloudEvent ce) throws Exception {
         final KnativeHttpServer server = new KnativeHttpServer(context);
         final String typeHeaderKey = httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_TYPE);
@@ -1528,6 +1574,51 @@ public class KnativeHttpTest {
         final String typeHeaderKey = httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_TYPE);
         final String typeHeaderVal = UUID.randomUUID().toString();
         final String sourceHeaderKey = httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_SOURCE);
+        final String sourceHeaderVal = UUID.randomUUID().toString();
+
+        KnativeComponent component = configureKnativeComponent(
+                context,
+                ce,
+                endpoint(
+                        Knative.EndpointKind.sink,
+                        "ep",
+                        String.format("http://%s:%d", server.getHost(), server.getPort()),
+                        Map.of(
+                                Knative.KNATIVE_CLOUD_EVENT_TYPE, "org.apache.camel.event",
+                                Knative.CONTENT_TYPE, "text/plain")));
+
+        component.getConfiguration().setCeOverride(Map.of(
+                Knative.KNATIVE_CE_OVERRIDE_PREFIX + typeHeaderKey, typeHeaderVal,
+                Knative.KNATIVE_CE_OVERRIDE_PREFIX + sourceHeaderKey, sourceHeaderVal));
+
+        RouteBuilder.addRoutes(context, b -> {
+            b.from("direct:start")
+                    .to("knative:endpoint/ep");
+        });
+
+        context.start();
+        try {
+            server.start();
+            template.sendBody("direct:start", "");
+
+            HttpServerRequest request = server.poll(30, TimeUnit.SECONDS);
+            assertThat(request.getHeader(httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_VERSION))).isEqualTo(ce.version());
+            assertThat(request.getHeader(httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_TYPE))).isEqualTo(typeHeaderVal);
+            assertThat(request.getHeader(httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_ID))).isNotNull();
+            assertThat(request.getHeader(httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_SOURCE))).isEqualTo(sourceHeaderVal);
+            assertThat(request.getHeader(Exchange.CONTENT_TYPE)).isEqualTo("text/plain");
+        } finally {
+            server.stop();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(CloudEvents.class)
+    void testHeadersOverrideFromYamlConf(CloudEvent ce) throws Exception {
+        final KnativeHttpServer server = new KnativeHttpServer(context);
+        final String typeHeaderKey = StringHelper.dashToCamelCase(httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_TYPE));
+        final String typeHeaderVal = UUID.randomUUID().toString();
+        final String sourceHeaderKey = StringHelper.dashToCamelCase(httpAttribute(ce, CloudEvent.CAMEL_CLOUD_EVENT_SOURCE));
         final String sourceHeaderVal = UUID.randomUUID().toString();
 
         KnativeComponent component = configureKnativeComponent(


### PR DESCRIPTION
# Description

- Makes sure that CloudEvent attributes use dash style keys even with YAML DSL where key get converted to camelCase style
- Also support property placeholders when setting ceOverrides option for CloudEvent attributes
- Add some unit tests

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

See CAMEL-20981

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

