### PR TITLE
Revert "chore(deps): Bump org.apache.mina:mina-core from 2.2.3 to 2.2.4 (#16647)"

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -364,7 +364,7 @@
         <microprofile-config-version>3.1</microprofile-config-version>
         <microprofile-fault-tolerance-version>4.1.1</microprofile-fault-tolerance-version>
         <milvus-client-version>2.5.2</milvus-client-version>
-        <mina-version>2.2.4</mina-version>
+        <mina-version>2.2.3</mina-version>
         <minidns-version>0.3.4</minidns-version>
         <minimal-json-version>0.9.5</minimal-json-version>
         <minio-version>8.5.14</minio-version>


### PR DESCRIPTION
This reverts commit 0624c499d0d657c9c034d21281164622fc27a679.

This breaks `camel-mina` and needs to be fixed: https://mina.apache.org/mina-project/