### PR TITLE
camel-test-infra-cli: Reads PID in case of background-wait=true

### DIFF
--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/it/AbstractTestSupport.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/it/AbstractTestSupport.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.infra.cli.it;
+
+import java.util.function.Consumer;
+
+import org.apache.camel.test.infra.cli.services.CliService;
+import org.apache.camel.test.infra.cli.services.CliServiceFactory;
+
+public abstract class AbstractTestSupport {
+
+    protected void execute(Consumer<CliService> consumer) {
+        try (CliService containerService = CliServiceFactory.createService()) {
+            containerService.beforeAll(null);
+            consumer.accept(containerService);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/it/CliConfigITCase.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/it/CliConfigITCase.java
@@ -19,10 +19,7 @@ package org.apache.camel.test.infra.cli.it;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.function.Consumer;
 
-import org.apache.camel.test.infra.cli.services.CliService;
-import org.apache.camel.test.infra.cli.services.CliServiceFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -31,7 +28,7 @@ import org.junitpioneer.jupiter.RestoreSystemProperties;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
 @RestoreSystemProperties
-public class CliConfigITCase {
+public class CliConfigITCase extends AbstractTestSupport {
 
     @Test
     @SetSystemProperty(key = "cli.service.version", value = "4.8.3")
@@ -109,14 +106,4 @@ public class CliConfigITCase {
             }
         });
     }
-
-    private void execute(Consumer<CliService> consumer) {
-        try (CliService containerService = CliServiceFactory.createService()) {
-            containerService.beforeAll(null);
-            consumer.accept(containerService);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
 }

--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/it/RunITCase.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/it/RunITCase.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.infra.cli.it;
+
+import org.apache.camel.test.infra.cli.services.CliService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junitpioneer.jupiter.ReadsSystemProperty;
+import org.junitpioneer.jupiter.RestoreSystemProperties;
+import org.junitpioneer.jupiter.SetSystemProperty;
+import org.testcontainers.shaded.org.apache.commons.lang3.StringUtils;
+
+@RestoreSystemProperties
+public class RunITCase extends AbstractTestSupport {
+
+    @Test
+    @ReadsSystemProperty
+    @EnabledIfSystemProperty(named = "currentProjectVersion", matches = "^(?!\\s*$).+",
+                             disabledReason = "currentProjectVersion system property must be set")
+    public void readPidFromBackgroundExecutionInCurrentVersionTest() {
+        String currentCamelVersion = System.getProperty("currentProjectVersion");
+        System.setProperty("cli.service.version", currentCamelVersion);
+        execute(this::checkPidFromBackgroundExec);
+        System.clearProperty("cli.service.version");
+    }
+
+    @Test
+    @SetSystemProperty(key = "cli.service.version", value = "4.8.3")
+    public void readPidFromBackgroundExecutionInPreviousVersionTest() {
+        execute(this::checkPidFromBackgroundExec);
+    }
+
+    private void checkPidFromBackgroundExec(CliService cliService) {
+        cliService.execute("init foo.yaml");
+        String pid = cliService.executeBackground("run foo.yaml");
+        Assertions.assertTrue(StringUtils.isNumeric(pid), "pid is numeric: " + pid);
+    }
+}

--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliLocalContainerService.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliLocalContainerService.java
@@ -116,7 +116,8 @@ public class CliLocalContainerService implements CliService, ContainerService<Cl
 
     @Override
     public String executeBackground(String command) {
-        return StringUtils.substringAfter(execute(command.concat(" --background")), "PID:").trim();
+        final String pid = StringUtils.substringAfter(execute(command.concat(" --background")), "PID:").trim();
+        return StringUtils.isNumeric(pid) ? pid : StringUtils.substringBefore(pid, " ");
     }
 
     @Override


### PR DESCRIPTION
Since the output from the execution in background can be different based on `background-wait` parameter, it is necessary to update the way the PID is retrieved 