### PR TITLE
Configure test container rabbitMQ with several startup attempt

### DIFF
--- a/test-infra/camel-test-infra-rabbitmq/src/test/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQLocalContainerService.java
+++ b/test-infra/camel-test-infra-rabbitmq/src/test/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQLocalContainerService.java
@@ -97,6 +97,7 @@ public class RabbitMQLocalContainerService implements RabbitMQService, Container
     @Override
     public void initialize() {
         LOG.info("Trying to start RabbitMQ container");
+        container.withStartupAttempts(5);
         container.start();
         LOG.info("RabbitMQ container running on {}", container.getAmqpUrl());
 


### PR DESCRIPTION
to stabilize build on CI

# Description

less chance to hit https://ci-builds.apache.org/job/Camel/job/Camel%20Core%20(Build%20and%20test)/job/main/315/testReport/junit/org.apache.camel.component.springrabbit.integration/RabbitMQProducerToDIT/BuildAndTest___Matrix___JDK_NAME____jdk_17_latest___PLATFORM____ppc64le____Test______/

```
org.testcontainers.containers.ContainerLaunchException: Container startup failed for image rabbitmq:3.13-management
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:359)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:330)
	at org.apache.camel.test.infra.rabbitmq.services.RabbitMQLocalContainerService.initialize(RabbitMQLocalContainerService.java:100)
	at org.apache.camel.test.infra.common.services.TestServiceUtil.tryInitialize(TestServiceUtil.java:43)
	at org.apache.camel.test.infra.common.services.TestService.beforeAll(TestService.java:50)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: org.rnorth.ducttape.RetryCountExceededException: Retry limit hit with exception
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:88)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:344)
	... 5 more
Caused by: org.testcontainers.containers.ContainerLaunchException: Could not create/start container
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:563)
	at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:354)
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
	... 6 more
Caused by: org.testcontainers.containers.ContainerLaunchException: Timed out waiting for log output matching '.*Server startup complete.*'
	at org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy.waitUntilReady(LogMessageWaitStrategy.java:47)
	at org.testcontainers.containers.wait.strategy.AbstractWaitStrategy.waitUntilReady(AbstractWaitStrategy.java:52)
	at org.testcontainers.containers.GenericContainer.waitUntilContainerStarted(GenericContainer.java:909)
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:500)
	... 8 more
```

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

