### PR TITLE
CAMEL-20199: Remove synchronized block from components D to F

### DIFF
--- a/components/camel-dhis2/camel-dhis2-component/src/main/java/org/apache/camel/component/dhis2/Dhis2Component.java
+++ b/components/camel-dhis2/camel-dhis2-component/src/main/java/org/apache/camel/component/dhis2/Dhis2Component.java
@@ -66,11 +66,14 @@ public class Dhis2Component extends AbstractApiComponent<Dhis2ApiName, Dhis2Conf
 
     public Dhis2Client getClient(Dhis2Configuration endpointConfiguration) {
         if (endpointConfiguration.equals(this.configuration)) {
-            synchronized (this) {
+            lock.lock();
+            try {
                 if (this.dhis2Client == null) {
                     this.dhis2Client = Dhis2ClientBuilder.newClient(endpointConfiguration.getBaseApiUrl(),
                             endpointConfiguration.getUsername(), endpointConfiguration.getPassword()).build();
                 }
+            } finally {
+                lock.unlock();
             }
 
             return this.dhis2Client;

--- a/components/camel-disruptor/src/main/java/org/apache/camel/component/disruptor/DisruptorComponent.java
+++ b/components/camel-disruptor/src/main/java/org/apache/camel/component/disruptor/DisruptorComponent.java
@@ -133,7 +133,8 @@ public class DisruptorComponent extends DefaultComponent {
         }
         sizeToUse = powerOfTwo(sizeToUse);
 
-        synchronized (this) {
+        lock.lock();
+        try {
             DisruptorReference ref = getDisruptors().get(key);
             if (ref == null) {
                 LOGGER.debug("Creating new disruptor for key {}", key);
@@ -151,6 +152,8 @@ public class DisruptorComponent extends DefaultComponent {
             }
 
             return ref;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -171,8 +174,11 @@ public class DisruptorComponent extends DefaultComponent {
 
     @Override
     protected void doStop() throws Exception {
-        synchronized (this) {
+        lock.lock();
+        try {
             getDisruptors().clear();
+        } finally {
+            lock.unlock();
         }
         super.doStop();
     }

--- a/components/camel-disruptor/src/main/java/org/apache/camel/component/disruptor/DisruptorEndpoint.java
+++ b/components/camel-disruptor/src/main/java/org/apache/camel/component/disruptor/DisruptorEndpoint.java
@@ -284,7 +284,8 @@ public class DisruptorEndpoint extends DefaultEndpoint implements AsyncEndpoint,
     }
 
     void onStarted(final DisruptorConsumer consumer) throws Exception {
-        synchronized (this) {
+        lock.lock();
+        try {
             // validate multiple consumers have been enabled is necessary
             if (!consumers.isEmpty() && !isMultipleConsumersSupported()) {
                 throw new IllegalStateException(
@@ -297,17 +298,22 @@ public class DisruptorEndpoint extends DefaultEndpoint implements AsyncEndpoint,
                 LOGGER.debug("Tried to start Consumer {} on endpoint {} but it was already started", consumer,
                         getEndpointUri());
             }
+        } finally {
+            lock.unlock();
         }
     }
 
     void onStopped(final DisruptorConsumer consumer) throws Exception {
-        synchronized (this) {
+        lock.lock();
+        try {
             if (consumers.remove(consumer)) {
                 LOGGER.debug("Stopping consumer {} on endpoint {}", consumer, getEndpointUri());
                 getDisruptor().reconfigure();
             } else {
                 LOGGER.debug("Tried to stop Consumer {} on endpoint {} but it was already stopped", consumer, getEndpointUri());
             }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/components/camel-elasticsearch/src/main/java/org/apache/camel/component/es/ElasticsearchProducer.java
+++ b/components/camel-elasticsearch/src/main/java/org/apache/camel/component/es/ElasticsearchProducer.java
@@ -80,7 +80,6 @@ class ElasticsearchProducer extends DefaultAsyncProducer {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchProducer.class);
 
     protected final ElasticsearchConfiguration configuration;
-    private final Object mutex = new Object();
     private volatile RestClient client;
     private Sniffer sniffer;
 
@@ -477,7 +476,8 @@ class ElasticsearchProducer extends DefaultAsyncProducer {
 
     private void startClient() {
         if (client == null) {
-            synchronized (mutex) {
+            lock.lock();
+            try {
                 if (client == null) {
                     LOG.info("Connecting to the ElasticSearch cluster: {}", configuration.getClusterName());
                     if (configuration.getHostAddressesList() != null
@@ -487,6 +487,8 @@ class ElasticsearchProducer extends DefaultAsyncProducer {
                         LOG.warn("Incorrect ip address and port parameters settings for ElasticSearch cluster");
                     }
                 }
+            } finally {
+                lock.unlock();
             }
         }
     }

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.file;
 
 import java.io.File;
 import java.io.InputStream;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -47,7 +46,7 @@ public class GenericFileProducer<T> extends DefaultProducer {
     protected GenericFileOperations<T> operations;
     // assume writing to 100 different files concurrently at most for the same
     // file producer
-    private final Map<String, Lock> locks = Collections.synchronizedMap(LRUCacheFactory.newLRUCache(100));
+    private final Map<String, Lock> locks = LRUCacheFactory.newLRUCache(100);
 
     protected GenericFileProducer(GenericFileEndpoint<T> endpoint, GenericFileOperations<T> operations) {
         super(endpoint);

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/cluster/FileLockClusterView.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/cluster/FileLockClusterView.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.camel.cluster.CamelClusterMember;
 import org.apache.camel.support.cluster.AbstractCamelClusterView;
@@ -38,6 +40,7 @@ import org.slf4j.LoggerFactory;
 public class FileLockClusterView extends AbstractCamelClusterView {
     private static final Logger LOGGER = LoggerFactory.getLogger(FileLockClusterView.class);
 
+    private static final Lock LOCK = new ReentrantLock();
     private final ClusterMember localMember;
     private final Path path;
     private RandomAccessFile lockFile;
@@ -134,7 +137,8 @@ public class FileLockClusterView extends AbstractCamelClusterView {
                     return;
                 }
 
-                synchronized (FileLockClusterView.this) {
+                LOCK.lock();
+                try {
                     if (lock != null) {
                         LOGGER.info("Lock on file {} lost (lock={})", path, lock);
                         fireLeadershipChangedEvent((CamelClusterMember) null);
@@ -152,6 +156,8 @@ public class FileLockClusterView extends AbstractCamelClusterView {
                     } else {
                         LOGGER.debug("Lock on file {} not acquired ", path);
                     }
+                } finally {
+                    LOCK.unlock();
                 }
             } catch (OverlappingFileLockException e) {
                 reason = new IOException(e);
@@ -169,8 +175,11 @@ public class FileLockClusterView extends AbstractCamelClusterView {
     private final class ClusterMember implements CamelClusterMember {
         @Override
         public boolean isLeader() {
-            synchronized (FileLockClusterView.this) {
+            LOCK.lock();
+            try {
                 return lock != null && lock.isValid();
+            } finally {
+                LOCK.unlock();
             }
         }
 

--- a/core/camel-api/src/main/java/org/apache/camel/support/service/BaseService.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/service/BaseService.java
@@ -451,4 +451,7 @@ public abstract class BaseService {
         return Holder.LOG;
     }
 
+    protected Lock getInternalLock() {
+        return lock;
+    }
 }


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-20199

## Motivation

For better support of virtual threads, we need to avoid lengthy and frequent pinning by replacing synchronized blocks with ReentrantLocks

## Modifications:

* Replace mutex with locks
* Use locks instead of synchronized blocks in case of a potentially long locking