### PR TITLE
CAMEL-21562. It's not a problem if the client is not allowed to do HeadBucket

### DIFF
--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Endpoint.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Endpoint.java
@@ -149,6 +149,12 @@ public class AWS2S3Endpoint extends ScheduledPollEndpoint implements EndpointSer
             LOG.trace("Bucket [{}] already exists", bucketName);
             return;
         } catch (AwsServiceException ase) {
+            if (ase.statusCode() == 403) { // means we can't check if the bucket exists
+                if (! getConfiguration().isAutoCreateBucket()) {
+                    // We are not requested to create it if it doesn't, so we can only assume that it does
+                    return;
+                }
+            }
             /* 404 means the bucket doesn't exist */
             if (!(ase.awsErrorDetails().sdkHttpResponse().statusCode() == 404)) {
                 throw ase;

--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Endpoint.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Endpoint.java
@@ -150,7 +150,7 @@ public class AWS2S3Endpoint extends ScheduledPollEndpoint implements EndpointSer
             return;
         } catch (AwsServiceException ase) {
             if (ase.statusCode() == 403) { // means we can't check if the bucket exists
-                if (! getConfiguration().isAutoCreateBucket()) {
+                if (!getConfiguration().isAutoCreateBucket()) {
                     // We are not requested to create it if it doesn't, so we can only assume that it does
                     return;
                 }


### PR DESCRIPTION
# Description

 The AWS2S3Endpoint tries to do a HeadBucket request, which may not be permitted. This is only a problem if the endpoint is also configured to create the bucket if it does not exist.

Otherwise it may simply be that other actions on the bucket will succeed, and there is not reason to fail if just the HeadBucket request is not permitted.

I though this would be CAMEL-18022, but  I think it is different. 
Now:
https://issues.apache.org/jira/browse/CAMEL-21562
 