### PR TITLE
Ban com.sun.xml.bind:jaxb-impl, replace it with jaxb-runtime where needed

### DIFF
--- a/apache-camel/pom.xml
+++ b/apache-camel/pom.xml
@@ -39,6 +39,7 @@
         <!-- we do not need remote resources in assembly -->
         <remoteresources.skip>true</remoteresources.skip>
         <tarLongFileMode>gnu</tarLongFileMode>
+        <enforcer.phase>none</enforcer.phase><!-- Save some time -->
     </properties>
 
     <repositories>

--- a/catalog/camel-allcomponents/pom.xml
+++ b/catalog/camel-allcomponents/pom.xml
@@ -32,6 +32,10 @@
     <name>Camel :: All Components Sync point</name>
     <description>Depends on all components to ensure correct build ordering</description>
 
+    <properties>
+        <enforcer.phase>none</enforcer.phase><!-- We enforce all dependencies individuall, so there is no point enforcing here again -->
+    </properties>
+
     <repositories>
         <repository>
             <id>atlassian</id>

--- a/components/camel-jaxb/pom.xml
+++ b/components/camel-jaxb/pom.xml
@@ -47,18 +47,6 @@
             <artifactId>camel-xml-jaxp</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <version>${jaxb-core-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>${jaxb-impl-version}</version>
-            <optional>true</optional>
-        </dependency>
-
         <!-- for testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/components/camel-jmx/pom.xml
+++ b/components/camel-jmx/pom.xml
@@ -51,9 +51,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>${jaxb-impl-version}</version>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
         </dependency>
 
         <!-- test dependencies -->

--- a/components/camel-parquet-avro/pom.xml
+++ b/components/camel-parquet-avro/pom.xml
@@ -31,6 +31,10 @@
     <name>Camel :: Parquet Avro</name>
     <description>Camel ParquetAvro DataFormat</description>
 
+    <properties>
+        <enforcer.phase>none</enforcer.phase><!-- hadoop-common seems to require com.sun.xml.bind:jaxb-impl via com.github.pjfanning:jersey-json -->
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/components/camel-salesforce/camel-salesforce-component/pom.xml
+++ b/components/camel-salesforce/camel-salesforce-component/pom.xml
@@ -116,9 +116,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>${jaxb-impl-version}</version>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
         </dependency>
         <!-- Pub/Sub API dependencies -->
         <dependency>

--- a/components/camel-soap/pom.xml
+++ b/components/camel-soap/pom.xml
@@ -47,11 +47,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>${jaxb-impl-version}</version>
-        </dependency>
-        <dependency>
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
             <version>${jakarta-xml-ws-api-version}</version>
@@ -112,15 +107,6 @@
             <version>${spring-version}</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- needed by jetty http server to load class: org.jvnet.staxex.util.XMLStreamReaderToXMLStreamWriter -->
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-osgi</artifactId>
-            <version>${jaxb-osgi-version}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/components/camel-swift/pom.xml
+++ b/components/camel-swift/pom.xml
@@ -45,6 +45,16 @@
             <groupId>com.prowidesoftware</groupId>
             <artifactId>pw-iso20022</artifactId>
             <version>${prowide-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
         </dependency>
 
         <!-- testing -->

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -33,7 +33,9 @@
 
     <properties>
         <skipOnUnsupported>true</skipOnUnsupported>
+        <enforcer.phase>none</enforcer.phase><!-- Save some time -->
     </properties>
+
 
     <repositories>
         <repository>

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_8.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_8.adoc
@@ -38,3 +38,11 @@ You can configure `startupOnly=true` to only sync the cache once on startup
 
 Continuing the multi-release tests cleanups, on this one, restricted methods from the `CamelTestSupport` class
 have been marked as final and cannot be extended.
+
+=== Preferred JAX-B implementation: `org.glassfish.jaxb:jaxb-runtime`
+
+We stopped relying on `com.sun.xml.bind:jaxb-impl` in favor of `org.glassfish.jaxb:jaxb-runtime`.
+This change should have no impact on existing code, because recent versions of the two artifacts bring the same classes.
+The main motivation for this change is to allow projects that still require classes from `javax.xml.bind` package
+to be able to depend on pre-3.x versions of `com.sun.xml.bind:jaxb-impl` together with the recent version of
+`org.glassfish.jaxb:jaxb-runtime` brought by Camel.

--- a/dsl/camel-componentdsl/pom.xml
+++ b/dsl/camel-componentdsl/pom.xml
@@ -36,6 +36,7 @@
         <firstVersion>3.1.0</firstVersion>
         <title>Java Component DSL</title>
         <label>dsl</label>
+        <enforcer.phase>none</enforcer.phase><!-- Save some time -->
     </properties>
 
     <repositories>

--- a/dsl/camel-endpointdsl/pom.xml
+++ b/dsl/camel-endpointdsl/pom.xml
@@ -36,6 +36,7 @@
         <firstVersion>3.0.0</firstVersion>
         <title>Java Endpoint DSL</title>
         <label>dsl</label>
+        <enforcer.phase>none</enforcer.phase><!-- Save some time -->
     </properties>
 
     <repositories>
@@ -50,7 +51,7 @@
                 <enabled>true</enabled>
             </releases>
         </repository>
-    </repositories>  
+    </repositories>
 
     <dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,8 @@
 
         <camel.javadoc.offline>false</camel.javadoc.offline>
         <invoker.skip>${skipTests}</invoker.skip>
+
+        <enforcer.phase>none</enforcer.phase><!-- We do not enforce with -Dquickly, the property is overridden in the full profile -->
     </properties>
 
     <!-- Comment out the snapshot repositories as we don't need them now -->
@@ -164,13 +166,21 @@
                 <executions>
                     <execution>
                         <id>enforce-maven-version</id>
-                        <phase>none
-                        </phase><!-- unbound here to speedup -Dquickly build; bound to a phase in the full profile -->
+                        <phase>${enforcer.phase}</phase>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.5.0</version>
+                                </requireMavenVersion>
+                                <externalRules>
+                                    <location>${maven.multiModuleProjectDirectory}/tooling/enforcer-rules/src/main/resources/camel-banned-dependencies.xml</location>
+                                </externalRules>
+                            </rules>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>enforce-java-version</id>
-                        <phase>none
-                        </phase><!-- unbound here to speedup -Dquickly build; bound to a phase in the full profile -->
+                        <phase>${enforcer.phase}</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -860,6 +870,9 @@
                     <name>!quickly</name>
                 </property>
             </activation>
+            <properties>
+                <enforcer.phase>validate</enforcer.phase><!-- We do not enforce with -Dquickly, but we enforce otherwise -->
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -872,25 +885,6 @@
                                     <goal>format</goal>
                                 </goals>
                                 <phase>process-sources</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>enforce-maven-version</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <requireMavenVersion>
-                                            <version>3.5.0</version>
-                                        </requireMavenVersion>
-                                    </rules>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/tests/camel-itest/pom.xml
+++ b/tests/camel-itest/pom.xml
@@ -218,7 +218,7 @@
             <artifactId>derbytools</artifactId>
             <version>${derby-version}</version>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-orm</artifactId>
@@ -363,15 +363,6 @@
             <artifactId>jboss-logging</artifactId>
             <version>${jboss-logging-version}</version>
         </dependency>
-
-        <!-- needed by jetty http server to load class: org.jvnet.staxex.util.XMLStreamReaderToXMLStreamWriter -->
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-osgi</artifactId>
-            <version>${jaxb-osgi-version}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/tooling/enforcer-rules/pom.xml
+++ b/tooling/enforcer-rules/pom.xml
@@ -22,44 +22,12 @@
 
     <parent>
         <groupId>org.apache.camel</groupId>
-        <artifactId>core</artifactId>
+        <artifactId>tooling</artifactId>
         <version>4.8.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>camel-xml-jaxb</artifactId>
-    <packaging>jar</packaging>
-    <name>Camel :: XML JAXB</name>
-    <description>Camel XML JAXB</description>
+    <artifactId>camel-enforcer-rules</artifactId>
 
-    <properties>
-        <firstVersion>3.1.0</firstVersion>
-        <label>dsl</label>
-    </properties>
-
-    <dependencies>
-
-        <!-- need JAXB API -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>${jakarta-xml-bind-api-version}</version>
-        </dependency>
-
-        <!-- need JAXB implementation -->
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-core-engine</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-xml-jaxp</artifactId>
-        </dependency>
-
-    </dependencies>
-
+    <name>Camel :: Enforcer rules</name>
+    <description>Rules for Maven Enforcer plugin packaged in a jar, so that they can be reused by Camel Quarkus, Camel SpringBoot and other projects</description>
 </project>

--- a/tooling/enforcer-rules/src/main/resources/camel-banned-dependencies.xml
+++ b/tooling/enforcer-rules/src/main/resources/camel-banned-dependencies.xml
@@ -1,0 +1,29 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<enforcer>
+    <rules>
+        <!-- Camel dependency bans -->
+        <bannedDependencies>
+            <excludes>
+                <exclude>com.sun.xml.bind:jaxb-core</exclude><!-- use org.glassfish.jaxb:jaxb-core instead -->
+                <exclude>com.sun.xml.bind:jaxb-impl</exclude><!-- use org.glassfish.jaxb:jaxb-runtime instead -->
+            </excludes>
+        </bannedDependencies>
+    </rules>
+</enforcer>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -42,6 +42,7 @@
         <module>openapi-rest-dsl-generator</module>
         <module>maven</module>
         <module>camel-tooling-maven</module>
+        <module>enforcer-rules</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
# Description

org.glassfish.jaxb:jaxb-runtime is the new Jakarta implementation of JAXB. It should be preferred to the old com.sun.xml.bind:jaxb-impl

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking

No Jira, because this is just housekeeping. But I can create one, if needed.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

