### PR TITLE
[CAMEL-21740] Check initial replay id validity on consumer startup

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/PubSubApiConsumer.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/PubSubApiConsumer.java
@@ -88,7 +88,7 @@ public class PubSubApiConsumer extends DefaultConsumer {
         this.pubSubClient.setUsePlainTextConnection(this.usePlainTextConnection);
 
         ServiceHelper.startService(pubSubClient);
-        pubSubClient.subscribe(this, initialReplayPreset, initialReplayId);
+        pubSubClient.subscribe(this, initialReplayPreset, initialReplayId, true);
     }
 
     @Override

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/PubSubApiClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/PubSubApiClient.java
@@ -24,8 +24,11 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.protobuf.ByteString;
 import com.salesforce.eventbus.protobuf.ConsumerEvent;
 import com.salesforce.eventbus.protobuf.FetchRequest;
@@ -145,7 +148,8 @@ public class PubSubApiClient extends ServiceSupport {
         return publishResults;
     }
 
-    public void subscribe(PubSubApiConsumer consumer, ReplayPreset replayPreset, String initialReplayId) {
+    public void subscribe(
+            PubSubApiConsumer consumer, ReplayPreset replayPreset, String initialReplayId, boolean initialSubscribe) {
         LOG.debug("Starting subscribe {}", consumer.getTopic());
         this.initialReplayPreset = replayPreset;
         this.initialReplayId = initialReplayId;
@@ -153,11 +157,14 @@ public class PubSubApiClient extends ServiceSupport {
             throw new RuntimeException("initialReplayId is required for ReplayPreset.CUSTOM");
         }
 
+        String topic = consumer.getTopic();
         ByteString replayId = null;
         if (initialReplayId != null) {
             replayId = base64DecodeToByteString(initialReplayId);
+            if (initialSubscribe) {
+                checkInitialReplayIdValidity(topic, replayId);
+            }
         }
-        String topic = consumer.getTopic();
         LOG.info("Subscribing to topic: {}.", topic);
         final FetchResponseObserver responseObserver = new FetchResponseObserver(consumer);
         StreamObserver<FetchRequest> serverStream = asyncStub.subscribe(responseObserver);
@@ -172,6 +179,52 @@ public class PubSubApiClient extends ServiceSupport {
             fetchRequestBuilder.setReplayId(replayId);
         }
         serverStream.onNext(fetchRequestBuilder.build());
+    }
+
+    public void checkInitialReplayIdValidity(String topic, ByteString replayId) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Checking initialReplayId {} for topic {}", base64EncodeByteString(replayId), topic);
+        }
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final StreamObserver<FetchResponse> responseObserver = new StreamObserver<>() {
+
+            @Override
+            public void onNext(FetchResponse value) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                error.set(t);
+                latch.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        };
+        StreamObserver<FetchRequest> serverStream = asyncStub.subscribe(responseObserver);
+        FetchRequest.Builder fetchRequestBuilder = FetchRequest.newBuilder()
+                .setReplayPreset(ReplayPreset.CUSTOM)
+                .setTopicName(topic)
+                .setNumRequested(1)
+                .setReplayId(replayId);
+        serverStream.onNext(fetchRequestBuilder.build());
+
+        try {
+            if (!Uninterruptibles.awaitUninterruptibly(latch, 10, TimeUnit.SECONDS)) {
+                throw new RuntimeException("timeout while checking initialReplayId.");
+            }
+        } finally {
+            serverStream.onCompleted();
+        }
+
+        if (error.get() != null) {
+            throw new RuntimeException(
+                    "initialReplayId " + base64EncodeByteString(replayId) + " is not valid",
+                    error.get());
+        }
     }
 
     public TopicInfo getTopicInfo(String name) {
@@ -369,12 +422,12 @@ public class PubSubApiClient extends ServiceSupport {
                 throw new RuntimeException(e);
             }
             if (replayId != null) {
-                subscribe(consumer, ReplayPreset.CUSTOM, replayId);
+                subscribe(consumer, ReplayPreset.CUSTOM, replayId, false);
             } else {
                 if (initialReplayPreset == ReplayPreset.CUSTOM) {
-                    subscribe(consumer, initialReplayPreset, initialReplayId);
+                    subscribe(consumer, initialReplayPreset, initialReplayId, false);
                 } else {
-                    subscribe(consumer, initialReplayPreset, null);
+                    subscribe(consumer, initialReplayPreset, null, false);
                 }
             }
         }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/PubSubApiClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/PubSubApiClient.java
