### PR TITLE
[CAMEL-21740] camel-salesforce - pub/sub API corrupt replay id causes infinite resubscribe loop fix

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/PubSubApiClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/PubSubApiClient.java
@@ -73,6 +73,7 @@ public class PubSubApiClient extends ServiceSupport {
 
     public static final String PUBSUB_ERROR_AUTH_ERROR = "sfdc.platform.eventbus.grpc.service.auth.error";
     private static final String PUBSUB_ERROR_AUTH_REFRESH_INVALID = "sfdc.platform.eventbus.grpc.service.auth.refresh.invalid";
+    private static final String PUBSUB_ERROR_CORRUPTED_REPLAY_ID = "sfdc.platform.eventbus.grpc.subscription.fetch.replayid.corrupted";
 
     protected PubSubGrpc.PubSubStub asyncStub;
     protected PubSubGrpc.PubSubBlockingStub blockingStub;
@@ -342,6 +343,11 @@ public class PubSubApiClient extends ServiceSupport {
                             LOG.error("attempting login");
                             session.attemptLoginUntilSuccessful(backoffIncrement, maxBackoff);
                             LOG.debug("logged in {}", consumer.getTopic());
+                        }
+                        case PUBSUB_ERROR_CORRUPTED_REPLAY_ID -> {
+                            LOG.error("replay id is corrupt. try resubscribing with LATEST replay preset");
+                            replayId = null;
+                            initialReplayPreset = ReplayPreset.LATEST;
                         }
                         default -> LOG.error("unexpected errorCode: {}", errorCode);
                     }


### PR DESCRIPTION
# Description
https://issues.apache.org/jira/browse/CAMEL-21740
https://lists.apache.org/thread/vdnzjcsmc0plxz558mqkvp6r19zxc1hl
My fix from the user mailing list.
This is my first pull request, so please be patient :)

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

