### PR TITLE
CAMEL-21211: Azure Service Bus - filter unknown header types

### DIFF
--- a/components/camel-azure/camel-azure-servicebus/pom.xml
+++ b/components/camel-azure/camel-azure-servicebus/pom.xml
@@ -65,6 +65,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito-version}</version>

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusHeaderFilterStrategy.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusHeaderFilterStrategy.java
@@ -16,16 +16,36 @@
  */
 package org.apache.camel.component.azure.servicebus;
 
+import java.util.Date;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.camel.Exchange;
 import org.apache.camel.support.DefaultHeaderFilterStrategy;
 
 public class ServiceBusHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
+    private static final Set<Class<?>> SUPPORTED_TYPES = Set.of(
+            Boolean.class,
+            Byte.class,
+            Character.class,
+            Double.class,
+            Float.class,
+            Integer.class,
+            Long.class,
+            Short.class,
+            String.class,
+            Date.class,
+            UUID.class);
+
     public ServiceBusHeaderFilterStrategy() {
         super();
-        initialise();
+        setOutFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH);
+        setInFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH);
     }
 
-    private void initialise() {
-        setOutFilterStartsWith("Camel", "camel", "org.apache.camel.");
-        setInFilterStartsWith("Camel", "camel", "org.apache.camel.");
+    @Override
+    public boolean applyFilterToCamelHeaders(String headerName, Object headerValue, Exchange exchange) {
+        return headerValue == null || !SUPPORTED_TYPES.contains(headerValue.getClass())
+                || super.applyFilterToCamelHeaders(headerName, headerValue, exchange);
     }
 }

--- a/components/camel-azure/camel-azure-servicebus/src/test/java/org/apache/camel/component/azure/servicebus/ServiceBusHeaderFilterStrategyTest.java
+++ b/components/camel-azure/camel-azure-servicebus/src/test/java/org/apache/camel/component/azure/servicebus/ServiceBusHeaderFilterStrategyTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.azure.servicebus;
+
+import java.util.Date;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServiceBusHeaderFilterStrategyTest {
+    private final ServiceBusHeaderFilterStrategy headerFilterStrategy = new ServiceBusHeaderFilterStrategy();
+
+    @ParameterizedTest
+    @ArgumentsSource(HeaderArgumentsProvider.class)
+    void testApplyFilterToCamelHeadersPassesKnownTypes(String headerName, Object headerValue) {
+        assertThat(headerFilterStrategy.applyFilterToCamelHeaders(headerName, headerValue, null)).isFalse();
+    }
+
+    @Test
+    void testApplyFilterToCamelHeadersFiltersUnknownType() {
+        assertThat(headerFilterStrategy.applyFilterToCamelHeaders("objectHeader", new Object(), null)).isTrue();
+    }
+
+    static class HeaderArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return Stream.of(
+                    Arguments.of("booleanHeader", true),
+                    Arguments.of("byteHeader", (byte) 1),
+                    Arguments.of("characterHeader", '1'),
+                    Arguments.of("doubleHeader", 1.0D),
+                    Arguments.of("floatHeader", 1.0F),
+                    Arguments.of("integerHeader", 1),
+                    Arguments.of("longHeader", 1L),
+                    Arguments.of("shortHeader", (short) 1),
+                    Arguments.of("stringHeader", "stringHeader"),
+                    Arguments.of("timestampHeader", new Date()),
+                    Arguments.of("uuidHeader", UUID.randomUUID()));
+        }
+    }
+}


### PR DESCRIPTION
# Description

The default `HeaderFilterStrategy` created when automatic header propagation was implemented for the Service Bus did not take steps to ensure that propagated headers are of a Java type that can be encoded as an application property by the underlying client libraries.

This would lead to errors of the form: `com.azure.messaging.servicebus.ServiceBusException: No encoding is known for map entry value of type: <unmappable class name>`

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.