### PR TITLE
Fix duplicate property in KubernetesExport of camel-jbang-plugin-kubernetes

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd
@@ -12685,7 +12685,8 @@ Sets the bean ref name of the error handler builder to use on this route.
           <xs:annotation>
             <xs:documentation xml:lang="en">
 <![CDATA[
-The group name for this route. Multiple routes can belong to the same group.
+The group that this route belongs to; could be the name of the RouteBuilder class or be explicitly configured in the
+XML. May be null.
 ]]>
             </xs:documentation>
           </xs:annotation>

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -220,7 +220,7 @@ public abstract class ExportBaseCommand extends CamelCommand {
 
     @CommandLine.Option(names = { "--property" },
                         description = "Camel application properties, ex. --property=prop1=foo")
-    String[] applicationProperties;
+    protected String[] applicationProperties;
 
     @CommandLine.Option(names = { "--logging" }, defaultValue = "false",
                         description = "Can be used to turn on logging (logs to file in <user home>/.camel directory)")

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
@@ -56,10 +56,6 @@ public class KubernetesExport extends Export {
     @CommandLine.Option(names = { "--service-account" }, description = "The service account used to run the application.")
     protected String serviceAccount;
 
-    @CommandLine.Option(names = { "--property" },
-                        description = "Add a runtime property or properties file from a path, a config map or a secret (syntax: [my-key=my-value|file:/path/to/my-conf.properties|[configmap|secret]:name]).")
-    protected String[] properties;
-
     @CommandLine.Option(names = { "--config" },
                         description = "Add a runtime configuration from a ConfigMap or a Secret (syntax: [configmap|secret]:name[/key], where name represents the configmap/secret name and key optionally represents the configmap/secret key to be filtered).")
     protected String[] configs;
@@ -251,7 +247,7 @@ public class KubernetesExport extends Export {
             // Remove OpenAPI spec option to avoid duplicate handling by parent export command
             openapi = null;
         }
-        TraitHelper.configureProperties(traitsSpec, properties);
+        TraitHelper.configureProperties(traitsSpec, applicationProperties);
         TraitHelper.configureContainerImage(traitsSpec, image,
                 resolvedImageRegistry, resolvedImageGroup, projectName, getVersion());
         TraitHelper.configureEnvVars(traitsSpec, envVars);
@@ -474,6 +470,10 @@ public class KubernetesExport extends Export {
         }
 
         return super.getVersion();
+    }
+
+    protected void setApplicationProperties(String[] props) {
+        this.applicationProperties = props;
     }
 
     /**

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
@@ -380,7 +380,7 @@ public class KubernetesRun extends KubernetesBaseCommand {
         export.imageBuilder = imageBuilder;
         export.clusterType = clusterType;
         export.serviceAccount = serviceAccount;
-        export.properties = properties;
+        export.setApplicationProperties(properties);
         export.configs = configs;
         export.resources = resources;
         export.envVars = envVars;


### PR DESCRIPTION
The picocli parameter "property" is duplicated in ExportBaseCommand and KubernetesExport causing CommandLine$DuplicateOptionAnnotationsException: Option name '--property' is used by both field

The `catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-spring.xsd` is from the catalog, probably from some previous unrelated change.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

