### PR TITLE
(chores) upgrade guides: fixed typos and grammar issues

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-3-migration-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3-migration-guide.adoc
@@ -8,9 +8,9 @@ xref:camel-3x-upgrade-guide.adoc[Camel 3.x Upgrade Guide].
 
 == Java versions
 
-Camel 3 supports Java 11. Support for Java 8 is best effort for early versions of Camel 3. However at some time in the 3.x lifeline we will drop support for Java 8.
+Camel 3 supports Java 11. Support for Java 8 is best effort for early versions of Camel 3. However, at some time in the 3.x lifeline we will drop support for Java 8.
 
-In Java 11 the JAXB modules have been **removed** from the JDK, therefore you will need to add them as Maven dependencies (if you use JAXB such as when using XML DSL or the camel-jaxb component):
+In Java 11, the JAXB modules have been **removed** from the JDK, therefore, you will need to add them as Maven dependencies (if you use JAXB such as when using XML DSL or the camel-jaxb component):
 
 [source,xml]
 ----
@@ -52,7 +52,7 @@ In Camel 2.x camel-core was one JAR file, it has now been split up into many JAR
 - camel-util-json
 
 Maven users of Apache Camel can keep using the dependency `camel-core` which has transitive dependencies on all of its modules, except for `camel-main`, and therefore no migration is needed.
-However, users who want to trim the size of the classes on the classpath, can use fine grained Maven dependencies on only the modules needed.
+However, users who want to trim the size of the classes on the classpath, can use fine-grained Maven dependencies on only the modules needed.
 You may find how to do that in the examples.
 
 We have also modularized many of the core components and moved them out of `camel-core` to individual components:
@@ -109,9 +109,9 @@ Use:
 
 == Multiple CamelContexts per application not supported
 
-Support for multiple CamelContexts has been removed and only 1 CamelContext per deployment is supported.
-The latter was not recommended anyway and was also not 100% implemented (for example in camel-cdi).
-For Camel 3 only 1 CamelContext per deployment is recommended and supported.
+Support for multiple CamelContexts has been removed, and only 1 CamelContext per deployment is supported.
+The latter was not recommended anyway and was also not 100% implemented, for example, in `camel-cdi`.
+For Camel 3, only 1 `CamelContext` per deployment is recommended and supported.
 
 The `context` attribute on the various Camel annotations such as `@EndpointInject`, `@Produce`, `@Consume` etc. has therefore been removed.
 
@@ -149,8 +149,8 @@ The properties component will now use OS environment variables as preferred valu
 
 The `properties` component no longer support using endpoints, such as `properties:myKey`. The properties component is now only a property placeholder service.
 You can therefore no longer lookup the properties component via `camelContext.getComponent("properties")`.
-Instead you can use `camelContext.getPropertiesComponent()`, which also returns an interface of the properties component as `org.apache.camel.spi.PropertiesComponent`.
-The implementation is still named `org.apache.camel.component.properties.PropertiesComponent`, however it should rarely be used, as you should favour using the interface instead.
+Instead, you can use `camelContext.getPropertiesComponent()`, which also returns an interface of the properties component as `org.apache.camel.spi.PropertiesComponent`.
+The implementation is still named `org.apache.camel.component.properties.PropertiesComponent`, however, it should rarely be used, as you should favour using the interface instead.
 
 
 === Removed components
@@ -193,7 +193,7 @@ We have also renamed `camel-jetty9` to `camel-jetty`. The supported scheme is no
 
 === Hystrix EIP
 
-The Hystrix EIP has been generalized as circuit breaker to allow to plugin other implementations.
+The Hystrix EIP has been generalized as a circuit breaker to allow plugging in other implementations.
 
 In the Java DSL you need to migrate from `.hystrix()` to `.circuitBreaker()`.
 And in XML DSL `<hystrix>` should be `<circuitBreaker>`.
@@ -258,7 +258,7 @@ And the same for `<setProperty>`.
 
 === <aggregate> EIP in XML DSL
 
-The aggregte EIP have renamed the expressions (not the attributes) for setting correlation size/timeout to avoid a name clash, so migrate:
+The aggregate EIP has renamed the expressions (not the attributes) for setting correlation size/timeout to avoid a name clash, so migrate:
 
 [source,xml]
 ----
@@ -317,17 +317,17 @@ It is the same for the other EIPs `<delay>`, `<sample>`, and `<throttle>`.
 
 ==== camel-cdi
 
-Support for multiple CamelContexts has been removed, and therefore `@ContextName` has been removed. Instead use standard CDI annotations such as `@Named` and `@ApplicationScoped`.
+Support for multiple CamelContexts has been removed, and therefore `@ContextName` has been removed. Instead, use standard CDI annotations such as `@Named` and `@ApplicationScoped`.
 
 === javax.script
 
-The `camel-script` component has been removed and there is no support for javax.script, which is also deprecated in the JDK and to be removed from Java 11 onwards.
+The `camel-script` component has been removed, and there is no support for `javax.script`, which is also deprecated in the JDK and to be removed from Java 11 onwards.
 
 === Attachments API on Message
 
-The attachments API (javax.activation) has been moved out of `org.apache.camel.message` into an extension `org.apache.camel.attachment.AttachmentMessage` from the `camel-attachments` JAR.
+The attachments API (`javax.activation`) has been moved out of `org.apache.camel.message` into an extension `org.apache.camel.attachment.AttachmentMessage` from the `camel-attachments` JAR.
 
-To use this API you can get it via the `getMessage` method on `Exchange`:
+To use this API, you can get it via the `getMessage` method on `Exchange`:
 
   AttachmentMessage am = exchange.getMessage(AttachmentMessage.class);
   am.addAttachment("myAtt", new DataHandler(...));
@@ -338,16 +338,17 @@ The fault API has been removed from `org.apache.camel.Message` as it was only us
 
 === getOut on Exchange
 
-The `hasOut` and `getOut` methods on `Exchange` has been deprecated in favour of using `getMessage` instead. (Side note: Camel-core is still using these methods in a few places to be backwards compatible and relies on this logic as Camel was initially designed with the concept of IN and OUT messages inspired by the JBI and SOAP-WS specifications.)
+The `hasOut` and `getOut` methods on `Exchange` has been deprecated in favour of using `getMessage` instead.
+(Side note: `camel-core` is still using these methods in a few places to be backwards compatible and relies on this logic as Camel was initially designed with the concept of IN and OUT messages inspired by the JBI and SOAP-WS specifications.)
 
 === OUT message removed from Simple language and Mock component
 
 The simple language has removed the OUT message concepts eg `${out.body}`.
-Also the mock component has removed OUT message from its assertion API, eg
+Also, the mock component has removed OUT message from its assertion API, eg
 
   mock.message(0).outBody()...
 
-Also the `@OutHeaders` annotation for bean parameter binding has been removed, instead use `@Headers` instead.
+Also, the `@OutHeaders` annotation for bean parameter binding has been removed, instead use `@Headers` instead.
 
 === Mock component
 
@@ -376,12 +377,12 @@ The component `camel-aws` has been split into multiple components:
 - camel-aws-sqs
 - camel-aws-swf
 
-So you'll have to add explicitly the dependencies for these components. From the OSGi perspective, there is still a `camel-aws` Karaf feature, which includes all the components features.
+So you'll have to explicitly add the dependencies for these components. From the OSGi perspective, there is still a `camel-aws` Karaf feature, which includes all the components features.
 
 === FHIR
 
 The camel-fhir component has upgraded it's hapi-fhir dependency to 4.1.0; Karaf support has been dropped until the hapi-fhir Karaf features are fixed and released.
-The default FHIR version has been changed to R4. Therefore if DSTU3 is desired it has to be explicitly set.
+The default FHIR version has been changed to R4. Therefore, if DSTU3 is desired, it has to be explicitly set.
 
 === Kafka
 
@@ -481,7 +482,7 @@ Before the default value was "DES/CBC/PKCS5Padding".
 
 === JSon DataFormat
 
-The default JSon library with the JSon dataformat has changed from `XStream` to `Jackson`.
+The default JSON library with the JSON dataformat has changed from `XStream` to `Jackson`.
 
 === Shiro Component
 
@@ -497,8 +498,8 @@ is now RSA-SHA256 (before it was RSA-SHA1).
 
 The default encryption key for the XML Security DataFormat has been removed,
 so it is now mandatory to supply the key String/bytes if you are using
-symmetric encryption. This means that some of the methods are removed that
-used the XMLSecurityDataFormat without specifying a key.
+symmetric encryption. This means that some methods are removed that
+used the `XMLSecurityDataFormat` without specifying a key.
 
 In addition, the default symmetric encryption algorithm has changed from
 Triple DES to AES-256 in GCM mode.
