### PR TITLE
CAMEL-21555: By default do not lazily start Smooks

### DIFF
--- a/components/camel-smooks/src/main/java/org/apache/camel/component/smooks/SmooksProcessor.java
+++ b/components/camel-smooks/src/main/java/org/apache/camel/component/smooks/SmooksProcessor.java
@@ -84,6 +84,7 @@ public class SmooksProcessor extends ServiceSupport implements Processor, CamelC
     private String configUri;
     private String reportPath;
     private Boolean allowExecutionContextFromHeader = false;
+    private Boolean lazyStartProducer = false;
 
     private final Set<VisitorAppender> visitorAppender = new HashSet<>();
     private final Map<String, Visitor> selectorVisitorMap = new HashMap<>();
@@ -278,6 +279,14 @@ public class SmooksProcessor extends ServiceSupport implements Processor, CamelC
             smooks.addVisitor(entry.getValue(), entry.getKey());
     }
 
+    public Boolean getLazyStartProducer() {
+        return lazyStartProducer;
+    }
+
+    public void setLazyStartProducer(Boolean lazyStartProducer) {
+        this.lazyStartProducer = lazyStartProducer;
+    }
+
     @Override
     protected void doStart() {
         try {
@@ -293,6 +302,10 @@ public class SmooksProcessor extends ServiceSupport implements Processor, CamelC
 
             addAppender(smooks, visitorAppender);
             addVisitor(smooks, selectorVisitorMap);
+
+            if (!lazyStartProducer) {
+                smooks.createExecutionContext();
+            }
 
         } catch (Exception e) {
             throw new SmooksException(e.getMessage(), e);


### PR DESCRIPTION
# Description

By default do not lazily start Smooks and use the `lazyStartProducer` option to lazily start Smooks.

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

