### PR TITLE
CAMEL-21858: Checking the httpMethod parameter when decorating the sp…

### DIFF
--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AbstractHttpSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AbstractHttpSpanDecorator.java
@@ -28,13 +28,7 @@ public abstract class AbstractHttpSpanDecorator extends AbstractSpanDecorator {
     public static final String GET_METHOD = "GET";
 
     public String getHttpMethod(Exchange exchange, Endpoint endpoint) {
-        //  1. Use method from httpMethod param, if present
-        String methodFromParameters = getMethodFromParameters(exchange, endpoint);
-        if (methodFromParameters != null) {
-            return methodFromParameters;
-        }
-
-        // 2. Use method provided in header.
+        // 1. Use method provided in header.
         Object method = exchange.getIn().getHeader(Exchange.HTTP_METHOD);
         if (method instanceof String) {
             return (String) method;
@@ -44,29 +38,23 @@ public abstract class AbstractHttpSpanDecorator extends AbstractSpanDecorator {
             return exchange.getContext().getTypeConverter().tryConvertTo(String.class, exchange, method);
         }
 
-        // 3. GET if query string is provided in header.
+        // 2. GET if query string is provided in header.
         if (exchange.getIn().getHeader(Exchange.HTTP_QUERY) != null) {
             return GET_METHOD;
         }
 
-        // 4. GET if endpoint is configured with a query string.
+        // 3. GET if endpoint is configured with a query string.
         if (endpoint.getEndpointUri().indexOf('?') != -1) {
             return GET_METHOD;
         }
 
-        // 5. POST if there is data to send (body is not null).
+        // 4. POST if there is data to send (body is not null).
         if (exchange.getIn().getBody() != null) {
             return POST_METHOD;
         }
 
-        // 6. GET otherwise.
+        // 5. GET otherwise.
         return GET_METHOD;
-    }
-
-    protected String getMethodFromParameters(Exchange exchange, Endpoint endpoint) {
-        // should be overriden by specific component decorators
-        // as each component might have different parameters for the http method
-        return null;
     }
 
     @Override

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/HttpMethodHelper.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/HttpMethodHelper.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+
+class HttpMethodHelper {
+
+    private static final Pattern HTTP_METHOD_PATTERN = Pattern.compile("(?i)httpMethod=([A-Z]+)");
+
+    /**
+     * This method searches for the httpMethod param on the endpoint and return it.
+     *
+     * @param  exchange
+     * @param  endpoint
+     * @return
+     */
+    public static String getHttpMethodFromParameters(Exchange exchange, Endpoint endpoint) {
+        String queryStringHeader = (String) exchange.getIn().getHeader(Exchange.HTTP_QUERY);
+        if (queryStringHeader != null) {
+            String methodFromQuery = getMethodFromQueryString(queryStringHeader);
+            if (methodFromQuery != null) {
+                return methodFromQuery;
+            }
+        }
+
+        // try to get the httpMethod parameter from the the query string in the uri
+        int queryIndex = endpoint.getEndpointUri().indexOf('?');
+        if (queryIndex != -1) {
+            String queryString = endpoint.getEndpointUri().substring(queryIndex + 1);
+            String methodFromQuery = getMethodFromQueryString(queryString);
+            if (methodFromQuery != null) {
+                return methodFromQuery;
+            }
+        }
+        return null;
+    }
+
+    private static String getMethodFromQueryString(String queryString) {
+        Matcher m = HTTP_METHOD_PATTERN.matcher(queryString);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/HttpSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/HttpSpanDecorator.java
@@ -27,6 +27,16 @@ public class HttpSpanDecorator extends AbstractHttpSpanDecorator {
     private static final Pattern HTTP_METHOD_PATTERN = Pattern.compile("(?i)httpMethod=([A-Z]+)");
 
     @Override
+    public String getHttpMethod(Exchange exchange, Endpoint endpoint) {
+        //this component supports the httpMethod parameter, so we try to find it first
+        String methodFromParameters = getMethodFromParameters(exchange, endpoint);
+        if (methodFromParameters != null) {
+            return methodFromParameters;
+        }
+        return super.getHttpMethod(exchange, endpoint);
+    }
+
+    @Override
     public String getComponent() {
         return "http";
     }
@@ -36,8 +46,7 @@ public class HttpSpanDecorator extends AbstractHttpSpanDecorator {
         return "org.apache.camel.component.http.HttpComponent";
     }
 
-    @Override
-    protected String getMethodFromParameters(Exchange exchange, Endpoint endpoint) {
+    private String getMethodFromParameters(Exchange exchange, Endpoint endpoint) {
         String queryStringHeader = (String) exchange.getIn().getHeader(Exchange.HTTP_QUERY);
         if (queryStringHeader != null) {
             String methodFromQuery = getMethodFromQueryString(queryStringHeader);

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/VertxHttpSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/VertxHttpSpanDecorator.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.telemetry.decorators;
 
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+
 public class VertxHttpSpanDecorator extends AbstractHttpSpanDecorator {
 
     @Override
@@ -26,6 +29,15 @@ public class VertxHttpSpanDecorator extends AbstractHttpSpanDecorator {
     @Override
     public String getComponentClassName() {
         return "org.apache.camel.component.vertx.http.VertxHttpComponent";
+    }
+
+    @Override
+    public String getHttpMethod(Exchange exchange, Endpoint endpoint) {
+        String methodFromParameters = HttpMethodHelper.getHttpMethodFromParameters(exchange, endpoint);
+        if (methodFromParameters != null) {
+            return methodFromParameters;
+        }
+        return super.getHttpMethod(exchange, endpoint);
     }
 
 }

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/HttpMethodHelperTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/HttpMethodHelperTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class HttpMethodHelperTest {
+
+    @Test
+    public void testHttpMethodPresent() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class))
+                .thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+        assertEquals("POST", HttpMethodHelper.getHttpMethodFromParameters(exchange, endpoint));
+    }
+
+    @Test
+    public void testHttpMethodMissing() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint");
+        assertNull(HttpMethodHelper.getHttpMethodFromParameters(exchange, endpoint));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/HttpSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/HttpSpanDecoratorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HttpSpanDecoratorTest {
+
+    private HttpSpanDecorator decorator;
+
+    @BeforeEach
+    public void before() {
+        this.decorator = new HttpSpanDecorator();
+    }
+
+    @Test
+    public void testMethodInHttpMethodParam() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class))
+                .thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+
+        assertEquals(AbstractHttpSpanDecorator.POST_METHOD,
+                decorator.getHttpMethod(exchange, endpoint));
+    }
+
+    @Test
+    public void testMethodInHttpMethodParamUsingHeader() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(Exchange.HTTP_METHOD)).thenReturn(HttpMethods.GET);
+        Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class))
+                .thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+
+        assertEquals(AbstractHttpSpanDecorator.POST_METHOD,
+                decorator.getHttpMethod(exchange, endpoint));
+    }
+}

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractHttpSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractHttpSpanDecorator.java
@@ -27,8 +27,14 @@ public abstract class AbstractHttpSpanDecorator extends AbstractSpanDecorator {
     public static final String POST_METHOD = "POST";
     public static final String GET_METHOD = "GET";
 
-    public static String getHttpMethod(Exchange exchange, Endpoint endpoint) {
-        // 1. Use method provided in header.
+    public String getHttpMethod(Exchange exchange, Endpoint endpoint) {
+        //  1. Use method from httpMethod param, if present
+        String methodFromParameters = getMethodFromParameters(exchange, endpoint);
+        if (methodFromParameters != null) {
+            return methodFromParameters;
+        }
+
+        // 2. Use method provided in header.
         Object method = exchange.getIn().getHeader(Exchange.HTTP_METHOD);
         if (method instanceof String) {
             return (String) method;
@@ -38,23 +44,29 @@ public abstract class AbstractHttpSpanDecorator extends AbstractSpanDecorator {
             return exchange.getContext().getTypeConverter().tryConvertTo(String.class, exchange, method);
         }
 
-        // 2. GET if query string is provided in header.
+        // 3. GET if query string is provided in header.
         if (exchange.getIn().getHeader(Exchange.HTTP_QUERY) != null) {
             return GET_METHOD;
         }
 
-        // 3. GET if endpoint is configured with a query string.
+        // 4. GET if endpoint is configured with a query string.
         if (endpoint.getEndpointUri().indexOf('?') != -1) {
             return GET_METHOD;
         }
 
-        // 4. POST if there is data to send (body is not null).
+        // 5. POST if there is data to send (body is not null).
         if (exchange.getIn().getBody() != null) {
             return POST_METHOD;
         }
 
-        // 5. GET otherwise.
+        // 6. GET otherwise.
         return GET_METHOD;
+    }
+
+    protected String getMethodFromParameters(Exchange exchange, Endpoint endpoint) {
+        // should be overriden by specific component decorators
+        // as each component might have different parameters for the http method
+        return null;
     }
 
     @Override
@@ -105,4 +117,5 @@ public abstract class AbstractHttpSpanDecorator extends AbstractSpanDecorator {
             }
         }
     }
+
 }

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractHttpSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/AbstractHttpSpanDecorator.java
@@ -28,13 +28,7 @@ public abstract class AbstractHttpSpanDecorator extends AbstractSpanDecorator {
     public static final String GET_METHOD = "GET";
 
     public String getHttpMethod(Exchange exchange, Endpoint endpoint) {
-        //  1. Use method from httpMethod param, if present
-        String methodFromParameters = getMethodFromParameters(exchange, endpoint);
-        if (methodFromParameters != null) {
-            return methodFromParameters;
-        }
-
-        // 2. Use method provided in header.
+        // 1. Use method provided in header.
         Object method = exchange.getIn().getHeader(Exchange.HTTP_METHOD);
         if (method instanceof String) {
             return (String) method;
@@ -44,29 +38,23 @@ public abstract class AbstractHttpSpanDecorator extends AbstractSpanDecorator {
             return exchange.getContext().getTypeConverter().tryConvertTo(String.class, exchange, method);
         }
 
-        // 3. GET if query string is provided in header.
+        // 2. GET if query string is provided in header.
         if (exchange.getIn().getHeader(Exchange.HTTP_QUERY) != null) {
             return GET_METHOD;
         }
 
-        // 4. GET if endpoint is configured with a query string.
+        // 3. GET if endpoint is configured with a query string.
         if (endpoint.getEndpointUri().indexOf('?') != -1) {
             return GET_METHOD;
         }
 
-        // 5. POST if there is data to send (body is not null).
+        // 4. POST if there is data to send (body is not null).
         if (exchange.getIn().getBody() != null) {
             return POST_METHOD;
         }
 
-        // 6. GET otherwise.
+        // 5. GET otherwise.
         return GET_METHOD;
-    }
-
-    protected String getMethodFromParameters(Exchange exchange, Endpoint endpoint) {
-        // should be overriden by specific component decorators
-        // as each component might have different parameters for the http method
-        return null;
     }
 
     @Override

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/HttpMethodHelper.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/HttpMethodHelper.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.tracing.decorators;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+
+class HttpMethodHelper {
+
+    private static final Pattern HTTP_METHOD_PATTERN = Pattern.compile("(?i)httpMethod=([A-Z]+)");
+
+    /**
+     * This method searches for the httpMethod param on the endpoint and return it.
+     *
+     * @param  exchange
+     * @param  endpoint
+     * @return
+     */
+    public static String getHttpMethodFromParameters(Exchange exchange, Endpoint endpoint) {
+        String queryStringHeader = (String) exchange.getIn().getHeader(Exchange.HTTP_QUERY);
+        if (queryStringHeader != null) {
+            String methodFromQuery = getMethodFromQueryString(queryStringHeader);
+            if (methodFromQuery != null) {
+                return methodFromQuery;
+            }
+        }
+
+        // try to get the httpMethod parameter from the the query string in the uri
+        int queryIndex = endpoint.getEndpointUri().indexOf('?');
+        if (queryIndex != -1) {
+            String queryString = endpoint.getEndpointUri().substring(queryIndex + 1);
+            String methodFromQuery = getMethodFromQueryString(queryString);
+            if (methodFromQuery != null) {
+                return methodFromQuery;
+            }
+        }
+        return null;
+    }
+
+    private static String getMethodFromQueryString(String queryString) {
+        Matcher m = HTTP_METHOD_PATTERN.matcher(queryString);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+}

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/HttpSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/HttpSpanDecorator.java
@@ -27,6 +27,16 @@ public class HttpSpanDecorator extends AbstractHttpSpanDecorator {
     private static final Pattern HTTP_METHOD_PATTERN = Pattern.compile("(?i)httpMethod=([A-Z]+)");
 
     @Override
+    public String getHttpMethod(Exchange exchange, Endpoint endpoint) {
+        //this component supports the httpMethod parameter, so we try to find it first
+        String methodFromParameters = getMethodFromParameters(exchange, endpoint);
+        if (methodFromParameters != null) {
+            return methodFromParameters;
+        }
+        return super.getHttpMethod(exchange, endpoint);
+    }
+
+    @Override
     public String getComponent() {
         return "http";
     }
@@ -36,8 +46,7 @@ public class HttpSpanDecorator extends AbstractHttpSpanDecorator {
         return "org.apache.camel.component.http.HttpComponent";
     }
 
-    @Override
-    protected String getMethodFromParameters(Exchange exchange, Endpoint endpoint) {
+    private String getMethodFromParameters(Exchange exchange, Endpoint endpoint) {
         String queryStringHeader = (String) exchange.getIn().getHeader(Exchange.HTTP_QUERY);
         if (queryStringHeader != null) {
             String methodFromQuery = getMethodFromQueryString(queryStringHeader);

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/HttpSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/HttpSpanDecorator.java
@@ -16,7 +16,15 @@
  */
 package org.apache.camel.tracing.decorators;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+
 public class HttpSpanDecorator extends AbstractHttpSpanDecorator {
+
+    private static final Pattern HTTP_METHOD_PATTERN = Pattern.compile("(?i)httpMethod=([A-Z]+)");
 
     @Override
     public String getComponent() {
@@ -26,6 +34,36 @@ public class HttpSpanDecorator extends AbstractHttpSpanDecorator {
     @Override
     public String getComponentClassName() {
         return "org.apache.camel.component.http.HttpComponent";
+    }
+
+    @Override
+    protected String getMethodFromParameters(Exchange exchange, Endpoint endpoint) {
+        String queryStringHeader = (String) exchange.getIn().getHeader(Exchange.HTTP_QUERY);
+        if (queryStringHeader != null) {
+            String methodFromQuery = getMethodFromQueryString(queryStringHeader);
+            if (methodFromQuery != null) {
+                return methodFromQuery;
+            }
+        }
+
+        // try to get the httpMethod parameter from the the query string in the uri
+        int queryIndex = endpoint.getEndpointUri().indexOf('?');
+        if (queryIndex != -1) {
+            String queryString = endpoint.getEndpointUri().substring(queryIndex + 1);
+            String methodFromQuery = getMethodFromQueryString(queryString);
+            if (methodFromQuery != null) {
+                return methodFromQuery;
+            }
+        }
+        return null;
+    }
+
+    private static String getMethodFromQueryString(String queryString) {
+        Matcher m = HTTP_METHOD_PATTERN.matcher(queryString);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return null;
     }
 
 }

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/HttpSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/HttpSpanDecorator.java
@@ -16,25 +16,10 @@
  */
 package org.apache.camel.tracing.decorators;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 
 public class HttpSpanDecorator extends AbstractHttpSpanDecorator {
-
-    private static final Pattern HTTP_METHOD_PATTERN = Pattern.compile("(?i)httpMethod=([A-Z]+)");
-
-    @Override
-    public String getHttpMethod(Exchange exchange, Endpoint endpoint) {
-        //this component supports the httpMethod parameter, so we try to find it first
-        String methodFromParameters = getMethodFromParameters(exchange, endpoint);
-        if (methodFromParameters != null) {
-            return methodFromParameters;
-        }
-        return super.getHttpMethod(exchange, endpoint);
-    }
 
     @Override
     public String getComponent() {
@@ -46,33 +31,14 @@ public class HttpSpanDecorator extends AbstractHttpSpanDecorator {
         return "org.apache.camel.component.http.HttpComponent";
     }
 
-    private String getMethodFromParameters(Exchange exchange, Endpoint endpoint) {
-        String queryStringHeader = (String) exchange.getIn().getHeader(Exchange.HTTP_QUERY);
-        if (queryStringHeader != null) {
-            String methodFromQuery = getMethodFromQueryString(queryStringHeader);
-            if (methodFromQuery != null) {
-                return methodFromQuery;
-            }
+    @Override
+    public String getHttpMethod(Exchange exchange, Endpoint endpoint) {
+        //this component supports the httpMethod parameter, so we try to find it first
+        String methodFromParameters = HttpMethodHelper.getHttpMethodFromParameters(exchange, endpoint);
+        if (methodFromParameters != null) {
+            return methodFromParameters;
         }
-
-        // try to get the httpMethod parameter from the the query string in the uri
-        int queryIndex = endpoint.getEndpointUri().indexOf('?');
-        if (queryIndex != -1) {
-            String queryString = endpoint.getEndpointUri().substring(queryIndex + 1);
-            String methodFromQuery = getMethodFromQueryString(queryString);
-            if (methodFromQuery != null) {
-                return methodFromQuery;
-            }
-        }
-        return null;
-    }
-
-    private static String getMethodFromQueryString(String queryString) {
-        Matcher m = HTTP_METHOD_PATTERN.matcher(queryString);
-        if (m.find()) {
-            return m.group(1);
-        }
-        return null;
+        return super.getHttpMethod(exchange, endpoint);
     }
 
 }

--- a/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/VertxHttpSpanDecorator.java
+++ b/components/camel-tracing/src/main/java/org/apache/camel/tracing/decorators/VertxHttpSpanDecorator.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.tracing.decorators;
 
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+
 public class VertxHttpSpanDecorator extends AbstractHttpSpanDecorator {
 
     @Override
@@ -28,4 +31,13 @@ public class VertxHttpSpanDecorator extends AbstractHttpSpanDecorator {
         return "org.apache.camel.component.vertx.http.VertxHttpComponent";
     }
 
+    @Override
+    public String getHttpMethod(Exchange exchange, Endpoint endpoint) {
+        //this component supports the httpMethod parameter, so we try to find it first
+        String methodFromParameters = HttpMethodHelper.getHttpMethodFromParameters(exchange, endpoint);
+        if (methodFromParameters != null) {
+            return methodFromParameters;
+        }
+        return super.getHttpMethod(exchange, endpoint);
+    }
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractHttpSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractHttpSpanDecoratorTest.java
@@ -20,7 +20,6 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.tracing.MockSpanAdapter;
-import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.TagConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,11 +32,21 @@ public class AbstractHttpSpanDecoratorTest {
 
     private static final String TEST_URI = "http://localhost:8080/test";
 
-    private HttpSpanDecorator decorator;
+    private AbstractHttpSpanDecorator decorator;
 
     @BeforeEach
     public void before() {
-        this.decorator = new HttpSpanDecorator();
+        this.decorator = new AbstractHttpSpanDecorator() {
+            @Override
+            public String getComponent() {
+                return null;
+            }
+
+            @Override
+            public String getComponentClassName() {
+                return null;
+            }
+        };
     }
 
     @Test
@@ -49,18 +58,6 @@ public class AbstractHttpSpanDecoratorTest {
         Mockito.when(exchange.getIn()).thenReturn(message);
         Mockito.when(message.getHeader(Exchange.HTTP_METHOD)).thenReturn("PUT");
         Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint");
-
-        SpanDecorator decorator = new AbstractHttpSpanDecorator() {
-            @Override
-            public String getComponent() {
-                return null;
-            }
-
-            @Override
-            public String getComponentClassName() {
-                return null;
-            }
-        };
 
         assertEquals("PUT", decorator.getOperationName(exchange, endpoint));
     }
@@ -159,18 +156,6 @@ public class AbstractHttpSpanDecoratorTest {
         Mockito.when(exchange.getIn()).thenReturn(message);
         Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class)).thenReturn(TEST_URI);
 
-        SpanDecorator decorator = new AbstractHttpSpanDecorator() {
-            @Override
-            public String getComponent() {
-                return null;
-            }
-
-            @Override
-            public String getComponentClassName() {
-                return null;
-            }
-        };
-
         MockSpanAdapter span = new MockSpanAdapter();
 
         decorator.pre(span, exchange, endpoint);
@@ -190,18 +175,6 @@ public class AbstractHttpSpanDecoratorTest {
         Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class)).thenReturn("Another URL");
         Mockito.when(message.getHeader(Exchange.HTTP_URL, String.class)).thenReturn(TEST_URI);
 
-        AbstractHttpSpanDecorator decorator = new AbstractHttpSpanDecorator() {
-            @Override
-            public String getComponent() {
-                return null;
-            }
-
-            @Override
-            public String getComponentClassName() {
-                return null;
-            }
-        };
-
         assertEquals(TEST_URI, decorator.getHttpURL(exchange, endpoint));
     }
 
@@ -215,18 +188,6 @@ public class AbstractHttpSpanDecoratorTest {
         Mockito.when(exchange.getIn()).thenReturn(message);
         Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class)).thenReturn(TEST_URI);
 
-        AbstractHttpSpanDecorator decorator = new AbstractHttpSpanDecorator() {
-            @Override
-            public String getComponent() {
-                return null;
-            }
-
-            @Override
-            public String getComponentClassName() {
-                return null;
-            }
-        };
-
         assertEquals(TEST_URI, decorator.getHttpURL(exchange, endpoint));
     }
 
@@ -238,18 +199,6 @@ public class AbstractHttpSpanDecoratorTest {
 
         Mockito.when(endpoint.getEndpointUri()).thenReturn(TEST_URI);
         Mockito.when(exchange.getIn()).thenReturn(message);
-
-        AbstractHttpSpanDecorator decorator = new AbstractHttpSpanDecorator() {
-            @Override
-            public String getComponent() {
-                return null;
-            }
-
-            @Override
-            public String getComponentClassName() {
-                return null;
-            }
-        };
 
         assertEquals(TEST_URI, decorator.getHttpURL(exchange, endpoint));
     }
@@ -263,18 +212,6 @@ public class AbstractHttpSpanDecoratorTest {
         Mockito.when(endpoint.getEndpointUri()).thenReturn("netty-http:" + TEST_URI);
         Mockito.when(exchange.getIn()).thenReturn(message);
 
-        AbstractHttpSpanDecorator decorator = new AbstractHttpSpanDecorator() {
-            @Override
-            public String getComponent() {
-                return null;
-            }
-
-            @Override
-            public String getComponentClassName() {
-                return null;
-            }
-        };
-
         assertEquals(TEST_URI, decorator.getHttpURL(exchange, endpoint));
     }
 
@@ -286,54 +223,11 @@ public class AbstractHttpSpanDecoratorTest {
         Mockito.when(exchange.getMessage()).thenReturn(message);
         Mockito.when(message.getHeader(Exchange.HTTP_RESPONSE_CODE, Integer.class)).thenReturn(200);
 
-        SpanDecorator decorator = new AbstractHttpSpanDecorator() {
-            @Override
-            public String getComponent() {
-                return null;
-            }
-
-            @Override
-            public String getComponentClassName() {
-                return null;
-            }
-        };
-
         MockSpanAdapter span = new MockSpanAdapter();
 
         decorator.post(span, exchange, null);
 
         assertEquals(200, span.tags().get(TagConstants.HTTP_STATUS));
-    }
-
-    @Test
-    public void testMethodInHttpMethodParam() {
-        Endpoint endpoint = Mockito.mock(Endpoint.class);
-        Exchange exchange = Mockito.mock(Exchange.class);
-        Message message = Mockito.mock(Message.class);
-
-        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
-        Mockito.when(exchange.getIn()).thenReturn(message);
-        Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class))
-                .thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
-
-        assertEquals(AbstractHttpSpanDecorator.POST_METHOD,
-                decorator.getHttpMethod(exchange, endpoint));
-    }
-
-    @Test
-    public void testMethodInHttpMethodParamUsingHeader() {
-        Endpoint endpoint = Mockito.mock(Endpoint.class);
-        Exchange exchange = Mockito.mock(Exchange.class);
-        Message message = Mockito.mock(Message.class);
-
-        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
-        Mockito.when(exchange.getIn()).thenReturn(message);
-        Mockito.when(message.getHeader(Exchange.HTTP_METHOD)).thenReturn(HttpMethods.GET);
-        Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class))
-                .thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
-
-        assertEquals(AbstractHttpSpanDecorator.POST_METHOD,
-                decorator.getHttpMethod(exchange, endpoint));
     }
 
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractHttpSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/AbstractHttpSpanDecoratorTest.java
@@ -22,6 +22,7 @@ import org.apache.camel.Message;
 import org.apache.camel.tracing.MockSpanAdapter;
 import org.apache.camel.tracing.SpanDecorator;
 import org.apache.camel.tracing.TagConstants;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -32,13 +33,22 @@ public class AbstractHttpSpanDecoratorTest {
 
     private static final String TEST_URI = "http://localhost:8080/test";
 
+    private HttpSpanDecorator decorator;
+
+    @BeforeEach
+    public void before() {
+        this.decorator = new HttpSpanDecorator();
+    }
+
     @Test
     public void testGetOperationName() {
         Exchange exchange = Mockito.mock(Exchange.class);
         Message message = Mockito.mock(Message.class);
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
 
         Mockito.when(exchange.getIn()).thenReturn(message);
         Mockito.when(message.getHeader(Exchange.HTTP_METHOD)).thenReturn("PUT");
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint");
 
         SpanDecorator decorator = new AbstractHttpSpanDecorator() {
             @Override
@@ -52,41 +62,47 @@ public class AbstractHttpSpanDecoratorTest {
             }
         };
 
-        assertEquals("PUT", decorator.getOperationName(exchange, null));
+        assertEquals("PUT", decorator.getOperationName(exchange, endpoint));
     }
 
     @Test
     public void testGetMethodFromMethodHeader() {
         Exchange exchange = Mockito.mock(Exchange.class);
         Message message = Mockito.mock(Message.class);
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
 
         Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint");
         Mockito.when(message.getHeader(Exchange.HTTP_METHOD)).thenReturn("PUT");
 
-        assertEquals("PUT", AbstractHttpSpanDecorator.getHttpMethod(exchange, null));
+        assertEquals("PUT", decorator.getHttpMethod(exchange, endpoint));
     }
 
     @Test
     public void testGetMethodFromMethodHeaderEnum() {
         Exchange exchange = Mockito.mock(Exchange.class);
         Message message = Mockito.mock(Message.class);
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
 
         Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint");
         Mockito.when(message.getHeader(Exchange.HTTP_METHOD)).thenReturn(HttpMethods.GET);
 
-        assertEquals("GET", AbstractHttpSpanDecorator.getHttpMethod(exchange, null));
+        assertEquals("GET", decorator.getHttpMethod(exchange, endpoint));
     }
 
     @Test
     public void testGetMethodQueryStringHeader() {
         Exchange exchange = Mockito.mock(Exchange.class);
         Message message = Mockito.mock(Message.class);
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
 
         Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint");
         Mockito.when(message.getHeader(Exchange.HTTP_QUERY)).thenReturn("MyQuery");
 
         assertEquals(AbstractHttpSpanDecorator.GET_METHOD,
-                AbstractHttpSpanDecorator.getHttpMethod(exchange, null));
+                decorator.getHttpMethod(exchange, endpoint));
     }
 
     @Test
@@ -101,7 +117,7 @@ public class AbstractHttpSpanDecoratorTest {
                 .thenReturn("http://localhost:8080/endpoint?query=hello");
 
         assertEquals(AbstractHttpSpanDecorator.GET_METHOD,
-                AbstractHttpSpanDecorator.getHttpMethod(exchange, endpoint));
+                decorator.getHttpMethod(exchange, endpoint));
     }
 
     @Test
@@ -116,7 +132,7 @@ public class AbstractHttpSpanDecoratorTest {
         Mockito.when(message.getBody()).thenReturn("Message Body");
 
         assertEquals(AbstractHttpSpanDecorator.POST_METHOD,
-                AbstractHttpSpanDecorator.getHttpMethod(exchange, endpoint));
+                decorator.getHttpMethod(exchange, endpoint));
     }
 
     @Test
@@ -130,7 +146,7 @@ public class AbstractHttpSpanDecoratorTest {
         Mockito.when(message.getHeader(Exchange.HTTP_URI)).thenReturn(TEST_URI);
 
         assertEquals(AbstractHttpSpanDecorator.GET_METHOD,
-                AbstractHttpSpanDecorator.getHttpMethod(exchange, endpoint));
+                decorator.getHttpMethod(exchange, endpoint));
     }
 
     @Test
@@ -287,6 +303,37 @@ public class AbstractHttpSpanDecoratorTest {
         decorator.post(span, exchange, null);
 
         assertEquals(200, span.tags().get(TagConstants.HTTP_STATUS));
+    }
+
+    @Test
+    public void testMethodInHttpMethodParam() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class))
+                .thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+
+        assertEquals(AbstractHttpSpanDecorator.POST_METHOD,
+                decorator.getHttpMethod(exchange, endpoint));
+    }
+
+    @Test
+    public void testMethodInHttpMethodParamUsingHeader() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(Exchange.HTTP_METHOD)).thenReturn(HttpMethods.GET);
+        Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class))
+                .thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+
+        assertEquals(AbstractHttpSpanDecorator.POST_METHOD,
+                decorator.getHttpMethod(exchange, endpoint));
     }
 
 }

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/HttpMethodHelperTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/HttpMethodHelperTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.tracing.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class HttpMethodHelperTest {
+
+    @Test
+    public void testHttpMethodPresent() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class))
+                .thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+        assertEquals("POST", HttpMethodHelper.getHttpMethodFromParameters(exchange, endpoint));
+    }
+
+    @Test
+    public void testHttpMethodMissing() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint");
+        assertNull(HttpMethodHelper.getHttpMethodFromParameters(exchange, endpoint));
+    }
+
+}

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/HttpSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/HttpSpanDecoratorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.tracing.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HttpSpanDecoratorTest {
+
+    private HttpSpanDecorator decorator;
+
+    @BeforeEach
+    public void before() {
+        this.decorator = new HttpSpanDecorator();
+    }
+
+    @Test
+    public void testMethodInHttpMethodParam() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class))
+                .thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+
+        assertEquals(AbstractHttpSpanDecorator.POST_METHOD,
+                decorator.getHttpMethod(exchange, endpoint));
+    }
+
+    @Test
+    public void testMethodInHttpMethodParamUsingHeader() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(Exchange.HTTP_METHOD)).thenReturn(HttpMethods.GET);
+        Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class))
+                .thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+
+        assertEquals(AbstractHttpSpanDecorator.POST_METHOD,
+                decorator.getHttpMethod(exchange, endpoint));
+    }
+}

