### PR TITLE
CAMEL-21143: disable unstable camel-tahu tests + set execution limit

### DIFF
--- a/components/camel-tahu/pom.xml
+++ b/components/camel-tahu/pom.xml
@@ -39,6 +39,8 @@
         <!-- HiveMQ container exists only for x86-->
         <skipITs.ppc64le>true</skipITs.ppc64le>
         <skipITs.s390x>true</skipITs.s390x>
+        <camel.surefire.forkTimeout>300</camel.surefire.forkTimeout>
+        <camel.failsafe.forkTimeout>300</camel.failsafe.forkTimeout>
     </properties>
 
     <dependencies>

--- a/components/camel-tahu/src/test/java/org/apache/camel/component/tahu/TahuEdgeProducerIT.java
+++ b/components/camel-tahu/src/test/java/org/apache/camel/component/tahu/TahuEdgeProducerIT.java
@@ -22,14 +22,17 @@ import java.util.concurrent.TimeUnit;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.test.infra.core.annotations.RouteFixture;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
+                          disabledReason = "CAMEL-21143: requires too much resources and blocks the CI")
 public class TahuEdgeProducerIT extends TahuTestSupport {
 
-    static enum EdgeNodeTestProfile {
+    enum EdgeNodeTestProfile {
 
         SESSION_ESTABLISHMENT_TEST("edge SessionEstablishmentTest IamHost G2 E2 D2", false, 0),
         SESSION_TERMINATION_TEST("edge SessionTerminationTest IamHost G2 E2 D2", false, 3),

--- a/components/camel-tahu/src/test/resources/logback-test.xml
+++ b/components/camel-tahu/src/test/resources/logback-test.xml
@@ -18,37 +18,23 @@
 -->
 <configuration>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d %.-1level [%-15.15t] %40.40logger{40} %8.8marker %msg%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>target/camel-tahu-test.log</file>
+        <append>true</append>
         <encoder>
             <pattern>%d [%-15.15t] %-5p %-30.30c{1} - %m%n</pattern>
         </encoder>
     </appender>
 
-    <!-- <logger name="org.apache.camel.component.tahu" level="TRACE" /> -->
-
-    <!-- <logger name="org.apache.camel.component.tahu.TahuEdgeProducer" level="TRACE" /> -->
-
-    <!-- <logger name="org.apache.camel.component.tahu.TahuEdgeClient" level="TRACE" /> -->
-
-    <!-- <logger name="org.apache.camel.component.tahu.TahuTestSupport" level="DEBUG" /> -->
-
-    <!-- <logger name="org.apache.camel.component.tahu" level="DEBUG" /> -->
-
-    <logger name="org.apache.camel.builder.NotifyBuilder" level="ERROR" />
-
     <logger name="org.eclipse.tahu.edge" level="OFF" />
     <logger name="org.eclipse.tahu.mqtt" level="OFF" />
 
+    <logger name="org.apache.camel.component.tahu" level="DEBUG" additivity="false" >
+        <appender-ref ref="FILE" />
+    </logger>
+
     <root level="INFO">
         <appender-ref ref="FILE" />
-        <appender-ref ref="STDOUT" />
     </root>
 
 </configuration>


### PR DESCRIPTION
This should fix test instabilities caused by Tahu (introduced in #15088):
- Set a max upper limit for the execution
- Disable unstable tests