### PR TITLE
(chores) avoid using StringWriter if possible

### DIFF
--- a/catalog/camel-csimple-maven-plugin/src/main/java/org/apache/camel/maven/GenerateMojo.java
+++ b/catalog/camel-csimple-maven-plugin/src/main/java/org/apache/camel/maven/GenerateMojo.java
@@ -21,7 +21,6 @@ import java.io.FileInputStream;
 import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -166,9 +165,9 @@ public class GenerateMojo extends AbstractExecMojo {
     }
 
     private void generatePropertiesFile(List<CSimpleGeneratedCode> classes) {
-        StringWriter w = new StringWriter();
-        w.append("# " + GENERATED_MSG + "\n");
-        classes.forEach(c -> w.write(c.getFqn() + "\n"));
+        StringBuilder w = new StringBuilder(4096);
+        w.append("# ").append(GENERATED_MSG).append("\n");
+        classes.forEach(c -> w.append(c.getFqn()).append("\n"));
         String fileName = RESOURCE_FILE;
         outputResourceDir.mkdirs();
         boolean saved = updateResource(outputResourceDir.toPath().resolve(fileName), w.toString());

--- a/components/camel-test/camel-test-spring-junit5/src/main/java/org/apache/camel/test/spring/junit5/CamelSpringTestSupport.java
+++ b/components/camel-test/camel-test-spring-junit5/src/main/java/org/apache/camel/test/spring/junit5/CamelSpringTestSupport.java
@@ -20,7 +20,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -311,15 +310,7 @@ public abstract class CamelSpringTestSupport extends CamelTestSupport {
         @Override
         public InputStream getInputStream() throws IOException {
             if (!properties.isEmpty()) {
-                StringWriter sw = new StringWriter();
-                try (InputStreamReader r = new InputStreamReader(delegate.getInputStream(), StandardCharsets.UTF_8)) {
-                    char[] buf = new char[32768];
-                    int l;
-                    while ((l = r.read(buf)) > 0) {
-                        sw.write(buf, 0, l);
-                    }
-                }
-                String before = sw.toString();
+                final String before = readBefore();
                 String p = properties.keySet().stream().map(Pattern::quote)
                         .collect(Collectors.joining("|", Pattern.quote("{{") + "(", ")" + Pattern.quote("}}")));
                 Matcher m = Pattern.compile(p).matcher(before);
@@ -333,6 +324,18 @@ public abstract class CamelSpringTestSupport extends CamelTestSupport {
             } else {
                 return delegate.getInputStream();
             }
+        }
+
+        private String readBefore() throws IOException {
+            StringBuilder sb = new StringBuilder();
+            try (InputStreamReader r = new InputStreamReader(delegate.getInputStream(), StandardCharsets.UTF_8)) {
+                char[] buf = new char[32768];
+                int l;
+                while ((l = r.read(buf)) > 0) {
+                    sb.append(buf, 0, l);
+                }
+            }
+            return sb.toString();
         }
     }
 }

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/AbstractGenerateConfigurerMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/AbstractGenerateConfigurerMojo.java
@@ -17,9 +17,6 @@
 package org.apache.camel.maven.packaging;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -489,16 +486,14 @@ public abstract class AbstractGenerateConfigurerMojo extends AbstractGeneratorMo
         int pos = targetFqn.lastIndexOf('.');
         String pn = targetFqn.substring(0, pos);
         String en = targetFqn.substring(pos + 1);
-        try (Writer w = new StringWriter()) {
-            w.append("# ").append(GENERATED_MSG).append("\n");
-            w.append("class=").append(pn).append(".").append(en).append("Configurer").append("\n");
-            String fileName = "META-INF/services/org/apache/camel/configurer/" + fqn;
-            boolean updated = updateResource(buildContext, resourcesOutputDir.toPath().resolve(fileName), w.toString());
-            if (updated) {
-                getLog().info("Updated " + fileName);
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+
+        StringBuilder w = new StringBuilder();
+        w.append("# ").append(GENERATED_MSG).append("\n");
+        w.append("class=").append(pn).append(".").append(en).append("Configurer").append("\n");
+        String fileName = "META-INF/services/org/apache/camel/configurer/" + fqn;
+        boolean updated = updateResource(buildContext, resourcesOutputDir.toPath().resolve(fileName), w.toString());
+        if (updated) {
+            getLog().info("Updated " + fileName);
         }
     }
 

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojo.java
@@ -20,8 +20,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -1682,13 +1680,11 @@ public class EndpointSchemaGeneratorMojo extends AbstractGeneratorMojo {
     }
 
     protected void generateMetaInfConfigurer(String name, String fqn) {
-        try (Writer w = new StringWriter()) {
-            w.append("# " + GENERATED_MSG + "\n");
-            w.append("class=").append(fqn).append("\n");
-            updateResource(resourcesOutputDir.toPath(), "META-INF/services/org/apache/camel/configurer/" + name, w.toString());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        StringBuilder w = new StringBuilder();
+
+        w.append("# ").append(GENERATED_MSG).append("\n");
+        w.append("class=").append(fqn).append("\n");
+        updateResource(resourcesOutputDir.toPath(), "META-INF/services/org/apache/camel/configurer/" + name, w.toString());
     }
 
     private IndexView getIndex() {


### PR DESCRIPTION
StringWriter uses the StringBuffer under the hood, so it's good to avoid if possible.