### PR TITLE
camel-kafka: Better pattern subscribe documentation sample

### DIFF
--- a/components/camel-kafka/src/main/docs/kafka-component.adoc
+++ b/components/camel-kafka/src/main/docs/kafka-component.adoc
@@ -135,7 +135,7 @@ It's also possible to subscribe to multiple topics giving a pattern as the topic
 
 [source,java]
 ----
-from("kafka:test*?brokers=localhost:9092&topicIsPattern=true")
+from("kafka:test.*?brokers=localhost:9092&topicIsPattern=true")
     .log("Message received from Kafka : ${body}")
     .log("    on the topic ${headers[kafka.TOPIC]}")
     .log("    on the partition ${headers[kafka.PARTITION]}")


### PR DESCRIPTION
# Description

Use better example how to subscribe to multiple topics based on the pattern. As it is Java Pattern when we want to allow arbitrary suffix, we want to use .* instead of just * as that means just arbitrary number of the last character.


# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- this is a trivial documentation change

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

- [X] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes
