### PR TITLE
CAMEL-20199: Remove synchronized block from components G to I

### DIFF
--- a/components/camel-as2/camel-as2-component/src/main/java/org/apache/camel/component/as2/internal/AS2PropertiesHelper.java
+++ b/components/camel-as2/camel-as2-component/src/main/java/org/apache/camel/component/as2/internal/AS2PropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.as2.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.as2.AS2Configuration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class AS2PropertiesHelper extends ApiMethodPropertiesHelper<AS2Configuration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static AS2PropertiesHelper helper;
 
     private AS2PropertiesHelper(CamelContext context) {
         super(context, AS2Configuration.class, AS2Constants.PROPERTY_PREFIX);
     }
 
-    public static synchronized AS2PropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new AS2PropertiesHelper(context);
+    public static AS2PropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new AS2PropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }

--- a/components/camel-box/camel-box-component/src/main/java/org/apache/camel/component/box/internal/BoxPropertiesHelper.java
+++ b/components/camel-box/camel-box-component/src/main/java/org/apache/camel/component/box/internal/BoxPropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.box.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.box.BoxConfiguration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class BoxPropertiesHelper extends ApiMethodPropertiesHelper<BoxConfiguration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static BoxPropertiesHelper helper;
 
     private BoxPropertiesHelper(CamelContext context) {
         super(context, BoxConfiguration.class, BoxConstants.PROPERTY_PREFIX);
     }
 
-    public static synchronized BoxPropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new BoxPropertiesHelper(context);
+    public static BoxPropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new BoxPropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }

--- a/components/camel-braintree/src/main/java/org/apache/camel/component/braintree/internal/BraintreePropertiesHelper.java
+++ b/components/camel-braintree/src/main/java/org/apache/camel/component/braintree/internal/BraintreePropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.braintree.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.braintree.BraintreeConfiguration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class BraintreePropertiesHelper extends ApiMethodPropertiesHelper<BraintreeConfiguration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static BraintreePropertiesHelper helper;
 
     private BraintreePropertiesHelper(CamelContext context) {
         super(context, BraintreeConfiguration.class, BraintreeConstants.PROPERTY_PREFIX);
     }
 
-    public static synchronized BraintreePropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new BraintreePropertiesHelper(context);
+    public static BraintreePropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new BraintreePropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }

--- a/components/camel-coap/src/main/java/org/apache/camel/coap/CoAPProducer.java
+++ b/components/camel-coap/src/main/java/org/apache/camel/coap/CoAPProducer.java
@@ -80,9 +80,14 @@ public class CoAPProducer extends DefaultProducer {
         }
     }
 
