### PR TITLE
Tar aggregation strategy null bodies

### DIFF
--- a/components/camel-tarfile/src/main/java/org/apache/camel/processor/aggregate/tarfile/TarAggregationStrategy.java
+++ b/components/camel-tarfile/src/main/java/org/apache/camel/processor/aggregate/tarfile/TarAggregationStrategy.java
@@ -176,38 +176,45 @@ public class TarAggregationStrategy implements AggregationStrategy {
         }
 
         if (body instanceof File appendFile) {
-            try {
-                // do not try to append empty files
-                if (appendFile.length() > 0) {
-                    String entryName = preserveFolderStructure
-                            ? newExchange.getIn().getHeader(Exchange.FILE_NAME, String.class)
-                            : newExchange.getIn().getMessageId();
-                    addFileToTar(tarFile, appendFile, this.preserveFolderStructure ? entryName : null);
-                }
-            } catch (Exception e) {
-                throw new GenericFileOperationFailedException(e.getMessage(), e);
-            }
+            addFileToTar(newExchange, appendFile, tarFile);
         } else {
-            // Handle all other messages
-            if (newExchange.getIn().getBody() != null) {
-                try {
-                    byte[] buffer = newExchange.getIn().getMandatoryBody(byte[].class);
-                    // do not try to append empty data
-                    if (buffer.length > 0) {
-                        String entryName = useFilenameHeader
-                            ? newExchange.getIn().getHeader(Exchange.FILE_NAME, String.class)
-                            : newExchange.getIn().getMessageId();
-                        addEntryToTar(tarFile, entryName, buffer, buffer.length);
-                    }
-                } catch (Exception e) {
-                    throw new GenericFileOperationFailedException(e.getMessage(), e);
-                }
-            }
+            appendIncomingBodyAsBytesToTar(newExchange, tarFile);
         }
         GenericFile<File> genericFile = FileConsumer.asGenericFile(
                 tarFile.getParent(), tarFile, Charset.defaultCharset().toString(), false);
         genericFile.bindToExchange(answer);
         return answer;
+    }
+
+    private void appendIncomingBodyAsBytesToTar(Exchange newExchange, File tarFile) {
+        if (newExchange.getIn().getBody() != null) {
+            try {
+                byte[] buffer = newExchange.getIn().getMandatoryBody(byte[].class);
+                // do not try to append empty data
+                if (buffer.length > 0) {
+                    String entryName = useFilenameHeader
+                            ? newExchange.getIn().getHeader(Exchange.FILE_NAME, String.class)
+                            : newExchange.getIn().getMessageId();
+                    addEntryToTar(tarFile, entryName, buffer, buffer.length);
+                }
+            } catch (Exception e) {
+                throw new GenericFileOperationFailedException(e.getMessage(), e);
+            }
+        }
+    }
+
+    private void addFileToTar(Exchange newExchange, File appendFile, File tarFile) {
+        try {
+            // do not try to append empty files
+            if (appendFile.length() > 0) {
+                String entryName = preserveFolderStructure
+                        ? newExchange.getIn().getHeader(Exchange.FILE_NAME, String.class)
+                        : newExchange.getIn().getMessageId();
+                addFileToTar(tarFile, appendFile, this.preserveFolderStructure ? entryName : null);
+            }
+        } catch (Exception e) {
+            throw new GenericFileOperationFailedException(e.getMessage(), e);
+        }
     }
 
     @Override
