### PR TITLE
CAMEL-20199: camel-jetty - Propagate exception

### DIFF
--- a/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
+++ b/components/camel-jetty-common/src/main/java/org/apache/camel/component/jetty/JettyHttpComponent.java
@@ -312,13 +312,17 @@ public abstract class JettyHttpComponent extends HttpCommonComponent
         JettyHttpEndpoint endpoint = (JettyHttpEndpoint) consumer.getEndpoint();
         String connectorKey = getConnectorKey(endpoint);
 
-        CONNECTORS.compute(connectorKey, (cKey, connectorRef) -> {
-            try {
-                return connect(consumer, endpoint, cKey, connectorRef);
-            } catch (Exception e) {
-                throw new RuntimeCamelException(e);
-            }
-        });
+        try {
+            CONNECTORS.compute(connectorKey, (cKey, connectorRef) -> {
+                try {
+                    return connect(consumer, endpoint, cKey, connectorRef);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+            });
+        } catch (RuntimeCamelException e) {
+            throw (Exception) e.getCause();
+        }
     }
 
     private ConnectorRef connect(
@@ -477,13 +481,17 @@ public abstract class JettyHttpComponent extends HttpCommonComponent
         HttpCommonEndpoint endpoint = consumer.getEndpoint();
         String connectorKey = getConnectorKey(endpoint);
 
-        CONNECTORS.computeIfPresent(connectorKey, (cKey, connectorRef) -> {
-            try {
-                return disconnect(consumer, connectorRef);
-            } catch (Exception e) {
-                throw new RuntimeCamelException(e);
-            }
-        });
+        try {
+            CONNECTORS.computeIfPresent(connectorKey, (cKey, connectorRef) -> {
+                try {
+                    return disconnect(consumer, connectorRef);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+            });
+        } catch (RuntimeCamelException e) {
+            throw (Exception) e.getCause();
+        }
     }
 
     private ConnectorRef disconnect(HttpConsumer consumer, ConnectorRef connectorRef) throws Exception {


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-20199

## Motivation

The PR https://github.com/apache/camel/pull/16134 causes some regressions in the pipeline https://ci-builds.apache.org/job/Camel/job/Camel%20Core%20(Build%20and%20test)/job/main/512/ 

## Modifications:

* Propagate properly the exceptions for backward compatibility reasons