--- a/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/VertxHttpSpanDecoratorTest.java
+++ b/components/camel-tracing/src/test/java/org/apache/camel/tracing/decorators/VertxHttpSpanDecoratorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.tracing.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class VertxHttpSpanDecoratorTest {
+
+    private VertxHttpSpanDecorator decorator;
+
+    @BeforeEach
+    public void before() {
+        this.decorator = new VertxHttpSpanDecorator();
+    }
+
+    @Test
+    public void testMethodInHttpMethodParam() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("vertx-http://localhost:8080/endpoint?httpMethod=POST");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class))
+                .thenReturn("http://localhost:8080/endpoint?httpMethod=POST");
+
+        assertEquals(AbstractHttpSpanDecorator.POST_METHOD,
+                decorator.getHttpMethod(exchange, endpoint));
+    }
+
+    @Test
+    public void testMethodInHttpMethodParamUsingHeader() {
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("vertx-http://localhost:8080/endpoint?httpMethod=POST");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(Exchange.HTTP_METHOD)).thenReturn(HttpMethods.GET);
+        Mockito.when(message.getHeader(Exchange.HTTP_URI, String.class))
+                .thenReturn("vertx-http://localhost:8080/endpoint?httpMethod=POST");
+
+        assertEquals(AbstractHttpSpanDecorator.POST_METHOD,
+                decorator.getHttpMethod(exchange, endpoint));
+    }
+}


### PR DESCRIPTION
…an for http components

# Description

The code checks if the endpoint uri for http components has the httpMethod parameter. If so, this is used as the http method in the tracing span. If not, we keep the current logic.

# Target

- [X ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [X ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

