### PR TITLE
chore: stabilizing DefaultSupervisingRouteControllerTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultSupervisingRouteControllerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultSupervisingRouteControllerTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.camel.impl.engine;
 
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -37,7 +39,10 @@ import org.apache.camel.spi.SupervisingRouteController;
 import org.apache.camel.support.SimpleEventNotifierSupport;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultSupervisingRouteControllerTest extends ContextTestSupport {
 
@@ -58,8 +63,8 @@ public class DefaultSupervisingRouteControllerTest extends ContextTestSupport {
         src.setInitialDelay(100);
         src.setThreadPoolSize(2);
 
-        List<CamelEvent.RouteRestartingFailureEvent> failures = new ArrayList<>();
-        List<CamelEvent.RouteRestartingEvent> events = new ArrayList<>();
+        List<CamelEvent.RouteRestartingFailureEvent> failures = Collections.synchronizedList(new ArrayList<>());
+        List<CamelEvent.RouteRestartingEvent> events = Collections.synchronizedList(new ArrayList<>());
 
         context.getManagementStrategy().addEventNotifier(new SimpleEventNotifierSupport() {
             @Override
@@ -94,8 +99,10 @@ public class DefaultSupervisingRouteControllerTest extends ContextTestSupport {
         // cake was not able to start
         assertEquals("Stopped", context.getRouteController().getRouteStatus("cake").toString());
 
+        await("Await all exceptions and retries finished")
+                .atMost(Duration.ofMillis(src.getInitialDelay() + src.getBackOffDelay() * (src.getBackOffMaxAttempts() + 1)))
+                .untilAsserted(() -> assertNotNull(src.getRestartException("cake")));
         Throwable e = src.getRestartException("cake");
-        assertNotNull(e);
         assertEquals("Cannot start", e.getMessage());
         boolean b = e instanceof IllegalArgumentException;
         assertTrue(b);
@@ -105,6 +112,7 @@ public class DefaultSupervisingRouteControllerTest extends ContextTestSupport {
 
         assertEquals(10, failures.size(),
                 "There should have 2 x 1 initial + 2 x 3 restart failure + 2 x 1 exhausted failures.");
+
         assertEquals(6, events.size(), "There should have been 2 x 3 restart attempts.");
 
         assertEquals(2, failures.stream().filter(failure -> failure.isExhausted()).count(),
@@ -135,8 +143,8 @@ public class DefaultSupervisingRouteControllerTest extends ContextTestSupport {
         src.setInitialDelay(100);
         src.setThreadPoolSize(2);
 
-        List<CamelEvent.RouteRestartingFailureEvent> failure = new ArrayList<>();
-        List<CamelEvent.RouteRestartingEvent> events = new ArrayList<>();
+        List<CamelEvent.RouteRestartingFailureEvent> failure = Collections.synchronizedList(new ArrayList<>());
+        List<CamelEvent.RouteRestartingEvent> events = Collections.synchronizedList(new ArrayList<>());
 
         context.getManagementStrategy().addEventNotifier(new SimpleEventNotifierSupport() {
             @Override


### PR DESCRIPTION
Previous improvement of assertion was when the list of failure was not arriving always in the same order. But the test is still flaky, there are 2 reasons:
* the exception was not set yet as all retries were not finished
* the lists used in test to collect events and failures were not synchronized and can be called in different threads. It seems that it was causing some elements to not be added correctly. I suspected a caught ConcurrentModificationException but in debug mode it is not hit. So not sure the root reason using syncehonizedList seems to do the trick.
Using @RepeatedTest locally, I had between 5 and 15 tests in error on 50 attempts before. Now I hit 100% success.

# Description

last falky failure on Ci https://ci-builds.apache.org/job/Camel/job/Camel%20Core%20(Build%20and%20test)/job/main/lastCompletedBuild/testReport/org.apache.camel.impl.engine/DefaultSupervisingRouteControllerTest/BuildAndTest___Matrix___JDK_NAME____jdk_21_latest___PLATFORM____ubuntu_avx____Test___testSupervising/

```
org.opentest4j.AssertionFailedError: expected: not <null>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:152)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertNotNull.failNull(AssertNotNull.java:49)
	at org.junit.jupiter.api.AssertNotNull.assertNotNull(AssertNotNull.java:35)
	at org.junit.jupiter.api.AssertNotNull.assertNotNull(AssertNotNull.java:30)
	at org.junit.jupiter.api.Assertions.assertNotNull(Assertions.java:304)
	at org.apache.camel.impl.engine.DefaultSupervisingRouteControllerTest.testSupervising(DefaultSupervisingRouteControllerTest.java:98)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

