### PR TITLE
CAMEL-20367: Adds camel debug test

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelDebugITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelDebugITCase.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.it;
+
+import java.io.IOException;
+
+import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.Test;
+
+public class CamelDebugITCase extends JBangTestSupport {
+    @Test
+    public void testDebug() throws IOException {
+        copyResourceInDataFolder(TestResources.ROUTE2);
+        execInContainer(String.format("nohup camel debug %s/route2.yaml&", mountPoint()));
+        checkLogContains("Debugger JMXConnector listening at:");
+    }
+}


### PR DESCRIPTION
Adds test for [camel debug](https://camel.apache.org/manual/camel-jbang.html#_camel_route_debugging). 

Unfortunately I don't think JVM debug tests can be practically implemented since capturing the command output using the tools available is not possible because the process will never finish without interaction (hence the use of nohup in camel debug test).