### PR TITLE
Upgrade jolokia to 2.1.2

### DIFF
--- a/components/camel-platform-http-jolokia/src/test/java/org/apache/camel/component/platform/http/plugin/DefaultJolokiaPlatformHttpPluginTest.java
+++ b/components/camel-platform-http-jolokia/src/test/java/org/apache/camel/component/platform/http/plugin/DefaultJolokiaPlatformHttpPluginTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DefaultJolokiaPlatformHttpPluginTest extends ContextTestSupport {
 
@@ -54,7 +55,7 @@ public class DefaultJolokiaPlatformHttpPluginTest extends ContextTestSupport {
         String type = (String) request.get("type");
 
         assertEquals("version", type);
-        assertEquals("2.1.0", agentVersion);
+        assertNotNull(agentVersion, "There should be an agent version");
     }
 
     private PlatformHttpPluginRegistry resolvePlatformHttpPluginRegistry() {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -283,7 +283,7 @@
         <jira-rest-client-api-version>6.0.1</jira-rest-client-api-version>
         <libthrift-version>0.20.0</libthrift-version>
         <jodatime2-version>2.12.7</jodatime2-version>
-        <jolokia-version>2.1.0</jolokia-version>
+        <jolokia-version>2.1.2</jolokia-version>
         <jolt-version>0.1.8</jolt-version>
         <jool-version>0.9.15</jool-version>
         <jooq-version>3.19.14</jooq-version>


### PR DESCRIPTION
# Description

Upgrade jolokia to 2.1.2 and cherry-pick over Otavio's commit that removes the assert checking agent version - the hard coded check on agent 2.1.0 will fail once we upgrade jolokia to 2.1.2.

Ran mvn -DskipTests clean install and test in camel-platform-http-jolokia