### PR TITLE
CAMEL-21821: drop support for declaring route condition in element text

### DIFF
--- a/components/camel-smooks/src/main/resources/META-INF/xsd/smooks/camel-1.5.xsd-smooks.xml
+++ b/components/camel-smooks/src/main/resources/META-INF/xsd/smooks/camel-1.5.xsd-smooks.xml
@@ -65,11 +65,6 @@
         <param name="attribute">if</param>
         <param name="mapTo">condition</param>
     </resource-config>
-    
-    <resource-config selector="camel:route/to">
-        <resource>org.smooks.engine.resource.config.loader.xml.extension.MapToResourceConfigFromText</resource>
-        <param name="mapTo">condition</param>
-    </resource-config>
 
     <resource-config selector="camel:route/to">
         <resource>org.smooks.engine.resource.config.loader.xml.extension.MapToResourceConfigFromAttribute</resource>


### PR DESCRIPTION
# Description

Remove untested and undocumented way for declaring route conditions in element text content. Route conditions should be declared in the `if` attribute.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

