### PR TITLE
Improve JBang Kubernetes plugin logs command parameter

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/Bind.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/Bind.java
@@ -207,7 +207,7 @@ public class Bind extends KubernetesBaseCommand {
         if (logs) {
             IntegrationLogs logsCommand = new IntegrationLogs(getMain());
             logsCommand.withClient(client());
-            logsCommand.name = pipeResource.getMetadata().getName();
+            logsCommand.withName(pipeResource.getMetadata().getName());
             logsCommand.doCall();
         }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationRun.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationRun.java
@@ -354,7 +354,7 @@ public class IntegrationRun extends KubernetesBaseCommand {
         if (logs) {
             IntegrationLogs logsCommand = new IntegrationLogs(getMain());
             logsCommand.withClient(client());
-            logsCommand.name = integration.getMetadata().getName();
+            logsCommand.withName(integration.getMetadata().getName());
             logsCommand.doCall();
         }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-k/src/test/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationLogsTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-k/src/test/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationLogsTest.java
@@ -31,7 +31,7 @@ class IntegrationLogsTest extends CamelKBaseTest {
     @Test
     public void shouldHandleIntegrationsNotFound() throws Exception {
         IntegrationLogs command = createCommand();
-        command.name = "mickey-mouse";
+        command.withName("mickey-mouse");
         command.doCall();
 
         Assertions.assertEquals("Integration mickey-mouse not found", printer.getOutput());
@@ -56,7 +56,7 @@ class IntegrationLogsTest extends CamelKBaseTest {
 
         IntegrationLogs command = createCommand();
 
-        command.name = "routes";
+        command.withName("routes");
         int exit = command.doCall();
         Assertions.assertEquals(0, exit);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesDelete.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesDelete.java
@@ -31,9 +31,9 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "delete", description = "Delete Camel application from Kubernetes", sortOptions = false)
 public class KubernetesDelete extends KubernetesBaseCommand {
 
-    @CommandLine.Parameters(description = "The Camel file(s) to delete.",
-                            arity = "0..9", paramLabel = "<files>")
-    String[] filePaths;
+    @CommandLine.Parameters(description = "The Camel file to delete. Integration name is derived from the file name.",
+                            arity = "0..1", paramLabel = "<file>")
+    String filePath;
 
     @CommandLine.Option(names = { "--name" },
                         description = "The integration name. Use this when the name should not get derived from the source file name.")
@@ -55,8 +55,8 @@ public class KubernetesDelete extends KubernetesBaseCommand {
             String projectName;
             if (name != null) {
                 projectName = KubernetesHelper.sanitize(name);
-            } else if (filePaths != null && filePaths.length > 0) {
-                projectName = KubernetesHelper.sanitize(FileUtil.onlyName(SourceScheme.onlyName(filePaths[0])));
+            } else if (filePath != null) {
+                projectName = KubernetesHelper.sanitize(FileUtil.onlyName(SourceScheme.onlyName(filePath)));
             } else {
                 printer().println("Name or source file must be set");
                 return 1;

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/PodLogs.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/PodLogs.java
@@ -26,11 +26,17 @@ import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.BaseTrait;
+import org.apache.camel.dsl.jbang.core.common.SourceScheme;
+import org.apache.camel.util.FileUtil;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "logs", description = "Print the logs of a Kubernetes pod", sortOptions = false)
 public class PodLogs extends KubernetesBaseCommand {
+
+    @CommandLine.Parameters(description = "The Camel file to get logs from. Integration name is derived from the file name.",
+                            arity = "0..1", paramLabel = "<file>")
+    protected String filePath;
 
     @CommandLine.Option(names = { "--name" },
                         description = "The integration name. Use this when the name should not get derived from the source file name.")
@@ -56,13 +62,20 @@ public class PodLogs extends KubernetesBaseCommand {
     }
 
     public Integer doCall() throws Exception {
-        if (name == null && label == null) {
+        if (name == null && label == null && filePath == null) {
             printer().println("Name or label selector must be set");
             return 1;
         }
 
-        if (name != null) {
-            label = "%s=%s".formatted(BaseTrait.INTEGRATION_LABEL, name);
+        if (label == null) {
+            String projectName;
+            if (name != null) {
+                projectName = KubernetesHelper.sanitize(name);
+            } else {
+                projectName = KubernetesHelper.sanitize(FileUtil.onlyName(SourceScheme.onlyName(filePath)));
+            }
+
+            label = "%s=%s".formatted(BaseTrait.INTEGRATION_LABEL, projectName);
         }
 
         String[] parts = label.split("=", 2);


### PR DESCRIPTION
# Description

- Support file path as a command parameter and automatically derive the integration name from the file name
- Support --name and --label arguments in Camel K plugin logs command

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

