### PR TITLE
CAMEL-21256: camel-github startingSha=last does not work with large history

### DIFF
--- a/components/camel-github/src/main/java/org/apache/camel/component/github/consumer/CommitConsumer.java
+++ b/components/camel-github/src/main/java/org/apache/camel/component/github/consumer/CommitConsumer.java
@@ -46,7 +46,7 @@ public class CommitConsumer extends AbstractGitHubConsumer {
     private boolean started = false;
 
     public CommitConsumer(GitHubEndpoint endpoint, Processor processor, String branchName,
-        String startingSha) throws Exception {
+                          String startingSha) throws Exception {
         super(endpoint, processor);
         this.branchName = branchName;
         this.startingSha = startingSha;

--- a/components/camel-github/src/main/java/org/apache/camel/component/github/consumer/CommitConsumer.java
+++ b/components/camel-github/src/main/java/org/apache/camel/component/github/consumer/CommitConsumer.java
@@ -43,9 +43,10 @@ public class CommitConsumer extends AbstractGitHubConsumer {
     // keep a chunk of the last 100 hashes, so we can filter out duplicates
     private final Queue<String> commitHashes = new LinkedBlockingQueue<>(CAPACITY);
     private volatile String lastSha;
+    private boolean started = false;
 
     public CommitConsumer(GitHubEndpoint endpoint, Processor processor, String branchName,
-                          String startingSha) throws Exception {
+        String startingSha) throws Exception {
         super(endpoint, processor);
         this.branchName = branchName;
         this.startingSha = startingSha;
@@ -74,19 +75,73 @@ public class CommitConsumer extends AbstractGitHubConsumer {
 
     @Override
     protected void doStart() throws Exception {
-        super.doStart();
+        synchronized (this) {
+            super.doStart();
 
-        // ensure we start from clean
-        commitHashes.clear();
-        lastSha = null;
+            // ensure we start from clean
+            commitHashes.clear();
+            lastSha = null;
 
-        if (startingSha.equals("last")) {
-            LOG.info("Indexing current commits on: {}/{}@{}", getEndpoint().getRepoOwner(), getEndpoint().getRepoName(),
+            if (startingSha.equals("last")) {
+                LOG.info("Indexing current commits on: {}/{}@{}", getEndpoint().getRepoOwner(), getEndpoint().getRepoName(),
                     branchName);
+                List<RepositoryCommit> commits = commitService.getCommits(getRepository(), branchName, null);
+                if (!commits.isEmpty()) {
+                    lastSha = commits.get(0).getSha();
+                }
+                LOG.info("Starting from last sha: {}", lastSha);
+            } else if (!startingSha.equals("beginning")) {
+                lastSha = startingSha;
+                LOG.info("Starting from sha: {}", lastSha);
+            } else {
+                LOG.info("Starting from beginning");
+            }
+            started = true;
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        synchronized (this) {
+            super.doStop();
+
+            commitHashes.clear();
+            lastSha = null;
+            started = false;
+        }
+    }
+
+    @Override
+    protected int poll() throws Exception {
+        synchronized (this) {
+
+            if (!started) {
+                return 0;
+            }
+
             List<RepositoryCommit> commits = commitService.getCommits(getRepository(), branchName, null);
+
+            // clip the list after the last sha
+            if (lastSha != null) {
+                int pos = -1;
+                for (int i = 0; i < commits.size(); i++) {
+                    RepositoryCommit commit = commits.get(i);
+                    if (lastSha.equals(commit.getSha())) {
+                        pos = i;
+                        break;
+                    }
+                }
+                if (pos != -1) {
+                    commits = commits.subList(0, pos);
+                }
+            }
+
+            // In the end, we want tags oldest to newest.
+            ArrayDeque<RepositoryCommit> newCommits = new ArrayDeque<>();
             for (RepositoryCommit commit : commits) {
                 String sha = commit.getSha();
                 if (!commitHashes.contains(sha)) {
+                    newCommits.push(commit);
                     // make room when adding new elements
                     while (commitHashes.size() > CAPACITY - 1) {
                         commitHashes.remove();
@@ -94,78 +149,27 @@ public class CommitConsumer extends AbstractGitHubConsumer {
                     commitHashes.add(sha);
                 }
             }
-            if (!commitHashes.isEmpty()) {
-                lastSha = commitHashes.peek();
-            }
-            LOG.info("Starting from last sha: {}", lastSha);
-        } else if (!startingSha.equals("beginning")) {
-            lastSha = startingSha;
-            LOG.info("Starting from sha: {}", lastSha);
-        } else {
-            LOG.info("Starting from beginning");
-        }
-    }
 
-    @Override
-    protected void doStop() throws Exception {
-        super.doStop();
-
-        commitHashes.clear();
-        lastSha = null;
-    }
-
-    @Override
-    protected int poll() throws Exception {
-        List<RepositoryCommit> commits = commitService.getCommits(getRepository(), branchName, null);
-
-        // clip the list after the last sha
-        if (lastSha != null) {
-            int pos = -1;
-            for (int i = 0; i < commits.size(); i++) {
-                RepositoryCommit commit = commits.get(i);
-                if (lastSha.equals(commit.getSha())) {
-                    pos = i;
-                    break;
+            int counter = 0;
+            while (!newCommits.isEmpty()) {
+                RepositoryCommit newCommit = newCommits.pop();
+                lastSha = newCommit.getSha();
+                Exchange e = createExchange(true);
+                if (newCommit.getAuthor() != null) {
+                    e.getMessage().setHeader(GitHubConstants.GITHUB_COMMIT_AUTHOR, newCommit.getAuthor().getName());
                 }
-            }
-            if (pos != -1) {
-                commits = commits.subList(0, pos);
-            }
-        }
-
-        // In the end, we want tags oldest to newest.
-        ArrayDeque<RepositoryCommit> newCommits = new ArrayDeque<>();
-        for (RepositoryCommit commit : commits) {
-            String sha = commit.getSha();
-            if (!commitHashes.contains(sha)) {
-                newCommits.push(commit);
-                // make room when adding new elements
-                while (commitHashes.size() > CAPACITY - 1) {
-                    commitHashes.remove();
+                if (newCommit.getCommitter() != null) {
+                    e.getMessage().setHeader(GitHubConstants.GITHUB_COMMIT_COMMITTER, newCommit.getCommitter().getName());
                 }
-                commitHashes.add(sha);
+                e.getMessage().setHeader(GitHubConstants.GITHUB_COMMIT_SHA, newCommit.getSha());
+                e.getMessage().setHeader(GitHubConstants.GITHUB_COMMIT_URL, newCommit.getUrl());
+                e.getMessage().setBody(newCommit.getCommit().getMessage());
+                getProcessor().process(e);
+                counter++;
             }
+            LOG.debug("Last sha: {}", lastSha);
+            return counter;
         }
-
-        int counter = 0;
-        while (!newCommits.isEmpty()) {
-            RepositoryCommit newCommit = newCommits.pop();
-            lastSha = newCommit.getSha();
-            Exchange e = createExchange(true);
-            if (newCommit.getAuthor() != null) {
-                e.getMessage().setHeader(GitHubConstants.GITHUB_COMMIT_AUTHOR, newCommit.getAuthor().getName());
-            }
-            if (newCommit.getCommitter() != null) {
-                e.getMessage().setHeader(GitHubConstants.GITHUB_COMMIT_COMMITTER, newCommit.getCommitter().getName());
-            }
-            e.getMessage().setHeader(GitHubConstants.GITHUB_COMMIT_SHA, newCommit.getSha());
-            e.getMessage().setHeader(GitHubConstants.GITHUB_COMMIT_URL, newCommit.getUrl());
-            e.getMessage().setBody(newCommit.getCommit().getMessage());
-            getProcessor().process(e);
-            counter++;
-        }
-        LOG.debug("Last sha: {}", lastSha);
-        return counter;
     }
 
 }

--- a/components/camel-github/src/main/java/org/apache/camel/component/github/consumer/CommitConsumer.java
+++ b/components/camel-github/src/main/java/org/apache/camel/component/github/consumer/CommitConsumer.java
@@ -84,7 +84,7 @@ public class CommitConsumer extends AbstractGitHubConsumer {
 
             if (startingSha.equals("last")) {
                 LOG.info("Indexing current commits on: {}/{}@{}", getEndpoint().getRepoOwner(), getEndpoint().getRepoName(),
-                    branchName);
+                        branchName);
                 List<RepositoryCommit> commits = commitService.getCommits(getRepository(), branchName, null);
                 if (!commits.isEmpty()) {
                     lastSha = commits.get(0).getSha();

--- a/components/camel-github/src/test/java/org/apache/camel/component/github/consumer/CommitConsumerLastTest.java
+++ b/components/camel-github/src/test/java/org/apache/camel/component/github/consumer/CommitConsumerLastTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.github.consumer;
 
-
 import org.apache.camel.BindToRegistry;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;

--- a/components/camel-github/src/test/java/org/apache/camel/component/github/consumer/CommitConsumerLastTest.java
+++ b/components/camel-github/src/test/java/org/apache/camel/component/github/consumer/CommitConsumerLastTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.github.consumer;
+
+
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.github.GitHubComponentTestBase;
+import org.apache.camel.component.github.GitHubConstants;
+import org.apache.camel.support.DefaultScheduledPollConsumerScheduler;
+import org.junit.jupiter.api.Test;
+
+public class CommitConsumerLastTest extends GitHubComponentTestBase {
+
+    @BindToRegistry("myScheduler")
+    private final MyScheduler scheduler = createScheduler();
+
+    private MyScheduler createScheduler() {
+        MyScheduler scheduler = new MyScheduler();
+        scheduler.setDelay(100);
+        scheduler.setInitialDelay(0);
+        return scheduler;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+
+            @Override
+            public void configure() {
+                from("github://commit/master?startingSha=last&repoOwner=anotherguy&repoName=somerepo&scheduler=#myScheduler")
+                        .routeId("foo").noAutoStartup()
+                        .process(new GitHubCommitProcessor())
+                        .to(mockResultEndpoint);
+            }
+        };
+    }
+
+    @Test
+    public void commitConsumerLongHistoryLastShaTest() throws Exception {
+        for (int i = 0; i < 2000; i++) {
+            commitService.addRepositoryCommit("existing commit " + i);
+        }
+
+        mockResultEndpoint.setAssertPeriod(500);
+        mockResultEndpoint.expectedBodiesReceived("new commit 1", "new commit 2");
+
+        context.getRouteController().startAllRoutes();
+
+        commitService.addRepositoryCommit("new commit 1");
+        commitService.addRepositoryCommit("new commit 2");
+
+        mockResultEndpoint.assertIsSatisfied();
+    }
+
+    public class GitHubCommitProcessor implements Processor {
+        @Override
+        public void process(Exchange exchange) {
+            String author = exchange.getMessage().getHeader(GitHubConstants.GITHUB_COMMIT_AUTHOR, String.class);
+            String sha = exchange.getMessage().getHeader(GitHubConstants.GITHUB_COMMIT_SHA, String.class);
+            if (log.isDebugEnabled()) {
+                System.out.println(sha);
+                log.debug("Got commit with author: {}: SHA {}", author, sha);
+            }
+        }
+    }
+
+    private static final class MyScheduler extends DefaultScheduledPollConsumerScheduler {
+
+        @Override
+        public void startScheduler() {
+            super.startScheduler();
+            try {
+                /*
+                    adding a delay to the CommitConsumer.doStart() method to force the CommitConsumer.poll()
+                    method to be called before the CommitConsumer.doStart() finishes which could leave the
+                    lastSha variable null
+                 */
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION

# Description

I encountered an issue using startingSha=last with a repository with a large history.  The last sha is not correctly resolved.   [CAMEL-17473](https://issues.apache.org/jira/browse/CAMEL-17473) did not resolve this issue.  

The following issues were discovered from real-world testing and a unit test:

1. it appears that the first commit returned from the GitHub API is the most recent and the sha from that should be used as the lastSha variable.
2. There is a threading issue where CommitConsumer.poll() can be called concurrently with CommitConsumer.doStart().  In some situations lastSha can be null in the poll() method, producing the same behavior as startingSha=beginning, which is undesired.

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

