### PR TITLE
chore: Group dependabot update for micrometer and opentelemetry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,11 @@ updates:
       - dependency-name: "io.smallrye:jandex:*"
       # Spring Boot Dependencies related
       - dependency-name: "org.apache.logging.log4j:*"
+    groups:
+      Micrometer:
+        patterns: ["micrometer*"]
+      Opentelemetry:
+        patterns: ["opentelemetry*"]
     open-pull-requests-limit: 20
   - package-ecosystem: "npm"
     directory: "docs"


### PR DESCRIPTION
There are 2 different versions produced for each of these groups of dependencies but that are always released at the same time and which corresponds to each other. I think it would make sense to update them in the same Pull Request.

see previous updates:
* https://github.com/apache/camel/pull/16799
* https://github.com/apache/camel/pull/16797
* https://github.com/apache/camel/pull/16792
* https://github.com/apache/camel/pull/16791

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

