### PR TITLE
CAMEL-21078: allow enabling adviceWith

### DIFF
--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/TestExecutionConfiguration.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/TestExecutionConfiguration.java
@@ -105,8 +105,7 @@ public class TestExecutionConfiguration {
      *
      * @return <tt>true</tt> if you use advice with in your unit tests.
      */
-    @Deprecated(since = "4.7.0")
-    protected TestExecutionConfiguration withUseAdviceWith(boolean useAdviceWith) {
+    public TestExecutionConfiguration withUseAdviceWith(boolean useAdviceWith) {
         this.useAdviceWith = useAdviceWith;
         return this;
     }


### PR DESCRIPTION
Preventing enabling adviceWith is overly restrictive and blocks usage of a valid user feature.