### PR TITLE
KnownDependenciesResolver to support packages

### DIFF
--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/KnownDependenciesResolver.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/KnownDependenciesResolver.java
@@ -66,7 +66,7 @@ public final class KnownDependenciesResolver {
 
     public MavenGav mavenGavForClass(String className) {
         MavenGav answer = null;
-        String gav = mappings.get(className);
+        String gav = findGav(className);
         if (gav != null) {
             answer = MavenGav.parseGav(gav, camelContext.getVersion());
         }
@@ -79,5 +79,14 @@ public final class KnownDependenciesResolver {
             }
         }
         return answer;
+    }
+
+    private String findGav(String prefix) {
+        String gav = mappings.get(prefix);
+        while (gav == null && prefix.lastIndexOf(".") != -1) {
+            prefix = prefix.substring(0, prefix.lastIndexOf("."));
+            gav = mappings.get(prefix);
+        }
+        return gav;
     }
 }

--- a/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/KnownDependenciesResolverTest.java
+++ b/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/KnownDependenciesResolverTest.java
@@ -1,0 +1,41 @@
+package org.apache.camel.main.download;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.apache.camel.impl.engine.SimpleCamelContext;
+import org.apache.camel.tooling.maven.MavenGav;
+import org.junit.jupiter.api.Test;
+
+public class KnownDependenciesResolverTest {
+
+  @Test
+  void mavenGavForClass_returnsClassScopedDependency() {
+    KnownDependenciesResolver resolver = new KnownDependenciesResolver(new SimpleCamelContext(), null, null);
+    resolver.loadKnownDependencies();
+
+    MavenGav dependency = resolver.mavenGavForClass(SomeClass.class.getName());
+
+    assertNotNull(dependency);
+    assertEquals(dependency.getGroupId(), "com.example");
+    assertEquals(dependency.getArtifactId(), "class-scoped");
+    assertEquals(dependency.getVersion(), "1.0.0");
+  }
+
+  @Test
+  void mavenGavForClass_returnsPackageScopedDependency() {
+    KnownDependenciesResolver resolver = new KnownDependenciesResolver(new SimpleCamelContext(), null, null);
+    resolver.loadKnownDependencies();
+
+    MavenGav dependency = resolver.mavenGavForClass(SomeClass.class.getPackage().getName());
+
+
+    assertNotNull(dependency);
+    assertEquals(dependency.getGroupId(), "org.example");
+    assertEquals(dependency.getArtifactId(), "package-scoped");
+    assertEquals(dependency.getVersion(), "2.0.0");
+  }
+
+  public static class SomeClass {
+  }
+}

--- a/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/KnownDependenciesResolverTest.java
+++ b/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/KnownDependenciesResolverTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.main.download;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/dsl/camel-kamelet-main/src/test/resources/camel-main-known-dependencies.properties
+++ b/dsl/camel-kamelet-main/src/test/resources/camel-main-known-dependencies.properties
@@ -1,0 +1,2 @@
+org.apache.camel.main.download.KnownDependenciesResolverTest$SomeClass=com.example:class-scoped:1.0.0
+org.apache.camel.main=org.example:package-scoped:2.0.0

--- a/dsl/camel-kamelet-main/src/test/resources/camel-main-known-dependencies.properties
+++ b/dsl/camel-kamelet-main/src/test/resources/camel-main-known-dependencies.properties
@@ -1,2 +1,19 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
 org.apache.camel.main.download.KnownDependenciesResolverTest$SomeClass=com.example:class-scoped:1.0.0
 org.apache.camel.main=org.example:package-scoped:2.0.0


### PR DESCRIPTION
This pull request enhances KnownDependenciesResolver to match the well known dependencies against packages up to the root package, so that a single entry in the camel-main-known-dependencies.properties file is sufficient to load any class from this jar, instead of having a separate entry for each class.

This is a cherry-pick from #17034