### PR TITLE
CAMEL-21044: Fix missing Azure Service Bus FQNS configuration

### DIFF
--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/client/ServiceBusClientFactory.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/client/ServiceBusClientFactory.java
@@ -21,10 +21,8 @@ import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.messaging.servicebus.ServiceBusClientBuilder;
 import com.azure.messaging.servicebus.ServiceBusReceiverAsyncClient;
 import com.azure.messaging.servicebus.ServiceBusSenderAsyncClient;
-import org.apache.camel.component.azure.servicebus.CredentialType;
 import org.apache.camel.component.azure.servicebus.ServiceBusConfiguration;
 import org.apache.camel.component.azure.servicebus.ServiceBusType;
-import org.apache.camel.util.ObjectHelper;
 
 public final class ServiceBusClientFactory {
 
@@ -57,16 +55,12 @@ public final class ServiceBusClientFactory {
         String fullyQualifiedNamespace = configuration.getFullyQualifiedNamespace();
         TokenCredential credential = configuration.getTokenCredential();
 
-        if (configuration.getCredentialType().equals(CredentialType.CONNECTION_STRING)) {
-            builder.connectionString(configuration.getConnectionString());
-        } else if (configuration.getCredentialType().equals(CredentialType.TOKEN_CREDENTIAL)) {
-            // If the FQNS and credential are available, use those to connect
-            if (ObjectHelper.isNotEmpty(fullyQualifiedNamespace) && ObjectHelper.isNotEmpty(credential)) {
-                builder.credential(fullyQualifiedNamespace, credential);
-            }
-        } else {
-            builder.credential(new DefaultAzureCredentialBuilder().build());
+        switch (configuration.getCredentialType()) {
+            case CONNECTION_STRING -> builder.connectionString(configuration.getConnectionString());
+            case TOKEN_CREDENTIAL -> builder.credential(fullyQualifiedNamespace, credential);
+            case AZURE_IDENTITY -> builder.credential(fullyQualifiedNamespace, new DefaultAzureCredentialBuilder().build());
         }
+
         return builder;
     }
 


### PR DESCRIPTION
# Description

The Azure Service Bus client requires that a FQNS be specified when not using a connection string. This was not being done in all applicable configurations.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes