### PR TITLE
Fix CVE

### DIFF
--- a/.github/actions/install-packages/action.yml
+++ b/.github/actions/install-packages/action.yml
@@ -22,5 +22,5 @@ runs:
   steps:
     - run: sudo apt-get update
       shell: bash
-    - run: sudo apt-get install -qqy --no-install-recommends libtinfo5
+    - run: sudo apt-get install -qqy --no-install-recommends libtinfo6
       shell: bash

--- a/components/camel-jackson-avro/pom.xml
+++ b/components/camel-jackson-avro/pom.xml
@@ -49,6 +49,18 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-avro</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Remove the exlcusion and the dependency once the CVE-2024-47561 is fixed in jackson-dataformat-avro -->
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro-version}</version>
         </dependency>
 
         <!-- testing -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,9 +72,9 @@
         <asterisk-java-version>3.39.0</asterisk-java-version>
         <atlassian-fugue-version>6.1.0</atlassian-fugue-version>
         <atmosphere-version>3.0.10</atmosphere-version>
-        <avro-version>1.12.0</avro-version>
-        <avro-ipc-jetty-version>1.12.0</avro-ipc-jetty-version>
-        <avro-ipc-netty-version>1.12.0</avro-ipc-netty-version>
+        <avro-version>1.11.4</avro-version>
+        <avro-ipc-jetty-version>1.11.4</avro-ipc-jetty-version>
+        <avro-ipc-netty-version>1.11.4</avro-ipc-netty-version>
         <awaitility-version>4.2.2</awaitility-version>
         <aws-java-sdk2-version>2.27.19</aws-java-sdk2-version>
         <aws-xray-version>2.18.1</aws-xray-version>


### PR DESCRIPTION
@davsclaus the latest released jackson-dataformat-avro:2.17.2 is not compatible with avro:1.12.0.

Do we really need avro:1.12.0 in Camel? would it be possible to downgrade it to 1.11.4?