### PR TITLE
CAMEL-21035: Fix property binding support for map typed values

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
@@ -714,7 +714,7 @@ public final class PropertyBindingSupport {
             obj = ((PropertyConfigurerGetter) configurer).getOptionValue(target, undashKey, ignoreCase);
         }
         if (obj == null) {
-            // it was supposed to be a list or map, but its null, so lets create a new list or map and set it automatically
+            // it was supposed to be a list or map, but its null, so let's create a new list or map and set it automatically
             Class<?> returnType = null;
             if (configurer instanceof PropertyConfigurerGetter) {
                 returnType = ((PropertyConfigurerGetter) configurer).getOptionType(undashKey, true);
@@ -734,6 +734,9 @@ public final class PropertyBindingSupport {
                                                        + " as either a Map/List/array because target bean is not a Map, List or array type: "
                                                        + target);
                 }
+
+                // get the fresh created and configured option value, because the target instance may have created a new list or map as part of the setter
+                obj = ((PropertyConfigurerGetter) configurer).getOptionValue(target, undashKey, ignoreCase);
                 target = obj;
             }
         }


### PR DESCRIPTION
# Description

- Make sure to get the map instance from the component when initializing the map via component configurer
- Avoids to lose the 1st value being set on a wrong map instance when component uses its own map instance in the setter
- See Knative ceOverride map

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

See CAMEL-21035

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

