### PR TITLE
CAMEL-20367: Adds scripting with pipes test

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ScriptingWithPipesITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ScriptingWithPipesITCase.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.it;
+
+import java.io.IOException;
+
+import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.Test;
+
+public class ScriptingWithPipesITCase extends JBangTestSupport {
+    @Test
+    public void testPipeScript() throws IOException {
+        newFileInDataFolder("UpperCase.java",
+                "///usr/bin/env jbang --quiet camel@apache/camel script \"$0\" \"$@\" ; exit $?\n" +
+                                              "import org.apache.camel.builder.RouteBuilder;\n" +
+                                              "\n" +
+                                              "public class UpperCase extends RouteBuilder {\n" +
+                                              "    @Override\n" +
+                                              "    public void configure() {\n" +
+                                              "        from(\"stream:in\")\n" +
+                                              "                .setBody()\n" +
+                                              "                .simple(\"${body.toUpperCase()}\")\n" +
+                                              "                .to(\"stream:out\");\n" +
+                                              "    }\n" +
+                                              "}");
+        execInHost(String.format("chmod +x %s/UpperCase.java", getDataFolder()));
+        execInContainer(String.format("echo \"hello camel\" | %s/UpperCase.java > %s/hello.txt", mountPoint(), mountPoint()));
+        assertFileInDataFolderContains("hello.txt", "HELLO CAMEL");
+    }
+}


### PR DESCRIPTION
Adds tests for [scripting with pipes](https://camel.apache.org/manual/camel-jbang.html#_scripting_from_terminal_using_pipes)

One thing to note is that when there are multiple lines of comments, the Java script seems to fail to compile. I got around this issue by adding the script into the data folder from the test itself rather than creating a resource file for it.