### PR TITLE
CAMEL-21017: Consolidate open-api options for Camel JBang export command

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
@@ -112,7 +112,7 @@ The Camel JBang Kubernetes export command provides several options to customize 
 |--resource
 |Add a runtime resource from a Configmap or a Secret (syntax: [configmap,secret]:name[/key][@path], where name represents the configmap/secret name, key optionally represents the configmap/secret key to be filtered and path represents the destination path).
 
-|--open-api-spec
+|--open-api
 |Add an OpenAPI spec (syntax: [configmap,file]:name).
 
 |--env
@@ -921,17 +921,17 @@ The syntax to specify openapi trait options is as follows:
 camel kubernetes export Sample.java --trait openapi.[key]=[value]
 ----
 
-TIP: There is also a shortcut option `--open-api-spec=configmap:my-configmap`.
-
-[source,bash]
-----
-camel kubernetes export Sample.java --open-api-spec configmap:[value]
-----
-
 .Example
 [source,bash]
 ----
 camel kubernetes export Sample.java --trait openapi.configmaps=configmap:my-spec
+----
+
+TIP: There is also a shortcut option `--open-api=configmap:my-configmap`.
+
+[source,bash]
+----
+camel kubernetes export Sample.java --open-api configmap:[name-of-configmap]
 ----
 
 This results in the following container specification in the Deployment resource.

--- a/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationRun.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationRun.java
@@ -363,7 +363,9 @@ public class IntegrationRun extends KubernetesBaseCommand {
 
     private void convertOptionsToTraits(Traits traitsSpec) {
         TraitHelper.configureMountTrait(traitsSpec, configs, resources, volumes);
-        TraitHelper.configureOpenApiSpec(traitsSpec, openApis);
+        if (openApis != null) {
+            Stream.of(openApis).forEach(openapi -> TraitHelper.configureOpenApiSpec(traitsSpec, openapi));
+        }
         TraitHelper.configureProperties(traitsSpec, properties);
         TraitHelper.configureBuildProperties(traitsSpec, buildProperties);
         TraitHelper.configureEnvVars(traitsSpec, envVars);

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
@@ -70,9 +70,6 @@ public class KubernetesExport extends Export {
                         description = "Add a runtime resource from a Configmap or a Secret (syntax: [configmap|secret]:name[/key][@path], where name represents the configmap/secret name, key optionally represents the configmap/secret key to be filtered and path represents the destination path).")
     protected String[] resources;
 
-    @CommandLine.Option(names = { "--open-api-spec" }, description = "Add an OpenAPI spec (syntax: [configmap|file]:name).")
-    protected String[] openApis;
-
     @CommandLine.Option(names = { "--env" },
                         description = "Set an environment variable in the integration container, for instance \"-e MY_VAR=my-value\".")
     protected String[] envVars;
@@ -140,6 +137,7 @@ public class KubernetesExport extends Export {
         exportDir = configurer.exportDir;
         files = configurer.files;
         gav = configurer.gav;
+        openapi = configurer.openapi;
         fresh = configurer.fresh;
         download = configurer.download;
         quiet = configurer.quiet;
@@ -224,7 +222,11 @@ public class KubernetesExport extends Export {
         Traits traitsSpec = getTraitSpec();
 
         TraitHelper.configureMountTrait(traitsSpec, configs, resources, volumes);
-        TraitHelper.configureOpenApiSpec(traitsSpec, openApis);
+        if (openapi != null && openapi.startsWith("configmap:")) {
+            TraitHelper.configureOpenApiSpec(traitsSpec, openapi);
+            // Remove OpenAPI spec option to avoid duplicate handling by parent export command
+            openapi = null;
+        }
         TraitHelper.configureProperties(traitsSpec, properties);
         TraitHelper.configureContainerImage(traitsSpec, image,
                 resolvedImageRegistry, resolvedImageGroup, projectName, getVersion());
@@ -472,6 +474,7 @@ public class KubernetesExport extends Export {
             String exportDir,
             List<String> files,
             String gav,
+            String openapi,
             boolean fresh,
             boolean download,
             boolean quiet,

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
@@ -68,7 +68,7 @@ public class KubernetesRun extends KubernetesBaseCommand {
     String[] resources;
 
     @CommandLine.Option(names = { "--open-api" }, description = "Add an OpenAPI spec (syntax: [configmap|file]:name).")
-    String[] openApis;
+    String openApi;
 
     @CommandLine.Option(names = { "--env" },
                         description = "Set an environment variable in the integration container, for instance \"-e MY_VAR=my-value\".")
@@ -182,6 +182,7 @@ public class KubernetesRun extends KubernetesBaseCommand {
                         workingDir,
                         List.of(filePaths),
                         gav,
+                        openApi,
                         true,
                         true,
                         true,
@@ -198,7 +199,6 @@ public class KubernetesRun extends KubernetesBaseCommand {
         export.properties = properties;
         export.configs = configs;
         export.resources = resources;
-        export.openApis = openApis;
         export.envVars = envVars;
         export.volumes = volumes;
         export.connects = connects;

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitHelper.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitHelper.java
@@ -244,8 +244,8 @@ public final class TraitHelper {
         traitsSpec.setCamel(camelTrait);
     }
 
-    public static void configureOpenApiSpec(Traits traitsSpec, String[] openApis) {
-        if (openApis == null || openApis.length == 0) {
+    public static void configureOpenApiSpec(Traits traitsSpec, String openApi) {
+        if (openApi == null || !openApi.startsWith("configmap:")) {
             return;
         }
 
@@ -253,7 +253,7 @@ public final class TraitHelper {
         if (openapiTrait.getConfigmaps() == null) {
             openapiTrait.setConfigmaps(new ArrayList<>());
         }
-        openapiTrait.getConfigmaps().addAll(List.of(openApis));
+        openapiTrait.getConfigmaps().add(openApi);
         traitsSpec.setOpenapi(openapiTrait);
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
@@ -600,8 +600,9 @@ class KubernetesExportTest extends KubernetesBaseTest {
     @ParameterizedTest
     @MethodSource("runtimeProvider")
     public void shouldAddOpenApis(RuntimeType rt) throws Exception {
-        KubernetesExport command = createCommand(new String[] { "classpath:route.yaml" }, "--runtime=" + rt.runtime());
-        command.openApis = new String[] { "configmap:openapi/spec.yaml" };
+        KubernetesExport command = createCommand(new String[] { "classpath:route.yaml" },
+                "--runtime=" + rt.runtime(),
+                "--open-api=configmap:openapi/spec.yaml");
         command.doCall();
 
         Deployment deployment = getDeployment(rt);


### PR DESCRIPTION
# Description

- Use single command option --open-api
- Kubernetes trait configures ConfigMap volume mount for values starting with prefix "configmap:"
- Arbitrary export command adds OpenAPI specification as source to exported project for values without "configmap:" prefix

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

