### PR TITLE
chore(docs): Fix Camel JBang --dep option typos

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
@@ -3742,21 +3742,21 @@ camel export --build-tool=gradle --runtime=spring-boot --gav=com.foo:acme:1.0-SN
 === Exporting with JMX management included
 
 Usually when exporting to Spring Boot, Quarkus or Camel Main, then JMX management is not included out of the box.
-To include JMX, you need to add `camel:management` in the `--deps` option, as shown below:
+To include JMX, you need to add `camel:management` in the `--dep` option, as shown below:
 
 [source,bash]
 ----
-camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --deps=camel:management --directory=../myproject
+camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --dep=camel:management --directory=../myproject
 ----
 
 === Exporting with Camel CLI included
 
 Usually when exporting to Spring Boot, Quarkus or Camel Main, then Camel JBang CLI is not included out of the box.
-To be able to continue to use Camel CLI (i.e. `camel`), you need to add `camel:cli-connector` in the `--deps` option, as shown below:
+To be able to continue to use Camel CLI (i.e. `camel`), you need to add `camel:cli-connector` in the `--dep` option, as shown below:
 
 [source,bash]
 ----
-camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --deps=camel:cli-connector --directory=../myproject
+camel export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --dep=camel:cli-connector --directory=../myproject
 ----
 
 === Configuring exporting


### PR DESCRIPTION
# Description
Fixing typos in Camel JBang documentation as the camel export `--deps` was replaced by `--dep`. Not every occurrence of `--deps` was replaced. 


<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

