### PR TITLE
Update commands in camel-jbang.adoc

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
@@ -3346,7 +3346,7 @@ The dependency output by default is _vanilla_ Apache Camel with the camel-main a
 
 [source,bash]
 ----
-camel dependency
+camel dependency list
 org.apache.camel:camel-dsl-modeline:3.20.0
 org.apache.camel:camel-health:3.20.0
 org.apache.camel:camel-kamelet:3.20.0
@@ -3365,7 +3365,7 @@ You can also specify the output should be in _Maven format_ as shown:
 
 [source,bash]
 ----
-camel dependency --output=maven
+camel dependency list --output=maven
 <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-main</artifactId>


### PR DESCRIPTION
`camel dependency` works, however `camel dependency --output=maven` (or when passing any options) does not and requires the `list` command. I included it in the command without options as well for the sake of consistency.
