### PR TITLE
Zipsplitter null body

### DIFF
--- a/components/camel-zipfile/src/test/java/org/apache/camel/dataformat/zipfile/ZipFileSplitAndDeleteTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/dataformat/zipfile/ZipFileSplitAndDeleteTest.java
@@ -31,6 +31,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
@@ -38,8 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class ZipFileSplitAndDeleteTest extends CamelTestSupport {
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void deleteTestDirs() {
         deleteDirectory("target/testDeleteZipFileWhenUnmarshalWithDataFormat");
         deleteDirectory("target/testDeleteZipFileWhenUnmarshalWithSplitter");
     }

--- a/components/camel-zipfile/src/test/java/org/apache/camel/dataformat/zipfile/ZipFileSplitOneFileTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/dataformat/zipfile/ZipFileSplitOneFileTest.java
@@ -30,14 +30,15 @@ import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
 
 public class ZipFileSplitOneFileTest extends CamelTestSupport {
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void deleteTestDirs() {
         deleteDirectory("target/zip-unmarshal");
     }
 

--- a/components/camel-zipfile/src/test/java/org/apache/camel/dataformat/zipfile/ZipSplitterRouteIssueTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/dataformat/zipfile/ZipSplitterRouteIssueTest.java
@@ -21,14 +21,15 @@ import java.io.File;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
 
 public class ZipSplitterRouteIssueTest extends CamelTestSupport {
 
-    @Override
-    public void doPreSetup() throws Exception {
+    @BeforeEach
+    public void deleteTestDirs() {
         deleteDirectory("target/zip");
     }
 

--- a/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/AggregationStrategyWithFilenameHeaderTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/AggregationStrategyWithFilenameHeaderTest.java
@@ -28,6 +28,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.util.IOHelper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
@@ -40,8 +41,8 @@ public class AggregationStrategyWithFilenameHeaderTest extends CamelTestSupport 
     private static final List<String> FILE_NAMES = Arrays.asList("foo", "bar");
     private static final String TEST_DIR = "target/out_AggregationStrategyWithFilenameHeaderTest";
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void deleteTestDirs() {
         deleteDirectory(TEST_DIR);
     }
 

--- a/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/AggregationStrategyWithPreservationTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/AggregationStrategyWithPreservationTest.java
@@ -28,6 +28,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.util.IOHelper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
@@ -40,8 +41,8 @@ public class AggregationStrategyWithPreservationTest extends CamelTestSupport {
     private static final int EXPECTED_NO_FILES = 5;
     private static final String TEST_DIR = "target/out_AggregationStrategyWithPreservationTest";
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void deleteTestDirs() {
         deleteDirectory(TEST_DIR);
     }
 

--- a/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategyEmptyFileTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategyEmptyFileTest.java
@@ -26,6 +26,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.util.IOHelper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
@@ -39,8 +40,8 @@ public class ZipAggregationStrategyEmptyFileTest extends CamelTestSupport {
     private static final int EXPECTED_WITH_EMPTY_FILE = 4;
     private static final String TEST_DIR = "target/out_ZipAggregationStrategyEmptyFileTest";
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void deleteTestDirs() {
         deleteDirectory("target/foo");
         deleteDirectory("target/bar");
         deleteDirectory(TEST_DIR);

--- a/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategyNullBodyTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategyNullBodyTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.aggregate.zipfile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.util.IOHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ZipAggregationStrategyNullBodyTest extends CamelTestSupport {
+
+    private static final String TEST_DIR = "target/out_ZipAggregationStrategyNullBodyTest";
+    public static final String MOCK_AGGREGATE_TO_ZIP_ENTRY = "mock:aggregateToZipEntry";
+
+    @BeforeEach
+    public void deleteTestDirs() {
+        deleteDirectory(TEST_DIR);
+    }
+
+    @Test
+    public void testNullBodyLast() throws Exception {
+        MockEndpoint mock = getMockEndpoint(MOCK_AGGREGATE_TO_ZIP_ENTRY);
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:start", "Hello");
+        template.sendBody("direct:start", "Hello again");
+        template.sendBody("direct:start", null);
+
+        assertZipContainsFiles(2);
+    }
+
+    @Test
+    public void testNullBodyFirst() throws Exception {
+        MockEndpoint mock = getMockEndpoint(MOCK_AGGREGATE_TO_ZIP_ENTRY);
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:start", null);
+        template.sendBody("direct:start", "Hello");
+        template.sendBody("direct:start", "Hello again");
+
+        assertZipContainsFiles(2);
+    }
+
+    @Test
+    public void testNullBodyMiddle() throws Exception {
+        MockEndpoint mock = getMockEndpoint(MOCK_AGGREGATE_TO_ZIP_ENTRY);
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:start", "Hello");
+        template.sendBody("direct:start", null);
+        template.sendBody("direct:start", "Hello again");
+
+        assertZipContainsFiles(2);
+    }
+
+    @Test
+    public void testNullBodiesOnly() throws Exception {
+        MockEndpoint mock = getMockEndpoint(MOCK_AGGREGATE_TO_ZIP_ENTRY);
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:start", null);
+        template.sendBody("direct:start", null);
+        template.sendBody("direct:start", null);
+
+        assertZipContainsFiles(0);
+    }
+
+    @Test
+    public void testTwoNullBodies() throws Exception {
+        MockEndpoint mock = getMockEndpoint(MOCK_AGGREGATE_TO_ZIP_ENTRY);
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:start", null);
+        template.sendBody("direct:start", null);
+        template.sendBody("direct:start", "Hello");
+
+        assertZipContainsFiles(1);
+    }
+
+    private void assertZipContainsFiles(int expectedCount) throws InterruptedException, IOException {
+        MockEndpoint.assertIsSatisfied(context);
+
+        File[] files = new File(TEST_DIR).listFiles();
+        assertNotNull(files);
+        assertTrue(files.length > 0, "Should be a file in " + TEST_DIR + " directory");
+
+        File resultFile = files[0];
+
+        ZipInputStream zin = new ZipInputStream(new FileInputStream(resultFile));
+        try {
+            int fileCount = 0;
+            for (ZipEntry ze = zin.getNextEntry(); ze != null; ze = zin.getNextEntry()) {
+                fileCount++;
+            }
+            assertEquals(expectedCount, fileCount,
+                    "Zip file should contains " + expectedCount + " files");
+        } finally {
+            IOHelper.close(zin);
+        }
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start")
+                        .aggregate(new ZipAggregationStrategy())
+                        .constant(true)
+                        .completionSize(3)
+                        .eagerCheckCompletion()
+                        .to("file:" + TEST_DIR)
+                        .to(MOCK_AGGREGATE_TO_ZIP_ENTRY)
+                        .log("Done processing zip file: ${header.CamelFileName}");
+
+            }
+        };
+
+    }
+}

--- a/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategySplitTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategySplitTest.java
@@ -28,6 +28,7 @@ import org.apache.camel.processor.aggregate.GroupedMessageAggregationStrategy;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.util.IOHelper;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
@@ -38,8 +39,8 @@ public class ZipAggregationStrategySplitTest extends CamelTestSupport {
     private static final int EXPECTED_NO_FILES = 3;
     private static final String TEST_DIR = "target/out_ZipAggregationStrategyTest";
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void deleteTestDirs() {
         deleteDirectory(TEST_DIR);
     }
 

--- a/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategyTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipAggregationStrategyTest.java
@@ -25,6 +25,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.util.IOHelper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
@@ -37,8 +38,8 @@ public class ZipAggregationStrategyTest extends CamelTestSupport {
     private static final int EXPECTED_NO_FILES = 3;
     private static final String TEST_DIR = "target/out_ZipAggregationStrategyTest";
 
-    @Override
-    public void doPreSetup() throws Exception {
+    @BeforeEach
+    public void deleteTestDirs() {
         deleteDirectory(TEST_DIR);
     }
 


### PR DESCRIPTION
# Description
See https://camel.zulipchat.com/#narrow/stream/257298-camel/topic/Idiomatic.20way.20to.20pollEnrich.20until.20there.20are.20no.20more.20items: In case one of the incoming bodies is null, this change should avoid failure of ZipAggregationStrategy.

I also addressed SonarQube warnings about cognitive complexity and removed deprecated annotations from test code while I was at it.

Viewing the three commits individually is probably best to see what changed in terms of functionality and what was just refactoring.

