### PR TITLE
CAMEL-21376 - null pointer exception fix in UseOriginalAggregationStrategy 

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/UseOriginalAggregationStrategy.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/UseOriginalAggregationStrategy.java
@@ -74,7 +74,7 @@ public class UseOriginalAggregationStrategy implements AggregationStrategy {
             if (exception != null) {
                 if (original != null) {
                     original.setProperty(Exchange.EXCEPTION_CAUGHT, exception);
-                } else {
+                } else if (oldExchange != null) {
                     oldExchange.setProperty(Exchange.EXCEPTION_CAUGHT, exception);
                 }
             }


### PR DESCRIPTION
# Description

Null pointer exception fix in UseOriginalAggregationStrategy.
On the first aggregation the oldest exchange is null (there is only the new exchange)

Details can be found in the jira link below.

# Tracking

https://issues.apache.org/jira/browse/CAMEL-21376

