### PR TITLE
fix: Apache Fury is not supporting architecture using Big Endian

### DIFF
--- a/components/camel-fury/pom.xml
+++ b/components/camel-fury/pom.xml
@@ -32,6 +32,7 @@
     <description>Camel Fury support</description>
 
     <properties>
+        <skipTests.s390x>true</skipTests.s390x>
     </properties>
 
     <dependencies>

--- a/components/camel-fury/src/main/docs/fury-dataformat.adoc
+++ b/components/camel-fury/src/main/docs/fury-dataformat.adoc
@@ -14,6 +14,9 @@
 Fury is a Data Format that uses the
 https://fury.apache.org/[Fury Library]
 
+[NOTE]
+Apache Fury is not supporting architecture using Big Endian (s390x for instance).
+
 == Fury Options
 
 


### PR DESCRIPTION
# Description

there was this error:
```
org.apache.camel.CamelExecutionException: Exception occurred during execution on the exchange: Exchange[21534DE353D2A93-0000000000000000]
	at org.apache.camel.CamelExecutionException.wrapCamelExecutionException(CamelExecutionException.java:45)
	at org.apache.camel.support.ExchangeHelper.extractResultBody(ExchangeHelper.java:698)
	at org.apache.camel.impl.engine.DefaultProducerTemplate.extractResultBody(DefaultProducerTemplate.java:591)
	at org.apache.camel.impl.engine.DefaultProducerTemplate.extractResultBody(DefaultProducerTemplate.java:587)
	at org.apache.camel.impl.engine.DefaultProducerTemplate.sendBody(DefaultProducerTemplate.java:189)
	at org.apache.camel.impl.engine.DefaultProducerTemplate.sendBody(DefaultProducerTemplate.java:195)
	at org.apache.camel.component.fury.FuryTest.testMarshalAndUnmarshalMap(FuryTest.java:37)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.IllegalArgumentException: false
	at org.apache.fury.util.Preconditions.checkArgument(Preconditions.java:52)
	at org.apache.fury.Fury.deserialize(Fury.java:765)
	at org.apache.fury.Fury.deserialize(Fury.java:815)
	at org.apache.fury.Fury.deserialize(Fury.java:808)
	at org.apache.camel.component.fury.FuryDataFormat.unmarshal(FuryDataFormat.java:79)
	at org.apache.camel.support.processor.UnmarshalProcessor.process(UnmarshalProcessor.java:83)
	at org.apache.camel.processor.errorhandler.RedeliveryErrorHandler$SimpleTask.handleFirst(RedeliveryErrorHandler.java:440)
	at org.apache.camel.processor.errorhandler.RedeliveryErrorHandler$SimpleTask.run(RedeliveryErrorHandler.java:416)
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.doRun(DefaultReactiveExecutor.java:199)
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.executeReactiveWork(DefaultReactiveExecutor.java:189)
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.tryExecuteReactiveWork(DefaultReactiveExecutor.java:166)
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.schedule(DefaultReactiveExecutor.java:148)
	at org.apache.camel.impl.engine.DefaultReactiveExecutor.scheduleMain(DefaultReactiveExecutor.java:59)
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:163)
	at org.apache.camel.impl.engine.CamelInternalProcessor.processNonTransacted(CamelInternalProcessor.java:347)
	at org.apache.camel.impl.engine.CamelInternalProcessor.process(CamelInternalProcessor.java:323)
	at org.apache.camel.component.direct.DirectProducer.process(DirectProducer.java:102)
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor.processNonTransacted(SharedCamelInternalProcessor.java:156)
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:133)
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor$1.process(SharedCamelInternalProcessor.java:89)
	at org.apache.camel.impl.engine.DefaultAsyncProcessorAwaitManager.process(DefaultAsyncProcessorAwaitManager.java:82)
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:86)
	at org.apache.camel.support.cache.DefaultProducerCache.send(DefaultProducerCache.java:178)
	at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:176)
	at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:172)
	at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:153)
	at org.apache.camel.impl.engine.DefaultProducerTemplate.sendBody(DefaultProducerTemplate.java:187)
	... 5 more
```
which leads me to this line of code in apche Fury which is  showing that Little Endian is required https://github.com/apache/fury/blob/baeff523b257b8b86bd8645e00975e6f8e81a81c/java/fury-core/src/main/java/org/apache/fury/Fury.java#L765C21-L765C34

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