@@ -538,9 +539,9 @@ The APIs on `CamelContext` has been reduced a bit to focus on relevant API for C
 
 === Checked vs unchecked exceptions
 
-Most of the Camel exception classes have been migrated to be unchecked (e.g. extends `RuntimeException`).
+Most of the Camel exception classes have been migrated to be unchecked (e.g., extends `RuntimeException`).
 
-Also the lifecycle of the `start`, `stop` and `suspend`, `resume` methods on `Service` and `SuspendableService` has been changed to not throw checked exceptions.
+Also, the lifecycle of the `start`, `stop` and `suspend`, `resume` methods on `Service` and `SuspendableService` has been changed to not throw checked exceptions.
 
 ==== Generic Information
 
@@ -608,7 +609,7 @@ as property placeholders are already supported via Camel Main, Camel Spring Boot
 === camel-test
 
 If you are using camel-test and override the `createRegistry` method, for example to register beans from the `JndiRegistry` class, then this is no longer necessary, and instead
-you should just use the `bind` method from the `Registry` API which you can call directly from `CamelContext`, such as:
+you should use the `bind` method from the `Registry` API which you can call directly from `CamelContext`, such as:
 
   context.getRegistry().bind("myId", myBean);
 
@@ -732,7 +733,7 @@ The `@FallbackConverter` annotation has been removed, and you should use `@Conve
 
 === Removed JMX APIs for explaining EIPs, components, etc.
 
-The APIs that could find, and explain EIPs, components, endpoints etc. has been removed. These APIs have little value for production runtimes, and you can obtain this kind of information via the `camel-catalog`. Also the related Camel Karaf commands that used these APIs has been removed.
+The APIs that could find, and explain EIPs, components, endpoints, etc. have been removed. These APIs have little value for production runtimes, and you can obtain this kind of information via the `camel-catalog`. Also the related Camel Karaf commands that used these APIs has been removed.
 
 === Other changes
 

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_11.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_11.adoc
@@ -1,7 +1,7 @@
 = Apache Camel 3.x Upgrade Guide
 
 This document is for helping you upgrade your Apache Camel application
-from Camel 3.x to 3.y. For example if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
+from Camel 3.x to 3.y. For example, if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
 from both 3.0 to 3.1 and 3.1 to 3.2.
 
 == Upgrading Camel 3.10 to 3.11
@@ -9,8 +9,8 @@ from both 3.0 to 3.1 and 3.1 to 3.2.
 === Bean Language
 
 When using `beanType` (full qualified class name) with the bean language,
-then the bean language will *now* lookup in registry and if there is a single instance of the same type, then the existing bean is used.
-If not then a new bean is created (same behavior as before).
+then the bean language will *now* look up in the registry, and if there is a single instance of the same type, then the existing bean is used.
+If not, then a new bean is created (same behavior as before).
 
 === Aggregate EIP
 
@@ -18,7 +18,7 @@ The aggregate EIP will now always use a worker thread pool for processing outgoi
 Previously a worker pool was only created when `parallelProcessing=true`. When having `parallelProcessing=false`
 then a single-threaded worker pool is created and used by the aggregator.
 
-Camels routing engine works better when a dedicated worker pool that eliminates a _hack_ that otherwise was needed in other EIPs that
+Camels routing engine works better when a dedicated worker pool that eliminates a _hack_ that otherwise was necessary in other EIPs that
 was affected if using the aggregator in some special configurations.
 
 === RemoveHeader EIP
@@ -54,7 +54,7 @@ The `streamFilter` option should now be configured as endpoint uri parameter, in
 === camel-saxon
 
 The camel-saxon component no longer depends on camel-xslt-saxon.
-Any applications in needs of XSLT transformation with saxon should now declare an explicit dependency upon camel-xslt-saxon.
+Any applications in need of XSLT transformation with saxon should now declare an explicit dependency upon camel-xslt-saxon.
 
 === camel-maven-plugin with OSGi blueprint
 
@@ -92,14 +92,14 @@ mvn camel-karaf:run
 
 === camel-sql
 
-Support of deprecated use of named dataSource in the URI has been removed.
+Support for deprecated use of named dataSource in the URI has been removed.
 
 You have to use `sql:select * from table where id=# order by name?dataSource=\#myDS` instead of `sql:select * from table where id=# order by name?dataSource=myDS`.
 
 === Spring Boot Starters
 
-Some of the Camel Spring Boot starters have additional auto configuration options that clashed with component.
-Therefore those configurations has renamed their configuration keys:
+Some of the Camel Spring Boot starters have additional autoconfiguration options that clashed with component.
+Therefore, those configurations have renamed their configuration keys:
 
 |====
 | *Old Key prefix* | *New key prefix*

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_14.adoc
@@ -1,7 +1,7 @@
 = Apache Camel 3.x Upgrade Guide
 
 This document is for helping you upgrade your Apache Camel application
-from Camel 3.x to 3.y. For example if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
+from Camel 3.x to 3.y. For example, if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
 from both 3.0 to 3.1 and 3.1 to 3.2.
 
 == Upgrading Camel 3.14.x to 3.14.10

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_18.adoc
@@ -1,7 +1,7 @@
 = Apache Camel 3.x Upgrade Guide
 
 This document is for helping you upgrade your Apache Camel application
-from Camel 3.x to 3.y. For example if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
+from Camel 3.x to 3.y. For example, if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
 from both 3.0 to 3.1 and 3.1 to 3.2.
 
 == Upgrading Camel 3.17 to 3.18
@@ -9,7 +9,7 @@ from both 3.0 to 3.1 and 3.1 to 3.2.
 === camel-core
 
 Camel will now mask all known secret values when logging endpoint URIs to avoid leaking sensitive details
-such as from stacktraces. Previously only a sub set of known _secret_ keys was masked.
+such as from stack traces. Previously only a subset of known _secret_ keys was masked.
 
 The type converter from `InputStream` to `byte[]` will now close the input stream after the conversion.
 
@@ -23,7 +23,7 @@ to better separate output between text and json based.
 
 === camel-cxf
 
-The `camel-cxf` JAR has been split up into SOAP vs REST and Spring and non Spring JARs.
+The `camel-cxf` JAR has been split up into SOAP vs. REST and Spring and non-Spring JARs.
 
 Users should therefore choose `camel-cxf` to migrate among the following JARs:
 
@@ -34,15 +34,15 @@ Users should therefore choose `camel-cxf` to migrate among the following JARs:
 - `camel-cxf-transport`
 - `camel-cxf-spring-transport`
 
-For example if you were using CXF for SOAP and with Spring XML, then you would need to migrate
+For example, if you were using CXF for SOAP and with Spring XML, then you would need to migrate
 from using `camel-cxf` to `camel-cxf-spring-soap` and `camel-cxf-spring-transport`.
 
-When using Spring Boot then you need to migrate from `camel-cxf-starter` to use SOAP or REST:
+When using Spring Boot, then you need to migrate from `camel-cxf-starter` to use SOAP or REST:
 
 - `camel-cxf-soap-starter`
 - `camel-cxf-rest-starter`
 
-The `camel-cxf` XML XSD schemas has also changed namespaces:
+The `camel-cxf` XML XSD schemas have also changed namespaces:
 
 |===
 |Old Namespace | New Namespace
