### PR TITLE
Do not play some tests of Tahu on s390x and ppc64le

### DIFF
--- a/components/camel-tahu/pom.xml
+++ b/components/camel-tahu/pom.xml
@@ -36,6 +36,9 @@
     <description>Camel Eclipse Tahu support for Sparkplug B</description>
 
     <properties>
+        <!-- HiveMQ container exists only for x86-->
+        <skipITs.ppc64le>true</skipITs.ppc64le>
+        <skipITs.s390x>true</skipITs.s390x>
     </properties>
 
     <dependencies>

--- a/components/camel-tahu/src/test/java/org/apache/camel/component/tahu/TahuEdgeProducerIT.java
+++ b/components/camel-tahu/src/test/java/org/apache/camel/component/tahu/TahuEdgeProducerIT.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TahuEdgeProducerTest extends TahuTestSupport {
+public class TahuEdgeProducerIT extends TahuTestSupport {
 
     static enum EdgeNodeTestProfile {
 

--- a/components/camel-tahu/src/test/java/org/apache/camel/component/tahu/TahuHostConsumerIT.java
+++ b/components/camel-tahu/src/test/java/org/apache/camel/component/tahu/TahuHostConsumerIT.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TahuHostConsumerTest extends TahuTestSupport {
+public class TahuHostConsumerIT extends TahuTestSupport {
 
     @Test
     public void hostSessionEstablishmentTest() throws Exception {

--- a/components/camel-tahu/src/test/java/org/apache/camel/component/tahu/handlers/TahuEdgeClientManualIT.java
+++ b/components/camel-tahu/src/test/java/org/apache/camel/component/tahu/handlers/TahuEdgeClientManualIT.java
@@ -56,9 +56,9 @@ import org.slf4j.LoggerFactory;
 
 @Disabled("Manual test for underlying TahuEdgeClient implementation complies with Sparkplug B TCK for Edge Nodes and Devices")
 @SuppressWarnings("unused")
-public class TahuEdgeClientManualTest {
+public class TahuEdgeClientManualIT {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TahuEdgeClientManualTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TahuEdgeClientManualIT.class);
 
     @RegisterExtension
     public static SparkplugTCKService spTckService = new SparkplugTCKService();

--- a/components/camel-tahu/src/test/java/org/apache/camel/component/tahu/handlers/TahuHostApplicationManualIT.java
+++ b/components/camel-tahu/src/test/java/org/apache/camel/component/tahu/handlers/TahuHostApplicationManualIT.java
@@ -49,9 +49,9 @@ import org.slf4j.LoggerFactory;
 
 @Disabled("Manual test for underlying TahuHostApplication implementation complies with Sparkplug B TCK for Host Applications")
 @SuppressWarnings("unused")
-public class TahuHostApplicationManualTest {
+public class TahuHostApplicationManualIT {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TahuHostApplicationManualTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TahuHostApplicationManualIT.class);
 
     @RegisterExtension
     public static SparkplugTCKService spTckService = new SparkplugTCKService();


### PR DESCRIPTION
Some Tahu tests are requiring a container to be started. Moved them to IT tests. It allows to not play them on s390x and ppc64le architecture as these containers require HiveMQ container which is not available on these platforms.

# Description

fix main branch, see https://ci-builds.apache.org/job/Camel/job/Camel%20Core%20(Build%20and%20test)/job/main/327/testReport/org.apache.camel.component.tahu/

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

