### PR TITLE
CAMEL-21336: Allow Kamelets configured by EnvVars only

### DIFF
--- a/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/Kamelet.java
+++ b/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/Kamelet.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.kamelet;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Predicate;
@@ -30,6 +31,7 @@ import org.apache.camel.spi.PropertiesComponent;
 import org.apache.camel.spi.UuidGenerator;
 import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.SimpleUuidGenerator;
+import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StringHelper;
 
@@ -37,6 +39,7 @@ import static org.apache.camel.model.ProcessorDefinitionHelper.filterTypeInOutpu
 
 public final class Kamelet {
     public static final String PROPERTIES_PREFIX = "camel.kamelet.";
+    public static final String ENV_VAR_PREFIX = "CAMEL_KAMELET_";
     public static final String SCHEME = "kamelet";
     public static final String SOURCE_ID = "source";
     public static final String SINK_ID = "sink";
@@ -124,6 +127,53 @@ public final class Kamelet {
             Properties prefixed = pc.loadProperties(Kamelet.startsWith(prefixBuffer.toString()));
             for (String name : prefixed.stringPropertyNames()) {
                 properties.put(name.substring(prefixBuffer.toString().length()), prefixed.getProperty(name));
+            }
+        }
+    }
+
+    /**
+     * Looking for OS environment variables that match the properties of the given Kamelet. At first lookup attempt is
+     * made without considering camelCase keys in the elements. The second lookup is converting camelCase to
+     * underscores.
+     *
+     * For example given an ENV variable in either format: - CAMEL_KAMELET_AWSS3SOURCE_BUCKETNAMEORARN=myArn -
+     * CAMEL_KAMELET_AWS_S3_SOURCE_BUCKET_NAME_OR_ARN=myArn
+     */
+    public static void extractKameletEnvironmentVariables(Map<String, Object> properties, String... elements) {
+        StringBuilder prefixBuffer = new StringBuilder(Kamelet.ENV_VAR_PREFIX);
+
+        // Map contains parameter name as key and full environment variable as value
+        Map<String, String> propertyMappings = new HashMap<>();
+        for (String element : elements) {
+            if (element == null) {
+                continue;
+            }
+            prefixBuffer.append(IOHelper.normalizeEnvironmentVariable(element)).append('_');
+
+            String prefix = prefixBuffer.toString();
+            System.getenv().keySet().stream()
+                    .filter(Kamelet.startsWith(prefix))
+                    .forEach(name -> propertyMappings.put(name.substring(prefix.length()), name));
+        }
+
+        prefixBuffer = new StringBuilder(Kamelet.ENV_VAR_PREFIX);
+
+        for (String element : elements) {
+            if (element == null) {
+                continue;
+            }
+            prefixBuffer.append(IOHelper.normalizeEnvironmentVariable(StringHelper.camelCaseToDash(element))).append('_');
+
+            String prefix = prefixBuffer.toString();
+            System.getenv().keySet().stream()
+                    .filter(Kamelet.startsWith(prefix))
+                    .forEach(name -> propertyMappings.put(name.substring(prefix.length()), name));
+        }
+
+        for (Map.Entry<String, String> mapping : propertyMappings.entrySet()) {
+            String value = System.getenv(mapping.getValue());
+            if (value != null) {
+                properties.put(mapping.getKey(), value);
             }
         }
     }

--- a/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/KameletComponent.java
+++ b/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/KameletComponent.java
@@ -219,6 +219,15 @@ public class KameletComponent extends DefaultComponent {
             }
 
             //
+            // Look for OS environment variables that match the Kamelet properties
+            // Environment variables are loaded in the following order:
+            //
+            //   CAMEL_KAMELET_" + templateId
+            //   CAMEL_KAMELET_" + templateId + "_" routeId
+            //
+            Kamelet.extractKameletEnvironmentVariables(kameletProperties, templateId, routeId);
+
+            //
             // Uri params have the highest precedence
             //
             kameletProperties.putAll(parameters);

