### PR TITLE
(chores) camel-etcd3: prevent manual test from running

### DIFF
--- a/components/camel-etcd3/src/test/java/org/apache/camel/component/etcd3/AggregateEtcd3ManualTest.java
+++ b/components/camel-etcd3/src/test/java/org/apache/camel/component/etcd3/AggregateEtcd3ManualTest.java
@@ -20,6 +20,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.etcd3.processor.aggregate.Etcd3AggregationRepository;
 import org.apache.camel.component.etcd3.support.Etcd3TestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
  * of message 1,2 and 4 as they use the same correlation key.
  * <p/>
  */
+@Disabled("This is a manual test and should not run automatically")
 class AggregateEtcd3ManualTest extends Etcd3TestSupport {
 
     @Test

--- a/components/camel-plc4x/src/test/java/org/apache/camel/component/plc4x/ManualTest.java
+++ b/components/camel-plc4x/src/test/java/org/apache/camel/component/plc4x/ManualTest.java
@@ -21,7 +21,9 @@ import java.util.Date;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
 import org.apache.camel.main.MainListenerSupport;
+import org.junit.jupiter.api.Disabled;
 
+@Disabled("Run this test manually")
 public class ManualTest {
 
     private Main main;


### PR DESCRIPTION
This blocks the test on multiple architectures