### PR TITLE
CAMEL-21013: Fix JBang kubernetes plugin deployment to OpenShift

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-k/src/test/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-k/src/test/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationExportTest.java
@@ -28,6 +28,8 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.ClusterType;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.KubernetesHelper;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.BaseTrait;
 import org.apache.camel.dsl.jbang.core.common.RuntimeType;
 import org.junit.jupiter.api.Assertions;
@@ -107,7 +109,9 @@ class IntegrationExportTest extends CamelKBaseTest {
     }
 
     private <T extends HasMetadata> Optional<T> getResource(RuntimeType rt, Class<T> type) throws IOException {
-        try (FileInputStream fis = new FileInputStream(new File(workingDir, "src/main/kubernetes/kubernetes.yml"))) {
+        try (FileInputStream fis = new FileInputStream(
+                KubernetesHelper.getKubernetesManifest(ClusterType.KUBERNETES.name(),
+                        new File(workingDir, "/src/main/kubernetes")))) {
             List<HasMetadata> resources = kubernetesClient.load(fis).items();
             return resources.stream()
                     .filter(it -> type.isAssignableFrom(it.getClass()))

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/ClusterType.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/ClusterType.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.dsl.jbang.core.commands.kubernetes;
+
+import java.util.Arrays;
+
+/**
+ * Known default cluster types.
+ */
+public enum ClusterType {
+    KUBERNETES,
+    OPENSHIFT,
+    KIND,
+    MINIKUBE;
+
+    public static ClusterType fromName(String name) {
+        return Arrays.stream(values())
+                .filter(ct -> ct.name().equalsIgnoreCase(name))
+                .findFirst().orElseThrow(() -> new IllegalArgumentException("Unknown cluster type: %s".formatted(name)));
+    }
+
+    public boolean isEqualTo(String clusterType) {
+        if (clusterType == null) {
+            return false;
+        }
+
+        return this == fromName(clusterType);
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesDelete.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesDelete.java
@@ -70,7 +70,7 @@ public class KubernetesDelete extends KubernetesBaseCommand {
             return 1;
         }
 
-        File manifest = new File(resolvedWorkingDir, "target/kubernetes/kubernetes.yml");
+        File manifest = KubernetesHelper.resolveKubernetesManifest(new File(resolvedWorkingDir, "target/kubernetes"));
         try (FileInputStream fis = new FileInputStream(manifest)) {
             List<StatusDetails> status;
             if (namespace != null) {

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
@@ -271,33 +271,34 @@ public class KubernetesExport extends Export {
         if (runtime == RuntimeType.quarkus) {
 
             // Quarkus specific dependencies
-            if (clusterType != null && clusterType.equals("openshift")) {
+            if (ClusterType.OPENSHIFT.isEqualTo(clusterType)) {
                 addDependencies("io.quarkus:quarkus-openshift");
-                if (imageBuilder == null) {
-                    // use s2i image builder as a default on OpenShift
-                    imageBuilder = "s2i";
-                }
             } else {
                 addDependencies("io.quarkus:quarkus-kubernetes");
+
+                // on clusters other than OpenShift we need a default image builder
+                if (imageBuilder == null) {
+                    imageBuilder = "jib";
+                }
             }
 
             // TODO: remove when fixed kubernetes-client version is part of the Quarkus platform
             // pin kubernetes-client to this version because of https://github.com/fabric8io/kubernetes-client/issues/6059
             addDependencies("io.fabric8:kubernetes-client:6.13.2");
 
-            // Configure image builder - use Jib by default
-            if (imageBuilder == null) {
-                addDependencies("io.quarkus:quarkus-container-image-jib");
-            } else if (imageBuilder.equals("s2i")) {
-                addDependencies("io.quarkus:quarkus-container-image-openshift");
-            } else {
+            // auto translate s2i image builder to openshift
+            if ("s2i".equals(imageBuilder)) {
+                imageBuilder = "openshift";
+            }
+
+            // Configure image builder
+            if (imageBuilder != null) {
                 addDependencies("io.quarkus:quarkus-container-image-%s".formatted(imageBuilder));
+                buildProperties.add("quarkus.container-image.builder=%s".formatted(imageBuilder));
             }
 
             // Quarkus specific properties
             buildProperties.add("quarkus.container-image.build=true");
-            buildProperties
-                    .add("quarkus.container-image.builder=%s".formatted(Optional.ofNullable(imageBuilder).orElse("jib")));
         }
 
         // SpringBoot Runtime specific
@@ -330,7 +331,7 @@ public class KubernetesExport extends Export {
         if (runtime == RuntimeType.quarkus) {
             var kubeManifest = kubeFragments.stream().map(KubernetesHelper::dumpYaml).collect(Collectors.joining("---\n"));
             safeCopy(new ByteArrayInputStream(kubeManifest.getBytes(StandardCharsets.UTF_8)),
-                    new File(exportDir + "/src/main/kubernetes/kubernetes.yml"));
+                    KubernetesHelper.getKubernetesManifest(clusterType, exportDir + "/src/main/kubernetes"));
         }
 
         // SpringBoot: dump each fragment to its respective kind
@@ -435,12 +436,10 @@ public class KubernetesExport extends Export {
             }
         }
 
-        if (clusterType != null) {
-            if (clusterType.equals("kind")) {
-                return "localhost:5001";
-            } else if (clusterType.equals("minikube")) {
-                return "localhost:5000";
-            }
+        if (ClusterType.KIND.isEqualTo(clusterType)) {
+            return "localhost:5001";
+        } else if (ClusterType.MINIKUBE.isEqualTo(clusterType)) {
+            return "localhost:5000";
         }
 
         return null;

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
@@ -740,7 +740,10 @@ class KubernetesExportTest extends KubernetesBaseTest {
 
     private <T extends HasMetadata> Optional<T> getResource(RuntimeType rt, Class<T> type) throws IOException {
         if (rt == RuntimeType.quarkus) {
-            try (FileInputStream fis = new FileInputStream(new File(workingDir, "src/main/kubernetes/kubernetes.yml"))) {
+            try (FileInputStream fis
+                    = new FileInputStream(
+                            KubernetesHelper.getKubernetesManifest(ClusterType.KUBERNETES.name(),
+                                    new File(workingDir, "/src/main/kubernetes")))) {
                 List<HasMetadata> resources = kubernetesClient.load(fis).items();
                 return resources.stream()
                         .filter(it -> type.isAssignableFrom(it.getClass()))


### PR DESCRIPTION
# Description

- Fix deploy to OpenShift for runtime Quarkus
- Use cluster specific Kubernetes manifest to deploy to OpenShift (kubernetes.yml or openshift.yml)
- Make sure generated manifest includes OpenShift specific resources such as ImageStream or BuildConfig
- Fix image builder name for S2i (use openshift instead of s2i)

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally and I have committed all auto-generated changes

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

