### PR TITLE
CAMEL-21283 - Switch back to repos parameter in Camel JBang run and export commands

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_8.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_8.adoc
@@ -32,7 +32,7 @@ if the parameter `includeProperties` is set to true.
 
 The `camel trace` command has changed to show tracing status (by default). To dump traced messages use `camel trace --action=dump`.
 
-*Breaking changes* The parameter `--repos` has been renamed `--repository` for `run` and `export` commands. It requires to be updated when using from command-line and in `application.properties`.
+*Breaking changes only in 4.8.0* The parameter `--repos` has been renamed `--repository` for `run` and `export` commands. It requires to be updated when using from command-line and in `application.properties`. In 4.8.1, the `--repos` has been set back and  `--repository` removed.
 
 === Deprecated Components
 

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
@@ -654,11 +654,11 @@ camel run foo.java --repos=https://packages.atlassian.com/maven-external
 TIP: Multiple repositories can be separated by comma
 
 The configuration for the 3rd-party Maven repositories can also be configured in `application.properties`
-with the key `camel.jbang.repositories` as shown:
+with the key `camel.jbang.repos` as shown:
 
 [source,properties]
 ----
-camel.jbang.repositories=https://packages.atlassian.com/maven-external
+camel.jbang.repos=https://packages.atlassian.com/maven-external
 ----
 
 And when running Camel then `application.properties` is automatically loaded:
@@ -3735,7 +3735,7 @@ The follow options related to _exporting_, can be configured in `application.pro
 |`camel.jbang.buildTool`
 |Build tool to use (Maven or Gradle)
 
-|`camel.jbang.repositories`
+|`camel.jbang.repos`
 |Additional maven repositories for download on-demand (Use commas to separate multiple repositories)
 
 |`camel.jbang.mavenSettings`

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
@@ -105,8 +105,7 @@ public class Export extends ExportBaseCommand {
             this.exportDir = props.getProperty("camel.jbang.exportDir", this.exportDir);
             this.buildTool = props.getProperty("camel.jbang.buildTool", this.buildTool);
             this.openapi = props.getProperty("camel.jbang.openApi", this.openapi);
-            this.repositories
-                    = RuntimeUtil.getCommaSeparatedPropertyAsList(props, "camel.jbang.repositories", this.repositories);
+            this.repositories = props.getProperty("camel.jbang.repos", this.repositories);
             this.mavenSettings = props.getProperty("camel.jbang.maven-settings", this.mavenSettings);
             this.mavenSettingsSecurity = props.getProperty("camel.jbang.maven-settings-security", this.mavenSettingsSecurity);
             this.mavenCentralEnabled = "true"

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -27,6 +27,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -88,8 +89,9 @@ public abstract class ExportBaseCommand extends CamelCommand {
 
     protected List<String> files = new ArrayList<>();
 
-    @CommandLine.Option(names = { "--repository" }, description = "Additional maven repositories")
-    protected List<String> repositories = new ArrayList<>();
+    @CommandLine.Option(names = { "--repos" },
+                        description = "Additional maven repositories (Use commas to separate multiple repositories)")
+    protected String repositories;
 
     @CommandLine.Option(names = { "--dep", "--dependency" }, description = "Add additional dependencies",
                         split = ",")
@@ -749,8 +751,8 @@ public abstract class ExportBaseCommand extends CamelCommand {
             }
         }
 
-        if (!repositories.isEmpty()) {
-            answer.addAll(repositories);
+        if (repositories != null) {
+            Collections.addAll(answer, this.repositories.split(","));
         }
 
         return answer.stream()

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -153,8 +153,9 @@ public class Run extends CamelCommand {
             split = ",")
     List<String> dependencies = new ArrayList<>();
 
-    @CommandLine.Option(names = { "--repository" }, description = "Additional maven repositories")
-    List<String> repositories = new ArrayList<>();
+    @CommandLine.Option(names = { "--repos" },
+                        description = "Additional maven repositories (Use commas to separate multiple repositories)")
+    String repositories;
 
     @Option(names = { "--gav" }, description = "The Maven group:artifact:version (used during exporting)")
     String gav;
@@ -1106,7 +1107,7 @@ public class Run extends CamelCommand {
                     = "true".equals(answer.getProperty("loggingColor", loggingColor ? "true" : "false"));
             loggingJson
                     = "true".equals(answer.getProperty("loggingJson", loggingJson ? "true" : "false"));
-            repositories = RuntimeUtil.getCommaSeparatedPropertyAsList(answer, "camel.jbang.repositories", repositories);
+            repositories = answer.getProperty("camel.jbang.repos", repositories);
             mavenSettings = answer.getProperty("camel.jbang.maven-settings", mavenSettings);
             mavenSettingsSecurity = answer.getProperty("camel.jbang.maven-settings-security", mavenSettingsSecurity);
             mavenCentralEnabled = "true"

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
@@ -529,7 +529,7 @@ public class KubernetesExport extends Export {
             String quarkusVersion,
             List<String> files,
             String gav,
-            List<String> repositories,
+            String repositories,
             List<String> dependencies,
             List<String> excludes,
             String mavenSettings,

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
@@ -154,8 +154,9 @@ public class KubernetesRun extends KubernetesBaseCommand {
 
     // Export base options
 
-    @CommandLine.Option(names = { "--repository" }, description = "Additional maven repositories")
-    List<String> repositories = new ArrayList<>();
+    @CommandLine.Option(names = { "--repos" },
+                        description = "Additional maven repositories (Use commas to separate multiple repositories)")
+    String repositories;
 
     @CommandLine.Option(names = { "--dep", "--dependency" }, description = "Add additional dependencies",
                         split = ",")


### PR DESCRIPTION
To stay coherent with other commands and keep working when using --camel-version using a previous version.

Removed the --repository option which would require a bunch of other changes to support it correctly

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

