### PR TITLE
CAMEL-21532: fix the Log4j2 config file not being respected in Camel JBang

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeUtil.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeUtil.java
@@ -87,7 +87,7 @@ public final class RuntimeUtil {
                 name = CommandLineHelper.CAMEL_JBANG_WORK_DIR + "/log4j2.properties";
                 Files.writeString(Paths.get(name), content);
 
-                Configurator.initialize("CamelJBang", "file://" + Path.of(name).toAbsolutePath());
+                Configurator.initialize("CamelJBang", Path.of(name).toAbsolutePath().toUri().toString());
             } else {
                 // use out of the box logging configuration
                 if (export) {


### PR DESCRIPTION
[CAMEL-21532](issues.apache.org/jira/browse/CAMEL-21532): Camel JBang --logging-category is not respected on Windows

# Description

This pull request fixes "java.lang.IllegalArgumentException: URI has an authority component" thrown by Camel JBang because of the incorrect Log4j2 config.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

