### PR TITLE
chore: Improve test assertion in FileProducerCharsetUTFtoUTFTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoUTFTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoUTFTest.java
@@ -22,9 +22,9 @@ import java.nio.file.Files;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.util.ObjectHelper;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FileProducerCharsetUTFtoUTFTest extends ContextTestSupport {
@@ -46,7 +46,8 @@ class FileProducerCharsetUTFtoUTFTest extends ContextTestSupport {
         assertFileExists(testFile(OUTPUT_FILE));
         byte[] target = Files.readAllBytes(testFile(OUTPUT_FILE));
 
-        assertTrue(ObjectHelper.equalByteArray(source, target));
+        assertArrayEquals(source, target, "The byte arrays should be equals but they are not.\n Source:\n" + new String(source)
+                                          + "\nTarget:\n" + new String(target));
     }
 
     @Override


### PR DESCRIPTION
the test is flaky on Jenkins CI. It could help to investigate what is the issue

# Description

previous message on test error:
```
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
	at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
	at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:31)
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:183)
	at org.apache.camel.component.file.FileProducerCharsetUTFtoUTFTest.testFileProducerCharsetUTFtoUTF(FileProducerCharsetUTFtoUTFTest.java:49)
```

example of new error message (modified test manually to have a failure):
```
org.opentest4j.AssertionFailedError: The byte arrays should be equals but they are not.
 Source:
ABCæ
Target:
random ==> array lengths differ, expected: <5> but was: <6>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertArrayEquals.assertArraysHaveSameLength(AssertArrayEquals.java:428)
	at org.junit.jupiter.api.AssertArrayEquals.assertArrayEquals(AssertArrayEquals.java:205)
	at org.junit.jupiter.api.AssertArrayEquals.assertArrayEquals(AssertArrayEquals.java:63)
	at org.junit.jupiter.api.Assertions.assertArrayEquals(Assertions.java:1238)
	at org.apache.camel.component.file.FileProducerCharsetUTFtoUTFTest.testFileProducerCharsetUTFtoUTF(FileProducerCharsetUTFtoUTFTest.java:49)
```

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

