### PR TITLE
CAMEL-20199: Remove synchronized blocks from components T to Z

### DIFF
--- a/components/camel-thymeleaf/src/main/java/org/apache/camel/component/thymeleaf/ThymeleafEndpoint.java
+++ b/components/camel-thymeleaf/src/main/java/org/apache/camel/component/thymeleaf/ThymeleafEndpoint.java
@@ -241,39 +241,44 @@ public class ThymeleafEndpoint extends ResourceEndpoint {
         this.cacheable = cacheable;
     }
 
-    protected synchronized TemplateEngine getTemplateEngine() {
-        if (templateEngine == null) {
-            ITemplateResolver templateResolver;
+    protected TemplateEngine getTemplateEngine() {
+        getInternalLock().lock();
+        try {
+            if (templateEngine == null) {
+                ITemplateResolver templateResolver;
 
-            switch (resolver) {
-                case CLASS_LOADER -> {
-                    templateResolver = classLoaderTemplateResolver();
+                switch (resolver) {
+                    case CLASS_LOADER -> {
+                        templateResolver = classLoaderTemplateResolver();
+                    }
+                    case DEFAULT -> {
+                        templateResolver = defaultTemplateResolver();
+                    }
+                    case FILE -> {
+                        templateResolver = fileTemplateResolver();
+                    }
+                    case STRING -> {
+                        templateResolver = stringTemplateResolver();
+                    }
+                    case URL -> {
+                        templateResolver = urlTemplateResolver();
+                    }
+                    case WEB_APP -> {
+                        templateResolver = webApplicationTemplateResolver();
+                    }
+                    default -> {
+                        throw new RuntimeCamelException("cannot determine TemplateResolver for type " + resolver);
+                    }
                 }
-                case DEFAULT -> {
-                    templateResolver = defaultTemplateResolver();
-                }
-                case FILE -> {
-                    templateResolver = fileTemplateResolver();
-                }
-                case STRING -> {
-                    templateResolver = stringTemplateResolver();
-                }
-                case URL -> {
-                    templateResolver = urlTemplateResolver();
-                }
-                case WEB_APP -> {
-                    templateResolver = webApplicationTemplateResolver();
-                }
-                default -> {
-                    throw new RuntimeCamelException("cannot determine TemplateResolver for type " + resolver);
-                }
+
+                templateEngine = new TemplateEngine();
+                templateEngine.setTemplateResolver(templateResolver);
             }
 
-            templateEngine = new TemplateEngine();
-            templateEngine.setTemplateResolver(templateResolver);
+            return templateEngine;
+        } finally {
+            getInternalLock().unlock();
         }
-
-        return templateEngine;
     }
 
     /**

--- a/components/camel-timer/src/main/java/org/apache/camel/component/timer/TimerComponent.java
+++ b/components/camel-timer/src/main/java/org/apache/camel/component/timer/TimerComponent.java
@@ -19,9 +19,9 @@ package org.apache.camel.component.timer;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Timer;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.Endpoint;
@@ -38,8 +38,7 @@ import org.apache.camel.support.DefaultComponent;
  */
 @org.apache.camel.spi.annotations.Component("timer")
 public class TimerComponent extends DefaultComponent {
-    private final Map<String, Timer> timers = new HashMap<>();
-    private final Map<String, AtomicInteger> refCounts = new HashMap<>();
+    private final Map<String, TimerHolder> timers = new ConcurrentHashMap<>();
 
     @Metadata
     private boolean includeMetadata;
@@ -66,26 +65,16 @@ public class TimerComponent extends DefaultComponent {
             key = "nonDaemon:" + key;
         }
 
-        Timer answer;
-        synchronized (timers) {
-            answer = timers.get(key);
-            if (answer == null) {
+        return timers.compute(key, (k, v) -> {
+            if (v == null) {
                 // the timer name is also the thread name, so lets resolve a name to be used
                 String name = consumer.getEndpoint().getCamelContext().getExecutorServiceManager()
                         .resolveThreadName("timer://" + consumer.getEndpoint().getTimerName());
-                answer = new Timer(name, consumer.getEndpoint().isDaemon());
-                timers.put(key, answer);
-                // store new reference counter
-                refCounts.put(key, new AtomicInteger(1));
-            } else {
-                // increase reference counter
-                AtomicInteger counter = refCounts.get(key);
-                if (counter != null) {
-                    counter.incrementAndGet();
-                }
+                return new TimerHolder(new Timer(name, consumer.getEndpoint().isDaemon()));
             }
-        }
-        return answer;
+            v.refCount.incrementAndGet();
+            return v;
+        }).timer;
     }
 
     public void removeTimer(TimerConsumer consumer) {
@@ -93,19 +82,13 @@ public class TimerComponent extends DefaultComponent {
         if (!consumer.getEndpoint().isDaemon()) {
             key = "nonDaemon:" + key;
         }
-
-        synchronized (timers) {
-            // decrease reference counter
-            AtomicInteger counter = refCounts.get(key);
-            if (counter != null && counter.decrementAndGet() <= 0) {
-                refCounts.remove(key);
-                // remove timer as its no longer in use
-                Timer timer = timers.remove(key);
-                if (timer != null) {
-                    timer.cancel();
-                }
+        timers.computeIfPresent(key, (k, v) -> {
+            if (v.refCount.decrementAndGet() == 0) {
+                v.timer.cancel();
+                return null;
             }
-        }
+            return v;
+        });
     }
 
     @Override
@@ -136,11 +119,20 @@ public class TimerComponent extends DefaultComponent {
 
     @Override
     protected void doStop() throws Exception {
-        Collection<Timer> collection = timers.values();
-        for (Timer timer : collection) {
-            timer.cancel();
+        Collection<TimerHolder> collection = timers.values();
+        for (TimerHolder holder : collection) {
+            holder.timer.cancel();
         }
         timers.clear();
-        refCounts.clear();
+    }
+
+    private static class TimerHolder {
+        private final Timer timer;
+        private final AtomicInteger refCount;
+
+        private TimerHolder(Timer timer) {
+            this.timer = timer;
+            this.refCount = new AtomicInteger(1);
+        }
     }
 }

--- a/components/camel-twilio/src/main/java/org/apache/camel/component/twilio/internal/TwilioPropertiesHelper.java
+++ b/components/camel-twilio/src/main/java/org/apache/camel/component/twilio/internal/TwilioPropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.twilio.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.twilio.TwilioConfiguration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class TwilioPropertiesHelper extends ApiMethodPropertiesHelper<TwilioConfiguration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static TwilioPropertiesHelper helper;
 
     private TwilioPropertiesHelper(CamelContext context) {
         super(context, TwilioConfiguration.class, TwilioConstants.PROPERTY_PREFIX);
     }
 
-    public static synchronized TwilioPropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new TwilioPropertiesHelper(context);
+    public static TwilioPropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new TwilioPropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/handlers/CamelPathHandler.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/handlers/CamelPathHandler.java
@@ -18,6 +18,8 @@ package org.apache.camel.component.undertow.handlers;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import io.undertow.server.HttpHandler;
 import io.undertow.server.handlers.PathHandler;
@@ -26,6 +28,7 @@ import io.undertow.server.handlers.PathHandler;
  * Extended PathHandler to monitor add/remove handlers.
  */
 public class CamelPathHandler extends PathHandler {
+    private final Lock lock = new ReentrantLock();
     private final Map<String, HttpHandler> handlers = new HashMap<>();
     private String handlerString;
 
@@ -34,35 +37,55 @@ public class CamelPathHandler extends PathHandler {
     }
 
     @Override
-    public synchronized PathHandler addPrefixPath(final String path, final HttpHandler handler) {
-        super.addPrefixPath(path, handler);
-        handlers.put(path, handler);
-        handlerString = null;
-        return this;
+    public PathHandler addPrefixPath(final String path, final HttpHandler handler) {
+        lock.lock();
+        try {
+            super.addPrefixPath(path, handler);
+            handlers.put(path, handler);
+            handlerString = null;
+            return this;
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
-    public synchronized PathHandler addExactPath(final String path, final HttpHandler handler) {
-        super.addExactPath(path, handler);
-        handlers.put(path, handler);
-        handlerString = null;
-        return this;
+    public PathHandler addExactPath(final String path, final HttpHandler handler) {
+        lock.lock();
+        try {
+            super.addExactPath(path, handler);
+            handlers.put(path, handler);
+            handlerString = null;
+            return this;
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
-    public synchronized PathHandler removePrefixPath(final String path) {
-        super.removePrefixPath(path);
-        handlers.remove(path);
-        handlerString = null;
-        return this;
+    public PathHandler removePrefixPath(final String path) {
+        lock.lock();
+        try {
+            super.removePrefixPath(path);
+            handlers.remove(path);
+            handlerString = null;
+            return this;
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
-    public synchronized PathHandler removeExactPath(final String path) {
-        super.removeExactPath(path);
-        handlers.remove(path);
-        handlerString = null;
-        return this;
+    public PathHandler removeExactPath(final String path) {
+        lock.lock();
+        try {
+            super.removeExactPath(path);
+            handlers.remove(path);
+            handlerString = null;
+            return this;
+        } finally {
+            lock.unlock();
+        }
     }
 
     public HttpHandler getHandler(String path) {

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/handlers/CamelRootHandler.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/handlers/CamelRootHandler.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.undertow.handlers;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.PathTemplate;
@@ -27,6 +30,7 @@ import io.undertow.util.URLUtils;
  * @see RestRootHandler
  */
 public class CamelRootHandler implements HttpHandler {
+    private final Lock lock = new ReentrantLock();
     private final CamelPathHandler pathHandler;
 
     public CamelRootHandler(HttpHandler defaultHandler) {
@@ -38,50 +42,56 @@ public class CamelRootHandler implements HttpHandler {
         pathHandler.handleRequest(exchange);
     }
 
-    public synchronized HttpHandler add(String path, String methods, boolean prefixMatch, HttpHandler handler) {
-        String basePath = getBasePath(path);
-        HttpHandler basePathHandler = pathHandler.getHandler(basePath);
+    public HttpHandler add(String path, String methods, boolean prefixMatch, HttpHandler handler) {
+        lock.lock();
+        try {
+            String basePath = getBasePath(path);
+            HttpHandler basePathHandler = pathHandler.getHandler(basePath);
 
-        CamelMethodHandler targetHandler;
-        if (path.contains("{")) {
-            // Adding a handler for the template path
-            String relativePath = path.substring(basePath.length());
-            if (basePathHandler instanceof CamelPathTemplateHandler) {
-                CamelPathTemplateHandler templateHandler = (CamelPathTemplateHandler) basePathHandler;
-                targetHandler = templateHandler.get(relativePath);
-                if (targetHandler == null) {
-                    targetHandler = new CamelMethodHandler();
-                    templateHandler.add(relativePath, targetHandler);
-                }
-            } else {
-                targetHandler = add(basePathHandler, relativePath, basePath);
-            }
-
-        } else {
-            // Adding a handler for the static path
-            if (basePathHandler instanceof CamelPathTemplateHandler) {
-                CamelPathTemplateHandler templateHandler = (CamelPathTemplateHandler) basePathHandler;
-                if (!prefixMatch) {
-                    targetHandler = templateHandler.getDefault();
-                } else {
-                    throw new IllegalArgumentException(String.format("Duplicate handlers on a path '%s'", path));
-                }
-            } else {
-                if (basePathHandler instanceof CamelMethodHandler) {
-                    targetHandler = (CamelMethodHandler) basePathHandler;
-                } else if (basePathHandler == null) {
-                    targetHandler = new CamelMethodHandler();
-                    if (prefixMatch) {
-                        pathHandler.addPrefixPath(basePath, targetHandler);
-                    } else {
-                        pathHandler.addExactPath(basePath, targetHandler);
+            CamelMethodHandler targetHandler;
+            if (path.contains("{")) {
+                // Adding a handler for the template path
+                String relativePath = path.substring(basePath.length());
+                if (basePathHandler instanceof CamelPathTemplateHandler) {
+                    CamelPathTemplateHandler templateHandler = (CamelPathTemplateHandler) basePathHandler;
+                    targetHandler = templateHandler.get(relativePath);
+                    if (targetHandler == null) {
+                        targetHandler = new CamelMethodHandler();
+                        templateHandler.add(relativePath, targetHandler);
                     }
                 } else {
-                    throw new IllegalArgumentException(String.format("Unsupported handler '%s' was found", basePathHandler));
+                    targetHandler = add(basePathHandler, relativePath, basePath);
+                }
+
+            } else {
+                // Adding a handler for the static path
+                if (basePathHandler instanceof CamelPathTemplateHandler) {
+                    CamelPathTemplateHandler templateHandler = (CamelPathTemplateHandler) basePathHandler;
+                    if (!prefixMatch) {
+                        targetHandler = templateHandler.getDefault();
+                    } else {
+                        throw new IllegalArgumentException(String.format("Duplicate handlers on a path '%s'", path));
+                    }
+                } else {
+                    if (basePathHandler instanceof CamelMethodHandler) {
+                        targetHandler = (CamelMethodHandler) basePathHandler;
+                    } else if (basePathHandler == null) {
+                        targetHandler = new CamelMethodHandler();
+                        if (prefixMatch) {
+                            pathHandler.addPrefixPath(basePath, targetHandler);
+                        } else {
+                            pathHandler.addExactPath(basePath, targetHandler);
+                        }
+                    } else {
+                        throw new IllegalArgumentException(
+                                String.format("Unsupported handler '%s' was found", basePathHandler));
+                    }
                 }
             }
+            return targetHandler.add(methods, handler);
+        } finally {
+            lock.unlock();
         }
-        return targetHandler.add(methods, handler);
     }
 
     private CamelMethodHandler add(HttpHandler basePathHandler, String relativePath, String basePath) {
@@ -101,52 +111,62 @@ public class CamelRootHandler implements HttpHandler {
         return targetHandler;
     }
 
-    public synchronized void remove(String path, String methods, boolean prefixMatch) {
-        String basePath = getBasePath(path);
-        HttpHandler basePathHandler = pathHandler.getHandler(basePath);
-        if (basePathHandler == null) {
-            return;
-        }
-
-        if (path.contains("{")) {
-            // Removing a handler for the template path
-            String relativePath = path.substring(basePath.length());
-            CamelPathTemplateHandler templateHandler = (CamelPathTemplateHandler) basePathHandler;
-            CamelMethodHandler targetHandler = templateHandler.get(relativePath);
-            if (targetHandler.remove(methods)) {
-                templateHandler.remove(relativePath);
-                if (templateHandler.isEmpty()) {
-                    pathHandler.removePrefixPath(basePath);
-                }
+    public void remove(String path, String methods, boolean prefixMatch) {
+        lock.lock();
+        try {
+            String basePath = getBasePath(path);
+            HttpHandler basePathHandler = pathHandler.getHandler(basePath);
+            if (basePathHandler == null) {
+                return;
             }
 
-        } else {
-            // Removing a handler for the static path
-            if (basePathHandler instanceof CamelPathTemplateHandler) {
+            if (path.contains("{")) {
+                // Removing a handler for the template path
                 String relativePath = path.substring(basePath.length());
                 CamelPathTemplateHandler templateHandler = (CamelPathTemplateHandler) basePathHandler;
-                CamelMethodHandler targetHandler = templateHandler.getDefault();
+                CamelMethodHandler targetHandler = templateHandler.get(relativePath);
                 if (targetHandler.remove(methods)) {
                     templateHandler.remove(relativePath);
                     if (templateHandler.isEmpty()) {
                         pathHandler.removePrefixPath(basePath);
                     }
                 }
+
             } else {
-                CamelMethodHandler targetHandler = (CamelMethodHandler) basePathHandler;
-                if (targetHandler.remove(methods)) {
-                    if (prefixMatch) {
-                        pathHandler.removePrefixPath(basePath);
-                    } else {
-                        pathHandler.removeExactPath(basePath);
+                // Removing a handler for the static path
+                if (basePathHandler instanceof CamelPathTemplateHandler) {
+                    String relativePath = path.substring(basePath.length());
+                    CamelPathTemplateHandler templateHandler = (CamelPathTemplateHandler) basePathHandler;
+                    CamelMethodHandler targetHandler = templateHandler.getDefault();
+                    if (targetHandler.remove(methods)) {
+                        templateHandler.remove(relativePath);
+                        if (templateHandler.isEmpty()) {
+                            pathHandler.removePrefixPath(basePath);
+                        }
+                    }
+                } else {
+                    CamelMethodHandler targetHandler = (CamelMethodHandler) basePathHandler;
+                    if (targetHandler.remove(methods)) {
+                        if (prefixMatch) {
+                            pathHandler.removePrefixPath(basePath);
+                        } else {
+                            pathHandler.removeExactPath(basePath);
+                        }
                     }
                 }
             }
+        } finally {
+            lock.unlock();
         }
     }
 
-    public synchronized boolean isEmpty() {
-        return pathHandler.isEmpty();
+    public boolean isEmpty() {
+        lock.lock();
+        try {
+            return pathHandler.isEmpty();
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/components/camel-xchange/src/main/java/org/apache/camel/component/xchange/XChangeComponent.java
+++ b/components/camel-xchange/src/main/java/org/apache/camel/component/xchange/XChangeComponent.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.component.xchange;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.camel.Endpoint;
 import org.apache.camel.spi.annotations.Component;
@@ -29,7 +29,7 @@ import org.knowm.xchange.utils.Assert;
 @Component("xchange")
 public class XChangeComponent extends DefaultComponent {
 
-    private final Map<String, XChange> xchanges = new HashMap<>();
+    private final Map<String, XChange> xchanges = new ConcurrentHashMap<>();
 
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
@@ -64,7 +64,7 @@ public class XChangeComponent extends DefaultComponent {
         return ExchangeFactory.INSTANCE.createExchange(exchangeClass);
     }
 
-    private synchronized XChange getOrCreateXChange(String name) {
+    private XChange getOrCreateXChange(String name) {
         return xchanges.computeIfAbsent(name, xc -> {
             Class<? extends Exchange> exchangeClass = XChangeHelper.loadXChangeClass(getCamelContext(), name);
             Assert.notNull(exchangeClass, "XChange not supported: " + name);

--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppPrivateChatProducer.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppPrivateChatProducer.java
@@ -110,12 +110,17 @@ public class XmppPrivateChatProducer extends DefaultProducer {
         return chatManager.chatWith(JidCreate.entityBareFrom(participant));
     }
 
-    private synchronized void reconnect() throws InterruptedException, IOException, SmackException, XMPPException {
-        if (!connection.isConnected()) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Reconnecting to: {}", XmppEndpoint.getConnectionMessage(connection));
+    private void reconnect() throws InterruptedException, IOException, SmackException, XMPPException {
+        lock.lock();
+        try {
+            if (!connection.isConnected()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Reconnecting to: {}", XmppEndpoint.getConnectionMessage(connection));
+                }
+                connection.connect();
             }
-            connection.connect();
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/components/camel-xslt/src/main/java/org/apache/camel/component/xslt/XsltBuilder.java
+++ b/components/camel-xslt/src/main/java/org/apache/camel/component/xslt/XsltBuilder.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.xml.transform.ErrorListener;
 import javax.xml.transform.Result;
@@ -75,7 +77,7 @@ public class XsltBuilder implements Processor {
     private XsltMessageLogger xsltMessageLogger;
 
     private final XMLConverterHelper converter = new XMLConverterHelper();
-    private final Object sourceHandlerFactoryLock = new Object();
+    private final Lock sourceHandlerFactoryLock = new ReentrantLock();
 
     public XsltBuilder() {
     }
@@ -298,12 +300,15 @@ public class XsltBuilder implements Processor {
 
     public SourceHandlerFactory getSourceHandlerFactory() {
         if (this.sourceHandlerFactory == null) {
-            synchronized (this.sourceHandlerFactoryLock) {
+            sourceHandlerFactoryLock.lock();
+            try {
                 if (this.sourceHandlerFactory == null) {
                     final XmlSourceHandlerFactoryImpl xmlSourceHandlerFactory = createXmlSourceHandlerFactoryImpl();
                     xmlSourceHandlerFactory.setFailOnNullBody(isFailOnNullBody());
                     this.sourceHandlerFactory = xmlSourceHandlerFactory;
                 }
+            } finally {
+                sourceHandlerFactoryLock.unlock();
             }
         }
 

--- a/components/camel-zendesk/src/main/java/org/apache/camel/component/zendesk/internal/ZendeskPropertiesHelper.java
+++ b/components/camel-zendesk/src/main/java/org/apache/camel/component/zendesk/internal/ZendeskPropertiesHelper.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.zendesk.internal;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.zendesk.ZendeskConfiguration;
 import org.apache.camel.support.component.ApiMethodPropertiesHelper;
@@ -25,16 +28,22 @@ import org.apache.camel.support.component.ApiMethodPropertiesHelper;
  */
 public final class ZendeskPropertiesHelper extends ApiMethodPropertiesHelper<ZendeskConfiguration> {
 
+    private static final Lock LOCK = new ReentrantLock();
     private static ZendeskPropertiesHelper helper;
 
     private ZendeskPropertiesHelper(CamelContext context) {
         super(context, ZendeskConfiguration.class, ZendeskConstants.PROPERTY_PREFIX);
     }
 
-    public static synchronized ZendeskPropertiesHelper getHelper(CamelContext context) {
-        if (helper == null) {
-            helper = new ZendeskPropertiesHelper(context);
+    public static ZendeskPropertiesHelper getHelper(CamelContext context) {
+        LOCK.lock();
+        try {
+            if (helper == null) {
+                helper = new ZendeskPropertiesHelper(context);
+            }
+            return helper;
+        } finally {
+            LOCK.unlock();
         }
-        return helper;
     }
 }


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-20199

## Motivation

For better support of virtual threads, we need to avoid lengthy and frequent pinning by replacing synchronized blocks with ReentrantLocks

## Modifications:

* Replace mutex with locks
* Use locks instead of synchronized blocks
* Leverage ConcurrentMap methods to get rid of synchronized blocks