### PR TITLE
make PythonLanguage and PythonExpression cache compiled PyCode objects

### DIFF
--- a/components/camel-python/src/test/java/org/apache/camel/language/python/PythonScriptingLanguageTest.java
+++ b/components/camel-python/src/test/java/org/apache/camel/language/python/PythonScriptingLanguageTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.language.python;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.spi.Language;
+import org.apache.camel.spi.ScriptingLanguage;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PythonScriptingLanguageTest extends CamelTestSupport {
+
+    @Test
+    public void testScripting() {
+        Language lan = context.resolveLanguage("python");
+        Assertions.assertTrue(lan instanceof ScriptingLanguage);
+        ScriptingLanguage slan = (ScriptingLanguage) lan;
+
+        int num = slan.evaluate("2 * 3", null, int.class);
+        Assertions.assertEquals(6, num);
+
+        Map<String, Object> bindings = new HashMap<>();
+        bindings.put("context", context());
+        String id = slan.evaluate("context.name", bindings, String.class);
+        Assertions.assertEquals(context.getName(), id);
+    }
+
+    @Test
+    public void testExternalScripting() {
+        Language lan = context.resolveLanguage("python");
+        Assertions.assertTrue(lan instanceof ScriptingLanguage);
+        ScriptingLanguage slan = (ScriptingLanguage) lan;
+
+        Map<String, Object> bindings = new HashMap<>();
+        bindings.put("body", 3);
+        String text = slan.evaluate("resource:classpath:mypython.py", bindings, String.class);
+        Assertions.assertEquals("The result is 6", text);
+    }
+}

--- a/components/camel-python/src/test/java/org/apache/camel/language/python/PythonTest.java
+++ b/components/camel-python/src/test/java/org/apache/camel/language/python/PythonTest.java
@@ -16,8 +16,12 @@
  */
 package org.apache.camel.language.python;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.test.junit5.LanguageTestSupport;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PythonTest extends LanguageTestSupport {
 
@@ -30,6 +34,19 @@ public class PythonTest extends LanguageTestSupport {
         exchange.getMessage().setBody(7);
         exchange.getMessage().setHeader("foo", "bar");
         assertExpression("headers['foo']", "bar");
+    }
+
+    @Test
+    void testPythonExpressionRepeatableEvaluation() {
+        PythonLanguage python = new PythonLanguage();
+        PythonExpression expression = (PythonExpression) python.createExpression("body == 5");
+        Exchange exchange = createExchange();
+
+        exchange.getIn().setBody(5);
+        assertTrue(expression.evaluate(exchange, Boolean.class));
+
+        exchange.getIn().setBody(6);
+        assertFalse(expression.evaluate(exchange, Boolean.class));
     }
 
     @Override

--- a/components/camel-python/src/test/resources/mypython.py
+++ b/components/camel-python/src/test/resources/mypython.py
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"The result is " + str(body * 2)


### PR DESCRIPTION
# Description
Instead of calling `PythonInterpreter`'s `eval(String s)` method each time we evaluate python expression, we can call `compile(String script)` method, cache the `PyCode` result and call `eval(PyObject code)`. This way we avoid making unnecessary `Py.compile_flags` calls.
This is also needed for camel-quarkus-python extension (https://github.com/apache/camel-quarkus/issues/4408) because if we're compiling expressions each time on evaluation, there is nothing to pre-process at the build stage.