### PR TITLE
chore: reduce flakiness of GrpcProducerStreamingTest

### DIFF
--- a/components/camel-grpc/pom.xml
+++ b/components/camel-grpc/pom.xml
@@ -142,6 +142,12 @@
             <version>3.0.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility-version}</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.grpc;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -35,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.camel.test.junit5.TestSupport.assertListSize;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
@@ -78,7 +80,7 @@ public class GrpcProducerStreamingTest extends CamelTestSupport {
         context().stop();
 
         assertNotNull(pingPongServer.getLastStreamRequests());
-        assertListSize(pingPongServer.getLastStreamRequests(), 1);
+        await().untilAsserted(() -> assertListSize(pingPongServer.getLastStreamRequests(), 1));
         assertListSize(pingPongServer.getLastStreamRequests().get(0), messageCount);
     }
 
@@ -110,7 +112,7 @@ public class GrpcProducerStreamingTest extends CamelTestSupport {
         context().stop();
 
         assertNotNull(pingPongServer.getLastStreamRequests());
-        assertListSize(pingPongServer.getLastStreamRequests(), 2);
+        await().untilAsserted(() -> assertListSize(pingPongServer.getLastStreamRequests(), 2));
         assertListSize(pingPongServer.getLastStreamRequests().get(0), messageGroupCount + 1);
         assertListSize(pingPongServer.getLastStreamRequests().get(1), messageGroupCount);
     }
@@ -139,9 +141,9 @@ public class GrpcProducerStreamingTest extends CamelTestSupport {
 
         @Override
         public StreamObserver<PingRequest> pingAsyncAsync(StreamObserver<PongResponse> responseObserver) {
-            StreamObserver<PingRequest> requestObserver = new StreamObserver<PingRequest>() {
+            return new StreamObserver<PingRequest>() {
 
-                private List<PingRequest> streamRequests = new LinkedList<>();
+                private List<PingRequest> streamRequests = Collections.synchronizedList(new LinkedList<>());
 
                 @Override
                 public void onNext(PingRequest request) {
@@ -167,7 +169,6 @@ public class GrpcProducerStreamingTest extends CamelTestSupport {
                     responseObserver.onCompleted();
                 }
             };
-            return requestObserver;
         }
 
         public List<List<PingRequest>> getLastStreamRequests() {


### PR DESCRIPTION
before while using @RepeatedTest locally, I had 4 kind of failures and it was around 40 out of 100 tests failing
Now, it remains 2 kinds of error which occurs 5 out of 100 times:
```
org.opentest4j.AssertionFailedError: List should be of size: 1 but is:
[] ==> expected: <1> but was: <0>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:563)
	at org.apache.camel.test.junit5.TestSupport.assertListSize(TestSupport.java:288)
	at org.apache.camel.test.junit5.TestSupport.assertListSize(TestSupport.java:280)
	at org.apache.camel.component.grpc.GrpcProducerStreamingTest.testPingAsyncAsync(GrpcProducerStreamingTest.java:84)
```

```
java.lang.AssertionError: mock://grpc-replies Received message count.
Expected: <5> but was: <3>
	at org.apache.camel.component.mock.MockEndpoint.fail(MockEndpoint.java:2015)
	at org.apache.camel.component.mock.MockEndpoint.assertEquals(MockEndpoint.java:1950)
	at org.apache.camel.component.mock.MockEndpoint.doAssertIsSatisfied(MockEndpoint.java:453)
	at org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied(MockEndpoint.java:431)
	at org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied(MockEndpoint.java:421)
	at org.apache.camel.component.grpc.GrpcProducerStreamingTest.testPingAsyncAsyncRecovery(GrpcProducerStreamingTest.java:111)
```

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

