### PR TITLE
Correct the artifact id of activemq6 dependency in the documentation

### DIFF
--- a/components/camel-activemq6/src/main/docs/activemq6-component.adoc
+++ b/components/camel-activemq6/src/main/docs/activemq6-component.adoc
@@ -19,7 +19,7 @@ Users of Apache ActiveMQ Artemis should use the JMS component.
 
 [IMPORTANT]
 ====
-The camel-activemq component is best intended for ActiveMQ 6.x brokers. If you use ActiveMQ 5.x brokers,
+The camel-activemq6 component is best intended for ActiveMQ 6.x brokers. If you use ActiveMQ 5.x brokers,
 then use the camel-activemq 5.x component instead.
 ====
 
@@ -37,7 +37,7 @@ for this component:
 ------------------------------------------------------------
 <dependency>
     <groupId>org.apache.camel</groupId>
-    <artifactId>camel-activemq</artifactId>
+    <artifactId>camel-activemq6</artifactId>
     <version>x.x.x</version>
     <!-- use the same version as your Camel core version -->
 </dependency>


### PR DESCRIPTION
# Description

There is a mistake in the artifact id of activemq6 dependency in the documentation

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