@@ -70,8 +70,8 @@ i.e. `org.apache.camel.component.cxf` is now `org.apache.camel.component.cxf.jaw
 This means, for example, the `CxfComponent` class is now located
 in `org.apache.camel.component.cxf.jaxws`.
 
-Some classes in the following packages were refactored, and the package was updated, 
-if you were using one of those packages and, after the migration, a ClassNotFoundException is thrown, 
+Some classes in the following packages were refactored, and the package was updated.
+If you were using one of those packages and, after the migration, a `ClassNotFoundException` is thrown,
 an update should be considered
 
 |===

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_20.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_20.adoc
@@ -1,7 +1,7 @@
 = Apache Camel 3.x Upgrade Guide
 
 This document is for helping you upgrade your Apache Camel application
-from Camel 3.x to 3.y. For example if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
+from Camel 3.x to 3.y. For example, if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
 from both 3.0 to 3.1 and 3.1 to 3.2.
 
 == Upgrading Camel 3.20.6 to 3.20.7
@@ -31,7 +31,7 @@ The old behavior can be archived by setting `backlogTracingStandby=true`.
 
 The xref:backlog-tracer.adoc[Backlog Tracer] has been enhanced and _fixed_ to trace message headers (also streaming types).
 This means that previously headers of type `InputStream` was not traced before, but is now included. This could mean that
-the header stream is positioned at end, and logging the header afterward, may appear as the header value is empty.
+the header stream is positioned at the end, and logging the header afterward may appear as the header value is empty.
 
 === camel-micrometer-starter
 
@@ -50,7 +50,7 @@ A route now have `<routeProperty>` in the top instead of the bottom.
 
 === YAML DSL
 
-Using _allowable values_ in Rest with YAML DSL is fixed to use correct name as other DSLs.
+Using _allowable values_ in Rest with YAML DSL is fixed to use the correct name as other DSLs.
 
 Before:
 
@@ -86,12 +86,12 @@ and configure them via Java code or classic Spring XML `<bean>` style.
 
 === camel-kafka
 
-The following options has changed default value as they were mistakenly out of sync with Apache Kafka.
+The following options have changed default value as they were mistakenly out of sync with Apache Kafka.
 This caused camel-kafka producer to not enable idempotence out of the box, that otherwise plain Apache Kafka client would do:
 
-- enableIdempotence: changed from `false` to `true`
-- requestRequiredAcks: changed from `1` to `all`
-- retries: changed from `0` to _unset_
+- `enableIdempotence`: changed from `false` to `true`
+- `requestRequiredAcks`: changed from `1` to `all`
+- `retries`: changed from `0` to `_unset_`
 
 == Upgrading Camel 3.19 to 3.20
 
@@ -123,7 +123,7 @@ Dependencies not intended for end users has been removed, such as all `-parent` 
 
 === camel-base64
 
-The `base64` property placeholder function will now lookup the value as a property key.
+The `base64` property placeholder function will now look up the value as a property key.
 For example
 
 [source,text]
@@ -164,7 +164,7 @@ that it is now the same, how error handlers are in other DSLs.
 
 The Mongodb Driver core has been updated to version 4.8.1
 
-This fully support MongoDB 6.1
+This fully supports MongoDB 6.1
 
 === camel-google-pubsub
 

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_21.adoc
@@ -1,7 +1,7 @@
 = Apache Camel 3.x Upgrade Guide
 
 This document is for helping you upgrade your Apache Camel application
-from Camel 3.x to 3.y. For example if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
+from Camel 3.x to 3.y. For example, if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
 from both 3.0 to 3.1 and 3.1 to 3.2.
 
 == Upgrading Camel 3.21 to 3.21.3
@@ -98,7 +98,7 @@ To enable access, then set `accessExternalSchemaProtocols=all` or specify allowe
 
 === camel-platform-http-vertx
 
-If the route or consumer is suspended then http status 503 is now returned instead of 404.
+If the route or consumer is suspended, then http status 503 is now returned instead of 404.
 
 === camel-spring-rabbitmq
 
@@ -111,15 +111,15 @@ XML parser in `StAXJAXBIteratorExpression` has been made more secure by disablin
 
 === camel-cm-sms
 
-XML parsers has been made more secure by disabling DOCTYPE and/or access to external DTD/Schema.
+XML parsers have been made more secure by disabling `DOCTYPE` and/or access to external DTD/Schema.
 
 === camel-schematron
 
-XML parsers has been made more secure by disabling DOCTYPE and/or access to external DTD/Schema.
+XML parsers have been made more secure by disabling `DOCTYPE` and/or access to external DTD/Schema.
 
 === camel-xmlsecurity
 
-XML parsers has been made more secure by disabling DOCTYPE and/or access to external DTD/Schema.
+XML parsers have been made more secure by disabling `DOCTYPE` and/or access to external DTD/Schema.
 
 === camel-jbang
 
@@ -169,7 +169,7 @@ with Camel on Spring Boot, then include the `camel-spring-boot-xml-starter` depe
 The health-check has aligned to be more similar to microprofile-health in the JSon output.
 Spring Boot now also includes additional data per check, when using full exposure level.
 
-For example as shown below for the context health check:
+For example, as shown below for the context health check:
 
 [source,json]
 ----
@@ -209,7 +209,7 @@ This can be enabled again by setting `camel.metrics.uriTagDynamic=true`.
 
 === camel-platform-http-starter
 
-If the route or consumer is suspended then http status 503 is now returned instead of 404.
+If the route or consumer is suspended, then http status 503 is now returned instead of 404.
 
 The `platform-http-starter` has been changed from using `camel-servlet` to use Spring HTTP server directly.
 Therefore, all the HTTP endpoints are no longer prefixed with the servlet context-path (default is `camel`).
@@ -222,7 +222,7 @@ from("platform-http:myservice")
   .to("...")
 ----
 
-Then calling _myservice_ would before require to include the context-path, such as `http://localhost:8080/camel/myservice`.
+Then calling `_myservice_` would before require including the context-path, such as `http://localhost:8080/camel/myservice`.
 Now the context-path is not in use, and the endpoint can be called with `http://localhost:8080/myservice`.
 
 NOTE: The `platform-http-starter` can also be used with Rest DSL.

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_22.adoc
@@ -1,7 +1,7 @@
 = Apache Camel 3.x Upgrade Guide
 
 This document is for helping you upgrade your Apache Camel application
-from Camel 3.x to 3.y. For example if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
+from Camel 3.x to 3.y. For example, if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
 from both 3.0 to 3.1 and 3.1 to 3.2.
 
 == Upgrading Camel 3.21 to 3.22
@@ -14,7 +14,7 @@ No changes expected.
 
 The `readLock=changed` with using `readLockMinAge` has been restored to same behaviour as previously in 3.x.
 
-For example using `readLockMinAge=5s` would pickup files that are older than 5 seconds from startup time.
+For example, using `readLockMinAge=5s` would pickup files that are older than 5 seconds from startup time.
 If you have many existing files on startup that are old, then Camel will now again be fast,
-and pickup these files immediately.
+and pick up these files immediately.
 

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_7.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_7.adoc
@@ -1,7 +1,7 @@
 = Apache Camel 3.x Upgrade Guide
 
 This document is for helping you upgrade your Apache Camel application
-from Camel 3.x to 3.y. For example if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
+from Camel 3.x to 3.y. For example, if you are upgrading Camel 3.0 to 3.2, then you should follow the guides
 from both 3.0 to 3.1 and 3.1 to 3.2.
 
 == Upgrading Camel 3.6 to 3.7
@@ -50,19 +50,19 @@ Two methods related to adding and removing error handlers were removed from the 
 === Type Converters
 
 Camel 3.7 has optimized its type converter system, which can impact 3rd party components which contain type converters.
-Previously the type converter system would attempt to find a type converter that would be capable of
+Previously, the type converter system would attempt to find a type converter that would be capable of
 converting between two given types (also by walking up the parent classes and super interfaces).
 But this leads to slower performance, and Camel now relies on there being converter methods with the exact combo
 of converting from/to types.
 
-==== Converting to milli seconds from text
+==== Converting to milliseconds from text
 
-When converting to milli seconds using the shorthands for time precision with hours, minutes and seconds, support
+When converting to milliseconds using the shorthands for time precision with hours, minutes and seconds, support
 for fractions was removed. For example `delay=0.5m` (half minute) is no longer supported, use `delay=30s` instead.
 
 Support for using units as `days`, `hours`, `minutes`, `seconds`, and `millis` has been removed.
 Units must now be one of `d` for days, `h` for hours, `m` for minutes, `s` for seconds, and `ms` for millis (can be omitted).
-So you can use `1h12m37s42ms` for 1 hour, 12 minutes, 37 seconds and 42 milli seconds.
+So you can use `1h12m37s42ms` for 1 hour, 12 minutes, 37 seconds and 42 milliseconds.
 
 === JMX
 
@@ -102,8 +102,8 @@ The event type header is no longer an enum, but it is now the explicit event as 
 
 === camel-leveldb
 
-Component uses different serialization mechanism, which is not backwards compatible with the original one.
-For full compatibility use the camel-leveldb-legacy component (the legacy component will be removed in a future release).
+Component uses a different serialization mechanism, which is not backwards compatible with the original one.
+For full compatibility, use the camel-leveldb-legacy component (the legacy component will be removed in a future release).
 
 === camel-mock
 
@@ -121,7 +121,7 @@ The `listTypeConverters` operation on `ManagedTypeConverterRegistryMBean` has be
 
 === camel-kafka
 
-We changed some options naming because they were a bit misleading:
+We changed some option's naming because they were a bit misleading:
 
 - From kafkaHeaderDeserializer to headerDeserializer
 - From kafkaHeaderSerializer to headerSerializer
@@ -134,152 +134,152 @@ For more information, have a look at CAMEL-15770
 
 The Camel Git Commit consumer has been changed a bit.
 
