### PR TITLE
CAMEL-21013: Add cluster-type and image-builder export command option

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
@@ -140,10 +140,16 @@ The Camel JBang Kubernetes export command provides several options to customize 
 |An image built externally (for instance via CI/CD). Enabling it will skip the integration build phase.
 
 |--image-registry
-|The image registry to hold the app container image. Default is `quay.io`
+|The image registry to hold the app container image.
 
 |--image-group
 |The image registry group used to push images to.
+
+|--image-builder
+|The image builder used to build the container image (e.g. docker, jib, podman, s2i).
+
+|--cluster-type
+|The target cluster type. Special configurations may be applied to different cluster types such as Kind or Minikube.
 |=======================================================================
 
 == Kubernetes manifest options

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
@@ -120,13 +120,20 @@ public class KubernetesRun extends KubernetesBaseCommand {
     String image;
 
     @CommandLine.Option(names = { "--image-registry" },
-                        defaultValue = "quay.io",
                         description = "The image registry to hold the app container image.")
-    String imageRegistry = "quay.io";
+    String imageRegistry;
 
     @CommandLine.Option(names = { "--image-group" },
                         description = "The image registry group used to push images to.")
     String imageGroup;
+
+    @CommandLine.Option(names = { "--image-builder" },
+                        description = "The image builder used to build the container image (e.g. docker, jib, podman, s2i).")
+    String imageBuilder;
+
+    @CommandLine.Option(names = { "--cluster-type" },
+                        description = "The target cluster type. Special configurations may be applied to different cluster types such as Kind or Minikube.")
+    String clusterType;
 
     @CommandLine.Option(names = { "--image-build" },
                         defaultValue = "true",
@@ -184,6 +191,8 @@ public class KubernetesRun extends KubernetesBaseCommand {
         export.image = image;
         export.imageRegistry = imageRegistry;
         export.imageGroup = imageGroup;
+        export.imageBuilder = imageBuilder;
+        export.clusterType = clusterType;
         export.traitProfile = traitProfile;
         export.serviceAccount = serviceAccount;
         export.properties = properties;

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesCommandTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesCommandTest.java
@@ -59,7 +59,7 @@ class KubernetesCommandTest extends KubernetesBaseTest {
         Assertions.assertEquals("route", deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
         Assertions.assertEquals(3, deployment.getSpec().getSelector().getMatchLabels().size());
         Assertions.assertEquals("route", deployment.getSpec().getSelector().getMatchLabels().get(BaseTrait.INTEGRATION_LABEL));
-        Assertions.assertEquals("quay.io/camel-test/route:1.0-SNAPSHOT",
+        Assertions.assertEquals("docker.io/camel-test/route:1.0-SNAPSHOT",
                 deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
         Assertions.assertEquals("Always",
                 deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy());

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRunTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRunTest.java
@@ -72,7 +72,7 @@ class KubernetesRunTest extends KubernetesBaseTest {
         Assertions.assertEquals("route", deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
         Assertions.assertEquals(3, deployment.getSpec().getSelector().getMatchLabels().size());
         Assertions.assertEquals("route", deployment.getSpec().getSelector().getMatchLabels().get(BaseTrait.INTEGRATION_LABEL));
-        Assertions.assertEquals("quay.io/camel-test/route:1.0-SNAPSHOT",
+        Assertions.assertEquals("docker.io/camel-test/route:1.0-SNAPSHOT",
                 deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
         Assertions.assertEquals("Always",
                 deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy());


### PR DESCRIPTION
# Description

- Cluster type specifies the target cluster Kind, Minikube, OpenShift and enables cluster specific configuration options on the export
- Image builder option allows to choose the container image builder technology: jib, docker, podman, s2i

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

