### PR TITLE
Fix Avro CVE In Jackson Databind Avro

### DIFF
--- a/.github/actions/install-packages/action.yml
+++ b/.github/actions/install-packages/action.yml
@@ -22,5 +22,5 @@ runs:
   steps:
     - run: sudo apt-get update
       shell: bash
-    - run: sudo apt-get install -qqy --no-install-recommends libtinfo5
+    - run: sudo apt-get install -qqy --no-install-recommends libtinfo6
       shell: bash

--- a/components/camel-jackson-avro/pom.xml
+++ b/components/camel-jackson-avro/pom.xml
@@ -49,6 +49,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-avro</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro-version}</version>
         </dependency>
 
         <!-- testing -->


### PR DESCRIPTION
@davsclaus the tests are successful, but with this PR we are going to upgrade avro from `1.8.2` to `1.11.4`