### PR TITLE
CAMEL-20982: Add Camel JBang Kubernetes service trait

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/VersionHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/VersionHelper.java
@@ -119,7 +119,15 @@ public final class VersionHelper {
         return s.compareTo(t);
     }
 
+    public static String extractCamelVersion() {
+        return org.apache.camel.main.util.VersionHelper.extractCamelVersion();
+    }
+
     public static String extractKameletsVersion() {
         return org.apache.camel.main.util.VersionHelper.extractKameletsVersion();
+    }
+
+    public static void setCamelVersion(String version) {
+        org.apache.camel.main.util.VersionHelper.setCamelVersion(version);
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/Agent.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/Agent.java
@@ -16,19 +16,11 @@
  */
 package org.apache.camel.dsl.jbang.core.commands.k;
 
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,45 +30,19 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
-import org.apache.camel.CamelContext;
-import org.apache.camel.Endpoint;
-import org.apache.camel.ExtendedCamelContext;
-import org.apache.camel.Route;
 import org.apache.camel.catalog.CamelCatalog;
-import org.apache.camel.component.kamelet.KameletEndpoint;
 import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
-import org.apache.camel.dsl.jbang.core.commands.k.support.Capability;
-import org.apache.camel.dsl.jbang.core.commands.k.support.SourceMetadata;
-import org.apache.camel.dsl.jbang.core.commands.k.support.StubComponentResolver;
-import org.apache.camel.dsl.jbang.core.commands.k.support.StubDataFormatResolver;
-import org.apache.camel.dsl.jbang.core.commands.k.support.StubLanguageResolver;
-import org.apache.camel.dsl.jbang.core.commands.k.support.StubTransformerResolver;
-import org.apache.camel.dsl.jbang.core.common.CatalogLoader;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.CatalogHelper;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.MetadataHelper;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.support.Capability;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.support.SourceMetadata;
 import org.apache.camel.dsl.jbang.core.common.RuntimeCompletionCandidates;
 import org.apache.camel.dsl.jbang.core.common.RuntimeType;
 import org.apache.camel.dsl.jbang.core.common.RuntimeTypeConverter;
-import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.camel.impl.DefaultModelReifierFactory;
-import org.apache.camel.model.CircuitBreakerDefinition;
-import org.apache.camel.model.FromDefinition;
-import org.apache.camel.model.Model;
-import org.apache.camel.model.ProcessorDefinition;
-import org.apache.camel.model.RouteDefinition;
-import org.apache.camel.reifier.DisabledReifier;
-import org.apache.camel.reifier.ProcessorReifier;
-import org.apache.camel.spi.ComponentResolver;
-import org.apache.camel.spi.DataFormatResolver;
-import org.apache.camel.spi.LanguageResolver;
-import org.apache.camel.spi.TransformerResolver;
-import org.apache.camel.support.PluginHelper;
-import org.apache.camel.support.ResourceHelper;
 import org.apache.camel.tooling.model.BaseModel;
-import org.apache.camel.tooling.model.ComponentModel;
-import org.apache.camel.tooling.model.DataFormatModel;
 import org.apache.camel.tooling.model.EntityRef;
 import org.apache.camel.tooling.model.Kind;
-import org.apache.camel.tooling.model.LanguageModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -90,29 +56,9 @@ public class Agent extends CamelCommand {
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 
-    private static final Map<String, BiConsumer<CamelCatalog, SourceMetadata>> COMPONENT_CUSTOMIZERS;
-
     public static final String ID = "agent";
-    public static final String STUB_PATTERN = "*";
     public static final String MIME_TYPE_JSON = "application/json";
     public static final String CONTENT_TYPE_HEADER = "Content-Type";
-
-    static {
-        // the core CircuitBreaker reifier fails as it depends on a specific implementation provided by
-        // a dedicated component/module, but as we are orly inspecting the route to determine its capabilities,
-        // we can safely disable the EIP with a disabled/stub reifier.
-        ProcessorReifier.registerReifier(CircuitBreakerDefinition.class, DisabledReifier::new);
-
-        COMPONENT_CUSTOMIZERS = new HashMap<>();
-        COMPONENT_CUSTOMIZERS.put("platform-http", (catalog, meta) -> {
-            meta.capabilities.put(
-                    Capability.PlatformHttp,
-                    catalog
-                            .findCapabilityRef(Capability.PlatformHttp.getValue())
-                            .orElseGet(() -> new EntityRef(null, null)));
-        });
-
-    }
 
     @CommandLine.Option(names = { "--listen-host" },
                         description = "The host to listen on")
@@ -207,7 +153,7 @@ public class Agent extends CamelCommand {
 
     private void handleCatalogCapability(RoutingContext ctx) {
         try {
-            final CamelCatalog catalog = loadCatalog(runtimeType, runtimeVersion);
+            final CamelCatalog catalog = CatalogHelper.loadCatalog(runtimeType, runtimeVersion, repos, quarkusGroupId);
             final String name = ctx.pathParam("name");
             final Optional<EntityRef> ref = catalog.findCapabilityRef(name);
 
@@ -228,7 +174,7 @@ public class Agent extends CamelCommand {
 
     private void handleCatalogModel(RoutingContext ctx) {
         try {
-            final CamelCatalog catalog = loadCatalog(runtimeType, runtimeVersion);
+            final CamelCatalog catalog = CatalogHelper.loadCatalog(runtimeType, runtimeVersion, repos, quarkusGroupId);
             final String kind = ctx.pathParam("kind");
             final String name = ctx.pathParam("name");
             final BaseModel<?> model = catalog.model(Kind.valueOf(kind), name);
@@ -253,178 +199,26 @@ public class Agent extends CamelCommand {
         List<String> rt = ctx.queryParam("runtimeType");
         List<String> rv = ctx.queryParam("runtimeVersion");
         List<String> capabilities = ctx.queryParam("capabilities");
+        final String name = ctx.pathParam("location");
 
-        try (CamelContext context = createCamelContext()) {
-            final Model model = context.getCamelContextExtension().getContextPlugin(Model.class);
-            final String name = ctx.pathParam("location");
-            final CamelCatalog catalog = loadCatalog(runtimeType, runtimeVersion);
-
-            PluginHelper.getRoutesLoader(context).loadRoutes(
-                    ResourceHelper.fromString(name, content));
-
-            context.start();
-
-            final Set<String> fromEndpoints = model.getRouteDefinitions().stream()
-                    .map(RouteDefinition::getInput)
-                    .map(FromDefinition::getEndpointUri)
-                    .map(context::getEndpoint)
-                    .map(Endpoint::getEndpointUri)
-                    .collect(Collectors.toSet());
-
-            final Set<String> toEndpoints = context.getEndpoints().stream()
-                    .map(Endpoint::getEndpointUri)
-                    .filter(Predicate.not(fromEndpoints::contains))
-                    .collect(Collectors.toSet());
-
-            final Set<String> kamelets = context.getEndpoints().stream()
-                    .filter(KameletEndpoint.class::isInstance)
-                    .map(KameletEndpoint.class::cast)
-                    .map(KameletEndpoint::getTemplateId)
-                    .collect(Collectors.toSet());
-
-            SourceMetadata meta = new SourceMetadata();
-            meta.resources.components.addAll(context.getComponentNames());
-            meta.resources.languages.addAll(context.getLanguageNames());
-            meta.resources.dataformats.addAll(context.getDataFormatNames());
-            meta.resources.kamelets.addAll(kamelets);
-            meta.endpoints.from.addAll(fromEndpoints);
-            meta.endpoints.to.addAll(toEndpoints);
-
-            // determine capabilities based on components
-            for (String component : meta.resources.components) {
-                // TODO: add this information to the model so we can retrieve them automatically
-                BiConsumer<CamelCatalog, SourceMetadata> consumer = COMPONENT_CUSTOMIZERS.get(component);
-                if (consumer != null) {
-                    consumer.accept(catalog, meta);
-                }
-            }
-
-            // determine capabilities based on EIP
-            for (RouteDefinition definition : model.getRouteDefinitions()) {
-                navigateRoute(
-                        definition,
-                        d -> {
-                            if (d instanceof CircuitBreakerDefinition) {
-
-                                meta.capabilities.put(
-                                        Capability.CircuitBreaker,
-                                        catalog
-                                                .findCapabilityRef(Capability.CircuitBreaker.getValue())
-                                                .orElseGet(() -> new EntityRef(null, null)));
-                            }
-                        });
-            }
+        try {
+            RuntimeType resolvedRuntimeType = rt.size() == 1 ? RuntimeType.fromValue(rt.get(0)) : runtimeType;
+            String resolvedRuntimeVersion = rv.size() == 1 ? rv.get(0) : runtimeVersion;
+            CamelCatalog catalog
+                    = CatalogHelper.loadCatalog(resolvedRuntimeType, resolvedRuntimeVersion, repos, quarkusGroupId);
+            SourceMetadata meta = MetadataHelper.readFromSource(catalog, name, content);
 
             if (capabilities.size() == 1) {
                 for (String item : capabilities.get(0).split(",")) {
-                    meta.capabilities.put(
-                            Capability.fromValue(item),
-                            catalog
-                                    .findCapabilityRef(item)
-                                    .orElseGet(() -> new EntityRef(null, null)));
+                    meta.capabilities.add(Capability.fromValue(item));
                 }
             }
-
-            meta.dependencies.addAll(deps(
-                    context,
-                    catalog,
-                    rt.size() == 1 ? RuntimeType.fromValue(rt.get(0)) : runtimeType,
-                    rv.size() == 1 ? rv.get(0) : runtimeVersion));
 
             ctx.response()
                     .putHeader(CONTENT_TYPE_HEADER, MIME_TYPE_JSON)
                     .end(MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(meta));
-
         } catch (Exception e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    private static void navigateRoute(ProcessorDefinition<?> root, Consumer<ProcessorDefinition<?>> consumer) {
-        consumer.accept(root);
-
-        for (ProcessorDefinition<?> def : root.getOutputs()) {
-            navigateRoute(def, consumer);
-        }
-    }
-
-    private Collection<String> deps(CamelContext context, CamelCatalog catalog, RuntimeType runtimeType, String runtimeVersion)
-            throws Exception {
-        final Set<String> answer = new TreeSet<>();
-
-        for (String name : context.getComponentNames()) {
-            ComponentModel model = catalog.componentModel(name);
-            if (model != null) {
-                answer.add(String.format("mvn:%s/%s/%s", model.getGroupId(), model.getArtifactId(), model.getVersion()));
-            }
-        }
-        for (String name : context.getLanguageNames()) {
-            LanguageModel model = catalog.languageModel(name);
-            if (model != null) {
-                answer.add(String.format("mvn:%s/%s/%s", model.getGroupId(), model.getArtifactId(), model.getVersion()));
-            }
-        }
-        for (String name : context.getDataFormatNames()) {
-            DataFormatModel model = catalog.dataFormatModel(name);
-            if (model != null) {
-                answer.add(String.format("mvn:%s/%s/%s", model.getGroupId(), model.getArtifactId(), model.getVersion()));
-            }
-        }
-
-        return answer;
-    }
-
-    private CamelCatalog loadCatalog(RuntimeType runtime, String runtimeVersion) throws Exception {
-        switch (runtime) {
-            case springBoot:
-                return CatalogLoader.loadSpringBootCatalog(repos, runtimeVersion);
-            case quarkus:
-                return CatalogLoader.loadQuarkusCatalog(repos, runtimeVersion, quarkusGroupId);
-            case main:
-                return CatalogLoader.loadCatalog(repos, runtimeVersion);
-            default:
-                throw new IllegalArgumentException("Unsupported runtime: " + runtime);
-        }
-    }
-
-    private CamelContext createCamelContext() {
-        final StubComponentResolver componentResolver = new StubComponentResolver(STUB_PATTERN, true);
-        final StubDataFormatResolver dataFormatResolver = new StubDataFormatResolver(STUB_PATTERN, true);
-        final StubLanguageResolver languageResolver = new StubLanguageResolver(STUB_PATTERN, true);
-        final StubTransformerResolver transformerResolver = new StubTransformerResolver(STUB_PATTERN, true);
-
-        CamelContext context = new DefaultCamelContext() {
-            @Override
-            public Set<String> getDataFormatNames() {
-                // data formats names are no necessary stored in the context as they
-                // are created on demand
-                //
-                // TODO: maybe the camel context should keep track of those ?
-                return dataFormatResolver.getNames();
-            }
-        };
-
-        final ExtendedCamelContext ec = context.getCamelContextExtension();
-        final Model model = ec.getContextPlugin(Model.class);
-
-        model.setModelReifierFactory(new AgentModelReifierFactory());
-
-        ec.addContextPlugin(ComponentResolver.class, componentResolver);
-        ec.addContextPlugin(DataFormatResolver.class, dataFormatResolver);
-        ec.addContextPlugin(LanguageResolver.class, languageResolver);
-        ec.addContextPlugin(TransformerResolver.class, transformerResolver);
-
-        return context;
-    }
-
-    private static final class AgentModelReifierFactory extends DefaultModelReifierFactory {
-        @Override
-        public Route createRoute(CamelContext camelContext, Object routeDefinition) {
-            if (routeDefinition instanceof RouteDefinition) {
-                ((RouteDefinition) routeDefinition).autoStartup(false);
-            }
-
-            return super.createRoute(camelContext, routeDefinition);
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationRun.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationRun.java
@@ -311,7 +311,9 @@ public class IntegrationRun extends KubernetesBaseCommand {
         if (output != null) {
             switch (output) {
                 case "k8s" -> {
-                    TraitContext context = new TraitContext(integration.getMetadata().getName(), "1.0-SNAPSHOT");
+                    List<Source> sources = SourceHelper.resolveSources(integrationSources);
+                    TraitContext context
+                            = new TraitContext(integration.getMetadata().getName(), "1.0-SNAPSHOT", printer(), sources);
                     TraitHelper.configureContainerImage(traitsSpec, image, "quay.io", null, integration.getMetadata().getName(),
                             "1.0-SNAPSHOT");
 

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/pom.xml
@@ -76,4 +76,19 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- Used in unit tests to resolve dependencies via Maven downloader -->
+                        <camel.version>${project.version}</camel.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/CatalogHelper.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/CatalogHelper.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dsl.jbang.core.commands.kubernetes;
+
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.dsl.jbang.core.common.CatalogLoader;
+import org.apache.camel.dsl.jbang.core.common.RuntimeType;
+
+public class CatalogHelper {
+
+    private CatalogHelper() {
+        // prevent instantiation of utility class
+    }
+
+    public static CamelCatalog loadCatalog(RuntimeType runtime, String runtimeVersion) throws Exception {
+        return loadCatalog(runtime, runtimeVersion, "", null);
+    }
+
+    public static CamelCatalog loadCatalog(RuntimeType runtime, String runtimeVersion, String repos, String quarkusGroupId)
+            throws Exception {
+        switch (runtime) {
+            case springBoot:
+                return CatalogLoader.loadSpringBootCatalog(repos, runtimeVersion);
+            case quarkus:
+                return CatalogLoader.loadQuarkusCatalog(repos, runtimeVersion, quarkusGroupId);
+            case main:
+                return CatalogLoader.loadCatalog(repos, runtimeVersion);
+            default:
+                throw new IllegalArgumentException("Unsupported runtime: " + runtime);
+        }
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
@@ -197,7 +197,7 @@ public class KubernetesRun extends KubernetesBaseCommand {
 
         int exit = export.export();
         if (exit != 0) {
-            printer().println("Project export failed!");
+            printer().println("Project export failed");
             return exit;
         }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/MetadataHelper.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/MetadataHelper.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dsl.jbang.core.commands.kubernetes;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.Route;
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.component.kamelet.KameletEndpoint;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.support.Capability;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.support.SourceMetadata;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.support.StubComponentResolver;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.support.StubDataFormatResolver;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.support.StubLanguageResolver;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.support.StubTransformerResolver;
+import org.apache.camel.dsl.jbang.core.common.RuntimeType;
+import org.apache.camel.dsl.jbang.core.common.Source;
+import org.apache.camel.dsl.jbang.core.common.VersionHelper;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.DefaultModelReifierFactory;
+import org.apache.camel.main.download.CamelCustomClassLoader;
+import org.apache.camel.main.download.DependencyDownloaderClassLoader;
+import org.apache.camel.main.download.DependencyDownloaderClassResolver;
+import org.apache.camel.main.download.DependencyDownloaderRoutesLoader;
+import org.apache.camel.main.download.DependencyDownloaderStrategy;
+import org.apache.camel.main.download.KnownDependenciesResolver;
+import org.apache.camel.main.download.MavenDependencyDownloader;
+import org.apache.camel.model.CircuitBreakerDefinition;
+import org.apache.camel.model.FromDefinition;
+import org.apache.camel.model.Model;
+import org.apache.camel.model.ProcessorDefinition;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.camel.reifier.DisabledReifier;
+import org.apache.camel.reifier.ProcessorReifier;
+import org.apache.camel.spi.ClassResolver;
+import org.apache.camel.spi.ComponentResolver;
+import org.apache.camel.spi.DataFormatResolver;
+import org.apache.camel.spi.FactoryFinder;
+import org.apache.camel.spi.FactoryFinderResolver;
+import org.apache.camel.spi.LanguageResolver;
+import org.apache.camel.spi.Resource;
+import org.apache.camel.spi.RoutesLoader;
+import org.apache.camel.spi.TransformerResolver;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.support.ResourceHelper;
+import org.apache.camel.tooling.model.ComponentModel;
+import org.apache.camel.tooling.model.DataFormatModel;
+import org.apache.camel.tooling.model.LanguageModel;
+
+public class MetadataHelper {
+
+    public static final String STUB_PATTERN = "*";
+
+    private static final Map<String, BiConsumer<CamelCatalog, SourceMetadata>> COMPONENT_CUSTOMIZERS;
+
+    static {
+        // the core CircuitBreaker reifier fails as it depends on a specific implementation provided by
+        // a dedicated component/module, but as we are only inspecting the route to determine its capabilities,
+        // we can safely disable the EIP with a disabled/stub reifier.
+        ProcessorReifier.registerReifier(CircuitBreakerDefinition.class, DisabledReifier::new);
+
+        COMPONENT_CUSTOMIZERS = new HashMap<>();
+        COMPONENT_CUSTOMIZERS.put(Capability.PlatformHttp.getValue(), (catalog, meta) -> {
+            meta.capabilities.add(Capability.PlatformHttp);
+        });
+    }
+
+    private MetadataHelper() {
+        // prevent instantiation of utility class
+    }
+
+    public static SourceMetadata readFromSource(CamelCatalog catalog, Source source) throws Exception {
+        return readFromSource(catalog, source.name(), source.content());
+    }
+
+    public static SourceMetadata readFromSource(CamelCatalog catalog, String location, String source) throws Exception {
+        try (CamelContext context = createCamelContext()) {
+            Resource resource = ResourceHelper.fromString(location, source);
+            PluginHelper.getRoutesLoader(context).loadRoutes(resource);
+
+            context.start();
+
+            final Model model = context.getCamelContextExtension().getContextPlugin(Model.class);
+            final Set<String> fromEndpoints = model.getRouteDefinitions().stream()
+                    .map(RouteDefinition::getInput)
+                    .map(FromDefinition::getEndpointUri)
+                    .map(context::getEndpoint)
+                    .map(Endpoint::getEndpointUri)
+                    .collect(Collectors.toSet());
+
+            final Set<String> toEndpoints = context.getEndpoints().stream()
+                    .map(Endpoint::getEndpointUri)
+                    .filter(Predicate.not(fromEndpoints::contains))
+                    .collect(Collectors.toSet());
+
+            final Set<String> kamelets = context.getEndpoints().stream()
+                    .filter(KameletEndpoint.class::isInstance)
+                    .map(KameletEndpoint.class::cast)
+                    .map(KameletEndpoint::getTemplateId)
+                    .collect(Collectors.toSet());
+
+            SourceMetadata meta = new SourceMetadata();
+            meta.resources.components.addAll(context.getComponentNames());
+            meta.resources.languages.addAll(context.getLanguageNames());
+            meta.resources.dataformats.addAll(context.getDataFormatNames());
+            meta.resources.kamelets.addAll(kamelets);
+            meta.endpoints.from.addAll(fromEndpoints);
+            meta.endpoints.to.addAll(toEndpoints);
+
+            // determine capabilities based on components
+            for (String component : meta.resources.components) {
+                // TODO: add this information to the model so we can retrieve them automatically
+                BiConsumer<CamelCatalog, SourceMetadata> consumer = COMPONENT_CUSTOMIZERS.get(component);
+                if (consumer != null) {
+                    consumer.accept(catalog, meta);
+                }
+            }
+
+            // determine capabilities based on EIP
+            for (RouteDefinition definition : model.getRouteDefinitions()) {
+                navigateRoute(
+                        definition,
+                        d -> {
+                            if (d instanceof CircuitBreakerDefinition) {
+                                meta.capabilities.add(Capability.CircuitBreaker);
+                            }
+                        });
+            }
+
+            meta.dependencies.addAll(deps(context, catalog));
+
+            return meta;
+        }
+    }
+
+    private static Collection<String> deps(CamelContext context, CamelCatalog catalog) {
+        final Set<String> answer = new TreeSet<>();
+
+        for (String name : context.getComponentNames()) {
+            ComponentModel model = catalog.componentModel(name);
+            if (model != null) {
+                answer.add(String.format("mvn:%s/%s/%s", model.getGroupId(), model.getArtifactId(), model.getVersion()));
+            }
+        }
+        for (String name : context.getLanguageNames()) {
+            LanguageModel model = catalog.languageModel(name);
+            if (model != null) {
+                answer.add(String.format("mvn:%s/%s/%s", model.getGroupId(), model.getArtifactId(), model.getVersion()));
+            }
+        }
+        for (String name : context.getDataFormatNames()) {
+            DataFormatModel model = catalog.dataFormatModel(name);
+            if (model != null) {
+                answer.add(String.format("mvn:%s/%s/%s", model.getGroupId(), model.getArtifactId(), model.getVersion()));
+            }
+        }
+
+        return answer;
+    }
+
+    private static CamelContext createCamelContext() throws Exception {
+        final StubComponentResolver componentResolver = new StubComponentResolver(STUB_PATTERN, true);
+        final StubDataFormatResolver dataFormatResolver = new StubDataFormatResolver(STUB_PATTERN, true);
+        final StubLanguageResolver languageResolver = new StubLanguageResolver(STUB_PATTERN, true);
+        final StubTransformerResolver transformerResolver = new StubTransformerResolver(STUB_PATTERN, true);
+
+        CamelContext context = new DefaultCamelContext(false) {
+            @Override
+            public Set<String> getDataFormatNames() {
+                // data formats names are no necessary stored in the context as they
+                // are created on demand
+                //
+                // TODO: maybe the camel context should keep track of those ?
+                return dataFormatResolver.getNames();
+            }
+        };
+
+        final ExtendedCamelContext ec = context.getCamelContextExtension();
+        final Model model = ec.getContextPlugin(Model.class);
+
+        model.setModelReifierFactory(new AgentModelReifierFactory());
+
+        ec.addContextPlugin(ComponentResolver.class, componentResolver);
+        ec.addContextPlugin(DataFormatResolver.class, dataFormatResolver);
+        ec.addContextPlugin(LanguageResolver.class, languageResolver);
+        ec.addContextPlugin(TransformerResolver.class, transformerResolver);
+
+        ec.getRegistry().bind(DependencyDownloaderStrategy.class.getSimpleName(),
+                new DependencyDownloaderStrategy(context));
+
+        ClassLoader cl = createClassLoader(context);
+        context.setApplicationContextClassLoader(cl);
+        PluginHelper.getPackageScanClassResolver(context).addClassLoader(cl);
+        PluginHelper.getPackageScanResourceResolver(context).addClassLoader(cl);
+
+        ClassResolver classResolver = new DependencyDownloaderClassResolver(
+                context, new KnownDependenciesResolver(context, RuntimeType.SPRING_BOOT_VERSION, RuntimeType.QUARKUS_VERSION),
+                true);
+        context.setClassResolver(classResolver);
+        // re-create factory finder with download class-resolver
+        FactoryFinderResolver ffr = PluginHelper.getFactoryFinderResolver(context);
+        FactoryFinder ff = ffr.resolveBootstrapFactoryFinder(classResolver);
+        context.getCamelContextExtension().setBootstrapFactoryFinder(ff);
+        ff = ffr.resolveDefaultFactoryFinder(classResolver);
+        context.getCamelContextExtension().setDefaultFactoryFinder(ff);
+
+        MavenDependencyDownloader downloader = new MavenDependencyDownloader();
+        downloader.setClassLoader(cl);
+        downloader.setCamelContext(context);
+        downloader.setVerbose(false);
+
+        context.addService(downloader);
+
+        DependencyDownloaderRoutesLoader routesLoader = new DependencyDownloaderRoutesLoader(
+                context, VersionHelper.extractCamelVersion(), VersionHelper.extractKameletsVersion());
+
+        ec.addContextPlugin(RoutesLoader.class, routesLoader);
+
+        // ensure camel context is build
+        context.build();
+
+        return context;
+    }
+
+    private static void navigateRoute(ProcessorDefinition<?> root, Consumer<ProcessorDefinition<?>> consumer) {
+        consumer.accept(root);
+
+        for (ProcessorDefinition<?> def : root.getOutputs()) {
+            navigateRoute(def, consumer);
+        }
+    }
+
+    public static boolean exposesHttpServices(CamelCatalog catalog, SourceMetadata sourceMetadata) {
+        for (String uri : sourceMetadata.endpoints.from) {
+            String componentName = catalog.endpointComponentName(uri);
+            if (componentName != null) {
+                // TODO: improve retrieval of Http component nature
+                if (catalog.componentModel(componentName).isConsumerOnly() && componentName.contains("http")) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static ClassLoader createClassLoader(CamelContext context) {
+        return new DependencyDownloaderClassLoader(new CamelCustomClassLoader(MetadataHelper.class.getClassLoader(), context));
+    }
+
+    private static final class AgentModelReifierFactory extends DefaultModelReifierFactory {
+        @Override
+        public Route createRoute(CamelContext camelContext, Object routeDefinition) {
+            if (routeDefinition instanceof RouteDefinition) {
+                ((RouteDefinition) routeDefinition).autoStartup(false);
+            }
+
+            return super.createRoute(camelContext, routeDefinition);
+        }
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/support/Capability.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/support/Capability.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.camel.dsl.jbang.core.commands.k.support;
+package org.apache.camel.dsl.jbang.core.commands.kubernetes.support;
 
 import java.util.Objects;
 

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/support/SourceMetadata.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/support/SourceMetadata.java
@@ -15,16 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.camel.dsl.jbang.core.commands.k.support;
+package org.apache.camel.dsl.jbang.core.commands.kubernetes.support;
 
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.TreeSet;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import org.apache.camel.tooling.model.EntityRef;
 
 @JsonPropertyOrder(alphabetic = true)
 public class SourceMetadata {
@@ -34,7 +33,7 @@ public class SourceMetadata {
     @JsonProperty
     public final Endpoints endpoints = new Endpoints();
     @JsonProperty
-    public final Map<Capability, EntityRef> capabilities = new TreeMap<>();
+    public final List<Capability> capabilities = new ArrayList<>();
     @JsonProperty
     public final Set<String> dependencies = new TreeSet<>();
 

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/support/StubDataFormatResolver.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/support/StubDataFormatResolver.java
@@ -15,31 +15,31 @@
  * limitations under the License.
  */
 
-package org.apache.camel.dsl.jbang.core.commands.k.support;
+package org.apache.camel.dsl.jbang.core.commands.kubernetes.support;
 
 import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.impl.engine.DefaultLanguageResolver;
-import org.apache.camel.main.stub.StubLanguage;
-import org.apache.camel.spi.Language;
+import org.apache.camel.impl.engine.DefaultDataFormatResolver;
+import org.apache.camel.main.stub.StubDataFormat;
+import org.apache.camel.spi.DataFormat;
 
-public final class StubLanguageResolver extends DefaultLanguageResolver {
+public final class StubDataFormatResolver extends DefaultDataFormatResolver {
     private final Set<String> names;
     private final String stubPattern;
     private final boolean silent;
 
-    public StubLanguageResolver(String stubPattern, boolean silent) {
+    public StubDataFormatResolver(String stubPattern, boolean silent) {
         this.names = new TreeSet<>();
         this.stubPattern = stubPattern;
         this.silent = silent;
     }
 
     @Override
-    public Language resolveLanguage(String name, CamelContext context) {
+    public DataFormat createDataFormat(String name, CamelContext context) {
         final boolean accept = accept(name);
-        final Language answer = accept ? super.resolveLanguage(name, context) : new StubLanguage();
+        final DataFormat answer = accept ? super.createDataFormat(name, context) : new StubDataFormat();
 
         this.names.add(name);
 
@@ -57,4 +57,5 @@ public final class StubLanguageResolver extends DefaultLanguageResolver {
     public Set<String> getNames() {
         return Set.copyOf(this.names);
     }
+
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/support/StubLanguageResolver.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/support/StubLanguageResolver.java
@@ -15,34 +15,33 @@
  * limitations under the License.
  */
 
-package org.apache.camel.dsl.jbang.core.commands.k.support;
+package org.apache.camel.dsl.jbang.core.commands.kubernetes.support;
 
 import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.impl.engine.DefaultTransformerResolver;
-import org.apache.camel.main.stub.StubTransformer;
-import org.apache.camel.spi.Transformer;
-import org.apache.camel.spi.TransformerKey;
+import org.apache.camel.impl.engine.DefaultLanguageResolver;
+import org.apache.camel.main.stub.StubLanguage;
+import org.apache.camel.spi.Language;
 
-public final class StubTransformerResolver extends DefaultTransformerResolver {
+public final class StubLanguageResolver extends DefaultLanguageResolver {
     private final Set<String> names;
     private final String stubPattern;
     private final boolean silent;
 
-    public StubTransformerResolver(String stubPattern, boolean silent) {
+    public StubLanguageResolver(String stubPattern, boolean silent) {
         this.names = new TreeSet<>();
         this.stubPattern = stubPattern;
         this.silent = silent;
     }
 
     @Override
-    public Transformer resolve(TransformerKey key, CamelContext context) {
-        final boolean accept = accept(key.toString());
-        final Transformer answer = accept ? super.resolve(key, context) : new StubTransformer();
+    public Language resolveLanguage(String name, CamelContext context) {
+        final boolean accept = accept(name);
+        final Language answer = accept ? super.resolveLanguage(name, context) : new StubLanguage();
 
-        this.names.add(key.toString());
+        this.names.add(name);
 
         return answer;
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/support/StubTransformerResolver.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/support/StubTransformerResolver.java
@@ -15,43 +15,34 @@
  * limitations under the License.
  */
 
-package org.apache.camel.dsl.jbang.core.commands.k.support;
+package org.apache.camel.dsl.jbang.core.commands.kubernetes.support;
 
 import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.Component;
-import org.apache.camel.component.stub.StubComponent;
-import org.apache.camel.impl.engine.DefaultComponentResolver;
+import org.apache.camel.impl.engine.DefaultTransformerResolver;
+import org.apache.camel.main.stub.StubTransformer;
+import org.apache.camel.spi.Transformer;
+import org.apache.camel.spi.TransformerKey;
 
-public final class StubComponentResolver extends DefaultComponentResolver {
-    private static final Set<String> ACCEPTED_STUB_NAMES = Set.of(
-            "stub", "bean", "class", "direct", "kamelet", "log", "rest", "rest-api", "seda", "vrtx-http");
-
+public final class StubTransformerResolver extends DefaultTransformerResolver {
     private final Set<String> names;
     private final String stubPattern;
     private final boolean silent;
 
-    public StubComponentResolver(String stubPattern, boolean silent) {
+    public StubTransformerResolver(String stubPattern, boolean silent) {
         this.names = new TreeSet<>();
         this.stubPattern = stubPattern;
         this.silent = silent;
     }
 
     @Override
-    public Component resolveComponent(String name, CamelContext context) {
-        final boolean accept = accept(name);
-        final Component answer = super.resolveComponent(accept ? name : "stub", context);
+    public Transformer resolve(TransformerKey key, CamelContext context) {
+        final boolean accept = accept(key.toString());
+        final Transformer answer = accept ? super.resolve(key, context) : new StubTransformer();
 
-        if ((silent || stubPattern != null) && answer instanceof StubComponent) {
-            StubComponent sc = (StubComponent) answer;
-            // enable shadow mode on stub component
-            sc.setShadow(true);
-            sc.setShadowPattern(stubPattern);
-        }
-
-        this.names.add(name);
+        this.names.add(key.toString());
 
         return answer;
     }
@@ -61,11 +52,10 @@ public final class StubComponentResolver extends DefaultComponentResolver {
             return true;
         }
 
-        // we are stubbing but need to accept the following
-        return ACCEPTED_STUB_NAMES.contains(name);
+        return false;
     }
 
     public Set<String> getNames() {
-        return Set.copyOf(names);
+        return Set.copyOf(this.names);
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/ServiceTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/ServiceTrait.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dsl.jbang.core.commands.kubernetes.traits;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.MetadataHelper;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.support.SourceMetadata;
+import org.apache.camel.dsl.jbang.core.common.Source;
+import org.apache.camel.v1.integrationspec.Traits;
+import org.apache.camel.v1.integrationspec.traits.Container;
+import org.apache.camel.v1.integrationspec.traits.Service;
+
+public class ServiceTrait extends BaseTrait {
+
+    public ServiceTrait() {
+        super("service", 1500);
+    }
+
+    @Override
+    public boolean configure(Traits traitConfig, TraitContext context) {
+        if (context.getService().isPresent()) {
+            return false;
+        }
+
+        if (traitConfig.getService() != null && traitConfig.getService().getEnabled() != null) {
+            // either explicitly enabled or disabled
+            return traitConfig.getService().getEnabled();
+        }
+
+        try {
+            boolean exposesHttpServices = false;
+            CamelCatalog catalog = context.getCatalog();
+            if (context.getSources() != null) {
+                for (Source source : context.getSources()) {
+                    SourceMetadata metadata = MetadataHelper.readFromSource(catalog, source);
+                    if (MetadataHelper.exposesHttpServices(catalog, metadata)) {
+                        exposesHttpServices = true;
+                        break;
+                    }
+                }
+            }
+
+            return exposesHttpServices;
+        } catch (Exception e) {
+            context.printer().printf("Failed to apply service trait %s%n", e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public void apply(Traits traitConfig, TraitContext context) {
+        Service serviceTrait = Optional.ofNullable(traitConfig.getService()).orElseGet(Service::new);
+        String serviceType = Optional.ofNullable(serviceTrait.getType()).map(Service.Type::getValue)
+                .orElse(Service.Type.NODEPORT.getValue());
+
+        Container containerTrait = Optional.ofNullable(traitConfig.getContainer()).orElseGet(Container::new);
+
+        ServiceBuilder service = new ServiceBuilder()
+                .withNewMetadata()
+                .withName(context.getName())
+                .endMetadata()
+                .withNewSpec()
+                .withType(serviceType)
+                .withSelector(Collections.singletonMap(BaseTrait.INTEGRATION_LABEL, context.getName()))
+                .addToPorts(new ServicePortBuilder()
+                        .withName(Optional.ofNullable(containerTrait.getServicePortName())
+                                .orElse(ContainerTrait.DEFAULT_CONTAINER_PORT_NAME))
+                        .withPort(Optional.ofNullable(containerTrait.getServicePort()).map(Long::intValue).orElse(80))
+                        .withTargetPort(
+                                new IntOrString(
+                                        Optional.ofNullable(containerTrait.getPortName())
+                                                .orElse(ContainerTrait.DEFAULT_CONTAINER_PORT_NAME)))
+                        .withProtocol("TCP")
+                        .build())
+                .endSpec();
+
+        context.add(service);
+    }
+
+    @Override
+    public boolean accept(TraitProfile profile) {
+        return TraitProfile.KNATIVE != profile;
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitCatalog.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitCatalog.java
@@ -35,6 +35,7 @@ public class TraitCatalog {
 
     public TraitCatalog() {
         register(new DeploymentTrait());
+        register(new ServiceTrait());
         register(new ContainerTrait());
         register(new EnvTrait());
         register(new MountTrait());

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitContext.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitContext.java
@@ -18,6 +18,7 @@
 package org.apache.camel.dsl.jbang.core.commands.kubernetes.traits;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,12 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.CronJobBuilder;
+import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.CatalogHelper;
+import org.apache.camel.dsl.jbang.core.common.Printer;
+import org.apache.camel.dsl.jbang.core.common.RuntimeType;
+import org.apache.camel.dsl.jbang.core.common.Source;
 
 public class TraitContext {
 
@@ -43,9 +50,30 @@ public class TraitContext {
     private final String name;
     private final String version;
 
-    public TraitContext(String name, String version) {
+    private CamelCatalog catalog;
+
+    private final Printer printer;
+
+    private final List<Source> sources;
+
+    public TraitContext(String name, String version, Printer printer, Source... sources) {
+        this(name, version, printer, null, sources);
+    }
+
+    public TraitContext(String name, String version, Printer printer, List<Source> sources) {
+        this(name, version, printer, null, sources);
+    }
+
+    public TraitContext(String name, String version, Printer printer, CamelCatalog catalog, Source... sources) {
+        this(name, version, printer, catalog, Arrays.asList(sources));
+    }
+
+    public TraitContext(String name, String version, Printer printer, CamelCatalog catalog, List<Source> sources) {
         this.name = name;
         this.version = version;
+        this.printer = printer;
+        this.catalog = catalog;
+        this.sources = sources;
     }
 
     /**
@@ -121,5 +149,25 @@ public class TraitContext {
 
     public Map<String, String> getAnnotations() {
         return annotations;
+    }
+
+    public CamelCatalog getCatalog() {
+        if (catalog == null) {
+            try {
+                catalog = CatalogHelper.loadCatalog(RuntimeType.quarkus, RuntimeType.QUARKUS_VERSION);
+            } catch (Exception e) {
+                throw new RuntimeCamelException("Failed to create default Quarkus Camel catalog", e);
+            }
+        }
+
+        return catalog;
+    }
+
+    public Printer printer() {
+        return printer;
+    }
+
+    public Source[] getSources() {
+        return sources.toArray(Source[]::new);
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRunTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRunTest.java
@@ -46,7 +46,7 @@ class KubernetesRunTest extends KubernetesBaseTest {
 
         Assertions.assertEquals(1, exit);
 
-        Assertions.assertTrue(printer.getOutput().contains("Project export failed!"));
+        Assertions.assertTrue(printer.getOutput().contains("Project export failed"));
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/MetadataHelperTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/MetadataHelperTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dsl.jbang.core.commands.kubernetes;
+
+import java.util.Arrays;
+
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.support.Capability;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.support.SourceMetadata;
+import org.apache.camel.dsl.jbang.core.common.RuntimeType;
+import org.apache.camel.dsl.jbang.core.common.Source;
+import org.apache.camel.dsl.jbang.core.common.SourceHelper;
+import org.apache.camel.dsl.jbang.core.common.VersionHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class MetadataHelperTest {
+
+    @BeforeAll
+    static void setup() {
+        // Set Camel version with system property value, usually set via Maven surefire plugin
+        // In case you run this test via local Java IDE you need to provide the system property or a default value here
+        VersionHelper.setCamelVersion(System.getProperty("camel.version", ""));
+    }
+
+    @Test
+    public void testInspectHttpService() throws Exception {
+        CamelCatalog catalog = CatalogHelper.loadCatalog(RuntimeType.quarkus, RuntimeType.quarkus.version());
+        Source source = SourceHelper.resolveSource("classpath:PlatformHttpServer.java");
+        SourceMetadata metadata = MetadataHelper.readFromSource(catalog, source);
+
+        Assertions.assertTrue(MetadataHelper.exposesHttpServices(catalog, metadata));
+        Assertions.assertTrue(metadata.capabilities.contains(Capability.PlatformHttp));
+        Assertions.assertEquals(1, metadata.resources.components.size());
+        Assertions.assertTrue(metadata.resources.components.contains("platform-http"));
+        Assertions.assertEquals(1, metadata.endpoints.from.size());
+        Assertions.assertTrue(metadata.endpoints.from.contains("platform-http:///hello?httpMethodRestrict=GET"));
+        Assertions.assertEquals(0, metadata.endpoints.to.size());
+
+        source = SourceHelper.resolveSource("classpath:route.yaml");
+        metadata = MetadataHelper.readFromSource(catalog, source);
+
+        Assertions.assertFalse(MetadataHelper.exposesHttpServices(catalog, metadata));
+        Assertions.assertEquals(3, metadata.resources.components.size());
+        Assertions.assertTrue(metadata.resources.components.containsAll(Arrays.asList("timer", "log")));
+        Assertions.assertEquals(1, metadata.endpoints.from.size());
+        Assertions.assertTrue(metadata.endpoints.from.contains("timer://tick"));
+        Assertions.assertEquals(1, metadata.endpoints.to.size());
+        Assertions.assertTrue(metadata.endpoints.to.contains("log://info"));
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/resources/PlatformHttpServer.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/resources/PlatformHttpServer.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.RouteBuilder;
+public class PlatformHttpServer extends RouteBuilder {
+  @Override
+  public void configure() throws Exception {
+    from("platform-http:/hello?httpMethodRestrict=GET").setBody(simple("Hello ${header.name}"));
+  }
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/resources/route-service.yaml
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/resources/route-service.yaml
@@ -16,8 +16,7 @@
 #
 
 - from:
-    uri: timer:tick
+    uri: 'platform-http:/roll-dice'
     steps:
-      - setBody:
-          constant: Hello Camel !!!
-      - to: log:info
+      - set-body:
+          simple: 'roll: $simple{random(1,6)}'

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/KameletMain.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/KameletMain.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import org.w3c.dom.Document;
@@ -758,9 +759,13 @@ public class KameletMain extends MainCommandLineSupport {
         }
 
         DependencyDownloaderRoutesLoader routesLoader;
+        Object camelVersion = getInitialProperties().get("camel.jbang.camelVersion");
         Object kameletsVersion = getInitialProperties().get("camel.jbang.kameletsVersion");
-        if (kameletsVersion != null) {
-            routesLoader = new DependencyDownloaderRoutesLoader(camelContext, kameletsVersion.toString());
+        if (camelVersion != null || kameletsVersion != null) {
+            routesLoader = new DependencyDownloaderRoutesLoader(
+                    camelContext,
+                    Optional.ofNullable(camelVersion).map(Object::toString).orElse(""),
+                    Optional.ofNullable(kameletsVersion).map(Object::toString).orElse(""));
         } else {
             routesLoader = new DependencyDownloaderRoutesLoader(camelContext);
         }

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DependencyDownloaderRoutesLoader.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DependencyDownloaderRoutesLoader.java
@@ -24,6 +24,7 @@ import org.apache.camel.spi.FactoryFinder;
 import org.apache.camel.spi.RoutesBuilderLoader;
 import org.apache.camel.support.ResolverHelper;
 import org.apache.camel.support.service.ServiceHelper;
+import org.apache.camel.util.ObjectHelper;
 
 /**
  * Auto downloaded needed DSL JARs.
@@ -31,15 +32,17 @@ import org.apache.camel.support.service.ServiceHelper;
 public class DependencyDownloaderRoutesLoader extends DefaultRoutesLoader {
 
     private final DependencyDownloader downloader;
+    private final String camelVersion;
     private final String kameletsVersion;
 
     public DependencyDownloaderRoutesLoader(CamelContext camelContext) {
-        this(camelContext, null);
+        this(camelContext, null, null);
     }
 
-    public DependencyDownloaderRoutesLoader(CamelContext camelContext, String kameletsVersion) {
+    public DependencyDownloaderRoutesLoader(CamelContext camelContext, String camelVersion, String kameletsVersion) {
         setCamelContext(camelContext);
         this.downloader = camelContext.hasService(DependencyDownloader.class);
+        this.camelVersion = camelVersion;
         this.kameletsVersion = kameletsVersion;
     }
 
@@ -95,10 +98,13 @@ public class DependencyDownloaderRoutesLoader extends DefaultRoutesLoader {
     }
 
     private void downloadLoader(String artifactId) {
-        if (!downloader.alreadyOnClasspath("org.apache.camel", artifactId,
-                getCamelContext().getVersion())) {
-            downloader.downloadDependency("org.apache.camel", artifactId,
-                    getCamelContext().getVersion());
+        String resolvedCamelVersion = getCamelContext().getVersion();
+        if (ObjectHelper.isEmpty(resolvedCamelVersion)) {
+            resolvedCamelVersion = camelVersion;
+        }
+
+        if (!downloader.alreadyOnClasspath("org.apache.camel", artifactId, resolvedCamelVersion)) {
+            downloader.downloadDependency("org.apache.camel", artifactId, resolvedCamelVersion);
         }
     }
 

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/KnownKameletRoutesBuilderLoader.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/KnownKameletRoutesBuilderLoader.java
@@ -55,7 +55,7 @@ public class KnownKameletRoutesBuilderLoader extends KameletRoutesBuilderLoader 
 
     private List<String> findKameletNames() {
         // download kamelet catalog for the correct version
-        if (kameletsVersion == null) {
+        if (kameletsVersion == null || kameletsVersion.isBlank()) {
             kameletsVersion = VersionHelper.extractKameletsVersion();
         }
 

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/util/VersionHelper.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/util/VersionHelper.java
@@ -21,12 +21,18 @@ import java.lang.management.RuntimeMXBean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StringHelper;
 
 public final class VersionHelper {
 
-    private static final String KAMELETS_DEFAULT_VERSION = "4.0.0-RC1";
+    private static String camelVersion;
+
+    private static final String KAMELETS_DEFAULT_VERSION = "4.7.0";
     private static final Pattern KAMELETS_LIBRARY = Pattern.compile("camel-kamelets-(\\d[A-Z\\d.-]*).jar", Pattern.DOTALL);
+    private static final Pattern CAMEL_BASE_ENGINE_LIBRARY
+            = Pattern.compile("camel-base-engine-(\\d[A-Z\\d.-]*).jar", Pattern.DOTALL);
+
     private static final String CP = System.getProperty("java.class.path");
 
     private VersionHelper() {
@@ -107,5 +113,23 @@ public final class VersionHelper {
         }
 
         return KAMELETS_DEFAULT_VERSION;
+    }
+
+    public static String extractCamelVersion() {
+        String catalogVersion = new org.apache.camel.catalog.VersionHelper().getVersion();
+        if (ObjectHelper.isNotEmpty(catalogVersion)) {
+            return catalogVersion;
+        }
+
+        Matcher matcher = CAMEL_BASE_ENGINE_LIBRARY.matcher(CP);
+        if (matcher.find() && matcher.groupCount() > 0) {
+            return matcher.group(1);
+        }
+
+        return camelVersion;
+    }
+
+    public static void setCamelVersion(String version) {
+        camelVersion = version;
     }
 }


### PR DESCRIPTION
# Description

- Add service trait to auto configure service Kubernetes resource for the export
- Only configure service resource when route exposed Http service
- Use metadata source inspection from Camel K agent command to retrieve routes that expose Http service
- Use Maven dependency download routes resolver and loader to dynamically load missing dependencies during metadata code inspection

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

See CAMEL-20982

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

