### PR TITLE
CAMEL-21668 : Force the creation of the parent log dir

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -1617,7 +1617,9 @@ public class Run extends CamelCommand {
             if (!scriptRun) {
                 // remember log file
                 String name = RuntimeUtil.getPid() + ".log";
-                logFile = new File(CommandLineHelper.getCamelDir(), name);
+                final File logDir = CommandLineHelper.getCamelDir();
+                logDir.mkdirs(); //make sure the parent dir exists
+                logFile = new File(logDir, name);
                 logFile.deleteOnExit();
             }
         } else {


### PR DESCRIPTION
Make sure the log directory exists during the logging configuration