### PR TITLE
CAMEL-20367: Adds list service test

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ListServiceITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ListServiceITCase.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.it;
+
+import java.io.IOException;
+
+import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.Test;
+
+public class ListServiceITCase extends JBangTestSupport {
+    @Test
+    public void listServicesTest() throws IOException {
+        copyResourceInDataFolder(TestResources.SERVER_ROUTE);
+        executeBackground(String.format("run %s/server.yaml", mountPoint()));
+        checkLogContains("http://0.0.0.0:8080/hello");
+        checkCommandOutputs("get service", "platform-http");
+    }
+
+}


### PR DESCRIPTION
Adds test for [this part of documentation](https://camel.apache.org/manual/camel-jbang.html#_listing_services)

Please note that this should be merged after https://github.com/apache/camel/pull/15648 as it uses resources added in that commit.