### PR TITLE
CAMEL-21402 Added means to verify expressions in MockEndpoint

### DIFF
--- a/components/camel-mock/src/main/java/org/apache/camel/component/mock/MockEndpoint.java
+++ b/components/camel-mock/src/main/java/org/apache/camel/component/mock/MockEndpoint.java
@@ -2076,6 +2076,15 @@ public class MockEndpoint extends DefaultEndpoint implements BrowsableEndpoint, 
             this.expectedValue = expectedValue;
             this.expectedValueClass = expectedValueClass;
         }
+
+        @Override
+        public String toString() {
+            return "ExpressionWithDescription{" +
+                    "description='" + description + '\'' +
+                    ", expectedValue=" + expectedValue +
+                    ", expectedValueClass=" + expectedValueClass +
+                    '}';
+        }
     }
 
     private class MockEvaluateExpressionTask implements AssertionTask {
@@ -2086,7 +2095,7 @@ public class MockEndpoint extends DefaultEndpoint implements BrowsableEndpoint, 
                 Object result
                         = expressionWithDescription.expression.evaluate(exchange, expressionWithDescription.expectedValueClass);
                 assertEquals(
-                        String.format("Expression '%s' isn't evaluated as expected value %s, was %s instead",
+                        String.format("Expression '%s' isn't evaluated as expected value [%s], was [%s]",
                                 expressionWithDescription.description,
                                 expressionWithDescription.expectedValue.toString(), result.toString()),
                         expressionWithDescription.expectedValue, result);

--- a/components/camel-mock/src/main/java/org/apache/camel/component/mock/MockEndpoint.java
+++ b/components/camel-mock/src/main/java/org/apache/camel/component/mock/MockEndpoint.java
@@ -1783,10 +1783,6 @@ public class MockEndpoint extends DefaultEndpoint implements BrowsableEndpoint, 
             assertExpectedHeaderValues(in);
         }
 
-        /*if (expectedExpressions != null) {
-            assertExpectedExpressionsMatch(exchange);
-        }*/
-
         Object actualBody = in.getBody();
 
         if (expectedBodyValues != null) {

--- a/core/camel-core/src/test/java/org/apache/camel/component/mock/MockEndpointTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/mock/MockEndpointTest.java
@@ -235,7 +235,7 @@ public class MockEndpointTest extends ContextTestSupport {
     }
 
     @Test
-    public void testExpectationOfExpression() throws InterruptedException {
+    public void testExpectationOfExpressionCase1() throws InterruptedException {
         MockEndpoint resultEndpoint = getMockEndpoint("mock:result");
         resultEndpoint.reset();
 
@@ -247,13 +247,27 @@ public class MockEndpointTest extends ContextTestSupport {
                 new SimpleExpression("simpleTest1")), "test regex case1", true, Boolean.class);
         resultEndpoint.expectedExpressionMatches(new RegexExpression(
                 "simpleTest\\d{2}",
-                new SimpleExpression("simpleTest1")), "test regex case1", false, Boolean.class);
-        sendHeader("header111", "value222_3333");
+                new SimpleExpression("simpleTest1")), "test regex case2", false, Boolean.class);
+        resultEndpoint.reset();
+
+        // No regex, simple comparison with expression
+        resultEndpoint.expectedExpressionMatches(HeaderLanguage.header("header111"), "simple retrieving of header case1","value222_3333", String.class );
+        // Actual header value doesn't match the regex
         resultEndpoint.expectedExpressionMatches(new RegexExpression(
                 "value\\d{3}_\\d{5}",
-                HeaderLanguage.header("header111")), "test regex case2", true, Boolean.class);
+                HeaderLanguage.header("header111")), "test regex case3", false, Boolean.class);
+        // Actual header value matches the regex
+        resultEndpoint.expectedExpressionMatches(new RegexExpression(
+                "value\\d{3}_\\d{4}",
+                HeaderLanguage.header("header111")), "test regex case4", true, Boolean.class);
+        // Actual header value matches the regex - very strict regex
+        resultEndpoint.expectedExpressionMatches(new RegexExpression(
+                "value222_3333",
+                HeaderLanguage.header("header111")), "test regex case5", true, Boolean.class);
+        sendHeader("header111", "value222_3333");
 
         resultEndpoint.assertIsSatisfied();
+        resultEndpoint.reset();
     }
 
     @Test

--- a/core/camel-core/src/test/java/org/apache/camel/component/mock/MockEndpointTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/mock/MockEndpointTest.java
@@ -30,6 +30,9 @@ import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.regex.RegexExpression;
+import org.apache.camel.language.header.HeaderLanguage;
+import org.apache.camel.model.language.SimpleExpression;
 import org.apache.camel.spi.Language;
 import org.apache.camel.spi.Registry;
 import org.junit.jupiter.api.Test;
@@ -227,6 +230,28 @@ public class MockEndpointTest extends ContextTestSupport {
         resultEndpoint.expectedMessageCount(3);
 
         sendMessages(11, 12, 13);
+
+        resultEndpoint.assertIsSatisfied();
+    }
+
+    @Test
+    public void testExpectationOfExpression() throws InterruptedException {
+        MockEndpoint resultEndpoint = getMockEndpoint("mock:result");
+        resultEndpoint.reset();
+
+        String simpleTest1 = "simpleTest1";
+        resultEndpoint.expectedExpressionMatches(new SimpleExpression(simpleTest1), "simple expression 1",
+                simpleTest1, String.class);
+        resultEndpoint.expectedExpressionMatches(new RegexExpression(
+                "simpleTest\\d",
+                new SimpleExpression("simpleTest1")), "test regex case1", true, Boolean.class);
+        resultEndpoint.expectedExpressionMatches(new RegexExpression(
+                "simpleTest\\d{2}",
+                new SimpleExpression("simpleTest1")), "test regex case1", false, Boolean.class);
+        sendHeader("header111", "value222_3333");
+        resultEndpoint.expectedExpressionMatches(new RegexExpression(
+                "value\\d{3}_\\d{5}",
+                HeaderLanguage.header("header111")), "test regex case2", true, Boolean.class);
 
         resultEndpoint.assertIsSatisfied();
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/regex/RegexExpression.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/regex/RegexExpression.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.regex;
+
+import java.util.regex.Pattern;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Expression;
+import org.apache.camel.Predicate;
+
+public class RegexExpression implements Expression {
+    private final String regexString;
+    private final Expression expression;
+
+    public RegexExpression(String regexString, Expression expression) {
+        this.regexString = regexString;
+        this.expression = expression;
+    }
+
+    @Override
+    public <T> T evaluate(Exchange exchange, Class<T> type) {
+        Predicate predicate = exchange1 -> Pattern.matches(regexString, expression.evaluate(exchange1, String.class));
+        Boolean matches = predicate.matches(exchange);
+        return exchange
+                .getContext()
+                .getTypeConverter()
+                .convertTo(type, exchange, matches);
+    }
+}


### PR DESCRIPTION
Yes, I know there is a way to verify expressions like:
mock.message(0).header("foo").matches().constant(123);

But still I can't verify a regex this way
There are more possible usages. Say, XpathExpression against a header. I don't think it's possible with the current API