### PR TITLE
[Backport 4.8.x] Fix for RestOpenApiProcessor for parsing path variables from the http…

### DIFF
--- a/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/RestOpenApiProcessor.java
+++ b/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/RestOpenApiProcessor.java
@@ -127,8 +127,15 @@ public class RestOpenApiProcessor extends DelegateAsyncProcessor implements Came
         if (m instanceof RestOpenApiConsumerPath rcp) {
             Operation o = rcp.getConsumer();
 
+            String consumerPath = rcp.getConsumerPath();
+
+            //if uri is not starting with slash then remove the slash in the consumerPath from the openApi spec
+            if (consumerPath.startsWith("/") && uri != null && !uri.startsWith("/")) {
+                consumerPath = consumerPath.substring(1);
+            }
+
             // map path-parameters from operation to camel headers
-            HttpHelper.evalPlaceholders(exchange.getMessage().getHeaders(), uri, rcp.getConsumerPath());
+            HttpHelper.evalPlaceholders(exchange.getMessage().getHeaders(), uri, consumerPath);
 
             // process the incoming request
             return restOpenapiProcessorStrategy.process(openAPI, o, verb, uri, rcp.getBinding(), exchange, callback);


### PR DESCRIPTION
… request uri succesfully.  (#16220)

* Update RestOpenApiProcessor.java

if uri is not starting with slash then remove the slash in the consumerPath from the openApi spec, because if there is any path variables (/../{id}) in the consumerPath and the uri does not start with "/" then  HttpHelper.evalPlaceholders method throws an ArrayIndexOutOfBoundsException.

* code style fixes and added null check the uri.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

