### PR TITLE
chore(camel-jbang): Fix route trait

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/RouteTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/RouteTrait.java
@@ -18,7 +18,6 @@ package org.apache.camel.dsl.jbang.core.commands.kubernetes.traits;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
@@ -49,17 +48,13 @@ public class RouteTrait extends BaseTrait {
             return false;
         }
 
-        // explicitly disabled
-        if (traitConfig.getRoute() != null && !Optional.ofNullable(traitConfig.getRoute().getEnabled()).orElse(true)) {
+        // must be explicitly enabled
+        if (traitConfig.getRoute() == null || !Optional.ofNullable(traitConfig.getRoute().getEnabled()).orElse(false)) {
             return false;
         }
 
         // configured service
-        if (traitConfig.getRoute() != null) {
-            return context.getService() != null;
-        }
-
-        return true;
+        return context.getService().isPresent();
     }
 
     @Override
@@ -136,8 +131,6 @@ public class RouteTrait extends BaseTrait {
             }
             try (InputStream is = new FileInputStream(file)) {
                 return IOHelper.loadText(is);
-            } catch (FileNotFoundException e) {
-                throw new RuntimeException(e);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/knative/KnativeServiceTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/knative/KnativeServiceTrait.java
@@ -53,17 +53,15 @@ public class KnativeServiceTrait extends KnativeBaseTrait {
             return false;
         }
 
-        if (traitConfig.getKnativeService() != null && traitConfig.getKnativeService().getEnabled() != null) {
-            // Knative service either explicitly enabled or disabled
-            return traitConfig.getKnativeService().getEnabled() && TraitHelper.exposesHttpService(context);
+        // one of Knative traits needs to be explicitly enabled
+        boolean enabled = false;
+        if (traitConfig.getKnativeService() != null) {
+            enabled = Optional.ofNullable(traitConfig.getKnativeService().getEnabled()).orElse(false);
+        } else if (traitConfig.getKnative() != null) {
+            enabled = Optional.ofNullable(traitConfig.getKnative().getEnabled()).orElse(false);
         }
 
-        if (traitConfig.getKnative() != null && traitConfig.getKnative().getEnabled() != null) {
-            // Knative either explicitly enabled or disabled
-            return traitConfig.getKnative().getEnabled() && TraitHelper.exposesHttpService(context);
-        }
-
-        return false;
+        return enabled && TraitHelper.exposesHttpService(context);
     }
 
     @Override

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesCommandTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesCommandTest.java
@@ -45,7 +45,7 @@ class KubernetesCommandTest extends KubernetesBaseTest {
                 "yaml");
 
         List<HasMetadata> resources = kubernetesClient.load(getKubernetesManifestAsStream(printer.getOutput())).items();
-        Assertions.assertEquals(4, resources.size());
+        Assertions.assertEquals(3, resources.size());
 
         Deployment deployment = resources.stream()
                 .filter(it -> Deployment.class.isAssignableFrom(it.getClass()))

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
@@ -258,6 +258,7 @@ class KubernetesExportTest extends KubernetesBaseTest {
         String key = IOHelper.loadText(new FileInputStream("src/test/resources/route/tls.key"));
         KubernetesExport command = createCommand(new String[] { "classpath:route-service.yaml" },
                 "--trait-profile", "openshift",
+                "--trait", "route.enabled=true",
                 "--trait", "route.host=example.com",
                 "--trait", "route.tls-termination=edge",
                 "--trait", "route.tls-certificate=" + certificate,

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRunTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRunTest.java
@@ -58,7 +58,7 @@ class KubernetesRunTest extends KubernetesBaseTest {
         Assertions.assertEquals(0, exit);
 
         List<HasMetadata> resources = kubernetesClient.load(getKubernetesManifestAsStream(printer.getOutput())).items();
-        Assertions.assertEquals(4, resources.size());
+        Assertions.assertEquals(3, resources.size());
 
         Deployment deployment = resources.stream()
                 .filter(it -> Deployment.class.isAssignableFrom(it.getClass()))


### PR DESCRIPTION
# Description

- Route trait only applies to OpenShift clusters
- Not all services should be exposed via Route resource
- Users need to explicitly enable the route trait because of that
- Avoids to add Route resource to non OpenShift clusters

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

