### PR TITLE
CAMEL-21387: camel-opentelementry use OTEL Java agent by default docu…

### DIFF
--- a/components/camel-opentelemetry/src/main/docs/opentelemetry.adoc
+++ b/components/camel-opentelemetry/src/main/docs/opentelemetry.adoc
@@ -72,13 +72,51 @@ NOTE: You would still need OpenTelemetry to instrument your code, which can be d
 
 == Spring Boot
 
-If you are using Spring Boot, just add
-the `camel-opentelemetry-starter` dependency to get started.
+When running on Spring Boot, add the `camel-opentelemetry-starter` dependency to get started.
 
-OpenTelemetry's `Tracer` will be
+There are several ways to configure instrumentation of your Camel application running on Spring Boot with OpenTelemetry.
+The first and easiest one is by using the https://opentelemetry.io/docs/zero-code/java/agent/[OpenTelemetry Java agent].
+The other one is through Spring Boot's Actuator. We'll cover both.
+
+[[OpenTelemetry-JavaAgent]]
+=== Java Agent
+
+Download the https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/[latest version].
+
+This package includes the instrumentation agent as well as instrumentation for all supported libraries and all available data exporters.
+The package provides a completely automatic, out-of-the-box experience.
+
+Enable the instrumentation agent using the `-javaagent` flag to the JVM.
+
+[source,bash]
+----
+java -javaagent:path/to/opentelemetry-javaagent.jar \
+     -jar myapp.jar
+----
+
+By default, the OpenTelemetry Java agent uses https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/otlp[OTLP exporter] configured to send data to https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md[OpenTelemetry collector] at `http://localhost:4318`.
+
+Configuration parameters are passed as Java system properties (`-D` flags) or as environment variables. See https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/agent-config.md[the configuration documentation] for the full list of configuration items. For example:
+
+[source,bash]
+----
+java -javaagent:path/to/opentelemetry-javaagent.jar \
+     -Dotel.service.name=your-service-name \
+     -Dotel.traces.exporter=otlp \
+     -jar myapp.jar
+----
+
+include::spring-boot:partial$starter.adoc[]
+
+
+=== Spring Boot's Actuator
+
+To have Spring Boot's Actuator configure OpenTelemetry, you need to add
+`org.springframework.boot:spring-boot-starter-actuator` and `io.micrometer:micrometer-tracing-bridge-otel` to your project.
+OpenTelemetry's `Tracer` will then be
 https://docs.spring.io/spring-boot/reference/actuator/tracing.html[configured] through `spring-boot-starter-actuator` unless a `Tracer` is already defined.
 
-*Noteworthy*: by default, Spring Boot samples only 10% of requests to prevent overwhelming the trace backend.
+*Noteworthy*: by default, this will sample only 10% of requests to prevent overwhelming the trace backend.
 Set the property `management.tracing.sampling.probability` to `1.0` if you want to see all traces.
 
 === SpanExporters
@@ -111,46 +149,6 @@ public SpanExporter logTraces() {
 
 Multiple `SpanExporters` can be used at the same time.
 
-[[OpenTelemetry-Collector]]
-== Testing OpenTelemetry collector
-
-If you need a quick way to verify the configuration of OpenTelemetry traces, you can start a local collector by running a Docker service:
-
-```bash
-docker run -p 4318:4318 otel/opentelemetry-collector-contrib:0.113.0
-```
-
-This service will expose the port `4318` to `localhost` which is the default setting expected by the agent. You can change this configuration accordingly.
-
-[[OpenTelemetry-JavaAgent]]
-== Java Agent
-
-Download the https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/[latest version].
-
-This package includes the instrumentation agent as well as instrumentation for all supported libraries and all available data exporters.
-The package provides a completely automatic, out-of-the-box experience.
-
-Enable the instrumentation agent using the `-javaagent` flag to the JVM.
-
-[source,bash]
-----
-java -javaagent:path/to/opentelemetry-javaagent.jar \
-     -jar myapp.jar
-----
-
-By default, the OpenTelemetry Java agent uses https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/otlp[OTLP exporter] configured to send data to https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md[OpenTelemetry collector] at `http://localhost:4318`.
-
-Configuration parameters are passed as Java system properties (`-D` flags) or as environment variables. See https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/agent-features.md[the configuration documentation] for the full list of configuration items. For example:
-
-[source,bash]
-----
-java -javaagent:path/to/opentelemetry-javaagent.jar \
-     -Dotel.service.name=your-service-name \
-     -Dotel.traces.exporter=otlp \
-     -jar myapp.jar
-----
-
-include::spring-boot:partial$starter.adoc[]
 
 == MDC Logging
 


### PR DESCRIPTION
…mentation

# Description

Following https://github.com/apache/camel-spring-boot/pull/1297, let's add some documentation to make it clear to use the OTEL agent by default when using camel-opentelemetry-starter. @Croway, Thanks !

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

