### PR TITLE
CAMEL-21331: Remove trait-profile parameter in camel-jbang Kubernetes…

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationRun.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/IntegrationRun.java
@@ -35,7 +35,6 @@ import org.apache.camel.dsl.jbang.core.commands.kubernetes.KubernetesBaseCommand
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.KubernetesHelper;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.TraitCatalog;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.TraitContext;
-import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.TraitProfile;
 import org.apache.camel.dsl.jbang.core.common.JSonHelper;
 import org.apache.camel.dsl.jbang.core.common.Printer;
 import org.apache.camel.dsl.jbang.core.common.Source;

--- a/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/TraitProfile.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-k/src/main/java/org/apache/camel/dsl/jbang/core/commands/k/TraitProfile.java
@@ -14,8 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.apache.camel.dsl.jbang.core.commands.kubernetes.traits;
+package org.apache.camel.dsl.jbang.core.commands.k;
 
 public enum TraitProfile {
 

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
@@ -38,7 +38,6 @@ import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.ContainerTrait
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.TraitCatalog;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.TraitContext;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.TraitHelper;
-import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.TraitProfile;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Container;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Traits;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
@@ -54,9 +53,6 @@ import picocli.CommandLine.Command;
 @Command(name = "export", description = "Export as Maven/Gradle project that contains a Kubernetes deployment manifest",
          sortOptions = false)
 public class KubernetesExport extends Export {
-
-    @CommandLine.Option(names = { "--trait-profile" }, description = "The trait profile to use for the deployment.")
-    protected String traitProfile;
 
     @CommandLine.Option(names = { "--service-account" }, description = "The service account used to run the application.")
     protected String serviceAccount;
@@ -114,7 +110,7 @@ public class KubernetesExport extends Export {
     protected String imageBuilder;
 
     @CommandLine.Option(names = { "--cluster-type" },
-                        description = "The target cluster type. Special configurations may be applied to different cluster types such as Kind or Minikube.")
+                        description = "The target cluster type. Special configurations may be applied to different cluster types such as Kind or Minikube or Openshift.")
     protected String clusterType;
 
     private static final String SRC_MAIN_RESOURCES = "/src/main/resources/";
@@ -241,8 +237,8 @@ public class KubernetesExport extends Export {
                 .filter(parts -> parts.length == 2)
                 .collect(Collectors.toMap(parts -> parts[0], parts -> parts[1])));
 
-        if (traitProfile != null) {
-            context.setProfile(TraitProfile.valueOf(traitProfile.toUpperCase()));
+        if (clusterType != null) {
+            context.setClusterType(ClusterType.valueOf(clusterType.toUpperCase()));
         }
 
         if (serviceAccount != null) {
@@ -357,7 +353,7 @@ public class KubernetesExport extends Export {
             printer().println("Building Kubernetes manifest ...");
         }
 
-        new TraitCatalog().apply(traitsSpec, context, traitProfile);
+        new TraitCatalog().apply(traitsSpec, context, clusterType);
 
         var kubeFragments = context.buildItems().stream().map(KubernetesHelper::toJsonMap).toList();
 

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
@@ -51,9 +51,6 @@ public class KubernetesRun extends KubernetesBaseCommand {
                             arity = "0..9", paramLabel = "<files>")
     String[] filePaths;
 
-    @CommandLine.Option(names = { "--trait-profile" }, description = "The trait profile to use for the deployment.")
-    String traitProfile;
-
     @CommandLine.Option(names = { "--service-account" }, description = "The service account used to run the application.")
     String serviceAccount;
 
@@ -363,7 +360,6 @@ public class KubernetesRun extends KubernetesBaseCommand {
         export.imageGroup = imageGroup;
         export.imageBuilder = imageBuilder;
         export.clusterType = clusterType;
-        export.traitProfile = traitProfile;
         export.serviceAccount = serviceAccount;
         export.properties = properties;
         export.configs = configs;

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/BaseTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/BaseTrait.java
@@ -17,6 +17,8 @@
 
 package org.apache.camel.dsl.jbang.core.commands.kubernetes.traits;
 
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.ClusterType;
+
 public abstract class BaseTrait implements Trait {
 
     public static final String KUBERNETES_NAME_LABEL = "app.kubernetes.io/name";
@@ -43,7 +45,7 @@ public abstract class BaseTrait implements Trait {
     }
 
     @Override
-    public boolean accept(TraitProfile profile) {
+    public boolean accept(ClusterType clusterType) {
         return true;
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/IngressTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/IngressTrait.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressPathBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressRule;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressRuleBuilder;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.ClusterType;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Container;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Ingress;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Traits;
@@ -100,7 +101,7 @@ public class IngressTrait extends BaseTrait {
     }
 
     @Override
-    public boolean accept(TraitProfile profile) {
-        return TraitProfile.KUBERNETES == profile;
+    public boolean accept(ClusterType clusterType) {
+        return ClusterType.OPENSHIFT != clusterType;
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/RouteTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/RouteTrait.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.IntOrStringBuilder;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.api.model.TLSConfigBuilder;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.ClusterType;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Container;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Route;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Traits;
@@ -115,8 +116,8 @@ public class RouteTrait extends BaseTrait {
     }
 
     @Override
-    public boolean accept(TraitProfile profile) {
-        return TraitProfile.OPENSHIFT == profile;
+    public boolean accept(ClusterType clusterType) {
+        return ClusterType.OPENSHIFT == clusterType;
     }
 
     private String getContent(String value) {

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/ServiceTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/ServiceTrait.java
@@ -85,8 +85,4 @@ public class ServiceTrait extends BaseTrait {
         context.add(service);
     }
 
-    @Override
-    public boolean accept(TraitProfile profile) {
-        return TraitProfile.KNATIVE != profile;
-    }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/Trait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/Trait.java
@@ -17,6 +17,7 @@
 
 package org.apache.camel.dsl.jbang.core.commands.kubernetes.traits;
 
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.ClusterType;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Traits;
 
 public interface Trait extends Comparable<Trait> {
@@ -27,7 +28,7 @@ public interface Trait extends Comparable<Trait> {
 
     int order();
 
-    boolean accept(TraitProfile profile);
+    boolean accept(ClusterType clusterType);
 
     @Override
     default int compareTo(Trait o) {

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitCatalog.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitCatalog.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.ClusterType;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.knative.KnativeServiceTrait;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.knative.KnativeTrait;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Traits;
@@ -55,8 +56,8 @@ public class TraitCatalog {
         return traits.stream().sorted().collect(Collectors.toList());
     }
 
-    public List<Trait> traitsForProfile(TraitProfile profile) {
-        return traits.stream().filter(t -> t.accept(profile)).sorted().collect(Collectors.toList());
+    public List<Trait> traitsForProfile(ClusterType clusterType) {
+        return traits.stream().filter(t -> t.accept(clusterType)).sorted().collect(Collectors.toList());
     }
 
     public void register(Trait trait) {
@@ -66,17 +67,18 @@ public class TraitCatalog {
     /**
      * Applies traits in this catalog for given profile or all traits if profile is not set.
      *
-     * @param traitsSpec   the trait configuration spec.
-     * @param context      the trait context.
-     * @param traitProfile the optional trait profile to select traits.
+     * @param traitsSpec  the trait configuration spec.
+     * @param context     the trait context.
+     * @param clusterType the optional trait profile to select traits.
      */
-    public void apply(Traits traitsSpec, TraitContext context, String traitProfile) {
-        if (traitProfile != null) {
-            new TraitCatalog().traitsForProfile(TraitProfile.valueOf(traitProfile.toUpperCase(Locale.US))).forEach(t -> {
-                if (t.configure(traitsSpec, context)) {
-                    t.apply(traitsSpec, context);
-                }
-            });
+    public void apply(Traits traitsSpec, TraitContext context, String clusterType) {
+        if (clusterType != null) {
+            new TraitCatalog().traitsForProfile(ClusterType.valueOf(clusterType.toUpperCase(Locale.US)))
+                    .forEach(t -> {
+                        if (t.configure(traitsSpec, context)) {
+                            t.apply(traitsSpec, context);
+                        }
+                    });
         } else {
             new TraitCatalog().allTraits().forEach(t -> {
                 if (t.configure(traitsSpec, context)) {

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitContext.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitContext.java
@@ -40,6 +40,7 @@ import io.fabric8.openshift.api.model.RouteBuilder;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.CatalogHelper;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.ClusterType;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.MetadataHelper;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.support.SourceMetadata;
 import org.apache.camel.dsl.jbang.core.common.Printer;
@@ -49,7 +50,7 @@ import org.apache.camel.dsl.jbang.core.common.Source;
 public class TraitContext {
 
     private final List<VisitableBuilder<?, ?>> resourceRegistry = new ArrayList<>();
-    private TraitProfile profile = TraitProfile.KUBERNETES;
+    private ClusterType clusterType = ClusterType.KUBERNETES;
 
     private final Map<String, String> configurationResources = new HashMap<>();
 
@@ -98,12 +99,12 @@ public class TraitContext {
         resourceRegistry.add(resource);
     }
 
-    public TraitProfile getProfile() {
-        return profile;
+    public ClusterType getClusterType() {
+        return this.clusterType;
     }
 
-    public void setProfile(TraitProfile profile) {
-        this.profile = profile;
+    public void setClusterType(ClusterType clusterType) {
+        this.clusterType = clusterType;
     }
 
     public void doWithServices(Visitor<ServiceBuilder> visitor) {

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/knative/KnativeBaseTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/knative/KnativeBaseTrait.java
@@ -18,7 +18,6 @@
 package org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.knative;
 
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.BaseTrait;
-import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.TraitProfile;
 
 abstract class KnativeBaseTrait extends BaseTrait {
 
@@ -26,8 +25,4 @@ abstract class KnativeBaseTrait extends BaseTrait {
         super(id, order);
     }
 
-    @Override
-    public boolean accept(TraitProfile profile) {
-        return TraitProfile.KNATIVE == profile;
-    }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportBaseTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportBaseTest.java
@@ -68,19 +68,22 @@ public class KubernetesExportBaseTest extends KubernetesBaseTest {
         return command;
     }
 
-    protected boolean hasService(RuntimeType rt) throws IOException {
-        return getResource(rt, Service.class).isPresent();
+    protected boolean hasService(RuntimeType rt, ClusterType ct) throws IOException {
+        return getResource(rt, ct, Service.class).isPresent();
     }
 
-    protected boolean hasKnativeService(RuntimeType rt) throws IOException {
-        return getResource(rt, io.fabric8.knative.serving.v1.Service.class).isPresent();
+    protected boolean hasKnativeService(RuntimeType rt, ClusterType ct) throws IOException {
+        return getResource(rt, ct, io.fabric8.knative.serving.v1.Service.class).isPresent();
     }
 
-    protected <T extends HasMetadata> Optional<T> getResource(RuntimeType rt, Class<T> type) throws IOException {
+    protected <T extends HasMetadata> Optional<T> getResource(RuntimeType rt, ClusterType ct, Class<T> type)
+            throws IOException {
         if (rt == RuntimeType.quarkus) {
             try (FileInputStream fis
                     = new FileInputStream(
-                            KubernetesHelper.getKubernetesManifest(ClusterType.KUBERNETES.name(),
+                            KubernetesHelper.getKubernetesManifest(
+                                    ClusterType.OPENSHIFT.equals(ct)
+                                            ? ClusterType.OPENSHIFT.name() : ClusterType.KUBERNETES.name(),
                                     new File(workingDir, "/src/main/kubernetes")))) {
                 List<HasMetadata> resources = kubernetesClient.load(fis).items();
                 return resources.stream()

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportKnativeTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportKnativeTest.java
@@ -60,11 +60,12 @@ public class KubernetesExportKnativeTest extends KubernetesExportBaseTest {
         int exit = command.doCall();
         Assertions.assertEquals(0, exit);
 
-        Assertions.assertFalse(hasService(rt));
-        Assertions.assertTrue(hasKnativeService(rt));
+        Assertions.assertFalse(hasService(rt, ClusterType.KUBERNETES));
+        Assertions.assertTrue(hasKnativeService(rt, ClusterType.KUBERNETES));
 
-        io.fabric8.knative.serving.v1.Service service = getResource(rt, io.fabric8.knative.serving.v1.Service.class)
-                .orElseThrow(() -> new RuntimeCamelException("Missing Knative service in Kubernetes manifest"));
+        io.fabric8.knative.serving.v1.Service service
+                = getResource(rt, ClusterType.KUBERNETES, io.fabric8.knative.serving.v1.Service.class)
+                        .orElseThrow(() -> new RuntimeCamelException("Missing Knative service in Kubernetes manifest"));
 
         Map<String, String> labelsA = service.getMetadata().getLabels();
         var labelsB = service.getSpec().getTemplate().getMetadata().getLabels();
@@ -96,10 +97,10 @@ public class KubernetesExportKnativeTest extends KubernetesExportBaseTest {
         int exit = command.doCall();
         Assertions.assertEquals(0, exit);
 
-        Assertions.assertTrue(hasService(rt));
-        Assertions.assertFalse(hasKnativeService(rt));
+        Assertions.assertTrue(hasService(rt, ClusterType.KUBERNETES));
+        Assertions.assertFalse(hasKnativeService(rt, ClusterType.KUBERNETES));
 
-        Trigger trigger = getResource(rt, Trigger.class)
+        Trigger trigger = getResource(rt, ClusterType.KUBERNETES, Trigger.class)
                 .orElseThrow(() -> new RuntimeCamelException("Missing Knative trigger in Kubernetes manifest"));
 
         Assertions.assertEquals("my-broker-knative-event-source-camel-event", trigger.getMetadata().getName());
@@ -138,10 +139,10 @@ public class KubernetesExportKnativeTest extends KubernetesExportBaseTest {
                 "--image-group=camel-test", "--runtime=" + rt.runtime());
         command.doCall();
 
-        Assertions.assertTrue(hasService(rt));
-        Assertions.assertFalse(hasKnativeService(rt));
+        Assertions.assertTrue(hasService(rt, ClusterType.KUBERNETES));
+        Assertions.assertFalse(hasKnativeService(rt, ClusterType.KUBERNETES));
 
-        Subscription subscription = getResource(rt, Subscription.class)
+        Subscription subscription = getResource(rt, ClusterType.KUBERNETES, Subscription.class)
                 .orElseThrow(() -> new RuntimeCamelException("Missing Knative subscription in Kubernetes manifest"));
 
         Assertions.assertEquals("my-channel-knative-channel-source", subscription.getMetadata().getName());
@@ -177,10 +178,10 @@ public class KubernetesExportKnativeTest extends KubernetesExportBaseTest {
                 "--image-group=camel-test", "--runtime=" + rt.runtime());
         command.doCall();
 
-        Assertions.assertTrue(hasService(rt));
-        Assertions.assertFalse(hasKnativeService(rt));
+        Assertions.assertTrue(hasService(rt, ClusterType.KUBERNETES));
+        Assertions.assertFalse(hasKnativeService(rt, ClusterType.KUBERNETES));
 
-        SinkBinding sinkBinding = getResource(rt, SinkBinding.class)
+        SinkBinding sinkBinding = getResource(rt, ClusterType.KUBERNETES, SinkBinding.class)
                 .orElseThrow(() -> new RuntimeCamelException("Missing Knative sinkBinding in Kubernetes manifest"));
 
         Assertions.assertEquals("knative-event-sink", sinkBinding.getMetadata().getName());
@@ -217,10 +218,10 @@ public class KubernetesExportKnativeTest extends KubernetesExportBaseTest {
                 "--image-group=camel-test", "--runtime=" + rt.runtime());
         command.doCall();
 
-        Assertions.assertTrue(hasService(rt));
-        Assertions.assertFalse(hasKnativeService(rt));
+        Assertions.assertTrue(hasService(rt, ClusterType.KUBERNETES));
+        Assertions.assertFalse(hasKnativeService(rt, ClusterType.KUBERNETES));
 
-        SinkBinding sinkBinding = getResource(rt, SinkBinding.class)
+        SinkBinding sinkBinding = getResource(rt, ClusterType.KUBERNETES, SinkBinding.class)
                 .orElseThrow(() -> new RuntimeCamelException("Missing Knative sinkBinding in Kubernetes manifest"));
 
         Assertions.assertEquals("knative-channel-sink", sinkBinding.getMetadata().getName());
@@ -257,10 +258,10 @@ public class KubernetesExportKnativeTest extends KubernetesExportBaseTest {
                 "--image-group=camel-test", "--runtime=" + rt.runtime());
         command.doCall();
 
-        Assertions.assertTrue(hasService(rt));
-        Assertions.assertFalse(hasKnativeService(rt));
+        Assertions.assertTrue(hasService(rt, ClusterType.KUBERNETES));
+        Assertions.assertFalse(hasKnativeService(rt, ClusterType.KUBERNETES));
 
-        SinkBinding sinkBinding = getResource(rt, SinkBinding.class)
+        SinkBinding sinkBinding = getResource(rt, ClusterType.KUBERNETES, SinkBinding.class)
                 .orElseThrow(() -> new RuntimeCamelException("Missing Knative sinkBinding in Kubernetes manifest"));
 
         Assertions.assertEquals("knative-endpoint-sink", sinkBinding.getMetadata().getName());


### PR DESCRIPTION
… plugin

# Description

Remove the `--trait-profile` parameter in the camel-jbang kubernetes plugin. It is a letfover from the camel-jbang camel k plugin that is redundant to `--cluster-type`.

# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

