### PR TITLE
Update camel-chunk documentation: Replace outdated URL with Correct one

### DIFF
--- a/components/camel-chunk/src/main/docs/chunk-component.adoc
+++ b/components/camel-chunk/src/main/docs/chunk-component.adoc
@@ -15,7 +15,7 @@
 *{component-header}*
 
 The Chunk component allows for processing a message using a
-http://www.x5software.com/chunk/examples/ChunkExample?loc=en_US[Chunk] template.
+https://github.com/tomj74/chunk-templates[Chunk] template.
 This can be ideal when using Templating to
 generate responses for requests.
 


### PR DESCRIPTION
# Description

This PR fixes the broken link in the camel-chunk documentation. The previous URL

`http://www.x5software.com/chunk/examples/ChunkExample?loc=en_US`

is no longer valid and redirects users incorrectly. I have updated the URL to point to the new, maintained repository at:

`https://github.com/tomj74/chunk-templates`

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

