### PR TITLE
Update azure-sdk-bom to 1.2.26

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -70,8 +70,8 @@
         <awaitility-version>4.2.1</awaitility-version>
         <aws-java-sdk2-version>2.24.0</aws-java-sdk2-version>
         <aws-xray-version>2.15.0</aws-xray-version>
-        <azure-sdk-bom-version>1.2.20</azure-sdk-bom-version>
-        <azure-storage-blob-changefeed-version>12.0.0-beta.19</azure-storage-blob-changefeed-version>
+        <azure-sdk-bom-version>1.2.26</azure-sdk-bom-version>
+        <azure-storage-blob-changefeed-version>12.0.0-beta.24</azure-storage-blob-changefeed-version>
         <beanio-version>3.0.0</beanio-version>
         <bouncycastle-version>1.77</bouncycastle-version>
         <box-java-sdk-version>4.7.0</box-java-sdk-version>

--- a/test-infra/camel-test-infra-azure-common/src/test/resources/org/apache/camel/test/infra/azure/common/services/container.properties
+++ b/test-infra/camel-test-infra-azure-common/src/test/resources/org/apache/camel/test/infra/azure/common/services/container.properties
@@ -14,4 +14,4 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-azure.container=mcr.microsoft.com/azure-storage/azurite:3.28.0
+azure.container=mcr.microsoft.com/azure-storage/azurite:3.31.0


### PR DESCRIPTION
# Description

Update azure-sdk-bom to 1.2.26 and upgrade the azurite container to 3.31.0 on 4.4.x

Built -DskipTests successfully and ran azure tests locally.