### PR TITLE
Revert "chore(deps): Bump swagger-openapi3-version from 2.2.23 to 2.2.24"

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -462,7 +462,7 @@
         <sshd-version>2.13.2</sshd-version>
         <stompjms-version>1.19</stompjms-version>
         <swagger-java-version>1.6.10</swagger-java-version>
-        <swagger-openapi3-version>2.2.24</swagger-openapi3-version>
+        <swagger-openapi3-version>2.2.23</swagger-openapi3-version>
         <swagger-java-parser-version>1.0.65</swagger-java-parser-version>
         <swagger-openapi3-java-parser-version>2.1.22</swagger-openapi3-java-parser-version>
         <swagger-request-validator-version>2.42.0</swagger-request-validator-version>


### PR DESCRIPTION
This reverts commit 8e3e4847eb101c9234625bc232037e796f78eb46.