-For each exchange now in the body you'll get the commit full message as a String and the Commit Object like before.
+For each exchange now in the body, you'll get the commit full message as a String and the Commit Object like before.
 
 Other information has been stored in headers declared in GitConstants class:
 
-* GIT_COMMIT_ID - "CamelGitCommitId" - The commit Id
-* GIT_COMMIT_AUTHOR_NAME - "CamelGitAuthorName" - The commit Author name
-* GIT_COMMIT_COMMITTER_NAME - "CamelGitCommiterName" - The commit committer name
-* GIT_COMMIT_TIME - "CamelGitCommitTime" - The commit time
+* `GIT_COMMIT_ID` - "CamelGitCommitId" - The commit Id
+* `GIT_COMMIT_AUTHOR_NAME` - "CamelGitAuthorName" - The commit Author name
+* `GIT_COMMIT_COMMITTER_NAME` - "CamelGitCommiterName" - The commit committer name
+* `GIT_COMMIT_TIME` - "CamelGitCommitTime" - The commit time
 
 The Camel Git Branch consumer has been changed a bit.
 
-For each exchange now in the body you'll get the branch ref name and not the full ref like before.
+For each exchange now in the body, you'll get the branch ref name and not the full ref like before.
 
 Other information has been stored in headers declared in `GitConstants` class:
 
-* GIT_BRANCH_LEAF - "CamelGitBranchLeaf" - Leaf
-* GIT_BRANCH_OBJECT_ID - "CamelGitBranchObjectId" - Object Id
+* `GIT_BRANCH_LEAF` - "CamelGitBranchLeaf" - Leaf
+* `GIT_BRANCH_OBJECT_ID` - "CamelGitBranchObjectId" - Object Id
 
 The Camel Git Tag consumer has been changed a bit.
 
-For each exchange now in the body you'll get the tag ref name and not the full ref like before.
+For each exchange now in the body, you'll get the tag ref name and not the full ref like before.
 
 Other information has been stored in headers declared in GitConstants class:
 
-* GIT_TAG_LEAF - "CamelGitTagLeaf" - Leaf
-* GIT_TAG_OBJECT_ID - "CamelGitTagObjectId" - Object Id
+* `GIT_TAG_LEAF` - "CamelGitTagLeaf" - Leaf
+* `GIT_TAG_OBJECT_ID` - "CamelGitTagObjectId" - Object Id
 
 === camel-github
 