@@ -346,14 +346,10 @@ public class PubSubApiClient extends ServiceSupport {
                             LOG.debug("logged in {}", consumer.getTopic());
                         }
                         case PUBSUB_ERROR_CORRUPTED_REPLAY_ID -> {
-                            if (initialReplayPreset == ReplayPreset.CUSTOM) {
-                                LOG.error("replay id: " + replayId + " is corrupt.");
-                            } else {
-                                LOG.error("replay id: " + replayId
-                                          + " is corrupt. Trying to recover by resubscribing with LATEST replay preset");
-                                replayId = null;
-                                initialReplayPreset = ReplayPreset.LATEST;
-                            }
+                            LOG.error("replay id: " + replayId
+                                      + " is corrupt. Trying to recover by resubscribing with LATEST replay preset");
+                            replayId = null;
+                            initialReplayPreset = ReplayPreset.LATEST;
                         }
                         default -> LOG.error("unexpected errorCode: {}", errorCode);
                     }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/PubSubApiClient.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/client/PubSubApiClient.java
@@ -196,7 +196,13 @@ public class PubSubApiClient extends ServiceSupport {
 
             @Override
             public void onError(Throwable t) {
-                error.set(t);
+                if (t instanceof StatusRuntimeException e) {
+                    Metadata trailers = e.getTrailers();
+                    if (trailers != null && PUBSUB_ERROR_CORRUPTED_REPLAY_ID
+                            .equals(trailers.get(Metadata.Key.of("error-code", Metadata.ASCII_STRING_MARSHALLER)))) {
+                        error.set(t);
+                    }
+                }
                 latch.countDown();
             }
 

--- a/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/PubSubApiTest.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/test/java/org/apache/camel/component/salesforce/PubSubApiTest.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -65,11 +64,11 @@ public class PubSubApiTest {
                 port, 1000, 10000, true));
         client.setUsePlainTextConnection(true);
         client.start();
-        client.subscribe(consumer, ReplayPreset.LATEST, null);
+        client.subscribe(consumer, ReplayPreset.LATEST, null, true);
 
         verify(session, timeout(5000)).attemptLoginUntilSuccessful(anyLong(), anyLong());
-        verify(client, timeout(5000).times(1)).subscribe(consumer, ReplayPreset.LATEST, null);
-        verify(client, timeout(5000).times(1)).subscribe(consumer, ReplayPreset.CUSTOM, "MTIz");
+        verify(client, timeout(5000).times(1)).subscribe(consumer, ReplayPreset.LATEST, null, true);
+        verify(client, timeout(5000).times(1)).subscribe(consumer, ReplayPreset.CUSTOM, "MTIz", false);
     }
 
     @Test
@@ -95,10 +94,10 @@ public class PubSubApiTest {
                 port, 1000, 10000, true));
         client.setUsePlainTextConnection(true);
         client.start();
-        client.subscribe(consumer, ReplayPreset.CUSTOM, "initial");
+        client.subscribe(consumer, ReplayPreset.CUSTOM, "initial", false);
 
         verify(session, timeout(5000)).attemptLoginUntilSuccessful(anyLong(), anyLong());
-        verify(client, timeout(5000).times(2)).subscribe(consumer, ReplayPreset.CUSTOM, "initial");
+        verify(client, timeout(5000).times(2)).subscribe(consumer, ReplayPreset.CUSTOM, "initial", false);
     }
 
     @Test
@@ -124,12 +123,12 @@ public class PubSubApiTest {
                 port, 1000, 10000, true));
         client.setUsePlainTextConnection(true);
         client.start();
-        client.subscribe(consumer, ReplayPreset.LATEST, null);
+        client.subscribe(consumer, ReplayPreset.LATEST, null, false);
 
         Thread.sleep(1000);
 
         verify(session, timeout(5000)).attemptLoginUntilSuccessful(anyLong(), anyLong());
-        verify(client, timeout(5000).times(2)).subscribe(consumer, ReplayPreset.LATEST, null);
+        verify(client, timeout(5000).times(2)).subscribe(consumer, ReplayPreset.LATEST, null, false);
     }
 
     @Test
@@ -155,7 +154,7 @@ public class PubSubApiTest {
                 port, 1000, 10000, true);
         client.setUsePlainTextConnection(true);
         client.start();
-        client.subscribe(consumer, ReplayPreset.LATEST, null);
+        client.subscribe(consumer, ReplayPreset.LATEST, null, true);
 
         verify(session, timeout(5000)).attemptLoginUntilSuccessful(anyLong(), anyLong());
     }


### PR DESCRIPTION
# Description
I have added a new checkInitialReplayIdValidity method that gets executed once during the consumer startup if the provided ReplayPreset is CUSTOM.
If the provided intial replay id is corrupt/invalid an exception is thrown and Camel shuts down. (The same behaviour as when a null initialReplayId is provided.)
This workaround is just suggestion. It feels a bit hacky to me, but seems to be the best solution.

I think the error handling of this commit https://github.com/apache/camel/commit/546a5016f05ce7bfc5a663bfd6ae6a0bf1d4d3e0 will not work like intended because the method resubscribeOnError() will always set the ReplayPreset to CUSTOM if replayId is not null.
Sorry for being a bit late :)

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

