### PR TITLE
CAMEL-20638: camel-platform-http - Do not return http request headers - FIX

### DIFF
--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpEndpoint.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpEndpoint.java
@@ -183,7 +183,7 @@ public class PlatformHttpEndpoint extends DefaultEndpoint
                 if (COMMON_HTTP_REQUEST_HEADERS.contains(headerName)) {
                     return true;
                 }
-                return headerFilterStrategy.applyFilterToExternalHeaders(headerName, headerValue, exchange);
+                return headerFilterStrategy.applyFilterToCamelHeaders(headerName, headerValue, exchange);
             }
 
             @Override

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/JettyCustomPlatformHttpConsumer.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/JettyCustomPlatformHttpConsumer.java
@@ -182,6 +182,11 @@ public class JettyCustomPlatformHttpConsumer extends DefaultConsumer implements 
         }
 
         for (HttpField header : request.getHeaders()) {
+            String headerName = header.getName();
+            String headerValue = header.getValue();
+            if (getEndpoint().getHeaderFilterStrategy().applyFilterToExternalHeaders(headerName, headerValue, exchange)) {
+                continue;
+            }
             message.setHeader(header.getName(), header.getValue());
         }
 

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/PlatformHttpReturnHttpRequestHeadersTest.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/PlatformHttpReturnHttpRequestHeadersTest.java
@@ -17,9 +17,11 @@
 package org.apache.camel.component.platform.http;
 
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.support.DefaultHeaderFilterStrategy;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
 
 public class PlatformHttpReturnHttpRequestHeadersTest extends AbstractPlatformHttpTest {
 
@@ -65,15 +67,42 @@ public class PlatformHttpReturnHttpRequestHeadersTest extends AbstractPlatformHt
                 .get("/get");
     }
 
+    @Test
+    void testReturnHttpRequestHeadersFalseWithCustomHeaderFilterStrategy() {
+        given()
+                .header("Accept", "application/json")
+                .header("User-Agent", "User-Agent-Camel")
+                .header("Custom_In_Header", "Custom_In_Header_Value")
+                .header("Custom_Out_Header", "Custom_Out_Header_Value")
+                .port(port)
+                .expect()
+                .statusCode(200)
+                .header("Accept", (String) null)
+                .header("User-Agent", (String) null)
+                .header("Custom_In_Header", (String) null)
+                .header("Custom_Out_Header", (String) null)
+                .body(is("Custom_In_Header=, Custom_Out_Header=Custom_Out_Header_Value"))
+                .when()
+                .get("/getWithCustomHeaderFilterStrategy");
+    }
+
     @Override
     protected RouteBuilder routes() {
         return new RouteBuilder() {
             @Override
             public void configure() {
+                DefaultHeaderFilterStrategy testHeaderFilterStrategy = new DefaultHeaderFilterStrategy();
+                testHeaderFilterStrategy.getInFilter().add("Custom_In_Header");
+                testHeaderFilterStrategy.getOutFilter().add("Custom_Out_Header");
+                getContext().getRegistry().bind("testHeaderFilterStrategy", testHeaderFilterStrategy);
+
                 from("platform-http:/getWithoutRequestHeadersReturn?returnHttpRequestHeaders=false")
                         .setBody().constant("getWithoutRequestHeadersReturn");
                 from("platform-http:/getWithRequestHeadersReturn?returnHttpRequestHeaders=true")
                         .setBody().constant("getWithRequestHeadersReturn");
+                from("platform-http:/getWithCustomHeaderFilterStrategy?headerFilterStrategy=#testHeaderFilterStrategy")
+                        .setBody()
+                        .simple("Custom_In_Header=${header.Custom_In_Header}, Custom_Out_Header=${header.Custom_Out_Header}");
                 from("platform-http:/get")
                         .setBody().constant("get");
             }


### PR DESCRIPTION
# Description
- fix typo in PlatformHttpEndpoint that was calling applyFilterToExternalHeaders in place where applyFilterToCamelHeaders must be called; added test that covers this behavior

# Tracking
https://issues.apache.org/jira/browse/CAMEL-20638
