### PR TITLE
CAMEL-20367: Adds Cmd start stop route tests

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdStartStopITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdStartStopITCase.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.it;
+
+import java.io.IOException;
+
+import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.Test;
+
+public class CmdStartStopITCase extends JBangTestSupport {
+
+    @Test
+    public void testCmdStop() throws IOException {
+        copyResourceInDataFolder(TestResources.DIR_ROUTE);
+        copyResourceInDataFolder(TestResources.ROUTE2);
+        executeBackground(String.format("run --source-dir=%s", mountPoint()));
+        checkLogContains("Hello world!");
+        checkCommandOutputsPattern("get route",
+                "route1\\s+timer:\\/\\/(yaml|java)\\?period=1000\\s+Started.*\\n.*route2\\s+timer:\\/\\/(yaml|java)\\?period=1000\\s+Started");
+        execute("cmd stop-route route2");
+        checkCommandOutputsPattern("get route",
+                "route1\\s+timer:\\/\\/(yaml|java)\\?period=1000\\s+Stopped.*\\n.*route2\\s+timer:\\/\\/(yaml|java)\\?period=1000\\s+Stopped");
+        execute("cmd start-route --id=route1");
+        checkCommandOutputsPattern("get route",
+                "route1\\s+timer:\\/\\/(yaml|java)\\?period=1000\\s+Started.*\\n.*route2\\s+timer:\\/\\/(yaml|java)\\?period=1000\\s+Stopped");
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -153,6 +153,12 @@ public abstract class JBangTestSupport {
                 .contains(contains);
     }
 
+    protected void checkCommandOutputsPattern(String command, String contains) {
+        Assertions.assertThat(execute(command))
+                .as("command camel" + command + "should output pattern" + contains)
+                .containsPattern(contains);
+    }
+
     protected void checkCommandDoesNotOutput(String command, String contains) {
         Assertions.assertThat(execute(command))
                 .as("command camel" + command + "should not output" + contains)


### PR DESCRIPTION
Adds tests for [this part of documentation](https://camel.apache.org/manual/camel-jbang.html#_starting_and_stopping_routes)