### PR TITLE
CAMEL-20199: Remove synchronized blocks from components R to S

### DIFF
--- a/components/camel-reactive-streams/src/main/java/org/apache/camel/component/reactive/streams/ReactiveStreamsComponent.java
+++ b/components/camel-reactive-streams/src/main/java/org/apache/camel/component/reactive/streams/ReactiveStreamsComponent.java
@@ -161,29 +161,34 @@ public class ReactiveStreamsComponent extends DefaultComponent {
      *
      * @return the reactive streams service
      */
-    public synchronized CamelReactiveStreamsService getReactiveStreamsService() {
-        if (reactiveStreamsEngineConfiguration == null) {
-            reactiveStreamsEngineConfiguration = new ReactiveStreamsEngineConfiguration();
-            reactiveStreamsEngineConfiguration.setThreadPoolMaxSize(threadPoolMaxSize);
-            reactiveStreamsEngineConfiguration.setThreadPoolMinSize(threadPoolMinSize);
-            reactiveStreamsEngineConfiguration.setThreadPoolName(threadPoolName);
-        }
-
-        if (service == null) {
-            this.service = ReactiveStreamsHelper.resolveReactiveStreamsService(
-                    getCamelContext(),
-                    this.serviceType,
-                    this.reactiveStreamsEngineConfiguration);
-
-            try {
-                // Start the service and add it to the Camel context to expose managed attributes
-                getCamelContext().addService(service, true, true);
-            } catch (Exception e) {
-                throw new RuntimeCamelException(e);
+    public CamelReactiveStreamsService getReactiveStreamsService() {
+        lock.lock();
+        try {
+            if (reactiveStreamsEngineConfiguration == null) {
+                reactiveStreamsEngineConfiguration = new ReactiveStreamsEngineConfiguration();
+                reactiveStreamsEngineConfiguration.setThreadPoolMaxSize(threadPoolMaxSize);
+                reactiveStreamsEngineConfiguration.setThreadPoolMinSize(threadPoolMinSize);
+                reactiveStreamsEngineConfiguration.setThreadPoolName(threadPoolName);
             }
-        }
 
-        return service;
+            if (service == null) {
+                this.service = ReactiveStreamsHelper.resolveReactiveStreamsService(
+                        getCamelContext(),
+                        this.serviceType,
+                        this.reactiveStreamsEngineConfiguration);
+
+                try {
+                    // Start the service and add it to the Camel context to expose managed attributes
+                    getCamelContext().addService(service, true, true);
+                } catch (Exception e) {
+                    throw new RuntimeCamelException(e);
+                }
+            }
+
+            return service;
+        } finally {
+            lock.unlock();
+        }
     }
 
     // ****************************************

--- a/components/camel-rocketmq/src/main/java/org/apache/camel/component/rocketmq/RocketMQProducer.java
+++ b/components/camel-rocketmq/src/main/java/org/apache/camel/component/rocketmq/RocketMQProducer.java
@@ -136,7 +136,8 @@ public class RocketMQProducer extends DefaultAsyncProducer {
 
     protected void initReplyManager() {
         if (!started.get()) {
-            synchronized (this) {
+            lock.lock();
+            try {
                 if (started.get()) {
                     return;
                 }
@@ -160,6 +161,8 @@ public class RocketMQProducer extends DefaultAsyncProducer {
                     }
                 }
                 started.set(true);
+            } finally {
+                lock.unlock();
             }
         }
     }

--- a/components/camel-scheduler/src/main/java/org/apache/camel/component/scheduler/SchedulerComponent.java
+++ b/components/camel-scheduler/src/main/java/org/apache/camel/component/scheduler/SchedulerComponent.java
@@ -17,8 +17,8 @@
 package org.apache.camel.component.scheduler;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -29,8 +29,7 @@ import org.apache.camel.support.HealthCheckComponent;
 @org.apache.camel.spi.annotations.Component("scheduler")
 public class SchedulerComponent extends HealthCheckComponent {
 
-    private final Map<String, ScheduledExecutorService> executors = new HashMap<>();
-    private final Map<String, AtomicInteger> refCounts = new HashMap<>();
+    private final Map<String, ScheduledExecutorServiceHolder> executors = new ConcurrentHashMap<>();
 
     @Metadata
     private boolean includeMetadata;
@@ -75,53 +74,46 @@ public class SchedulerComponent extends HealthCheckComponent {
 
     protected ScheduledExecutorService addConsumer(SchedulerConsumer consumer) {
         String name = consumer.getEndpoint().getName();
-        int poolSize = consumer.getEndpoint().getPoolSize();
-
-        ScheduledExecutorService answer;
-        synchronized (executors) {
-            answer = executors.get(name);
-            if (answer == null) {
-                answer = getCamelContext().getExecutorServiceManager().newScheduledThreadPool(this, "scheduler://" + name,
-                        poolSize);
-                executors.put(name, answer);
-                // store new reference counter
-                refCounts.put(name, new AtomicInteger(1));
-            } else {
-                // increase reference counter
-                AtomicInteger counter = refCounts.get(name);
-                if (counter != null) {
-                    counter.incrementAndGet();
-                }
+        return executors.compute(name, (k, v) -> {
+            if (v == null) {
+                int poolSize = consumer.getEndpoint().getPoolSize();
+                return new ScheduledExecutorServiceHolder(
+                        getCamelContext().getExecutorServiceManager().newScheduledThreadPool(this, "scheduler://" + name,
+                                poolSize));
             }
-        }
-        return answer;
+            v.refCount.incrementAndGet();
+            return v;
+        }).executorService;
     }
 
     protected void removeConsumer(SchedulerConsumer consumer) {
         String name = consumer.getEndpoint().getName();
 
-        synchronized (executors) {
-            // decrease reference counter
-            AtomicInteger counter = refCounts.get(name);
-            if (counter != null && counter.decrementAndGet() <= 0) {
-                refCounts.remove(name);
-                // remove scheduler as its no longer in use
-                ScheduledExecutorService scheduler = executors.remove(name);
-                if (scheduler != null) {
-                    getCamelContext().getExecutorServiceManager().shutdown(scheduler);
-                }
+        executors.computeIfPresent(name, (k, v) -> {
+            if (v.refCount.decrementAndGet() == 0) {
+                getCamelContext().getExecutorServiceManager().shutdown(v.executorService);
+                return null;
             }
-        }
+            return v;
+        });
     }
 
     @Override
     protected void doStop() throws Exception {
-        Collection<ScheduledExecutorService> collection = executors.values();
-        for (ScheduledExecutorService scheduler : collection) {
-            getCamelContext().getExecutorServiceManager().shutdown(scheduler);
+        Collection<ScheduledExecutorServiceHolder> collection = executors.values();
+        for (ScheduledExecutorServiceHolder holder : collection) {
+            getCamelContext().getExecutorServiceManager().shutdown(holder.executorService);
         }
         executors.clear();
-        refCounts.clear();
     }
 
+    private static class ScheduledExecutorServiceHolder {
+        private final ScheduledExecutorService executorService;
+        private final AtomicInteger refCount;
+
+        ScheduledExecutorServiceHolder(ScheduledExecutorService executorService) {
+            this.executorService = executorService;
+            this.refCount = new AtomicInteger(1);
+        }
+    }
 }

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaComponent.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaComponent.java
@@ -144,69 +144,78 @@ public class SedaComponent extends DefaultComponent {
         this.defaultPollTimeout = defaultPollTimeout;
     }
 
-    public synchronized QueueReference getOrCreateQueue(
+    public QueueReference getOrCreateQueue(
             SedaEndpoint endpoint, Integer size, Boolean multipleConsumers, BlockingQueueFactory<Exchange> customQueueFactory) {
+        lock.lock();
+        try {
+            String key = getQueueKey(endpoint.getEndpointUri());
 
-        String key = getQueueKey(endpoint.getEndpointUri());
-
-        if (size == null) {
-            // there may be a custom size during startup
-            size = customSize.get(key);
-        }
-
-        QueueReference ref = getQueues().get(key);
-        if (ref != null) {
-            // if the given size is not provided, we just use the existing queue as is
-            if (size != null && !size.equals(ref.getSize())) {
-                // there is already a queue, so make sure the size matches
-                throw new IllegalArgumentException(
-                        "Cannot use existing queue " + key + " as the existing queue size "
-                                                   + (ref.getSize() != null ? ref.getSize() : SedaConstants.QUEUE_SIZE)
-                                                   + " does not match given queue size " + size);
+            if (size == null) {
+                // there may be a custom size during startup
+                size = customSize.get(key);
             }
-            // add the reference before returning queue
-            ref.addReference(endpoint);
 
-            if (log.isDebugEnabled()) {
-                log.debug("Reusing existing queue {} with size {} and reference count {}", key, size, ref.getCount());
+            QueueReference ref = getQueues().get(key);
+            if (ref != null) {
+                // if the given size is not provided, we just use the existing queue as is
+                if (size != null && !size.equals(ref.getSize())) {
+                    // there is already a queue, so make sure the size matches
+                    throw new IllegalArgumentException(
+                            "Cannot use existing queue " + key + " as the existing queue size "
+                                                       + (ref.getSize() != null ? ref.getSize() : SedaConstants.QUEUE_SIZE)
+                                                       + " does not match given queue size " + size);
+                }
+                // add the reference before returning queue
+                ref.addReference(endpoint);
+
+                if (log.isDebugEnabled()) {
+                    log.debug("Reusing existing queue {} with size {} and reference count {}", key, size, ref.getCount());
+                }
+                return ref;
             }
-            return ref;
-        }
 
-        // create queue
-        BlockingQueue<Exchange> queue;
-        BlockingQueueFactory<Exchange> queueFactory = customQueueFactory == null ? defaultQueueFactory : customQueueFactory;
-        if (size != null && size > 0) {
-            queue = queueFactory.create(size);
-        } else {
-            if (getQueueSize() > 0) {
-                size = getQueueSize();
-                queue = queueFactory.create(getQueueSize());
+            // create queue
+            BlockingQueue<Exchange> queue;
+            BlockingQueueFactory<Exchange> queueFactory = customQueueFactory == null ? defaultQueueFactory : customQueueFactory;
+            if (size != null && size > 0) {
+                queue = queueFactory.create(size);
             } else {
-                queue = queueFactory.create();
+                if (getQueueSize() > 0) {
+                    size = getQueueSize();
+                    queue = queueFactory.create(getQueueSize());
+                } else {
+                    queue = queueFactory.create();
+                }
             }
-        }
-        log.debug("Created queue {} with size {}", key, size);
+            log.debug("Created queue {} with size {}", key, size);
 
-        // create and add a new reference queue
-        ref = new QueueReference(queue, size, multipleConsumers);
-        ref.addReference(endpoint);
-        getQueues().put(key, ref);
-
-        return ref;
-    }
-
-    public synchronized QueueReference registerQueue(SedaEndpoint endpoint, BlockingQueue<Exchange> queue) {
-        String key = getQueueKey(endpoint.getEndpointUri());
-
-        QueueReference ref = getQueues().get(key);
-        if (ref == null) {
-            ref = new QueueReference(queue, endpoint.getSize(), endpoint.isMultipleConsumers());
+            // create and add a new reference queue
+            ref = new QueueReference(queue, size, multipleConsumers);
             ref.addReference(endpoint);
             getQueues().put(key, ref);
-        }
 
-        return ref;
+            return ref;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public QueueReference registerQueue(SedaEndpoint endpoint, BlockingQueue<Exchange> queue) {
+        lock.lock();
+        try {
+            String key = getQueueKey(endpoint.getEndpointUri());
+
+            QueueReference ref = getQueues().get(key);
+            if (ref == null) {
+                ref = new QueueReference(queue, endpoint.getSize(), endpoint.isMultipleConsumers());
+                ref.addReference(endpoint);
+                getQueues().put(key, ref);
+            }
+
+            return ref;
+        } finally {
+            lock.unlock();
+        }
     }
 
     public Map<String, QueueReference> getQueues() {

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsComponent.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsComponent.java
@@ -134,14 +134,19 @@ public class SjmsComponent extends HeaderFilterStrategyComponent {
         super.doShutdown();
     }
 
-    protected synchronized ExecutorService getAsyncStartStopExecutorService() {
-        if (asyncStartStopExecutorService == null) {
-            // use a cached thread pool for async start tasks as they can run for a while, and we need a dedicated thread
-            // for each task, and the thread pool will shrink when no more tasks running
-            asyncStartStopExecutorService
-                    = getCamelContext().getExecutorServiceManager().newCachedThreadPool(this, "AsyncStartStopListener");
+    protected ExecutorService getAsyncStartStopExecutorService() {
+        lock.lock();
+        try {
+            if (asyncStartStopExecutorService == null) {
+                // use a cached thread pool for async start tasks as they can run for a while, and we need a dedicated thread
+                // for each task, and the thread pool will shrink when no more tasks running
+                asyncStartStopExecutorService
+                        = getCamelContext().getExecutorServiceManager().newCachedThreadPool(this, "AsyncStartStopListener");
+            }
+            return asyncStartStopExecutorService;
+        } finally {
+            lock.unlock();
         }
-        return asyncStartStopExecutorService;
     }
 
     public void setConnectionFactory(ConnectionFactory connectionFactory) {

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsProducer.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsProducer.java
@@ -95,7 +95,8 @@ public class SjmsProducer extends DefaultAsyncProducer {
 
     protected void initReplyManager() {
         if (!started.get()) {
-            synchronized (this) {
+            lock.lock();
+            try {
                 if (started.get()) {
                     return;
                 }
@@ -136,6 +137,8 @@ public class SjmsProducer extends DefaultAsyncProducer {
                     Thread.currentThread().setContextClassLoader(oldClassLoader);
                 }
                 started.set(true);
+            } finally {
+                lock.unlock();
             }
         }
     }

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/reply/QueueReplyManager.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/reply/QueueReplyManager.java
@@ -73,12 +73,15 @@ public class QueueReplyManager extends ReplyManagerSupport {
 
         @Override
         public Destination createDestination(Session session, String destinationName, boolean topic) throws JMSException {
-            synchronized (QueueReplyManager.this) {
+            QueueReplyManager.this.lock.lock();
+            try {
                 // resolve the reply to destination
                 if (destination == null) {
                     destination = delegate.createDestination(session, destinationName, topic);
                     setReplyTo(destination);
                 }
+            } finally {
+                QueueReplyManager.this.lock.unlock();
             }
             return destination;
         }

--- a/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkConnectionFactory.java
+++ b/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkConnectionFactory.java
@@ -21,6 +21,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.splunk.HttpService;
 import com.splunk.SSLSecurityProtocol;
@@ -45,6 +47,7 @@ public class SplunkConnectionFactory {
     private boolean useSunHttpsHandler;
     private SSLSecurityProtocol sslProtocol;
     private boolean validateCertificates;
+    private final Lock lock = new ReentrantLock();
 
     public SplunkConnectionFactory(final String host, final int port, final String username, final String password) {
         this.host = host;
@@ -113,81 +116,86 @@ public class SplunkConnectionFactory {
         this.token = token;
     }
 
-    public synchronized Service createService(CamelContext camelContext) {
-        final ServiceArgs args = new ServiceArgs();
-        if (host != null) {
-            args.setHost(host);
-        }
-        if (port > 0) {
-            args.setPort(port);
-        }
-        if (scheme != null) {
-            args.setScheme(scheme);
-        }
-        if (app != null) {
-            args.setApp(app);
-        }
-        if (owner != null) {
-            args.setOwner(owner);
-        }
-        if (username != null) {
-            args.setUsername(username);
-        }
-        if (password != null && token == null) {
-            args.setPassword(password);
-        }
-        if (token != null) {
-            args.setToken(String.format("Bearer %s", token));
-            args.remove("username");
-            args.remove("password");
-        }
-        // useful in cases where you want to bypass app. servers https handling
-        // (wls i'm looking at you)
-        if (isUseSunHttpsHandler()) {
-            String sunHandlerClassName = "sun.net.www.protocol.https.Handler";
-            Class<URLStreamHandler> clazz
-                    = camelContext.getClassResolver().resolveClass(sunHandlerClassName, URLStreamHandler.class);
-            if (clazz != null) {
-                URLStreamHandler handler = camelContext.getInjector().newInstance(clazz);
-                args.setHTTPSHandler(handler);
-                LOG.debug("using the URLStreamHandler {} for {}", handler, args);
-            } else {
-                LOG.warn("could not resolve and use the URLStreamHandler class '{}'", sunHandlerClassName);
-            }
-        }
-
-        ExecutorService executor
-                = camelContext.getExecutorServiceManager().newSingleThreadExecutor(this, "DefaultSplunkConnectionFactory");
-
-        Future<Service> future = executor.submit(new Callable<Service>() {
-            public Service call() throws Exception {
-                if (Service.DEFAULT_SCHEME.equals(getScheme())) {
-                    LOG.debug("Https in use. Setting SSL protocol to {} and sertificate validation to %s", getSslProtocol(),
-                            isValidateCertificates());
-                    HttpService.setValidateCertificates(isValidateCertificates());
-                    HttpService.setSslSecurityProtocol(getSslProtocol());
-                }
-                return Service.connect(args);
-            }
-        });
+    public Service createService(CamelContext camelContext) {
+        lock.lock();
         try {
-            Service service = null;
-            if (connectionTimeout > 0) {
-                service = future.get(connectionTimeout, TimeUnit.MILLISECONDS);
-            } else {
-                service = future.get();
+            final ServiceArgs args = new ServiceArgs();
+            if (host != null) {
+                args.setHost(host);
             }
-            LOG.info("Successfully connected to Splunk");
-            return service;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(
-                    String.format("could not connect to Splunk Server @ %s:%d - %s", host, port, e.getMessage()), e);
-        } catch (Exception e) {
-            throw new RuntimeException(
-                    String.format("could not connect to Splunk Server @ %s:%d - %s", host, port, e.getMessage()), e);
+            if (port > 0) {
+                args.setPort(port);
+            }
+            if (scheme != null) {
+                args.setScheme(scheme);
+            }
+            if (app != null) {
+                args.setApp(app);
+            }
+            if (owner != null) {
+                args.setOwner(owner);
+            }
+            if (username != null) {
+                args.setUsername(username);
+            }
+            if (password != null && token == null) {
+                args.setPassword(password);
+            }
+            if (token != null) {
+                args.setToken(String.format("Bearer %s", token));
+                args.remove("username");
+                args.remove("password");
+            }
+            // useful in cases where you want to bypass app. servers https handling
+            // (wls i'm looking at you)
+            if (isUseSunHttpsHandler()) {
+                String sunHandlerClassName = "sun.net.www.protocol.https.Handler";
+                Class<URLStreamHandler> clazz
+                        = camelContext.getClassResolver().resolveClass(sunHandlerClassName, URLStreamHandler.class);
+                if (clazz != null) {
+                    URLStreamHandler handler = camelContext.getInjector().newInstance(clazz);
+                    args.setHTTPSHandler(handler);
+                    LOG.debug("using the URLStreamHandler {} for {}", handler, args);
+                } else {
+                    LOG.warn("could not resolve and use the URLStreamHandler class '{}'", sunHandlerClassName);
+                }
+            }
+
+            ExecutorService executor
+                    = camelContext.getExecutorServiceManager().newSingleThreadExecutor(this, "DefaultSplunkConnectionFactory");
+
+            Future<Service> future = executor.submit(new Callable<Service>() {
+                public Service call() throws Exception {
+                    if (Service.DEFAULT_SCHEME.equals(getScheme())) {
+                        LOG.debug("Https in use. Setting SSL protocol to {} and sertificate validation to %s", getSslProtocol(),
+                                isValidateCertificates());
+                        HttpService.setValidateCertificates(isValidateCertificates());
+                        HttpService.setSslSecurityProtocol(getSslProtocol());
+                    }
+                    return Service.connect(args);
+                }
+            });
+            try {
+                Service service = null;
+                if (connectionTimeout > 0) {
+                    service = future.get(connectionTimeout, TimeUnit.MILLISECONDS);
+                } else {
+                    service = future.get();
+                }
+                LOG.info("Successfully connected to Splunk");
+                return service;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(
+                        String.format("could not connect to Splunk Server @ %s:%d - %s", host, port, e.getMessage()), e);
+            } catch (Exception e) {
+                throw new RuntimeException(
+                        String.format("could not connect to Splunk Server @ %s:%d - %s", host, port, e.getMessage()), e);
+            } finally {
+                camelContext.getExecutorServiceManager().shutdownNow(executor);
+            }
         } finally {
-            camelContext.getExecutorServiceManager().shutdownNow(executor);
+            lock.unlock();
         }
     }
 }

--- a/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkEndpoint.java
+++ b/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/SplunkEndpoint.java
@@ -130,14 +130,19 @@ public class SplunkEndpoint extends ScheduledPollEndpoint implements EndpointSer
         return configuration;
     }
 
-    public synchronized boolean reset(Exception e) {
-        boolean answer = false;
-        if (e instanceof RuntimeException && e.getCause() instanceof ConnectException
-                || e instanceof SocketException || e instanceof SSLException) {
-            LOG.warn("Got exception from Splunk. Service will be reset.");
-            this.service = null;
-            answer = true;
+    public boolean reset(Exception e) {
+        lock.lock();
+        try {
+            boolean answer = false;
+            if (e instanceof RuntimeException && e.getCause() instanceof ConnectException
+                    || e instanceof SocketException || e instanceof SSLException) {
+                LOG.warn("Got exception from Splunk. Service will be reset.");
+                this.service = null;
+                answer = true;
+            }
+            return answer;
+        } finally {
+            lock.unlock();
         }
-        return answer;
     }
 }

--- a/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/support/SubmitDataWriter.java
+++ b/components/camel-splunk/src/main/java/org/apache/camel/component/splunk/support/SubmitDataWriter.java
@@ -33,13 +33,18 @@ public class SubmitDataWriter extends SplunkDataWriter {
     }
 
     @Override
-    protected synchronized void doWrite(String event) throws IOException {
-        Index index = getIndex();
-        if (index != null) {
-            index.submit(args, event);
-        } else {
-            Receiver receiver = endpoint.getService().getReceiver();
-            receiver.submit(args, event);
+    protected void doWrite(String event) throws IOException {
+        lock.lock();
+        try {
+            Index index = getIndex();
+            if (index != null) {
+                index.submit(args, event);
+            } else {
+                Receiver receiver = endpoint.getService().getReceiver();
+                receiver.submit(args, event);
+            }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/components/camel-spring/src/main/java/org/apache/camel/component/event/EventEndpoint.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/component/event/EventEndpoint.java
@@ -121,14 +121,24 @@ public class EventEndpoint extends DefaultEndpoint implements ApplicationContext
 
     // Implementation methods
     // -------------------------------------------------------------------------
-    public synchronized void consumerStarted(EventConsumer consumer) {
-        getComponent().consumerStarted(this);
-        getLoadBalancer().addProcessor(consumer.getAsyncProcessor());
+    public void consumerStarted(EventConsumer consumer) {
+        lock.lock();
+        try {
+            getComponent().consumerStarted(this);
+            getLoadBalancer().addProcessor(consumer.getAsyncProcessor());
+        } finally {
+            lock.unlock();
+        }
     }
 
-    public synchronized void consumerStopped(EventConsumer consumer) {
-        getComponent().consumerStopped(this);
-        getLoadBalancer().removeProcessor(consumer.getAsyncProcessor());
+    public void consumerStopped(EventConsumer consumer) {
+        lock.lock();
+        try {
+            getComponent().consumerStopped(this);
+            getLoadBalancer().removeProcessor(consumer.getAsyncProcessor());
+        } finally {
+            lock.unlock();
+        }
     }
 
     protected LoadBalancer createLoadBalancer() {

--- a/components/camel-spring/src/main/java/org/apache/camel/spring/spi/TransactionErrorHandlerReifier.java
+++ b/components/camel-spring/src/main/java/org/apache/camel/spring/spi/TransactionErrorHandlerReifier.java
@@ -191,29 +191,34 @@ public class TransactionErrorHandlerReifier extends ErrorHandlerReifier<SpringTr
         return answer;
     }
 
-    protected synchronized ScheduledExecutorService getExecutorService(
+    protected ScheduledExecutorService getExecutorService(
             ScheduledExecutorService executorService, String executorServiceRef) {
-        if (executorService == null || executorService.isShutdown()) {
-            // camel context will shutdown the executor when it shutdown so no
-            // need to shut it down when stopping
-            if (executorServiceRef != null) {
-                executorService = lookupByNameAndType(executorServiceRef, ScheduledExecutorService.class);
-                if (executorService == null) {
-                    ExecutorServiceManager manager = camelContext.getExecutorServiceManager();
-                    ThreadPoolProfile profile = manager.getThreadPoolProfile(executorServiceRef);
-                    executorService = manager.newScheduledThreadPool(this, executorServiceRef, profile);
+        lock.lock();
+        try {
+            if (executorService == null || executorService.isShutdown()) {
+                // camel context will shutdown the executor when it shutdown so no
+                // need to shut it down when stopping
+                if (executorServiceRef != null) {
+                    executorService = lookupByNameAndType(executorServiceRef, ScheduledExecutorService.class);
+                    if (executorService == null) {
+                        ExecutorServiceManager manager = camelContext.getExecutorServiceManager();
+                        ThreadPoolProfile profile = manager.getThreadPoolProfile(executorServiceRef);
+                        executorService = manager.newScheduledThreadPool(this, executorServiceRef, profile);
+                    }
+                    if (executorService == null) {
+                        throw new IllegalArgumentException("ExecutorService " + executorServiceRef + " not found in registry.");
+                    }
+                } else {
+                    // no explicit configured thread pool, so leave it up to the
+                    // error handler to decide if it need a default thread pool from
+                    // CamelContext#getErrorHandlerExecutorService
+                    executorService = null;
                 }
-                if (executorService == null) {
-                    throw new IllegalArgumentException("ExecutorService " + executorServiceRef + " not found in registry.");
-                }
-            } else {
-                // no explicit configured thread pool, so leave it up to the
-                // error handler to decide if it need a default thread pool from
-                // CamelContext#getErrorHandlerExecutorService
-                executorService = null;
             }
+            return executorService;
+        } finally {
+            lock.unlock();
         }
-        return executorService;
     }
 
 }

--- a/components/camel-stax/src/main/java/org/apache/camel/component/stax/StAXJAXBIteratorExpression.java
+++ b/components/camel-stax/src/main/java/org/apache/camel/component/stax/StAXJAXBIteratorExpression.java
@@ -101,16 +101,17 @@ public class StAXJAXBIteratorExpression<T> extends ExpressionAdapter {
     }
 
     private static JAXBContext jaxbContext(Class<?> handled) throws JAXBException {
-        if (JAX_CONTEXTS.containsKey(handled)) {
-            return JAX_CONTEXTS.get(handled);
+        try {
+            return JAX_CONTEXTS.computeIfAbsent(handled, k -> {
+                try {
+                    return JAXBContext.newInstance(handled);
+                } catch (JAXBException e) {
+                    throw new RuntimeCamelException(e);
+                }
+            });
+        } catch (RuntimeCamelException e) {
+            throw (JAXBException) e.getCause();
         }
-
-        JAXBContext context;
-        synchronized (JAX_CONTEXTS) {
-            context = JAXBContext.newInstance(handled);
-            JAX_CONTEXTS.put(handled, context);
-        }
-        return context;
     }
 
     @Override

--- a/components/camel-stream/src/main/java/org/apache/camel/component/stream/StreamProducer.java
+++ b/components/camel-stream/src/main/java/org/apache/camel/component/stream/StreamProducer.java
@@ -69,14 +69,16 @@ public class StreamProducer extends DefaultAsyncProducer {
     public boolean process(Exchange exchange, AsyncCallback callback) {
         try {
             delay(endpoint.getDelay());
-
-            synchronized (this) {
+            lock.lock();
+            try {
                 try {
                     openStream(exchange);
                     writeToStream(outputStream, exchange);
                 } finally {
                     closeStream(exchange, false);
                 }
+            } finally {
+                lock.unlock();
             }
         } catch (InterruptedException e) {
             exchange.setException(e);


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-20199

## Motivation

For better support of virtual threads, we need to avoid lengthy and frequent pinning by replacing synchronized blocks with ReentrantLocks

## Modifications:

* Replace mutex with locks
* Use locks instead of synchronized blocks
* Leverage ConcurrentMap methods to get rid of synchronized blocks