### PR TITLE
CAMEL-21559, mongodb: insertOne instead of replaceOne when saving without _id

### DIFF
--- a/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbProducer.java
+++ b/components/camel-mongodb/src/main/java/org/apache/camel/component/mongodb/MongoDbProducer.java
@@ -16,44 +16,6 @@
  */
 package org.apache.camel.component.mongodb;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import com.mongodb.client.AggregateIterable;
-import com.mongodb.client.DistinctIterable;
-import com.mongodb.client.FindIterable;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.BulkWriteOptions;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.FindOneAndDeleteOptions;
-import com.mongodb.client.model.FindOneAndReplaceOptions;
-import com.mongodb.client.model.FindOneAndUpdateOptions;
-import com.mongodb.client.model.ReplaceOptions;
-import com.mongodb.client.model.ReturnDocument;
-import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.WriteModel;
-import com.mongodb.client.result.DeleteResult;
-import com.mongodb.client.result.UpdateResult;
-import org.apache.camel.Exchange;
-import org.apache.camel.InvalidPayloadException;
-import org.apache.camel.Processor;
-import org.apache.camel.TypeConverter;
-import org.apache.camel.support.DefaultProducer;
-import org.apache.camel.support.MessageHelper;
-import org.apache.camel.util.ObjectHelper;
-import org.bson.Document;
-import org.bson.conversions.Bson;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import static com.mongodb.client.model.Filters.eq;
 import static org.apache.camel.component.mongodb.MongoDbConstants.BATCH_SIZE;
 import static org.apache.camel.component.mongodb.MongoDbConstants.COLLECTION;
@@ -76,6 +38,45 @@ import static org.apache.camel.component.mongodb.MongoDbConstants.RETURN_DOCUMEN
 import static org.apache.camel.component.mongodb.MongoDbConstants.SORT_BY;
 import static org.apache.camel.component.mongodb.MongoDbConstants.UPSERT;
 import static org.apache.camel.component.mongodb.MongoDbConstants.WRITERESULT;
