### PR TITLE
CAMEL-6766 Generated produces string now includes media types from all responses

### DIFF
--- a/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/OpenApiUtils.java
+++ b/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/OpenApiUtils.java
@@ -92,11 +92,16 @@ public class OpenApiUtils {
     public String getProduces(Operation operation) {
         // the operation may have specific information what it can produce
         if (operation.getResponses() != null) {
+            HashSet<String> mediaTypes = new HashSet<>();
             for (var apiResponse : operation.getResponses().values()) {
                 Content content = apiResponse.getContent();
                 if (content != null) {
-                    return content.keySet().stream().sorted().collect(Collectors.joining(","));
+                    mediaTypes.addAll(content.keySet());
                 }
+            }
+
+            if (!mediaTypes.isEmpty()) {
+                return mediaTypes.stream().sorted().collect(Collectors.joining(","));
             }
         }
         return null;

--- a/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/OpenApiUtilsTest.java
+++ b/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/OpenApiUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.rest.openapi;
+
+import io.swagger.v3.oas.models.Operation;
+
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OpenApiUtilsTest {
+    @Test
+    public void shouldReturnAllProduces() {
+        Operation operation = new Operation();
+
+        ApiResponses responses = new ApiResponses();
+        responses.addApiResponse("200", createResponse("application/json", "application/xml"));
+        responses.addApiResponse("400", createResponse("application/problem+json"));
+        responses.addApiResponse("404", createResponse("application/problem+json"));
+        operation.setResponses(responses);
+
+        OpenApiUtils utils = new OpenApiUtils(null, null, null);
+        assertThat(utils.getProduces(operation)).isEqualTo("application/json,application/problem+json,application/xml");
+    }
+
+    private ApiResponse createResponse(String... contentTypes) {
+        ApiResponse response = new ApiResponse();
+
+        Content content = new Content();
+        for (String contentType : contentTypes) {
+            content.addMediaType(contentType, new MediaType());
+        }
+        response.setContent(content);
+
+        return response;
+    }
+}

--- a/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/OpenApiUtilsTest.java
+++ b/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/OpenApiUtilsTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.rest.openapi;
 
 import io.swagger.v3.oas.models.Operation;
-
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.responses.ApiResponse;


### PR DESCRIPTION
# Description

Changed the behavior to include media types from all existing responses when generating produces string. Information about previous behavior can be seen in [issue 6776](https://github.com/apache/camel-quarkus/issues/6766).

Of some reason, I wasn't able to download artifacts from https://repository.apache.org/snapshots so I have not been able to run `mvn clean install -DskipTests`.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

