### PR TITLE
camel-test-infra-cli: Adds the parameter to mount local maven repository

### DIFF
--- a/test-infra/camel-test-infra-cli/README.adoc
+++ b/test-infra/camel-test-infra-cli/README.adoc
@@ -18,5 +18,6 @@ System variables are defined in link:{config-class}[CliProperties]
  - `cli.service.ssh.password` : ssh password set to access to the container via ssh, default `jbang`
  - `cli.service.execute.version` : Camel version set just after container start, default is empty so the version is the one in the branch
  - `cli.service.mvn.repos` : comma separated list of custom Maven repositories, default empty
+ - `cli.service.mvn.local` : path to the host folder mounted as container local maven repository
  - `cli.service.extra.hosts` : comma separated host=ip pairs to add in the hosts file
  - `cli.service.trusted.paths` : commas separated paths, relative to the host, of the files containing PEM trusted certificates

--- a/test-infra/camel-test-infra-cli/pom.xml
+++ b/test-infra/camel-test-infra-cli/pom.xml
@@ -99,6 +99,27 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>pre-integration-test</id>
+                                <phase>pre-integration-test</phase>
+                                <configuration>
+                                    <target>
+                                        <mkdir dir="target/tmp-repo"/>
+                                        <chmod perm="ugo+rwx">
+                                            <dirset dir="target/tmp-repo"/>
+                                        </chmod>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <executions>
                             <execution>

--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/common/CliProperties.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/common/CliProperties.java
@@ -33,6 +33,8 @@ public final class CliProperties {
 
     public static final String MVN_REPOS = "cli.service.mvn.repos";
 
+    public static final String MVN_LOCAL_REPO = "cli.service.mvn.local";
+
     public static final String EXTRA_HOSTS = "cli.service.extra.hosts";
 
     public static final String TRUSTED_CERT_PATHS = "cli.service.trusted.paths";

--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/it/CliConfigITCase.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/it/CliConfigITCase.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.test.infra.cli.it;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.function.Consumer;
 
 import org.apache.camel.test.infra.cli.services.CliService;
@@ -89,6 +92,22 @@ public class CliConfigITCase {
             Assertions.assertEquals(currentCamelVersion, version, "Check Camel JBang version in the current codebase");
         });
         System.clearProperty("cli.service.version");
+    }
+
+    @Test
+    @SetSystemProperty(key = "cli.service.mvn.local", value = "target/tmp-repo")
+    public void setLocalMavenRepoTest() {
+        final Path dir = Path.of("target/tmp-repo");
+        execute(cliService -> {
+            cliService.version();
+            Assertions.assertTrue(dir.toFile().exists(), "Check the local maven repository is created");
+            try {
+                Assertions.assertTrue(Files.list(dir).findFirst().isPresent(),
+                        "Check the local maven repository is not empty");
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     private void execute(Consumer<CliService> consumer) {

--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliBuiltContainer.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliBuiltContainer.java
@@ -43,6 +43,7 @@ public class CliBuiltContainer extends GenericContainer<CliBuiltContainer> {
     protected static final int DEV_CONSOLE_PORT = 8080;
     protected static final int SSH_PORT = 22;
     protected static final String TRUSTED_CERT_FOLDER = "/etc/pki/ca-trust/source/anchors";
+    public static final String CONTAINER_MVN_REPO = "/home/jbang/.m2/repository";
 
     private final String sshPassword;
 
@@ -81,6 +82,9 @@ public class CliBuiltContainer extends GenericContainer<CliBuiltContainer> {
                         String.format("%s/%s", TRUSTED_CERT_FOLDER, path.getFileName()));
             });
         }
+        if (StringUtils.isNotBlank(params.getLocalMavenRepo())) {
+            withFileSystemBind(params.getLocalMavenRepo(), CONTAINER_MVN_REPO, BindMode.READ_WRITE);
+        }
     }
 
     public String getMountPoint() {
@@ -101,6 +105,7 @@ public class CliBuiltContainer extends GenericContainer<CliBuiltContainer> {
         private String sshPassword;
         private Map<String, String> extraHosts;
         private List<String> trustedCertPaths;
+        private String localMavenRepo;
 
         public String getCamelRepo() {
             return camelRepo;
@@ -171,6 +176,15 @@ public class CliBuiltContainer extends GenericContainer<CliBuiltContainer> {
 
         public CliBuiltContainerParams setTrustedCertPaths(List<String> trustedCertPaths) {
             this.trustedCertPaths = trustedCertPaths;
+            return this;
+        }
+
+        public String getLocalMavenRepo() {
+            return localMavenRepo;
+        }
+
+        public CliBuiltContainerParams setLocalMavenRepo(String localMavenRepo) {
+            this.localMavenRepo = localMavenRepo;
             return this;
         }
     }

--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliLocalContainerService.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliLocalContainerService.java
@@ -51,7 +51,8 @@ public class CliLocalContainerService implements CliService, ContainerService<Cl
                 .setDataFolder(System.getProperty(CliProperties.DATA_FOLDER))
                 .setSshPassword(System.getProperty(CliProperties.SSH_PASSWORD, "jbang"))
                 .setExtraHosts(getHostsMap())
-                .setTrustedCertPaths(getCertPaths()),
+                .setTrustedCertPaths(getCertPaths())
+                .setLocalMavenRepo(System.getProperty(CliProperties.MVN_LOCAL_REPO)),
              System.getProperty(CliProperties.FORCE_RUN_VERSION, ""), System.getProperty(CliProperties.MVN_REPOS));
     }
 


### PR DESCRIPTION
Adds the parameter to mount the local maven repository, it may be useful to improve the tests execution time, avoiding to download the maven artifacts on each container