+
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.DistinctIterable;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.BulkWriteOptions;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.FindOneAndDeleteOptions;
+import com.mongodb.client.model.FindOneAndReplaceOptions;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.ReturnDocument;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.WriteModel;
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.InsertOneResult;
+import com.mongodb.client.result.UpdateResult;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.camel.Exchange;
+import org.apache.camel.InvalidPayloadException;
+import org.apache.camel.Processor;
+import org.apache.camel.TypeConverter;
+import org.apache.camel.support.DefaultProducer;
+import org.apache.camel.support.MessageHelper;
+import org.apache.camel.util.ObjectHelper;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The MongoDb producer.
@@ -635,10 +636,13 @@ public class MongoDbProducer extends DefaultProducer {
                 MongoCollection<Document> dbCol = calculateCollection(exchange);
                 Document saveObj = exchange.getIn().getMandatoryBody(Document.class);
                 ReplaceOptions options = new ReplaceOptions().upsert(true);
-                UpdateResult result;
+                Object result;
                 if (null == saveObj.get(MONGO_ID)) {
-                    result = dbCol.replaceOne(Filters.where("false"), saveObj, options);
-                    exchange.getIn().setHeader(OID, result.getUpsertedId().asObjectId().getValue());
+                    result = dbCol.insertOne(saveObj);
+                    BsonValue insertedId = ((InsertOneResult) result).getInsertedId();
+                    if (insertedId != null) {
+                        exchange.getIn().setHeader(OID, insertedId.asObjectId().getValue());
+                    }
                 } else {
                     Bson mongoIdQuery = eq(MONGO_ID, saveObj.get(MONGO_ID));
                     //You can pass sharded key query via CRITERIA header to allow update sharded collection

--- a/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/integration/MongoDbOperationsIT.java
+++ b/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/integration/MongoDbOperationsIT.java
@@ -16,15 +16,32 @@
  */
 package org.apache.camel.component.mongodb.integration;
 
-import java.util.Arrays;
-import java.util.Formatter;
-import java.util.HashMap;
-import java.util.List;
+import static com.mongodb.client.model.Accumulators.sum;
+import static com.mongodb.client.model.Aggregates.group;
+import static com.mongodb.client.model.Aggregates.match;
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.or;
+import static com.mongodb.client.model.Updates.combine;
+import static com.mongodb.client.model.Updates.currentTimestamp;
+import static com.mongodb.client.model.Updates.set;
+import static org.apache.camel.component.mongodb.MongoDbConstants.CRITERIA;
+import static org.apache.camel.component.mongodb.MongoDbConstants.MONGO_ID;
+import static org.apache.camel.test.junit5.TestSupport.assertListSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.InsertOneResult;
 import com.mongodb.client.result.UpdateResult;
+import java.util.Arrays;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.List;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -39,22 +56,6 @@ import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static com.mongodb.client.model.Accumulators.sum;
-import static com.mongodb.client.model.Aggregates.group;
-import static com.mongodb.client.model.Aggregates.match;
-import static com.mongodb.client.model.Filters.eq;
-import static com.mongodb.client.model.Filters.or;
-import static com.mongodb.client.model.Updates.combine;
-import static com.mongodb.client.model.Updates.currentTimestamp;
-import static com.mongodb.client.model.Updates.set;
-import static org.apache.camel.component.mongodb.MongoDbConstants.CRITERIA;
-import static org.apache.camel.component.mongodb.MongoDbConstants.MONGO_ID;
-import static org.apache.camel.test.junit5.TestSupport.assertListSize;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MongoDbOperationsIT extends AbstractMongoDbITSupport implements ConfigurableRoute {
 
@@ -169,14 +170,16 @@ public class MongoDbOperationsIT extends AbstractMongoDbITSupport implements Con
         // save (upsert) a document without Id => insert with new Id
         doc = new Document("scientist", "Einstein");
         assertNull(doc.get(MONGO_ID));
-        UpdateResult result = template.requestBody("direct:save", doc, UpdateResult.class);
-        assertNotNull(result.getUpsertedId());
-        // Without Id save perform an insert not an update.
-        assertEquals(0, result.getModifiedCount());
+        Object resultObj = template.requestBody("direct:save", doc);
+        // Without Id save performs an insert not an update.
+        assertInstanceOf(InsertOneResult.class, resultObj);
+        InsertOneResult resultInsertOne = (InsertOneResult) resultObj;
+        assertNotNull(resultInsertOne.getInsertedId());
+
         // Testing the save logic
-        Document record1 = testCollection.find(eq(MONGO_ID, result.getUpsertedId())).first();
+        Document record1 = testCollection.find(eq(MONGO_ID, resultInsertOne.getInsertedId())).first();
         assertEquals("Einstein", record1.get("scientist"),
-                "Scientist field of '" + result.getUpsertedId() + "' must equal 'Einstein'");
+                "Scientist field of '" + resultInsertOne.getInsertedId() + "' must equal 'Einstein'");
     }
 
     @Test
@@ -196,14 +199,13 @@ public class MongoDbOperationsIT extends AbstractMongoDbITSupport implements Con
     @Test
     public void testUpdate() {
         for (int i = 1; i <= 100; i++) {
-            String body = null;
-            try (Formatter f = new Formatter();) {
+            String body;
+            try (Formatter f = new Formatter()) {
                 if (i % 2 == 0) {
                     body = f.format("{\"_id\":\"testSave%d\", \"scientist\":\"Einstein\"}", i).toString();
                 } else {
                     body = f.format("{\"_id\":\"testSave%d\", \"scientist\":\"Einstein\", \"extraField\": true}", i).toString();
                 }
-                f.close();
             }
             template.requestBody("direct:insert", body);
         }
@@ -240,14 +242,13 @@ public class MongoDbOperationsIT extends AbstractMongoDbITSupport implements Con
         Assumptions.assumeTrue(0 == testCollection.countDocuments(), "The collection should have no documents");
 
         for (int i = 1; i <= 100; i++) {
-            String body = null;
-            try (Formatter f = new Formatter();) {
+            String body;
+            try (Formatter f = new Formatter()) {
                 if (i % 2 == 0) {
                     body = f.format("{\"_id\":\"testSave%d\", \"scientist\":\"Einstein\"}", i).toString();
                 } else {
                     body = f.format("{\"_id\":\"testSave%d\", \"scientist\":\"Einstein\", \"extraField\": true}", i).toString();
                 }
-                f.close();
             }
             template.requestBody("direct:insert", body);
         }
@@ -285,14 +286,13 @@ public class MongoDbOperationsIT extends AbstractMongoDbITSupport implements Con
     @Test
     public void testUpdateUsingFieldsFilterHeader() {
         for (int i = 1; i <= 100; i++) {
-            String body = null;
-            try (Formatter f = new Formatter();) {
+            String body;
+            try (Formatter f = new Formatter()) {
                 if (i % 2 == 0) {
                     body = f.format("{\"_id\":\"testSave%d\", \"scientist\":\"Einstein\"}", i).toString();
                 } else {
                     body = f.format("{\"_id\":\"testSave%d\", \"scientist\":\"Einstein\", \"extraField\": true}", i).toString();
                 }
-                f.close();
             }
             template.requestBody("direct:insert", body);
         }
@@ -320,14 +320,13 @@ public class MongoDbOperationsIT extends AbstractMongoDbITSupport implements Con
     @Test
     public void testRemove() {
         for (int i = 1; i <= 100; i++) {
-            String body = null;
+            String body;
             try (Formatter f = new Formatter()) {
                 if (i % 2 == 0) {
                     body = f.format("{\"_id\":\"testSave%d\", \"scientist\":\"Einstein\"}", i).toString();
                 } else {
                     body = f.format("{\"_id\":\"testSave%d\", \"scientist\":\"Einstein\", \"extraField\": true}", i).toString();
                 }
-                f.close();
             }
             template.requestBody("direct:insert", body);
         }
@@ -383,10 +382,9 @@ public class MongoDbOperationsIT extends AbstractMongoDbITSupport implements Con
     public void testColStats() {
         // Add some records to the collection (and do it via camel-mongodb)
         for (int i = 1; i <= 100; i++) {
-            String body = null;
-            try (Formatter f = new Formatter();) {
+            String body;
+            try (Formatter f = new Formatter()) {
                 body = f.format("{\"_id\":\"testSave%d\", \"scientist\":\"Einstein\"}", i).toString();
-                f.close();
             }
             template.requestBody("direct:insert", body);
         }


### PR DESCRIPTION
# Description

The current implementation of the mongodb save operation forces mongodb to scan the whole collection when a document is saved without _id. This change makes an insert if no _id is given, instead of making an upsert with a filter condition that can never be satisfied. The behaviour for the save operation _with_ _id remains untouched.

See also https://camel.zulipchat.com/#narrow/channel/257298-camel/topic/mongodb.20save.20operation.20performance