### PR TITLE
CAMEL-21190 - Configure Maven Javadoc Plugin for Java version used for compilation

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -3546,12 +3546,12 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
                         <attach>true</attach>
-                        <source>${jdk.version}</source>
+                        <release>${maven.javadoc.release}</release>
                         <quiet>true</quiet>
                         <bottom>Apache Camel</bottom>
                         <detectOfflineLinks>false</detectOfflineLinks>
-                        <javadocVersion>1.8.0</javadocVersion>
                         <encoding>UTF-8</encoding>
+                        <doclint>none</doclint>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -3717,14 +3717,15 @@
                 <version>${maven-javadoc-plugin-version}</version>
                 <configuration>
                     <links>
-                        <link>http://docs.oracle.com/javase/8/docs/api/</link>
-                        <link>http://docs.oracle.com/javaee/7/api/</link>
-                        <link>http://docs.spring.io/spring/docs/${spring-version}/javadoc-api/</link>
+                        <link>https://docs.oracle.com/javase/17/docs/api/</link>
+                        <link>https://docs.oracle.com/javaee/7/api/</link>
+                        <link>https://docs.spring.io/spring/docs/${spring-version}/javadoc-api/</link>
                     </links>
                     <stylesheetfile>${basedir}/../../etc/css/stylesheet.css</stylesheetfile>
                     <linksource>true</linksource>
                     <maxmemory>500m</maxmemory>
-                    <source>${jdk.version}</source>
+                    <release>${maven.javadoc.release}</release>
+                    <doclint>none</doclint>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <maven.compiler.source>${jdk.version}</maven.compiler.source>
         <maven.compiler.target>${jdk.version}</maven.compiler.target>
         <maven.compiler.release>${jdk.version}</maven.compiler.release>
+        <maven.javadoc.release>${jdk.version}</maven.javadoc.release>
         <minimalJavaBuildVersion>${jdk.version}</minimalJavaBuildVersion>
 
         <!-- reproduceable builds: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
@@ -634,7 +635,7 @@
                                     <goal>jar</goal>
                                 </goals>
                                 <configuration>
-                                    <source>11</source>
+                                    <release>${maven.javadoc.release}</release>
                                     <doclint>none</doclint>
                                 </configuration>
                             </execution>
@@ -708,7 +709,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <source>8</source>
+                            <release>${maven.javadoc.release}</release>
                             <additionalOptions>${javadoc.opts}</additionalOptions>
                             <!-- disable Javadoc linting for buildung the release with Java 11 -->
                             <doclint>none</doclint>


### PR DESCRIPTION
# Description

it requires then to not use the doclint as there are a bunch of invalid or no more valid Javadoc in the codebase.

It was already used and mentioned as a workaround for one of the configuration of the maven-javadoc-plugin: https://github.com/apache/camel/blob/0c63d15314d90e03da251214c7f9e12bf0f938dd/pom.xml#L714

reported https://issues.apache.org/jira/browse/CAMEL-21356 to fix the Javadoc issues

to test locally (at least a part of the changes), we can call `mvn javadoc:javadoc`

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

