### PR TITLE
Undertow component javadocs typos fixes

### DIFF
--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHost.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHost.java
@@ -48,9 +48,10 @@ public interface UndertowHost {
 
     /**
      * Unregister a handler with the given {@link HttpHandlerRegistrationInfo}. Note that if
-     * {@link #registerHandler(HttpHandlerRegistrationInfo, HttpHandler)} was successfully invoked multiple times for an
-     * equivalent {@link HttpHandlerRegistrationInfo} then {@link #unregisterHandler(HttpHandlerRegistrationInfo)} must
-     * be called the same number of times to unregister the associated handler completely.
+     * {@link #registerHandler(UndertowConsumer, HttpHandlerRegistrationInfo, HttpHandler)} was successfully invoked
+     * multiple times for an equivalent {@link HttpHandlerRegistrationInfo} then
+     * {@link #unregisterHandler(UndertowConsumer, HttpHandlerRegistrationInfo)} must be called the same number of times
+     * to unregister the associated handler completely.
      */
     void unregisterHandler(UndertowConsumer consumer, HttpHandlerRegistrationInfo registrationInfo);
 

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowProducer.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowProducer.java
@@ -56,7 +56,7 @@ import org.xnio.ssl.XnioSsl;
  *
  * The implementation of Producer is considered as experimental. The Undertow client classes are not thread safe, their
  * purpose is for the reverse proxy usage inside Undertow itself. This may change in the future versions and general
- * purpose HTTP client wrapper will be added. Therefore this Producer may be changed too.
+ * purpose HTTP client wrapper will be added. Therefore, this producer may be changed too.
  */
 public class UndertowProducer extends DefaultAsyncProducer {
 

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/handlers/CamelWebSocketHandler.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/handlers/CamelWebSocketHandler.java
@@ -90,7 +90,7 @@ public class CamelWebSocketHandler implements HttpHandler {
      * Send the given {@code message} to the given {@code channel} and report the outcome to the given {@code callback}
      * within the given {@code timeoutMillis}.
      *
-     * @param  channel       the channel to sent the {@code message} to
+     * @param  channel       the channel to send the {@code message} to
      * @param  message       the message to send
      * @param  callback      where to report the outcome
      * @param  timeoutMillis the timeout in milliseconds
@@ -238,7 +238,7 @@ public class CamelWebSocketHandler implements HttpHandler {
         }
 
         /**
-         * {@link #finish()} should be called only inside a <code>synchronized(lock) { ... }</code> block to prevent
+         * This method should be called only inside a <code>synchronized(lock) { ... }</code> block to prevent
          * concurrent access to {@link #errors}.
          */
         private void finish() {

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/spi/UndertowSecurityProvider.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/spi/UndertowSecurityProvider.java
@@ -35,7 +35,7 @@ public interface UndertowSecurityProvider {
 
     /**
      * Provider can add headers into Camel's exchange. Method is called right after creation of Camel's exchange.
-     * Typical usage is to add authentication information into message (eg. authenticated principal)
+     * Typical usage is to add authentication information into message (e.g. authenticated principal)
      *
      * @param consumer     BiConsumer is the only way how to add parameter into exchange (it accepts pair String,
      *                     Object)
@@ -58,8 +58,8 @@ public interface UndertowSecurityProvider {
      * should be tested here, if it is meant for this securityProvider and provider should initialize its state from it.
      * If configuration is not acceptable, return false.
      *
-     * @param  configuration Object which contain connfiguration passed to camel-undertow
-     * @param  endpointUri   Uri of endpoint (could be important for intialization)
+     * @param  configuration Object which contain configuration passed to camel-undertow
+     * @param  endpointUri   Uri of endpoint (could be important for initialization)
      * @return               True if securityProvider is initialized from data and is able to authenticate requests.
      */
     boolean acceptConfiguration(Object configuration, String endpointUri) throws Exception;


### PR DESCRIPTION
# Description

Undertow javadoc typos

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes
