### PR TITLE
Fixed NPE when no response body in DefaultRawClient

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultRawClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/DefaultRawClient.java
@@ -54,6 +54,10 @@ public class DefaultRawClient extends AbstractClientBase implements RawClient {
 
     @Override
     protected SalesforceException createRestException(Response response, InputStream responseContent) {
+        if (responseContent == null) {
+            return new SalesforceException(
+                    "Unexpected error: " + response.getReason() + ", with content: null", response.getStatus());
+        }
         String message = null;
         try {
             message = IOUtils.toString(responseContent, StandardCharsets.UTF_8);

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/client/DefaultRawClientTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/internal/client/DefaultRawClientTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.salesforce.internal.client;
+
+import org.apache.camel.component.salesforce.SalesforceHttpClient;
+import org.apache.camel.component.salesforce.SalesforceLoginConfig;
+import org.apache.camel.component.salesforce.api.SalesforceException;
+import org.apache.camel.component.salesforce.internal.SalesforceSession;
+import org.eclipse.jetty.client.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+
+public class DefaultRawClientTest {
+
+    @Test
+    public void shouldNotThrowNPEWhenNoResponseContent() throws SalesforceException {
+        var client = new DefaultRawClient(
+                mock(SalesforceHttpClient.class), "", mock(SalesforceSession.class), new SalesforceLoginConfig());
+
+        var response = mock(Response.class);
+        var resultException = client.createRestException(response, null);
+        assertInstanceOf(SalesforceException.class, resultException);
+    }
+
+}


### PR DESCRIPTION
# Description

When performing raw requests using the `raw` endpoint in the salesforce component, if there's an error without body the `DefaultRawClient` is unable to create a `SalesforceException` because it throws a `NullPointerException`, I see other internal clients implementations, and there the null response body is handled correctly.

[This following branch can be used to see the current wrong behavior.](https://github.com/baconberry/camel/blob/reproduce-salesforce-raw-client-npe/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/RawPayloadTest.java)


# Target

- [X] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

Is this trivial enough?


# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.


- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.


