### PR TITLE
camel-jbang-plugin-kubernetes: make the delete op to delete from the k8s resources

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>openshift-model</artifactId>
             <version>${kubernetes-client-version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-client</artifactId>
+            <version>${kubernetes-client-version}</version>
+        </dependency>
 
         <!-- Knative model -->
         <dependency>
@@ -96,12 +101,6 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-server-mock</artifactId>
-            <version>${kubernetes-client-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>openshift-client</artifactId>
             <version>${kubernetes-client-version}</version>
             <scope>test</scope>
         </dependency>

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesBaseCommand.java
@@ -60,8 +60,6 @@ public abstract class KubernetesBaseCommand extends CamelCommand {
 
     List<Supplier<String>> projectNameSuppliers = new ArrayList<>();
 
-    private KubernetesClient kubernetesClient;
-
     public KubernetesBaseCommand(CamelJBangMain main) {
         super(main);
         projectNameSuppliers.add(() -> name);
@@ -130,22 +128,14 @@ public abstract class KubernetesBaseCommand extends CamelCommand {
      * uses default client.
      */
     protected KubernetesClient client() {
-        if (kubernetesClient == null) {
-            if (kubeConfig != null) {
-                kubernetesClient = KubernetesHelper.getKubernetesClient(kubeConfig);
-            } else {
-                kubernetesClient = KubernetesHelper.getKubernetesClient();
-            }
-        }
-
-        return kubernetesClient;
+        return KubernetesHelper.getKubernetesClient();
     }
 
     /**
      * Sets the Kubernetes client.
      */
     public KubernetesBaseCommand withClient(KubernetesClient kubernetesClient) {
-        this.kubernetesClient = kubernetesClient;
+        KubernetesHelper.setKubernetesClient(kubernetesClient);
         return this;
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesCommandTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesCommandTest.java
@@ -64,7 +64,7 @@ class KubernetesCommandTest extends KubernetesBaseTest {
         Assertions.assertEquals("route", deployment.getMetadata().getLabels().get(BaseTrait.KUBERNETES_LABEL_NAME));
         Assertions.assertEquals("route", deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
         Assertions.assertEquals("route", matchLabels.get(BaseTrait.KUBERNETES_LABEL_NAME));
-        Assertions.assertEquals("jkube", matchLabels.get(BaseTrait.KUBERNETES_LABEL_MANAGED_BY));
+        Assertions.assertEquals("camel-jbang", matchLabels.get(BaseTrait.KUBERNETES_LABEL_MANAGED_BY));
         Assertions.assertEquals("camel-test/route:1.0-SNAPSHOT",
                 deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
         Assertions.assertEquals("IfNotPresent",

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesDeleteTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesDeleteTest.java
@@ -17,86 +17,198 @@
 
 package org.apache.camel.dsl.jbang.core.commands.kubernetes;
 
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
-import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.ServiceBuilder;
-import io.fabric8.kubernetes.api.model.ServicePortBuilder;
-import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeBuilder;
+import io.fabric8.kubernetes.api.model.NodeList;
+import io.fabric8.kubernetes.api.model.NodeListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.openshift.api.model.config.v1.ClusterVersion;
+import io.fabric8.openshift.api.model.config.v1.ClusterVersionBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
-import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.BaseTrait;
+import org.apache.camel.dsl.jbang.core.common.StringPrinter;
+import org.apache.camel.dsl.jbang.core.common.VersionHelper;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.condition.EnabledIf;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                           disabledReason = "Requires too much network resources")
-@EnabledIf("isDockerAvailable")
-class KubernetesDeleteTest extends KubernetesBaseTest {
+@EnableKubernetesMockClient
+class KubernetesDeleteTest {
 
-    @Test
-    public void shouldDeleteKubernetesResources() throws Exception {
-        kubernetesClient.apps().deployments().resource(new DeploymentBuilder()
-                .withNewMetadata()
-                .withName("route")
-                .addToLabels(BaseTrait.KUBERNETES_LABEL_NAME, "route")
-                .endMetadata()
-                .withNewSpec()
-                .withNewTemplate()
-                .withNewSpec()
-                .addToContainers(new ContainerBuilder()
-                        .withName("route")
-                        .withImage("quay.io/camel-test/route:1.0-SNAPSHOT")
-                        .build())
-                .endSpec()
-                .endTemplate()
-                .endSpec()
-                .build()).create();
+    protected KubernetesMockServer server;
+    protected KubernetesClient client;
+    protected StringPrinter printer;
 
-        kubernetesClient.services().resource(new ServiceBuilder()
-                .withNewMetadata()
-                .withName("route")
-                .endMetadata()
-                .withNewSpec()
-                .withPorts(new ServicePortBuilder()
-                        .withPort(80)
-                        .withProtocol("TCP")
-                        .withName("http")
-                        .withTargetPort(new IntOrString(8080))
-                        .build())
-                .endSpec()
-                .build()).create();
-
-        KubernetesRun run = new KubernetesRun(new CamelJBangMain().withPrinter(printer));
-        run.withClient(kubernetesClient);
-        run.imageGroup = "camel-test";
-        run.imageBuild = false;
-        run.imagePush = false;
-        run.filePaths = new String[] { "classpath:route.yaml" };
-        run.output = "yaml";
-        int exit = run.doCall();
-        Assertions.assertEquals(0, exit);
-
-        KubernetesDelete command = new KubernetesDelete(new CamelJBangMain().withPrinter(printer));
-        command.withClient(kubernetesClient);
-        command.name = "route";
-        exit = command.doCall();
-
-        Assertions.assertEquals(0, exit);
-        Assertions.assertNull(kubernetesClient.apps().deployments().withName("route").get());
-        Assertions.assertNull(kubernetesClient.services().withName("route").get());
+    @BeforeEach
+    public void setup() {
+        // Set Camel version with system property value, usually set via Maven surefire plugin
+        // In case you run this test via local Java IDE you need to provide the system property or a default value here
+        VersionHelper.setCamelVersion(System.getProperty("camel.version", ""));
+        printer = new StringPrinter();
     }
 
     @Test
-    public void shouldHandleNoExportFound() throws Exception {
+    public void shouldDeleteNonExistentApp() throws Exception {
         KubernetesDelete command = new KubernetesDelete(new CamelJBangMain().withPrinter(printer));
-        command.withClient(kubernetesClient);
-        command.name = "does-not-exist";
+        command.withClient(client);
+        command.appName = "does-not-exist";
+        int exit = command.doCall();
+        boolean errorOutput = printer.getOutput().contains("Error trying to delete the app");
+        if (errorOutput) {
+            Assertions.assertEquals(1, exit, printer.getOutput());
+        } else {
+            Assertions.assertEquals(0, exit, printer.getOutput());
+            Assertions.assertTrue(printer.getOutput().contains("No deployment found with name"), printer.getOutput());
+        }
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "MINIKUBE_ACTIVE_DOCKERD", value = "foo")
+    @SetEnvironmentVariable(key = "DOCKER_TLS_VERIFY", value = "foo")
+    public void shouldDeleteNonExistentAppInMinikube() throws Exception {
+        Node nodeCR = new NodeBuilder()
+                .withNewMetadata()
+                .withName("minikube")
+                .withLabels(Collections.singletonMap("minikube.k8s.io/name", "minikube"))
+                .endMetadata()
+                .build();
+        NodeList nodeList = new NodeListBuilder().addToItems(nodeCR)
+                .build();
+
+        serverExpect("/api/v1/nodes?labelSelector=minikube.k8s.io%2Fname", nodeList);
+
+        KubernetesDelete command = new KubernetesDelete(new CamelJBangMain().withPrinter(printer));
+        command.withClient(client);
+        command.appName = "does-not-exist";
+        int exit = command.doCall();
+        boolean errorOutput = printer.getOutput().contains("Error trying to delete the app");
+        if (errorOutput) {
+            Assertions.assertEquals(1, exit, printer.getOutput());
+        } else {
+            Assertions.assertEquals(0, exit, printer.getOutput());
+            Assertions.assertTrue(printer.getOutput().contains("No deployment found with name"), printer.getOutput());
+        }
+    }
+
+    @Test
+    public void shouldDeleteNonExistentAppInOpenshift() throws Exception {
+        ClusterVersion versionCR = new ClusterVersionBuilder()
+                .withNewMetadata().withName("version").endMetadata()
+                .withNewStatus()
+                .withNewDesired()
+                .withVersion("4.14.5")
+                .endDesired()
+                .endStatus()
+                .build();
+
+        serverExpect("/apis/config.openshift.io/v1/clusterversions/version", versionCR);
+
+        KubernetesDelete command = new KubernetesDelete(new CamelJBangMain().withPrinter(printer));
+        command.withClient(client);
+        command.appName = "does-not-exist";
+        int exit = command.doCall();
+        boolean errorOutput = printer.getOutput().contains("Error trying to delete the app");
+        if (errorOutput) {
+            Assertions.assertEquals(1, exit, printer.getOutput());
+        } else {
+            Assertions.assertEquals(0, exit, printer.getOutput());
+            Assertions.assertTrue(printer.getOutput().contains("No deployment found with name"), printer.getOutput());
+        }
+    }
+
+    @Test
+    public void shouldDeleteOnKubernetes() throws Exception {
+        String appName = "my-route";
+
+        // Mock the delete request expectation
+        serverDeleteExpect(
+                "/apis/apps/v1/namespaces/test/deployments?labelSelector=app%3Dmy-route%2Capp.kubernetes.io%2Fmanaged-by%3Dcamel-jbang");
+        serverDeleteExpect(
+                "/api/v1/namespaces/test/services?labelSelector=app%3Dmy-route%2Capp.kubernetes.io%2Fmanaged-by%3Dcamel-jbang");
+
+        // Execute delete command
+        KubernetesDelete command = new KubernetesDelete(new CamelJBangMain().withPrinter(printer));
+        command.withClient(client);
+        command.namespace = "test";
+        command.appName = appName;
         int exit = command.doCall();
 
-        Assertions.assertEquals(1, exit);
-        Assertions.assertEquals("ERROR: Failed to resolve exported project: does-not-exist",
-                printer.getOutput());
+        // Verify command execution
+        Assertions.assertEquals(0, exit, printer.getOutput());
+
+        // Verify deployment was deleted
+        Assertions.assertNull(client.apps().deployments().withName(appName).get());
+        Assertions.assertNull(client.services().withName(appName).get());
+    }
+
+    @Test
+    public void shouldDeleteOnOpenShift() throws Exception {
+        ClusterVersion versionCR = new ClusterVersionBuilder()
+                .withNewMetadata().withName("version").endMetadata()
+                .withNewStatus()
+                .withNewDesired()
+                .withVersion("4.14.5")
+                .endDesired()
+                .endStatus()
+                .build();
+
+        serverExpect("/apis/config.openshift.io/v1/clusterversions/version", versionCR);
+
+        String appName = "my-route";
+
+        // Mock the delete request expectations for openshift resources
+        serverDeleteExpect(
+                "/apis/apps/v1/namespaces/test/deployments?labelSelector=app%3Dmy-route%2Capp.kubernetes.io%2Fmanaged-by%3Dcamel-jbang");
+        serverDeleteExpect(
+                "/api/v1/namespaces/test/services?labelSelector=app%3Dmy-route%2Capp.kubernetes.io%2Fmanaged-by%3Dcamel-jbang");
+        serverDeleteExpect(
+                "/apis/build.openshift.io/v1/namespaces/test/buildconfigs?labelSelector=app%3Dmy-route%2Capp.kubernetes.io%2Fmanaged-by%3Dcamel-jbang");
+        serverDeleteExpect(
+                "/apis/image.openshift.io/v1/namespaces/test/imagestreams?labelSelector=app%3Dmy-route%2Capp.kubernetes.io%2Fmanaged-by%3Dcamel-jbang");
+        serverDeleteExpect(
+                "/apis/route.openshift.io/v1/namespaces/test/routes?labelSelector=app%3Dmy-route%2Capp.kubernetes.io%2Fmanaged-by%3Dcamel-jbang");
+
+        // Execute delete command
+        KubernetesDelete command = new KubernetesDelete(new CamelJBangMain().withPrinter(printer));
+        command.withClient(client);
+        command.namespace = "test";
+        command.appName = appName;
+        int exit = command.doCall();
+
+        // Verify command execution
+        Assertions.assertEquals(0, exit, printer.getOutput());
+
+        OpenShiftClient ocpClient = client.adapt(OpenShiftClient.class);
+
+        // Verify deployment was deleted
+        Assertions.assertNull(client.apps().deployments().withName(appName).get());
+        Assertions.assertNull(client.services().withName(appName).get());
+        Assertions.assertNull(ocpClient.buildConfigs().withName(appName).get());
+        Assertions.assertNull(ocpClient.imageStreams().withName(appName).get());
+        Assertions.assertNull(ocpClient.routes().withName(appName).get());
+    }
+
+    private void serverDeleteExpect(String path) {
+        server.expect().delete()
+                .withPath(path)
+                .andReturn(HttpURLConnection.HTTP_OK, null)
+                .once();
+    }
+
+    private void serverExpect(String path, Object response) {
+        server.expect().get()
+                .withPath(path)
+                .andReturn(HttpURLConnection.HTTP_OK, response)
+                .once();
     }
 
 }


### PR DESCRIPTION

Do not use the camel-jbang temporary directory
The "run" op sets labels used in the "del" op
Use a single KubernetesClient instance in the KubernetesHelper

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

