### PR TITLE
CAMEL-21432: camel-core - Prevent 0 as cache size for multicast EIP (4.4)

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -172,7 +171,7 @@ public class MulticastProcessor extends AsyncProcessorSupport
     private boolean shutdownAggregateExecutorService;
     private final long timeout;
     private final int cacheSize;
-    private final ConcurrentMap<Processor, Processor> errorHandlers;
+    private final Map<Processor, Processor> errorHandlers;
     private final boolean shareUnitOfWork;
 
     public MulticastProcessor(CamelContext camelContext, Route route, Collection<Processor> processors) {
@@ -183,7 +182,7 @@ public class MulticastProcessor extends AsyncProcessorSupport
                               AggregationStrategy aggregationStrategy) {
         this(camelContext, route, processors, aggregationStrategy, false, null,
              false, false, false, 0, null,
-             false, false, CamelContextHelper.getMaximumCachePoolSize(camelContext));
+             false, false, 0);
     }
 
     public MulticastProcessor(CamelContext camelContext, Route route, Collection<Processor> processors,
@@ -212,9 +211,9 @@ public class MulticastProcessor extends AsyncProcessorSupport
         this.parallelAggregate = parallelAggregate;
         this.processorExchangeFactory = camelContext.getCamelContextExtension()
                 .getProcessorExchangeFactory().newProcessorExchangeFactory(this);
-        this.cacheSize = cacheSize;
-        if (cacheSize >= 0) {
-            this.errorHandlers = (ConcurrentMap) LRUCacheFactory.newLRUCache(cacheSize);
+        this.cacheSize = cacheSize == 0 ? CamelContextHelper.getMaximumCachePoolSize(camelContext) : cacheSize;
+        if (this.cacheSize > 0) {
+            this.errorHandlers = LRUCacheFactory.newLRUCache(this.cacheSize);
         } else {
             // no cache
             this.errorHandlers = null;

--- a/core/camel-core/src/test/java/org/apache/camel/support/cache/SimpleLRUCacheTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/cache/SimpleLRUCacheTest.java
@@ -324,6 +324,13 @@ class SimpleLRUCacheTest {
     }
 
     @ParameterizedTest
+    @ValueSource(ints = { 0, -1 })
+    void validateCacheSize(int maximumCacheSize) {
+        assertThrows(IllegalArgumentException.class, () -> new SimpleLRUCache<>(16, maximumCacheSize, x -> {
+        }));
+    }
+
+    @ParameterizedTest
     @ValueSource(ints = { 1, 2, 5, 10, 20, 50, 100, 1_000 })
     void concurrentPut(int maximumCacheSize) throws Exception {
         int threads = Runtime.getRuntime().availableProcessors();

--- a/core/camel-support/src/main/java/org/apache/camel/support/cache/SimpleLRUCache.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/cache/SimpleLRUCache.java
@@ -68,6 +68,9 @@ public class SimpleLRUCache<K, V> extends ConcurrentHashMap<K, V> {
 
     public SimpleLRUCache(int initialCapacity, int maximumCacheSize, Consumer<V> evicted) {
         super(initialCapacity, DEFAULT_LOAD_FACTOR);
+        if (maximumCacheSize <= 0) {
+            throw new IllegalArgumentException("The maximum cache size must be greater than 0");
+        }
         this.maximumCacheSize = maximumCacheSize;
         this.evict = Objects.requireNonNull(evicted);
     }


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-21432 (v 4.4)

## Motivation

The splitter and multicast EIPs set the cache size to 0 by default which causes endless evictions

## Modifications:

1. Prevent to set 0 as cache size at the cache level
2. Use the value of `CamelContextHelper.getMaximumCachePoolSize` as the default cache size for the splitter and multicast EIPs 