### PR TITLE
Align versions with spring-boot 3.3.6

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -195,7 +195,7 @@
         <graphql-java-version>22.3</graphql-java-version>
         <greenmail-version>2.0.1</greenmail-version>
         <grizzly-websockets-version>2.4.4</grizzly-websockets-version>
-        <groovy-version>4.0.22</groovy-version>
+        <groovy-version>4.0.24</groovy-version>
         <grpc-version>1.66.0</grpc-version>
         <grpc-google-auth-library-version>1.24.1</grpc-google-auth-library-version>
         <grpc-java-jwt-version>4.4.0</grpc-java-jwt-version>
@@ -226,14 +226,14 @@
         <icu4j-version>75.1</icu4j-version>
         <ignite-version>2.16.0</ignite-version>
         <impsort-maven-plugin-version>1.11.0</impsort-maven-plugin-version>
-        <infinispan-version>15.0.10.Final</infinispan-version>
+        <infinispan-version>15.0.11.Final</infinispan-version>
         <influx-java-driver-version>2.24</influx-java-driver-version>
         <influx-client-java-driver-version>7.2.0</influx-client-java-driver-version>
         <irclib-version>1.10</irclib-version>
         <ironmq-version>3.0.5</ironmq-version>
         <ivy-version>2.5.2</ivy-version>
         <jackson-jq-version>1.0.0</jackson-jq-version>
-        <jackson2-version>2.17.2</jackson2-version>
+        <jackson2-version>2.17.3</jackson2-version>
         <jackrabbit-version>2.22.0</jackrabbit-version>
         <jasminb-jsonapi-version>0.14</jasminb-jsonapi-version>
         <jandex-version>3.2.2</jandex-version>
@@ -351,8 +351,8 @@
         <maven-wagon-version>3.5.2</maven-wagon-version>
         <maven-war-plugin-version>3.4.0</maven-war-plugin-version>
         <metrics-version>4.2.27</metrics-version>
-        <micrometer-version>1.13.6</micrometer-version>
-        <micrometer-tracing-version>1.3.5</micrometer-tracing-version>
+        <micrometer-version>1.13.8</micrometer-version>
+        <micrometer-tracing-version>1.3.6</micrometer-tracing-version>
         <microprofile-config-version>3.1</microprofile-config-version>
         <microprofile-fault-tolerance-version>4.1</microprofile-fault-tolerance-version>
         <milvus-client-version>2.4.3</milvus-client-version>
@@ -371,7 +371,7 @@
         <mybatis-version>3.5.16</mybatis-version>
         <narayana-version>5.13.1.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
-        <netty-version>4.1.114.Final</netty-version>
+        <netty-version>4.1.115.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.5.1</networknt-json-schema-validator-version>
         <nimbus-jose-jwt>9.40</nimbus-jose-jwt>
@@ -450,11 +450,11 @@
         <spock-version>2.3-groovy-4.0</spock-version>
         <spring-batch-version>5.1.2</spring-batch-version>
         <spring-data-redis-version>3.3.3</spring-data-redis-version>
-        <spring-ldap-version>3.2.7</spring-ldap-version>
+        <spring-ldap-version>3.2.8</spring-ldap-version>
         <spring-vault-core-version>3.1.2</spring-vault-core-version>
-        <spring-version>6.1.14</spring-version>
+        <spring-version>6.1.15</spring-version>
         <spring-rabbitmq-version>3.1.7</spring-rabbitmq-version>
-        <spring-security-version>6.3.4</spring-security-version>
+        <spring-security-version>6.3.5</spring-security-version>
         <spring-ws-version>4.0.11</spring-ws-version>
         <sql-maven-plugin-version>3.0.0</sql-maven-plugin-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>


### PR DESCRIPTION
# Description

https://github.com/apache/camel-spring-boot/pull/1293 updated camel-spring-boot-4.8.x to spring-boot 3.3.6.     This PR is a number of micro release upgrades to match the versions within spring-boot-dependencies 3.3.6.

Ran the tests locally for all of the components where a dependency was upgraded (netty, infinispan, jackson, groovy, micrometer)

# Target

- [x ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