@@ -220,13 +227,13 @@ public class TarAggregationStrategy implements AggregationStrategy {
 
     private void addFileToTar(File source, File file, String fileName) throws IOException, ArchiveException {
         File tmpTar = Files.createTempFile(parentDir.toPath(), source.getName(), null).toFile();
-        tmpTar.delete();
+        Files.delete(tmpTar.toPath());
         if (!source.renameTo(tmpTar)) {
             throw new IOException("Could not make temp file (" + source.getName() + ")");
         }
 
         try (FileInputStream fis = new FileInputStream(tmpTar)) {
-            try (TarArchiveInputStream tin = (TarArchiveInputStream) new ArchiveStreamFactory()
+            try (TarArchiveInputStream tin = new ArchiveStreamFactory()
                     .createArchiveInputStream(ArchiveStreamFactory.TAR, fis)) {
                 try (TarArchiveOutputStream tos = new TarArchiveOutputStream(new FileOutputStream(source))) {
                     tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
@@ -265,13 +272,13 @@ public class TarAggregationStrategy implements AggregationStrategy {
 
     private void addEntryToTar(File source, String entryName, byte[] buffer, int length) throws IOException, ArchiveException {
         File tmpTar = Files.createTempFile(parentDir.toPath(), source.getName(), null).toFile();
-        tmpTar.delete();
+        Files.delete(tmpTar.toPath());
         if (!source.renameTo(tmpTar)) {
             throw new IOException("Cannot create temp file: " + source.getName());
         }
 
         try (FileInputStream fis = new FileInputStream(tmpTar)) {
-            try (TarArchiveInputStream tin = (TarArchiveInputStream) new ArchiveStreamFactory()
+            try (TarArchiveInputStream tin = new ArchiveStreamFactory()
                     .createArchiveInputStream(ArchiveStreamFactory.TAR, fis)) {
                 try (TarArchiveOutputStream tos = new TarArchiveOutputStream(new FileOutputStream(source))) {
                     tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);

--- a/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/SpringTarFileDataFormatTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/SpringTarFileDataFormatTest.java
@@ -25,6 +25,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
@@ -40,11 +41,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SpringTarFileDataFormatTest extends CamelSpringTestSupport {
+class SpringTarFileDataFormatTest extends CamelSpringTestSupport {
     private static final File TEST_DIR = new File("target/springtar");
 
     @Test
-    public void testTarWithoutFileName() throws Exception {
+    void testTarWithoutFileName() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:tar");
         mock.expectedMessageCount(1);
 
@@ -65,7 +66,7 @@ public class SpringTarFileDataFormatTest extends CamelSpringTestSupport {
     }
 
     @Test
-    public void testTarWithFileName() throws Exception {
+    void testTarWithFileName() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:tar");
         mock.expectedMessageCount(1);
         mock.expectedHeaderReceived(FILE_NAME, "poem.txt.tar");
@@ -87,7 +88,7 @@ public class SpringTarFileDataFormatTest extends CamelSpringTestSupport {
     }
 
     @Test
-    public void testUntar() throws Exception {
+    void testUntar() throws Exception {
         getMockEndpoint("mock:untar").expectedBodiesReceived(TEXT);
         getMockEndpoint("mock:untar").expectedHeaderReceived(FILE_NAME, "file");
 
@@ -97,7 +98,7 @@ public class SpringTarFileDataFormatTest extends CamelSpringTestSupport {
     }
 
     @Test
-    public void testTarAndUntar() throws Exception {
+    void testTarAndUntar() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:tarAndUntar");
         mock.expectedMessageCount(1);
 
@@ -111,7 +112,7 @@ public class SpringTarFileDataFormatTest extends CamelSpringTestSupport {
     }
 
     @Test
-    public void testTarToFileWithoutFileName() throws Exception {
+    void testTarToFileWithoutFileName() throws Exception {
         NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
 
         String[] files = TEST_DIR.list();
@@ -142,7 +143,7 @@ public class SpringTarFileDataFormatTest extends CamelSpringTestSupport {
     }
 
     @Test
-    public void testTarToFileWithFileName() throws Exception {
+    void testTarToFileWithFileName() throws Exception {
         NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
 
         MockEndpoint mock = getMockEndpoint("mock:tarToFile");
@@ -172,7 +173,7 @@ public class SpringTarFileDataFormatTest extends CamelSpringTestSupport {
     }
 
     @Test
-    public void testDslTar() throws Exception {
+    void testDslTar() throws Exception {
         getMockEndpoint("mock:dslTar").expectedHeaderReceived(FILE_NAME, "poem.txt.tar");
 
         template.sendBodyAndHeader("direct:dslTar", TEXT, FILE_NAME, "poem.txt");
@@ -181,7 +182,7 @@ public class SpringTarFileDataFormatTest extends CamelSpringTestSupport {
     }
 
     @Test
-    public void testDslUntar() throws Exception {
+    void testDslUntar() throws Exception {
         getMockEndpoint("mock:dslUntar").expectedBodiesReceived(TEXT);
         getMockEndpoint("mock:dslUntar").expectedHeaderReceived(FILE_NAME, "test.txt");
 
@@ -190,8 +191,8 @@ public class SpringTarFileDataFormatTest extends CamelSpringTestSupport {
         MockEndpoint.assertIsSatisfied(context);
     }
 
-    @Override
-    public void doPostSetup() {
+    @AfterEach
+    public void cleanOutputDirectory() {
         deleteDirectory(TEST_DIR);
     }
 

--- a/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/SpringTarSplitterRouteTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/SpringTarSplitterRouteTest.java
@@ -21,10 +21,10 @@ import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-public class SpringTarSplitterRouteTest extends CamelSpringTestSupport {
+class SpringTarSplitterRouteTest extends CamelSpringTestSupport {
 
     @Test
-    public void testSplitter() throws InterruptedException {
+    void testSplitter() throws InterruptedException {
         MockEndpoint processTarEntry = getMockEndpoint("mock:processTarEntry");
 
         processTarEntry.expectedBodiesReceivedInAnyOrder("chau", "hi", "hola", "hello", "greetings");

--- a/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileDataFormatTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileDataFormatTest.java
@@ -40,6 +40,7 @@ import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.Exchange.FILE_NAME;
@@ -56,13 +57,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Unit tests for {@link TarFileDataFormat}.
  */
-public class TarFileDataFormatTest extends CamelTestSupport {
+class TarFileDataFormatTest extends CamelTestSupport {
 
     private static final File TEST_DIR = new File("target/tar");
     private TarFileDataFormat tar;
 
     @Test
-    public void testTarWithoutFileName() throws Exception {
+    void testTarWithoutFileName() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:tar");
         mock.expectedMessageCount(1);
 
@@ -84,7 +85,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testTarWithFileName() throws Exception {
+    void testTarWithFileName() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:tar");
         mock.expectedMessageCount(1);
         mock.expectedHeaderReceived(FILE_NAME, "poem.txt.tar");
@@ -106,7 +107,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testTarWithPathElements() throws Exception {
+    void testTarWithPathElements() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:tar");
         mock.expectedMessageCount(1);
         mock.expectedHeaderReceived(FILE_NAME, "poem.txt.tar");
@@ -127,7 +128,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testTarWithPreservedPathElements() throws Exception {
+    void testTarWithPreservedPathElements() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:tar");
         mock.expectedMessageCount(1);
         mock.expectedHeaderReceived(FILE_NAME, "poem.txt.tar");
@@ -155,7 +156,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testUntar() throws Exception {
+    void testUntar() throws Exception {
         getMockEndpoint("mock:untar").expectedBodiesReceived(TEXT);
         getMockEndpoint("mock:untar").expectedHeaderReceived(FILE_NAME, "file");
 
@@ -165,7 +166,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testUntarWithCorruptedTarFile() {
+    void testUntarWithCorruptedTarFile() {
         final File body = new File("src/test/resources/data/corrupt.tar");
 
         assertThrows(CamelExecutionException.class,
@@ -173,7 +174,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testTarAndUntar() throws Exception {
+    void testTarAndUntar() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:tarAndUntar");
         mock.expectedMessageCount(1);
 
@@ -187,7 +188,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testTarToFileWithoutFileName() throws Exception {
+    void testTarToFileWithoutFileName() throws Exception {
         NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
 
         String[] files = TEST_DIR.list();
@@ -218,7 +219,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testTarToFileWithFileName() throws Exception {
+    void testTarToFileWithFileName() throws Exception {
         NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
 
         MockEndpoint mock = getMockEndpoint("mock:tarToFile");
@@ -249,7 +250,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testDslTar() throws Exception {
+    void testDslTar() throws Exception {
         getMockEndpoint("mock:dslTar").expectedHeaderReceived(FILE_NAME, "poem.txt.tar");
 
         template.sendBodyAndHeader("direct:dslTar", TEXT, FILE_NAME, "poem.txt");
@@ -258,7 +259,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testDslUntar() throws Exception {
+    void testDslUntar() throws Exception {
         getMockEndpoint("mock:dslUntar").expectedBodiesReceived(TEXT);
         getMockEndpoint("mock:dslUntar").expectedHeaderReceived(FILE_NAME, "test.txt");
 
@@ -268,7 +269,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testUntarWithEmptyDirectorySupported() {
+    void testUntarWithEmptyDirectorySupported() {
         deleteDirectory(new File("hello_out"));
         tar.setUsingIterator(true);
         tar.setAllowEmptyDirectory(true);
@@ -278,7 +279,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testUntarWithEmptyDirectoryUnsupported() {
+    void testUntarWithEmptyDirectoryUnsupported() {
         deleteDirectory(new File("hello_out"));
         tar.setUsingIterator(true);
         tar.setAllowEmptyDirectory(false);
@@ -288,7 +289,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
     }
 
     @Test
-    public void testUnzipMaxDecompressedSize() throws Exception {
+    void testUnzipMaxDecompressedSize() throws Exception {
         final byte[] files = getTaredText("file");
 
         // We are only allowing 10 bytes to be decompressed, so we expect an error
@@ -296,8 +297,8 @@ public class TarFileDataFormatTest extends CamelTestSupport {
                 () -> template.sendBody("direct:untarMaxDecompressedSize", files));
     }
 
-    @Override
-    public void doPostSetup() {
+    @AfterEach
+    public void cleanOutputDirectory() {
         deleteDirectory(TEST_DIR);
     }
 
@@ -352,7 +353,7 @@ public class TarFileDataFormatTest extends CamelTestSupport {
                                 } else {
                                     outputFile.getParentFile().mkdirs();
                                     try (TarArchiveInputStream debInputStream
-                                            = (TarArchiveInputStream) new ArchiveStreamFactory().createArchiveInputStream("tar",
+                                            = new ArchiveStreamFactory().createArchiveInputStream("tar",
                                                     is)) {
                                         copy(debInputStream, outputFile);
                                     }

--- a/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileSplitAndDeleteTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileSplitAndDeleteTest.java
@@ -29,21 +29,22 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class TarFileSplitAndDeleteTest extends CamelTestSupport {
+class TarFileSplitAndDeleteTest extends CamelTestSupport {
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void cleanOutputDirectories() {
         deleteDirectory("target/testDeleteTarFileWhenUnmarshalWithDataFormat");
         deleteDirectory("target/testDeleteTarFileWhenUnmarshalWithSplitter");
     }
 
     @Test
-    public void testDeleteTarFileWhenUnmarshalWithDataFormat() throws Exception {
+    void testDeleteTarFileWhenUnmarshalWithDataFormat() throws Exception {
         NotifyBuilder notify = new NotifyBuilder(context)
                 .from("file://target/" + "testDeleteTarFileWhenUnmarshalWithDataFormat").whenDone(1).create();
         getMockEndpoint("mock:end").expectedMessageCount(3);
@@ -58,7 +59,7 @@ public class TarFileSplitAndDeleteTest extends CamelTestSupport {
     }
 
     @Test
-    public void testDeleteTarFileWhenUnmarshalWithSplitter() throws Exception {
+    void testDeleteTarFileWhenUnmarshalWithSplitter() throws Exception {
         NotifyBuilder notify = new NotifyBuilder(context).from("file://target/" + "testDeleteTarFileWhenUnmarshalWithSplitter")
                 .whenDone(1).create();
         getMockEndpoint("mock:end").expectedMessageCount(3);

--- a/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileSplitIteratorCorruptTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileSplitIteratorCorruptTest.java
@@ -25,10 +25,10 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
-public class TarFileSplitIteratorCorruptTest extends CamelTestSupport {
+class TarFileSplitIteratorCorruptTest extends CamelTestSupport {
 
     @Test
-    public void testTarFileUnmarshal() throws Exception {
+    void testTarFileUnmarshal() throws Exception {
         getMockEndpoint("mock:dead").expectedMessageCount(1);
         getMockEndpoint("mock:dead").message(0).exchangeProperty(Exchange.EXCEPTION_CAUGHT)
                 .isInstanceOf(IllegalStateException.class);

--- a/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarSplitterRouteIssueTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarSplitterRouteIssueTest.java
@@ -21,19 +21,20 @@ import java.io.File;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
 
-public class TarSplitterRouteIssueTest extends CamelTestSupport {
+class TarSplitterRouteIssueTest extends CamelTestSupport {
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void cleanOutputDirectory() {
         deleteDirectory("target/tar");
     }
 
     @Test
-    public void testSplitter() throws Exception {
+    void testSplitter() throws Exception {
         getMockEndpoint("mock:entry").expectedMessageCount(3);
 
         template.sendBody("direct:decompressFiles", new File("src/test/resources/data/tarfile3.tar"));
@@ -42,7 +43,7 @@ public class TarSplitterRouteIssueTest extends CamelTestSupport {
     }
 
     @Test
-    public void testSplitterWithWrongFile() throws Exception {
+    void testSplitterWithWrongFile() throws Exception {
         getMockEndpoint("mock:entry").expectedMessageCount(0);
         getMockEndpoint("mock:errors").expectedMessageCount(1);
 

--- a/components/camel-tarfile/src/test/java/org/apache/camel/processor/aggregate/tarfile/AggregationStrategyWithFilenameHeaderTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/processor/aggregate/tarfile/AggregationStrategyWithFilenameHeaderTest.java
@@ -30,6 +30,7 @@ import org.apache.camel.util.IOHelper;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
@@ -37,21 +38,21 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AggregationStrategyWithFilenameHeaderTest extends CamelTestSupport {
+class AggregationStrategyWithFilenameHeaderTest extends CamelTestSupport {
 
     private static final List<String> FILE_NAMES = Arrays.asList("foo", "bar");
 
     private TarAggregationStrategy tar = new TarAggregationStrategy(false, true);
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void cleanOutputDirectories() {
         tar.setParentDir("target/temp");
         deleteDirectory("target/temp");
         deleteDirectory("target/out");
     }
 
     @Test
-    public void testSplitter() throws Exception {
+    void testSplitter() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:aggregateToTarEntry");
         mock.expectedMessageCount(1);
 
@@ -69,7 +70,7 @@ public class AggregationStrategyWithFilenameHeaderTest extends CamelTestSupport 
         File resultFile = files[0];
 
         final TarArchiveInputStream tis
-                = (TarArchiveInputStream) new ArchiveStreamFactory().createArchiveInputStream(ArchiveStreamFactory.TAR,
+                = new ArchiveStreamFactory().createArchiveInputStream(ArchiveStreamFactory.TAR,
                         new BufferedInputStream(new FileInputStream(resultFile)));
         try {
             int fileCount = 0;

--- a/components/camel-tarfile/src/test/java/org/apache/camel/processor/aggregate/tarfile/AggregationStrategyWithPreservationTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/processor/aggregate/tarfile/AggregationStrategyWithPreservationTest.java
@@ -28,6 +28,7 @@ import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.util.IOHelper;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
@@ -35,21 +36,21 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class AggregationStrategyWithPreservationTest extends CamelTestSupport {
+class AggregationStrategyWithPreservationTest extends CamelTestSupport {
 
     private static final int EXPECTED_NO_FILES = 5;
 
     private TarAggregationStrategy tar = new TarAggregationStrategy(true, true);
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void cleanOutputDirectories() {
         tar.setParentDir("target/temp");
         deleteDirectory("target/temp");
         deleteDirectory("target/out");
     }
 
     @Test
-    public void testSplitter() throws Exception {
+    void testSplitter() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:aggregateToTarEntry");
         mock.expectedMessageCount(1);
 

--- a/components/camel-tarfile/src/test/java/org/apache/camel/processor/aggregate/tarfile/TarAggregationStrategyEmptyFirstFileTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/processor/aggregate/tarfile/TarAggregationStrategyEmptyFirstFileTest.java
@@ -34,34 +34,35 @@ import org.apache.camel.util.IOHelper;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.logging.log4j.core.util.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TarAggregationStrategyEmptyFirstFileTest extends CamelTestSupport {
+class TarAggregationStrategyEmptyFirstFileTest extends CamelTestSupport {
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void cleanOutputDirectory() {
         TestSupport.deleteDirectory("target/out");
     }
 
     @Test
-    public void testNormal() throws Exception {
+    void testNormal() throws Exception {
         doTest("A", "B", "C");
     }
 
     @Test
-    public void testEmptyFirst() throws Exception {
+    void testEmptyFirst() throws Exception {
         doTest("", "A");
     }
 
     @Test
-    public void testEmptyOnly() throws Exception {
+    void testEmptyOnly() throws Exception {
         doTest("");
     }
 
     @Test
-    public void testEmptyMiddle() throws Exception {
+    void testEmptyMiddle() throws Exception {
         doTest("Start", "", "", "End");
     }
 
@@ -122,9 +123,9 @@ public class TarAggregationStrategyEmptyFirstFileTest extends CamelTestSupport {
         Map<String, String> content = new TreeMap<>();
         TarArchiveInputStream tin = new TarArchiveInputStream(new FileInputStream(file));
         try {
-            for (TarArchiveEntry te = (TarArchiveEntry) tin.getNextEntry();
+            for (TarArchiveEntry te = tin.getNextEntry();
                  te != null;
-                 te = (TarArchiveEntry) tin.getNextEntry()) {
+                 te = tin.getNextEntry()) {
                 String c = IOUtils.toString(new InputStreamReader(tin));
                 content.put(te.getName(), c);
             }

--- a/components/camel-tarfile/src/test/java/org/apache/camel/processor/aggregate/tarfile/TarAggregationStrategyNullBodyTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/processor/aggregate/tarfile/TarAggregationStrategyNullBodyTest.java
@@ -30,6 +30,7 @@ import org.apache.camel.util.IOHelper;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.logging.log4j.core.util.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.awaitility.Awaitility.await;
@@ -37,8 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TarAggregationStrategyNullBodyTest extends CamelTestSupport {
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void cleanOutputDir() {
         TestSupport.deleteDirectory("target/out");
     }
 
@@ -94,10 +95,10 @@ class TarAggregationStrategyNullBodyTest extends CamelTestSupport {
     }
 
     @Override
-    protected RouteBuilder createRouteBuilder() throws Exception {
+    protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             @Override
-            public void configure() throws Exception {
+            public void configure() {
                 // @formatter:off
                 from("direct:start")
                         .aggregate(new TarAggregationStrategy(false))

--- a/components/camel-tarfile/src/test/java/org/apache/camel/processor/aggregate/tarfile/TarAggregationStrategyNullBodyTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/processor/aggregate/tarfile/TarAggregationStrategyNullBodyTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.aggregate.tarfile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.test.junit5.TestSupport;
+import org.apache.camel.util.IOHelper;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.logging.log4j.core.util.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TarAggregationStrategyNullBodyTest extends CamelTestSupport {
+
+    @Override
+    public void doPreSetup() {
+        TestSupport.deleteDirectory("target/out");
+    }
+
+    @Test
+    void testNullBodyLast() throws Exception {
+        template.sendBody("direct:start", "Hello");
+        template.sendBody("direct:start", "Hello again");
+        template.sendBody("direct:start", null);
+        assertTarFileContains(2);
+    }
+
+    @Test
+    void testNullBodyFirst() throws Exception {
+        template.sendBody("direct:start", null);
+        template.sendBody("direct:start", "Hello");
+        template.sendBody("direct:start", "Hello again");
+        assertTarFileContains(2);
+    }
+
+    @Test
+    void testNullBodyMiddle() throws Exception {
+        template.sendBody("direct:start", "Hello");
+        template.sendBody("direct:start", null);
+        template.sendBody("direct:start", "Hello again");
+        assertTarFileContains(2);
+    }
+
+    @Test
+    void testNullBodiesOnly() throws Exception {
+        template.sendBody("direct:start", null);
+        template.sendBody("direct:start", null);
+        template.sendBody("direct:start", null);
+        assertTarFileContains(0);
+    }
+
+    @Test
+    void testTwoNullBodies() throws Exception {
+        template.sendBody("direct:start", null);
+        template.sendBody("direct:start", null);
+        template.sendBody("direct:start", "Hello");
+        assertTarFileContains(1);
+    }
+
+    public void assertTarFileContains(int filesInTarExpected) throws Exception {
+        await("Should be a file in target/out directory").until(() -> {
+            File[] files = new File("target/out").listFiles();
+            return files != null && files.length > 0;
+        });
+        File[] files = new File("target/out").listFiles();
+        assertEquals(1, files.length, "Should only be one file in target/out directory");
+        Map<String, String> tar = readTar(files[0]);
+        assertEquals(filesInTarExpected, tar.size());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                // @formatter:off
+                from("direct:start")
+                        .aggregate(new TarAggregationStrategy(false))
+                        .constant(true)
+                        .completionSize(3)
+                        .eagerCheckCompletion()
+                        .to("file:target/out")
+                        .to("mock:aggregateToTarEntry");
+                // @formatter:on
+            }
+        };
+    }
+
+    private static Map<String, String> readTar(File file) throws IOException {
+        Map<String, String> content = new TreeMap<>();
+        TarArchiveInputStream tin = new TarArchiveInputStream(new FileInputStream(file));
+        try {
+            for (TarArchiveEntry te = tin.getNextEntry();
+                 te != null;
+                 te = tin.getNextEntry()) {
+                String c = IOUtils.toString(new InputStreamReader(tin));
+                content.put(te.getName(), c);
+            }
+        } finally {
+            IOHelper.close(tin);
+        }
+        return content;
+    }
+}

--- a/components/camel-tarfile/src/test/java/org/apache/camel/processor/aggregate/tarfile/TarAggregationStrategyTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/processor/aggregate/tarfile/TarAggregationStrategyTest.java
@@ -25,27 +25,28 @@ import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.util.IOHelper;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TarAggregationStrategyTest extends CamelTestSupport {
+class TarAggregationStrategyTest extends CamelTestSupport {
 
     private static final int EXPECTED_NO_FILES = 3;
 
     private TarAggregationStrategy tar = new TarAggregationStrategy();
 
-    @Override
-    public void doPreSetup() {
+    @BeforeEach
+    public void cleanOutputDirectories() {
         tar.setParentDir("target/temp");
         deleteDirectory("target/temp");
         deleteDirectory("target/out");
     }
 
     @Test
-    public void testSplitter() throws Exception {
+    void testSplitter() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:aggregateToTarEntry");
         mock.expectedMessageCount(1);
         mock.expectedHeaderReceived("foo", "bar");


### PR DESCRIPTION
# Description
Same as https://github.com/apache/camel/pull/15638, just for the tar component, this time: Avoid exception in TarAggregationStrategy when one of the bodies is null.
