### PR TITLE
[CAMEL-21199] Camel-jackson not properly marshalling 4-byte characters

### DIFF
--- a/components/camel-jackson/src/test/java/org/apache/camel/component/jackson/JacksonMarshalMultibyteCharactersTest.java
+++ b/components/camel-jackson/src/test/java/org/apache/camel/component/jackson/JacksonMarshalMultibyteCharactersTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jackson;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class JacksonMarshalMultibyteCharactersTest extends CamelTestSupport {
+
+    @Test
+    public void testMarshal4ByteCharacter() throws Exception {
+        Map<String, Object> in = new HashMap<>();
+        in.put("name", "システム\uD867\uDE3D");
+
+        MockEndpoint mock = getMockEndpoint("mock:reverse");
+        mock.expectedMessageCount(1);
+        mock.message(0).body().isInstanceOf(Map.class);
+        mock.message(0).body().isEqualTo(in);
+
+        Object marshalled = template.requestBody("direct:in", in);
+        String marshalledAsString = context.getTypeConverter().convertTo(String.class, marshalled);
+
+        // prior to fixing CAMEL-21199, this was the result returned by Jackson
+        assertNotEquals("{\"name\":\"システム\\uD867\\uDE3D\"}", marshalledAsString);
+
+        assertEquals("{\"name\":\"システム\uD867\uDE3D\"}", marshalledAsString);
+
+        template.sendBody("direct:back", marshalled);
+        mock.assertIsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+
+            @Override
+            public void configure() {
+                JacksonDataFormat format = new JacksonDataFormat();
+                from("direct:in").marshal(format);
+                from("direct:back").unmarshal(format).to("mock:reverse");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-21199

Jackson doesn't handle 4-byte characters well. Marshalling a 4-byte Japanese kanji character results in two UTF-16 escapes to be written instead of the character itself. While this is ok for emoji an such, it's not for natural languages. 

Jackson issue: https://github.com/FasterXML/jackson-core/issues/223

Reproducer:
```
from("file:data?file-name=input.txt&noop=true")
    .log("${body}")
    .unmarshal().json(JsonLibrary.Jackson)
    .log("${body[0]['name']}")
    .marshal().json(JsonLibrary.Jackson, true)
    .log("${body}");
```

with the file input.txt containing:
`[{"name": "システム𩸽"}]`

Solution:
While it's an error in Jackson-core, it could be avoided by forcing Jackson to use _WriterBasedJsonGenerator_ instead of _UTF8JsonGenerator_ (see the original Jackson issue reproducer in the [topmost comment](https://github.com/FasterXML/jackson-core/issues/223#issue-110880547))