### PR TITLE
CAMEL-20199: Remove synchronized block from Api Collections

### DIFF
--- a/components/camel-as2/camel-as2-component/src/generated/java/org/apache/camel/component/as2/internal/AS2ApiCollection.java
+++ b/components/camel-as2/camel-as2-component/src/generated/java/org/apache/camel/component/as2/internal/AS2ApiCollection.java
@@ -23,8 +23,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class AS2ApiCollection extends ApiCollection<AS2ApiName, AS2Configuration> {
 
-    private static AS2ApiCollection collection;
-
     private AS2ApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<AS2ApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(AS2ApiName.class);
@@ -67,10 +65,11 @@ public final class AS2ApiCollection extends ApiCollection<AS2ApiName, AS2Configu
         return result;
     }
 
-    public static synchronized AS2ApiCollection getCollection() {
-        if (collection == null) {
-            collection = new AS2ApiCollection();
-        }
-        return collection;
+    public static AS2ApiCollection getCollection() {
+        return AS2ApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class AS2ApiCollectionHolder {
+        private static final AS2ApiCollection INSTANCE = new AS2ApiCollection();
     }
 }

--- a/components/camel-box/camel-box-component/src/generated/java/org/apache/camel/component/box/internal/BoxApiCollection.java
+++ b/components/camel-box/camel-box-component/src/generated/java/org/apache/camel/component/box/internal/BoxApiCollection.java
@@ -30,8 +30,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class BoxApiCollection extends ApiCollection<BoxApiName, BoxConfiguration> {
 
-    private static BoxApiCollection collection;
-
     private BoxApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<BoxApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(BoxApiName.class);
@@ -206,10 +204,11 @@ public final class BoxApiCollection extends ApiCollection<BoxApiName, BoxConfigu
         return result;
     }
 
-    public static synchronized BoxApiCollection getCollection() {
-        if (collection == null) {
-            collection = new BoxApiCollection();
-        }
-        return collection;
+    public static BoxApiCollection getCollection() {
+        return BoxApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class BoxApiCollectionHolder {
+        private static final BoxApiCollection INSTANCE = new BoxApiCollection();
     }
 }

--- a/components/camel-braintree/src/generated/java/org/apache/camel/component/braintree/internal/BraintreeApiCollection.java
+++ b/components/camel-braintree/src/generated/java/org/apache/camel/component/braintree/internal/BraintreeApiCollection.java
@@ -39,8 +39,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class BraintreeApiCollection extends ApiCollection<BraintreeApiName, BraintreeConfiguration> {
 
-    private static BraintreeApiCollection collection;
-
     private BraintreeApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<BraintreeApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(BraintreeApiName.class);
@@ -211,10 +209,11 @@ public final class BraintreeApiCollection extends ApiCollection<BraintreeApiName
         return result;
     }
 
-    public static synchronized BraintreeApiCollection getCollection() {
-        if (collection == null) {
-            collection = new BraintreeApiCollection();
-        }
-        return collection;
+    public static BraintreeApiCollection getCollection() {
+        return BraintreeApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class BraintreeApiCollectionHolder {
+        private static final BraintreeApiCollection INSTANCE = new BraintreeApiCollection();
     }
 }

--- a/components/camel-dhis2/camel-dhis2-component/src/generated/java/org/apache/camel/component/dhis2/internal/Dhis2ApiCollection.java
+++ b/components/camel-dhis2/camel-dhis2-component/src/generated/java/org/apache/camel/component/dhis2/internal/Dhis2ApiCollection.java
@@ -25,8 +25,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class Dhis2ApiCollection extends ApiCollection<Dhis2ApiName, Dhis2Configuration> {
 
-    private static Dhis2ApiCollection collection;
-
     private Dhis2ApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<Dhis2ApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(Dhis2ApiName.class);
@@ -85,10 +83,11 @@ public final class Dhis2ApiCollection extends ApiCollection<Dhis2ApiName, Dhis2C
         return result;
     }
 
-    public static synchronized Dhis2ApiCollection getCollection() {
-        if (collection == null) {
-            collection = new Dhis2ApiCollection();
-        }
-        return collection;
+    public static Dhis2ApiCollection getCollection() {
+        return Dhis2ApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class Dhis2ApiCollectionHolder {
+        private static final Dhis2ApiCollection INSTANCE = new Dhis2ApiCollection();
     }
 }

--- a/components/camel-fhir/camel-fhir-component/src/generated/java/org/apache/camel/component/fhir/internal/FhirApiCollection.java
+++ b/components/camel-fhir/camel-fhir-component/src/generated/java/org/apache/camel/component/fhir/internal/FhirApiCollection.java
@@ -33,8 +33,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class FhirApiCollection extends ApiCollection<FhirApiName, FhirConfiguration> {
 
-    private static FhirApiCollection collection;
-
     private FhirApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<FhirApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(FhirApiName.class);
@@ -157,10 +155,11 @@ public final class FhirApiCollection extends ApiCollection<FhirApiName, FhirConf
         return result;
     }
 
-    public static synchronized FhirApiCollection getCollection() {
-        if (collection == null) {
-            collection = new FhirApiCollection();
-        }
-        return collection;
+    public static FhirApiCollection getCollection() {
+        return FhirApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class FhirApiCollectionHolder {
+        private static final FhirApiCollection INSTANCE = new FhirApiCollection();
     }
 }

--- a/components/camel-google/camel-google-calendar/src/generated/java/org/apache/camel/component/google/calendar/internal/GoogleCalendarApiCollection.java
+++ b/components/camel-google/camel-google-calendar/src/generated/java/org/apache/camel/component/google/calendar/internal/GoogleCalendarApiCollection.java
@@ -28,8 +28,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class GoogleCalendarApiCollection extends ApiCollection<GoogleCalendarApiName, GoogleCalendarConfiguration> {
 
-    private static GoogleCalendarApiCollection collection;
-
     private GoogleCalendarApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<GoogleCalendarApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(GoogleCalendarApiName.class);
@@ -112,10 +110,11 @@ public final class GoogleCalendarApiCollection extends ApiCollection<GoogleCalen
         return result;
     }
 
-    public static synchronized GoogleCalendarApiCollection getCollection() {
-        if (collection == null) {
-            collection = new GoogleCalendarApiCollection();
-        }
-        return collection;
+    public static GoogleCalendarApiCollection getCollection() {
+        return GoogleCalendarApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class GoogleCalendarApiCollectionHolder {
+        private static final GoogleCalendarApiCollection INSTANCE = new GoogleCalendarApiCollection();
     }
 }

--- a/components/camel-google/camel-google-drive/src/generated/java/org/apache/camel/component/google/drive/internal/GoogleDriveApiCollection.java
+++ b/components/camel-google/camel-google-drive/src/generated/java/org/apache/camel/component/google/drive/internal/GoogleDriveApiCollection.java
@@ -30,8 +30,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class GoogleDriveApiCollection extends ApiCollection<GoogleDriveApiName, GoogleDriveConfiguration> {
 
-    private static GoogleDriveApiCollection collection;
-
     private GoogleDriveApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<GoogleDriveApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(GoogleDriveApiName.class);
@@ -130,10 +128,11 @@ public final class GoogleDriveApiCollection extends ApiCollection<GoogleDriveApi
         return result;
     }
 
-    public static synchronized GoogleDriveApiCollection getCollection() {
-        if (collection == null) {
-            collection = new GoogleDriveApiCollection();
-        }
-        return collection;
+    public static GoogleDriveApiCollection getCollection() {
+        return GoogleDriveApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class GoogleDriveApiCollectionHolder {
+        private static final GoogleDriveApiCollection INSTANCE = new GoogleDriveApiCollection();
     }
 }

--- a/components/camel-google/camel-google-mail/src/generated/java/org/apache/camel/component/google/mail/internal/GoogleMailApiCollection.java
+++ b/components/camel-google/camel-google-mail/src/generated/java/org/apache/camel/component/google/mail/internal/GoogleMailApiCollection.java
@@ -27,8 +27,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class GoogleMailApiCollection extends ApiCollection<GoogleMailApiName, GoogleMailConfiguration> {
 
-    private static GoogleMailApiCollection collection;
-
     private GoogleMailApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<GoogleMailApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(GoogleMailApiName.class);
@@ -103,10 +101,11 @@ public final class GoogleMailApiCollection extends ApiCollection<GoogleMailApiNa
         return result;
     }
 
-    public static synchronized GoogleMailApiCollection getCollection() {
-        if (collection == null) {
-            collection = new GoogleMailApiCollection();
-        }
-        return collection;
+    public static GoogleMailApiCollection getCollection() {
+        return GoogleMailApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class GoogleMailApiCollectionHolder {
+        private static final GoogleMailApiCollection INSTANCE = new GoogleMailApiCollection();
     }
 }

--- a/components/camel-google/camel-google-sheets/src/generated/java/org/apache/camel/component/google/sheets/internal/GoogleSheetsApiCollection.java
+++ b/components/camel-google/camel-google-sheets/src/generated/java/org/apache/camel/component/google/sheets/internal/GoogleSheetsApiCollection.java
@@ -22,8 +22,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class GoogleSheetsApiCollection extends ApiCollection<GoogleSheetsApiName, GoogleSheetsConfiguration> {
 
-    private static GoogleSheetsApiCollection collection;
-
     private GoogleSheetsApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<GoogleSheetsApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(GoogleSheetsApiName.class);
@@ -58,10 +56,11 @@ public final class GoogleSheetsApiCollection extends ApiCollection<GoogleSheetsA
         return result;
     }
 
-    public static synchronized GoogleSheetsApiCollection getCollection() {
-        if (collection == null) {
-            collection = new GoogleSheetsApiCollection();
-        }
-        return collection;
+    public static GoogleSheetsApiCollection getCollection() {
+        return GoogleSheetsApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class GoogleSheetsApiCollectionHolder {
+        private static final GoogleSheetsApiCollection INSTANCE = new GoogleSheetsApiCollection();
     }
 }

--- a/components/camel-olingo2/camel-olingo2-component/src/generated/java/org/apache/camel/component/olingo2/internal/Olingo2ApiCollection.java
+++ b/components/camel-olingo2/camel-olingo2-component/src/generated/java/org/apache/camel/component/olingo2/internal/Olingo2ApiCollection.java
@@ -21,8 +21,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class Olingo2ApiCollection extends ApiCollection<Olingo2ApiName, Olingo2Configuration> {
 
-    private static Olingo2ApiCollection collection;
-
     private Olingo2ApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<Olingo2ApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(Olingo2ApiName.class);
@@ -49,10 +47,11 @@ public final class Olingo2ApiCollection extends ApiCollection<Olingo2ApiName, Ol
         return result;
     }
 
-    public static synchronized Olingo2ApiCollection getCollection() {
-        if (collection == null) {
-            collection = new Olingo2ApiCollection();
-        }
-        return collection;
+    public static Olingo2ApiCollection getCollection() {
+        return Olingo2ApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class Olingo2ApiCollectionHolder {
+        private static final Olingo2ApiCollection INSTANCE = new Olingo2ApiCollection();
     }
 }

--- a/components/camel-olingo4/camel-olingo4-component/src/generated/java/org/apache/camel/component/olingo4/internal/Olingo4ApiCollection.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/generated/java/org/apache/camel/component/olingo4/internal/Olingo4ApiCollection.java
@@ -21,8 +21,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class Olingo4ApiCollection extends ApiCollection<Olingo4ApiName, Olingo4Configuration> {
 
-    private static Olingo4ApiCollection collection;
-
     private Olingo4ApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<Olingo4ApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(Olingo4ApiName.class);
@@ -49,10 +47,11 @@ public final class Olingo4ApiCollection extends ApiCollection<Olingo4ApiName, Ol
         return result;
     }
 
-    public static synchronized Olingo4ApiCollection getCollection() {
-        if (collection == null) {
-            collection = new Olingo4ApiCollection();
-        }
-        return collection;
+    public static Olingo4ApiCollection getCollection() {
+        return Olingo4ApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class Olingo4ApiCollectionHolder {
+        private static final Olingo4ApiCollection INSTANCE = new Olingo4ApiCollection();
     }
 }

--- a/components/camel-twilio/src/generated/java/org/apache/camel/component/twilio/internal/TwilioApiCollection.java
+++ b/components/camel-twilio/src/generated/java/org/apache/camel/component/twilio/internal/TwilioApiCollection.java
@@ -74,8 +74,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class TwilioApiCollection extends ApiCollection<TwilioApiName, TwilioConfiguration> {
 
-    private static TwilioApiCollection collection;
-
     private TwilioApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<TwilioApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(TwilioApiName.class);
@@ -796,10 +794,11 @@ public final class TwilioApiCollection extends ApiCollection<TwilioApiName, Twil
         return result;
     }
 
-    public static synchronized TwilioApiCollection getCollection() {
-        if (collection == null) {
-            collection = new TwilioApiCollection();
-        }
-        return collection;
+    public static TwilioApiCollection getCollection() {
+        return TwilioApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class TwilioApiCollectionHolder {
+        private static final TwilioApiCollection INSTANCE = new TwilioApiCollection();
     }
 }

--- a/components/camel-zendesk/src/generated/java/org/apache/camel/component/zendesk/internal/ZendeskApiCollection.java
+++ b/components/camel-zendesk/src/generated/java/org/apache/camel/component/zendesk/internal/ZendeskApiCollection.java
@@ -21,8 +21,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class ZendeskApiCollection extends ApiCollection<ZendeskApiName, ZendeskConfiguration> {
 
-    private static ZendeskApiCollection collection;
-
     private ZendeskApiCollection() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<ZendeskApiName, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(ZendeskApiName.class);
@@ -49,10 +47,11 @@ public final class ZendeskApiCollection extends ApiCollection<ZendeskApiName, Ze
         return result;
     }
 
-    public static synchronized ZendeskApiCollection getCollection() {
-        if (collection == null) {
-            collection = new ZendeskApiCollection();
-        }
-        return collection;
+    public static ZendeskApiCollection getCollection() {
+        return ZendeskApiCollectionHolder.INSTANCE;
+    }
+
+    private static final class ZendeskApiCollectionHolder {
+        private static final ZendeskApiCollection INSTANCE = new ZendeskApiCollection();
     }
 }

--- a/tooling/maven/camel-api-component-maven-plugin/src/main/resources/api-collection.vm
+++ b/tooling/maven/camel-api-component-maven-plugin/src/main/resources/api-collection.vm
@@ -41,8 +41,6 @@ import org.apache.camel.support.component.ApiMethodHelper;
  */
 public final class $collectionName extends ApiCollection<${apiNameEnum}, ${componentConfig}> {
 
-    private static $collectionName collection;
-
     private ${collectionName}() {
         final Map<String, String> aliases = new HashMap<>();
         final Map<${apiNameEnum}, ApiMethodHelper<? extends ApiMethod>> apiHelpers = new EnumMap<>(${apiNameEnum}.class);
@@ -78,10 +76,11 @@ public final class $collectionName extends ApiCollection<${apiNameEnum}, ${compo
         return result;
     }
 
-    public static synchronized $collectionName getCollection() {
-        if (collection == null) {
-            collection = new $collectionName();
-        }
-        return collection;
+    public static $collectionName getCollection() {
+        return ${collectionName}Holder.INSTANCE;
+    }
+
+    private static final class ${collectionName}Holder {
+        private static final $collectionName INSTANCE = new $collectionName();
     }
 }


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-20199

## Motivation

For better support of virtual threads, we need to avoid lengthy and frequent pinning by replacing synchronized blocks with ReentrantLocks

## Modifications:

* Uses the [initialization-on-demand holder idiom](https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom) to avoid using synchronized blocks in Api Collections

