### PR TITLE
(chores) core: use more adequately sized buffers

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/CamelExchangeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelExchangeException.java
@@ -54,7 +54,7 @@ public class CamelExchangeException extends CamelException {
      * @return          an error message (without stacktrace from exception)
      */
     public static String createExceptionMessage(String message, Exchange exchange, Throwable cause) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(1024);
         if (message != null) {
             sb.append(message);
         }

--- a/core/camel-api/src/main/java/org/apache/camel/catalog/EndpointValidationResult.java
+++ b/core/camel-api/src/main/java/org/apache/camel/catalog/EndpointValidationResult.java
@@ -244,7 +244,7 @@ public class EndpointValidationResult extends PropertiesValidationResult impleme
         String format = "%" + maxLen + "s    %s";
 
         // build the human error summary
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         if (includeHeader) {
             sb.append("Endpoint validator error\n");
             sb.append(

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/debugger/BacklogTracer.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/debugger/BacklogTracer.java
@@ -378,7 +378,7 @@ public final class BacklogTracer extends ServiceSupport implements org.apache.ca
     }
 
     private static String wrapAroundRootTag(List<BacklogTracerEventMessage> events) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         sb.append("<").append(BacklogTracerEventMessage.ROOT_TAG).append("s>");
         for (BacklogTracerEventMessage event : events) {
             sb.append("\n").append(event.toXml(2));

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/debugger/DefaultBacklogTracerEventMessage.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/debugger/DefaultBacklogTracerEventMessage.java
@@ -245,10 +245,9 @@ public final class DefaultBacklogTracerEventMessage implements BacklogTracerEven
      */
     @Override
     public String toXml(int indent) {
-        StringBuilder prefix = new StringBuilder();
-        prefix.append(" ".repeat(indent));
+        final String prefix = " ".repeat(indent);
 
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         sb.append(prefix).append("<").append(ROOT_TAG).append(">\n");
         sb.append(prefix).append("  <uid>").append(uid).append("</uid>\n");
         sb.append(prefix).append("  <first>").append(first).append("</first>\n");

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultAsyncProcessorAwaitManager.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultAsyncProcessorAwaitManager.java
@@ -178,7 +178,7 @@ public class DefaultAsyncProcessorAwaitManager extends ServiceSupport implements
         AwaitThreadEntry entry = (AwaitThreadEntry) inflight.get(exchange);
         if (entry != null) {
             try {
-                StringBuilder sb = new StringBuilder();
+                StringBuilder sb = new StringBuilder(512);
                 sb.append(
                         "Interrupted while waiting for asynchronous callback, will release the following blocked thread which was waiting for exchange to finish processing with exchangeId: ");
                 sb.append(exchange.getExchangeId());
@@ -227,7 +227,7 @@ public class DefaultAsyncProcessorAwaitManager extends ServiceSupport implements
         if (count > 0) {
             LOG.warn("Shutting down while there are still {} inflight threads currently blocked.", count);
 
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(1024);
             for (AwaitThread entry : threads) {
                 sb.append(dumpBlockedThread(entry));
             }
@@ -254,7 +254,7 @@ public class DefaultAsyncProcessorAwaitManager extends ServiceSupport implements
     }
 
     private static String dumpBlockedThread(AwaitThread entry) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         sb.append("\n");
         sb.append("Blocked Thread\n");
         sb.append(

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultShutdownStrategy.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultShutdownStrategy.java
@@ -817,7 +817,9 @@ public class DefaultShutdownStrategy extends ServiceSupport implements ShutdownS
             return;
         }
 
-        StringBuilder sb = new StringBuilder("There are " + size + " inflight exchanges:");
+        StringBuilder sb = new StringBuilder(512);
+
+        sb.append("There are ").append(size).append(" inflight exchanges:");
         for (InflightRepository.InflightExchange inflight : filtered) {
             sb.append("\n\tInflightExchange: [exchangeId=").append(inflight.getExchange().getExchangeId())
                     .append(", fromRouteId=").append(inflight.getExchange().getFromRouteId())

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultTracer.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultTracer.java
@@ -98,7 +98,7 @@ public class DefaultTracer extends ServiceSupport implements CamelContextAware, 
             // characters in the sanitizeUri method and will be reasonably fast
             String label = URISupport.sanitizeUri(StringHelper.limitLength(node.getLabel(), 50));
 
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(512);
             sb.append(String.format(tracingFormat, "   ", routeId, label));
             sb.append(" ");
             String data = exchangeFormatter.format(exchange);
@@ -127,7 +127,7 @@ public class DefaultTracer extends ServiceSupport implements CamelContextAware, 
         if (shouldTrace(node)) {
             String routeId = ExpressionBuilder.routeIdExpression().evaluate(exchange, String.class);
 
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(128);
             sb.append(String.format(tracingFormat, "   ", routeId, ""));
             sb.append(" ");
 

--- a/core/camel-base/src/main/java/org/apache/camel/component/properties/DefaultPropertiesParser.java
+++ b/core/camel-base/src/main/java/org/apache/camel/component/properties/DefaultPropertiesParser.java
@@ -135,7 +135,7 @@ public class DefaultPropertiesParser implements PropertiesParser {
                 return null;
             }
 
-            StringBuilder answer = new StringBuilder();
+            StringBuilder answer = new StringBuilder(input.length());
             Property property;
             while ((property = readProperty(input)) != null) {
                 String before = input.substring(0, property.getBeginIndex());
@@ -390,7 +390,7 @@ public class DefaultPropertiesParser implements PropertiesParser {
                     return UNRESOLVED_PREFIX_TOKEN + key + UNRESOLVED_SUFFIX_TOKEN;
                 }
                 if (!optional) {
-                    StringBuilder esb = new StringBuilder();
+                    StringBuilder esb = new StringBuilder(256);
                     esb.append("Property with key [").append(key).append("] ");
                     esb.append("not found in properties from text: ").append(input);
                     throw new IllegalArgumentException(esb.toString());

--- a/core/camel-base/src/main/java/org/apache/camel/impl/scan/AssignableToPackageScanFilter.java
+++ b/core/camel-base/src/main/java/org/apache/camel/impl/scan/AssignableToPackageScanFilter.java
@@ -74,7 +74,7 @@ public class AssignableToPackageScanFilter implements PackageScanFilter {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         for (Class<?> parent : parents) {
             sb.append(parent.getSimpleName()).append(", ");
         }

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/csimple/CSimpleCodeGenerator.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/csimple/CSimpleCodeGenerator.java
@@ -74,7 +74,7 @@ public class CSimpleCodeGenerator {
         script = alias(script);
 
         //  wrap text into a class method we can call
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(4096);
         sb.append("package ").append(qn).append(";\n");
         sb.append("\n");
         sb.append("import java.util.*;\n");

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/csimple/CSimpleHelper.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/csimple/CSimpleHelper.java
@@ -707,7 +707,7 @@ public final class CSimpleHelper {
 
     public static Object join(Exchange exchange, Object value, String separator, String prefix) {
         Iterator<?> it = convertTo(exchange, Iterator.class, value);
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         while (it.hasNext()) {
             Object o = it.next();
             if (o != null) {

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleExpressionParser.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleExpressionParser.java
@@ -203,7 +203,7 @@ public class SimpleExpressionParser extends BaseSimpleParser {
      * Second step parsing into code
      */
     protected String doParseCode() {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         boolean firstIsLiteral = false;
         for (SimpleNode node : nodes) {
             String exp = node.createCode(expression);

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimplePredicateParser.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimplePredicateParser.java
@@ -163,7 +163,7 @@ public class SimplePredicateParser extends BaseSimpleParser {
      * Second step parsing into code
      */
     protected String doParseCode() {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         for (SimpleNode node : nodes) {
             String exp = node.createCode(expression);
             SimpleExpressionParser.parseLiteralNode(sb, node, exp);

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleTokenizer.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleTokenizer.java
@@ -158,7 +158,7 @@ public final class SimpleTokenizer {
         boolean numericAllowed = acceptType(TokenType.numericValue, filters);
         if (numericAllowed) {
             // is it a numeric value
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(256);
             boolean digit = true;
             while (digit && index < expression.length()) {
                 digit = Character.isDigit(expression.charAt(index));
@@ -186,7 +186,7 @@ public final class SimpleTokenizer {
 
         boolean escapeAllowed = allowEscape && acceptType(TokenType.escape, filters);
         if (escapeAllowed) {
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(256);
             char ch = expression.charAt(index);
             boolean escaped = '\\' == ch;
             if (escaped && index < expression.length() - 1) {

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/CompositeNodes.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/CompositeNodes.java
@@ -75,7 +75,7 @@ public class CompositeNodes extends BaseSimpleNode {
         } else if (children.size() == 1) {
             return children.get(0).createCode(expression);
         } else {
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(256);
             for (SimpleNode child : children) {
                 String code = child.createCode(expression);
                 if (code != null) {

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/LiteralExpression.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/LiteralExpression.java
@@ -27,7 +27,7 @@ import org.apache.camel.support.builder.ExpressionBuilder;
  */
 public class LiteralExpression extends BaseSimpleNode implements LiteralNode {
 
-    protected final StringBuilder text = new StringBuilder();
+    protected final StringBuilder text = new StringBuilder(256);
 
     public LiteralExpression(SimpleToken token) {
         super(token);

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/SimpleFunctionExpression.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/SimpleFunctionExpression.java
@@ -1892,7 +1892,7 @@ public class SimpleFunctionExpression extends LiteralExpression {
             if (generator == null) {
                 generator = "default";
             }
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(128);
             if ("classic".equals(generator)) {
                 sb.append("    UuidGenerator uuid = new org.apache.camel.support.ClassicUuidGenerator();\n");
                 sb.append("return uuid.generateUuid();");
@@ -1971,7 +1971,7 @@ public class SimpleFunctionExpression extends LiteralExpression {
     }
 
     private static String ognlCodeMethods(String remainder, String type) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
 
         if (remainder != null) {
             List<String> methods = splitOgnl(remainder);
@@ -2072,7 +2072,7 @@ public class SimpleFunctionExpression extends LiteralExpression {
         }
 
         List<String> answer = new ArrayList<>();
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
 
         int codeLevel = 0;
         boolean singleQuoted = false;

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/SimpleFunctionStart.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/SimpleFunctionStart.java
@@ -79,7 +79,7 @@ public class SimpleFunctionStart extends BaseSimpleNode implements BlockStart {
         return new Expression() {
             @Override
             public <T> T evaluate(Exchange exchange, Class<T> type) {
-                StringBuilder sb = new StringBuilder();
+                StringBuilder sb = new StringBuilder(256);
                 boolean quoteEmbeddedFunctions = false;
 
                 // we need to concat the block so we have the expression
@@ -168,7 +168,7 @@ public class SimpleFunctionStart extends BaseSimpleNode implements BlockStart {
     }
 
     private String doCreateCompositeCode(String expression) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         boolean quoteEmbeddedFunctions = false;
 
         // we need to concat the block, so we have the expression

--- a/core/camel-core-model/src/main/java/org/apache/camel/builder/NotifyBuilder.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/builder/NotifyBuilder.java
@@ -1273,7 +1273,7 @@ public class NotifyBuilder {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         for (EventPredicateHolder eventPredicateHolder : predicates) {
             if (!sb.isEmpty()) {
                 sb.append(".");
@@ -1653,7 +1653,7 @@ public class NotifyBuilder {
 
         @Override
         public String toString() {
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(256);
             for (EventPredicate eventPredicate : predicates) {
                 if (!sb.isEmpty()) {
                     sb.append(".");

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/SagaDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/SagaDefinition.java
@@ -296,7 +296,7 @@ public class SagaDefinition extends OutputDefinition<SagaDefinition> {
     // Utils
 
     protected String description() {
-        StringBuilder desc = new StringBuilder();
+        StringBuilder desc = new StringBuilder(256);
         addField(desc, "compensation", compensation);
         addField(desc, "completion", completion);
         addField(desc, "propagation", propagation);

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/WhenDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/WhenDefinition.java
@@ -57,7 +57,7 @@ public class WhenDefinition extends OutputExpressionNode {
     }
 
     protected String description() {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         if (getExpression() != null) {
             String language = getExpression().getLanguage();
             if (language != null) {

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/console/BeanModelDevConsole.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/console/BeanModelDevConsole.java
@@ -58,7 +58,7 @@ public class BeanModelDevConsole extends AbstractDevConsole {
         boolean properties = "true".equals(options.getOrDefault(PROPERTIES, "true"));
         boolean nulls = "true".equals(options.getOrDefault(NULLS, "true"));
 
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
 
         BeanIntrospection bi = PluginHelper.getBeanIntrospection(getCamelContext());
         Model model = getCamelContext().getCamelContextExtension().getContextPlugin(Model.class);

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/language/ExpressionDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/language/ExpressionDefinition.java
@@ -121,7 +121,7 @@ public class ExpressionDefinition
             return getExpressionValue().toString();
         }
 
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         if (getLanguage() != null) {
             sb.append(getLanguage()).append("{");
         }

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/PipelineHelper.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/PipelineHelper.java
@@ -45,7 +45,7 @@ public final class PipelineHelper {
             // The errorErrorHandler is only set if satisfactory handling was done
             // by the error handler. It's still an exception, the exchange still failed.
             if (log.isDebugEnabled()) {
-                StringBuilder sb = new StringBuilder();
+                StringBuilder sb = new StringBuilder(256);
                 sb.append("Message exchange has failed: ").append(message).append(" for exchange: ").append(exchange);
                 if (exchange.isRollbackOnly() || exchange.isRollbackOnlyLast()) {
                     sb.append(" Marked as rollback only.");

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetHeadersProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetHeadersProcessor.java
@@ -73,7 +73,8 @@ public class SetHeadersProcessor extends AsyncProcessorSupport implements Tracea
 
     @Override
     public String getTraceLabel() {
-        StringBuilder sb = new StringBuilder("setHeaders[");
+        StringBuilder sb = new StringBuilder(256);
+        sb.append("setHeaders[");
         int headerIndex = 0;
         for (Expression expression : expressions) {
             if (headerIndex > 0) {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetVariablesProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetVariablesProcessor.java
@@ -71,7 +71,9 @@ public class SetVariablesProcessor extends AsyncProcessorSupport implements Trac
 
     @Override
     public String getTraceLabel() {
-        StringBuilder sb = new StringBuilder("setVariables[");
+        StringBuilder sb = new StringBuilder(256);
+
+        sb.append("setVariables[");
         int variableIndex = 0;
         for (Expression expression : expressions) {
             if (variableIndex > 0) {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/AggregationStrategyParameterInfo.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/AggregationStrategyParameterInfo.java
@@ -50,7 +50,7 @@ public class AggregationStrategyParameterInfo {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
+        final StringBuilder sb = new StringBuilder(256);
         sb.append("ParameterInfo");
         sb.append("[index=").append(index);
         sb.append(", type=").append(type);

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/OptimisticLockRetryPolicy.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/OptimisticLockRetryPolicy.java
@@ -147,7 +147,8 @@ public class OptimisticLockRetryPolicy {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("OptimisticLockRetryPolicy[");
+        final StringBuilder sb = new StringBuilder(256);
+        sb.append("OptimisticLockRetryPolicy[");
         sb.append("maximumRetries=").append(maximumRetries);
         sb.append(", retryDelay=").append(retryDelay);
         sb.append(", maximumRetryDelay=").append(maximumRetryDelay);

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/StringAggregationStrategy.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/StringAggregationStrategy.java
@@ -83,7 +83,7 @@ public class StringAggregationStrategy implements AggregationStrategy {
     @Override
     public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
         StringBuffer result; // Aggregate in StringBuffer instead of StringBuilder, to make it thread safe
-        StringBuilder value = new StringBuilder();
+        StringBuilder value = new StringBuilder(512);
         if (oldExchange == null) {
             result = getStringBuffer(newExchange); // do not prepend delimiter for first invocation
         } else {

--- a/core/camel-support/src/main/java/org/apache/camel/support/MessageHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/MessageHelper.java
@@ -490,10 +490,9 @@ public final class MessageHelper {
             Message message, boolean includeExchangeProperties, boolean includeExchangeVariables,
             boolean includeBody, int indent, boolean allowCachedStreams, boolean allowStreams,
             boolean allowFiles, int maxChars) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(1024);
 
-        StringBuilder prefix = new StringBuilder();
-        prefix.append(" ".repeat(indent));
+        final String prefix = " ".repeat(indent);
 
         // include exchangeId/exchangePattern/type as attribute on the <message> tag
         sb.append(prefix);
@@ -753,7 +752,7 @@ public final class MessageHelper {
         boolean enabled = list != null;
         boolean source = !loc.isEmpty();
 
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(2048);
         sb.append("\n");
         sb.append("Message History");
         if (!source && !enabled) {
@@ -1101,10 +1100,9 @@ public final class MessageHelper {
      * @return        the XML
      */
     public static String dumpExceptionAsXML(Throwable exception, int indent) {
-        StringBuilder prefix = new StringBuilder();
-        prefix.append(" ".repeat(indent));
+        final String prefix = " ".repeat(indent);
 
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         try {
             sb.append(prefix).append("<exception");
             String type = ObjectHelper.classCanonicalName(exception);

--- a/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
@@ -1664,7 +1664,7 @@ public final class PropertyBindingSupport {
         List<String> parts = new ArrayList<>();
 
         boolean mapKey = false;
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(key.length() + 16);
         for (char ch : key.toCharArray()) {
             if (ch == '[') {
                 mapKey = true;

--- a/core/camel-support/src/main/java/org/apache/camel/support/RestComponentHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/RestComponentHelper.java
@@ -143,9 +143,11 @@ public final class RestComponentHelper {
     }
 
     private static String applyFormatAndQuery(String format, String query, Object... formatOptions) {
+        final String initial = String.format(format, formatOptions);
         // get the endpoint
-        StringBuilder urlBuilder = new StringBuilder(String.format(format, formatOptions));
+        StringBuilder urlBuilder = new StringBuilder(initial.length() + query.length() + 1);
 
+        urlBuilder.append(initial);
         if (!query.isEmpty()) {
             urlBuilder.append("?");
             urlBuilder.append(query);

--- a/core/camel-support/src/main/java/org/apache/camel/support/RestConsumerContextPathMatcher.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/RestConsumerContextPathMatcher.java
@@ -408,7 +408,7 @@ public final class RestConsumerContextPathMatcher {
      */
     private static String prepareConsumerPathRegex(String consumerPath) {
         Matcher m = CONSUMER_PATH_PARAMETER_PATTERN.matcher(consumerPath);
-        StringBuilder regexBuilder = new StringBuilder();
+        StringBuilder regexBuilder = new StringBuilder(256);
         while (m.find()) {
             m.appendReplacement(regexBuilder, m.group(1) + m.group(2).replaceAll("[\\_\\-]", "") + m.group(3));
         }

--- a/core/camel-support/src/main/java/org/apache/camel/support/builder/ExpressionBuilder.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/builder/ExpressionBuilder.java
@@ -1777,7 +1777,7 @@ public class ExpressionBuilder {
                 ObjectHelper.notNull(it,
                         "expression: " + expression + " evaluated on " + exchange + " must return an java.util.Iterator");
 
-                StringBuilder sb = new StringBuilder();
+                StringBuilder sb = new StringBuilder(128);
                 while (it.hasNext()) {
                     Object o = it.next();
                     if (o != null) {
@@ -2052,7 +2052,7 @@ public class ExpressionBuilder {
 
             @Override
             public Object evaluate(Exchange exchange) {
-                StringBuilder buffer = new StringBuilder();
+                StringBuilder buffer = new StringBuilder(256);
                 for (Expression expression : expressions) {
                     String text = expression.evaluate(exchange, String.class);
                     if (text != null) {
@@ -2098,7 +2098,7 @@ public class ExpressionBuilder {
                 if (optimizedValue != null) {
                     return optimizedValue;
                 }
-                StringBuilder buffer = new StringBuilder();
+                StringBuilder buffer = new StringBuilder(256);
                 Collection<?> col = optimized != null ? optimized : expressions;
                 for (Object obj : col) {
                     if (obj instanceof Expression expression) {
@@ -2130,7 +2130,7 @@ public class ExpressionBuilder {
                         }
                     }
                     if (constantsOnly) {
-                        StringBuilder sb = new StringBuilder();
+                        StringBuilder sb = new StringBuilder(256);
                         for (Object o : preprocessedExpression) {
                             sb.append(o);
                         }

--- a/core/camel-support/src/main/java/org/apache/camel/support/builder/TokenXMLExpressionIterator.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/builder/TokenXMLExpressionIterator.java
@@ -241,7 +241,7 @@ public class TokenXMLExpressionIterator extends ExpressionAdapter {
                     head = head.substring(0, head.length() - 1);
                     empty = true;
                 }
-                StringBuilder sb = new StringBuilder();
+                StringBuilder sb = new StringBuilder(256);
                 // append root namespaces to local start token
                 // grab the text
                 String tail = StringHelper.after(next, ">");
@@ -250,7 +250,7 @@ public class TokenXMLExpressionIterator extends ExpressionAdapter {
                         .toString();
             } else if (wrapToken) {
                 // wrap the token
-                StringBuilder sb = new StringBuilder();
+                StringBuilder sb = new StringBuilder(256);
                 next = sb.append(wrapHead).append(next).append(wrapTail).toString();
             }
 
@@ -258,7 +258,7 @@ public class TokenXMLExpressionIterator extends ExpressionAdapter {
         }
 
         private String getMissingInherritNamespaces(final String text) {
-            final StringBuilder sb = new StringBuilder();
+            final StringBuilder sb = new StringBuilder(256);
             if (text != null) {
                 boolean first = true;
                 final String[] containedNamespaces = getNamespacesFromNamespaceTokenSplitter(text);
@@ -304,7 +304,7 @@ public class TokenXMLExpressionIterator extends ExpressionAdapter {
             }
 
             // build namespace String
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(256);
             for (Map.Entry<String, String> entry : namespaces.entrySet()) {
                 String key = entry.getKey();
                 // note the value is already quoted
@@ -401,7 +401,7 @@ public class TokenXMLExpressionIterator extends ExpressionAdapter {
                 p = ep;
             }
         }
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(128);
         for (int i = tags.size() - 1; i >= 0; i--) {
             sb.append("</").append(tags.get(i)).append(">");
         }

--- a/core/camel-support/src/main/java/org/apache/camel/support/component/ApiMethodArg.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/component/ApiMethodArg.java
@@ -53,7 +53,7 @@ public class ApiMethodArg {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
+        StringBuilder builder = new StringBuilder(128);
         builder.append(type.getCanonicalName());
         if (typeArgs != null) {
             builder.append("<").append(typeArgs).append(">");

--- a/core/camel-support/src/main/java/org/apache/camel/support/component/ApiMethodHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/component/ApiMethodHelper.java
@@ -107,7 +107,7 @@ public final class ApiMethodHelper<T extends Enum<T> & ApiMethod> {
                     ObjectHelper.notNullOrEmpty(alias, "alias");
                     final char firstChar = alias.charAt(0);
                     if (!Character.isLowerCase(firstChar)) {
-                        final StringBuilder builder = new StringBuilder();
+                        final StringBuilder builder = new StringBuilder(alias.length() + 2);
                         builder.append(Character.toLowerCase(firstChar)).append(alias, 1, alias.length());
                         alias = builder.toString();
                     }

--- a/core/camel-support/src/main/java/org/apache/camel/support/component/ApiMethodImpl.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/component/ApiMethodImpl.java
@@ -109,7 +109,7 @@ public final class ApiMethodImpl implements ApiMethod {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
+        StringBuilder builder = new StringBuilder(128);
         builder.append("{")
                 .append("name=").append(name)
                 .append(", resultType=").append(resultType)

--- a/core/camel-support/src/main/java/org/apache/camel/support/component/ApiMethodParser.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/component/ApiMethodParser.java
@@ -399,7 +399,7 @@ public abstract class ApiMethodParser<T> {
 
         @Override
         public String toString() {
-            StringBuilder builder = new StringBuilder();
+            StringBuilder builder = new StringBuilder(256);
             builder.append(resultType.getName()).append(" ");
             builder.append(name).append("(");
             for (ApiMethodArg argument : arguments) {

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/DefaultExchangeFormatter.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/DefaultExchangeFormatter.java
@@ -129,12 +129,11 @@ public class DefaultExchangeFormatter implements ExchangeFormatter {
     public String format(Exchange exchange) {
         Message in = exchange.getIn();
 
-        StringBuilder sb = new StringBuilder();
-
         if (plain) {
             return getBodyAsString(in);
         }
 
+        StringBuilder sb = new StringBuilder(512);
         if (showAll || showExchangeId) {
             if (multiline) {
                 sb.append(SEPARATOR);
@@ -242,7 +241,7 @@ public class DefaultExchangeFormatter implements ExchangeFormatter {
 
         // only cut if we hit max-chars limit (or are using multiline
         if (multiline || maxChars > 0 && sb.length() > maxChars) {
-            StringBuilder answer = new StringBuilder();
+            StringBuilder answer = new StringBuilder(sb.length());
             for (String s : sb.toString().split(SEPARATOR)) {
                 if (s != null) {
                     if (s.length() > maxChars) {

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/DefaultMaskingFormatter.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/DefaultMaskingFormatter.java
@@ -206,7 +206,7 @@ public class DefaultMaskingFormatter implements MaskingFormatter {
     }
 
     protected StringBuilder createOneOfThemRegex(Set<String> keywords) {
-        StringBuilder regex = new StringBuilder();
+        StringBuilder regex = new StringBuilder(256);
         if (keywords == null || keywords.isEmpty()) {
             return null;
         }

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/PredicateValidationException.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/PredicateValidationException.java
@@ -37,7 +37,9 @@ public class PredicateValidationException extends ValidationException {
     }
 
     protected static String buildMessage(Predicate predicate, Exchange exchange) {
-        StringBuilder builder = new StringBuilder("Validation failed for Predicate[");
+        StringBuilder builder = new StringBuilder(256);
+
+        builder.append("Validation failed for Predicate[");
         builder.append(predicate.toString());
         builder.append("]");
         return builder.toString();

--- a/core/camel-util/src/main/java/org/apache/camel/util/AntPathMatcher.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/AntPathMatcher.java
@@ -405,7 +405,7 @@ public class AntPathMatcher {
         String[] patternParts = tokenizeToStringArray(pattern, this.pathSeparator);
         String[] pathParts = tokenizeToStringArray(path, this.pathSeparator);
 
-        StringBuilder buffer = new StringBuilder();
+        StringBuilder buffer = new StringBuilder(path.length());
 
         // Add any path parts that have a wildcarded pattern part.
         int puts = 0;

--- a/core/camel-util/src/main/java/org/apache/camel/util/CollectionHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/CollectionHelper.java
@@ -105,7 +105,7 @@ public final class CollectionHelper {
             return "";
         }
 
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         Iterator<?> it = col.iterator();
         while (it.hasNext()) {
             sb.append(it.next().toString());

--- a/core/camel-util/src/main/java/org/apache/camel/util/FileUtil.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/FileUtil.java
@@ -338,7 +338,7 @@ public final class FileUtil {
         }
 
         // build path based on stack
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         if (scheme != null) {
             sb.append(scheme);
             sb.append(":");

--- a/core/camel-util/src/main/java/org/apache/camel/util/IOHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/IOHelper.java
@@ -523,7 +523,7 @@ public final class IOHelper {
      * Warning, don't use for crazy big streams :)
      */
     public static String loadText(InputStream in) throws IOException {
-        StringBuilder builder = new StringBuilder();
+        StringBuilder builder = new StringBuilder(2048);
         InputStreamReader isr = new InputStreamReader(in);
         try {
             BufferedReader reader = buffered(isr);
@@ -856,7 +856,7 @@ public final class IOHelper {
      * @return                 the filtered content of the file
      */
     public static String stripLineComments(Path path, String commentPrefix, boolean stripBlankLines) {
-        StringBuilder result = new StringBuilder();
+        StringBuilder result = new StringBuilder(2048);
         try (Stream<String> lines = Files.lines(path)) {
             lines
                     .filter(l -> !stripBlankLines || !l.isBlank())

--- a/core/camel-util/src/main/java/org/apache/camel/util/ObjectHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/ObjectHelper.java
@@ -917,7 +917,8 @@ public final class ObjectHelper {
         if (objects == null) {
             return "null";
         } else {
-            StringBuilder buffer = new StringBuilder("{");
+            StringBuilder buffer = new StringBuilder(256);
+            buffer.append("{");
             int counter = 0;
             for (Object object : objects) {
                 if (counter++ > 0) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/OgnlHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/OgnlHelper.java
@@ -183,7 +183,7 @@ public final class OgnlHelper {
         }
 
         List<String> methods = new ArrayList<>(4);
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
 
         int j = 0; // j is used as counter per method
         int squareBracketCnt = 0; // special to keep track if and how deep we are inside a square bracket block, eg: [foo]
@@ -288,7 +288,7 @@ public final class OgnlHelper {
     }
 
     public static String methodAsDoubleQuotes(String ognl) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(ognl.length() + 32);
 
         int singleBracketCnt = 0;
         int doubleBracketCnt = 0;

--- a/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
@@ -1152,7 +1152,7 @@ public final class StringHelper {
         if (text == null || text.isEmpty()) {
             return text;
         }
-        StringBuilder answer = new StringBuilder();
+        StringBuilder answer = new StringBuilder(text.length() + 16);
 
         Character prev = null;
         Character next;

--- a/core/camel-util/src/main/java/org/apache/camel/util/StringQuoteHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringQuoteHelper.java
@@ -119,7 +119,7 @@ public final class StringQuoteHelper {
         }
 
         List<String> answer = new ArrayList<>();
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(input.length());
 
         boolean singleQuoted = false;
         boolean doubleQuoted = false;

--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -879,7 +879,7 @@ public final class URISupport {
             return "";
         }
 
-        final StringBuilder joined = new StringBuilder();
+        final StringBuilder joined = new StringBuilder(paths.length * 64);
 
         boolean addedLast = false;
         for (int i = paths.length - 1; i >= 0; i--) {
@@ -907,7 +907,7 @@ public final class URISupport {
     }
 
     public static String buildMultiValueQuery(String key, Iterable<Object> values) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         for (Object v : values) {
             if (!sb.isEmpty()) {
                 sb.append("&");

--- a/core/camel-util/src/main/java/org/apache/camel/util/backoff/BackOff.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/backoff/BackOff.java
@@ -111,7 +111,7 @@ public final class BackOff {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         sb.append("BackOff[");
         sb.append("delay=").append(delay.toMillis());
         if (maxDelay != MAX_DURATION) {

--- a/core/camel-xml-io/src/test/java/org/apache/camel/xml/in/ParserTest.java
+++ b/core/camel-xml-io/src/test/java/org/apache/camel/xml/in/ParserTest.java
@@ -134,7 +134,7 @@ public class ParserTest {
 
     @Test
     public void parseTheEdge() throws XmlPullParserException, IOException {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         sb.append("<?xml version='1.0'?>\n");
         sb.append("<!--\n");
         for (int i = sb.toString().length() + 4 - 2; i < 8 * 1024; i += 4) {

--- a/core/camel-xml-jaxp-util/src/main/java/org/apache/camel/util/xml/pretty/XmlPrettyPrinter.java
+++ b/core/camel-xml-jaxp-util/src/main/java/org/apache/camel/util/xml/pretty/XmlPrettyPrinter.java
@@ -104,7 +104,7 @@ public final class XmlPrettyPrinter {
         factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
         parser = factory.newSAXParser();
 
-        final StringBuilder sb = new StringBuilder();
+        final StringBuilder sb = new StringBuilder(256);
         final DefaultHandler handler = new DefaultHandler() {
             int indent;
             boolean inElement;
@@ -112,7 +112,7 @@ public final class XmlPrettyPrinter {
             @Override
             public void declaration(String version, String encoding, String standalone) throws SAXException {
                 if (declaration) {
-                    StringBuilder lb = new StringBuilder();
+                    StringBuilder lb = new StringBuilder(256);
                     lb.append("<?xml");
                     if (version != null) {
                         lb.append(" version=\"").append(version).append("\"");
@@ -136,7 +136,7 @@ public final class XmlPrettyPrinter {
                 inElement = true;
                 sb.append(XmlPrettyPrinter.padString(indent, blanks));
 
-                StringBuilder lb = new StringBuilder();
+                StringBuilder lb = new StringBuilder(256);
                 lb.append("<");
                 lb.append(qName);
 
@@ -170,7 +170,7 @@ public final class XmlPrettyPrinter {
                 inElement = false;
                 --indent;
 
-                StringBuilder lb = new StringBuilder();
+                StringBuilder lb = new StringBuilder(256);
                 lb.append("</");
                 lb.append(qName);
                 lb.append(">");

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/DomConverter.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/DomConverter.java
@@ -54,7 +54,7 @@ public final class DomConverter {
         // sometimes the NodeList is a Node which we can then leverage
         // the XML converter to turn into XML incl. tags
 
-        StringBuilder buffer = new StringBuilder();
+        StringBuilder buffer = new StringBuilder(128);
 
         // use XML converter at first since it preserves tag names
         boolean found = false;
@@ -93,7 +93,7 @@ public final class DomConverter {
         if (node instanceof Text) {
             Text textnode = (Text) node;
 
-            StringBuilder b = new StringBuilder();
+            StringBuilder b = new StringBuilder(128);
             b.append(textnode.getNodeValue());
             textnode = (Text) textnode.getNextSibling();
             while (textnode != null) {
@@ -109,7 +109,7 @@ public final class DomConverter {
 
     @Converter(order = 3)
     public static Integer toInteger(NodeList nodeList) {
-        StringBuilder buffer = new StringBuilder();
+        StringBuilder buffer = new StringBuilder(128);
         append(buffer, nodeList);
         String s = buffer.toString();
         return Integer.valueOf(s);
@@ -117,7 +117,7 @@ public final class DomConverter {
 
     @Converter(order = 4)
     public static Long toLong(NodeList nodeList) {
-        StringBuilder buffer = new StringBuilder();
+        StringBuilder buffer = new StringBuilder(128);
         append(buffer, nodeList);
         String s = buffer.toString();
         return Long.valueOf(s);

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/XmlConverter.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/XmlConverter.java
@@ -951,7 +951,7 @@ public class XmlConverter {
             }
         }
         if (!features.isEmpty()) {
-            StringBuilder featureString = new StringBuilder();
+            StringBuilder featureString = new StringBuilder(256);
             // just log the configured feature
             for (String feature : features) {
                 if (!featureString.isEmpty()) {

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/support/builder/xml/XMLConverterHelper.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/support/builder/xml/XMLConverterHelper.java
@@ -309,7 +309,7 @@ public class XMLConverterHelper {
             }
         }
         if (!features.isEmpty()) {
-            StringBuilder featureString = new StringBuilder();
+            StringBuilder featureString = new StringBuilder(256);
             // just log the configured feature
             for (String feature : features) {
                 if (!featureString.isEmpty()) {

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/support/processor/validation/SchemaValidationException.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/support/processor/validation/SchemaValidationException.java
@@ -75,7 +75,8 @@ public class SchemaValidationException extends ValidationException {
     protected static String message(
             Object schema, List<SAXParseException> fatalErrors,
             List<SAXParseException> errors, List<SAXParseException> warnings) {
-        StringBuilder buffer = new StringBuilder("Validation failed for: ")
+        StringBuilder buffer = new StringBuilder(128)
+                .append("Validation failed for: ")
                 .append(schema)
                 .append("\n");
 

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/util/xml/XmlLineNumberParser.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/util/xml/XmlLineNumberParser.java
@@ -142,7 +142,7 @@ public final class XmlLineNumberParser {
         doc = docBuilder.newDocument();
 
         final ArrayDeque<Element> elementStack = new ArrayDeque<>();
-        final StringBuilder textBuffer = new StringBuilder();
+        final StringBuilder textBuffer = new StringBuilder(256);
         final DefaultHandler handler = new DefaultHandler() {
             private Locator locator;
             private boolean found;


### PR DESCRIPTION
We have lots of places requiring larger buffer sizes, but still relying on the default value from the JVM (16 bytes). This tries to size the buffers more appropriately (using a naive approach / manual calculation). 