### PR TITLE
CAMEL-21770: Avoid closing autowired KubernetesClient in ConfigmapsReloadTriggerTask

### DIFF
--- a/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/config_maps/vault/ConfigmapsReloadTriggerTask.java
+++ b/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/config_maps/vault/ConfigmapsReloadTriggerTask.java
@@ -106,7 +106,7 @@ public class ConfigmapsReloadTriggerTask extends ServiceSupport implements Camel
     protected void doShutdown() throws Exception {
         super.doShutdown();
 
-        if (kubernetesClient != null) {
+        if (kubernetesClient != null && !propertiesFunction.isAutowiredClient()) {
             try {
                 kubernetesClient.close();
             } catch (Exception e) {


### PR DESCRIPTION
Follow up to #17240. I missed `ConfigmapsReloadTriggerTask`.