--- a/core/camel-api/src/main/java/org/apache/camel/RouteTemplateContext.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RouteTemplateContext.java
@@ -109,6 +109,17 @@ public interface RouteTemplateContext extends HasCamelContext {
     Object getProperty(String name);
 
     /**
+     * Gets the environment variable parameter that matches the given property name. The match is performed by
+     * normalizing the given property name as an OS environment variable name. The environment variable name may use
+     * pure uppercase or camelCase converted to underscore property names. As an example bucketNameOrArn property
+     * matches BUCKETNAMEORARN and BUCKET_NAME_OR_ARN environment variables.
+     *
+     * @param  name name of property
+     * @return      the property value or <tt>null</tt> if no property exists
+     */
+    Object getEnvironmentVariable(String name);
+
+    /**
      * Gets the property with the given name
      *
      * @param  name                    name of property
@@ -138,6 +149,17 @@ public interface RouteTemplateContext extends HasCamelContext {
      * @return      true if exists
      */
     boolean hasParameter(String name);
+
+    /**
+     * Whether the route template has an environment variable parameter that matches the given parameter name. The match
+     * is performed by normalizing the given name as an OS environment variable name. The environment variable name may
+     * use pure uppercase or camelCase converted to underscore property names. As an example bucketNameOrArn property
+     * matches BUCKETNAMEORARN and BUCKET_NAME_OR_ARN environment variables.
+     *
+     * @param  name the parameter name
+     * @return      true if exists
+     */
+    boolean hasEnvironmentVariable(String name);
 
     /**
      * Gets the local bean repository for the route template when creating the new route

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/DefaultRouteTemplateContext.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/DefaultRouteTemplateContext.java
@@ -27,6 +27,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.RouteTemplateContext;
 import org.apache.camel.spi.BeanRepository;
 import org.apache.camel.support.LocalBeanRegistry;
+import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
 
 /**
@@ -127,6 +128,32 @@ public final class DefaultRouteTemplateContext implements RouteTemplateContext {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public boolean hasEnvironmentVariable(String name) {
+        String normalizedKey = IOHelper.normalizeEnvironmentVariable(name);
+        if (parameters.containsKey(normalizedKey)) {
+            return true;
+        }
+        normalizedKey = IOHelper.normalizeEnvironmentVariable(StringHelper.camelCaseToDash(name));
+        if (parameters.containsKey(normalizedKey)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Object getEnvironmentVariable(String name) {
+        String normalizedKey = IOHelper.normalizeEnvironmentVariable(name);
+        if (parameters.containsKey(normalizedKey)) {
+            return parameters.get(normalizedKey);
+        }
+        normalizedKey = IOHelper.normalizeEnvironmentVariable(StringHelper.camelCaseToDash(name));
+        if (parameters.containsKey(normalizedKey)) {
+            return parameters.get(normalizedKey);
+        }
+        return null;
     }
 
     @Override

--- a/core/camel-util/src/main/java/org/apache/camel/util/IOHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/IOHelper.java
@@ -674,7 +674,7 @@ public final class IOHelper {
      * For example given an ENV variable in either format: - CAMEL_KAMELET_AWS_S3_SOURCE_BUCKETNAMEORARN=myArn -
      * CAMEL_KAMELET_AWS_S3_SOURCE_BUCKET_NAME_OR_ARN=myArn
      *
-     * Then the following keys can lookup both ENV formats above: - camel.kamelet.awsS3Source.bucketNameOrArn -
+     * Then the following keys can look up both ENV formats above: - camel.kamelet.awsS3Source.bucketNameOrArn -
      * camel.kamelet.aws-s3-source.bucketNameOrArn - camel.kamelet.aws-s3-source.bucket-name-or-arn
      */
     public static String lookupEnvironmentVariable(String key) {
@@ -683,29 +683,28 @@ public final class IOHelper {
         String value = System.getenv(upperKey);
 
         if (value == null) {
-            // some OS do not support dashes in keys, so replace with underscore
-            String normalizedKey = upperKey.replace('-', '_');
-
-            // and replace dots with underscores so keys like my.key are
-            // translated to MY_KEY
-            normalizedKey = normalizedKey.replace('.', '_');
-
-            value = System.getenv(normalizedKey);
+            value = System.getenv(normalizeEnvironmentVariable(upperKey));
         }
         if (value == null) {
             // camelCase keys should use underscore as separator
             String caseKey = StringHelper.camelCaseToDash(key);
-            caseKey = caseKey.toUpperCase();
-            // some OS do not support dashes in keys, so replace with underscore
-            String normalizedKey = caseKey.replace('-', '_');
-
-            // and replace dots with underscores so keys like my.key are
-            // translated to MY_KEY
-            normalizedKey = normalizedKey.replace('.', '_');
-
-            value = System.getenv(normalizedKey);
+            value = System.getenv(normalizeEnvironmentVariable(caseKey));
         }
         return value;
+    }
+
+    /**
+     * Convert given key into an OS environment variable. Uses uppercase keys and converts dashes and dots to
+     * underscores.
+     */
+    public static String normalizeEnvironmentVariable(String key) {
+        String upperKey = key.toUpperCase();
+        // some OS do not support dashes in keys, so replace with underscore
+        String normalizedKey = upperKey.replace('-', '_');
+
+        // and replace dots with underscores so keys like my.key are
+        // translated to MY_KEY
+        return normalizedKey.replace('.', '_');
     }
 
     /**


### PR DESCRIPTION
# Description

- Consider environment variables when validating Kamelet parameter configuration
- Avoids errors due to missing required Kamelet parameter validation when parameter is configured via environment variables

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

See CAMEL-21336

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

