### PR TITLE
CAMEL-20367: Adds stub test

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandOnMqttITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandOnMqttITCase.java
@@ -58,6 +58,16 @@ public class RunCommandOnMqttITCase extends JBangTestSupport {
         checkLogContains("The temperature is 21");
     }
 
+    @Test
+    public void testStub() throws IOException {
+        copyResourceInDataFolder(TestResources.STUB_ROUTE);
+        final String ipAddr = getIpAddr(service.getContainer());
+        final String pid = executeBackground(String.format("run %s/%s --stub=jms",
+                mountPoint(), TestResources.STUB_ROUTE.getName()));
+        checkCommandOutputs("cmd send --body=\"Hello camel from stubbed jms\"" + pid, "jms://inbox : Sent (success)");
+        checkCommandOutputs("cmd stub --browse", "Hello camel from stubbed jms");
+    }
+
     private String getIpAddr(final GenericContainer container) {
         return container.getCurrentContainerInfo().getNetworkSettings().getNetworks().entrySet()
                 .stream().filter(entry -> "127.0.0.1" != entry.getValue().getIpAddress())

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ScriptingWithPipesITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ScriptingWithPipesITCase.java
@@ -37,7 +37,7 @@ public class ScriptingWithPipesITCase extends JBangTestSupport {
                                               "                .to(\"stream:out\");\n" +
                                               "    }\n" +
                                               "}");
-        execInHost(String.format("chmod +x %s/UpperCase.java", getDataFolder()));
+        execInContainer(String.format("chmod +x %s/UpperCase.java", mountPoint()));
         execInContainer(String.format("echo \"hello camel\" | %s/UpperCase.java > %s/hello.txt", mountPoint(), mountPoint()));
         assertFileInDataFolderContains("hello.txt", "HELLO CAMEL");
     }

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -106,6 +106,7 @@ public abstract class JBangTestSupport {
         COMP_MAPPING_DATA("data.xml", "/jbang/it/data-mapping/components/data.xml"),
         COMP_MAPPING_TEMPLATE("transform.xml", "/jbang/it/data-mapping/components/transform.xml"),
         FORMATS_MAPPING_DATA("data.csv", "/jbang/it/data-mapping/data-formats/data.csv"),
+        STUB_ROUTE("StubRoute.java", "/jbang/it/StubRoute.java"),
         USER_SOURCE_KAMELET("user-source.kamelet.yaml", "/jbang/it/user-source.kamelet.yaml");
 
         private String name;

--- a/dsl/camel-jbang/camel-jbang-it/src/test/resources/jbang/it/StubRoute.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/resources/jbang/it/StubRoute.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.camel.builder.RouteBuilder;
+
+public class StubRoute extends RouteBuilder {
+
+    @Override
+    public void configure() {
+        from("jms:inbox")
+                .log("Incoming order")
+                .log("After transformation")
+                .to("jms:process");
+    }
+}


### PR DESCRIPTION
Adds test for [stubbing components](https://camel.apache.org/manual/camel-jbang.html#_stub_components_that_should_not_be_active).

A small change to avoid use of `execInHost()` also included.