### PR TITLE
fix(components/plc4x): fix NPE when Camel can not establish connection

### DIFF
--- a/components/camel-plc4x/src/main/java/org/apache/camel/component/plc4x/Plc4XEndpoint.java
+++ b/components/camel-plc4x/src/main/java/org/apache/camel/component/plc4x/Plc4XEndpoint.java
@@ -123,7 +123,7 @@ public class Plc4XEndpoint extends DefaultEndpoint implements EndpointServiceLoc
     public void setupConnection() throws PlcConnectionException {
         try {
             connection = plcDriverManager.getConnection(this.uri);
-            if (!connection.isConnected()) {
+            if (!isConnected()) {
                 reconnectIfNeeded();
             }
         } catch (PlcConnectionException e) {
@@ -147,15 +147,15 @@ public class Plc4XEndpoint extends DefaultEndpoint implements EndpointServiceLoc
      * @throws PlcConnectionException If reconnect failed and auto-reconnect is turned on
      */
     public void reconnectIfNeeded() throws PlcConnectionException {
-        if (connection != null && connection.isConnected()) {
+        if (isConnected()) {
             LOGGER.trace("No reconnect needed, already connected");
         } else if (autoReconnect && connection == null) {
             connection = plcDriverManager.getConnection(uri);
             LOGGER.debug("Successfully reconnected");
-        } else if (autoReconnect && !connection.isConnected()) {
+        } else if (autoReconnect && !isConnected()) {
             connection.connect();
             // If reconnection fails without Exception, reset connection
-            if (!connection.isConnected()) {
+            if (!isConnected()) {
                 LOGGER.debug("No connection established after connect, resetting connection");
                 connection = plcDriverManager.getConnection(uri);
             }
@@ -171,6 +171,13 @@ public class Plc4XEndpoint extends DefaultEndpoint implements EndpointServiceLoc
      */
     public boolean canWrite() {
         return connection.getMetadata().isWriteSupported();
+    }
+
+    /**
+     * @return true if connection is established and still connected
+     */
+    public boolean isConnected() {
+        return connection != null && connection.isConnected();
     }
 
     @Override
@@ -251,7 +258,7 @@ public class Plc4XEndpoint extends DefaultEndpoint implements EndpointServiceLoc
     @Override
     public void doStop() throws Exception {
         //Shutting down the connection when leaving the Context
-        if (connection != null && connection.isConnected()) {
+        if (isConnected()) {
             connection.close();
             connection = null;
         }

--- a/components/camel-plc4x/src/main/java/org/apache/camel/component/plc4x/Plc4XProducer.java
+++ b/components/camel-plc4x/src/main/java/org/apache/camel/component/plc4x/Plc4XProducer.java
@@ -49,6 +49,9 @@ public class Plc4XProducer extends DefaultAsyncProducer {
         super.doStart();
         try {
             plc4XEndpoint.setupConnection();
+            if (plc4XEndpoint.isConnected() && !plc4XEndpoint.canWrite()) {
+                throw new PlcException("This connection (" + plc4XEndpoint.getUri() + ") doesn't support writing.");
+            }
         } catch (PlcConnectionException e) {
             if (log.isTraceEnabled()) {
                 log.error("Connection setup failed, stopping producer", e);
@@ -57,15 +60,15 @@ public class Plc4XProducer extends DefaultAsyncProducer {
             }
             doStop();
         }
-        if (!plc4XEndpoint.canWrite()) {
-            throw new PlcException("This connection (" + plc4XEndpoint.getUri() + ") doesn't support writing.");
-        }
     }
 
     @Override
     public void process(Exchange exchange) throws Exception {
         try {
             plc4XEndpoint.reconnectIfNeeded();
+            if (plc4XEndpoint.isConnected() && !plc4XEndpoint.canWrite()) {
+                throw new PlcException("This connection (" + plc4XEndpoint.getUri() + ") doesn't support writing.");
+            }
         } catch (PlcConnectionException e) {
             if (log.isTraceEnabled()) {
                 log.warn("Unable to reconnect, skipping request", e);


### PR DESCRIPTION
# Description
When Camel can not establish the connection to the S7 PLC, the component is throwing follow-up exceptions which are causing the application start up to fail and which hide the real connection issue.
- Added isConnected() to endpoint which checks if connection is null. This method is public to allow external logic to check if endpoint is really connected.
- Moved canWrite() call to be checked only when connected.
- Added additional canWrite() check after reconnectIfNeeded().

Steps to reproduce:
- Add Camel route with S7 driver
- PLC is not available
- Connection failure
- Additional NullPointerExceptions are thrown

# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

