### PR TITLE
CAMEL-21395: camel-debezium - Add a note to the upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_8.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_8.adoc
@@ -60,6 +60,13 @@ The chat-with-tools feature was deprecated. Use the new `camel-langchain4j-tool`
 Continuing the multi-release tests cleanups, on this one, restricted methods from the `CamelTestSupport` class
 have been marked as final and cannot be extended.
 
+=== camel-debezium
+
+To avoid split package that can be a problem in environments like OSGI, each camel-debezium module has its own
+sub package corresponding to the database type. So for example, all the classes of the module `camel-debezium-postgres`
+have been moved to a dedicated package which is `org.apache.camel.component.debezium.postgres` instead of having
+everything under the root package `org.apache.camel.component.debezium`.
+
 === Preferred JAX-B implementation: `org.glassfish.jaxb:jaxb-runtime`
 
 We stopped relying on `com.sun.xml.bind:jaxb-impl` in favor of `org.glassfish.jaxb:jaxb-runtime`.


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-21395 (v 4.8)

## Motivation

The project camel-debezium-common shares the same package with the other camel-debezium sub-projects, which causes issues on environments like OSGI.

## Modifications:

* Add a note to the upgrade guide