### PR TITLE
(WIP) CAMEL-20682 - review File tests for incorrectly shared resources - set 6

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentKeyChangedIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentKeyChangedIssueTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
@@ -25,6 +26,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
 
 public class FileConsumerIdempotentKeyChangedIssueTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     private Endpoint endpoint;
 
@@ -32,7 +34,7 @@ public class FileConsumerIdempotentKeyChangedIssueTest extends ContextTestSuppor
     public void testFile() throws Exception {
         getMockEndpoint("mock:file").expectedBodiesReceived("Hello World");
 
-        template.sendBodyAndHeader(endpoint, "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(endpoint, "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         context.getRouteController().startAllRoutes();
 
@@ -42,7 +44,7 @@ public class FileConsumerIdempotentKeyChangedIssueTest extends ContextTestSuppor
         resetMocks();
         getMockEndpoint("mock:file").expectedBodiesReceived("Hello World Again");
 
-        template.sendBodyAndHeader(endpoint, "Hello World Again", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(endpoint, "Hello World Again", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentOnExceptionHandledTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentOnExceptionHandledTest.java
@@ -16,18 +16,21 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
 
 public class FileConsumerIdempotentOnExceptionHandledTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testIdempotent() throws Exception {
         getMockEndpoint("mock:invalid").expectedMessageCount(1);
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         oneExchangeDone.matchesWaitTime();
 
@@ -35,8 +38,8 @@ public class FileConsumerIdempotentOnExceptionHandledTest extends ContextTestSup
 
         // the error is handled and the file is regarded as success and
         // therefore moved to .camel
-        assertFileNotExists(testFile("hello.txt"));
-        assertFileExists(testFile(".camel/hello.txt"));
+        assertFileNotExists(testFile(TEST_FILE_NAME));
+        assertFileExists(testFile(".camel/" + TEST_FILE_NAME));
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerNoopTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerNoopTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.file;
 
 import java.nio.file.Files;
+import java.util.UUID;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -27,19 +28,21 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FileConsumerNoopTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME_1 = "hello" + UUID.randomUUID() + ".txt";
+    private static final String TEST_FILE_NAME_2 = "bye" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testNoop() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(2);
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
-        template.sendBodyAndHeader(fileUri(), "Bye World", Exchange.FILE_NAME, "bye.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME_1);
+        template.sendBodyAndHeader(fileUri(), "Bye World", Exchange.FILE_NAME, TEST_FILE_NAME_2);
 
         assertMockEndpointsSatisfied();
 
-        assertTrue(Files.exists(testFile("hello.txt")));
-        assertTrue(Files.exists(testFile("bye.txt")));
+        assertTrue(Files.exists(testFile(TEST_FILE_NAME_1)));
+        assertTrue(Files.exists(testFile(TEST_FILE_NAME_2)));
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileMarkerFileRecursiveDoNotDeleteOldLockFilesTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileMarkerFileRecursiveDoNotDeleteOldLockFilesTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -23,6 +25,9 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
 public class FileMarkerFileRecursiveDoNotDeleteOldLockFilesTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME_1 = "hello" + UUID.randomUUID() + ".txt";
+    private static final String TEST_FILE_NAME_2 = "gooday" + UUID.randomUUID() + ".txt";
+    private static final String TEST_FILE_NAME_3 = "new" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testDeleteOldLockOnStartup() throws Exception {
@@ -30,13 +35,13 @@ public class FileMarkerFileRecursiveDoNotDeleteOldLockFilesTest extends ContextT
         mock.expectedBodiesReceived("New World");
 
         template.sendBodyAndHeader(fileUri(), "locked", Exchange.FILE_NAME,
-                "hello.txt" + FileComponent.DEFAULT_LOCK_FILE_POSTFIX);
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+                TEST_FILE_NAME_1 + FileComponent.DEFAULT_LOCK_FILE_POSTFIX);
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME_1);
         template.sendBodyAndHeader(fileUri("foo"), "locked", Exchange.FILE_NAME,
-                "gooday.txt" + FileComponent.DEFAULT_LOCK_FILE_POSTFIX);
-        template.sendBodyAndHeader(fileUri("foo"), "Goodday World", Exchange.FILE_NAME, "gooday.txt");
+                TEST_FILE_NAME_2 + FileComponent.DEFAULT_LOCK_FILE_POSTFIX);
+        template.sendBodyAndHeader(fileUri("foo"), "Goodday World", Exchange.FILE_NAME, TEST_FILE_NAME_2);
         // and a new file that has no lock
-        template.sendBodyAndHeader(fileUri(), "New World", Exchange.FILE_NAME, "new.txt");
+        template.sendBodyAndHeader(fileUri(), "New World", Exchange.FILE_NAME, TEST_FILE_NAME_3);
 
         // start the route
         context.getRouteController().startRoute("foo");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilePollEnrichNoWaitTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilePollEnrichNoWaitTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.file;
 
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.UUID;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -29,17 +30,18 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class FilePollEnrichNoWaitTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     @BeforeEach
     public void sendMessage() {
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
     }
 
     @Test
     public void testFilePollEnrichNoWait() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Hello World");
-        mock.expectedFileExists(testFile("done/hello.txt"));
+        mock.expectedFileExists(testFile("done/" + TEST_FILE_NAME));
 
         oneExchangeDone.matchesWaitTime();
         mock.assertIsSatisfied(Duration.ofSeconds(2).toMillis());

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilePollEnrichTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilePollEnrichTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.file;
 
 import java.nio.file.Files;
+import java.util.UUID;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -27,20 +28,21 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class FilePollEnrichTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testFilePollEnrich() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Hello World");
-        mock.expectedFileExists(testFile("done/hello.txt"));
+        mock.expectedFileExists(testFile("done/" + TEST_FILE_NAME));
 
-        template.sendBodyAndHeader("file:" + testDirectory(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader("file:" + testDirectory(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
         oneExchangeDone.matchesWaitTime();
 
         // file should be moved
-        assertFalse(Files.exists(testFile("hello.txt")), "File should have been moved");
+        assertFalse(Files.exists(testFile(TEST_FILE_NAME)), "File should have been moved");
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProduceAppendCharsEmptyMessageTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProduceAppendCharsEmptyMessageTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -26,12 +28,13 @@ import org.junit.jupiter.api.Test;
  * Unit test to verify the append chars option
  */
 public class FileProduceAppendCharsEmptyMessageTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testAppendChars() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
-        mock.expectedFileExists(testFile("hello.txt"), "@@@");
+        mock.expectedFileExists(testFile(TEST_FILE_NAME), "@@@");
 
         template.sendBody("direct:start", "");
 
@@ -42,7 +45,7 @@ public class FileProduceAppendCharsEmptyMessageTest extends ContextTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from("direct:start").setHeader(Exchange.FILE_NAME, constant("hello.txt"))
+                from("direct:start").setHeader(Exchange.FILE_NAME, constant(TEST_FILE_NAME))
                         .to(fileUri("?fileExist=Append&appendChars=@@@"), "mock:result");
             }
         };

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProduceAppendCharsSingleMessageTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProduceAppendCharsSingleMessageTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -26,12 +28,13 @@ import org.junit.jupiter.api.Test;
  * Unit test to verify the append chars option
  */
 public class FileProduceAppendCharsSingleMessageTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testAppendChars() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
-        mock.expectedFileExists(testFile("hello.txt"), "Hello@@@");
+        mock.expectedFileExists(testFile(TEST_FILE_NAME), "Hello@@@");
 
         template.sendBody("direct:start", "Hello");
 
@@ -42,7 +45,7 @@ public class FileProduceAppendCharsSingleMessageTest extends ContextTestSupport 
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from("direct:start").setHeader(Exchange.FILE_NAME, constant("hello.txt"))
+                from("direct:start").setHeader(Exchange.FILE_NAME, constant(TEST_FILE_NAME))
                         .to(fileUri("?fileExist=Append&appendChars=@@@"), "mock:result");
             }
         };

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProduceAppendCharsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProduceAppendCharsTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -26,12 +28,13 @@ import org.junit.jupiter.api.Test;
  * Unit test to verify the append chars option
  */
 public class FileProduceAppendCharsTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testAppendChars() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(3);
-        mock.expectedFileExists(testFile("hello.txt"), "Hello\nWorld\nHow are you?\n");
+        mock.expectedFileExists(testFile(TEST_FILE_NAME), "Hello\nWorld\nHow are you?\n");
 
         template.sendBody("direct:start", "Hello");
         template.sendBody("direct:start", "World");
@@ -44,7 +47,7 @@ public class FileProduceAppendCharsTest extends ContextTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from("direct:start").setHeader(Exchange.FILE_NAME, constant("hello.txt"))
+                from("direct:start").setHeader(Exchange.FILE_NAME, constant(TEST_FILE_NAME))
                         .to(fileUri("?fileExist=Append&appendChars=\\n"), "mock:result");
             }
         };

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProduceOverruleOnlyOnceTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProduceOverruleOnlyOnceTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.file;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -29,20 +30,22 @@ import org.junit.jupiter.api.Test;
  * Unit test to verify the overrule filename header
  */
 public class FileProduceOverruleOnlyOnceTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME_1 = "hello" + UUID.randomUUID() + ".txt";
+    private static final String TEST_FILE_NAME_2 = "ruled" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testBoth() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
-        mock.expectedHeaderReceived(Exchange.FILE_NAME, "hello.txt");
+        mock.expectedHeaderReceived(Exchange.FILE_NAME, TEST_FILE_NAME_1);
         mock.message(0).header(Exchange.OVERRULE_FILE_NAME).isNull();
-        mock.expectedFileExists(testFile("write/ruled.txt"), "Hello World");
-        mock.expectedFileExists(testFile("again/hello.txt"), "Hello World");
+        mock.expectedFileExists(testFile("write/" + TEST_FILE_NAME_2), "Hello World");
+        mock.expectedFileExists(testFile("again/" + TEST_FILE_NAME_1), "Hello World");
 
         Map<String, Object> map = new HashMap<>();
-        map.put(Exchange.FILE_NAME, "hello.txt");
+        map.put(Exchange.FILE_NAME, TEST_FILE_NAME_1);
         // this header should overrule the endpoint configuration
-        map.put(Exchange.OVERRULE_FILE_NAME, "ruled.txt");
+        map.put(Exchange.OVERRULE_FILE_NAME, TEST_FILE_NAME_2);
 
         template.sendBodyAndHeaders("direct:start", "Hello World", map);
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProduceTempPrefixTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProduceTempPrefixTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
@@ -26,6 +28,8 @@ import org.junit.jupiter.api.Test;
  * Unit test for file producer option tempPrefix
  */
 public class FileProduceTempPrefixTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME_1 = "hello" + UUID.randomUUID() + ".txt";
+    private static final String TEST_FILE_NAME_2 = "claus" + UUID.randomUUID() + ".txt";
 
     public static final String FILE_QUERY = "?tempPrefix=inprogress.";
 
@@ -34,10 +38,10 @@ public class FileProduceTempPrefixTest extends ContextTestSupport {
         Endpoint endpoint = context.getEndpoint(fileUri(FILE_QUERY));
         GenericFileProducer<?> producer = (GenericFileProducer<?>) endpoint.createProducer();
         Exchange exchange = endpoint.createExchange();
-        exchange.getIn().setHeader(Exchange.FILE_NAME, "claus.txt");
+        exchange.getIn().setHeader(Exchange.FILE_NAME, TEST_FILE_NAME_2);
 
-        String tempFileName = producer.createTempFileName(exchange, testFile("claus.txt").toString());
-        assertDirectoryEquals(testFile("inprogress.claus.txt").toString(), tempFileName);
+        String tempFileName = producer.createTempFileName(exchange, testFile(TEST_FILE_NAME_2).toString());
+        assertDirectoryEquals(testFile("inprogress." + TEST_FILE_NAME_2).toString(), tempFileName);
     }
 
     @Test
@@ -45,10 +49,10 @@ public class FileProduceTempPrefixTest extends ContextTestSupport {
         Endpoint endpoint = context.getEndpoint(fileUri(FILE_QUERY));
         GenericFileProducer<?> producer = (GenericFileProducer<?>) endpoint.createProducer();
         Exchange exchange = endpoint.createExchange();
-        exchange.getIn().setHeader(Exchange.FILE_NAME, "foo/claus.txt");
+        exchange.getIn().setHeader(Exchange.FILE_NAME, "foo/" + TEST_FILE_NAME_2);
 
-        String tempFileName = producer.createTempFileName(exchange, testFile("foo/claus.txt").toString());
-        assertDirectoryEquals(testFile("foo/inprogress.claus.txt").toString(), tempFileName);
+        String tempFileName = producer.createTempFileName(exchange, testFile("foo/" + TEST_FILE_NAME_2).toString());
+        assertDirectoryEquals(testFile("foo/inprogress." + TEST_FILE_NAME_2).toString(), tempFileName);
     }
 
     @Test
@@ -56,17 +60,17 @@ public class FileProduceTempPrefixTest extends ContextTestSupport {
         Endpoint endpoint = context.getEndpoint(fileUri(FILE_QUERY));
         GenericFileProducer<?> producer = (GenericFileProducer<?>) endpoint.createProducer();
         Exchange exchange = endpoint.createExchange();
-        exchange.getIn().setHeader(Exchange.FILE_NAME, "claus.txt");
+        exchange.getIn().setHeader(Exchange.FILE_NAME, TEST_FILE_NAME_2);
 
         String tempFileName = producer.createTempFileName(exchange, ".");
-        assertDirectoryEquals("inprogress.claus.txt", tempFileName);
+        assertDirectoryEquals("inprogress." + TEST_FILE_NAME_2, tempFileName);
     }
 
     @Test
     public void testTempPrefix() {
-        template.sendBodyAndHeader("direct:a", "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader("direct:a", "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME_1);
 
-        assertFileExists(testFile("hello.txt"));
+        assertFileExists(testFile(TEST_FILE_NAME_1));
     }
 
     @Test

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistAppendNoFileBeforeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistAppendNoFileBeforeTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -23,14 +25,15 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
 public class FileProducerFileExistAppendNoFileBeforeTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testAppend() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Bye World");
-        mock.expectedFileExists(testFile("hello.txt"), "Bye World");
+        mock.expectedFileExists(testFile(TEST_FILE_NAME), "Bye World");
 
-        template.sendBodyAndHeader(fileUri("?fileExist=Append"), "Bye World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri("?fileExist=Append"), "Bye World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistOverrideNoFileBeforeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistOverrideNoFileBeforeTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -23,14 +25,15 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
 public class FileProducerFileExistOverrideNoFileBeforeTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testOverride() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Bye World");
-        mock.expectedFileExists(testFile("hello.txt"), "Bye World");
+        mock.expectedFileExists(testFile(TEST_FILE_NAME), "Bye World");
 
-        template.sendBodyAndHeader(fileUri("?fileExist=Override"), "Bye World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri("?fileExist=Override"), "Bye World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerRenameUsingCopyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerRenameUsingCopyTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -26,22 +28,23 @@ import org.junit.jupiter.api.parallel.Isolated;
 
 @Isolated("This test is regularly flaky")
 public class FileProducerRenameUsingCopyTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testMove() throws Exception {
         final String body = "Hello Camel";
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
-        mock.expectedFileExists(testFile("done/hello.txt"), body);
+        mock.expectedFileExists(testFile("done/" + TEST_FILE_NAME), body);
 
-        template.sendBodyAndHeader(fileUri(), body, Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), body, Exchange.FILE_NAME, TEST_FILE_NAME);
 
         // wait a bit for the file move to be completed
         assertMockEndpointsSatisfied();
 
         Awaitility.await().untilAsserted(() -> {
-            assertFileExists(testFile("done/hello.txt"));
-            assertFileNotExists(testFile("hello.txt"));
+            assertFileExists(testFile("done/" + TEST_FILE_NAME));
+            assertFileNotExists(testFile(TEST_FILE_NAME));
         });
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNameDeleteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNameDeleteTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
@@ -28,12 +29,13 @@ import org.junit.jupiter.api.Test;
  * Unit test for writing done files
  */
 public class FilerConsumerDoneFileNameDeleteTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testDoneFile() throws Exception {
         getMockEndpoint("mock:result").expectedMessageCount(0);
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         // wait a bit and it should not pickup the written file as there are no
         // done file
@@ -54,7 +56,7 @@ public class FilerConsumerDoneFileNameDeleteTest extends ContextTestSupport {
         assertFileNotExists(testFile("done"));
 
         // as well the original file should be deleted
-        assertFileNotExists(testFile("hello.txt"));
+        assertFileNotExists(testFile(TEST_FILE_NAME));
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNoopTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDoneFileNoopTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -25,6 +27,7 @@ import org.junit.jupiter.api.Test;
  * Unit test for writing done files
  */
 public class FilerConsumerDoneFileNoopTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testDoneFile() throws Exception {
@@ -33,7 +36,7 @@ public class FilerConsumerDoneFileNoopTest extends ContextTestSupport {
         // done file
         getMockEndpoint("mock:result").setResultMinimumWaitTime(50);
 
-        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
         resetMocks();
@@ -51,7 +54,7 @@ public class FilerConsumerDoneFileNoopTest extends ContextTestSupport {
         assertFileExists(testFile("done"));
 
         // as well the original file should be kept due noop
-        assertFileExists(testFile("hello.txt"));
+        assertFileExists(testFile(TEST_FILE_NAME));
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDualDoneFileNameTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerConsumerDualDoneFileNameTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
@@ -28,15 +29,17 @@ import org.junit.jupiter.api.Test;
  * Unit test for writing done files
  */
 public class FilerConsumerDualDoneFileNameTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME_1 = "hello" + UUID.randomUUID() + ".txt";
+    private static final String TEST_FILE_NAME_2 = "bye" + UUID.randomUUID() + ".txt";
 
     @Test
     public void testTwoDoneFile() throws Exception {
         getMockEndpoint("mock:result").expectedBodiesReceivedInAnyOrder("Hello World", "Bye World");
 
         template.sendBodyAndHeader(fileUri("?doneFileName=${file:name}.ready"), "Hello World", Exchange.FILE_NAME,
-                "hello.txt");
+                TEST_FILE_NAME_1);
         template.sendBodyAndHeader(fileUri("?doneFileName=${file:name}.ready"), "Bye World", Exchange.FILE_NAME,
-                "bye.txt");
+                TEST_FILE_NAME_2);
 
         assertMockEndpointsSatisfied();
     }
@@ -46,8 +49,8 @@ public class FilerConsumerDualDoneFileNameTest extends ContextTestSupport {
         getMockEndpoint("mock:result").expectedBodiesReceived("Hello World");
 
         template.sendBodyAndHeader(fileUri("?doneFileName=${file:name}.ready"), "Hello World", Exchange.FILE_NAME,
-                "hello.txt");
-        template.sendBodyAndHeader(fileUri(), "Bye World", Exchange.FILE_NAME, "bye.txt");
+                TEST_FILE_NAME_1);
+        template.sendBodyAndHeader(fileUri(), "Bye World", Exchange.FILE_NAME, TEST_FILE_NAME_2);
 
         // give chance to poll 2nd file but it lacks the done file
         Awaitility.await().pollDelay(250, TimeUnit.MILLISECONDS).untilAsserted(() -> assertMockEndpointsSatisfied());

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FilerProducerDoneFileNameRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FilerProducerDoneFileNameRouteTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.file;
 
 import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for writing done files
  */
 public class FilerProducerDoneFileNameRouteTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     private final Properties myProp = new Properties();
 
@@ -45,14 +47,14 @@ public class FilerProducerDoneFileNameRouteTest extends ContextTestSupport {
     public void testProducerPlaceholderPrefixDoneFileName() throws Exception {
         getMockEndpoint("mock:result").expectedMessageCount(1);
 
-        template.sendBodyAndHeader("direct:start", "Hello World", Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader("direct:start", "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
         assertMockEndpointsSatisfied();
 
         assertTrue(oneExchangeDone.matches(5, TimeUnit.SECONDS));
 
-        assertFileExists(testFile("hello.txt"));
-        assertFileExists(testFile("done-hello.txt"));
+        assertFileExists(testFile(TEST_FILE_NAME));
+        assertFileExists(testFile("done-" + TEST_FILE_NAME));
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FromFilePollThirdTimeOkTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FromFilePollThirdTimeOkTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.component.file;
 
-import java.util.UUID;
-
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -29,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FromFilePollThirdTimeOkTest extends ContextTestSupport {
-    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     private static int counter;
 
@@ -38,7 +35,7 @@ public class FromFilePollThirdTimeOkTest extends ContextTestSupport {
         NotifyBuilder notify = new NotifyBuilder(context).whenDone(3).create();
 
         String body = "Hello World this file will be deleted";
-        template.sendBodyAndHeader(fileUri(), body, Exchange.FILE_NAME, TEST_FILE_NAME);
+        template.sendBodyAndHeader(fileUri(), body, Exchange.FILE_NAME, "hello.txt");
         context.getRouteController().startRoute("FromFilePollThirdTimeOkTest");
 
         getMockEndpoint("mock:result").expectedBodiesReceived(body);
@@ -48,7 +45,7 @@ public class FromFilePollThirdTimeOkTest extends ContextTestSupport {
         assertEquals(3, counter);
 
         // assert the file is deleted
-        assertFileNotExists(testFile(TEST_FILE_NAME));
+        assertFileNotExists(testFile("hello.txt"));
     }
 
     @Override
@@ -61,7 +58,7 @@ public class FromFilePollThirdTimeOkTest extends ContextTestSupport {
                                 counter++;
                                 if (counter < 3) {
                                     // file should exists
-                                    assertFileExists(testFile(TEST_FILE_NAME));
+                                    assertFileExists(testFile("hello.txt"));
                                     throw new IllegalArgumentException("Forced by unittest");
                                 }
                             }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FromFilePollThirdTimeOkTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FromFilePollThirdTimeOkTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.UUID;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -27,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FromFilePollThirdTimeOkTest extends ContextTestSupport {
+    private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     private static int counter;
 
@@ -35,7 +38,7 @@ public class FromFilePollThirdTimeOkTest extends ContextTestSupport {
         NotifyBuilder notify = new NotifyBuilder(context).whenDone(3).create();
 
         String body = "Hello World this file will be deleted";
-        template.sendBodyAndHeader(fileUri(), body, Exchange.FILE_NAME, "hello.txt");
+        template.sendBodyAndHeader(fileUri(), body, Exchange.FILE_NAME, TEST_FILE_NAME);
         context.getRouteController().startRoute("FromFilePollThirdTimeOkTest");
 
         getMockEndpoint("mock:result").expectedBodiesReceived(body);
@@ -45,7 +48,7 @@ public class FromFilePollThirdTimeOkTest extends ContextTestSupport {
         assertEquals(3, counter);
 
         // assert the file is deleted
-        assertFileNotExists(testFile("hello.txt"));
+        assertFileNotExists(testFile(TEST_FILE_NAME));
     }
 
     @Override
@@ -58,7 +61,7 @@ public class FromFilePollThirdTimeOkTest extends ContextTestSupport {
                                 counter++;
                                 if (counter < 3) {
                                     // file should exists
-                                    assertFileExists(testFile("hello.txt"));
+                                    assertFileExists(testFile(TEST_FILE_NAME));
                                     throw new IllegalArgumentException("Forced by unittest");
                                 }
                             }


### PR DESCRIPTION
# Description

<!--
Changed static filename references to dynamically generated ones using UUID. 
Details in CAMEL-20686. 
Added an in-progress file list
-->

# Target

- [ x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x ] If this is a large change, bug fix, or code improvement, I checked there is a [CAMEL-20686](https://issues.apache.org/jira/browse/CAMEL-20686) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

