### PR TITLE
Remove tests for kafka 2

### DIFF
--- a/components/camel-kafka/pom.xml
+++ b/components/camel-kafka/pom.xml
@@ -151,42 +151,6 @@
             </properties>
         </profile>
         <profile>
-            <id>backwards-compatibility</id>
-            <activation>
-                <os>
-                    <arch>amd64</arch>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skipITs>${skipITs}</skipITs>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>kafka-2</id>
-                                <configuration>
-                                    <skipITs>${skipITs}</skipITs>
-                                    <systemPropertyVariables>
-                                        <kafka.instance.type>local-kafka2-container</kafka.instance.type>
-                                    </systemPropertyVariables>
-                                    <reportNameSuffix>kafka-2</reportNameSuffix>
-                                    <excludedGroups>non-abstract,health,idempotent</excludedGroups>
-                                </configuration>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>full</id>
             <activation>
                 <property>

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/common/KafkaProperties.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/common/KafkaProperties.java
@@ -22,7 +22,6 @@ public final class KafkaProperties {
     public static final String KAFKA_ZOOKEEPER_ADDRESS = "kafka.zookeeper.address";
     public static final String KAFKA_CONTAINER = "kafka.container";
     public static final String KAFKA3_CONTAINER = "kafka3.container";
-    public static final String KAFKA2_CONTAINER = "kafka2.container";
     public static final String REDPANDA_CONTAINER = "redpanda.container.image";
     public static final String STRIMZI_CONTAINER = "strimzi.container.image";
 

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaService.java
@@ -29,9 +29,6 @@ public class ContainerLocalKafkaService implements KafkaService, ContainerServic
     public static final String KAFKA3_IMAGE_NAME = LocalPropertyResolver.getProperty(
             ContainerLocalKafkaService.class,
             KafkaProperties.KAFKA3_CONTAINER);
-    public static final String KAFKA2_IMAGE_NAME = LocalPropertyResolver.getProperty(
-            ContainerLocalKafkaService.class,
-            KafkaProperties.KAFKA2_CONTAINER);
 
     private static final Logger LOG = LoggerFactory.getLogger(ContainerLocalKafkaService.class);
     private final KafkaContainer kafka;
@@ -75,16 +72,6 @@ public class ContainerLocalKafkaService implements KafkaService, ContainerServic
     @Override
     public KafkaContainer getContainer() {
         return kafka;
-    }
-
-    public static ContainerLocalKafkaService kafka2Container() {
-        KafkaContainer container
-                = new KafkaContainer(
-                        DockerImageName.parse(System.getProperty(KafkaProperties.KAFKA_CONTAINER, KAFKA2_IMAGE_NAME))
-                                .asCompatibleSubstituteFor(ContainerLocalKafkaService.KAFKA2_IMAGE_NAME));
-        container = container.withEmbeddedZookeeper();
-
-        return new ContainerLocalKafkaService(container);
     }
 
     public static ContainerLocalKafkaService kafka3Container() {

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/KafkaServiceFactory.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/KafkaServiceFactory.java
@@ -59,7 +59,6 @@ public final class KafkaServiceFactory {
                 .addMapping("local-strimzi-container", StrimziService::new)
                 .addRemoteMapping(RemoteKafkaService::new)
                 .addMapping("local-kafka3-container", ContainerLocalKafkaService::kafka3Container)
-                .addMapping("local-kafka2-container", ContainerLocalKafkaService::kafka2Container)
                 .addMapping("local-redpanda-container", RedpandaService::new)
                 .build();
     }
@@ -78,8 +77,6 @@ public final class KafkaServiceFactory {
                     .addRemoteMapping(RemoteKafkaService::new)
                     .addMapping("local-kafka3-container",
                             () -> new SingletonKafkaService(ContainerLocalKafkaService.kafka3Container(), "kafka3"))
-                    .addMapping("local-kafka2-container",
-                            () -> new SingletonKafkaService(ContainerLocalKafkaService.kafka2Container(), "kafka2"))
                     .addMapping("local-strimzi-container",
                             () -> new SingletonKafkaService(new StrimziService(), "strimzi"))
                     .addMapping("local-redpanda-container",

--- a/test-infra/camel-test-infra-kafka/src/test/resources/org/apache/camel/test/infra/kafka/services/container.properties
+++ b/test-infra/camel-test-infra-kafka/src/test/resources/org/apache/camel/test/infra/kafka/services/container.properties
@@ -15,6 +15,5 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 kafka3.container=confluentinc/cp-kafka:7.4.5
-kafka2.container=confluentinc/cp-kafka:5.5.12
 redpanda.container.image=redpandadata/redpanda:v24.1.16
 strimzi.container.image=quay.io/strimzi/kafka:latest-kafka-3.7.0


### PR DESCRIPTION
Kafka 2.x has reached end of life on June 2023
It allows to simplify codebase and will ease migration of containers from Confluent to Apache ones. see https://issues.apache.org/jira/browse/CAMEL-20593
It will also reduce time execution of build. For me locally, it went from 13 minutes to 7 minutes to build and test the Camel Kafka component.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

