### PR TITLE
Revert "chore(deps): Bump org.smooks:smooks-bom from 2.0.0-RC4 to 2.0.1 (#16016)"

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -450,7 +450,7 @@
         <smallrye-health-version>4.1.0</smallrye-health-version>
         <smallrye-fault-tolerance-version>6.5.0</smallrye-fault-tolerance-version>
         <smbj-version>0.13.0</smbj-version>
-        <smooks-version>2.0.1</smooks-version>
+        <smooks-version>2.0.0-RC4</smooks-version>
         <snakeyaml-version>2.3</snakeyaml-version>
         <snakeyaml-engine-version>2.8</snakeyaml-engine-version>
         <snmp4j-version>3.8.2</snmp4j-version>


### PR DESCRIPTION
This reverts commit 79f434e69f0b8dff34dc7302492a5148b071746d.

Breaks the build.