### PR TITLE
Update protobuf-maven-plugin to v2.4.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -402,7 +402,7 @@
         <properties-maven-plugin-version>1.2.1</properties-maven-plugin-version>
         <proto-google-common-protos-version>2.22.0</proto-google-common-protos-version>
         <protobuf-version>3.25.3</protobuf-version>
-        <protobuf-maven-plugin-version>2.3.0</protobuf-maven-plugin-version>
+        <protobuf-maven-plugin-version>2.4.0</protobuf-maven-plugin-version>
         <protonpack-version>1.8</protonpack-version>
         <protostream-version>5.0.5.Final</protostream-version>
         <prowide-version>SRU2023-10.1.6</prowide-version>


### PR DESCRIPTION
I released a few bug fixes yesterday. This includes a fix for dependency management that may affect users  using ehcache in their projects, and a fix for the plugin pulling in the wrong dependency scope when analysing dependencies.

Apache CLA has been signed for work on previous projects.