### PR TITLE
CAMEL-20199: Remove synchronized block from components N to Q

### DIFF
--- a/components/camel-ai/camel-pinecone/src/main/java/org/apache/camel/component/pinecone/PineconeVectorDbEndpoint.java
+++ b/components/camel-ai/camel-pinecone/src/main/java/org/apache/camel/component/pinecone/PineconeVectorDbEndpoint.java
@@ -73,14 +73,19 @@ public class PineconeVectorDbEndpoint extends DefaultEndpoint {
         return collection;
     }
 
-    public synchronized Pinecone getClient() {
-        if (this.client == null) {
-            this.client = this.configuration.getClient();
+    public Pinecone getClient() {
+        lock.lock();
+        try {
             if (this.client == null) {
-                this.client = createClient();
+                this.client = this.configuration.getClient();
+                if (this.client == null) {
+                    this.client = createClient();
+                }
             }
+            return this.client;
+        } finally {
+            lock.unlock();
         }
-        return this.client;
     }
 
     @Override

--- a/components/camel-ai/camel-qdrant/src/main/java/org/apache/camel/component/qdrant/QdrantEndpoint.java
+++ b/components/camel-ai/camel-qdrant/src/main/java/org/apache/camel/component/qdrant/QdrantEndpoint.java
@@ -55,8 +55,6 @@ public class QdrantEndpoint extends DefaultEndpoint implements EndpointServiceLo
     @UriParam
     private QdrantConfiguration configuration;
 
-    private final Object lock;
-
     private volatile boolean closeClient;
     private volatile QdrantClient client;
 
@@ -70,8 +68,6 @@ public class QdrantEndpoint extends DefaultEndpoint implements EndpointServiceLo
 
         this.collection = collection;
         this.configuration = configuration;
-
-        this.lock = new Object();
     }
 
     @Override
@@ -92,9 +88,10 @@ public class QdrantEndpoint extends DefaultEndpoint implements EndpointServiceLo
         return collection;
     }
 
