### PR TITLE
camel-jbang: Add camel-rest dependency when running with Quarkus

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
@@ -1456,13 +1456,17 @@ In Spring Boot you add the following dependency:
 </dependency>
 ----
 
-In Quarkus you need to add the following dependency:
+In Quarkus you need to add the following dependencies:
 
 [source,xml]
 ----
 <dependency>
     <groupId>org.apache.camel.quarkus</groupId>
     <artifactId>camel-quarkus-cli-connector</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.apache.camel.quarkus</groupId>
+    <artifactId>camel-quarkus-rest</artifactId>
 </dependency>
 ----
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -888,6 +888,7 @@ public class Run extends CamelCommand {
         eq.dependencies = this.dependencies;
         if (!this.exportRun) {
             eq.addDependencies("camel:cli-connector");
+            eq.addDependencies("camel:rest");
         }
         eq.fresh = this.fresh;
         eq.download = this.download;


### PR DESCRIPTION
# Description
Rest is now only exported if it's really in use. See the changes in this [commit](https://github.com/apache/camel/commit/06e351d491cdb69379208d38b692b084c6ed8b52#diff-a5457bc70852851aa5a0665d100d62ebbbfca28d0703c637160413056ea2102d). It seems that this only impacts Quarkus runtime since in Spring Boot, `camel-rest-starter` is a dependency of `camel-spring-boot-starter`.

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

