### PR TITLE
Camel 21403 as2 component   incorrect message length calculation when generating mic for edi messages with multi byte characters

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/ApplicationEntity.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/ApplicationEntity.java
@@ -64,7 +64,7 @@ public abstract class ApplicationEntity extends MimeEntity {
                 canonicalOutstream.writeln(); // ensure empty line between headers and body; RFC2046 - 5.1.1
             }
 
-            transferEncodedStream.write(ediMessage.getBytes(getCharset()), 0, ediMessage.length());
+            transferEncodedStream.write(ediMessage.getBytes(getCharset()));
         } catch (Exception e) {
             throw new IOException("Failed to write to output stream", e);
         }

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/entity/ApplicationEntityTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/entity/ApplicationEntityTest.java
@@ -1,12 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.as2.api.entity;
-
-
-import org.apache.hc.core5.http.ContentType;
-import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+
+import org.apache.hc.core5.http.ContentType;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,7 +32,8 @@ public class ApplicationEntityTest {
     void checkWriteToWithMultiByteCharacter() throws IOException {
         String message = "Test message with special char ó";
 
-        ApplicationEntity applicationEntity = new ApplicationEntity(message, ContentType.TEXT_PLAIN, "binary", true, null) {
+        ContentType contentType = ContentType.create("text/plain", StandardCharsets.UTF_8);
+        ApplicationEntity applicationEntity = new ApplicationEntity(message, contentType, "binary", true, null) {
             @Override
             public void close() throws IOException {
             }
@@ -29,6 +45,7 @@ public class ApplicationEntityTest {
         byte[] actualBytes = outputStream.toByteArray();
 
         assertArrayEquals(expectedBytes, actualBytes, "The output bytes should match the expected UTF-8 encoded bytes.");
-        assertEquals(expectedBytes.length, actualBytes.length, "The byte length should match the length of the UTF-8 encoded message.");
+        assertEquals(expectedBytes.length, actualBytes.length,
+                "The byte length should match the length of the UTF-8 encoded message.");
     }
 }

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/entity/ApplicationEntityTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/entity/ApplicationEntityTest.java
@@ -1,0 +1,34 @@
+package org.apache.camel.component.as2.api.entity;
+
+
+import org.apache.hc.core5.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ApplicationEntityTest {
+
+    @Test
+    void checkWriteToWithMultiByteCharacter() throws IOException {
+        String message = "Test message with special char ó";
+
+        ApplicationEntity applicationEntity = new ApplicationEntity(message, ContentType.TEXT_PLAIN, "binary", true, null) {
+            @Override
+            public void close() throws IOException {
+            }
+        };
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        applicationEntity.writeTo(outputStream);
+
+        byte[] expectedBytes = message.getBytes(StandardCharsets.UTF_8);
+        byte[] actualBytes = outputStream.toByteArray();
+
+        assertArrayEquals(expectedBytes, actualBytes, "The output bytes should match the expected UTF-8 encoded bytes.");
+        assertEquals(expectedBytes.length, actualBytes.length, "The byte length should match the length of the UTF-8 encoded message.");
+    }
+}


### PR DESCRIPTION
# Description
This pull request addresses an issue with the AS2 component in Apache Camel where the message length was incorrectly calculated when generating the Message Integrity Code (MIC) for EDI messages that contain multi-byte characters. The `writeTo` method in the `ApplicationEntity` class was modified to use the correct byte length when writing the EDI message to the output stream.

The fix ensures that the MIC is generated accurately, preventing potential verification issues on the receiving end. A unit test has also been added to verify that the output matches the expected byte array, particularly for multi-byte characters.

# Target

- [x] I checked that the commit is targeting the correct branch (4.8.x)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-21403) filed for the change.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.


