### PR TITLE
Fix link

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/building.adoc
+++ b/docs/user-manual/modules/ROOT/pages/building.adoc
@@ -1,4 +1,4 @@
 = Building Camel from Source
 
-This content was moved to the link:/camel-core/contributing[Getting Started].
+This content was moved to the link:/camel-core/getting-started[Getting Started].
 


### PR DESCRIPTION
# Description

The link used to direct to the /camel-core/contributing page, I corrected it.

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

This fix aims at correcting a link on the website and does not apply to a specific Came version.

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

Trivial change.

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

No Jira ticket

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

No

