### PR TITLE
chore: stabilize FtpRecursiveDepth2IT

### DIFF
--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpRecursiveDepth2IT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpRecursiveDepth2IT.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file.remote.integration;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -45,7 +47,7 @@ public class FtpRecursiveDepth2IT extends FtpServerTestSupport {
         template.sendBodyAndHeader("ftp://admin@localhost:{{ftp.server.port}}/depth2/bar/foo?password=admin", "b3",
                 Exchange.FILE_NAME, "b3.txt");
 
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 20, TimeUnit.SECONDS);
     }
 
     @Override


### PR DESCRIPTION
this test failed several times in a row on Jenkins Ci with slightly different errors.
```
mock://result Message with body a2 was expected but not found in [b2,
b3, b2, a3]
```
```
mock://result Message with body a3 was expected but not found in [b3,
b2]
```

When playing locally with @RepeatedTest(100), I do not reproduce the error but noticed that 4 or 5 tests took more than 5 seconds although others took 1 second. When I tried to set a low timeout locally, it is failing the test with similar kind of errors.
So trying with an higher timeout, even though it seems strange that there can be that much variation in route execution.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

