### PR TITLE
CAMEL-21011 - improve error message with Camel JBang

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-core/pom.xml
@@ -135,6 +135,12 @@
             <artifactId>camel-test-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>${junit-pioneer-version}</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelJBangMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelJBangMain.java
@@ -36,6 +36,7 @@ import org.apache.camel.dsl.jbang.core.commands.config.ConfigGet;
 import org.apache.camel.dsl.jbang.core.commands.config.ConfigList;
 import org.apache.camel.dsl.jbang.core.commands.config.ConfigSet;
 import org.apache.camel.dsl.jbang.core.commands.config.ConfigUnset;
+import org.apache.camel.dsl.jbang.core.commands.exceptionhandler.MissingPluginParameterExceptionHandler;
 import org.apache.camel.dsl.jbang.core.commands.plugin.PluginAdd;
 import org.apache.camel.dsl.jbang.core.commands.plugin.PluginCommand;
 import org.apache.camel.dsl.jbang.core.commands.plugin.PluginDelete;
@@ -155,7 +156,8 @@ public class CamelJBangMain implements Callable<Integer> {
                 .addSubcommand("version", new CommandLine(new VersionCommand(main))
                         .addSubcommand("get", new CommandLine(new VersionGet(main)))
                         .addSubcommand("set", new CommandLine(new VersionSet(main)))
-                        .addSubcommand("list", new CommandLine(new VersionList(main))));
+                        .addSubcommand("list", new CommandLine(new VersionList(main))))
+                .setParameterExceptionHandler(new MissingPluginParameterExceptionHandler());
 
         PluginHelper.addPlugins(commandLine, main, args);
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/exceptionhandler/MissingPluginParameterExceptionHandler.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/exceptionhandler/MissingPluginParameterExceptionHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.exceptionhandler;
+
+import java.io.PrintWriter;
+
+import picocli.CommandLine;
+import picocli.CommandLine.IParameterExceptionHandler;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.UnmatchedArgumentException;
+
+public class MissingPluginParameterExceptionHandler implements IParameterExceptionHandler {
+
+    @Override
+    public int handleParseException(ParameterException ex, String[] args) throws Exception {
+        CommandLine cmd = ex.getCommandLine();
+        PrintWriter err = cmd.getErr();
+
+        if ("DEBUG".equalsIgnoreCase(System.getProperty("picocli.trace"))) {
+            err.println(cmd.getColorScheme().stackTraceText(ex));
+        }
+
+        err.println(cmd.getColorScheme().errorText(ex.getMessage()));
+        UnmatchedArgumentException.printSuggestions(ex, err);
+        err.print(cmd.getHelp().fullSynopsis());
+
+        CommandSpec spec = cmd.getCommandSpec();
+        err.printf("Try '%s --help' for more information.%n", spec.qualifiedName());
+
+        if (ex.getMessage().startsWith("Unmatched argument at index 0")) {
+            err.println(cmd.getColorScheme().errorText("Maybe a specific plugin must be installed?"));
+        }
+
+        return cmd.getExitCodeExceptionMapper() != null
+                ? cmd.getExitCodeExceptionMapper().getExitCode(ex)
+                : spec.exitCodeOnInvalidInput();
+    }
+
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/exceptionhandler/ParameterExceptionHandlerTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/exceptionhandler/ParameterExceptionHandlerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.exceptionhandler;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.StdErr;
+import org.junitpioneer.jupiter.StdIo;
+
+class ParameterExceptionHandlerTest {
+
+    @Test
+    @StdIo
+    void testPluginMessage(StdErr err) {
+        CamelJBangMain camelJBangMainNotExiting = createCamelJBangMain();
+        CamelJBangMain.run(camelJBangMainNotExiting, "firstInvalid");
+
+        String[] lines = err.capturedLines();
+        Assertions.assertEquals(5, lines.length, "5 lines for the error is expected but received " + lines.length);
+        Assertions.assertEquals("Unmatched argument at index 0: 'firstInvalid'", lines[0],
+                "First line mentioning unmatched argument");
+        Assertions.assertEquals("Did you mean: camel bind or camel plugin or camel version?", lines[1],
+                "Second line with suggestion in case it is a typo");
+        Assertions.assertEquals("Maybe a specific plugin must be installed?", lines[4], "Last line suggesting new plugin");
+    }
+
+    @Test
+    @StdIo
+    void testNotPluginMessageWhenErrorNotOnFirstArgument(StdErr err) {
+        CamelJBangMain camelJBangMainNotExiting = createCamelJBangMain();
+        CamelJBangMain.run(camelJBangMainNotExiting, "plugin", "secondInvalid");
+
+        String[] lines = err.capturedLines();
+        Assertions.assertEquals(3, lines.length, "3 lines for the error is expected but received " + lines.length);
+        Assertions.assertEquals("Unmatched argument at index 1: 'secondInvalid'", lines[0],
+                "First line mentioning unmatched argument");
+        Assertions.assertEquals("Usage: camel plugin [-h] [COMMAND]", lines[1], "Second line with usage");
+        Assertions.assertEquals("Try 'camel plugin --help' for more information.", lines[2],
+                "Last line with what to try to get help");
+    }
+
+    private CamelJBangMain createCamelJBangMain() {
+        CamelJBangMain camelJBangMainNotExiting = new CamelJBangMain() {
+            @Override
+            public void quit(int exitCode) {
+                // Do not exit in unit test
+            }
+        };
+        return camelJBangMainNotExiting;
+    }
+
+}


### PR DESCRIPTION
when a plugin might not be installed and is required

# Description

see documentation in picocli https://picocli.info/#_handling_errors it is providing the example providing the same message than the default handler

This can be further improved if we have access to the list of installable plugins and providing the exact command to do it.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

