### PR TITLE
CAMEL-21731: Adding reference to external Open API docs

### DIFF
--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/BeanConfig.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/BeanConfig.java
@@ -18,6 +18,7 @@ package org.apache.camel.openapi;
 
 import java.util.Map;
 
+import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.ComposedSchema;
@@ -41,6 +42,7 @@ public class BeanConfig {
     String basePath;
     String defaultConsumes = DEFAULT_MEDIA_TYPE;
     String defaultProduces = DEFAULT_MEDIA_TYPE;
+    ExternalDocumentation externalDocs;
 
     public String[] getSchemes() {
         return schemes;
@@ -128,10 +130,22 @@ public class BeanConfig {
         this.defaultProduces = defaultProduces;
     }
 
+    public ExternalDocumentation getExternalDocs() {
+        return externalDocs;
+    }
+
+    public void setExternalDocs(ExternalDocumentation externalDocs) {
+        this.externalDocs = externalDocs;
+    }
+
     public OpenAPI configure(OpenAPI openApi) {
         if (info != null) {
             openApi.setInfo(info);
         }
+        if (externalDocs != null) {
+            openApi.setExternalDocs(externalDocs);
+        }
+
         if (this.schemes != null) {
             for (String scheme : this.schemes) {
                 String url = scheme + "://" + this.host;

--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiSupport.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiSupport.java
@@ -33,6 +33,7 @@ import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.Json31;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.core.util.Yaml31;
+import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
@@ -244,6 +245,20 @@ public class RestOpenApiSupport {
 
         setInfo(openApiConfig, version, title, description, termsOfService, licenseName, licenseUrl,
                 contactName, contactUrl, contactEmail);
+
+        String externalDocsDescription = (String) config.get("externalDocs.description");
+        String externalDocsUrl = (String) config.get("externalDocs.url");
+
+        setExternalDocs(openApiConfig, externalDocsUrl, externalDocsDescription);
+    }
+
+    private static void setExternalDocs(BeanConfig openApiConfig, String externalDocsUrl, String externalDocsDescription) {
+        if (externalDocsUrl != null) {
+            ExternalDocumentation externalDocumentation = new ExternalDocumentation();
+            externalDocumentation.setDescription(externalDocsDescription);
+            externalDocumentation.setUrl(externalDocsUrl);
+            openApiConfig.setExternalDocs(externalDocumentation);
+        }
     }
 
     private void setInfo(

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiLicenseInfoTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiLicenseInfoTest.java
@@ -43,7 +43,9 @@ public class RestOpenApiLicenseInfoTest {
                         .apiProperty("api.contact.email", "camel@apache.org")
                         .apiProperty("api.contact.url", "https://camel.apache.org")
                         .apiProperty("api.license.name", "Apache V2")
-                        .apiProperty("api.license.url", "https://www.apache.org/licenses/LICENSE-2.0");
+                        .apiProperty("api.license.url", "https://www.apache.org/licenses/LICENSE-2.0")
+                        .apiProperty("externalDocs.url", "https://openweathermap.org/api")
+                        .apiProperty("externalDocs.description", "API Documentation");
 
                 rest("/api")
                         .get("/api").to("direct:api");
@@ -68,5 +70,7 @@ public class RestOpenApiLicenseInfoTest {
         assertTrue(json.contains("\"name\" : \"Mr Camel\""));
         assertTrue(json.contains("\"email\" : \"camel@apache.org\""));
         assertTrue(json.contains("\"url\" : \"https://camel.apache.org\""));
+        assertTrue(json.contains("\"externalDocs\" :"));
+        assertTrue(json.contains("\"description\" : \"API Documentation\""));
     }
 }

--- a/docs/user-manual/modules/ROOT/pages/rest-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/rest-dsl.adoc
@@ -865,4 +865,6 @@ Most of the properties affect the OpenAPI https://github.com/OAI/OpenAPI-Specifi
 | api.contact.email | The email address of the contact person/organization
 | api.specification.contentType.json | The Content-Type of the served OpenAPI JSON specification, `application/json` by default
 | api.specification.contentType.yaml | The Content-Type of the served OpenAPI YAML specification, `text/yaml` by default
+| externalDocs.url |  The URI for the target documentation. This must be in the form of a URI
+| externalDocs.description | A description of the target documentation
 |===


### PR DESCRIPTION
Make it possible to reference external Open API docs via `.apiProperty(..)`

```
restConfiguration()
    .apiProperty("externalDocs.url", "https://openweathermap.org/api")
    .apiProperty("externalDocs.description", "API Documentation"); 
```