### PR TITLE
CAMEL-21011 - improve error message with Camel JBang

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/exceptionhandler/MissingPluginParameterExceptionHandler.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/exceptionhandler/MissingPluginParameterExceptionHandler.java
@@ -43,7 +43,8 @@ public class MissingPluginParameterExceptionHandler implements IParameterExcepti
         err.printf("Try '%s --help' for more information.%n", spec.qualifiedName());
 
         if (ex.getMessage().startsWith("Unmatched argument at index 0")) {
-            err.println(cmd.getColorScheme().errorText("Maybe a specific plugin must be installed?"));
+            err.println(cmd.getColorScheme().errorText(
+                    "Maybe a specific Camel JBang plugin must be installed? (Try camel plugin --help' for more information)"));
         }
 
         return cmd.getExitCodeExceptionMapper() != null

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/exceptionhandler/ParameterExceptionHandlerTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/exceptionhandler/ParameterExceptionHandlerTest.java
@@ -36,7 +36,9 @@ class ParameterExceptionHandlerTest {
                 "First line mentioning unmatched argument");
         Assertions.assertEquals("Did you mean: camel bind or camel plugin or camel version?", lines[1],
                 "Second line with suggestion in case it is a typo");
-        Assertions.assertEquals("Maybe a specific plugin must be installed?", lines[4], "Last line suggesting new plugin");
+        Assertions.assertEquals(
+                "Maybe a specific Camel JBang plugin must be installed? (Try camel plugin --help' for more information)",
+                lines[4], "Last line suggesting new plugin");
     }
 
     @Test


### PR DESCRIPTION
when a plugin might not be installed and is required

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

