### PR TITLE
Use the newly maintained univocity parsers

### DIFF
--- a/components/camel-univocity-parsers/pom.xml
+++ b/components/camel-univocity-parsers/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>camel-univocity-parsers</artifactId>
     <packaging>jar</packaging>
-    <name>Camel :: UniVocity Parsers (deprecated)</name>
+    <name>Camel :: UniVocity Parsers</name>
     <description>Camel UniVocity parsers data format support</description>
 
     <properties>
@@ -40,7 +40,7 @@
             <artifactId>camel-support</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.univocity</groupId>
+            <groupId>com.sonofab1rd</groupId>
             <artifactId>univocity-parsers</artifactId>
             <version>${univocity-parsers-version}</version>
             <type>jar</type>

--- a/components/camel-univocity-parsers/src/generated/resources/META-INF/services/org/apache/camel/dataformat.properties
+++ b/components/camel-univocity-parsers/src/generated/resources/META-INF/services/org/apache/camel/dataformat.properties
@@ -3,5 +3,5 @@ dataFormats=univocityCsv univocityFixed univocityTsv
 groupId=org.apache.camel
 artifactId=camel-univocity-parsers
 version=4.9.0-SNAPSHOT
-projectName=Camel :: UniVocity Parsers (deprecated)
+projectName=Camel :: UniVocity Parsers
 projectDescription=Camel UniVocity parsers data format support

--- a/components/camel-univocity-parsers/src/main/java/org/apache/camel/dataformat/univocity/HeaderRowProcessor.java
+++ b/components/camel-univocity-parsers/src/main/java/org/apache/camel/dataformat/univocity/HeaderRowProcessor.java
@@ -23,7 +23,7 @@ import com.univocity.parsers.common.processor.RowProcessor;
  * This class is used by the unmarshaller in order to retrieve the headers.
  */
 final class HeaderRowProcessor implements RowProcessor {
-    private String[] headers;
+    private final static ThreadLocal<String[]> headers = new ThreadLocal<>();
 
     /**
      * Called when the processing starts, it clears the headers
@@ -32,7 +32,7 @@ final class HeaderRowProcessor implements RowProcessor {
      */
     @Override
     public void processStarted(ParsingContext context) {
-        headers = null;
+        headers.set(null);
     }
 
     /**
@@ -43,8 +43,8 @@ final class HeaderRowProcessor implements RowProcessor {
      */
     @Override
     public void rowProcessed(String[] row, ParsingContext context) {
-        if (headers == null) {
-            headers = context.headers();
+        if (headers.get() == null) {
+            headers.set(context.headers());
         }
     }
 
@@ -55,7 +55,7 @@ final class HeaderRowProcessor implements RowProcessor {
      */
     @Override
     public void processEnded(ParsingContext context) {
-        headers = null;
+        headers.set(null);
     }
 
     /**
@@ -64,6 +64,6 @@ final class HeaderRowProcessor implements RowProcessor {
      * @return the headers
      */
     public String[] getHeaders() {
-        return headers;
+        return headers.get();
     }
 }

--- a/components/camel-univocity-parsers/src/main/java/org/apache/camel/dataformat/univocity/UniVocityCsvDataFormat.java
+++ b/components/camel-univocity-parsers/src/main/java/org/apache/camel/dataformat/univocity/UniVocityCsvDataFormat.java
@@ -29,7 +29,6 @@ import org.apache.camel.spi.annotations.Dataformat;
  * This class is the data format that uses the CSV uniVocity parser.
  */
 @Dataformat("univocityCsv")
-@Deprecated(since = "4.8.0")
 public class UniVocityCsvDataFormat
         extends
         AbstractUniVocityDataFormat<CsvFormat, CsvWriterSettings, CsvWriter, CsvParserSettings, CsvParser, UniVocityCsvDataFormat> {

--- a/components/camel-univocity-parsers/src/main/java/org/apache/camel/dataformat/univocity/UniVocityFixedDataFormat.java
+++ b/components/camel-univocity-parsers/src/main/java/org/apache/camel/dataformat/univocity/UniVocityFixedDataFormat.java
@@ -31,7 +31,6 @@ import org.apache.camel.spi.annotations.Dataformat;
  * This class is the data format that uses the fixed-width uniVocity parser.
  */
 @Dataformat("univocityFixed")
-@Deprecated(since = "4.8.0")
 public class UniVocityFixedDataFormat
         extends
         AbstractUniVocityDataFormat<FixedWidthFormat, FixedWidthWriterSettings, FixedWidthWriter, FixedWidthParserSettings, FixedWidthParser, UniVocityFixedDataFormat> {

--- a/components/camel-univocity-parsers/src/main/java/org/apache/camel/dataformat/univocity/UniVocityTsvDataFormat.java
+++ b/components/camel-univocity-parsers/src/main/java/org/apache/camel/dataformat/univocity/UniVocityTsvDataFormat.java
@@ -29,7 +29,6 @@ import org.apache.camel.spi.annotations.Dataformat;
  * This class is the data format that uses the TSV uniVocity parser.
  */
 @Dataformat("univocityTsv")
-@Deprecated(since = "4.8.0")
 public class UniVocityTsvDataFormat
         extends
         AbstractUniVocityDataFormat<TsvFormat, TsvWriterSettings, TsvWriter, TsvParserSettings, TsvParser, UniVocityTsvDataFormat> {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -475,7 +475,7 @@
         <twilio-version>10.5.0</twilio-version>
         <twitter4j-version>4.1.2</twitter4j-version>
         <undertow-version>2.3.17.Final</undertow-version>
-        <univocity-parsers-version>2.9.1</univocity-parsers-version>
+        <univocity-parsers-version>2.10.0</univocity-parsers-version>
         <validation-api-version>2.0.1.Final</validation-api-version>
         <vavr-version>0.10.4</vavr-version>
         <velocity-tools-version>3.1</velocity-tools-version>


### PR DESCRIPTION
* remove locking for lazy initialized fields, as those are not very expensive to create, so worst case, we have double initiatization, which is not a problem
* move the TLS into the HeaderRowProcessor
* remove 'or not' in 'whether or not'
