### PR TITLE
CAMEL-21038 Filter out app/bean.json so that EIPDocumentationEnricher produces consistent results

### DIFF
--- a/tooling/maven/camel-eip-documentation-enricher-maven-plugin/src/main/java/org/apache/camel/maven/EipDocumentationEnricherMojo.java
+++ b/tooling/maven/camel-eip-documentation-enricher-maven-plugin/src/main/java/org/apache/camel/maven/EipDocumentationEnricherMojo.java
@@ -167,10 +167,15 @@ public class EipDocumentationEnricherMojo extends AbstractMojo {
 
         // include schema files from camel-core-model, camel-core-xml and from camel-spring
         Set<File> files = new HashSet<>();
-        PackageHelper.findJsonFiles(new File(camelCoreModelDir, pathToModelDir), files);
-        PackageHelper.findJsonFiles(new File(camelCoreXmlDir, pathToCoreXmlModelDir), files);
+
+        // Do not include the model/app/bean.json file for enhancement (there are two bean.json)
+        Predicate<File> beanFilter = f -> !(f.getName().equals("bean.json") && f.getParentFile().getName().equals("app"));
+        PackageHelper.findJsonFiles(new File(camelCoreModelDir, pathToModelDir), files, beanFilter);
+        PackageHelper.findJsonFiles(new File(camelCoreXmlDir, pathToCoreXmlModelDir), files, beanFilter);
+
         // spring/blueprint should not include SpringErrorHandlerDefinition (duplicates a file from camel-core-model)
         Predicate<File> filter = f -> !f.getName().equals("errorHandler.json");
+
         if (blueprint) {
             PackageHelper.findJsonFiles(new File(camelSpringDir, pathToSpringModelDir), files, filter);
         } else {


### PR DESCRIPTION

# Description

camel-spring.xsd is being updated quite a bit when devs do builds and devs are having to remove it from their commits quite a bit.     The changes that keep sneaking in look like they are because there are two bean.json's - we need to filter the app/bean.json out when doing documentation enrichment and then the camel-spring.xsd generation will be consistent.

CAMEL-21038 Filter out app/bean.json so that EIPDocumentationEnricher produces consistent results

# Target

- [ x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