-    protected synchronized void initClient() throws Exception {
-        if (client == null) {
-            client = endpoint.createCoapClient(endpoint.getUri());
+    protected void initClient() throws Exception {
+        lock.lock();
+        try {
+            if (client == null) {
+                client = endpoint.createCoapClient(endpoint.getUri());
+            }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/components/camel-consul/src/main/java/org/apache/camel/component/consul/ConsulEndpoint.java
+++ b/components/camel-consul/src/main/java/org/apache/camel/component/consul/ConsulEndpoint.java
@@ -91,13 +91,18 @@ public class ConsulEndpoint extends DefaultEndpoint {
         return this.apiEndpoint;
     }
 
-    public synchronized Consul getConsul() throws Exception {
-        if (consul == null && ObjectHelper.isEmpty(getConfiguration().getConsulClient())) {
-            consul = configuration.createConsulClient(getCamelContext());
-        } else if (ObjectHelper.isNotEmpty(getConfiguration().getConsulClient())) {
-            consul = getConfiguration().getConsulClient();
-        }
+    public Consul getConsul() throws Exception {
+        lock.lock();
+        try {
+            if (consul == null && ObjectHelper.isEmpty(getConfiguration().getConsulClient())) {
+                consul = configuration.createConsulClient(getCamelContext());
+            } else if (ObjectHelper.isNotEmpty(getConfiguration().getConsulClient())) {
+                consul = getConfiguration().getConsulClient();
+            }
 
-        return consul;
+            return consul;
+        } finally {
+            lock.unlock();
+        }
     }
 }

--- a/components/camel-controlbus/src/main/java/org/apache/camel/component/controlbus/ControlBusComponent.java
+++ b/components/camel-controlbus/src/main/java/org/apache/camel/component/controlbus/ControlBusComponent.java
@@ -48,11 +48,16 @@ public class ControlBusComponent extends DefaultComponent {
         return answer;
     }
 
-    synchronized ExecutorService getExecutorService() {
-        if (executorService == null) {
-            executorService = getCamelContext().getExecutorServiceManager().newDefaultThreadPool(this, "ControlBus");
+    ExecutorService getExecutorService() {
+        lock.lock();
+        try {
+            if (executorService == null) {
+                executorService = getCamelContext().getExecutorServiceManager().newDefaultThreadPool(this, "ControlBus");
+            }
+            return executorService;
+        } finally {
+            lock.unlock();
         }
-        return executorService;
     }
 
     @Override

--- a/components/camel-dhis2/camel-dhis2-component/src/main/java/org/apache/camel/component/dhis2/internal/Dhis2PropertiesHelper.java
+++ b/components/camel-dhis2/camel-dhis2-component/src/main/java/org/apache/camel/component/dhis2/internal/Dhis2PropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.dhis2.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.dhis2.Dhis2Configuration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class Dhis2PropertiesHelper extends ApiMethodPropertiesHelper<Dhis2Configuration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static Dhis2PropertiesHelper helper;
 
     private Dhis2PropertiesHelper(CamelContext context) {
         super(context, Dhis2Configuration.class, Dhis2Constants.PROPERTY_PREFIX);
     }
 
-    public static synchronized Dhis2PropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new Dhis2PropertiesHelper(context);
+    public static Dhis2PropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new Dhis2PropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }

--- a/components/camel-fhir/camel-fhir-component/src/main/java/org/apache/camel/component/fhir/internal/FhirPropertiesHelper.java
+++ b/components/camel-fhir/camel-fhir-component/src/main/java/org/apache/camel/component/fhir/internal/FhirPropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.fhir.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.fhir.FhirConfiguration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class FhirPropertiesHelper extends ApiMethodPropertiesHelper<FhirConfiguration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static FhirPropertiesHelper helper;
 
     private FhirPropertiesHelper(CamelContext context) {
         super(context, FhirConfiguration.class, FhirConstants.PROPERTY_PREFIX);
     }
 
-    public static synchronized FhirPropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new FhirPropertiesHelper(context);
+    public static FhirPropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new FhirPropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }

--- a/components/camel-google/camel-google-calendar/src/main/java/org/apache/camel/component/google/calendar/internal/GoogleCalendarPropertiesHelper.java
+++ b/components/camel-google/camel-google-calendar/src/main/java/org/apache/camel/component/google/calendar/internal/GoogleCalendarPropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.google.calendar.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.google.calendar.GoogleCalendarConfiguration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class GoogleCalendarPropertiesHelper extends ApiMethodPropertiesHelper<GoogleCalendarConfiguration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static GoogleCalendarPropertiesHelper helper;
 
     private GoogleCalendarPropertiesHelper(CamelContext context) {
         super(context, GoogleCalendarConfiguration.class, GoogleCalendarConstants.PROPERTY_PREFIX);
     }
 
-    public static synchronized GoogleCalendarPropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new GoogleCalendarPropertiesHelper(context);
+    public static GoogleCalendarPropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new GoogleCalendarPropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }

--- a/components/camel-google/camel-google-drive/src/main/java/org/apache/camel/component/google/drive/internal/GoogleDrivePropertiesHelper.java
+++ b/components/camel-google/camel-google-drive/src/main/java/org/apache/camel/component/google/drive/internal/GoogleDrivePropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.google.drive.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.google.drive.GoogleDriveConfiguration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class GoogleDrivePropertiesHelper extends ApiMethodPropertiesHelper<GoogleDriveConfiguration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static GoogleDrivePropertiesHelper helper;
 
     private GoogleDrivePropertiesHelper(CamelContext context) {
         super(context, GoogleDriveConfiguration.class, GoogleDriveConstants.PROPERTY_PREFIX);
     }
 
-    public static synchronized GoogleDrivePropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new GoogleDrivePropertiesHelper(context);
+    public static GoogleDrivePropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new GoogleDrivePropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }

--- a/components/camel-google/camel-google-mail/src/main/java/org/apache/camel/component/google/mail/internal/GoogleMailPropertiesHelper.java
+++ b/components/camel-google/camel-google-mail/src/main/java/org/apache/camel/component/google/mail/internal/GoogleMailPropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.google.mail.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.google.mail.GoogleMailConfiguration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class GoogleMailPropertiesHelper extends ApiMethodPropertiesHelper<GoogleMailConfiguration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static GoogleMailPropertiesHelper helper;
 
     private GoogleMailPropertiesHelper(CamelContext context) {
         super(context, GoogleMailConfiguration.class, GoogleMailConstants.PROPERTY_PREFIX);
     }
 
-    public static synchronized GoogleMailPropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new GoogleMailPropertiesHelper(context);
+    public static GoogleMailPropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new GoogleMailPropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }

--- a/components/camel-google/camel-google-sheets/src/main/java/org/apache/camel/component/google/sheets/internal/GoogleSheetsPropertiesHelper.java
+++ b/components/camel-google/camel-google-sheets/src/main/java/org/apache/camel/component/google/sheets/internal/GoogleSheetsPropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.google.sheets.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.google.sheets.GoogleSheetsConfiguration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class GoogleSheetsPropertiesHelper extends ApiMethodPropertiesHelper<GoogleSheetsConfiguration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static GoogleSheetsPropertiesHelper helper;
 
     private GoogleSheetsPropertiesHelper(CamelContext context) {
         super(context, GoogleSheetsConfiguration.class, GoogleSheetsConstants.PROPERTY_PREFIX);
     }
 
-    public static synchronized GoogleSheetsPropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new GoogleSheetsPropertiesHelper(context);
+    public static GoogleSheetsPropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new GoogleSheetsPropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }

--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/DefaultHttpRegistry.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/DefaultHttpRegistry.java
@@ -16,11 +16,13 @@
  */
 package org.apache.camel.http.common;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import jakarta.servlet.Servlet;
 
@@ -30,9 +32,9 @@ import org.slf4j.LoggerFactory;
 public class DefaultHttpRegistry implements HttpRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultHttpRegistry.class);
 
-    private static final Map<String, HttpRegistry> registries = new HashMap<>();
+    private static final Map<String, HttpRegistry> registries = new ConcurrentHashMap<>();
 
-    private final Object lock = new Object();
+    private final Lock lock = new ReentrantLock();
 
     private final Set<HttpConsumer> consumers;
     private final Set<HttpRegistryProvider> providers;
@@ -45,20 +47,21 @@ public class DefaultHttpRegistry implements HttpRegistry {
     /**
      * Lookup or create a new registry if none exists with the given name
      */
-    public static synchronized HttpRegistry getHttpRegistry(String name) {
+    public static HttpRegistry getHttpRegistry(String name) {
         return registries.computeIfAbsent(name, k -> new DefaultHttpRegistry());
     }
 
     /**
      * Removes the http registry with the given name
      */
-    public static synchronized void removeHttpRegistry(String name) {
+    public static void removeHttpRegistry(String name) {
         registries.remove(name);
     }
 
     @Override
     public void register(HttpConsumer consumer) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Registering consumer for path {} providers present: {}", consumer.getPath(), providers.size());
             }
@@ -66,12 +69,15 @@ public class DefaultHttpRegistry implements HttpRegistry {
             for (HttpRegistryProvider provider : providers) {
                 provider.connect(consumer);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void unregister(HttpConsumer consumer) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Unregistering consumer for path {}", consumer.getPath());
             }
@@ -79,6 +85,8 @@ public class DefaultHttpRegistry implements HttpRegistry {
             for (HttpRegistryProvider provider : providers) {
                 provider.disconnect(consumer);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -90,7 +98,8 @@ public class DefaultHttpRegistry implements HttpRegistry {
 
     @Override
     public void register(HttpRegistryProvider provider) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Registering CamelServlet with name {} consumers present: {}", provider.getServletName(),
                         consumers.size());
@@ -99,39 +108,50 @@ public class DefaultHttpRegistry implements HttpRegistry {
             for (HttpConsumer consumer : consumers) {
                 provider.connect(consumer);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void unregister(HttpRegistryProvider provider) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Unregistering CamelServlet with name {}", provider.getServletName());
             }
             providers.remove(provider);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public HttpRegistryProvider getCamelServlet(String servletName) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             for (HttpRegistryProvider provider : providers) {
                 if (provider.getServletName().equals(servletName)) {
                     return provider;
                 }
             }
             return null;
+        } finally {
+            lock.unlock();
         }
     }
 
     public void setServlets(List<Servlet> servlets) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             providers.clear();
             for (Servlet servlet : servlets) {
                 if (servlet instanceof HttpRegistryProvider httpRegistryProvider) {
                     providers.add(httpRegistryProvider);
                 }
             }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpEndpoint.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpEndpoint.java
@@ -207,18 +207,28 @@ public class HttpEndpoint extends HttpCommonEndpoint {
         return answer;
     }
 
-    public synchronized HttpClient getHttpClient() {
-        if (httpClient == null) {
-            httpClient = createHttpClient();
+    public HttpClient getHttpClient() {
+        lock.lock();
+        try {
+            if (httpClient == null) {
+                httpClient = createHttpClient();
+            }
+            return httpClient;
+        } finally {
+            lock.unlock();
         }
-        return httpClient;
     }
 
     /**
      * Sets a custom HttpClient to be used by the producer
      */
-    public synchronized void setHttpClient(HttpClient httpClient) {
-        this.httpClient = httpClient;
+    public void setHttpClient(HttpClient httpClient) {
+        lock.lock();
+        try {
+            this.httpClient = httpClient;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**

--- a/components/camel-iec60870/src/main/java/org/apache/camel/component/iec60870/AbstractIecComponent.java
+++ b/components/camel-iec60870/src/main/java/org/apache/camel/component/iec60870/AbstractIecComponent.java
@@ -133,7 +133,8 @@ public abstract class AbstractIecComponent<T1, T2 extends BaseOptions<T2>> exten
 
         LOG.debug("parse connection - fullUri: {} -> {}", fullUri, id);
 
-        synchronized (this) {
+        lock.lock();
+        try {
             LOG.debug("Locating connection - {}", id);
 
             T1 connection = this.connections.get(id);
@@ -148,6 +149,8 @@ public abstract class AbstractIecComponent<T1, T2 extends BaseOptions<T2>> exten
                 this.connections.put(id, connection);
             }
             return connection;
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/components/camel-infinispan/camel-infinispan-embedded/src/main/java/org/apache/camel/component/infinispan/embedded/cluster/InfinispanEmbeddedClusterView.java
+++ b/components/camel-infinispan/camel-infinispan-embedded/src/main/java/org/apache/camel/component/infinispan/embedded/cluster/InfinispanEmbeddedClusterView.java
@@ -198,60 +198,55 @@ public class InfinispanEmbeddedClusterView extends InfinispanClusterView {
             ((LocalMember) getLocalMember()).setLeader(leader);
         }
 
-        private synchronized void run() {
-            if (!running.get()) {
-                return;
-            }
-
-            final String leaderKey = InfinispanClusterService.LEADER_KEY;
-            final String localId = getLocalMember().getId();
-
-            if (isLeader()) {
-                LOGGER.debug("Lock refresh key={}, id{}", leaderKey, localId);
-
-                // I'm still the leader, so refresh the key so it does not expire.
-                if (!cache.replace(
-                        InfinispanClusterService.LEADER_KEY,
-                        getClusterService().getId(),
-                        getClusterService().getId(),
-                        configuration.getLifespan(),
-                        configuration.getLifespanTimeUnit())) {
-
-                    LOGGER.debug("Failed to refresh the lock key={}, id={}", leaderKey, localId);
-
-                    // Looks like I've lost the leadership.
-                    setLeader(false);
+        private void run() {
+            lock.lock();
+            try {
+                if (!running.get()) {
+                    return;
                 }
-            }
-            if (!isLeader()) {
-                LOGGER.debug("Try to acquire lock key={}, id={}", leaderKey, localId);
 
-                Object result = cache.putIfAbsent(
-                        InfinispanClusterService.LEADER_KEY,
-                        getClusterService().getId(),
-                        configuration.getLifespan(),
+                final String leaderKey = InfinispanClusterService.LEADER_KEY;
+                final String localId = getLocalMember().getId();
+
+                if (isLeader()) {
+                    LOGGER.debug("Lock refresh key={}, id{}", leaderKey, localId);
+
+                    // I'm still the leader, so refresh the key so it does not expire.
+                    if (!cache.replace(InfinispanClusterService.LEADER_KEY, getClusterService().getId(),
+                            getClusterService().getId(), configuration.getLifespan(), configuration.getLifespanTimeUnit())) {
+
+                        LOGGER.debug("Failed to refresh the lock key={}, id={}", leaderKey, localId);
+
+                        // Looks like I've lost the leadership.
+                        setLeader(false);
+                    }
+                }
+                if (!isLeader()) {
+                    LOGGER.debug("Try to acquire lock key={}, id={}", leaderKey, localId);
+
+                    Object result = cache.putIfAbsent(InfinispanClusterService.LEADER_KEY, getClusterService().getId(),
+                            configuration.getLifespan(), configuration.getLifespanTimeUnit());
+                    if (result == null) {
+                        LOGGER.debug("Lock acquired key={}, id={}", leaderKey, localId);
+                        // Acquired the key so I'm the leader.
+                        setLeader(true);
+                    } else if (Objects.equals(getClusterService().getId(), result) && !isLeader()) {
+                        LOGGER.debug("Lock resumed key={}, id={}", leaderKey, localId);
+                        // Hey, I may have recovered from failure (or reboot was really
+                        // fast) and my key was still there so yeah, I'm the leader again!
+                        setLeader(true);
+                    } else {
+                        LOGGER.debug("Failed to acquire the lock key={}, id={}", leaderKey, localId);
+                        setLeader(false);
+                    }
+                }
+
+                // refresh local membership
+                cache.put(getLocalMember().getId(), isLeader() ? "true" : "false", configuration.getLifespan(),
                         configuration.getLifespanTimeUnit());
-                if (result == null) {
-                    LOGGER.debug("Lock acquired key={}, id={}", leaderKey, localId);
-                    // Acquired the key so I'm the leader.
-                    setLeader(true);
-                } else if (Objects.equals(getClusterService().getId(), result) && !isLeader()) {
-                    LOGGER.debug("Lock resumed key={}, id={}", leaderKey, localId);
-                    // Hey, I may have recovered from failure (or reboot was really
-                    // fast) and my key was still there so yeah, I'm the leader again!
-                    setLeader(true);
-                } else {
-                    LOGGER.debug("Failed to acquire the lock key={}, id={}", leaderKey, localId);
-                    setLeader(false);
-                }
+            } finally {
+                lock.unlock();
             }
-
-            // refresh local membership
-            cache.put(
-                    getLocalMember().getId(),
-                    isLeader() ? "true" : "false",
-                    configuration.getLifespan(),
-                    configuration.getLifespanTimeUnit());
         }
 
         @CacheEntryRemoved

--- a/components/camel-infinispan/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/remote/cluster/InfinispanRemoteClusterView.java
+++ b/components/camel-infinispan/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/remote/cluster/InfinispanRemoteClusterView.java
@@ -210,75 +210,68 @@ public class InfinispanRemoteClusterView extends InfinispanClusterView {
             ((LocalMember) getLocalMember()).setLeader(leader);
         }
 
-        private synchronized void run() {
-            if (!running.get()) {
-                return;
-            }
-
-            final String leaderKey = InfinispanClusterService.LEADER_KEY;
-            final String localId = getLocalMember().getId();
-
-            if (isLeader() && version != null) {
-                LOGGER.debug("Lock refresh key={}, id{} with version={}", leaderKey, localId, version);
-
-                // I'm still the leader, so refresh the key so it does not expire.
-                if (!cache.replaceWithVersion(
-                        leaderKey,
-                        getClusterService().getId(),
-                        version,
-                        lifespan)) {
-
-                    LOGGER.debug("Failed to refresh the lock key={}, id={}, version={}", leaderKey, localId, version);
-
-                    setLeader(false);
-                } else {
-                    version = cache.getWithMetadata(leaderKey).getVersion();
-
-                    LOGGER.debug("Lock refreshed key={}, ud={}, with new version={}", leaderKey, localId, version);
+        private void run() {
+            lock.lock();
+            try {
+                if (!running.get()) {
+                    return;
                 }
-            }
 
-            if (!isLeader()) {
-                LOGGER.debug("Try to acquire lock key={}, id={}", leaderKey, localId);
+                final String leaderKey = InfinispanClusterService.LEADER_KEY;
+                final String localId = getLocalMember().getId();
 
-                Object result = cache.withFlags(Flag.FORCE_RETURN_VALUE)
-                        .putIfAbsent(
-                                leaderKey,
-                                localId,
-                                configuration.getLifespan(),
-                                configuration.getLifespanTimeUnit());
+                if (isLeader() && version != null) {
+                    LOGGER.debug("Lock refresh key={}, id{} with version={}", leaderKey, localId, version);
 
-                if (result == null) {
-                    // Acquired the key so I'm the leader.
-                    setLeader(true);
+                    // I'm still the leader, so refresh the key so it does not expire.
+                    if (!cache.replaceWithVersion(leaderKey, getClusterService().getId(), version, lifespan)) {
 
-                    // Get the version
-                    version = cache.getWithMetadata(leaderKey).getVersion();
+                        LOGGER.debug("Failed to refresh the lock key={}, id={}, version={}", leaderKey, localId, version);
 
-                    LOGGER.debug("Lock acquired key={}, id={}, with version={}", leaderKey, localId, version);
+                        setLeader(false);
+                    } else {
+                        version = cache.getWithMetadata(leaderKey).getVersion();
 
-                } else if (Objects.equals(getClusterService().getId(), result) && !isLeader()) {
-                    // Hey, I may have recovered from failure (or reboot was really
-                    // fast) and my key was still there so yeah, I'm the leader again!
-                    setLeader(true);
-
-                    // Get the version
-                    version = cache.getWithMetadata(leaderKey).getVersion();
-
-                    LOGGER.debug("Lock resumed key={}, id={} with version={}", leaderKey, localId, version);
-                } else {
-                    LOGGER.debug("Failed to acquire the lock key={}, id={}", leaderKey, localId);
-
-                    setLeader(false);
+                        LOGGER.debug("Lock refreshed key={}, ud={}, with new version={}", leaderKey, localId, version);
+                    }
                 }
-            }
 
-            // refresh local membership
-            cache.put(
-                    getLocalMember().getId(),
-                    isLeader() ? "true" : "false",
-                    configuration.getLifespan(),
-                    configuration.getLifespanTimeUnit());
+                if (!isLeader()) {
+                    LOGGER.debug("Try to acquire lock key={}, id={}", leaderKey, localId);
+
+                    Object result = cache.withFlags(Flag.FORCE_RETURN_VALUE)
+                            .putIfAbsent(leaderKey, localId, configuration.getLifespan(), configuration.getLifespanTimeUnit());
+
+                    if (result == null) {
+                        // Acquired the key so I'm the leader.
+                        setLeader(true);
+
+                        // Get the version
+                        version = cache.getWithMetadata(leaderKey).getVersion();
+
+                        LOGGER.debug("Lock acquired key={}, id={}, with version={}", leaderKey, localId, version);
+                    } else if (Objects.equals(getClusterService().getId(), result) && !isLeader()) {
+                        // Hey, I may have recovered from failure (or reboot was really
+                        // fast) and my key was still there so yeah, I'm the leader again!
+                        setLeader(true);
+
+                        // Get the version
+                        version = cache.getWithMetadata(leaderKey).getVersion();
+
+                        LOGGER.debug("Lock resumed key={}, id={} with version={}", leaderKey, localId, version);
+                    } else {
+                        LOGGER.debug("Failed to acquire the lock key={}, id={}", leaderKey, localId);
+
+                        setLeader(false);
+                    }
+                }
+
+                // refresh local membership
+                cache.put(getLocalMember().getId(), isLeader() ? "true" : "false", configuration.getLifespan(),
+                        configuration.getLifespanTimeUnit());
+            } finally {
+                lock.unlock();
+            }
         }
 
         @ClientCacheEntryRemoved


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-20199

## Motivation

For better support of virtual threads, we need to avoid lengthy and frequent pinning by replacing synchronized blocks with ReentrantLocks

## Modifications:

* Replace mutex with locks
* Use locks instead of synchronized blocks
* Use ConcurrentHashMap instead of HashMap when possible