### PR TITLE
CAMEL-21403: retrieve full message for content containing non ASCII chars

### DIFF
--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/util/MicUtilsTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/util/MicUtilsTest.java
@@ -76,6 +76,33 @@ public class MicUtilsTest {
                                               + "UNT+23+00000000000117'\n"
                                               + "UNZ+1+00000000000778'";
 
+    private static final String EDI_MESSAGE_WITH_NON_ASCII = "UNB+UNOA:1+005435656:1+006415160:1+060515:1434+00000000000778'\n"
+                                                             + "UNH+00000000000117+INVOIC:D:97B:UN'\n"
+                                                             + "BGM+380+342459+9'\n"
+                                                             + "DTM+3:20060515:102'\n"
+                                                             + "RFF+ON:521052'\n"
+                                                             + "NAD+BY+792820524::16++CUMMINS MID-RANGE ENGINE PLANT ΠΠΠ'\n"
+                                                             + "NAD+SE+005435656::16++GENERAL WIDGET COMPANY óóó'\n"
+                                                             + "CUX+1:USD'\n"
+                                                             + "LIN+1++157870:IN'\n"
+                                                             + "IMD+F++:::WIDGET ΣΣΣ'\n"
+                                                             + "QTY+47:1020:EA'\n"
+                                                             + "ALI+US'\n"
+                                                             + "MOA+203:1202.58'\n"
+                                                             + "PRI+INV:1.179'\n"
+                                                             + "LIN+2++157871:IN'\n"
+                                                             + "IMD+F++:::DIFFERENT WIDGET ΦΦΦ'\n"
+                                                             + "QTY+47:20:EA'\n"
+                                                             + "ALI+JP'\n"
+                                                             + "MOA+203:410'\n"
+                                                             + "PRI+INV:20.5'\n"
+                                                             + "UNS+S'\n"
+                                                             + "MOA+39:2137.58'\n"
+                                                             + "ALC+C+ABG'\n"
+                                                             + "MOA+8:525'\n"
+                                                             + "UNT+23+00000000000117'\n"
+                                                             + "UNZ+1+00000000000778'";
+
     private static final String EXPECTED_MESSAGE_DIGEST_ALGORITHM = "sha1";
     private static final String EXPECTED_ENCODED_MESSAGE_DIGEST = "XUt+ug5GEDD0X9+Nv8DGYZZThOQ=";
 
@@ -110,6 +137,34 @@ public class MicUtilsTest {
         LOG.debug("Encoded Message Digest: {}", receivedContentMic.getEncodedMessageDigest());
         assertEquals(EXPECTED_ENCODED_MESSAGE_DIGEST, receivedContentMic.getEncodedMessageDigest(),
                 "Unexpected encoded message digest value");
+    }
+
+    // verify that a MIC is calculated correctly for an EDI message containing non ASCII chars
+    @Test
+    public void createReceivedContentMicWithNonAsciiContentTest() throws Exception {
+
+        BasicClassicHttpRequest request = new BasicClassicHttpRequest("POST", "/");
+        request.addHeader(AS2Header.DISPOSITION_NOTIFICATION_OPTIONS, DISPOSITION_NOTIFICATION_OPTIONS_VALUE);
+        request.addHeader(AS2Header.CONTENT_TYPE, "application/edifact;charset=UTF-8");
+
+        InputStream is = new ApplicationEDIFACTEntity(
+                EDI_MESSAGE_WITH_NON_ASCII, StandardCharsets.UTF_8.name(), AS2TransferEncoding.NONE, true, "filename.txt")
+                .getContent();
+        request.setEntity(new BasicHttpEntity(is, ContentType.create(CONTENT_TYPE_VALUE, StandardCharsets.UTF_8)));
+        ReceivedContentMic receivedContentMic = MicUtils.createReceivedContentMic(request, null, null);
+
+        assertNotNull(receivedContentMic, "Failed to create Received Content MIC");
+        assertEquals(EXPECTED_MESSAGE_DIGEST_ALGORITHM, receivedContentMic.getDigestAlgorithmId(),
+                "Unexpected digest algorithm value");
+
+        // calculate the MIC of the EDI message directly for comparison
+        String expectedDigest = new ReceivedContentMic(
+                "sha1", MicUtils.createMic(
+                        // the entity parser appends 'CR' and 'LF' for each line
+                        EDI_MESSAGE_WITH_NON_ASCII.replaceAll("\n", "\r\n").getBytes(StandardCharsets.UTF_8), "sha1"))
+                .getEncodedMessageDigest();
+
+        assertEquals(expectedDigest, receivedContentMic.getEncodedMessageDigest(), "Unexpected encoded message digest value");
     }
 
     @ParameterizedTest

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2AsyncMDNServerManagerIT.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2AsyncMDNServerManagerIT.java
@@ -112,13 +112,9 @@ public class AS2AsyncMDNServerManagerIT extends AbstractAS2ITSupport {
 
     private static final int RECEIPT_SERVER_PORT = AvailablePortFinder.getNextAvailable();
     private static final int RECEIPT_SERVER_PORT2 = AvailablePortFinder.getNextAvailable();
-
     private static final int RECEIPT_SERVER_PORT3 = AvailablePortFinder.getNextAvailable();
     private static final int RECEIPT_SERVER_PORT4 = AvailablePortFinder.getNextAvailable();
 
-    //    private static final String RECIPIENT_DELIVERY_ADDRESS = "http://localhost:" + RECEIPT_SERVER_PORT + "/handle-receipts";
-    //    private static final String RECIPIENT_DELIVERY_ADDRESS2 = "http://localhost:" + RECEIPT_SERVER_PORT2 + "/handle-receipts";
-    //    private static final String MOCK_RECEIPT_ENDPOINT = "mock:as2RcvRcptMsgs";
     private static AS2ServerConnection serverConnection;
     private static RequestHandler requestHandler;
     private static final String[] SIGNED_RECEIPT_MIC_ALGORITHMS = new String[] { "sha1", "md5" };


### PR DESCRIPTION
# Description

For a message containing non ASCII chars the length of the message byte array may be longer than the EDI message string length since non ASCII chars can be more that one byte. 

Also fixes one of the Integration tests that appeared a bit flaky.

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

