### PR TITLE
CAMEL-20199: Remove synchronized block from components J to M

### DIFF
--- a/components/camel-ai/camel-milvus/src/main/java/org/apache/camel/component/milvus/MilvusEndpoint.java
+++ b/components/camel-ai/camel-milvus/src/main/java/org/apache/camel/component/milvus/MilvusEndpoint.java
@@ -56,8 +56,6 @@ public class MilvusEndpoint extends DefaultEndpoint implements EndpointServiceLo
     @UriParam
     private MilvusConfiguration configuration;
 
-    private final Object lock;
-
     private volatile boolean closeClient;
     private volatile MilvusClient client;
 
@@ -71,8 +69,6 @@ public class MilvusEndpoint extends DefaultEndpoint implements EndpointServiceLo
 
         this.collection = collection;
         this.configuration = configuration;
-
-        this.lock = new Object();
     }
 
     @Override
@@ -93,9 +89,10 @@ public class MilvusEndpoint extends DefaultEndpoint implements EndpointServiceLo
         return collection;
     }
 
-    public synchronized MilvusClient getClient() {
+    public MilvusClient getClient() {
         if (this.client == null) {
-            synchronized (this.lock) {
+            lock.lock();
+            try {
                 if (this.client == null) {
                     this.client = this.configuration.getClient();
                     this.closeClient = false;
@@ -105,6 +102,8 @@ public class MilvusEndpoint extends DefaultEndpoint implements EndpointServiceLo
                         this.closeClient = true;
                     }
                 }
+            } finally {
+                lock.unlock();
             }
         }
 

--- a/components/camel-github/src/main/java/org/apache/camel/component/github/consumer/CommitConsumer.java
+++ b/components/camel-github/src/main/java/org/apache/camel/component/github/consumer/CommitConsumer.java
@@ -75,7 +75,8 @@ public class CommitConsumer extends AbstractGitHubConsumer {
 
     @Override
     protected void doStart() throws Exception {
-        synchronized (this) {
+        lock.lock();
+        try {
             super.doStart();
 
             // ensure we start from clean
@@ -97,24 +98,29 @@ public class CommitConsumer extends AbstractGitHubConsumer {
                 LOG.info("Starting from beginning");
             }
             started = true;
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     protected void doStop() throws Exception {
-        synchronized (this) {
+        lock.lock();
+        try {
             super.doStop();
 
             commitHashes.clear();
             lastSha = null;
             started = false;
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     protected int poll() throws Exception {
-        synchronized (this) {
-
+        lock.lock();
+        try {
             if (!started) {
                 return 0;
             }
@@ -169,6 +175,8 @@ public class CommitConsumer extends AbstractGitHubConsumer {
             }
             LOG.debug("Last sha: {}", lastSha);
             return counter;
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/components/camel-jackson/src/main/java/org/apache/camel/component/jackson/converter/JacksonTypeConverters.java
+++ b/components/camel-jackson/src/main/java/org/apache/camel/component/jackson/converter/JacksonTypeConverters.java
@@ -25,6 +25,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -57,7 +59,7 @@ import org.slf4j.LoggerFactory;
 public final class JacksonTypeConverters {
     private static final Logger LOG = LoggerFactory.getLogger(JacksonTypeConverters.class);
 
-    private final Object lock;
+    private final Lock lock;
     private volatile ObjectMapper defaultMapper;
 
     private boolean init;
@@ -66,7 +68,7 @@ public final class JacksonTypeConverters {
     private String moduleClassNames;
 
     public JacksonTypeConverters() {
-        this.lock = new Object();
+        this.lock = new ReentrantLock();
     }
 
     @Converter
@@ -306,7 +308,8 @@ public final class JacksonTypeConverters {
         }
 
         if (defaultMapper == null) {
-            synchronized (lock) {
+            lock.lock();
+            try {
                 if (defaultMapper == null) {
                     ObjectMapper mapper = new ObjectMapper();
                     if (moduleClassNames != null) {
@@ -322,6 +325,8 @@ public final class JacksonTypeConverters {
 
                     defaultMapper = mapper;
                 }
+            } finally {
+                lock.unlock();
             }
         }
 

--- a/components/camel-jasypt/src/main/java/org/apache/camel/component/jasypt/JasyptPropertiesParser.java
+++ b/components/camel-jasypt/src/main/java/org/apache/camel/component/jasypt/JasyptPropertiesParser.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.jasypt;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -43,14 +45,12 @@ public class JasyptPropertiesParser extends DefaultPropertiesParser {
             = JASYPT_PREFIX_TOKEN.replace("(", "\\(") + "(.+?)" + JASYPT_SUFFIX_TOKEN.replace(")", "\\)");
     private static final Pattern PATTERN = Pattern.compile(JASYPT_REGEX);
 
+    private final Lock lock = new ReentrantLock();
     private StringEncryptor encryptor;
     private String password;
     private String algorithm;
     private String randomSaltGeneratorAlgorithm;
     private String randomIvGeneratorAlgorithm;
-
-    public JasyptPropertiesParser() {
-    }
 
     @Override
     public String parseProperty(String key, String value, PropertiesLookup properties) {
@@ -69,27 +69,32 @@ public class JasyptPropertiesParser extends DefaultPropertiesParser {
         return value;
     }
 
-    private synchronized void initEncryptor() {
-        if (encryptor == null) {
-            StringHelper.notEmpty("password", password);
-            StandardPBEStringEncryptor pbeStringEncryptor = new StandardPBEStringEncryptor();
+    private void initEncryptor() {
+        lock.lock();
+        try {
+            if (encryptor == null) {
+                StringHelper.notEmpty("password", password);
+                StandardPBEStringEncryptor pbeStringEncryptor = new StandardPBEStringEncryptor();
 
-            pbeStringEncryptor.setPassword(password);
-            if (algorithm != null) {
-                pbeStringEncryptor.setAlgorithm(algorithm);
-                log.debug("Initialized encryptor using {} algorithm and provided password", algorithm);
-            } else {
-                log.debug("Initialized encryptor using default algorithm and provided password");
-            }
+                pbeStringEncryptor.setPassword(password);
+                if (algorithm != null) {
+                    pbeStringEncryptor.setAlgorithm(algorithm);
+                    log.debug("Initialized encryptor using {} algorithm and provided password", algorithm);
+                } else {
+                    log.debug("Initialized encryptor using default algorithm and provided password");
+                }
 
-            if (randomSaltGeneratorAlgorithm != null) {
-                pbeStringEncryptor.setSaltGenerator(new RandomSaltGenerator(randomSaltGeneratorAlgorithm));
-            }
-            if (randomIvGeneratorAlgorithm != null) {
-                pbeStringEncryptor.setIvGenerator(new RandomIvGenerator(randomIvGeneratorAlgorithm));
-            }
+                if (randomSaltGeneratorAlgorithm != null) {
+                    pbeStringEncryptor.setSaltGenerator(new RandomSaltGenerator(randomSaltGeneratorAlgorithm));
+                }
+                if (randomIvGeneratorAlgorithm != null) {
+                    pbeStringEncryptor.setIvGenerator(new RandomIvGenerator(randomIvGeneratorAlgorithm));
+                }
 
-            encryptor = pbeStringEncryptor;
+                encryptor = pbeStringEncryptor;
+            }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/components/camel-jaxb/src/main/java/org/apache/camel/converter/jaxb/FallbackTypeConverter.java
+++ b/components/camel-jaxb/src/main/java/org/apache/camel/converter/jaxb/FallbackTypeConverter.java
@@ -28,6 +28,8 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
@@ -63,6 +65,7 @@ public class FallbackTypeConverter {
 
     private static final Logger LOG = LoggerFactory.getLogger(FallbackTypeConverter.class);
 
+    private final Lock lock = new ReentrantLock();
     private final Map<AnnotatedElement, JAXBContext> contexts = new HashMap<>();
     private final StaxConverter staxConverter = new StaxConverter();
     private boolean defaultPrettyPrint = true;
@@ -318,19 +321,24 @@ public class FallbackTypeConverter {
         return exchange != null && exchange.getProperty(Exchange.FILTER_NON_XML_CHARS, Boolean.FALSE, Boolean.class);
     }
 
-    protected synchronized <T> JAXBContext createContext(Class<T> type) throws JAXBException {
+    protected <T> JAXBContext createContext(Class<T> type) throws JAXBException {
         AnnotatedElement ae = hasXmlRootElement(type) ? type : type.getPackage();
-        JAXBContext context = contexts.get(ae);
-        if (context == null) {
-            if (hasXmlRootElement(type)) {
-                context = JAXBContext.newInstance(type);
-                contexts.put(type, context);
-            } else {
-                context = JAXBContext.newInstance(type.getPackage().getName());
-                contexts.put(type.getPackage(), context);
+        lock.lock();
+        try {
+            JAXBContext context = contexts.get(ae);
+            if (context == null) {
+                if (hasXmlRootElement(type)) {
+                    context = JAXBContext.newInstance(type);
+                    contexts.put(type, context);
+                } else {
+                    context = JAXBContext.newInstance(type.getPackage().getName());
+                    contexts.put(type.getPackage(), context);
+                }
             }
+            return context;
+        } finally {
+            lock.unlock();
         }
-        return context;
     }
 
     protected <T> Unmarshaller getUnmarshaller(Class<T> type) throws JAXBException {

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsComponent.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsComponent.java
@@ -1157,14 +1157,19 @@ public class JmsComponent extends HeaderFilterStrategyComponent {
         super.doShutdown();
     }
 
-    protected synchronized ExecutorService getAsyncStartStopExecutorService() {
-        if (asyncStartStopExecutorService == null) {
-            // use a cached thread pool for async start tasks as they can run for a while, and we need a dedicated thread
-            // for each task, and the thread pool will shrink when no more tasks running
-            asyncStartStopExecutorService
-                    = getCamelContext().getExecutorServiceManager().newCachedThreadPool(this, "AsyncStartStopListener");
+    protected ExecutorService getAsyncStartStopExecutorService() {
+        lock.lock();
+        try {
+            if (asyncStartStopExecutorService == null) {
+                // use a cached thread pool for async start tasks as they can run for a while, and we need a dedicated thread
+                // for each task, and the thread pool will shrink when no more tasks running
+                asyncStartStopExecutorService
+                        = getCamelContext().getExecutorServiceManager().newCachedThreadPool(this, "AsyncStartStopListener");
+            }
+            return asyncStartStopExecutorService;
+        } finally {
+            lock.unlock();
         }
-        return asyncStartStopExecutorService;
     }
 
     @Override

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsProducer.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsProducer.java
@@ -78,7 +78,8 @@ public class JmsProducer extends DefaultAsyncProducer {
 
     protected void initReplyManager() {
         if (!started.get()) {
-            synchronized (this) {
+            lock.lock();
+            try {
                 if (started.get()) {
                     return;
                 }
@@ -119,6 +120,8 @@ public class JmsProducer extends DefaultAsyncProducer {
                     Thread.currentThread().setContextClassLoader(oldClassLoader);
                 }
                 started.set(true);
+            } finally {
+                lock.unlock();
             }
         }
     }

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsTemporaryQueueEndpoint.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsTemporaryQueueEndpoint.java
@@ -57,11 +57,16 @@ public class JmsTemporaryQueueEndpoint extends JmsQueueEndpoint implements Desti
     }
 
     @Override
-    public synchronized Destination getJmsDestination(Session session) throws JMSException {
-        if (jmsDestination == null) {
-            jmsDestination = createJmsDestination(session);
+    public Destination getJmsDestination(Session session) throws JMSException {
+        lock.lock();
+        try {
+            if (jmsDestination == null) {
+                jmsDestination = createJmsDestination(session);
+            }
+            return jmsDestination;
+        } finally {
+            lock.unlock();
         }
-        return jmsDestination;
     }
 
     protected Destination createJmsDestination(Session session) throws JMSException {

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsTemporaryTopicEndpoint.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsTemporaryTopicEndpoint.java
@@ -50,11 +50,16 @@ public class JmsTemporaryTopicEndpoint extends JmsEndpoint implements Destinatio
     }
 
     @Override
-    public synchronized Destination getJmsDestination(Session session) throws JMSException {
-        if (jmsDestination == null) {
-            jmsDestination = createJmsDestination(session);
+    public Destination getJmsDestination(Session session) throws JMSException {
+        lock.lock();
+        try {
+            if (jmsDestination == null) {
+                jmsDestination = createJmsDestination(session);
+            }
+            return jmsDestination;
+        } finally {
+            lock.unlock();
         }
-        return jmsDestination;
     }
 
     protected Destination createJmsDestination(Session session) throws JMSException {

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/StreamMessageInputStream.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/StreamMessageInputStream.java
@@ -18,6 +18,8 @@ package org.apache.camel.component.jms;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import jakarta.jms.JMSException;
 import jakarta.jms.MessageEOFException;
@@ -25,6 +27,7 @@ import jakarta.jms.StreamMessage;
 
 public class StreamMessageInputStream extends InputStream {
 
+    private final Lock lock = new ReentrantLock();
     private final StreamMessage message;
     private volatile boolean eof;
 
@@ -74,11 +77,14 @@ public class StreamMessageInputStream extends InputStream {
     }
 
     @Override
-    public synchronized void reset() throws IOException {
+    public void reset() throws IOException {
+        lock.lock();
         try {
             message.reset();
         } catch (JMSException e) {
             throw new IOException(e);
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/reply/QueueReplyManager.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/reply/QueueReplyManager.java
@@ -109,12 +109,15 @@ public class QueueReplyManager extends ReplyManagerSupport {
                 Session session, String destinationName,
                 boolean pubSubDomain)
                 throws JMSException {
-            synchronized (QueueReplyManager.this) {
+            QueueReplyManager.this.lock.lock();
+            try {
                 // resolve the reply to destination
                 if (destination == null) {
                     destination = delegate.resolveDestinationName(session, destinationName, pubSubDomain);
                     setReplyTo(destination);
                 }
+            } finally {
+                QueueReplyManager.this.lock.unlock();
             }
             return destination;
         }

--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaComponent.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaComponent.java
@@ -121,13 +121,18 @@ public class JpaComponent extends HealthCheckComponent {
         return aliases;
     }
 
-    synchronized ExecutorService getOrCreatePollingConsumerExecutorService() {
-        if (pollingConsumerExecutorService == null) {
-            LOG.debug("Creating thread pool for JpaPollingConsumer to support polling using timeout");
-            pollingConsumerExecutorService
-                    = getCamelContext().getExecutorServiceManager().newDefaultThreadPool(this, "JpaPollingConsumer");
+    ExecutorService getOrCreatePollingConsumerExecutorService() {
+        lock.lock();
+        try {
+            if (pollingConsumerExecutorService == null) {
+                LOG.debug("Creating thread pool for JpaPollingConsumer to support polling using timeout");
+                pollingConsumerExecutorService
+                        = getCamelContext().getExecutorServiceManager().newDefaultThreadPool(this, "JpaPollingConsumer");
+            }
+            return pollingConsumerExecutorService;
+        } finally {
+            lock.unlock();
         }
-        return pollingConsumerExecutorService;
     }
 
     // Implementation methods

--- a/components/camel-json-validator/src/main/java/org/apache/camel/component/jsonvalidator/JsonValidatorEndpoint.java
+++ b/components/camel-json-validator/src/main/java/org/apache/camel/component/jsonvalidator/JsonValidatorEndpoint.java
@@ -188,10 +188,13 @@ public class JsonValidatorEndpoint extends ResourceEndpoint {
      * @return The currently loaded schema
      */
     private JsonSchema getOrCreateSchema() throws Exception {
-        synchronized (this) {
+        getInternalLock().lock();
+        try {
             if (this.schema == null) {
                 this.schema = this.uriSchemaLoader.createSchema(getCamelContext(), getResourceUri());
             }
+        } finally {
+            getInternalLock().unlock();
         }
         return this.schema;
     }

--- a/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/JsonStream.java
+++ b/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/JsonStream.java
@@ -275,7 +275,7 @@ public class JsonStream extends FilterInputStream {
     }
 
     @Override
-    public synchronized void reset() throws IOException {
+    public void reset() throws IOException {
         throw new IOException("reset not supported");
     }
 

--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Component.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400Component.java
@@ -86,12 +86,17 @@ public class Jt400Component extends HealthCheckComponent {
      *
      * @return the default connection pool used by this component
      */
-    public synchronized AS400ConnectionPool getConnectionPool() {
-        if (connectionPool == null) {
-            LOG.info("Instantiating the default connection pool ...");
-            connectionPool = new AS400ConnectionPool();
+    public AS400ConnectionPool getConnectionPool() {
+        lock.lock();
+        try {
+            if (connectionPool == null) {
+                LOG.info("Instantiating the default connection pool ...");
+                connectionPool = new AS400ConnectionPool();
+            }
+            return connectionPool;
+        } finally {
+            lock.unlock();
         }
-        return connectionPool;
     }
 
     public void setConnectionPool(AS400ConnectionPool connectionPool) {

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
@@ -651,7 +651,7 @@ public class KafkaFetchRecords implements Runnable {
         state = State.RESUME_REQUESTED;
     }
 
-    private synchronized void setLastError(Exception lastError) {
+    private void setLastError(Exception lastError) {
         this.lastError = lastError;
     }
 

--- a/components/camel-knative/camel-knative-component/src/main/java/org/apache/camel/component/knative/KnativeComponent.java
+++ b/components/camel-knative/camel-knative-component/src/main/java/org/apache/camel/component/knative/KnativeComponent.java
@@ -132,11 +132,16 @@ public class KnativeComponent extends HealthCheckComponent {
         return producerFactory;
     }
 
-    public synchronized KnativeProducerFactory getOrCreateProducerFactory() throws Exception {
-        if (producerFactory == null) {
-            producerFactory = setUpProducerFactory();
+    public KnativeProducerFactory getOrCreateProducerFactory() throws Exception {
+        lock.lock();
+        try {
+            if (producerFactory == null) {
+                producerFactory = setUpProducerFactory();
+            }
+            return producerFactory;
+        } finally {
+            lock.unlock();
         }
-        return producerFactory;
     }
 
     /**
@@ -150,11 +155,16 @@ public class KnativeComponent extends HealthCheckComponent {
         return consumerFactory;
     }
 
-    public synchronized KnativeConsumerFactory getOrCreateConsumerFactory() throws Exception {
-        if (consumerFactory == null) {
-            consumerFactory = setUpConsumerFactory();
+    public KnativeConsumerFactory getOrCreateConsumerFactory() throws Exception {
+        lock.lock();
+        try {
+            if (consumerFactory == null) {
+                consumerFactory = setUpConsumerFactory();
+            }
+            return consumerFactory;
+        } finally {
+            lock.unlock();
         }
-        return consumerFactory;
     }
 
     /**

--- a/components/camel-mybatis/src/main/java/org/apache/camel/component/mybatis/MyBatisComponent.java
+++ b/components/camel-mybatis/src/main/java/org/apache/camel/component/mybatis/MyBatisComponent.java
@@ -45,17 +45,22 @@ public class MyBatisComponent extends HealthCheckComponent {
         return answer;
     }
 
-    protected synchronized SqlSessionFactory createSqlSessionFactory() throws IOException {
-        if (sqlSessionFactory == null) {
-            ObjectHelper.notNull(configurationUri, "configurationUri", this);
-            InputStream is = ResourceHelper.resolveMandatoryResourceAsInputStream(getCamelContext(), configurationUri);
-            try {
-                sqlSessionFactory = new SqlSessionFactoryBuilder().build(is);
-            } finally {
-                IOHelper.close(is);
+    protected SqlSessionFactory createSqlSessionFactory() throws IOException {
+        lock.lock();
+        try {
+            if (sqlSessionFactory == null) {
+                ObjectHelper.notNull(configurationUri, "configurationUri", this);
+                InputStream is = ResourceHelper.resolveMandatoryResourceAsInputStream(getCamelContext(), configurationUri);
+                try {
+                    sqlSessionFactory = new SqlSessionFactoryBuilder().build(is);
+                } finally {
+                    IOHelper.close(is);
+                }
             }
+            return sqlSessionFactory;
+        } finally {
+            lock.unlock();
         }
-        return sqlSessionFactory;
     }
 
     public SqlSessionFactory getSqlSessionFactory() {


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-20199

## Motivation

For better support of virtual threads, we need to avoid lengthy and frequent pinning by replacing synchronized blocks with ReentrantLocks

## Modifications:

* Replace mutex with locks
* Use locks instead of synchronized blocks
* Use ConcurrentHashMap instead of HashMap when possible