### PR TITLE
camel-jbang-plugin-kubernetes - jkube to generate Deployment instead of DeploymentConfig

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
@@ -292,6 +292,9 @@ public class KubernetesExport extends Export {
                 printer().printf("OpenShift forcing --image-builder=docker%n");
                 imageBuilder = "docker";
             }
+            // the deployment trait already generates the src/main/jkube/deployment.yml
+            // but we also have to set in the jkube to generate Deployment instead of DeploymentConfig
+            buildProperties.add("jkube.build.switchToDeployment=true");
             buildProperties.add("jkube.maven.plugin=%s".formatted("openshift-maven-plugin"));
         } else {
             buildProperties.add("jkube.maven.plugin=%s".formatted("kubernetes-maven-plugin"));

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
@@ -314,6 +314,21 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
 
     @ParameterizedTest
     @MethodSource("runtimeProvider")
+    public void shouldAddJkubeOpenshiftDeploymentProperty(RuntimeType rt) throws Exception {
+        KubernetesExport command = createCommand(new String[] { "classpath:route-service.yaml" },
+                "--cluster-type", "openshift",
+                "--runtime=" + rt.runtime());
+        var exit = command.doCall();
+        Assertions.assertEquals(0, exit);
+
+        Model model = readMavenModel();
+        Properties props = model.getProperties();
+        Assertions.assertEquals("true", props.get("jkube.build.switchToDeployment"),
+                "property jkube.build.switchToDeployment=true not set in pom.xml");
+    }
+
+    @ParameterizedTest
+    @MethodSource("runtimeProvider")
     public void shouldAddContainerSpec(RuntimeType rt) throws Exception {
         KubernetesExport command = createCommand(new String[] { "classpath:route-service.yaml" },
                 "--gav=camel-test:route-service:1.0.0", "--runtime=" + rt.runtime());


### PR DESCRIPTION
when the target is an openshift cluster

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

