### PR TITLE
(chores) camel-jetty: isolate HTTPS tests to reduce flakiness

### DIFF
--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpsRouteTest.java
@@ -42,6 +42,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Isolated
 @ResourceLock(SSL_SYSPROPS)
 @EnabledOnOs(value = { OS.LINUX, OS.MAC, OS.FREEBSD, OS.OPENBSD },
              architectures = { "amd64", "aarch64", "ppc64le" },


### PR DESCRIPTION
Signed-off-by: Otavio R. Piske <angusyoung@gmail.com>