### PR TITLE
CAMEL-21252 Add checking for non .*-versions to sync-properties-maven-plugin

### DIFF
--- a/camel-dependencies/pom.xml
+++ b/camel-dependencies/pom.xml
@@ -63,6 +63,9 @@
                         <goals>
                             <goal>sync-properties</goal>
                         </goals>
+                        <configuration>
+                            <checkForInvalidVersions>true</checkForInvalidVersions>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/components/camel-zeebe/pom.xml
+++ b/components/camel-zeebe/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.camunda</groupId>
             <artifactId>zeebe-client-java</artifactId>
-            <version>${zeebe.version}</version>
+            <version>${zeebe-version}</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/docs/user-manual/modules/ROOT/pages/camel-report-maven-plugin.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-report-maven-plugin.adoc
@@ -357,7 +357,7 @@ The maven plugin *coverage* goal supports the following options which can be con
  patterns (wildcard and regular expression). Multiple values can be separated by comma.
 | excludes | | To filter the names of java and xml files to exclude files matching any of the given list of
  patterns (wildcard and regular expression). Multiple values can be separated by comma.
-| anonymousRoutes | false | Whether to allow anonymous routes (routes without any route id assigned).
+| anonymousRoutes | false | **Deprecated** Whether to allow anonymous routes (routes without any route id assigned).
  By using route id's then it is safer to match the route cover data with the route source code.
  Anonymous routes are less safe to use for route coverage as its harder to know exactly which route
  that was tested corresponds to which of the routes from the source code.

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -264,7 +264,7 @@
         <jboss-el-api_3.0_spec-version>2.0.0.Final</jboss-el-api_3.0_spec-version>
         <jboss-logging-version>3.6.1.Final</jboss-logging-version>
         <jboss-marshalling-version>1.4.10.Final</jboss-marshalling-version>
-        <jboss-transaction-spi.version>7.6.1.Final</jboss-transaction-spi.version>
+        <jboss-transaction-spi-version>7.6.1.Final</jboss-transaction-spi-version>
         <jboss-xnio-version>3.3.8.Final</jboss-xnio-version>
         <jcache-version>1.1.1</jcache-version>
         <jcr-version>2.0</jcr-version>
@@ -501,7 +501,7 @@
         <xpp3-version>1.1.4c</xpp3-version>
         <yasson-version>3.0.4</yasson-version>
         <yetus-audience-annotations-version>0.15.0</yetus-audience-annotations-version>
-        <zeebe.version>8.5.7</zeebe.version>
+        <zeebe-version>8.5.7</zeebe-version>
         <zendesk-client-version>1.0.0</zendesk-client-version>
         <zookeeper-version>3.9.2</zookeeper-version>
         <zxing-version>3.5.3</zxing-version>

--- a/tests/camel-itest/pom.xml
+++ b/tests/camel-itest/pom.xml
@@ -356,7 +356,7 @@
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-transaction-spi-jakarta</artifactId>
-            <version>${jboss-transaction-spi.version}</version>
+            <version>${jboss-transaction-spi-version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
# Description

Noticed today that sync-properties-maven-plugin will not sync a property where the format is `<project>.<version>`, but only syncs `<project>-<version>`.      Added a check to sync-properties-maven-plugin that errors if a property is added to camel-parent of the "project.version" format with an explanation so we can catch these, and changed the two properties that are not being synced from camel-parent to camel-dependencies to match the correct version.

