### PR TITLE
Configure test container Solr with several startup attempt

### DIFF
--- a/test-infra/camel-test-infra-solr/src/test/java/org/apache/camel/test/infra/solr/services/SolrLocalContainerService.java
+++ b/test-infra/camel-test-infra-solr/src/test/java/org/apache/camel/test/infra/solr/services/SolrLocalContainerService.java
@@ -38,6 +38,7 @@ public class SolrLocalContainerService implements SolrService, ContainerService<
     @Override
     public void initialize() {
         LOG.info("Trying to start solr container");
+        container.withStartupAttempts(5);
         container.start();
 
         registerProperties();


### PR DESCRIPTION
to stabilize build on CI

# Description

it shoudl avoid this kind of errors:

```
[ERROR] org.apache.camel.component.solr.integration.SolrCloudProducerIT -- Time elapsed: 93.50 s <<< ERROR!
org.testcontainers.containers.ContainerLaunchException: Container startup failed for image solr:9.6.1
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:359)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:330)
	at org.apache.camel.test.infra.solr.services.SolrLocalContainerService.initialize(SolrLocalContainerService.java:41)
	at org.apache.camel.test.infra.common.services.TestServiceUtil.tryInitialize(TestServiceUtil.java:43)
	at org.apache.camel.test.infra.solr.services.SolrService.beforeAll(SolrService.java:36)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: org.rnorth.ducttape.RetryCountExceededException: Retry limit hit with exception
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:88)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:344)
	... 5 more
Caused by: org.testcontainers.containers.ContainerLaunchException: Could not create/start container
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:563)
	at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:354)
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
	... 6 more
Caused by: java.lang.IllegalStateException: Wait strategy failed. Container exited with code 1
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:533)
	... 8 more
Caused by: org.testcontainers.containers.ContainerLaunchException: Timed out waiting for log output matching '.*Server.*Started.*'
	at org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy.waitUntilReady(LogMessageWaitStrategy.java:47)
	at org.testcontainers.containers.wait.strategy.AbstractWaitStrategy.waitUntilReady(AbstractWaitStrategy.java:52)
	at org.testcontainers.containers.GenericContainer.waitUntilContainerStarted(GenericContainer.java:909)
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:500)
	... 8 more
```

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

