### PR TITLE
feat(dsl/jbang): Run --observe to replace --metrics and --health

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_11.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_11.adoc
@@ -57,3 +57,7 @@ The camel-kafka option `recordMetadata` has changed default from `true` to `fals
 
 The option `lazy-bean` has changed to be default `true` when exporting to make the export
 work in more situations out of the box.
+
+From this version onward the `export` command add the `camel-observability-services` dependency (which includes telemetry, metrics, health and JMX management services out of the box).
+
+The `--health` and `--metrics` flags of `run` command have been deprecated in favor of the newly `--observe` flag which add the `camel-observability-services` dependency (hence including telemetry, metrics, health and JMX management out of the box). For the run command, this has to be explicitly enabled (ie, `camel run  ... --observe`).

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -287,12 +287,17 @@ public class Run extends CamelCommand {
     @Option(names = { "--console" }, description = "Developer console at /q/dev on local HTTP server (port 8080 by default)")
     boolean console;
 
-    @Option(names = { "--health" }, description = "Health check at /q/health on local HTTP server (port 8080 by default)")
+    @Option(names = { "--health" },
+            description = "Deprecated: use --observe instead. Health check at /q/health on local HTTP server (port 8080 by default)")
     boolean health;
 
     @Option(names = { "--metrics" },
-            description = "Metrics (Micrometer and Prometheus) at /q/metrics on local HTTP server (port 8080 by default)")
+            description = "Deprecated: use --observe instead. Metrics (Micrometer and Prometheus) at /q/metrics on local HTTP server (port 8080 by default)")
     boolean metrics;
+
+    @Option(names = { "--observe" },
+            description = "Enable observability services")
+    boolean observe;
 
     @Option(names = { "--modeline" }, defaultValue = "true",
             description = "Deprecated, to be removed: Enables Camel-K style modeline")
@@ -605,6 +610,10 @@ public class Run extends CamelCommand {
         writeSetting(main, profileProperties, "camel.jbang.quarkusVersion", quarkusVersion);
         writeSetting(main, profileProperties, "camel.jbang.quarkusGroupId", quarkusGroupId);
         writeSetting(main, profileProperties, "camel.jbang.quarkusArtifactId", quarkusArtifactId);
+
+        if (observe) {
+            main.addInitialProperty("camel.jbang.dependencies", "camel:observability-services");
+        }
 
         // command line arguments
         if (property != null) {

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/KameletMain.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/KameletMain.java
@@ -538,12 +538,14 @@ public class KameletMain extends MainCommandLineSupport {
             configure().httpServer().withEnabled(true);
             configure().httpServer().withInfoEnabled(true);
         }
+        // Deprecated: to be replaced by observe flag
         boolean health = "true".equals(getInitialProperties().get(getInstanceType() + ".health"));
         if (health) {
             configure().health().withEnabled(true);
             configure().httpServer().withEnabled(true);
             configure().httpServer().withHealthCheckEnabled(true);
         }
+        // Deprecated: to be replaced by observe flag
         boolean metrics = "true".equals(getInitialProperties().get(getInstanceType() + ".metrics"));
         if (metrics) {
             configure().metrics()


### PR DESCRIPTION
# Description

Introduce a new flag (`--observe`) which will include the deprecated `--health` and `--metrics` when running Camel via JBang.

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

