### PR TITLE
CAMEL-21509: Upgrade kubernetes-client to 7.0.1

### DIFF
--- a/components/camel-kubernetes/pom.xml
+++ b/components/camel-kubernetes/pom.xml
@@ -34,23 +34,6 @@
     <properties>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.fabric8</groupId>
-                <artifactId>mockwebserver</artifactId>
-                <version>${mockwebserver-version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.sun</groupId>
-                        <artifactId>tools</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel</groupId>
@@ -87,14 +70,8 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>openshift-server-mock</artifactId>
-            <version>${kubernetes-client-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>${mockwebserver-version}</version>
+            <version>${kubernetes-client-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -126,13 +103,6 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${awaitility-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- forcing okhttp v3.x related to https://issues.apache.org/jira/browse/CAMEL-16336 -->
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${squareup-okhttp-version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-kubernetes/src/generated/java/io/fabric8/kubernetes/client/ConfigFluentImplConfigurer.java
+++ b/components/camel-kubernetes/src/generated/java/io/fabric8/kubernetes/client/ConfigFluentImplConfigurer.java
@@ -56,7 +56,6 @@ public class ConfigFluentImplConfigurer extends org.apache.camel.support.compone
         case "customHeaders": target.withCustomHeaders(property(camelContext, java.util.Map.class, value)); return true;
         case "disablehostnameverification":
         case "disableHostnameVerification": target.withDisableHostnameVerification(property(camelContext, java.lang.Boolean.class, value)); return true;
-        case "file": target.withFile(property(camelContext, java.io.File.class, value)); return true;
         case "http2disable":
         case "http2Disable": target.withHttp2Disable(property(camelContext, java.lang.Boolean.class, value)); return true;
         case "httpproxy":
@@ -162,7 +161,6 @@ public class ConfigFluentImplConfigurer extends org.apache.camel.support.compone
         case "customHeaders": return java.util.Map.class;
         case "disablehostnameverification":
         case "disableHostnameVerification": return java.lang.Boolean.class;
-        case "file": return java.io.File.class;
         case "http2disable":
         case "http2Disable": return java.lang.Boolean.class;
         case "httpproxy":
@@ -269,7 +267,6 @@ public class ConfigFluentImplConfigurer extends org.apache.camel.support.compone
         case "customHeaders": return target.getCustomHeaders();
         case "disablehostnameverification":
         case "disableHostnameVerification": return target.getDisableHostnameVerification();
-        case "file": return target.getFile();
         case "http2disable":
         case "http2Disable": return target.getHttp2Disable();
         case "httpproxy":

--- a/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/deployments/KubernetesDeploymentsProducer.java
+++ b/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/deployments/KubernetesDeploymentsProducer.java
@@ -204,7 +204,7 @@ public class KubernetesDeploymentsProducer extends DefaultProducer {
             throw new IllegalArgumentException("Scale a specific deployment require specify a replicas number");
         }
         Deployment deploymentScaled = getEndpoint().getKubernetesClient().apps().deployments().inNamespace(namespaceName)
-                .withName(deploymentName).scale(replicasNumber, false);
+                .withName(deploymentName).scale(replicasNumber);
 
         prepareOutboundMessage(exchange, deploymentScaled.getStatus().getReplicas());
     }

--- a/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/replication_controllers/KubernetesReplicationControllersProducer.java
+++ b/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/replication_controllers/KubernetesReplicationControllersProducer.java
@@ -229,7 +229,7 @@ public class KubernetesReplicationControllersProducer extends DefaultProducer {
             throw new IllegalArgumentException("Scale a specific replication controller require specify a replicas number");
         }
         ReplicationController rcScaled = getEndpoint().getKubernetesClient().replicationControllers().inNamespace(namespaceName)
-                .withName(rcName).scale(replicasNumber, false);
+                .withName(rcName).scale(replicasNumber);
 
         prepareOutboundMessage(exchange, rcScaled.getStatus().getReplicas());
     }

--- a/components/camel-kubernetes/src/main/java/org/apache/camel/component/openshift/deploymentconfigs/OpenshiftDeploymentConfigsProducer.java
+++ b/components/camel-kubernetes/src/main/java/org/apache/camel/component/openshift/deploymentconfigs/OpenshiftDeploymentConfigsProducer.java
@@ -199,7 +199,7 @@ public class OpenshiftDeploymentConfigsProducer extends DefaultProducer {
         DeploymentConfig deploymentConfigScaled
                 = getEndpoint().getKubernetesClient().adapt(OpenShiftClient.class).deploymentConfigs()
                         .inNamespace(namespaceName)
-                        .withName(deploymentName).scale(replicasNumber, false);
+                        .withName(deploymentName).scale(replicasNumber);
 
         prepareOutboundMessage(exchange, deploymentConfigScaled.getStatus().getReplicas());
     }

--- a/components/camel-kubernetes/src/test/java/org/apache/camel/component/kubernetes/cluster/utils/LockTestServer.java
+++ b/components/camel-kubernetes/src/test/java/org/apache/camel/component/kubernetes/cluster/utils/LockTestServer.java
@@ -33,9 +33,9 @@ import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.mockwebserver.http.Headers;
+import io.fabric8.mockwebserver.http.RecordedRequest;
 import io.fabric8.mockwebserver.utils.ResponseProvider;
-import okhttp3.Headers;
-import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.camel.RuntimeCamelException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,7 +132,7 @@ public class LockTestServer<T extends HasMetadata> extends KubernetesMockServer 
 
                             boolean done = lockSimulator.setResource(resource, true);
                             if (done) {
-                                lockNames.put(request.getSequenceNumber(), lockSimulator.getResourceName());
+                                lockNames.put(LockTestServer.super.getRequestCount(), lockSimulator.getResourceName());
                                 return 201;
                             }
                             return 500;
@@ -142,8 +142,9 @@ public class LockTestServer<T extends HasMetadata> extends KubernetesMockServer 
                         public Object getBody(RecordedRequest recordedRequest) {
                             delayIfNecessary();
 
-                            if (lockNames.containsKey(recordedRequest.getSequenceNumber())) {
-                                T resource = simulators.get(lockNames.get(recordedRequest.getSequenceNumber())).getResource();
+                            if (lockNames.containsKey(LockTestServer.super.getRequestCount())) {
+                                T resource
+                                        = simulators.get(lockNames.get(LockTestServer.super.getRequestCount())).getResource();
                                 if (resource != null) {
                                     return resource;
                                 }

--- a/components/camel-kubernetes/src/test/java/org/apache/camel/component/kubernetes/consumer/integration/KubernetesEventsConsumerIT.java
+++ b/components/camel-kubernetes/src/test/java/org/apache/camel/component/kubernetes/consumer/integration/KubernetesEventsConsumerIT.java
@@ -31,6 +31,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.kubernetes.KubernetesConstants;
 import org.apache.camel.component.kubernetes.KubernetesTestSupport;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,11 @@ public class KubernetesEventsConsumerIT extends KubernetesTestSupport {
 
     @EndpointInject("mock:result")
     protected MockEndpoint mockResultEndpoint;
+
+    @BeforeEach
+    void beforeEach() {
+        MockEndpoint.resetMocks(context);
+    }
 
     private void setupFullEventWithHeaders(Exchange exchange) {
         exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_NAMESPACE_NAME, "default");

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/pom.xml
@@ -47,18 +47,6 @@
           <artifactId>camel-jbang-core</artifactId>
         </dependency>
 
-        <!-- Needed for TLS access to private registries -->
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-            <version>${bouncycastle-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk18on</artifactId>
-            <version>${bouncycastle-version}</version>
-        </dependency>
-
         <!-- Kubernetes -->
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -77,7 +65,7 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>knative-model</artifactId>
-            <version>${knative-client-version}</version>
+            <version>${kubernetes-client-version}</version>
         </dependency>
 
        <!-- Test dependencies -->

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/knative/KnativeTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/knative/KnativeTrait.java
@@ -30,13 +30,13 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.fabric8.knative.duck.v1.DestinationBuilder;
+import io.fabric8.knative.duck.v1.KReference;
+import io.fabric8.knative.duck.v1.KReferenceBuilder;
 import io.fabric8.knative.eventing.v1.TriggerBuilder;
 import io.fabric8.knative.eventing.v1.TriggerFilterBuilder;
-import io.fabric8.knative.internal.pkg.apis.duck.v1.DestinationBuilder;
-import io.fabric8.knative.internal.pkg.apis.duck.v1.KReference;
-import io.fabric8.knative.internal.pkg.apis.duck.v1.KReferenceBuilder;
-import io.fabric8.knative.internal.pkg.tracker.ReferenceBuilder;
 import io.fabric8.knative.messaging.v1.SubscriptionBuilder;
+import io.fabric8.knative.pkg.tracker.ReferenceBuilder;
 import io.fabric8.knative.sources.v1.SinkBindingBuilder;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.KubernetesHelper;

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesBaseTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesBaseTest.java
@@ -26,7 +26,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.mockwebserver.Context;
-import okhttp3.mockwebserver.MockWebServer;
+import io.fabric8.mockwebserver.MockWebServer;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.dsl.jbang.core.common.PluginHelper;
 import org.apache.camel.dsl.jbang.core.common.PluginType;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -316,8 +316,7 @@
         <jython-version>2.7.4</jython-version>
         <jzlib-version>1.1.3</jzlib-version>
         <kafka-version>3.8.1</kafka-version>
-        <knative-client-version>6.13.4</knative-client-version>
-        <kubernetes-client-version>6.13.4</kubernetes-client-version>
+        <kubernetes-client-version>7.0.1</kubernetes-client-version>
         <kudu-version>1.17.1</kudu-version>
         <langchain4j-version>0.36.2</langchain4j-version>
         <leveldbjni-version>1.8</leveldbjni-version>
@@ -368,7 +367,6 @@
         <minimal-json-version>0.9.5</minimal-json-version>
         <minio-version>8.5.15</minio-version>
         <mock-javamail-version>1.9</mock-javamail-version>
-        <mockwebserver-version>6.13.4</mockwebserver-version>
         <mockito-version>5.15.2</mockito-version>
         <mojo-executor-version>2.4.0</mojo-executor-version>
         <mongo-java-driver-version>5.2.1</mongo-java-driver-version>


### PR DESCRIPTION
* Unit / integration tests on k8s and OpenShift pass

* Removed duplicate version properties

* Removed bouncycastle from `camel-jbang-plugin-kubernetes`. Apparently, it is [no longer required](https://github.com/fabric8io/kubernetes-client/blob/main/doc/MIGRATION-v7.md#bouncy-castle-is-no-longer-needed-).