-Login using username and password is no longer supported by github and these options have been removed
+Login using username and password is no longer supported by GitHub and these options have been removed
 (https://developer.github.com/changes/2020-02-14-deprecating-password-auth/).
 
 Login must be done using the `oauthToken` option.
 
 === Camel-AWS2-S3 Autowire support
 
-The camel-aws2-s3 component now has support for autowiring the amazonS3Client option with a S3Client instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-s3 component now has support for autowiring the `amazonS3Client` option with a `S3Client` instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-S3 UseIamCredentials
 
-The option useIamCredentials has been renamed to useDefaultCredentialsProvider, since we changed to a DefaultCredentialsProvider approach.
+The option useIamCredentials has been renamed to `useDefaultCredentialsProvider`, since we changed to a `DefaultCredentialsProvider` approach.
 
 === Camel-AWS2-Cloudwatch Autowire support
 
-The camel-aws2-cw component now has support for autowiring the amazonCwClient option with a CloudWatchClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-cw component now has support for autowiring the `amazonCwClient` option with a CloudWatchClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-DDB Autowire support
 
-The camel-aws2-ddb component now has support for autowiring the amazonDDBClient option with a DynamoDbClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-ddb component now has support for autowiring the `amazonDDBClient` option with a DynamoDbClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
-The camel-aws2-ddbstreams component now has support for autowiring the amazonDynamoDbStreamsClient option with a DynamoDbStreamsClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-ddbstreams component now has support for autowiring the `amazonDynamoDbStreamsClient` option with a DynamoDbStreamsClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-EC2 Autowire support
 
-The camel-aws2-ec2 component now has support for autowiring the amazonEc2Client option with an Ec2Client instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-ec2 component now has support for autowiring the `amazonEc2Client` option with an Ec2Client instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-ECS Autowire support
 
-The camel-aws2-ecs component now has support for autowiring the ecsClient option with an EcsClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-ecs component now has support for autowiring the `ecsClient` option with an EcsClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-EKS Autowire support
 
-The camel-aws2-eks component now has support for autowiring the eksClient option with an EksClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-eks component now has support for autowiring the `eksClient` option with an EksClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-Eventbridge Autowire support
 
-The camel-aws2-eventbridge component now has support for autowiring the eventBridgeClient option with an EventBridgeClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-eventbridge component now has support for autowiring the `eventBridgeClient` option with an EventBridgeClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-IAM Autowire support
 
-The camel-aws2-iam component now has support for autowiring the iamClient option with an IamClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-iam component now has support for autowiring the `iamClient` option with an IamClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-Kinesis Autowire support
 
-The camel-aws2-kinesis component now has support for autowiring the amazonKinesisClient option with a KinesisClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-kinesis component now has support for autowiring the `amazonKinesisClient` option with a KinesisClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
-The camel-aws2-kinesis-firehose component now has support for autowiring the amazonKinesisFirehoseClient option with a FirehoseClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-kinesis-firehose component now has support for autowiring the `amazonKinesisFirehoseClient` option with a FirehoseClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-KMS Autowire support
 
-The camel-aws2-kms component now has support for autowiring the awsLambdaClient option with a LambdaClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-kms component now has support for autowiring the `awsLambdaClient` option with a LambdaClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-Lambda Autowire support
 
-The camel-aws2-kms component now has support for autowiring the kmsClient option with a KmsClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-kms component now has support for autowiring the `kmsClient` option with a KmsClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-MQ Autowire support
 
-The camel-aws2-mq component now has support for autowiring the amazonMqClient option with a MqClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-mq component now has support for autowiring the `amazonMqClient` option with a MqClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-MSK Autowire support
 
-The camel-aws2-msk component now has support for autowiring the mskClient option with a KafkaClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-msk component now has support for autowiring the `mskClient` option with a KafkaClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-SES Autowire support
 
-The camel-aws2-ses component now has support for autowiring the amazonSESClient option with a SesClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-ses component now has support for autowiring the `amazonSESClient` option with a SesClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-SNS Autowire support
 
-The camel-aws2-sns component now has support for autowiring the amazonSNSClient option with a SnsClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-sns component now has support for autowiring the `amazonSNSClient` option with a SnsClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-SNS UseIamCredentials
 
-The option useIamCredentials has been renamed to useDefaultCredentialsProvider, since we changed to a DefaultCredentialsProvider approach.
+The option useIamCredentials has been renamed to `useDefaultCredentialsProvider`, since we changed to a DefaultCredentialsProvider approach.
 
 === Camel-AWS2-SQS Autowire support
 
-The camel-aws2-sqs component now has support for autowiring the amazonSQSClient option with a SqsClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-sqs component now has support for autowiring the 1 `amazonSQSClient` option with a SqsClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-SQS UseIamCredentials
 
-The option useIamCredentials has been renamed to useDefaultCredentialsProvider, since we changed to a DefaultCredentialsProvider approach.
+The option useIamCredentials has been renamed to `useDefaultCredentialsProvider`, since we changed to a `DefaultCredentialsProvider` approach.
 
 === Camel-AWS2-STS Autowire support
 
-The camel-aws2-sts component now has support for autowiring the stsClient option with a StsClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-sts component now has support for autowiring the `stsClient` option with a StsClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-Translate Autowire support
 
-The camel-aws2-translate component now has support for autowiring the translateClient option with a TranslateClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-translate component now has support for autowiring the `translateClient` option with a TranslateClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === Camel-AWS2-Athena Autowire support
 
-The camel-aws2-athena component now has support for autowiring the amazonAthenaClient option with an AthenaClient instance coming from the registry.
-In this context, it wasn't making sense to maintain the autodiscoverClient option, which has been removed.
+The camel-aws2-athena component now has support for autowiring the `amazonAthenaClient` option with an AthenaClient instance coming from the registry.
+In this context, it wasn't making sense to maintain the `autodiscoverClient` option, which has been removed.
 
 === camel-salesforce
 
@@ -298,5 +298,5 @@ you may need to have a transformation that explicitly converts spaces to "{plus}
 The camel-google-bigquery component was updated to use the latest version of `google-cloud-bigquery`. Some features of `GoogleBigQueryConnectionFactory` are no longer supported.
 
 It is no longer possible to provide the service account private key as a String parameter to `GoogleBigQueryConnectionFactory`. Instead, you should use `setCredentialsFileLocation` to 
-discover the private key from your credentials file. Or use the fallback mechanism for discovering credentials by setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. Refer to the 
+discover the private key from your credential's file. Or use the fallback mechanism for discovering credentials by setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. Refer to the
 component documentation for more information. 

--- a/docs/user-manual/modules/ROOT/pages/camel-4-migration-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4-migration-guide.adoc
@@ -14,7 +14,7 @@ Camel 4 supports Java 17. Support for Java 11 is dropped.
 
 == Removed Components
 
-The following components has been removed:
+The following components have been removed:
 
 [options="header"]
 |===
@@ -204,7 +204,7 @@ from routes that was created by Rest DSL or route templates or Kamelets. You can
 
 The xref:backlog-tracer.adoc[Backlog Tracer] has been enhanced and _fixed_ to trace message headers (also streaming types).
 This means that previously headers of type `InputStream` was not traced before, but is now included. This could mean that
-the header stream is positioned at end, and logging the header afterward, may appear as the header value is empty.
+the header stream is positioned at the end, and logging the header afterward may appear as the header value is empty.
 
 == UseOriginalMessage / UseOriginalBody
 
@@ -220,15 +220,15 @@ Health checks are now by default only readiness checks out of the box.
 Camel provides the `CamelContextCheck` as both readiness and liveness checks, so there is at least
 one of each out of the box.
 
-Only consumer based health-checks is enabled by default.
+Only consumer-based health checks are enabled by default.
 
 === Producer Health Checks
 
 The option `camel.health.components-enabled` has been renamed to `camel.health.producers-enabled`.
 
-Some components (in particular AWS) provides also health checks for producers; in Camel 3.x
+Some components, in particular AWS, also provide health checks for producers. In Camel 3.x
 these health checks did not work properly and has been disabled in the source.
-To continue this behaviour in Camel 4, then producer based health checks are disabled.
+To continue this behaviour in Camel 4, then producer-based health checks are disabled.
 
 Notice that `camel-kafka` comes with producer based health-check that worked in Camel 3,
 and therefore this change in Camel 4, means that this health-check is disabled.
@@ -278,7 +278,7 @@ should be changed to:
 == Backlog Tracing
 
 The option `backlogTracing=true` now automatic enabled the tracer on startup. The previous behavior
-was _surprisingly_ that the tracer was only made available, and had to be manually enabled afterwards.
+was _surprisingly_ that the tracer was only made available, and had to be manually enabled afterward.
 The old behavior can be archived by setting `backlogTracingStandby=true`.
 
 Move the following class from `org.apache.camel.api.management.mbean.BacklogTracerEventMessage` in `camel-management-api` JAR
@@ -290,13 +290,13 @@ that contains the input and outgoing (if `InOut`) messages.
 
 == XML serialization
 
-The default xml serialization using `ModelToXMLDumper` has been improved and now uses a generated xml
+The default XML serialization using `ModelToXMLDumper` has been improved and now uses a generated XML
 serializer located in the `camel-xml-io` module instead of the JAXB based one from `camel-jaxb`.
 
 == OpenAPI Maven Plugin
 
 The `camel-restdsl-openapi-plugin` Maven plugin now uses `platform-http` as the default rest component
-in the generated Rest DSL code. Previously the default was servlet. However, platform-http is a better
+in the generated Rest DSL code. Previously, the default was servlet. However, platform-http is a better
 default that works out of the box with Spring Boot and Quarkus.
 
 == Component changes
@@ -305,7 +305,7 @@ default that works out of the box with Spring Boot and Quarkus.
 
 The number of enums for `org.apache.camel.Category` has been reduced from 83 to 37, which means custom components
 that are using removed values need to choose one of the remainder values. We have done this to consolidate
-the number of categories of all components in the Camel community.
+the number of categories of components in the Camel community.
 
 === camel-openapi-rest-dsl-generator
 
@@ -313,7 +313,7 @@ This dsl-generator has updated the underlying model classes (`apicurio-data-mode
 
 === camel-atom
 
-The `camel-atom` component has changed the 3rd party atom client from Apache Abdera to RSSReader.
+The `camel-atom` component has changed the third party atom client from Apache Abdera to RSSReader.
 This means the feed object is changed from `org.apache.abdera.model.Feed` to `com.apptasticsoftware.rssreader.Item`.
 
 === camel-azure-cosmosdb
@@ -330,7 +330,7 @@ The example from above should now be as follows:
 
     "bean:myBean?method=foo(com.foo.MyOrder.class, true)"
 
-This also applies to Java types such as String, int, etc:
+This also applies to Java types such as String, int, etc.:
 
     "bean:myBean?method=bar(String.class, int.class)"
 
@@ -349,7 +349,7 @@ The underlying `hapi-fhir` library has been upgraded from 4.2.0 to 6.2.4. Only t
 
 === camel-google
 
-The API based components `camel-google-drive`, `camel-google-calendar`, `camel-google-sheets` and `camel-google-mail`
+The API-based components `camel-google-drive`, `camel-google-calendar`, `camel-google-sheets` and `camel-google-mail`
 has been upgraded from Google Java SDK v1 to v2 and to latest API revisions. The `camel-google-drive` and `camel-google-sheets`
 have some API methods changes, but the others are identical as before.
 
@@ -380,7 +380,7 @@ constants in class `KubernetesOperations` are also renamed. `REPLACE_CONFIGMAP_O
 
 === camel-web3j
 
-The `camel-web3j` has upgrade web3j JAR from 3.x to 5.0 which has many API changes, and so
+The `camel-web3j` has upgraded the `web3j` JAR from 3.x to 5.0 which has many API changes, and so
 some previous API calls are no long provided.
 
 === camel-main
@@ -471,7 +471,7 @@ Solver Daemon solutions should be migrated to use SolverManager.
 
 === camel-platform-http-vertx
 
-If the route or consumer is suspended then http status 503 is now returned instead of 404.
+If the route or consumer is suspended, then http status 503 is now returned instead of 404.
 
 === camel-salesforce
 
@@ -479,7 +479,7 @@ Property names of blob fields on generated DTOs no longer have 'Url' affixed. E.
 
 === camel-slack
 
-The default delay (on slack consumer) is changed from 0.5s to 10s to avoid being rate limited to often by Slack.
+The default delay (on Slack consumer) is changed from 0.5s to 10s to avoid being rate limited to often by Slack.
 
 === camel-spring-rabbitmq
 
@@ -494,7 +494,7 @@ with Camel on Spring Boot, then include the `camel-spring-boot-xml-starter` depe
 
 === Graceful Shutdown
 
-Camel now shutdowns a bit later during Spring Boot shutdown. This allows Spring Boot graceful shutdown
+Apache Camel shutdowns a bit later during Spring Boot shutdown. This allows Spring Boot graceful shutdown
 to complete first (stopping Spring Boot HTTP server gracefully),
 and then afterward Camel is doing its own xref:graceful-shutdown.adoc[].
 
@@ -524,7 +524,7 @@ Now the context-path is not in use, and the endpoint can be called with `http://
 
 NOTE: The `platform-http-starter` can also be used with Rest DSL.
 
-If the route or consumer is suspended then http status 503 is now returned instead of 404.
+If the route or consumer is suspended, then http status 503 is now returned instead of 404.
 
 === camel-twitter
 
@@ -537,9 +537,9 @@ The component was updated to use Twitter4j version 4.1.2, which https://twitter4
 
 The `readLock=changed` with using `readLockMinAge` has been restored to same behaviour as 3.x.
 
-For example using `readLockMinAge=5s` would pickup files that are older than 5 seconds from startup time.
+For example, using `readLockMinAge=5s` would pick up files that are older than 5 seconds from startup time.
 If you have many existing files on startup that are old, then Camel will now again be fast,
-and pickup these files immediately.
+and pick up these files immediately.
 
 
 == Upgrading Camel 4.0.0 to 4.0.1

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_1.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_1.adoc
@@ -1,7 +1,7 @@
 = Apache Camel 4.x Upgrade Guide
 
 This document is for helping you upgrade your Apache Camel application
-from Camel 4.x to 4.y. For example if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
+from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
 == Upgrading Camel 4.0 to 4.1
@@ -188,7 +188,7 @@ from("direct:start")
 
 === camel-pdf
 
-The Camel-PDF component has been updated to Apache PDFBox 3.0.0 and the font parameter is now defined through the following enum values: COURIER,COURIER_BOLD,COURIER_OBLIQUE,COURIER_BOLD_OBLIQUE, HELVETICA,HELVETICA_BOLD,HELVETICA_OBLIQUE,HELVETICA_BOLD_OBLIQUE,TIMES_ROMAN,TIMES_BOLD,TIMES_ITALIC,TIMES_BOLD_ITALIC,SYMBOL and ZAPF_DINGBATS
+The Camel-PDF component has been updated to Apache PDFBox 3.0.0, and the font parameter is now defined through the following enum values: COURIER,COURIER_BOLD,COURIER_OBLIQUE,COURIER_BOLD_OBLIQUE, HELVETICA,HELVETICA_BOLD,HELVETICA_OBLIQUE,HELVETICA_BOLD_OBLIQUE,TIMES_ROMAN,TIMES_BOLD,TIMES_ITALIC,TIMES_BOLD_ITALIC,SYMBOL and ZAPF_DINGBATS
 
 === camel-jbang
 
@@ -196,14 +196,14 @@ The `pipe` command has been renamed to `script`.
 
 The `--secrets-refresh` and `--secret-refresh-providers` have been removed, since they were logically incorrect in the export command context. More information at CAMEL-19927 issue.
 
-The generated xml route, created using the command `camel init`, now uses `<camel>` as the root tag instead of `<routes>`.
+The generated XML route, created using the command `camel init`, now uses `<camel>` as the root tag instead of `<routes>`.
 
 === camel-jetty / camel-servlet / camel-atmosphere-websocket / camel-http-common
 
-By default stack traces will not be included in HTTP responses,
+By default, stack traces will not be included in HTTP responses,
 exceptions are muted.
 Stack traces can be included in HTTP responses by disabling `muteException`.
-For example
+For example:
 
 ----
 from("jetty:http://localhost:{{port}}/myapp/myservice?muteException=false")
@@ -226,8 +226,7 @@ The `Tag` Enum containing constants for tagging spans has been deprecated.
 Instead,
 use constants from the `TagConstants` Class that align to Open Telemetry v1.21.0 semantic conventions.
 
-For example,
-instead of
+For example, instead of
 
 ----
 span.setTag(Tag.URL_SCHEME, scheme);

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_2.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_2.adoc
@@ -1,7 +1,7 @@
 = Apache Camel 4.x Upgrade Guide
 
 This document is for helping you upgrade your Apache Camel application
-from Camel 4.x to 4.y. For example if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
+from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
 == Upgrading Camel 4.1 to 4.2
@@ -30,13 +30,13 @@ are sent to have access to exchange properties.
 
 The `readLock=changed` with using `readLockMinAge` has been restored to same behaviour as 3.x.
 
-For example using `readLockMinAge=5s` would pickup files that are older than 5 seconds from startup time.
+For example, using `readLockMinAge=5s` would pick up files that are older than 5 seconds from startup time.
 If you have many existing files on startup that are old, then Camel will now again be fast,
-and pickup these files immediately.
+and pick up these files immediately.
 
 === camel-kafka
 
-The consumer will now pre validate hostname:port and DNS resolution on startup, and fail-fast
+The consumer will now pre-validate `hostname:port` and DNS resolution on startup, and fail-fast
 in case of mis-configuration or invalid hostname.
 
 This can be disabled by setting `preValidateHostAndPort=false`, which will postpone validation
@@ -55,7 +55,7 @@ The `org.apache.camel.service.lra.LRAClient` can now access `Exchange` to retrie
 - `org.apache.camel.saga.CamelSagaCoordinator.newSaga` is now `org.apache.camel.saga.CamelSagaCoordinator.newSaga(Exchange exchange)`
 to support the transport of `Exchange`.
 
-As result of interface changes also the known implementation classes and usages have been adopted.
+As a result of interface changes, also the known implementation classes and usages have been adopted.
 
 === camel-ignite
 
@@ -75,17 +75,17 @@ configuring the Multicast Processor within the Dynamic Router EIP component, so 
 are identical to that of the Multicast Processor.
 
 When upgrading to this version, you should still be able to use this component with the configuration from previous
-versions.  The new options allow more specific configuration, if you need it.
+versions.  The new options allow more specific configuration if you need it.
 
 === camel-spring & camel-spring-boot
 
 ==== Autowiring Primary beans
 
 Camel will now take into account `@Primary` beans from Spring when autowiring by type.
-For example a JDBC `DataSource` in the SQL component will now use the `@Primary` data source
+For example, a JDBC `DataSource` in the SQL component will now use the `@Primary` data source
 when multiple data sources are defined.
 
-Previously Camel would not autowire if there are 2 or more beans for a given type.
+Previously, Camel would not autowire if there are two or more beans for a given type.
 
 NOTE: This is a change in behaviour, that can affect your applications when upgrading.
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_3.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_3.adoc
@@ -1,7 +1,7 @@
 = Apache Camel 4.x Upgrade Guide
 
 This document is for helping you upgrade your Apache Camel application
-from Camel 4.x to 4.y. For example if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
+from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
 == Upgrading Camel 4.2 to 4.3
@@ -79,11 +79,11 @@ from("seda:c")
 
 === Consumer health checks
 
-The scheduled consumers has been improved to mark the consumer as _ready_ sooner, when possible. Previously a consumer,
-would mark as ready after the first poll was completed. For example, a FTP consumer downloading a big file on first poll,
-could take so long time, that the readiness check would timeout and fail during startup of your Camel application.
+The scheduled consumers have been improved to mark the consumer as _ready_ sooner, when possible. Previously a consumer
+would mark as ready after the first poll was completed. For example, an FTP consumer downloading a big file on the first poll
+could take so long time that the readiness check would timeout and fail during the startup of your Camel application.
 
-The following components is now marking the consumer as ready sooner:
+The following components are now marking the consumer as ready sooner:
 
 - camel-aws
 - camel-azure
@@ -114,7 +114,7 @@ in their `ObjectName` also.
 
 === camel-console
 
-The context and route consoles has changed some values in their JSon output data for timestamp for created, completed and failed exchanges.
+The context and route consoles have changed some values in their JSON output data for timestamp for created, completed and failed exchanges.
 
 |===
 |**Old Key** |**New Key**
@@ -123,7 +123,7 @@ The context and route consoles has changed some values in their JSon output data
 | `sinceLastFailedExchange` | `lastFailedExchangeTimestamp`
 |===
 
-The values are also changed from String ago to timestamp in millis.For example old value `3m5s` is now `1701599263337`.
+The values are also changed from String ago to timestamp in millis.For example, old value `3m5s` is now `1701599263337`.
 
 === camel-jbang
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_4.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_4.adoc
@@ -101,7 +101,7 @@ The reason is that this link should only be for EIPs with sub exchanges such as 
 
 ==== Throttle EIP
 
-Previously Camel used a throttler based on the total number of requests over a period of time ("TotalRequests" mode). That was
+Previously, Camel used a throttler based on the total number of requests over a period of time ("TotalRequests" mode). That was
 the default on Camel up to version 4.2.0. On Camel 4.3.0 we introduced a new one based on the number of concurrent requests and
 replaced the former.
 
@@ -123,65 +123,69 @@ And the option `camel.main.routeControllerSuperviseEnabled` has been renamed to 
 
 === camel-kamelet
 
-All kamelets are now turned off error handling in the route templates. This is done to make using kamelets
+All Kamelets are now turned off error handling in the route templates. This is done to make using Kamelets
 the same as calling a regular Camel component endpoint. Backwards mode can be enabled by setting `noErrorHandler=false`
 on the `KameletComponent` or as URI parameter `to("kamelet:http-sink?noErrorHandler=false&uri=xxxxx")`.
 
 === camel-azure-cosmosdb
 
-The useDefaultIdentity parameter has been removed in favor of the credentialType parameter. Now user should select between SHARED_ACCOUNT_KEY and AZURE_IDENTITY.
+The `useDefaultIdentity` parameter has been removed in favor of the credentialType parameter.
+Now user should select between `SHARED_ACCOUNT_KEY` and `AZURE_IDENTITY`.
 This is part of the effort explained in CAMEL-18590.
 
 === camel-azure-eventhubs
 
-The credentialType parameter has been introduced with three possible values: AZURE_IDENTITY, CONNECTION_STRING and TOKEN_CREDENTIAL.
-With the CONNECTION_STRING mode the user could explicitly set the connectionString parameters or use the sharedAccessName and sharedAccessKey to automatically build the connection string.
-With the TOKEN_CREDENTIAL mode the user could pass a TokenCredential instance.
-With the AZURE_IDENTITY mode the user will be able to use the Default Azure Credentials Chain.
+The credentialType parameter has been introduced with three possible values: `AZURE_IDENTITY`, `CONNECTION_STRING` and `TOKEN_CREDENTIAL`.
+With the `CONNECTION_STRING` mode the user could explicitly set the `connectionString` parameters or use the `sharedAccessName` and `sharedAccessKey` to automatically build the connection string.
+With the `TOKEN_CREDENTIAL` mode the user could pass a `TokenCredential` instance.
+With the `AZURE_IDENTITY` mode the user will be able to use the Default Azure Credentials Chain.
 This is part of the effort explained in CAMEL-18590.
 
 === camel-azure-servicebus
 
-The credentialType parameter has been introduced with three possible values: AZURE_IDENTITY, CONNECTION_STRING and TOKEN_CREDENTIAL.
-With the CONNECTION_STRING mode the user could explicitly set the connectionString parameter.
-With the TOKEN_CREDENTIAL mode the user could pass a TokenCredential instance.
-With the AZURE_IDENTITY mode the user will be able to use the Default Azure Credentials Chain.
+The credentialType parameter has been introduced with three possible values: `AZURE_IDENTITY`, `CONNECTION_STRING` and `TOKEN_CREDENTIAL`.
+With the `CONNECTION_STRING` mode the user could explicitly set the `connectionString` parameter.
+With the `TOKEN_CREDENTIAL` mode the user could pass a `TokenCredential` instance.
+With the `AZURE_IDENTITY` mode the user will be able to use the Default Azure Credentials Chain.
 This is part of the effort explained in CAMEL-18590.
 
 === camel-azure-files
 
-The credentialType parameter has been introduced with three possible values: AZURE_IDENTITY, SHARED_ACCOUNT_KEY and AZURE_SAS.
-With the SHARED_ACCOUNT_KEY mode the user could explicitly set the sharedKey parameter.
-With the AZURE_IDENTITY mode the user will be able to use the Default Azure Credentials Chain.
-With the AZURE_SAS mode the user could explicitly set the token parameter.
+The credentialType parameter has been introduced with three possible values: `AZURE_IDENTITY`, `SHARED_ACCOUNT_KEY` and `AZURE_SAS`.
+With the `SHARED_ACCOUNT_KEY` mode the user could explicitly set the `sharedKey` parameter.
+With the `AZURE_IDENTITY` mode the user will be able to use the Default Azure Credentials Chain.
+With the `AZURE_SAS` mode the user could explicitly set the token parameter.
 This is part of the effort explained in CAMEL-18590.
 
 === camel-azure-storage-datalake
 
-The useDefaultIdentity parameter has been removed in favor of the credentialType parameter. Now user should select between AZURE_IDENTITY, CLIENT_SECRET, SHARED_KEY_CREDENTIAL, AZURE_SAS and SERVICE_CLIENT_INSTANCE
-With the SHARED_KEY_CREDENTIAL mode the user could explicitly set the sharedKey parameter or a SharedKeyCredential instance.
-With the AZURE_IDENTITY mode the user will be able to use the Default Azure Credentials Chain.
-With the AZURE_SAS mode the user could explicitly set the sasSignature or sasCredential parameter.
-With the CLIENT_SECRET mode the user could explicitly set clientId, clientSecret and tenantId or specify a ClientSecretCredential instance.
-With the SERVICE_CLIENT_INSTANCE the user could explicitly set a serviceClient parameter by passing a DataLakeServiceClient instance.
+The useDefaultIdentity parameter has been removed in favor of the `credentialType` parameter. Now user should select between `AZURE_IDENTITY`, `CLIENT_SECRET`, `SHARED_KEY_CREDENTIAL`, `AZURE_SAS` and `SERVICE_CLIENT_INSTANCE`.
+With the `SHARED_KEY_CREDENTIAL` mode the user could explicitly set the `sharedKey` parameter or a `SharedKeyCredential` instance.
+With the `AZURE_IDENTITY` mode the user will be able to use the Default Azure Credentials Chain.
+With the `AZURE_SAS` mode the user could explicitly set the `sasSignature` or `sasCredential` parameter.
+With the `CLIENT_SECRET` mode the user could explicitly set `clientId`, `clientSecret` and `tenantId` or specify a `ClientSecretCredential` instance.
+With the `SERVICE_CLIENT_INSTANCE` the user could explicitly set a `serviceClient` parameter by passing a `DataLakeServiceClient` instance.
 This is part of the effort explained in CAMEL-18590.
 
 === camel-azure-storage-queue
 
-The useDefaultIdentity parameter has been removed in favor of the credentialType parameter. Now user should select between AZURE_IDENTITY, SHARED_KEY_CREDENTIAL and SHARED_ACCOUNT_KEY
-With the SHARED_KEY_CREDENTIAL mode the user could explicitly set the SharedKeyCredential instance.
-With the AZURE_IDENTITY mode the user will be able to use the Default Azure Credentials Chain.
-With the SHARED_ACCOUNT_KEY mode the user could explicitly set the accessKey parameter.
+The `useDefaultIdentity` parameter has been removed in favor of the `credentialType` parameter. Now user should select between `AZURE_IDENTITY`, `SHARED_KEY_CREDENTIAL` and `SHARED_ACCOUNT_KEY`.
+With the `SHARED_KEY_CREDENTIAL` mode the user could explicitly set the `SharedKeyCredential` instance.
+With the `AZURE_IDENTITY` mode the user will be able to use the Default Azure Credentials Chain.
+With the `SHARED_ACCOUNT_KEY` mode the user could explicitly set the `accessKey` parameter.
 This is part of the effort explained in CAMEL-18590.
 
 === camel-cassandraql
 
-The NamedCassandraAggregationRepository now provides a deserializationFilter parameter. The default value for it is allowing all java packages and subpackages and all org.apache.camel packages and subpackages. If you plan to use particular classes and you want to expand the filter, you should change the value according to your needs. More details in CAMEL-20306.
+The `NamedCassandraAggregationRepository` now provides a `deserializationFilter` parameter.
+The default value for it is allowing all java packages and subpackages and all `org.apache.camel` packages and subpackages.
+If you plan to use particular classes, and you want to expand the filter, you should change the value according to your needs.
+More details in CAMEL-20306.
 
 === camel-coap
 
-Upgraded from org.eclipse.californium v2 to v3 which was a painful upgrade. Removed the `"CamelCoapUri` header that would
-allow a producer to create dynamic client to send to another Url. Use Camel's existing `toD` EIP for that instead.
+Upgraded from `org.eclipse.californium` v2 to v3 which was a painful upgrade. Removed the `"CamelCoapUri` header that would
+allow a producer to create the dynamic client to send to another URL. Use Camel's existing `toD` EIP for that instead.
 
 === camel-consul
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_5.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_5.adoc
@@ -181,10 +181,10 @@ The shorthand `-p` option from `run` and `script` command has been removed. Use 
 === camel-jsonpath
 
 The `camel-jsonpath` will now work more similar as `camel-jq` when you specify a `resultType` and have a list of entities.
-Before `camel-jsonapath` would attempt to convert the `List` to the given `restultType` which often is not useable. What
+Before `camel-jsonapath` would attempt to convert the `List` to the given `restultType` which often is not usable. What
 users want is to be able to convert each entry in the list to a given type such as a POJO.
 
-For example the snippet below select all books from a JSon document, which will be in a `List<Map>` object where each
+For example, the snippet below selects all books from a JSON document, which will be in a `List<Map>` object where each
 book is an entry as a `Map`. Before Camel would attempt to convert `List` to `Book` which would not be possible.
 From this release onwards, Camel will convert each entry to a `Book` so the result is `List<Book>`.
 
@@ -215,7 +215,7 @@ The `camel-micrometer` have renamed tag `serviceName` to `kind` and use naming t
 | serviceName="MicrometerRoutePolicyService" | kind="CamelRoute"
 |===
 
-Due to Kamelets are changed to act more like a Camel component, and not expose internal details as JMX MBeans, then
+Because the Kamelets were changed to act more like a Camel component, and not expose internal details as JMX MBeans, then
 micrometer and metrics no longer include statistics for those Kamelet routes.
 
 The old behaviour can be enabled by setting `registerRoutesCreateByKamelet=true`
@@ -272,10 +272,10 @@ The class `org.apache.camel.component.redis.processor.idempotent.RedisStringIdem
 
 == Camel Spring Boot
 
-The auto configuration with `camel.springboot.xxx` properties has been harmonized to use same naming for
-all the Camel runtimes (camel-main, canel-quarkus, and camel-spring-boot). These options have been marked
+The autoconfiguration with `camel.springboot.xxx` properties has been harmonized to use same naming for
+all the Camel runtimes (`camel-main`, `camel-quarkus`, and `camel-spring-boot`). These options have been marked
 as deprecated, and you can migrate to use `camel.main.xxx` naming instead.
 
-For example `camel.springboot.name = Foo` to `camel.main.name = Foo`.
+For example, `camel.springboot.name = Foo` to `camel.main.name = Foo`.
 
 Only the special Spring Boot options are still named `camel.springboot.xxx`.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_6.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_6.adoc
@@ -10,15 +10,15 @@ from both 4.0 to 4.1 and 4.1 to 4.2.
 
 When using `variableReceive` then the variable is only set if processing the `Exchange` was completely successfully.
 
-For example calling a route that fails due to an exception being thrown (even if `onException` or `errorHandler` are in use)
-then the variable is no longer set. Also, if the route is marked for rollback, or to stop continue routing with `.stop()`.
+For example, calling a route that fails due to an exception being thrown (even if `onException` or `errorHandler` are in use)
+then the variable is no longer set. Also, if the route is marked for rollback, or to stop continuing routing with `.stop()`.
 
 This is the same logic that the routing engine uses, whether to continue routing the `Exchange` or not.
 
 === camel-core-model
 
 Harmonized model for defining custom beans to be the same for Kamelets and generic beans in XML/YAML DSLs.
-Before there used to be 3 specialized model classes that has been refactored into a single class, offering the same capabilities
+Before, there used to be three specialized model classes that have been refactored into a single class, offering the same capabilities
 for configuring beans (constructors, properties, builder classes, init/destroy methods etc.)
 
 === XML DSL
@@ -86,8 +86,8 @@ The `specifciationUri` in the `rest-api` component has changed from being a `jav
 , as it uses Camels `ResourceLoader` to load from pluggable resources and also more tooling friendly.
 
 The validator using Atlassian `swagger-request-validator` JAR has been removed, as this library is not JakartaEE compatible,
-and was causing classloading problems. The validator is now using similar validation as Rest DSL. However, the validator
-no longer check for JSon payloads if any required nodes is missing.
+and was causing classloading problems. The validator is now using a similar validation as Rest DSL. However, the validator
+no longer checks for JSON payloads if any required nodes are missing.
 
 === camel-langchain4j-chat
 
@@ -146,13 +146,13 @@ The Camel Azure ServiceBus consumer has been refactored to internally use the hi
 === camel-jbang
 
 When running using `camel run --source-dir=mydir` then Camel JBang will now preload existing files on startup, such as `application.properties`,
-and beans and routes (same as if you run with `cd mydir; camel run *`). This allows to configure settings on Camel on startup, which was not possible beforehand.
+and beans and routes (same as if you run with `cd mydir; camel run *`). This allows configuring settings on Camel on startup, which was not possible beforehand.
 
 The `--open-api` option has changed from _code-first_ to use the new _contract-first_ Rest DSL style by using the specification file direct as-is.
 
 === camel-as2
 
-The `camel-as2` component has upgraded HTTP Client 4.x to 5.x and because of that, there are some options that have changed.
+The `camel-as2` component has upgraded HTTP Client 4.x to 5.x, and because of that, there are some options that have changed.
 
 Changes for AS2-MDN asynchronous delivery:
 
@@ -163,7 +163,7 @@ message receiver confirming receipt of the message.
 
 === camel-spring-boot
 
-The auto configuration of xref:clustering.adoc[Cluster Service] implementations has been moved to dedicated starters:
+The autoconfiguration of xref:clustering.adoc[Cluster Service] implementations has been moved to dedicated starters:
 
 [%header, cols="1,2"]
 |===
@@ -178,7 +178,7 @@ The auto configuration of xref:clustering.adoc[Cluster Service] implementations 
 |===
 
 
-The Cluster Services are turned on by default unless they are explicit disabled, as example:
+The Cluster Services are turned on by default unless they are explicitly disabled, for example:
 
 [source, properties]
 ----

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_7.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_7.adoc
@@ -26,15 +26,16 @@ prior to creating the type converter registry
 
 === camel-health
 
-Routes which has are set to **not** auto-startup are reported as UP in health-checks.
-We have now implemented similar logic for the consumer health check as well (the route and consumer health check are linked together).
+Routes that have been set to **not** auto-startup are reported as UP in health-checks.
+We have now implemented similar logic for the consumer health check as well. In this case, the route and consumer health check
+are linked together.
 
 Previously a route that has not been started due to `auto-startup=false` would still have its consumer health-check being executed,
 which could lead to DOWN due to consumer failing the check.
 
 The `SupervisingRouteController` has now been pre-configured to report `DOWN` during restart attempts, and also when
 giving up starting a route. It is the `UnhealthyOnExhausted` and `UnhealthyOnRestarting` options that have been changed to be default `true`.
-To have previous behavior you can set these options to `false`.
+To have previous behavior, you can set these options to `false`.
 
 == camel-cloud
 
@@ -61,7 +62,7 @@ The Load Balancer EIP has aligned naming and the following balancers has been re
 | weighted | weightedLoadBalancer
 |===
 
-For example in XML you need to change from:
+For example in XML, you need to change from:
 
 [source,xml]
 ----
@@ -109,14 +110,14 @@ The `generate` commands has been moved into separate plugin which you need to in
 camel plugin add generate
 ----
 
-TIP: You can see list of available plugins using `camel plugin get --all`.
+TIP: You can see the list of available plugins using `camel plugin get --all`.
 
 === camel-jetty / camel-servlet / camel-undertow
 
 When using embedded HTTP server (consumer) then the headers `CamelHttpServletRequest` and `CamelHttpServletResponse`
 has been removed.
 
-To gain access to these then you need to use the `HttpMessage` API instead as shown below:
+To gain access to these, then you need to use the `HttpMessage` API instead as shown below:
 
 [source,java]
 ----
@@ -203,7 +204,7 @@ Upgraded PubNub client from v6 to v9 and the `wherenow` operation is removed due
 The `camel-as2` component has been updated so that the client can compress a MIME body before signing or compress a MIME body before signing and encrypting as described in
 sections https://datatracker.ietf.org/doc/html/rfc5402/#section-3.2[3.2] and https://datatracker.ietf.org/doc/html/rfc5402/#section-3.5[3.5] of https://datatracker.ietf.org/doc/html/rfc5402/[rfc 5402].
 
-When the AS2 server is configured with a decryption key all received messages require encryption otherwise the server
+When the AS2 server is configured with a decryption key, all received messages require encryption. Otherwise, the server
 will return an 'insufficient-security' error disposition. Only messages with valid encryption will be successfully processed,
 for instance, 'encrypted', 'signed-encrypted', 'encrypted-compressed', 'encrypted-compressed-signed' and 
 'encrypted-signed-compressed' message types.
@@ -212,15 +213,16 @@ Messages that cannot be successfully decrypted will return a 'decryption-failed'
 This includes messages encrypted with a invalid key or if the server receives encrypted messages but is not 
 configured with a decryption key.
 
-When the AS2 server is configured with a message signature validation certificate chain all received messages
-require a signature otherwise the server will return an 'insufficient-security' error disposition.
+When the AS2 server is configured with a message signature validation certificate chain, all received messages
+require a signature. Otherwise, the server will return an 'insufficient-security' error disposition.
 Only messages with a valid signature will be processed, for instance, 'signed', 'compressed-signed',
 and 'signed-compressed' message types.
 
 The server will return an 'authentication-failure' error when a message fails signature validation.
 
-When the AS2 server is configured with a message signature validation certificate chain and a decryption key all received messages 
-require encryption and a signature otherwise the server will return an 'insufficient-security' error disposition. 
+When the AS2 server is configured with a message signature validation certificate chain and a decryption key,
+all received messages require encryption and a signature.
+Otherwise, the server will return an 'insufficient-security' error disposition.
 Only messages with a valid signature and encryption will be processed, for instance, 'signed-encrypted', 'encrypted-compressed-signed', 
 and 'encrypted-signed-compressed'.
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide.adoc
@@ -4,10 +4,10 @@ IMPORTANT: If you are migrating from Camel 3.x then use the
 xref:camel-4-migration-guide.adoc[Camel 3.x to 4.0 Migration Guide] first.
 
 This document is for helping you upgrade your Apache Camel application
-from Camel 4.x to 4.y. For example if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
+from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-You can find upgrade guide for each release in the following pages:
+You can find the upgrade guide for each release in the following pages:
 
 - xref:camel-4x-upgrade-guide-4_1.adoc[Upgrade guide 4.0 -> 4.1]
 - xref:camel-4x-upgrade-guide-4_2.adoc[Upgrade guide 4.1 -> 4.2]


### PR DESCRIPTION
Fix typos and grammar issues on the upgrade guides

Added a special focus on recent versions, but also a few of the LTSs
from 3.x + the migration guides.