### PR TITLE
CAMEL-20367: Adds exporting with dependencies tests

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ExportITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ExportITCase.java
@@ -82,4 +82,32 @@ public class ExportITCase extends JBangTestSupport {
                 "export --gav=com.foo:acme:1.0-SNAPSHOT --directory=%s", mountPoint()));
         assertFileInDataFolderContains("pom.xml", "<groupId>org.apache.camel.quarkus</groupId>");
     }
+
+    @Test
+    public void testExportWithAgent() throws IOException {
+        newFileInDataFolder("application.properties",
+                "camel.jbang.dependencies=camel:opentelemetry,agent:io.opentelemetry.javaagent:opentelemetry-javaagent:1.31.0\n"
+                                                      +
+                                                      "camel.opentelemetry.enabled=true");
+        execInContainer(String.format("mv %s/application.properties .", mountPoint()));
+        execute(String.format(
+                "export --runtime=camel-main --gav=com.foo:acme:1.0-SNAPSHOT --directory=%s", mountPoint()));
+        assertFileInDataFolderExists("agent/opentelemetry-javaagent-1.31.0.jar");
+    }
+
+    @Test
+    public void testExportWithJMXManagement() throws IOException {
+        execute(String.format(
+                "export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --dep=camel:management --directory=%s",
+                mountPoint()));
+        assertFileInDataFolderContains("pom.xml", "<artifactId>camel-quarkus-management</artifactId>\n");
+    }
+
+    @Test
+    public void testExportWithCliConnector() throws IOException {
+        execute(String.format(
+                "export --runtime=quarkus --gav=com.foo:acme:1.0-SNAPSHOT --dep=camel:cli-connector --directory=%s",
+                mountPoint()));
+        assertFileInDataFolderContains("pom.xml", "<artifactId>camel-quarkus-cli-connector</artifactId>\n");
+    }
 }


### PR DESCRIPTION
Adds tests for [exporting with JMX manager](https://camel.apache.org/manual/camel-jbang.html#_exporting_with_jmx_management_included), [exporting with cli-connector](https://camel.apache.org/manual/camel-jbang.html#_exporting_with_camel_cli_included) and [exporting with Java agent](https://camel.apache.org/manual/camel-jbang.html#_exporting_with_java_agent_included)

