### PR TITLE
CAMEL-21048: Add required dot in MLLP ACK timestamp pattern.

### DIFF
--- a/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/internal/Hl7Util.java
+++ b/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/internal/Hl7Util.java
@@ -35,7 +35,7 @@ public final class Hl7Util {
 
     public static final Map<Character, String> CHARACTER_REPLACEMENTS;
 
-    public static final SimpleDateFormat TIMESTAMP_FORMAT = new SimpleDateFormat("yyyyMMddHHmmssSSSZZZZ");
+    public static final SimpleDateFormat TIMESTAMP_FORMAT = new SimpleDateFormat("yyyyMMddHHmmss.SSSZZZZ");
 
     static final int STRING_BUFFER_PAD_SIZE = 100;
 

--- a/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/internal/Hl7UtilTest.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/internal/Hl7UtilTest.java
@@ -29,6 +29,7 @@ import static org.apache.camel.component.mllp.MllpExceptionTestSupport.LOG_PHI_T
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -206,6 +207,16 @@ public class Hl7UtilTest {
 
         assertThat(actual, startsWith(EXPECTED_ACKNOWLEDGEMENT_PAYLOAD_START));
         assertThat(actual, endsWith(EXPECTED_ACKNOWLEDGEMENT_PAYLOAD_END));
+    }
+
+    @Test
+    public void testGenerateAcknowledgementPayloadTimestamp() throws Exception {
+        MllpSocketBuffer mllpSocketBuffer = new MllpSocketBuffer(new MllpEndpointStub());
+        hl7util.generateAcknowledgementPayload(mllpSocketBuffer, TEST_MESSAGE.getBytes(), "AA");
+
+        String actualMsh7Field = mllpSocketBuffer.toString().split("\\|")[6];
+
+        assertThat(actualMsh7Field, matchesPattern("\\d{14}\\.\\d{3}[+-]\\d{4}"));
     }
 
     /**


### PR DESCRIPTION
# Description

When using Camel MLLP an ACK is sent for each message received. Each ACK contains a timestamp in MSH-7.1. The ACK being sent was using an invalid pattern for this timestamp: yyyyMMddHHmmssSSSZZZZ instead of yyyyMMddHHmmss.SSSZZZZ (see: https://hl7-definition.caristix.com/v2/HL7v2.5.1/DataTypes/DTM)


# Target

main

# Tracking
[https://issues.apache.org/jira/browse/CAMEL-21048](https://issues.apache.org/jira/browse/CAMEL-21048)

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

- [X] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes
