### PR TITLE
CAMEL-21432: camel-core - Prevent 0 as cache size for multicast EIP (4.8)

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/support/cache/SimpleLRUCacheTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/cache/SimpleLRUCacheTest.java
@@ -327,6 +327,13 @@ class SimpleLRUCacheTest {
     }
 
     @ParameterizedTest
+    @ValueSource(ints = { 0, -1 })
+    void validateCacheSize(int maximumCacheSize) {
+        assertThrows(IllegalArgumentException.class, () -> new SimpleLRUCache<>(16, maximumCacheSize, x -> {
+        }));
+    }
+
+    @ParameterizedTest
     @ValueSource(ints = { 1, 2, 5, 10, 20, 50, 100, 1_000 })
     void concurrentPut(int maximumCacheSize) throws Exception {
         int threads = Runtime.getRuntime().availableProcessors() - 1;

--- a/core/camel-support/src/main/java/org/apache/camel/support/cache/SimpleLRUCache.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/cache/SimpleLRUCache.java
@@ -68,6 +68,9 @@ public class SimpleLRUCache<K, V> extends ConcurrentHashMap<K, V> {
 
     public SimpleLRUCache(int initialCapacity, int maximumCacheSize, Consumer<V> evicted) {
         super(initialCapacity, DEFAULT_LOAD_FACTOR);
+        if (maximumCacheSize <= 0) {
+            throw new IllegalArgumentException("The maximum cache size must be greater than 0");
+        }
         this.maximumCacheSize = maximumCacheSize;
         this.evict = Objects.requireNonNull(evicted);
     }


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-21432 (v 4.8)

## Motivation

The splitter and multicast EIPs set the cache size to 0 by default which causes endless evictions

## Modifications:

1. Prevent to set 0 as cache size at the cache level
2. Use the value of `CamelContextHelper.getMaximumCachePoolSize` as the default cache size for the splitter and multicast EIPs 