### PR TITLE
[CAMEL-21119] Improve support for java.nio.file.Path

### DIFF
--- a/core/camel-base/src/generated/java/org/apache/camel/converter/CamelBaseBulkConverterLoader.java
+++ b/core/camel-base/src/generated/java/org/apache/camel/converter/CamelBaseBulkConverterLoader.java
@@ -41,7 +41,7 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
 
     @Override
     public int size() {
-        return 122;
+        return 129;
     }
 
     @Override
@@ -76,6 +76,9 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             }
             if (value instanceof java.io.File) {
                 return org.apache.camel.converter.IOConverter.toByteArray((java.io.File) value);
+            }
+            if (value instanceof java.nio.file.Path) {
+                return org.apache.camel.converter.IOConverter.toByteArray((java.nio.file.Path) value);
             }
             if (value instanceof java.io.BufferedReader) {
                 return org.apache.camel.converter.IOConverter.toByteArray((java.io.BufferedReader) value, exchange);
@@ -118,9 +121,15 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             if (value instanceof java.io.File) {
                 return org.apache.camel.converter.IOConverter.toReader((java.io.File) value, exchange);
             }
+            if (value instanceof java.nio.file.Path) {
+                return org.apache.camel.converter.IOConverter.toReader((java.nio.file.Path) value, exchange);
+            }
         } else if (to == java.io.BufferedWriter.class) {
             if (value instanceof java.io.File) {
                 return org.apache.camel.converter.IOConverter.toWriter((java.io.File) value, exchange);
+            }
+            if (value instanceof java.nio.file.Path) {
+                return org.apache.camel.converter.IOConverter.toWriter((java.nio.file.Path) value, exchange);
             }
         } else if (to == java.io.File.class) {
             if (value instanceof java.nio.file.Path) {
@@ -139,14 +148,17 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             if (value instanceof java.io.File) {
                 return org.apache.camel.converter.IOConverter.toInputStream((java.io.File) value);
             }
+            if (value instanceof java.nio.file.Path) {
+                return org.apache.camel.converter.IOConverter.toInputStream((java.nio.file.Path) value);
+            }
+            if (value instanceof java.nio.ByteBuffer) {
+                return org.apache.camel.converter.NIOConverter.toInputStream((java.nio.ByteBuffer) value);
+            }
             if (value instanceof java.lang.String) {
                 return org.apache.camel.converter.IOConverter.toInputStream((java.lang.String) value, exchange);
             }
             if (value instanceof java.lang.StringBuffer) {
                 return org.apache.camel.converter.IOConverter.toInputStream((java.lang.StringBuffer) value, exchange);
-            }
-            if (value instanceof java.nio.ByteBuffer) {
-                return org.apache.camel.converter.NIOConverter.toInputStream((java.nio.ByteBuffer) value);
             }
             if (value instanceof java.lang.StringBuilder) {
                 return org.apache.camel.converter.IOConverter.toInputStream((java.lang.StringBuilder) value, exchange);
@@ -171,6 +183,9 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
         } else if (to == java.io.OutputStream.class) {
             if (value instanceof java.io.File) {
                 return org.apache.camel.converter.IOConverter.toOutputStream((java.io.File) value);
+            }
+            if (value instanceof java.nio.file.Path) {
+                return org.apache.camel.converter.IOConverter.toOutputStream((java.nio.file.Path) value);
             }
         } else if (to == java.io.Reader.class) {
             if (value instanceof org.apache.camel.spi.Resource) {
@@ -332,6 +347,9 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             if (value instanceof java.io.File) {
                 return org.apache.camel.converter.IOConverter.toString((java.io.File) value, exchange);
             }
+            if (value instanceof java.nio.file.Path) {
+                return org.apache.camel.converter.IOConverter.toString((java.nio.file.Path) value, exchange);
+            }
             if (value instanceof java.net.URL) {
                 return org.apache.camel.converter.IOConverter.toString((java.net.URL) value, exchange);
             }
@@ -343,9 +361,6 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             }
             if (value instanceof java.io.InputStream) {
                 return org.apache.camel.converter.IOConverter.toString((java.io.InputStream) value, exchange);
-            }
-            if (value instanceof java.io.ByteArrayOutputStream) {
-                return org.apache.camel.converter.IOConverter.toString((java.io.ByteArrayOutputStream) value, exchange);
             }
             if (value instanceof java.lang.Integer) {
                 return org.apache.camel.converter.ObjectConverter.toString((java.lang.Integer) value);
@@ -361,6 +376,9 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             }
             if (value instanceof java.lang.StringBuilder) {
                 return org.apache.camel.converter.ObjectConverter.toString((java.lang.StringBuilder) value);
+            }
+            if (value instanceof java.io.ByteArrayOutputStream) {
+                return org.apache.camel.converter.IOConverter.toString((java.io.ByteArrayOutputStream) value, exchange);
             }
         } else if (to == java.math.BigInteger.class) {
             if (value instanceof java.lang.Object) {
@@ -384,6 +402,9 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             }
             if (value instanceof java.io.File) {
                 return org.apache.camel.converter.NIOConverter.toByteBuffer((java.io.File) value);
+            }
+            if (value instanceof java.nio.file.Path) {
+                return org.apache.camel.converter.NIOConverter.toByteBuffer((java.nio.file.Path) value);
             }
             if (value instanceof java.lang.String) {
                 return org.apache.camel.converter.NIOConverter.toByteBuffer((java.lang.String) value, exchange);
@@ -511,6 +532,7 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
         registry.addConverter(new TypeConvertible<>(java.nio.ByteBuffer.class, byte[].class), this);
         registry.addConverter(new TypeConvertible<>(org.apache.camel.spi.Resource.class, byte[].class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, byte[].class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, byte[].class), this);
         registry.addConverter(new TypeConvertible<>(java.io.BufferedReader.class, byte[].class), this);
         registry.addConverter(new TypeConvertible<>(java.io.Reader.class, byte[].class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.String.class, byte[].class), this);
@@ -523,15 +545,18 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
         registry.addConverter(new TypeConvertible<>(java.lang.String.class, char.class), this);
         registry.addConverter(new TypeConvertible<>(byte[].class, char.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, java.io.BufferedReader.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, java.io.BufferedReader.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, java.io.BufferedWriter.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, java.io.BufferedWriter.class), this);
         registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, java.io.File.class), this);
         registry.addConverter(new TypeConvertible<>(java.util.stream.Stream.class, java.io.InputStream.class), this);
         registry.addConverter(new TypeConvertible<>(org.apache.camel.spi.Resource.class, java.io.InputStream.class), this);
         registry.addConverter(new TypeConvertible<>(java.net.URL.class, java.io.InputStream.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, java.io.InputStream.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.ByteBuffer.class, java.io.InputStream.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.String.class, java.io.InputStream.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.StringBuffer.class, java.io.InputStream.class), this);
-        registry.addConverter(new TypeConvertible<>(java.nio.ByteBuffer.class, java.io.InputStream.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.StringBuilder.class, java.io.InputStream.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.BufferedReader.class, java.io.InputStream.class), this);
         registry.addConverter(new TypeConvertible<>(byte[].class, java.io.InputStream.class), this);
@@ -539,6 +564,7 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
         registry.addConverter(new TypeConvertible<>(java.io.InputStream.class, java.io.ObjectInput.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.OutputStream.class, java.io.ObjectOutput.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, java.io.OutputStream.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, java.io.OutputStream.class), this);
         registry.addConverter(new TypeConvertible<>(org.apache.camel.spi.Resource.class, java.io.Reader.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.InputStream.class, java.io.Reader.class), this);
         registry.addConverter(new TypeConvertible<>(byte[].class, java.io.Reader.class), this);
@@ -581,21 +607,23 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
         registry.addConverter(new TypeConvertible<>(char[].class, java.lang.String.class), this);
         registry.addConverter(new TypeConvertible<>(byte[].class, java.lang.String.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, java.lang.String.class), this);
         registry.addConverter(new TypeConvertible<>(java.net.URL.class, java.lang.String.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.BufferedReader.class, java.lang.String.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.Reader.class, java.lang.String.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.InputStream.class, java.lang.String.class), this);
-        registry.addConverter(new TypeConvertible<>(java.io.ByteArrayOutputStream.class, java.lang.String.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.Integer.class, java.lang.String.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.Long.class, java.lang.String.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.Boolean.class, java.lang.String.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.StringBuffer.class, java.lang.String.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.StringBuilder.class, java.lang.String.class), this);
+        registry.addConverter(new TypeConvertible<>(java.io.ByteArrayOutputStream.class, java.lang.String.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.Object.class, java.math.BigInteger.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.CharSequence.class, java.net.URI.class), this);
         registry.addConverter(new TypeConvertible<>(byte[].class, java.nio.ByteBuffer.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.ByteArrayOutputStream.class, java.nio.ByteBuffer.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, java.nio.ByteBuffer.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, java.nio.ByteBuffer.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.String.class, java.nio.ByteBuffer.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.Short.class, java.nio.ByteBuffer.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.Integer.class, java.nio.ByteBuffer.class), this);
@@ -643,6 +671,9 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             if (from == java.io.File.class) {
                 return this;
             }
+            if (from == java.nio.file.Path.class) {
+                return this;
+            }
             if (from == java.io.BufferedReader.class) {
                 return this;
             }
@@ -684,8 +715,14 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             if (from == java.io.File.class) {
                 return this;
             }
+            if (from == java.nio.file.Path.class) {
+                return this;
+            }
         } else if (to == java.io.BufferedWriter.class) {
             if (from == java.io.File.class) {
+                return this;
+            }
+            if (from == java.nio.file.Path.class) {
                 return this;
             }
         } else if (to == java.io.File.class) {
@@ -705,13 +742,16 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             if (from == java.io.File.class) {
                 return this;
             }
+            if (from == java.nio.file.Path.class) {
+                return this;
+            }
+            if (from == java.nio.ByteBuffer.class) {
+                return this;
+            }
             if (from == java.lang.String.class) {
                 return this;
             }
             if (from == java.lang.StringBuffer.class) {
-                return this;
-            }
-            if (from == java.nio.ByteBuffer.class) {
                 return this;
             }
             if (from == java.lang.StringBuilder.class) {
@@ -736,6 +776,9 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             }
         } else if (to == java.io.OutputStream.class) {
             if (from == java.io.File.class) {
+                return this;
+            }
+            if (from == java.nio.file.Path.class) {
                 return this;
             }
         } else if (to == java.io.Reader.class) {
@@ -878,6 +921,9 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
             if (from == java.io.File.class) {
                 return this;
             }
+            if (from == java.nio.file.Path.class) {
+                return this;
+            }
             if (from == java.net.URL.class) {
                 return this;
             }
@@ -888,9 +934,6 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
                 return this;
             }
             if (from == java.io.InputStream.class) {
-                return this;
-            }
-            if (from == java.io.ByteArrayOutputStream.class) {
                 return this;
             }
             if (from == java.lang.Integer.class) {
@@ -906,6 +949,9 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
                 return this;
             }
             if (from == java.lang.StringBuilder.class) {
+                return this;
+            }
+            if (from == java.io.ByteArrayOutputStream.class) {
                 return this;
             }
         } else if (to == java.math.BigInteger.class) {
@@ -924,6 +970,9 @@ public final class CamelBaseBulkConverterLoader implements TypeConverterLoader, 
                 return this;
             }
             if (from == java.io.File.class) {
+                return this;
+            }
+            if (from == java.nio.file.Path.class) {
                 return this;
             }
             if (from == java.lang.String.class) {

--- a/core/camel-base/src/main/java/org/apache/camel/converter/IOConverter.java
+++ b/core/camel-base/src/main/java/org/apache/camel/converter/IOConverter.java
@@ -39,6 +39,7 @@ import java.io.StringReader;
 import java.io.Writer;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Properties;
@@ -83,90 +84,114 @@ public final class IOConverter {
     }
 
     @Converter(order = 4)
+    public static InputStream toInputStream(Path file) throws IOException {
+        return IOHelper.buffered(Files.newInputStream(file));
+    }
+
+    @Converter(order = 5)
     public static BufferedReader toReader(File file, Exchange exchange) throws IOException {
         return IOHelper.toReader(file, ExchangeHelper.getCharset(exchange));
     }
 
-    @Converter(order = 5)
+    @Converter(order = 6)
+    public static BufferedReader toReader(Path path, Exchange exchange) throws IOException {
+        return IOHelper.toReader(path, ExchangeHelper.getCharset(exchange));
+    }
+
+    @Converter(order = 7)
     public static OutputStream toOutputStream(File file) throws FileNotFoundException {
         return IOHelper.buffered(new FileOutputStream(file));
     }
 
-    @Converter(order = 6)
-    public static BufferedWriter toWriter(File file, Exchange exchange) throws IOException {
-        FileOutputStream os = new FileOutputStream(file, false);
-        return IOHelper.toWriter(os, ExchangeHelper.getCharset(exchange));
+    @Converter(order = 8)
+    public static OutputStream toOutputStream(Path file) throws IOException {
+        return IOHelper.buffered(Files.newOutputStream(file));
     }
 
-    @Converter(order = 7)
+    @Converter(order = 9)
+    public static BufferedWriter toWriter(File file, Exchange exchange) throws IOException {
+        return toWriter(file.toPath(), exchange);
+    }
+
+    @Converter(order = 10)
+    public static BufferedWriter toWriter(Path file, Exchange exchange) throws IOException {
+        return Files.newBufferedWriter(file, ExchangeHelper.getCharset(exchange));
+    }
+
+    @Converter(order = 11)
     public static Reader toReader(InputStream in, Exchange exchange) throws IOException {
         return IOHelper.buffered(new InputStreamReader(in, ExchangeHelper.getCharset(exchange)));
     }
 
-    @Converter(order = 8)
+    @Converter(order = 12)
     public static Reader toReader(byte[] data, Exchange exchange) throws IOException {
         return toReader(new ByteArrayInputStream(data), exchange);
     }
 
-    @Converter(order = 9)
+    @Converter(order = 13)
     public static Writer toWriter(OutputStream out, Exchange exchange) throws IOException {
         return IOHelper.buffered(new OutputStreamWriter(out, ExchangeHelper.getCharset(exchange)));
     }
 
-    @Converter(order = 10)
+    @Converter(order = 14)
     public static Reader toReader(String text) {
         // no buffering required as the complete string input is already passed
         // over as a whole
         return new StringReader(text);
     }
 
-    @Converter(order = 11)
+    @Converter(order = 15)
     public static InputStream toInputStream(String text, Exchange exchange) throws IOException {
         return toInputStream(text.getBytes(ExchangeHelper.getCharset(exchange)));
     }
 
-    @Converter(order = 12)
+    @Converter(order = 16)
     public static InputStream toInputStream(StringBuffer buffer, Exchange exchange) throws IOException {
         return toInputStream(buffer.toString(), exchange);
     }
 
-    @Converter(order = 13)
+    @Converter(order = 17)
     public static InputStream toInputStream(StringBuilder builder, Exchange exchange) throws IOException {
         return toInputStream(builder.toString(), exchange);
     }
 
-    @Converter(order = 14)
+    @Converter(order = 18)
     public static InputStream toInputStream(BufferedReader buffer, Exchange exchange) throws IOException {
         return toInputStream(toString(buffer), exchange);
     }
 
-    @Converter(order = 15)
+    @Converter(order = 19)
     public static String toString(byte[] data, Exchange exchange) throws IOException {
         return new String(data, ExchangeHelper.getCharset(exchange));
     }
 
-    @Converter(order = 16)
+    @Converter(order = 20)
     public static String toString(File file, Exchange exchange) throws IOException {
-        return toString(toReader(file, exchange));
+        return toString(file.toPath(), exchange);
     }
 
-    @Converter(order = 17)
+    @Converter(order = 21)
+    public static String toString(Path file, Exchange exchange) throws IOException {
+        return Files.readString(file, ExchangeHelper.getCharset(exchange));
+    }
+
+    @Converter(order = 22)
     public static byte[] toByteArray(File file) throws IOException {
-        InputStream is = toInputStream(file);
-        try {
-            return toBytes(is);
-        } finally {
-            IOHelper.close(is, "file", LOG);
-        }
+        return toByteArray(file.toPath());
     }
 
-    @Converter(order = 18)
+    @Converter(order = 23)
+    public static byte[] toByteArray(Path file) throws IOException {
+        return Files.readAllBytes(file);
+    }
+
+    @Converter(order = 24)
     public static byte[] toByteArray(BufferedReader reader, Exchange exchange) throws IOException {
         String s = toString(reader);
         return toByteArray(s, exchange);
     }
 
-    @Converter(order = 19)
+    @Converter(order = 25)
     public static String toString(URL url, Exchange exchange) throws IOException {
         InputStream is = toInputStream(url);
         try {
@@ -176,39 +201,39 @@ public final class IOConverter {
         }
     }
 
-    @Converter(order = 20)
+    @Converter(order = 26)
     public static String toString(BufferedReader reader) throws IOException {
         return IOHelper.toString(reader);
     }
 
-    @Converter(order = 21)
+    @Converter(order = 27)
     public static String toString(Reader reader) throws IOException {
         return IOHelper.toString(reader);
     }
 
-    @Converter(order = 22)
+    @Converter(order = 28)
     public static byte[] toByteArray(Reader reader, Exchange exchange) throws IOException {
         return toByteArray(IOHelper.buffered(reader), exchange);
     }
 
-    @Converter(order = 23)
+    @Converter(order = 29)
     public static byte[] toByteArray(String value, Exchange exchange) throws IOException {
         return value.getBytes(ExchangeHelper.getCharset(exchange));
     }
 
-    @Converter(order = 24)
+    @Converter(order = 30)
     public static String toString(InputStream in, Exchange exchange) throws IOException {
         return toString(toReader(in, exchange));
     }
 
-    @Converter(order = 25)
+    @Converter(order = 31)
     public static InputStream toInputStream(byte[] data) {
         // no buffering required as the complete byte input is already passed
         // over as a whole
         return new ByteArrayInputStream(data);
     }
 
-    @Converter(order = 26)
+    @Converter(order = 32)
     public static ObjectOutput toObjectOutput(OutputStream stream) throws IOException {
         if (stream instanceof ObjectOutput out) {
             return out;
@@ -217,7 +242,7 @@ public final class IOConverter {
         }
     }
 
-    @Converter(order = 27)
+    @Converter(order = 33)
     public static ObjectInput toObjectInput(final InputStream stream, final Exchange exchange) throws IOException {
         if (stream instanceof ObjectInput objectInput) {
             return objectInput;
@@ -244,7 +269,7 @@ public final class IOConverter {
         }
     }
 
-    @Converter(order = 28)
+    @Converter(order = 34)
     public static byte[] toBytes(InputStream stream) throws IOException {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         IOHelper.copyAndCloseInput(IOHelper.buffered(stream), bos);
@@ -254,36 +279,36 @@ public final class IOConverter {
         return bos.toByteArray();
     }
 
-    @Converter(order = 29)
+    @Converter(order = 35)
     public static byte[] toByteArray(ByteArrayOutputStream os) {
         return os.toByteArray();
     }
 
-    @Converter(order = 30)
+    @Converter(order = 36)
     public static ByteBuffer covertToByteBuffer(InputStream is) throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         IOHelper.copyAndCloseInput(is, os);
         return ByteBuffer.wrap(os.toByteArray());
     }
 
-    @Converter(order = 31)
+    @Converter(order = 37)
     public static String toString(ByteArrayOutputStream os, Exchange exchange) throws IOException {
         return os.toString(ExchangeHelper.getCharset(exchange));
     }
 
-    @Converter(order = 32)
+    @Converter(order = 38)
     public static InputStream toInputStream(ByteArrayOutputStream os) {
         // no buffering required as the complete byte array input is already
         // passed over as a whole
         return new ByteArrayInputStream(os.toByteArray());
     }
 
-    @Converter(order = 33)
+    @Converter(order = 39)
     public static Properties toProperties(File file) throws IOException {
         return toProperties(new FileInputStream(file));
     }
 
-    @Converter(order = 34)
+    @Converter(order = 40)
     public static Properties toProperties(InputStream is) throws IOException {
         Properties prop = new Properties();
         try {
@@ -294,7 +319,7 @@ public final class IOConverter {
         return prop;
     }
 
-    @Converter(order = 35)
+    @Converter(order = 41)
     public static Properties toProperties(Reader reader) throws IOException {
         Properties prop = new Properties();
         try {
@@ -305,12 +330,12 @@ public final class IOConverter {
         return prop;
     }
 
-    @Converter(order = 36)
+    @Converter(order = 42)
     public static Path toPath(File file) {
         return file.toPath();
     }
 
-    @Converter(order = 37)
+    @Converter(order = 43)
     public static File toFile(Path path) {
         return path.toFile();
     }

--- a/core/camel-base/src/main/java/org/apache/camel/converter/NIOConverter.java
+++ b/core/camel-base/src/main/java/org/apache/camel/converter/NIOConverter.java
@@ -18,16 +18,16 @@ package org.apache.camel.converter;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.camel.Converter;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePropertyKey;
-import org.apache.camel.util.IOHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,31 +71,22 @@ public final class NIOConverter {
 
     @Converter(order = 5)
     public static ByteBuffer toByteBuffer(File file) throws IOException {
-        if (file.length() > Integer.MAX_VALUE) {
-            // very big file we cannot load into memory
-            throw new IOException(
-                    "Cannot convert file: " + file.getName() + " to ByteBuffer. The file length is too large: "
-                                  + file.length());
-        }
-
-        InputStream in = null;
-        try {
-            byte[] buf = new byte[(int) file.length()];
-            in = IOHelper.buffered(new FileInputStream(file));
-            int sizeLeft = (int) file.length();
-            int offset = 0;
-            while (sizeLeft > 0) {
-                int readSize = in.read(buf, offset, sizeLeft);
-                sizeLeft -= readSize;
-                offset += readSize;
-            }
-            return ByteBuffer.wrap(buf);
-        } finally {
-            IOHelper.close(in, "Failed to close file stream: " + file.getPath(), LOG);
-        }
+        return toByteBuffer(file.toPath());
     }
 
     @Converter(order = 6)
+    public static ByteBuffer toByteBuffer(Path file) throws IOException {
+        long length = Files.size(file);
+        if (length > Integer.MAX_VALUE) {
+            // very big file we cannot load into memory
+            throw new IOException(
+                    "Cannot convert file: " + file + " to ByteBuffer. The file length is too large: "
+                                  + length);
+        }
+        return ByteBuffer.wrap(Files.readAllBytes(file));
+    }
+
+    @Converter(order = 7)
     public static ByteBuffer toByteBuffer(String value, Exchange exchange) {
         byte[] bytes = null;
         if (exchange != null) {
@@ -114,7 +105,7 @@ public final class NIOConverter {
         return ByteBuffer.wrap(bytes);
     }
 
-    @Converter(order = 7)
+    @Converter(order = 8)
     public static ByteBuffer toByteBuffer(Short value) {
         ByteBuffer buf = ByteBuffer.allocate(2);
         buf.putShort(value);
@@ -122,7 +113,7 @@ public final class NIOConverter {
         return buf;
     }
 
-    @Converter(order = 8)
+    @Converter(order = 9)
     public static ByteBuffer toByteBuffer(Integer value) {
         ByteBuffer buf = ByteBuffer.allocate(4);
         buf.putInt(value);
@@ -130,7 +121,7 @@ public final class NIOConverter {
         return buf;
     }
 
-    @Converter(order = 9)
+    @Converter(order = 10)
     public static ByteBuffer toByteBuffer(Long value) {
         ByteBuffer buf = ByteBuffer.allocate(8);
         buf.putLong(value);
@@ -138,7 +129,7 @@ public final class NIOConverter {
         return buf;
     }
 
-    @Converter(order = 10)
+    @Converter(order = 11)
     public static ByteBuffer toByteBuffer(Float value) {
         ByteBuffer buf = ByteBuffer.allocate(4);
         buf.putFloat(value);
@@ -146,7 +137,7 @@ public final class NIOConverter {
         return buf;
     }
 
-    @Converter(order = 11)
+    @Converter(order = 12)
     public static ByteBuffer toByteBuffer(Double value) {
         ByteBuffer buf = ByteBuffer.allocate(8);
         buf.putDouble(value);
@@ -154,7 +145,7 @@ public final class NIOConverter {
         return buf;
     }
 
-    @Converter(order = 12)
+    @Converter(order = 13)
     public static InputStream toInputStream(ByteBuffer bufferbuffer) {
         return IOConverter.toInputStream(toByteArray(bufferbuffer));
     }

--- a/core/camel-core/src/test/java/org/apache/camel/language/simple/SimpleOverrideMethodTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/simple/SimpleOverrideMethodTest.java
@@ -33,7 +33,7 @@ public class SimpleOverrideMethodTest extends LanguageTestSupport {
     public void testOverrideMethod() {
         Path path = new File("target").toPath();
         exchange.getIn().setBody(path);
-        assertExpression("${body.getFileName}", path.getFileName().toString());
+        assertExpression("${body.getFileName.toString}", path.getFileName().toString());
     }
 
 }

--- a/core/camel-support/src/main/java/org/apache/camel/support/ExchangeHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/ExchangeHelper.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -997,7 +1000,7 @@ public final class ExchangeHelper {
                 value = body;
             } else {
                 // generic file is just a wrapper for the real file so call again with the real file
-                return getScanner(exchange, gf.getFile(), delimiter);
+                value = gf.getFile();
             }
         }
 
@@ -1008,7 +1011,14 @@ public final class ExchangeHelper {
             scanner = new Scanner(str, delimiter);
         } else {
             String charset = exchange.getProperty(ExchangePropertyKey.CHARSET_NAME, String.class);
-            if (value instanceof File file) {
+            if (value instanceof Path path) {
+                try {
+                    scanner = new Scanner(
+                            Files.newByteChannel(path, StandardOpenOption.READ), charset, delimiter);
+                } catch (IOException e) {
+                    throw new RuntimeCamelException(e);
+                }
+            } else if (value instanceof File file) {
                 try {
                     scanner = new Scanner(file, charset, delimiter);
                 } catch (IOException e) {

--- a/core/camel-support/src/main/java/org/apache/camel/support/MessageHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/MessageHelper.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.lang.reflect.Array;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -345,7 +346,7 @@ public final class MessageHelper {
         }
 
         if (!allowFiles) {
-            if (obj instanceof WrappedFile || obj instanceof File) {
+            if (obj instanceof WrappedFile || obj instanceof File || obj instanceof Path) {
                 return "[Body is file based: " + obj + "]";
             }
         }

--- a/core/camel-util/src/main/java/org/apache/camel/util/FileUtil.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/FileUtil.java
@@ -19,6 +19,7 @@ package org.apache.camel.util;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -405,8 +406,21 @@ public final class FileUtil {
      * @throws java.io.IOException       is thrown if error renaming file
      */
     public static boolean renameFile(File from, File to, boolean copyAndDeleteOnRenameFail) throws IOException {
+        return renameFile(from.toPath(), to.toPath(), copyAndDeleteOnRenameFail);
+    }
+
+    /**
+     * Renames a file.
+     *
+     * @param  from                      the from file
+     * @param  to                        the to file
+     * @param  copyAndDeleteOnRenameFail whether to fallback and do copy and delete, if renameTo fails
+     * @return                           <tt>true</tt> if the file was renamed, otherwise <tt>false</tt>
+     * @throws java.io.IOException       is thrown if error renaming file
+     */
+    public static boolean renameFile(Path from, Path to, boolean copyAndDeleteOnRenameFail) throws IOException {
         // do not try to rename non existing files
-        if (!from.exists()) {
+        if (!Files.exists(from)) {
             return false;
         }
 
@@ -419,7 +433,12 @@ public final class FileUtil {
                 LOG.debug("Retrying attempt {} to rename file from: {} to: {}", count, from, to);
             }
 
-            renamed = from.renameTo(to);
+            try {
+                Files.move(from, to, StandardCopyOption.ATOMIC_MOVE);
+                renamed = true;
+            } catch (IOException e) {
+                // failed
+            }
             if (!renamed && count > 0) {
                 try {
                     Thread.sleep(1000);
@@ -455,8 +474,21 @@ public final class FileUtil {
      * @throws IOException If an I/O error occurs during copy or delete operations.
      */
     public static boolean renameFileUsingCopy(File from, File to) throws IOException {
+        return renameFileUsingCopy(from.toPath(), to.toPath());
+    }
+
+    /**
+     * Rename file using copy and delete strategy. This is primarily used in environments where the regular rename
+     * operation is unreliable.
+     *
+     * @param  from        the file to be renamed
+     * @param  to          the new target file
+     * @return             <tt>true</tt> if the file was renamed successfully, otherwise <tt>false</tt>
+     * @throws IOException If an I/O error occurs during copy or delete operations.
+     */
+    public static boolean renameFileUsingCopy(Path from, Path to) throws IOException {
         // do not try to rename non existing files
-        if (!from.exists()) {
+        if (!Files.exists(from)) {
             return false;
         }
 
@@ -480,7 +512,18 @@ public final class FileUtil {
      * @throws IOException If an I/O error occurs during copy operation
      */
     public static void copyFile(File from, File to) throws IOException {
-        Files.copy(from.toPath(), to.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        copyFile(from.toPath(), to.toPath());
+    }
+
+    /**
+     * Copies the file
+     *
+     * @param  from        the source file
+     * @param  to          the destination file
+     * @throws IOException If an I/O error occurs during copy operation
+     */
+    public static void copyFile(Path from, Path to) throws IOException {
+        Files.copy(from, to, StandardCopyOption.REPLACE_EXISTING);
     }
 
     /**
@@ -492,8 +535,20 @@ public final class FileUtil {
      * @param file the file to delete
      */
     public static boolean deleteFile(File file) {
+        return deleteFile(file.toPath());
+    }
+
+    /**
+     * Deletes the file.
+     * <p/>
+     * This implementation will attempt to delete the file up till three times with one second delay, which can mitigate
+     * problems on deleting files on some platforms such as Windows.
+     *
+     * @param file the file to delete
+     */
+    public static boolean deleteFile(Path file) {
         // do not try to delete non existing files
-        if (!file.exists()) {
+        if (!Files.exists(file)) {
             return false;
         }
 
@@ -505,7 +560,7 @@ public final class FileUtil {
             LOG.debug("Retrying attempt {} to delete file: {}", count, file);
 
             try {
-                Files.delete(file.toPath());
+                Files.delete(file);
                 deleted = true;
             } catch (IOException e) {
                 if (count > 0) {
@@ -533,7 +588,7 @@ public final class FileUtil {
      * makes the logic consistent across all OS platforms.
      *
      * @param  file the file
-     * @return      <tt>true</ff> if its an absolute path, <tt>false</tt> otherwise.
+     * @return      <tt>true</ff> if it's an absolute path, <tt>false</tt> otherwise.
      */
     public static boolean isAbsolute(File file) {
         if (isWindows()) {

--- a/core/camel-xml-jaxp/src/generated/java/org/apache/camel/converter/jaxp/CamelXmlJaxpBulkConverterLoader.java
+++ b/core/camel-xml-jaxp/src/generated/java/org/apache/camel/converter/jaxp/CamelXmlJaxpBulkConverterLoader.java
@@ -41,7 +41,7 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
 
     @Override
     public int size() {
-        return 95;
+        return 101;
     }
 
     @Override
@@ -221,6 +221,9 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
             if (value instanceof java.io.File) {
                 return getXmlConverter().toDOMSource((java.io.File) value, exchange);
             }
+            if (value instanceof java.nio.file.Path) {
+                return getXmlConverter().toDOMSource((java.nio.file.Path) value, exchange);
+            }
             if (value instanceof javax.xml.transform.stream.StreamSource) {
                 return getXmlConverter().toDOMSourceFromStream((javax.xml.transform.stream.StreamSource) value, exchange);
             }
@@ -245,6 +248,9 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
             }
             if (value instanceof java.io.File) {
                 return getXmlConverter().toSAXSource((java.io.File) value, exchange);
+            }
+            if (value instanceof java.nio.file.Path) {
+                return getXmlConverter().toSAXSource((java.nio.file.Path) value, exchange);
             }
             if (value instanceof javax.xml.transform.stream.StreamSource) {
                 return getXmlConverter().toSAXSourceFromStream((javax.xml.transform.stream.StreamSource) value, exchange);
@@ -271,6 +277,9 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
             if (value instanceof java.io.File) {
                 return getXmlConverter().toStAXSource((java.io.File) value, exchange);
             }
+            if (value instanceof java.nio.file.Path) {
+                return getXmlConverter().toStAXSource((java.nio.file.Path) value, exchange);
+            }
         } else if (to == javax.xml.transform.stream.StreamSource.class) {
             if (value instanceof java.lang.String) {
                 return getXmlConverter().toStreamSource((java.lang.String) value);
@@ -283,6 +292,9 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
             }
             if (value instanceof java.io.File) {
                 return getXmlConverter().toStreamSource((java.io.File) value);
+            }
+            if (value instanceof java.nio.file.Path) {
+                return getXmlConverter().toStreamSource((java.nio.file.Path) value);
             }
             if (value instanceof byte[]) {
                 return getXmlConverter().toStreamSource((byte[]) value, exchange);
@@ -345,6 +357,9 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
             if (value instanceof java.io.File) {
                 return getXmlConverter().toDOMDocument((java.io.File) value, exchange);
             }
+            if (value instanceof java.nio.file.Path) {
+                return getXmlConverter().toDOMDocument((java.nio.file.Path) value, exchange);
+            }
             if (value instanceof javax.xml.transform.Source) {
                 return getXmlConverter().toDOMDocument((javax.xml.transform.Source) value);
             }
@@ -392,6 +407,9 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
             }
             if (value instanceof java.io.File) {
                 return getXmlConverter().toInputSource((java.io.File) value, exchange);
+            }
+            if (value instanceof java.nio.file.Path) {
+                return getXmlConverter().toInputSource((java.nio.file.Path) value, exchange);
             }
         }
         return null;
@@ -444,6 +462,7 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
         registry.addConverter(new TypeConvertible<>(org.apache.camel.StreamCache.class, javax.xml.transform.dom.DOMSource.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.InputStream.class, javax.xml.transform.dom.DOMSource.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, javax.xml.transform.dom.DOMSource.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, javax.xml.transform.dom.DOMSource.class), this);
         registry.addConverter(new TypeConvertible<>(javax.xml.transform.stream.StreamSource.class, javax.xml.transform.dom.DOMSource.class), this);
         registry.addConverter(new TypeConvertible<>(javax.xml.transform.sax.SAXSource.class, javax.xml.transform.dom.DOMSource.class), this);
         registry.addConverter(new TypeConvertible<>(javax.xml.transform.stax.StAXSource.class, javax.xml.transform.dom.DOMSource.class), this);
@@ -452,6 +471,7 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
         registry.addConverter(new TypeConvertible<>(java.io.InputStream.class, javax.xml.transform.sax.SAXSource.class), this);
         registry.addConverter(new TypeConvertible<>(byte[].class, javax.xml.transform.sax.SAXSource.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, javax.xml.transform.sax.SAXSource.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, javax.xml.transform.sax.SAXSource.class), this);
         registry.addConverter(new TypeConvertible<>(javax.xml.transform.stream.StreamSource.class, javax.xml.transform.sax.SAXSource.class), this);
         registry.addConverter(new TypeConvertible<>(javax.xml.transform.dom.DOMSource.class, javax.xml.transform.sax.SAXSource.class), this);
         registry.addConverter(new TypeConvertible<>(javax.xml.transform.stax.StAXSource.class, javax.xml.transform.sax.SAXSource.class), this);
@@ -460,10 +480,12 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
         registry.addConverter(new TypeConvertible<>(byte[].class, javax.xml.transform.stax.StAXSource.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.InputStream.class, javax.xml.transform.stax.StAXSource.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, javax.xml.transform.stax.StAXSource.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, javax.xml.transform.stax.StAXSource.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.String.class, javax.xml.transform.stream.StreamSource.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.InputStream.class, javax.xml.transform.stream.StreamSource.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.Reader.class, javax.xml.transform.stream.StreamSource.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, javax.xml.transform.stream.StreamSource.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, javax.xml.transform.stream.StreamSource.class), this);
         registry.addConverter(new TypeConvertible<>(byte[].class, javax.xml.transform.stream.StreamSource.class), this);
         registry.addConverter(new TypeConvertible<>(java.nio.ByteBuffer.class, javax.xml.transform.stream.StreamSource.class), this);
         registry.addConverter(new TypeConvertible<>(javax.xml.transform.sax.SAXSource.class, javax.xml.transform.stream.StreamSource.class), this);
@@ -483,6 +505,7 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
         registry.addConverter(new TypeConvertible<>(org.xml.sax.InputSource.class, org.w3c.dom.Document.class), this);
         registry.addConverter(new TypeConvertible<>(java.lang.String.class, org.w3c.dom.Document.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, org.w3c.dom.Document.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, org.w3c.dom.Document.class), this);
         registry.addConverter(new TypeConvertible<>(javax.xml.transform.Source.class, org.w3c.dom.Document.class), this);
         registry.addConverter(new TypeConvertible<>(org.w3c.dom.NodeList.class, org.w3c.dom.Document.class), this);
         registry.addConverter(new TypeConvertible<>(javax.xml.transform.Source.class, org.w3c.dom.Element.class), this);
@@ -493,6 +516,7 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
         registry.addConverter(new TypeConvertible<>(javax.xml.transform.Source.class, org.w3c.dom.Node.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.InputStream.class, org.xml.sax.InputSource.class), this);
         registry.addConverter(new TypeConvertible<>(java.io.File.class, org.xml.sax.InputSource.class), this);
+        registry.addConverter(new TypeConvertible<>(java.nio.file.Path.class, org.xml.sax.InputSource.class), this);
     }
 
     public TypeConverter lookup(Class<?> to, Class<?> from) {
@@ -650,6 +674,9 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
             if (from == java.io.File.class) {
                 return this;
             }
+            if (from == java.nio.file.Path.class) {
+                return this;
+            }
             if (from == javax.xml.transform.stream.StreamSource.class) {
                 return this;
             }
@@ -673,6 +700,9 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
                 return this;
             }
             if (from == java.io.File.class) {
+                return this;
+            }
+            if (from == java.nio.file.Path.class) {
                 return this;
             }
             if (from == javax.xml.transform.stream.StreamSource.class) {
@@ -700,6 +730,9 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
             if (from == java.io.File.class) {
                 return this;
             }
+            if (from == java.nio.file.Path.class) {
+                return this;
+            }
         } else if (to == javax.xml.transform.stream.StreamSource.class) {
             if (from == java.lang.String.class) {
                 return this;
@@ -711,6 +744,9 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
                 return this;
             }
             if (from == java.io.File.class) {
+                return this;
+            }
+            if (from == java.nio.file.Path.class) {
                 return this;
             }
             if (from == byte[].class) {
@@ -774,6 +810,9 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
             if (from == java.io.File.class) {
                 return this;
             }
+            if (from == java.nio.file.Path.class) {
+                return this;
+            }
             if (from == javax.xml.transform.Source.class) {
                 return this;
             }
@@ -805,6 +844,9 @@ public final class CamelXmlJaxpBulkConverterLoader implements TypeConverterLoade
                 return this;
             }
             if (from == java.io.File.class) {
+                return this;
+            }
+            if (from == java.nio.file.Path.class) {
                 return this;
             }
         }

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/XmlConverter.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/XmlConverter.java
@@ -30,6 +30,8 @@ import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -369,7 +371,16 @@ public class XmlConverter {
      */
     @Converter(order = 21)
     public SAXSource toSAXSource(File file, Exchange exchange) throws IOException, SAXException, TransformerException {
-        InputStream is = IOHelper.buffered(new FileInputStream(file));
+        return toSAXSource(file.toPath(), exchange);
+    }
+
+    /**
+     * Converts the source instance to a {@link SAXSource} or returns null if the conversion is not supported (making it
+     * easy to derive from this class to add new kinds of conversion).
+     */
+    @Converter(order = 22)
+    public SAXSource toSAXSource(Path file, Exchange exchange) throws IOException, SAXException, TransformerException {
+        InputStream is = IOHelper.buffered(Files.newInputStream(file));
         return toSAXSource(is, exchange);
     }
 
@@ -377,46 +388,60 @@ public class XmlConverter {
      * Converts the source instance to a {@link StAXSource} or returns null if the conversion is not supported (making
      * it easy to derive from this class to add new kinds of conversion).
      */
-    @Converter(order = 22)
-    public StAXSource toStAXSource(File file, Exchange exchange) throws FileNotFoundException, XMLStreamException {
-        InputStream is = IOHelper.buffered(new FileInputStream(file));
+    @Converter(order = 23)
+    public StAXSource toStAXSource(File file, Exchange exchange) throws IOException, XMLStreamException {
+        return toStAXSource(file.toPath(), exchange);
+    }
+
+    /**
+     * Converts the source instance to a {@link StAXSource} or returns null if the conversion is not supported (making
+     * it easy to derive from this class to add new kinds of conversion).
+     */
+    @Converter(order = 24)
+    public StAXSource toStAXSource(Path file, Exchange exchange) throws IOException, XMLStreamException {
+        InputStream is = IOHelper.buffered(Files.newInputStream(file));
         XMLStreamReader r = new StaxConverter().createXMLStreamReader(is, exchange);
         return new StAXSource(r);
     }
 
-    @Converter(order = 23)
+    @Converter(order = 25)
     public StreamSource toStreamSource(String in) {
         return new StreamSource(new ByteArrayInputStream(in.getBytes()));
     }
 
-    @Converter(order = 24)
+    @Converter(order = 26)
     public StreamSource toStreamSource(InputStream in) {
         return new StreamSource(in);
     }
 
-    @Converter(order = 25)
+    @Converter(order = 27)
     public StreamSource toStreamSource(Reader in) {
         return new StreamSource(in);
     }
 
-    @Converter(order = 26)
+    @Converter(order = 28)
     public StreamSource toStreamSource(File in) {
         return new StreamSource(in);
     }
 
-    @Converter(order = 27)
+    @Converter(order = 29)
+    public StreamSource toStreamSource(Path in) throws IOException {
+        return new StreamSource(Files.newInputStream(in), in.toUri().toString());
+    }
+
+    @Converter(order = 30)
     public StreamSource toStreamSource(byte[] in, Exchange exchange) {
         InputStream is = exchange.getContext().getTypeConverter().convertTo(InputStream.class, exchange, in);
         return new StreamSource(is);
     }
 
-    @Converter(order = 28)
+    @Converter(order = 31)
     public StreamSource toStreamSource(ByteBuffer in, Exchange exchange) {
         InputStream is = exchange.getContext().getTypeConverter().convertTo(InputStream.class, exchange, in);
         return new StreamSource(is);
     }
 
-    @Converter(order = 29)
+    @Converter(order = 32)
     public StreamSource toStreamSourceFromSAX(SAXSource source, Exchange exchange) throws TransformerException {
         InputSource inputSource = source.getInputSource();
         if (inputSource != null) {
@@ -431,19 +456,19 @@ public class XmlConverter {
         return new StringSource(result);
     }
 
-    @Converter(order = 30)
+    @Converter(order = 33)
     public StreamSource toStreamSourceFromDOM(DOMSource source, Exchange exchange) throws TransformerException {
         String result = toString(source, exchange);
         return new StringSource(result);
     }
 
-    @Converter(order = 31)
+    @Converter(order = 34)
     public StreamSource toStreamSourceFromStAX(StAXSource source, Exchange exchange) throws TransformerException {
         String result = toString(source, exchange);
         return new StringSource(result);
     }
 
-    @Converter(order = 32)
+    @Converter(order = 35)
     public SAXSource toSAXSourceFromStream(StreamSource source, Exchange exchange) throws SAXException {
         InputSource inputSource;
         if (source.getReader() != null) {
@@ -478,7 +503,7 @@ public class XmlConverter {
         return new SAXSource(xmlReader, inputSource);
     }
 
-    @Converter(order = 33)
+    @Converter(order = 36)
     public Reader toReader(StreamSource source) {
         Reader r = source.getReader();
         if (r == null) {
@@ -487,7 +512,7 @@ public class XmlConverter {
         return r;
     }
 
-    @Converter(order = 34)
+    @Converter(order = 37)
     public Reader toReaderFromSource(Source src, Exchange exchange) throws TransformerException {
         StreamSource stSrc = toStreamSource(src, exchange);
         Reader r = stSrc.getReader();
@@ -497,7 +522,7 @@ public class XmlConverter {
         return r;
     }
 
-    @Converter(order = 35)
+    @Converter(order = 38)
     public DOMSource toDOMSource(StreamCache cache, Exchange exchange)
             throws ParserConfigurationException, IOException, SAXException {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -505,7 +530,7 @@ public class XmlConverter {
         return toDOMSource(new ByteArrayInputStream(bos.toByteArray()), exchange);
     }
 
-    @Converter(order = 36)
+    @Converter(order = 39)
     public DOMSource toDOMSource(InputStream is, Exchange exchange)
             throws ParserConfigurationException, IOException, SAXException {
         InputSource source = new InputSource(is);
@@ -515,13 +540,18 @@ public class XmlConverter {
         return new DOMSource(document, systemId);
     }
 
-    @Converter(order = 37)
+    @Converter(order = 40)
     public DOMSource toDOMSource(File file, Exchange exchange) throws ParserConfigurationException, IOException, SAXException {
-        InputStream is = IOHelper.buffered(new FileInputStream(file));
+        return toDOMSource(file.toPath(), exchange);
+    }
+
+    @Converter(order = 41)
+    public DOMSource toDOMSource(Path file, Exchange exchange) throws ParserConfigurationException, IOException, SAXException {
+        InputStream is = IOHelper.buffered(Files.newInputStream(file));
         return toDOMSource(is, exchange);
     }
 
-    @Converter(order = 38)
+    @Converter(order = 42)
     public DOMSource toDOMSourceFromStream(StreamSource source, Exchange exchange)
             throws ParserConfigurationException, IOException, SAXException {
         Document document;
@@ -544,33 +574,33 @@ public class XmlConverter {
         return new DOMSource(document, systemId);
     }
 
-    @Converter(order = 39)
+    @Converter(order = 43)
     public SAXSource toSAXSourceFromDOM(DOMSource source, Exchange exchange) throws TransformerException {
         String str = toString(source, exchange);
         StringReader reader = new StringReader(str);
         return new SAXSource(new InputSource(reader));
     }
 
-    @Converter(order = 40)
+    @Converter(order = 44)
     public SAXSource toSAXSourceFromStAX(StAXSource source, Exchange exchange) throws TransformerException {
         String str = toString(source, exchange);
         StringReader reader = new StringReader(str);
         return new SAXSource(new InputSource(reader));
     }
 
-    @Converter(order = 41)
+    @Converter(order = 45)
     public DOMSource toDOMSourceFromSAX(SAXSource source)
             throws TransformerException {
         return new DOMSource(toDOMNodeFromSAX(source));
     }
 
-    @Converter(order = 42)
+    @Converter(order = 46)
     public DOMSource toDOMSourceFromStAX(StAXSource source)
             throws TransformerException {
         return new DOMSource(toDOMNodeFromStAX(source));
     }
 
-    @Converter(order = 43)
+    @Converter(order = 47)
     public Node toDOMNodeFromSAX(SAXSource source)
             throws TransformerException {
         DOMResult result = new DOMResult();
@@ -578,7 +608,7 @@ public class XmlConverter {
         return result.getNode();
     }
 
-    @Converter(order = 44)
+    @Converter(order = 48)
     public Node toDOMNodeFromStAX(StAXSource source)
             throws TransformerException {
         DOMResult result = new DOMResult();
@@ -592,7 +622,7 @@ public class XmlConverter {
      * @param  nl the NodeList
      * @return    the DOM Node
      */
-    @Converter(order = 45, allowNull = true)
+    @Converter(order = 49, allowNull = true)
     public Node toDOMNodeFromSingleNodeList(NodeList nl) {
         return nl.getLength() == 1 ? nl.item(0) : null;
     }
@@ -603,7 +633,7 @@ public class XmlConverter {
      * If the node is a document, just cast it, if the node is an root element, retrieve its owner element or create a
      * new document and import the node.
      */
-    @Converter(order = 46)
+    @Converter(order = 50)
     public Document toDOMDocument(final Node node) throws ParserConfigurationException, TransformerException {
         ObjectHelper.notNull(node, "node");
 
@@ -634,7 +664,7 @@ public class XmlConverter {
     /**
      * Converts the given Source into a W3C DOM node
      */
-    @Converter(order = 47, allowNull = true)
+    @Converter(order = 51, allowNull = true)
     public Node toDOMNode(Source source) throws TransformerException, ParserConfigurationException, IOException, SAXException {
         DOMSource domSrc = toDOMSource(source, null);
         return domSrc != null ? domSrc.getNode() : null;
@@ -643,7 +673,7 @@ public class XmlConverter {
     /**
      * Create a DOM element from the given source.
      */
-    @Converter(order = 48)
+    @Converter(order = 52)
     public Element toDOMElement(Source source)
             throws TransformerException, ParserConfigurationException, IOException, SAXException {
         Node node = toDOMNode(source);
@@ -654,7 +684,7 @@ public class XmlConverter {
      * Create a DOM element from the DOM node. Simply cast if the node is an Element, or return the root element if it
      * is a Document.
      */
-    @Converter(order = 49)
+    @Converter(order = 53)
     public Element toDOMElement(Node node) throws TransformerException {
         // If the node is an document, return the root element
         if (node instanceof Document) {
@@ -675,14 +705,14 @@ public class XmlConverter {
      * @param  exchange is the exchange to be used when calling the converter
      * @return          the parsed document
      */
-    @Converter(order = 50)
+    @Converter(order = 54)
     public Document toDOMDocument(byte[] data, Exchange exchange)
             throws IOException, SAXException, ParserConfigurationException {
         DocumentBuilder documentBuilder = createDocumentBuilder(getDocumentBuilderFactory(exchange));
         return documentBuilder.parse(new ByteArrayInputStream(data));
     }
 
-    @Converter(order = 51)
+    @Converter(order = 55)
     public Document toDOMDocument(StreamCache cache, Exchange exchange)
             throws IOException, SAXException, ParserConfigurationException {
         InputStream is = exchange.getContext().getTypeConverter().convertTo(InputStream.class, exchange, cache);
@@ -696,7 +726,7 @@ public class XmlConverter {
      * @param  exchange is the exchange to be used when calling the converter
      * @return          the parsed document
      */
-    @Converter(order = 52)
+    @Converter(order = 56)
     public Document toDOMDocument(InputStream in, Exchange exchange)
             throws IOException, SAXException, ParserConfigurationException {
         DocumentBuilder documentBuilder = createDocumentBuilder(getDocumentBuilderFactory(exchange));
@@ -716,7 +746,7 @@ public class XmlConverter {
      * @param  exchange is the exchange to be used when calling the converter
      * @return          the parsed document
      */
-    @Converter(order = 53)
+    @Converter(order = 57)
     public Document toDOMDocument(Reader in, Exchange exchange) throws IOException, SAXException, ParserConfigurationException {
         return toDOMDocument(new InputSource(in), exchange);
     }
@@ -728,7 +758,7 @@ public class XmlConverter {
      * @param  exchange is the exchange to be used when calling the converter
      * @return          the parsed document
      */
-    @Converter(order = 54)
+    @Converter(order = 58)
     public Document toDOMDocument(InputSource in, Exchange exchange)
             throws IOException, SAXException, ParserConfigurationException {
         DocumentBuilder documentBuilder = createDocumentBuilder(getDocumentBuilderFactory(exchange));
@@ -742,7 +772,7 @@ public class XmlConverter {
      * @param  exchange is the exchange to be used when calling the converter
      * @return          the parsed document
      */
-    @Converter(order = 55)
+    @Converter(order = 59)
     public Document toDOMDocument(String text, Exchange exchange)
             throws IOException, SAXException, ParserConfigurationException {
         return toDOMDocument(new StringReader(text), exchange);
@@ -755,16 +785,29 @@ public class XmlConverter {
      * @param  exchange is the exchange to be used when calling the converter
      * @return          the parsed document
      */
-    @Converter(order = 56)
+    @Converter(order = 60)
     public Document toDOMDocument(File file, Exchange exchange) throws IOException, SAXException, ParserConfigurationException {
         DocumentBuilder documentBuilder = createDocumentBuilder(getDocumentBuilderFactory(exchange));
         return documentBuilder.parse(file);
     }
 
     /**
+     * Converts the given {@link File} to a DOM document
+     *
+     * @param  file     is the data to be parsed
+     * @param  exchange is the exchange to be used when calling the converter
+     * @return          the parsed document
+     */
+    @Converter(order = 61)
+    public Document toDOMDocument(Path file, Exchange exchange) throws IOException, SAXException, ParserConfigurationException {
+        DocumentBuilder documentBuilder = createDocumentBuilder(getDocumentBuilderFactory(exchange));
+        return documentBuilder.parse(IOHelper.buffered(Files.newInputStream(file)), file.toUri().toString());
+    }
+
+    /**
      * Create a DOM document from the given source.
      */
-    @Converter(order = 57)
+    @Converter(order = 62)
     public Document toDOMDocument(Source source)
             throws TransformerException, ParserConfigurationException, IOException, SAXException {
         Node node = toDOMNode(source);
@@ -782,7 +825,7 @@ public class XmlConverter {
      * @param  nl the NodeList
      * @return    the DOM Document
      */
-    @Converter(order = 58, allowNull = true)
+    @Converter(order = 63, allowNull = true)
     public Document toDOMDocumentFromSingleNodeList(NodeList nl) throws ParserConfigurationException, TransformerException {
         if (nl.getLength() == 1) {
             return toDOMDocument(nl.item(0));
@@ -795,24 +838,30 @@ public class XmlConverter {
         }
     }
 
-    @Converter(order = 59)
+    @Converter(order = 64)
     public InputStream toInputStream(DOMSource source, Exchange exchange) throws TransformerException {
         return new ByteArrayInputStream(toByteArray(source, exchange));
     }
 
-    @Converter(order = 60)
+    @Converter(order = 65)
     public InputStream toInputStream(Document dom, Exchange exchange) throws TransformerException {
         return toInputStream(new DOMSource(dom), exchange);
     }
 
-    @Converter(order = 61)
+    @Converter(order = 66)
     public InputSource toInputSource(InputStream is, Exchange exchange) {
         return new InputSource(is);
     }
 
-    @Converter(order = 62)
+    @Converter(order = 67)
     public InputSource toInputSource(File file, Exchange exchange) throws FileNotFoundException {
         InputStream is = IOHelper.buffered(new FileInputStream(file));
+        return new InputSource(is);
+    }
+
+    @Converter(order = 68)
+    public InputSource toInputSource(Path file, Exchange exchange) throws IOException {
+        InputStream is = IOHelper.buffered(Files.newInputStream(file));
         return new InputSource(is);
     }
 
@@ -820,7 +869,7 @@ public class XmlConverter {
      * Converts the source instance to a {@link DOMSource} or returns null if the conversion is not supported (making it
      * easy to derive from this class to add new kinds of conversion).
      */
-    @Converter(order = 63)
+    @Converter(order = 69)
     public DOMSource toDOMSource(Source source, Exchange exchange)
             throws ParserConfigurationException, IOException, SAXException, TransformerException {
         if (source instanceof DOMSource) {
@@ -840,7 +889,7 @@ public class XmlConverter {
      * Converts the source instance to a {@link SAXSource} or returns null if the conversion is not supported (making it
      * easy to derive from this class to add new kinds of conversion).
      */
-    @Converter(order = 64)
+    @Converter(order = 70)
     public SAXSource toSAXSource(Source source, Exchange exchange) throws SAXException, TransformerException {
         if (source instanceof SAXSource) {
             return (SAXSource) source;
@@ -855,7 +904,7 @@ public class XmlConverter {
         }
     }
 
-    @Converter(order = 65)
+    @Converter(order = 71)
     public StreamSource toStreamSource(Source source, Exchange exchange) throws TransformerException {
         if (source instanceof StreamSource) {
             return (StreamSource) source;
@@ -870,7 +919,7 @@ public class XmlConverter {
         }
     }
 
-    @Converter(order = 66)
+    @Converter(order = 72)
     public InputStream toInputStream(StreamSource source) throws IOException {
         InputStream is = source.getInputStream();
         if (is == null) {


### PR DESCRIPTION
Provides better support for conveying `java.nio.file.Path` objects in messages with the same converters that are registered for `java.io.File` objects.
JIRA issue: https://issues.apache.org/jira/browse/CAMEL-21119