### PR TITLE
chore(camel-jbang): Remove obsolete kubernetes-client workaround

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
@@ -282,10 +282,6 @@ public class KubernetesExport extends Export {
                 }
             }
 
-            // TODO: remove when fixed kubernetes-client version is part of the Quarkus platform
-            // pin kubernetes-client to this version because of https://github.com/fabric8io/kubernetes-client/issues/6059
-            addDependencies("io.fabric8:kubernetes-client:6.13.2");
-
             // auto translate s2i image builder to openshift
             if ("s2i".equals(imageBuilder)) {
                 imageBuilder = "openshift";


### PR DESCRIPTION
# Description

No need to pin the kubernetes-client version anymore as Camel uses Quarkus 3.13.1
