### PR TITLE
Missing regex parameter for TokenizerExpression on ExpressionClauseSupport

### DIFF
--- a/core/camel-core-model/src/main/java/org/apache/camel/builder/ExpressionClauseSupport.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/builder/ExpressionClauseSupport.java
@@ -856,6 +856,7 @@ public class ExpressionClauseSupport<T> implements ExpressionFactoryAware, Predi
     public T tokenize(String token, boolean regex, int group, boolean skipFirst) {
         TokenizerExpression expression = new TokenizerExpression();
         expression.setToken(token);
+        expression.setRegex(Boolean.toString(regex));
         expression.setSkipFirst(Boolean.toString(skipFirst));
         expression.setGroup(Integer.toString(group));
         expression.setSkipFirst(Boolean.toString(skipFirst));
@@ -875,6 +876,7 @@ public class ExpressionClauseSupport<T> implements ExpressionFactoryAware, Predi
     public T tokenize(String token, boolean regex, String group, boolean skipFirst) {
         TokenizerExpression expression = new TokenizerExpression();
         expression.setToken(token);
+        expression.setRegex(Boolean.toString(regex));
         expression.setSkipFirst(Boolean.toString(skipFirst));
         expression.setGroup(group);
         expression.setSkipFirst(Boolean.toString(skipFirst));
@@ -1198,9 +1200,4 @@ public class ExpressionClauseSupport<T> implements ExpressionFactoryAware, Predi
         }
         return getExpressionValue();
     }
-
-    protected void configureExpression(CamelContext camelContext, Expression expression) {
-        // noop
-    }
-
 }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/language/TokenizerExpression.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/language/TokenizerExpression.java
@@ -238,7 +238,7 @@ public class TokenizerExpression extends SingleInputTypedExpressionDefinition {
         private String skipFirst;
 
         /**
-         * The (start) token to use as tokenizer, for example you can use the new line token. You can use simple
+         * The (start) token to use as tokenizer, for example, you can use the new line token. You can use simple
          * language as the token to support dynamic tokens.
          */
         public Builder token(String token) {
@@ -256,7 +256,7 @@ public class TokenizerExpression extends SingleInputTypedExpressionDefinition {
         }
 
         /**
-         * To inherit namespaces from a root/parent tag name when using XML You can use simple language as the tag name
+         * To inherit namespaces from a root/parent tag name when using XML, you can use simple language as the tag name
          * to support dynamic names.
          */
         public Builder inheritNamespaceTagName(String inheritNamespaceTagName) {
@@ -321,7 +321,7 @@ public class TokenizerExpression extends SingleInputTypedExpressionDefinition {
         }
 
         /**
-         * To group N parts together, for example to split big files into chunks of 1000 lines. You can use simple
+         * To group N parts together, for example, to split big files into chunks of 1000 lines. You can use simple
          * language as the group to support dynamic group sizes.
          */
         public Builder group(String group) {
@@ -330,7 +330,7 @@ public class TokenizerExpression extends SingleInputTypedExpressionDefinition {
         }
 
         /**
-         * To group N parts together, for example to split big files into chunks of 1000 lines. You can use simple
+         * To group N parts together, for example, to split big files into chunks of 1000 lines. You can use simple
          * language as the group to support dynamic group sizes.
          */
         public Builder group(int group) {
@@ -339,7 +339,8 @@ public class TokenizerExpression extends SingleInputTypedExpressionDefinition {
         }
 
         /**
-         * Sets the delimiter to use when grouping. If this has not been set then token will be used as the delimiter.
+         * Sets the delimiter to use when grouping. If this has not been set, then the token will be used as the
+         * delimiter.
          */
         public Builder groupDelimiter(String groupDelimiter) {
             this.groupDelimiter = groupDelimiter;

--- a/core/camel-core/src/test/java/org/apache/camel/language/TokenizeLanguageTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/TokenizeLanguageTest.java
@@ -46,8 +46,8 @@ class TokenizeLanguageTest extends AbstractSingleInputTypedLanguageTest<Tokenize
 
     @Override
     protected void assertBodyReceived(Object expected, Object body) {
-        // uses an scanner, so we need to walk it to get the body
-        if (body instanceof Iterator it) {
+        // uses a scanner, so we need to walk it to get the body
+        if (body instanceof Iterator<?> it) {
             body = it.next();
         }
         super.assertBodyReceived(expected, body);


### PR DESCRIPTION
# Description

Sets `regex` property on `tokenizer()` method on `ExpressionClauseSupport`.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

