### PR TITLE
Changed Main constructor in camel-main to use instances CamelConfiguration

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/Main.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/Main.java
@@ -58,7 +58,7 @@ public class Main extends MainCommandLineSupport {
      * @param configurationClasses additional camel configuration classes
      */
     @SafeVarargs
-    public Main(Class<?> mainClass, Class<CamelConfiguration>... configurationClasses) {
+    public Main(Class<?> mainClass, Class<? extends CamelConfiguration>... configurationClasses) {
         super(configurationClasses);
         this.mainClass = mainClass;
         configure().withBasePackageScan(mainClass.getPackageName());

--- a/core/camel-main/src/main/java/org/apache/camel/main/MainCommandLineSupport.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/MainCommandLineSupport.java
@@ -40,7 +40,7 @@ public abstract class MainCommandLineSupport extends MainSupport {
     private volatile boolean initOptionsDone;
 
     @SafeVarargs
-    public MainCommandLineSupport(Class<CamelConfiguration>... configurationClasses) {
+    public MainCommandLineSupport(Class<? extends CamelConfiguration>... configurationClasses) {
         super(configurationClasses);
     }
 


### PR DESCRIPTION
# Description

super constructor in MainSupport use `Class<? extends CamelConfiguration>`, but in MainCommandLineSupport and Main use `Class<CamelConfiguration>`.
