### PR TITLE
Align with netty/spring redis with spring-boot 3.3.9; refresh

### DIFF
--- a/bom/camel-bom/pom.xml
+++ b/bom/camel-bom/pom.xml
@@ -2015,7 +2015,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test</artifactId>
-        <version>4.8.5</version>
+        <version>4.8.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -375,7 +375,7 @@
         <mybatis-version>3.5.16</mybatis-version>
         <narayana-version>5.13.1.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
-        <netty-version>4.1.118.Final</netty-version>
+        <netty-version>4.1.119.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.5.1</networknt-json-schema-validator-version>
         <nimbus-jose-jwt>9.40</nimbus-jose-jwt>
@@ -453,7 +453,7 @@
         <splunk-version>1.9.5_1</splunk-version>
         <spock-version>2.3-groovy-4.0</spock-version>
         <spring-batch-version>5.1.3</spring-batch-version>
-        <spring-data-redis-version>3.3.3</spring-data-redis-version>
+        <spring-data-redis-version>3.3.9</spring-data-redis-version>
         <spring-ldap-version>3.2.11</spring-ldap-version>
         <spring-vault-core-version>3.1.2</spring-vault-core-version>
         <spring-version>6.1.17</spring-version>


### PR DESCRIPTION
# Description

Align with netty/spring redis with spring-boot 3.3.9; refresh

Note - this is for the 4.8.x branch.    

Also : due to the branch being dirty, this PR will collide with https://github.com/apache/camel/pull/17421 - both PRs include a refresh of the branch - I can rebase once one of these PRs gets merged