### PR TITLE
(chores) camel-jpa: enforce a timeout for some thread-unsafe tests

### DIFF
--- a/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNamedQueryTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNamedQueryTest.java
@@ -34,6 +34,7 @@ import org.apache.camel.support.service.ServiceHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.TransactionStatus;
@@ -44,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Timeout(30)
 public class JpaWithNamedQueryTest {
 
     protected static final Logger LOG = LoggerFactory.getLogger(JpaWithNamedQueryTest.class);
@@ -102,7 +104,7 @@ public class JpaWithNamedQueryTest {
         });
         consumer.start();
 
-        assertTrue(latch.await(50, TimeUnit.SECONDS));
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
 
         assertReceivedResult(receivedExchange);
 

--- a/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNativeQueryTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNativeQueryTest.java
@@ -18,11 +18,13 @@ package org.apache.camel.component.jpa;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.examples.MultiSteps;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@Timeout(30)
 @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
                           disabledReason = "Apache CI is hanging on this test")
 public class JpaWithNativeQueryTest extends JpaWithNamedQueryTest {

--- a/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithQueryTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithQueryTest.java
@@ -17,10 +17,12 @@
 package org.apache.camel.component.jpa;
 
 import org.apache.camel.examples.MultiSteps;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Timeout(30)
 @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
                           disabledReason = "Apache CI is hanging on this test")
 public class JpaWithQueryTest extends JpaWithNamedQueryTest {

--- a/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaProducerWithQueryTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaProducerWithQueryTest.java
@@ -29,9 +29,11 @@ import org.apache.camel.support.SimpleRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Timeout(30)
 public class JpaProducerWithQueryTest {
 
     protected DefaultCamelContext camelContext;


### PR DESCRIPTION
Sometimes these tests hang indefinitely