### PR TITLE
Fix since attribute for Flowable Component

### DIFF
--- a/components/camel-flowable/src/main/docs/flowable-component.adoc
+++ b/components/camel-flowable/src/main/docs/flowable-component.adoc
@@ -3,7 +3,7 @@
 :shortname: flowable
 :artifactid: camel-flowable
 :description: Send and receive messages from the Flowable BPMN and CMMN engines.
-:since: 4.19
+:since: 4.9
 :supportlevel: Preview
 :tabs-sync-option:
 :component-header: Both producer and consumer are supported


### PR DESCRIPTION
# Description

Fix a typo in the documentation for flowable component

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)



