### PR TITLE
camel-jbang-it: Use current uid/gid to run processes in the container

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-it/pom.xml
@@ -226,7 +226,7 @@
                 <maven.test.skip>false</maven.test.skip>
                 <shared.data.folder>target/data</shared.data.folder>
                 <cli.jbang.version>${project.version}</cli.jbang.version>
-                <shared.maven.local.repo>target/mvn-repo</shared.maven.local.repo>
+                <shared.maven.local.repo>${settings.localRepository}</shared.maven.local.repo>
                 <x11.display>:0</x11.display>
             </properties>
             <build>
@@ -241,13 +241,7 @@
                                 <configuration>
                                     <target>
                                         <mkdir dir="${shared.data.folder}"/>
-                                        <chmod perm="ugo+rwx">
-                                            <dirset dir="${shared.data.folder}"/>
-                                        </chmod>
                                         <mkdir dir="${shared.maven.local.repo}"/>
-                                        <chmod perm="ugo+rwx">
-                                            <dirset dir="${shared.maven.local.repo}"/>
-                                        </chmod>
                                     </target>
                                 </configuration>
                                 <goals>

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/DevModeITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/DevModeITCase.java
@@ -43,7 +43,6 @@ public class DevModeITCase extends JBangTestSupport {
         executeBackground(String.format("run %s/cheese.xml --dev", mountPoint()));
         checkLogContains("cheese", DEFAULT_MSG);
         final Path routeFile = Path.of(getDataFolder(), "cheese.xml");
-        makeTheFileWriteable(String.format("%s/cheese.xml", mountPoint()));
         Files.write(routeFile,
                 Files.readAllLines(routeFile).stream()
                         .map(line -> line.replace("${routeId}", "custom"))
@@ -107,7 +106,6 @@ public class DevModeITCase extends JBangTestSupport {
                 Path.of(getDataFolder() + "/source-dir/FromDirectoryRoute.java"));
         executeBackground(String.format("run --dev --console --source-dir=%s/source-dir", mountPoint()));
         checkLogContains("Hello world!");
-        makeTheFileWriteable(String.format("%s/FromDirectoryRoute.java", mountPoint()));
         Path routeFile = Path.of(getDataFolder(), "FromDirectoryRoute.java");
         Files.write(routeFile,
                 Files.readAllLines(routeFile).stream()

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -312,18 +312,14 @@ public abstract class JBangTestSupport {
                     .atMost(Duration.ofMinutes(2))
                     .pollInterval(Duration.ofSeconds(1))
                     .until(() -> !process.isAlive());
+            final String out = new String(process.getInputStream().readAllBytes());
             if (process.exitValue() != 0) {
-                logger.error(String.valueOf(process.getErrorStream()));
-                logger.info(String.valueOf(process.getOutputStream()));
+                logger.error(out);
             }
-            return new String(process.getInputStream().readAllBytes());
+            return out;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    protected String makeTheFileWriteable(String containerPath) {
-        return containerService.executeGenericCommand("chmod 777 " + containerPath);
     }
 
     protected String downloadNewFileInDataFolder(String downloadUrl) {

--- a/test-infra/camel-test-infra-cli/pom.xml
+++ b/test-infra/camel-test-infra-cli/pom.xml
@@ -112,9 +112,6 @@
                                 <configuration>
                                     <target>
                                         <mkdir dir="target/tmp-repo"/>
-                                        <chmod perm="ugo+rwx">
-                                            <dirset dir="target/tmp-repo"/>
-                                        </chmod>
                                     </target>
                                 </configuration>
                                 <goals>
@@ -136,6 +133,7 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</rerunFailingTestsCount>
                             <systemPropertyVariables>
                                 <cli.service.data.folder>target/data</cli.service.data.folder>
                                 <currentProjectVersion>${project.version}</currentProjectVersion>

--- a/test-infra/camel-test-infra-cli/src/test/resources/org/apache/camel/test/infra/cli/services/Dockerfile
+++ b/test-infra/camel-test-infra-cli/src/test/resources/org/apache/camel/test/infra/cli/services/Dockerfile
@@ -19,6 +19,8 @@ ARG FROMIMAGE
 
 FROM $FROMIMAGE
 
+ARG CUSTOM_UID=1000
+ARG CUSTOM_GID=1000
 ARG CAMEL_JBANG_VERSION=default
 ARG CAMEL_REF=main
 ARG CAMEL_REPO=apache/camel
@@ -37,7 +39,8 @@ ADD 99-ssh-jbang.conf /etc/ssh/sshd_config.d/
 RUN	sed -i "s|#auth		sufficient	pam_wheel.so trust use_uid|auth		sufficient	pam_wheel.so trust use_uid|g" /etc/pam.d/su
 
 #create new user
-RUN useradd -s /bin/bash jbang
+RUN groupadd -g $CUSTOM_GID jbang \
+    && useradd -u $CUSTOM_UID -g $CUSTOM_GID -s /bin/bash jbang
 
 #to avoid prompt su - root password
 RUN usermod -a -G wheel jbang


### PR DESCRIPTION

- build the camel-test-infra-cli container with the same uid and gid owner of the current maven process to avoid permissions issues
- revert the usage of the maven repo with the one defined in the maven settings, to allow to use the current snapshot version if it is compiled in the host
- allow the rerun configuration in the camel-test-infra-cli module
- minor fixes in camel-jbang-it module