### PR TITLE
CAMEL-20367: Adds tests for file management via http in dev mode

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -185,6 +185,26 @@ public abstract class JBangTestSupport {
                         .contains(contains)));
     }
 
+    protected void checkLogDoesNotContain(String route, String contains, int waitForSeconds) {
+        Assertions.assertThatNoException().isThrownBy(() -> Awaitility.await()
+                .atMost(waitForSeconds, TimeUnit.SECONDS)
+                .untilAsserted(() -> Assertions.assertThat(getLogs(route))
+                        .as("log does not contain " + contains)
+                        .doesNotContain(contains)));
+    }
+
+    protected void checkLogDoesNotContain(String contains, int waitForSeconds) {
+        checkLogDoesNotContain(null, contains, waitForSeconds);
+    }
+
+    protected void checkLogDoesNotContain(String route, String contains) {
+        checkLogDoesNotContain(route, contains, ASSERTION_WAIT_SECONDS);
+    }
+
+    protected void checkLogDoesNotContain(String contains) {
+        checkLogDoesNotContain(contains, ASSERTION_WAIT_SECONDS);
+    }
+
     protected void checkLogContainsPattern(String contains) {
         checkLogContainsPattern(contains, ASSERTION_WAIT_SECONDS);
     }
@@ -256,6 +276,10 @@ public abstract class JBangTestSupport {
                     .atMost(Duration.ofMinutes(2))
                     .pollInterval(Duration.ofSeconds(1))
                     .until(() -> !process.isAlive());
+            if (process.exitValue() != 0) {
+                logger.error(String.valueOf(process.getErrorStream()));
+                logger.info(String.valueOf(process.getOutputStream()));
+            }
             return new String(process.getInputStream().readAllBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Adds tests for [this part of documentation](https://camel.apache.org/manual/camel-jbang.html#_uploading_files_to_source_directory_via_http)

Also an additional set of methods to check logs don't contain a string and debug prints when a command fails inside host.