### PR TITLE
camel-jbang-it: Fixes/Updates jbang tests

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-it/pom.xml
@@ -225,6 +225,8 @@
             <properties>
                 <maven.test.skip>false</maven.test.skip>
                 <shared.data.folder>target/data</shared.data.folder>
+                <cli.jbang.version>${project.version}</cli.jbang.version>
+                <shared.maven.local.repo>${settings.localRepository}</shared.maven.local.repo>
                 <x11.display>:0</x11.display>
             </properties>
             <build>
@@ -239,6 +241,9 @@
                                 <configuration>
                                     <target>
                                         <mkdir dir="${shared.data.folder}"/>
+                                        <chmod perm="ugo+rwx">
+                                            <dirset dir="${shared.data.folder}"/>
+                                        </chmod>
                                     </target>
                                 </configuration>
                                 <goals>
@@ -258,19 +263,17 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <rerunFailingTestsCount>0</rerunFailingTestsCount>
-                            <forkCount>2C</forkCount>
+                            <rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</rerunFailingTestsCount>
+                            <forkCount>1C</forkCount>
                             <argLine>-DforkNumber=${surefire.forkNumber}</argLine>
-                            <systemProperties>
-                                <property>
-                                    <name>cli.service.data.folder</name>
-                                    <value>${shared.data.folder}</value>
-                                </property>
-                                <property>
-                                    <name>DISPLAY</name>
-                                    <value>${x11.display}</value>
-                                </property>
-                            </systemProperties>
+                            <threadCountClasses>1</threadCountClasses>
+                            <systemPropertyVariables>
+                                <cli.service.data.folder>${shared.data.folder}</cli.service.data.folder>
+                                <cli.service.version>${cli.jbang.version}</cli.service.version>
+                                <cli.service.mvn.local>${shared.maven.local.repo}</cli.service.mvn.local>
+                                <jbang.it.assert.wait.timeout>300</jbang.it.assert.wait.timeout>
+                                <DISPLAY>${x11.display}</DISPLAY>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/OpenApiITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/OpenApiITCase.java
@@ -60,14 +60,17 @@ public class OpenApiITCase extends JBangTestSupport {
                 = "https://raw.githubusercontent.com/apache/camel-kamelets-examples/main/jbang/open-api-contract-first/petstore-v3.json";
         final String openApiConfig
                 = "https://raw.githubusercontent.com/apache/camel-kamelets-examples/main/jbang/open-api-contract-first/petstore.camel.yaml";
+        final String appConfig
+                = "https://raw.githubusercontent.com/apache/camel-kamelets-examples/refs/heads/main/jbang/open-api-contract-first/application.properties";
 
         downloadFile(openApiUrl);
         downloadFile(openApiConfig);
+        downloadFile(appConfig);
         containerService.executeGenericCommand("mkdir -p camel-mock/pet");
         downloadFile(
                 "https://raw.githubusercontent.com/apache/camel-kamelets-examples/main/jbang/open-api-contract-first/camel-mock/pet/123.json");
         containerService.executeGenericCommand("mv 123.json camel-mock/pet/");
-        executeBackground("run petstore-v3.json petstore.camel.yaml");
+        executeBackground("run petstore-v3.json petstore.camel.yaml application.properties");
         checkLogContains("HTTP endpoints summary");
 
         //verify mock

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandITCase.java
@@ -30,7 +30,7 @@ import org.apache.camel.dsl.jbang.it.support.JiraIssue;
 import org.apache.camel.test.infra.cli.common.CliProperties;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.Assume;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -43,10 +43,11 @@ import static org.junit.jupiter.api.condition.OS.LINUX;
 public class RunCommandITCase extends JBangTestSupport {
 
     @Test
-    public void initClearDirectoryTest() {
-        initFileInDataFolder("willbedeleted.yaml");
+    @JiraIssue("CAMEL-21082")
+    public void initKeepFilesInDirectoryTest() {
+        initFileInDataFolder("willbekept.yaml");
         initFileInDataFolder("keepthisone.yaml");
-        assertFileInDataFolderDoesNotExist("willbedeleted.yaml");
+        assertFileInDataFolderExists("willbekept.yaml");
         assertFileInDataFolderExists("keepthisone.yaml");
     }
 
@@ -102,9 +103,6 @@ public class RunCommandITCase extends JBangTestSupport {
     @Test
     @JiraIssue("CAMEL-20351")
     public void runRouteFromGithubUsingWildcardTest() {
-        executeBackground("run https://github.com/apache/camel-kamelets-examples/tree/main/jbang/languages/*.groovy");
-        checkLogContains("Hello Camel K from groovy");
-        execute("stop simple");
         execute("init https://github.com/apache/camel-kamelets-examples/tree/main/jbang/languages/rou*");
         executeBackground("run *");
         checkLogContains("HELLO YAML !!!");
@@ -163,8 +161,8 @@ public class RunCommandITCase extends JBangTestSupport {
     @EnabledOnOs(LINUX)
     @DisabledIf(value = "java.awt.GraphicsEnvironment#isHeadless")
     public void runFromClipboardTest() throws IOException {
-        Assume.assumeTrue(execInHost("command -v ssh").contains("ssh"));
-        Assume.assumeTrue(execInHost("command -v sshpass").contains("sshpass"));
+        Assumptions.assumeTrue(execInHost("command -v ssh").contains("ssh"));
+        Assumptions.assumeTrue(execInHost("command -v sshpass").contains("sshpass"));
         final String msg = "Hello World " + new Date();
         Toolkit.getDefaultToolkit().getSystemClipboard()
                 .setContents(new StringSelection(
@@ -180,9 +178,9 @@ public class RunCommandITCase extends JBangTestSupport {
             Assertions.assertThatCode(() -> Awaitility.await()
                     .pollInterval(Duration.ofSeconds(1))
                     .atMost(Duration.ofMinutes(1))
-                    .untilAsserted(() -> Assertions.assertThat(input.readLine()).isNotNull()
-                            .contains("generated-clipboard.xml")
-                            .contains(msg)))
+                    .untilAsserted(() -> Assertions.assertThat(input.lines()
+                            .anyMatch(line -> line.contains("generated-clipboard.xml") && line.contains(msg))).isTrue()))
+                    .as("Check application log")
                     .doesNotThrowAnyException();
         }
     }

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -80,7 +80,7 @@ public abstract class JBangTestSupport {
     }
 
     @AfterEach
-    protected void afterEach(TestInfo testInfo) throws IOException {
+    protected void afterEach(TestInfo testInfo) {
         logger.debug("ending {}#{} using data folder {}", getClass().getName(), testInfo.getDisplayName(), getDataFolder());
         assertNoErrors();
         logger.debug("clean up data folder");
@@ -167,19 +167,19 @@ public abstract class JBangTestSupport {
 
     protected void checkCommandOutputs(String command, String contains) {
         Assertions.assertThat(execute(command))
-                .as("command camel" + command + "should output" + contains)
+                .as("command camel " + command + " should output " + contains)
                 .contains(contains);
     }
 
     protected void checkCommandOutputsPattern(String command, String contains) {
         Assertions.assertThat(execute(command))
-                .as("command camel" + command + "should output pattern" + contains)
+                .as("command camel " + command + " should output pattern " + contains)
                 .containsPattern(contains);
     }
 
     protected void checkCommandDoesNotOutput(String command, String contains) {
         Assertions.assertThat(execute(command))
-                .as("command camel" + command + "should not output" + contains)
+                .as("command camel " + command + " should not output " + contains)
                 .doesNotContain(contains);
     }
 

--- a/dsl/camel-jbang/camel-jbang-it/src/test/resources/logback-test.xml
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/resources/logback-test.xml
@@ -19,7 +19,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%highlight(%level)] [%property{forkNumber}] %logger{36}.%M - %msg%n</pattern>
+            <pattern>[%highlight(%level)] [%property{forkNumber}] [%thread] %logger{36}.%M - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/test-infra/camel-test-infra-cli/pom.xml
+++ b/test-infra/camel-test-infra-cli/pom.xml
@@ -84,6 +84,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>logback-test.xml</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliService.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliService.java
@@ -20,26 +20,14 @@ import java.util.stream.Stream;
 
 import org.apache.camel.test.infra.common.services.TestService;
 import org.apache.camel.test.infra.common.services.TestServiceUtil;
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test infra service for Camel Cli (Camel JBang)
  */
-public interface CliService extends BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback, TestService {
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryInitialize(this, extensionContext);
-    }
-
-    @Override
-    default void afterAll(ExtensionContext extensionContext) throws Exception {
-        TestServiceUtil.tryShutdown(this, extensionContext);
-    }
+public interface CliService extends BeforeEachCallback, AfterEachCallback, TestService {
 
     @Override
     default void afterEach(ExtensionContext extensionContext) throws Exception {


### PR DESCRIPTION
Update jbang IT module in order to:

- run tests with the current version of Camel JBang (in main it will be the current snapshot)
- improve/fix parallel exuctions
- use common maven local repository to avoid to download all the dependencies on each running container
- fix tests, make them compatible with the latest jbang commands