### PR TITLE
Align versions with spring-boot-dependencies 3.3.8

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -57,7 +57,7 @@
 
         <!-- dependency versions -->
         <activemq-version>5.18.6</activemq-version>
-        <activemq6-version>6.1.3</activemq6-version>
+        <activemq6-version>6.1.5</activemq6-version>
         <activemq-artemis-version>2.37.0</activemq-artemis-version>
         <amazon-kinesis-client-version>2.6.0</amazon-kinesis-client-version>
         <angus-mail-version>2.0.3</angus-mail-version>
@@ -448,7 +448,7 @@
         <solr-zookeeper-version>3.9.2</solr-zookeeper-version>
         <splunk-version>1.9.5_1</splunk-version>
         <spock-version>2.3-groovy-4.0</spock-version>
-        <spring-batch-version>5.1.2</spring-batch-version>
+        <spring-batch-version>5.1.3</spring-batch-version>
         <spring-data-redis-version>3.3.3</spring-data-redis-version>
         <spring-ldap-version>3.2.10</spring-ldap-version>
         <spring-vault-core-version>3.1.2</spring-vault-core-version>


### PR DESCRIPTION
# Description

Align the versions of activemq6 and spring-batch to the versions used in spring-boot-dependencies 3.3.8

This change coincides with the spring-boot 3.3.8 upgrade PR in camel-spring-boot https://github.com/apache/camel-spring-boot/pull/1351


# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

No JIRA, small change


# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.


- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

