### PR TITLE
[CAMEL-20995] Fix bug in azure-blob. Enable retry during upload if input stream support mark/reset

### DIFF
--- a/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/client/BlobClientWrapper.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/client/BlobClientWrapper.java
@@ -124,7 +124,7 @@ public class BlobClientWrapper {
             final Map<String, String> metadata, AccessTier tier, final byte[] contentMd5,
             final BlobRequestConditions requestConditions,
             final Duration timeout) {
-        Flux<ByteBuffer> dataBuffer = Utility.convertStreamToByteBuffer(data, length, 4194304, false);
+        Flux<ByteBuffer> dataBuffer = Utility.convertStreamToByteBuffer(data, length, 4194304, data.markSupported());
         BlockBlobSimpleUploadOptions uploadOptions = new BlockBlobSimpleUploadOptions(dataBuffer, length).setHeaders(headers)
                 .setMetadata(metadata).setTier(tier).setContentMd5(contentMd5).setRequestConditions(requestConditions);
         return getBlockBlobClient().uploadWithResponse(uploadOptions, timeout, Context.NONE);


### PR DESCRIPTION


# Description

Azure Blob upload is support retry  if upload is facing some network issue.
For now Azure SDK is supporting it if input stream support mark/reset. 
Patch is enabling this feature. 

# Target

- [ X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [X ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue]
# Apache Camel coding standards and style

- [ X] I checked that each commit in the pull request has a meaningful subject line and body.

- [X ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes


