### PR TITLE
camel-jbang-plugin-kubernetes disable the knative by default

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
@@ -449,7 +449,7 @@ https://knative.dev/docs/serving/[Knative serving] defines a set of resources on
 When Knative serving is available on the target Kubernetes cluster, you may want to use the Knative service resource instead of an arbitrary Kubernetes service resource.
 The Knative service trait will create such a resource as part of the Kubernetes manifest.
 
-NOTE: You need to enable the Knative service trait with `--trait knative-service.enabled=true` option. Otherwise, the Camel JBang export will always create an arbitrary Kubernetes service resource.
+NOTE: The `knative-service` trait is disabled by default, you need to enable the Knative service trait with `--trait knative-service.enabled=true` option. Otherwise, the Camel JBang export will always create an arbitrary Kubernetes service resource.
 
 The trait offers following options for customization:
 
@@ -532,6 +532,8 @@ The export command assists you in configuring both the Knative component and the
 
 You can configure the Knative component with the Knative trait.
 
+NOTE: The `knative` trait is disabled by default, you need to enable the Knative trait with `--trait knative.enabled=true` option.
+
 The trait offers the following options for customization:
 
 [cols="2m,1m,5a"]
@@ -594,6 +596,8 @@ In case your Camel route uses the Knative component as a consumer you may need t
 to connect your Camel application with the Knative broker.
 
 The Camel JBang Kubernetes plugin is able to automatically create this trigger for you.
+
+NOTE: The `knative` trait is disabled by default, you need to enable the Knative trait with `--trait knative.enabled=true` option.
 
 The following Camel route uses the Knative event component and references a Knative broker by its name.
 The plugin inspects the code and automatically generates the Knative trigger as part of the Kubernetes manifest that is used
@@ -672,6 +676,8 @@ Now you can just deploy the application using the Kubernetes manifest and see th
 Knative channels represent another form of producing and consuming events from the Knative broker.
 Instead of using a trigger, you can create a subscription for a Knative channel to consume events.
 
+NOTE: The `knative` trait is disabled by default, you need to enable the Knative trait with `--trait knative.enabled=true` option.
+
 The Camel route that connects to a Knative channel in order to receive events looks like this:
 
 [source,yaml]
@@ -749,6 +755,8 @@ The Knative URL injection uses environment variables (`K_SINK`, `K_CE_OVERRIDES`
 The Knative eventing operator will automatically resolve the Knative resource (e.g. a Knative broker URL) and inject the value so your application does not need to know the actual URL when deploying.
 
 The Camel JBang Kubernetes plugin leverages the sink binding concept for all routes that use the Knative component as an output.
+
+NOTE: The `knative` trait is disabled by default, you need to enable the Knative trait with `--trait knative.enabled=true` option.
 
 The following route produces events on a Knative broker:
 

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/knative/KnativeServiceTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/knative/KnativeServiceTrait.java
@@ -52,15 +52,11 @@ public class KnativeServiceTrait extends KnativeBaseTrait {
         if (context.getKnativeService().isPresent()) {
             return false;
         }
-
         // one of Knative traits needs to be explicitly enabled
         boolean enabled = false;
         if (traitConfig.getKnativeService() != null) {
             enabled = Optional.ofNullable(traitConfig.getKnativeService().getEnabled()).orElse(false);
-        } else if (traitConfig.getKnative() != null) {
-            enabled = Optional.ofNullable(traitConfig.getKnative().getEnabled()).orElse(false);
         }
-
         return enabled && TraitHelper.exposesHttpService(context);
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/knative/KnativeTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/knative/KnativeTrait.java
@@ -64,13 +64,15 @@ public class KnativeTrait extends KnativeBaseTrait {
 
     @Override
     public boolean configure(Traits traitConfig, TraitContext context) {
-        Knative knativeTrait = Optional.ofNullable(traitConfig.getKnative()).orElseGet(Knative::new);
-
-        if (knativeTrait.getEnabled() != null && !knativeTrait.getEnabled()) {
-            // Knative explicitly disabled
+        // Knative trait needs to be explicitly enabled
+        boolean enabled = false;
+        if (traitConfig.getKnative() != null) {
+            enabled = Optional.ofNullable(traitConfig.getKnative().getEnabled()).orElse(false);
+        }
+        if (!enabled) {
             return false;
         }
-
+        Knative knativeTrait = Optional.ofNullable(traitConfig.getKnative()).orElseGet(Knative::new);
         List<SourceMetadata> allSourcesMetadata = context.getSourceMetadata();
 
         if (knativeTrait.getChannelSources() == null) {

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportKnativeTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportKnativeTest.java
@@ -98,6 +98,7 @@ public class KubernetesExportKnativeTest extends KubernetesExportBaseTest {
         KubernetesExport command = createCommand(new String[] { "classpath:knative-event-source.yaml" },
                 "--image-group=camel-test", "--runtime=" + rt.runtime());
         command.traits = new String[] {
+                "knative.enabled=true",
                 "knative.filters=source=my-source" };
         int exit = command.doCall();
         Assertions.assertEquals(0, exit);
@@ -142,6 +143,8 @@ public class KubernetesExportKnativeTest extends KubernetesExportBaseTest {
     public void shouldAddKnativeSubscription(RuntimeType rt) throws Exception {
         KubernetesExport command = createCommand(new String[] { "classpath:knative-channel-source.yaml" },
                 "--image-group=camel-test", "--runtime=" + rt.runtime());
+        command.traits = new String[] {
+                "knative.enabled=true" };
         command.doCall();
 
         Assertions.assertTrue(hasService(rt));
@@ -181,6 +184,9 @@ public class KubernetesExportKnativeTest extends KubernetesExportBaseTest {
     public void shouldAddKnativeBrokerSinkBinding(RuntimeType rt) throws Exception {
         KubernetesExport command = createCommand(new String[] { "classpath:knative-event-sink.yaml" },
                 "--image-group=camel-test", "--runtime=" + rt.runtime());
+
+        command.traits = new String[] {
+                "knative.enabled=true" };
         command.doCall();
 
         Assertions.assertTrue(hasService(rt));
@@ -221,6 +227,9 @@ public class KubernetesExportKnativeTest extends KubernetesExportBaseTest {
     public void shouldAddKnativeChannelSinkBinding(RuntimeType rt) throws Exception {
         KubernetesExport command = createCommand(new String[] { "classpath:knative-channel-sink.yaml" },
                 "--image-group=camel-test", "--runtime=" + rt.runtime());
+
+        command.traits = new String[] {
+                "knative.enabled=true" };
         command.doCall();
 
         Assertions.assertTrue(hasService(rt));
@@ -261,6 +270,8 @@ public class KubernetesExportKnativeTest extends KubernetesExportBaseTest {
     public void shouldAddKnativeEndpointSinkBinding(RuntimeType rt) throws Exception {
         KubernetesExport command = createCommand(new String[] { "classpath:knative-endpoint-sink.yaml" },
                 "--image-group=camel-test", "--runtime=" + rt.runtime());
+        command.traits = new String[] {
+                "knative.enabled=true" };
         command.doCall();
 
         Assertions.assertTrue(hasService(rt));


### PR DESCRIPTION
If the knative trait is enabled by default, the MetadataHelper loads the route, resulting in the following error
```
IllegalStateException: Cannot find RestConsumerFactory in Registry or as a Component to use 
```
when there is an http consumer.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

