### PR TITLE
fix: solve pagination exception in DHIS2 component caused by Jackson update

### DIFF
--- a/components/camel-dhis2/camel-dhis2-api/src/test/java/org/apache/camel/component/dhis2/api/Dhis2GetTestCase.java
+++ b/components/camel-dhis2/camel-dhis2-api/src/test/java/org/apache/camel/component/dhis2/api/Dhis2GetTestCase.java
@@ -180,10 +180,7 @@ public class Dhis2GetTestCase {
         Dhis2Response dhis2Response = new Dhis2Response() {
             @Override
             public <T> T returnAs(Class<T> responseType) {
-                Page page = new Page(1, 50);
-                page.setAdditionalProperty("bunnies", new ArrayList<>());
-
-                return (T) page;
+                return (T) new Page(1, 50, Map.of("bunnies", new ArrayList<>()));
             }
 
             @Override

--- a/components/camel-dhis2/camel-dhis2-component/src/test/java/org/apache/camel/component/dhis2/Dhis2GetIT.java
+++ b/components/camel-dhis2/camel-dhis2-component/src/test/java/org/apache/camel/component/dhis2/Dhis2GetIT.java
@@ -48,7 +48,7 @@ public class Dhis2GetIT extends AbstractDhis2TestSupport {
         final Map<String, Object> headers = new HashMap<>();
         headers.put("CamelDhis2.path", "organisationUnits");
         headers.put("CamelDhis2.arrayName", "organisationUnits");
-        headers.put("CamelDhis2.paging", false); // https://github.com/dhis2/dhis2-java-sdk/issues/209
+        headers.put("CamelDhis2.paging", true);
         headers.put("CamelDhis2.fields", null);
         headers.put("CamelDhis2.filter", null);
         headers.put("CamelDhis2.queryParams", new HashMap<>());

--- a/components/camel-dhis2/pom.xml
+++ b/components/camel-dhis2/pom.xml
@@ -34,7 +34,7 @@
     <description>Camel DHIS2 Component</description>
 
     <properties>
-        <dhis2-java-sdk.version>3.0.0</dhis2-java-sdk.version>
+        <dhis2-java-sdk.version>3.0.1</dhis2-java-sdk.version>
 
          <!-- DHIS2 container is not available on these platforms -->
         <skipITs.ppc64le>true</skipITs.ppc64le>


### PR DESCRIPTION
# Description

Solve pagination exception in DHIS2 component caused by Jackson update. See https://github.com/dhis2/dhis2-java-sdk/issues/209

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

