### PR TITLE
CAMEL-20367: Adds camel doc test

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelDocITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelDocITCase.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.it;
+
+import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.Test;
+
+public class CamelDocITCase extends JBangTestSupport {
+    @Test
+    public void testDisplayComponent() {
+        checkCommandOutputs("doc kafka", "Component Name: kafka");
+    }
+
+    @Test
+    public void testDisplayDataformat() {
+        checkCommandOutputs("doc dataformat:thrift", "Dataformat Name: thrift");
+        checkCommandDoesNotOutput("doc dataformat:thrift", "Component Name: thrift");
+    }
+}


### PR DESCRIPTION
Adds a simple test to check [camel documentation is displayed](https://camel.apache.org/manual/camel-jbang.html#_displaying_component_documentation)