### PR TITLE
CAMEL-21720: Filter candidate Kubernetes cluster members by whether they are in running and ready states

### DIFF
--- a/components/camel-kubernetes/src/test/java/org/apache/camel/component/kubernetes/cluster/KubernetesClusterServiceTest.java
+++ b/components/camel-kubernetes/src/test/java/org/apache/camel/component/kubernetes/cluster/KubernetesClusterServiceTest.java
@@ -96,6 +96,13 @@ public class KubernetesClusterServiceTest extends CamelTestSupport {
     public void testSimpleLeaderElection(LeaseResourceType type) {
         LeaderRecorder mypod1 = addMember("mypod1", type);
         LeaderRecorder mypod2 = addMember("mypod2", type);
+
+        // Add some unhealthy members to verify they are not considered for leadership
+        addMember("badpod1", type);
+        addMember("badpod2", type);
+        addMember("notreadypod1", type);
+        addMember("notreadypod2", type);
+
         context.start();
 
         mypod1.waitForAnyLeader(5, TimeUnit.SECONDS);


### PR DESCRIPTION
I am not super familiar with the k8s clustering stuff with camel-master. So would be good to have a second pair of eyes (or more) on this.