### PR TITLE
CAMEL-21334 - use specific ppc64le container image for OpenSearch Integration tests

### DIFF
--- a/test-infra/camel-test-infra-opensearch/src/test/java/org/apache/camel/test/infra/opensearch/common/OpenSearchProperties.java
+++ b/test-infra/camel-test-infra-opensearch/src/test/java/org/apache/camel/test/infra/opensearch/common/OpenSearchProperties.java
@@ -25,6 +25,7 @@ public final class OpenSearchProperties {
     public static final String OPEN_SEARCH_USERNAME = "opensearch.username";
     public static final String OPEN_SEARCH_PASSWORD = "opensearch.password";
     public static final String OPEN_SEARCH_CONTAINER = "opensearch.container";
+    public static final String OPEN_SEARCH_CONTAINER_PPC64LE = "opensearch.container.ppc64le";
     public static final String OPEN_SEARCH_CONTAINER_STARTUP
             = OPEN_SEARCH_CONTAINER + ContainerEnvironmentUtil.STARTUP_ATTEMPTS_PROPERTY;
 

--- a/test-infra/camel-test-infra-opensearch/src/test/java/org/apache/camel/test/infra/opensearch/services/OpenSearchLocalContainerService.java
+++ b/test-infra/camel-test-infra-opensearch/src/test/java/org/apache/camel/test/infra/opensearch/services/OpenSearchLocalContainerService.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.shaded.org.apache.commons.lang3.SystemUtils;
 import org.testcontainers.utility.DockerImageName;
 
 public class OpenSearchLocalContainerService implements OpenSearchService, ContainerService<OpensearchContainer> {
@@ -39,7 +40,15 @@ public class OpenSearchLocalContainerService implements OpenSearchService, Conta
 
     public OpenSearchLocalContainerService() {
         this(LocalPropertyResolver.getProperty(OpenSearchLocalContainerService.class,
-                OpenSearchProperties.OPEN_SEARCH_CONTAINER));
+                getPropertyKeyForContainerImage()));
+    }
+
+    private static String getPropertyKeyForContainerImage() {
+        if (SystemUtils.OS_ARCH == "ppc64le") {
+            return OpenSearchProperties.OPEN_SEARCH_CONTAINER_PPC64LE;
+        } else {
+            return OpenSearchProperties.OPEN_SEARCH_CONTAINER;
+        }
     }
 
     public OpenSearchLocalContainerService(String imageName) {

--- a/test-infra/camel-test-infra-opensearch/src/test/resources/org/apache/camel/test/infra/opensearch/services/container.properties
+++ b/test-infra/camel-test-infra-opensearch/src/test/resources/org/apache/camel/test/infra/opensearch/services/container.properties
@@ -15,3 +15,4 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 opensearch.container=opensearchproject/opensearch:2.14.0
+opensearch.container.ppc64le=icr.io/ppc64le-oss/opensearch-ppc64le:2.12.0


### PR DESCRIPTION
# Description

the ppc64le image is provided separately. The "official" OpenSearch container does not support ppc64le

it will fix tests on main branch

note that I do not have access to a ppc64le machine so cannot test that it is really fixing the issue

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

