### PR TITLE
[Jetty] custom SecureRequestCustomizer configuration

### DIFF
--- a/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
+++ b/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
@@ -127,6 +127,7 @@ public abstract class JettyHttpComponent extends HttpCommonComponent
     private Long maxFileSize = -1L;
     private Long maxRequestSize = -1L;
     private Integer fileSizeThreshold = 0;
+    protected SecureRequestCustomizer secureRequestCustomizer;
 
     protected JettyHttpComponent() {
     }
@@ -503,6 +504,19 @@ public abstract class JettyHttpComponent extends HttpCommonComponent
 
     // Properties
     // -------------------------------------------------------------------------
+
+    public SecureRequestCustomizer getSecureRequestCustomizer() {
+        return secureRequestCustomizer;
+    }
+
+    /**
+     * To use a custom SecureRequestCustomizer. The option is a org.eclipse.jetty.server.SecureRequestCustomizer type.
+     */
+    @Metadata(description = "To use a custom SecureRequestCustomizer. The option is a org.eclipse.jetty.server.SecureRequestCustomizer type.",
+              label = "advanced")
+    public void setSecureRequestCustomizer(SecureRequestCustomizer secureRequestCustomizer) {
+        this.secureRequestCustomizer = secureRequestCustomizer;
+    }
 
     public String getSslKeyPassword() {
         return sslKeyPassword;

--- a/components/camel-jetty/src/main/java/org/apache/camel/component/jetty12/JettyHttpComponent12.java
+++ b/components/camel-jetty/src/main/java/org/apache/camel/component/jetty12/JettyHttpComponent12.java
@@ -84,7 +84,7 @@ public class JettyHttpComponent12 extends JettyHttpComponent {
             ArrayList<ConnectionFactory> connectionFactories = new ArrayList<>();
             ServerConnector result = new org.eclipse.jetty.server.ServerConnector(server);
             if (sslcf != null) {
-                httpConfig.addCustomizer(new org.eclipse.jetty.server.SecureRequestCustomizer());
+                httpConfig.addCustomizer(secureRequestCustomizer != null ? secureRequestCustomizer : new org.eclipse.jetty.server.SecureRequestCustomizer());
                 SslConnectionFactory scf = new org.eclipse.jetty.server.SslConnectionFactory(
                         sslcf,
                         httpFactory.getProtocol());


### PR DESCRIPTION
# Description

When using camel 4.4.x, I found that the Jetty component cannot flexibly configure sniHostCheck and turn off SNI verification.I need to inherit and rewrite the httpConfig.addCustomizer(new SecureRequestCustomizer()) in the createConnectorJettyInternal method of JettyHttpComponent in the project and replace it with httpConfig.addCustomizer(new SecureRequestCustomizer(false)); this is quite troublesome! So I submit the following changes: JettyHttpComponent adds the secureRequestCustomizer attribute, which can be customized in the project and flexibly loaded into the Jetty component

# Target

- [4.4.x]
- [main]