-    public synchronized QdrantClient getClient() {
+    public QdrantClient getClient() {
         if (this.client == null) {
-            synchronized (this.lock) {
+            lock.lock();
+            try {
                 if (this.client == null) {
                     this.client = this.configuration.getClient();
                     this.closeClient = false;
@@ -104,6 +101,8 @@ public class QdrantEndpoint extends DefaultEndpoint implements EndpointServiceLo
                         this.closeClient = true;
                     }
                 }
+            } finally {
+                lock.unlock();
             }
         }
 

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpComponent.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpComponent.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.netty.http;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Consumer;
@@ -64,8 +65,8 @@ public class NettyHttpComponent extends NettyComponent
     private static final Logger LOG = LoggerFactory.getLogger(NettyHttpComponent.class);
 
     // factories which is created by this component and therefore manage their lifecycles
-    private final Map<Integer, HttpServerConsumerChannelFactory> multiplexChannelHandlers = new HashMap<>();
-    private final Map<String, HttpServerBootstrapFactory> bootstrapFactories = new HashMap<>();
+    private final Map<Integer, HttpServerConsumerChannelFactory> multiplexChannelHandlers = new ConcurrentHashMap<>();
+    private final Map<String, HttpServerBootstrapFactory> bootstrapFactories = new ConcurrentHashMap<>();
     @Metadata(label = "advanced")
     private NettyHttpBinding nettyHttpBinding;
     @Metadata(label = "advanced")
@@ -329,7 +330,7 @@ public class NettyHttpComponent extends NettyComponent
         this.muteException = muteException;
     }
 
-    public synchronized HttpServerConsumerChannelFactory getMultiplexChannelHandler(int port) {
+    public HttpServerConsumerChannelFactory getMultiplexChannelHandler(int port) {
         return multiplexChannelHandlers.computeIfAbsent(port, s -> newHttpServerConsumerChannelFactory(port));
     }
 
@@ -339,8 +340,14 @@ public class NettyHttpComponent extends NettyComponent
         return answer;
     }
 
-    protected synchronized HttpServerBootstrapFactory getOrCreateHttpNettyServerBootstrapFactory(NettyHttpConsumer consumer) {
-        String key = consumer.getConfiguration().getAddress();
+    protected HttpServerBootstrapFactory getOrCreateHttpNettyServerBootstrapFactory(NettyHttpConsumer consumer) {
+        String key;
+        lock.lock();
+        try {
+            key = consumer.getConfiguration().getAddress();
+        } finally {
+            lock.unlock();
+        }
         return bootstrapFactories.computeIfAbsent(key, s -> newHttpServerBootstrapFactory(consumer));
     }
 

--- a/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2AppWrapper.java
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2AppWrapper.java
@@ -18,6 +18,8 @@ package org.apache.camel.component.olingo2;
 
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.olingo2.api.Olingo2App;
@@ -31,6 +33,7 @@ import org.apache.olingo.odata2.api.edm.Edm;
  */
 public class Olingo2AppWrapper {
 
+    private final Lock lock = new ReentrantLock();
     private final Olingo2App olingo2App;
     private volatile Edm edm;
 
@@ -51,8 +54,8 @@ public class Olingo2AppWrapper {
     public Edm getEdm(Map<String, String> endpointHttpHeaders) throws RuntimeCamelException {
         Edm localEdm = edm;
         if (localEdm == null) {
-
-            synchronized (this) {
+            lock.lock();
+            try {
 
                 localEdm = edm;
                 if (localEdm == null) {
@@ -101,6 +104,8 @@ public class Olingo2AppWrapper {
 
                     localEdm = edm;
                 }
+            } finally {
+                lock.unlock();
             }
         }
 

--- a/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Component.java
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Component.java
@@ -122,10 +122,13 @@ public class Olingo2Component extends AbstractApiComponent<Olingo2ApiName, Oling
     public Olingo2AppWrapper createApiProxy(Olingo2Configuration endpointConfiguration) {
         final Olingo2AppWrapper result;
         if (endpointConfiguration.equals(getConfiguration())) {
-            synchronized (this) {
+            lock.lock();
+            try {
                 if (apiProxy == null) {
                     apiProxy = createOlingo2App(getConfiguration());
                 }
+            } finally {
+                lock.unlock();
             }
             result = apiProxy;
         } else {

--- a/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Endpoint.java
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/Olingo2Endpoint.java
@@ -195,8 +195,13 @@ public class Olingo2Endpoint extends AbstractApiEndpoint<Olingo2ApiName, Olingo2
     }
 
     @Override
-    public synchronized Object getApiProxy(ApiMethod method, Map<String, Object> args) {
-        return apiProxy.getOlingo2App();
+    public Object getApiProxy(ApiMethod method, Map<String, Object> args) {
+        lock.lock();
+        try {
+            return apiProxy.getOlingo2App();
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/internal/Olingo2PropertiesHelper.java
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/java/org/apache/camel/component/olingo2/internal/Olingo2PropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.olingo2.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.olingo2.Olingo2Configuration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class Olingo2PropertiesHelper extends ApiMethodPropertiesHelper<Olingo2Configuration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static Olingo2PropertiesHelper helper;
 
     private Olingo2PropertiesHelper(CamelContext context) {
         super(context, Olingo2Configuration.class, Olingo2Constants.PROPERTY_PREFIX);
     }
 
-    public static synchronized Olingo2PropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new Olingo2PropertiesHelper(context);
+    public static Olingo2PropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new Olingo2PropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }

--- a/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4AppWrapper.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4AppWrapper.java
@@ -18,6 +18,8 @@ package org.apache.camel.component.olingo4;
 
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.olingo4.api.Olingo4App;
@@ -32,6 +34,7 @@ import org.apache.olingo.commons.api.edm.Edm;
  */
 public class Olingo4AppWrapper {
 
+    private final Lock lock = new ReentrantLock();
     private final Olingo4App olingo4App;
     private volatile Edm edm;
 
@@ -52,8 +55,8 @@ public class Olingo4AppWrapper {
     public Edm getEdm(Map<String, String> endpointHttpHeaders) throws RuntimeCamelException {
         Edm localEdm = edm;
         if (localEdm == null) {
-
-            synchronized (this) {
+            lock.lock();
+            try {
 
                 localEdm = edm;
                 if (localEdm == null) {
@@ -102,6 +105,8 @@ public class Olingo4AppWrapper {
 
                     localEdm = edm;
                 }
+            } finally {
+                lock.unlock();
             }
         }
 

--- a/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Component.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Component.java
@@ -122,10 +122,13 @@ public class Olingo4Component extends AbstractApiComponent<Olingo4ApiName, Oling
     public Olingo4AppWrapper createApiProxy(Olingo4Configuration endpointConfiguration) {
         final Olingo4AppWrapper result;
         if (endpointConfiguration.equals(getConfiguration())) {
-            synchronized (this) {
+            lock.lock();
+            try {
                 if (apiProxy == null) {
                     apiProxy = createOlingo4App(getConfiguration());
                 }
+            } finally {
+                lock.unlock();
             }
             result = apiProxy;
         } else {

--- a/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Endpoint.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/Olingo4Endpoint.java
@@ -195,8 +195,13 @@ public class Olingo4Endpoint extends AbstractApiEndpoint<Olingo4ApiName, Olingo4
     }
 
     @Override
-    public synchronized Object getApiProxy(ApiMethod method, Map<String, Object> args) {
-        return apiProxy.getOlingo4App();
+    public Object getApiProxy(ApiMethod method, Map<String, Object> args) {
+        lock.lock();
+        try {
+            return apiProxy.getOlingo4App();
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/internal/Olingo4PropertiesHelper.java
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/java/org/apache/camel/component/olingo4/internal/Olingo4PropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.olingo4.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.olingo4.Olingo4Configuration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class Olingo4PropertiesHelper extends ApiMethodPropertiesHelper<Olingo4Configuration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static Olingo4PropertiesHelper helper;
 
     private Olingo4PropertiesHelper(CamelContext context) {
         super(context, Olingo4Configuration.class, Olingo4Constants.PROPERTY_PREFIX);
     }
 
-    public static synchronized Olingo4PropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new Olingo4PropertiesHelper(context);
+    public static Olingo4PropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new Olingo4PropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }

--- a/components/camel-opensearch/src/main/java/org/apache/camel/component/opensearch/OpensearchProducer.java
+++ b/components/camel-opensearch/src/main/java/org/apache/camel/component/opensearch/OpensearchProducer.java
@@ -83,7 +83,6 @@ class OpensearchProducer extends DefaultAsyncProducer {
     private static final Logger LOG = LoggerFactory.getLogger(OpensearchProducer.class);
 
     protected final OpensearchConfiguration configuration;
-    private final Object mutex = new Object();
     private volatile RestClient client;
     private Sniffer sniffer;
 
@@ -452,7 +451,8 @@ class OpensearchProducer extends DefaultAsyncProducer {
 
     private void startClient() {
         if (client == null) {
-            synchronized (mutex) {
+            lock.lock();
+            try {
                 if (client == null) {
                     LOG.info("Connecting to the OpenSearch cluster: {}", configuration.getClusterName());
                     if (ObjectHelper.isNotEmpty(configuration.getHostAddressesList())
@@ -462,6 +462,8 @@ class OpensearchProducer extends DefaultAsyncProducer {
                         LOG.warn("Incorrect ip address and port parameters settings for OpenSearch cluster");
                     }
                 }
+            } finally {
+                lock.unlock();
             }
         }
     }

--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpComponent.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpComponent.java
@@ -65,7 +65,6 @@ public class PlatformHttpComponent extends HeaderFilterStrategyComponent
     private final Set<HttpEndpointModel> httpEndpoints = new TreeSet<>();
     private final List<PlatformHttpListener> listeners = new ArrayList<>();
     private volatile boolean localEngine;
-    private final Object lock = new Object();
 
     public PlatformHttpComponent() {
         this(null);
@@ -270,7 +269,8 @@ public class PlatformHttpComponent extends HeaderFilterStrategyComponent
 
     PlatformHttpEngine getOrCreateEngine() {
         if (engine == null) {
-            synchronized (lock) {
+            lock.lock();
+            try {
                 if (engine == null) {
                     LOG.debug("Lookup platform http engine from registry");
 
@@ -290,6 +290,8 @@ public class PlatformHttpComponent extends HeaderFilterStrategyComponent
                         localEngine = true;
                     }
                 }
+            } finally {
+                lock.unlock();
             }
         }
 

--- a/components/camel-printer/src/main/java/org/apache/camel/component/printer/PrintDocument.java
+++ b/components/camel-printer/src/main/java/org/apache/camel/component/printer/PrintDocument.java
@@ -21,12 +21,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.print.Doc;
 import javax.print.DocFlavor;
 import javax.print.attribute.DocAttributeSet;
 
 class PrintDocument implements Doc {
+    private final Lock lock = new ReentrantLock();
     private DocFlavor docFlavor;
     private InputStream stream;
     private Reader reader;
@@ -54,7 +57,8 @@ class PrintDocument implements Doc {
 
     @Override
     public Reader getReaderForText() throws IOException {
-        synchronized (this) {
+        lock.lock();
+        try {
             if (reader != null) {
                 return reader;
             }
@@ -75,6 +79,8 @@ class PrintDocument implements Doc {
             }
 
             return reader;
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarProducer.java
+++ b/components/camel-pulsar/src/main/java/org/apache/camel/component/pulsar/PulsarProducer.java
@@ -39,7 +39,6 @@ public class PulsarProducer extends DefaultAsyncProducer {
 
     private static final Logger LOG = LoggerFactory.getLogger(PulsarProducer.class);
 
-    private final Object mutex = new Object();
     private final PulsarEndpoint pulsarEndpoint;
     private volatile Producer<byte[]> producer;
 
@@ -120,7 +119,8 @@ public class PulsarProducer extends DefaultAsyncProducer {
     }
 
     private void createProducer() throws PulsarClientException {
-        synchronized (mutex) {
+        lock.lock();
+        try {
             if (producer == null) {
                 final String topicUri = pulsarEndpoint.getUri();
                 PulsarConfiguration configuration = pulsarEndpoint.getPulsarConfiguration();
@@ -147,6 +147,8 @@ public class PulsarProducer extends DefaultAsyncProducer {
                 }
                 producer = producerBuilder.create();
             }
+        } finally {
+            lock.unlock();
         }
     }
 


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-20199

## Motivation

For better support of virtual threads, we need to avoid lengthy and frequent pinning by replacing synchronized blocks with ReentrantLocks

## Modifications:

* Replace mutex with locks
* Use locks instead of synchronized blocks
* Use ConcurrentHashMap instead of HashMap when possible