### PR TITLE
CAMEL-21716: Improve JBang Kubernetes plugin container image options

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
@@ -160,6 +160,15 @@ The Camel JBang Kubernetes export command provides several options to customize 
 |--image-builder
 |The image builder used to build the container image (e.g. docker, jib, podman, s2i).
 
+|--image-platform
+|List of target platforms. Each platform is defined using os and architecture (e.g. linux/amd64).
+
+|--base-image
+|The base image that is used to build the container image from (default is eclipse-temurin:<java-version>).
+
+|--registry-mirror
+|Optional Docker registry mirror where to pull images from when building the container image.
+
 |--cluster-type
 |The target cluster type. Special configurations may be applied to different cluster types such as Kind or Minikube.
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/main-kubernetes-pom.tmpl
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/main-kubernetes-pom.tmpl
@@ -132,7 +132,7 @@
                     <images>
                         <image>
                             <build>
-                                <from>eclipse-temurin:{{ .JavaVersion }}</from>
+                                <from>${jkube.base.image}</from>
                                 <entryPoint>
                                     <exec>
                                         <arg>java</arg>

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/quarkus-kubernetes-pom.tmpl
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/quarkus-kubernetes-pom.tmpl
@@ -97,7 +97,7 @@
                     <images>
                         <image>
                             <build>
-                                <from>eclipse-temurin:{{ .JavaVersion }}</from>
+                                <from>${jkube.base.image}</from>
                                 <assembly>
                                     <layers>
                                         <layer>

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/spring-boot-kubernetes-pom.tmpl
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/spring-boot-kubernetes-pom.tmpl
@@ -83,7 +83,7 @@
                     <images>
                         <image>
                             <build>
-                                <from>eclipse-temurin:{{ .JavaVersion }}</from>
+                                <from>${jkube.base.image}</from>
                                 <entryPoint>
                                     <exec>
                                         <arg>java</arg>

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
@@ -144,7 +144,7 @@ public class KubernetesRun extends KubernetesBaseCommand {
 
     @CommandLine.Option(names = { "--image-builder" }, defaultValue = "jib",
                         description = "The image builder used to build the container image (e.g. docker, jib, podman).")
-    String imageBuilder;
+    String imageBuilder = "jib";
 
     @CommandLine.Option(names = { "--cluster-type" },
                         description = "The target cluster type. Special configurations may be applied to different cluster types such as Kind or Minikube.")
@@ -158,9 +158,17 @@ public class KubernetesRun extends KubernetesBaseCommand {
                         description = "Whether to push image to given image registry as part of the run.")
     boolean imagePush = true;
 
-    @CommandLine.Option(names = { "--image-platforms" },
-                        description = "List of target platforms. Each platform is defined using the pattern.")
-    String imagePlatforms;
+    @CommandLine.Option(names = { "--image-platform" },
+                        description = "List of target platforms. Each platform is defined using os and architecture (e.g. linux/amd64).")
+    String[] imagePlatforms;
+
+    @CommandLine.Option(names = { "--base-image" },
+                        description = "The base image that is used to build the container image from (default is eclipse-temurin:<java-version>).")
+    String baseImage;
+
+    @CommandLine.Option(names = { "--registry-mirror" },
+                        description = "Optional Docker registry mirror where to pull images from when building the container image.")
+    String registryMirror;
 
     // Export base options
 
@@ -386,6 +394,9 @@ public class KubernetesRun extends KubernetesBaseCommand {
         export.imageGroup = imageGroup;
         export.imagePush = imagePush;
         export.imageBuilder = imageBuilder;
+        export.imagePlatforms = imagePlatforms;
+        export.baseImage = baseImage;
+        export.registryMirror = registryMirror;
         export.clusterType = clusterType;
         export.serviceAccount = serviceAccount;
         export.setApplicationProperties(properties);


### PR DESCRIPTION
# Description

- Set basic settings on JIB image builder
- Introduce configurable base image (default is still eclipse-temurin:17)
- Set image platforms on JKube properties
- Set proper image push registry on JKube properties

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

Fixes CAMEL-21716

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

