### PR TITLE
extends fix of  CAMEL-21713: endpoint url override to aws-secret-manager

### DIFF
--- a/components/camel-aws/camel-aws-secrets-manager/src/main/java/org/apache/camel/component/aws/secretsmanager/vault/CloudTrailReloadTriggerTask.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/main/java/org/apache/camel/component/aws/secretsmanager/vault/CloudTrailReloadTriggerTask.java
@@ -202,46 +202,40 @@ public class CloudTrailReloadTriggerTask extends ServiceSupport implements Camel
             }
         }
         if (!useSqsNotification) {
+            CloudTrailClientBuilder clientBuilder = CloudTrailClient.builder();
             if (ObjectHelper.isNotEmpty(accessKey) && ObjectHelper.isNotEmpty(secretKey) && ObjectHelper.isNotEmpty(region)) {
-                CloudTrailClientBuilder clientBuilder = CloudTrailClient.builder();
+
                 AwsBasicCredentials cred = AwsBasicCredentials.create(accessKey, secretKey);
                 clientBuilder = clientBuilder.credentialsProvider(StaticCredentialsProvider.create(cred));
                 clientBuilder.region(Region.of(region));
-                cloudTrailClient = clientBuilder.build();
             } else if (useDefaultCredentialsProvider && ObjectHelper.isNotEmpty(region)) {
-                CloudTrailClientBuilder clientBuilder = CloudTrailClient.builder();
                 clientBuilder.region(Region.of(region));
-                cloudTrailClient = clientBuilder.build();
             } else if (useProfileCredentialsProvider && ObjectHelper.isNotEmpty(profileName)) {
-                CloudTrailClientBuilder clientBuilder = CloudTrailClient.builder();
                 clientBuilder.credentialsProvider(ProfileCredentialsProvider.create(profileName));
                 clientBuilder.region(Region.of(region));
-                cloudTrailClient = clientBuilder.build();
             } else {
                 throw new RuntimeCamelException(
                         "Using the AWS Secrets Refresh Task requires setting AWS credentials as application properties or environment variables");
             }
+            cloudTrailClient = isOverrideEndpoint
+                    ? clientBuilder.endpointOverride(URI.create(uriEndpointOverride)).build() : clientBuilder.build();
         } else {
+            SqsClientBuilder clientBuilder = SqsClient.builder();
             if (ObjectHelper.isNotEmpty(accessKey) && ObjectHelper.isNotEmpty(secretKey) && ObjectHelper.isNotEmpty(region)) {
-                SqsClientBuilder clientBuilder = SqsClient.builder();
                 AwsBasicCredentials cred = AwsBasicCredentials.create(accessKey, secretKey);
                 clientBuilder = clientBuilder.credentialsProvider(StaticCredentialsProvider.create(cred));
                 clientBuilder.region(Region.of(region));
-                sqsClient = isOverrideEndpoint
-                        ? clientBuilder.endpointOverride(URI.create(uriEndpointOverride)).build() : clientBuilder.build();
             } else if (useDefaultCredentialsProvider && ObjectHelper.isNotEmpty(region)) {
-                SqsClientBuilder clientBuilder = SqsClient.builder();
                 clientBuilder.region(Region.of(region));
-                sqsClient = clientBuilder.build();
             } else if (useProfileCredentialsProvider && ObjectHelper.isNotEmpty(profileName)) {
-                SqsClientBuilder clientBuilder = SqsClient.builder();
                 clientBuilder.credentialsProvider(ProfileCredentialsProvider.create(profileName));
                 clientBuilder.region(Region.of(region));
-                sqsClient = clientBuilder.build();
             } else {
                 throw new RuntimeCamelException(
                         "Using the AWS Secrets Refresh Task requires setting AWS credentials as application properties or environment variables");
             }
+            sqsClient = isOverrideEndpoint
+                    ? clientBuilder.endpointOverride(URI.create(uriEndpointOverride)).build() : clientBuilder.build();
         }
     }
 


### PR DESCRIPTION
follows https://github.com/apache/camel/pull/17052

The override endpoint url is missing also for `CloudTrailClient`.
The localstack cloudtrail lookup is not implemented yet, therefore endpoint url override cannot be  used now in this case. But I think that it is better to have the code prepared for the future.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

