### PR TITLE
CAMEL-21606 - Camel route validation mojo fails if it depends on external sources without cleaning the target folder

### DIFF
--- a/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/ValidateMojo.java
+++ b/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/ValidateMojo.java
@@ -359,11 +359,9 @@ public class ValidateMojo extends AbstractMojo {
 
             Path target = extraSourcesPath.resolve(artifact.getGav().getArtifactId());
             getLog().info("Unzipping the artifact: " + artifact + " to " + target);
-            if (Files.exists(target)) {
-                continue;
+            if (!Files.exists(target)) {
+                unzipArtifact(artifact, target);
             }
-
-            unzipArtifact(artifact, target);
 
             FileUtil.findJavaFiles(target.toFile(), javaFiles);
             FileUtil.findXmlFiles(target.toFile(), xmlFiles);
@@ -560,7 +558,7 @@ public class ValidateMojo extends AbstractMojo {
 
         // find all java route builder classes
         findJavaRouteBuilderClasses(javaFiles, includeJava, includeTest, project);
-        // find all xml routes
+        // find all XML routes
         findXmlRouters(xmlFiles, includeXml, includeTest, project);
 
         for (File file : javaFiles) {
@@ -852,7 +850,7 @@ public class ValidateMojo extends AbstractMojo {
             String fqn = file.getPath();
             String baseDir = ".";
             JavaType<?> out = Roaster.parse(file);
-            // we should only parse java classes (not interfaces and enums etc)
+            // we should only parse java classes (not interfaces and enums etc.)
             if (out instanceof JavaClassSource clazz) {
                 RouteBuilderParser.parseRouteBuilderEndpoints(clazz, baseDir, fqn, fileEndpoints, unparsable, includeTest);
                 RouteBuilderParser.parseRouteBuilderSimpleExpressions(clazz, baseDir, fqn, fileSimpleExpressions);
@@ -904,7 +902,7 @@ public class ValidateMojo extends AbstractMojo {
         Set<CamelEndpointDetails> producers = endpoints.stream()
                 .filter(e -> e.isProducerOnly() && e.getEndpointUri().startsWith(scheme + ":")).collect(Collectors.toSet());
 
-        // are there any producers that do not have a consumer pair
+        // are there any producers that do not have a consumer pair?
         for (CamelEndpointDetails detail : producers) {
             boolean none = consumers.stream().noneMatch(c -> matchEndpointPath(detail.getEndpointUri(), c.getEndpointUri()));
             if (none) {


### PR DESCRIPTION
# Description

Camel route validation mojo fails if it depends on external sources without cleaning the target folder

# Target

- [x] I checked that the commit is targeting the correct branch (note that Camel 3 uses `camel-3.x`, whereas Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.