### PR TITLE
[CAMEL-21877] fix body comparison - model is the parent/super type of body

### DIFF
--- a/components/camel-servicenow/camel-servicenow-component/src/main/java/org/apache/camel/component/servicenow/AbstractServiceNowProcessor.java
+++ b/components/camel-servicenow/camel-servicenow-component/src/main/java/org/apache/camel/component/servicenow/AbstractServiceNowProcessor.java
@@ -151,7 +151,7 @@ public abstract class AbstractServiceNowProcessor implements Processor {
     protected AbstractServiceNowProcessor validateBody(Object body, Class<?> model) {
         ObjectHelper.notNull(body, "body");
 
-        if (!body.getClass().isAssignableFrom(model)) {
+        if (!model.isAssignableFrom(body.getClass())) {
             throw new IllegalArgumentException(
                     "Body is not compatible with model (body=" + body.getClass() + ", model=" + model);
         }


### PR DESCRIPTION
# Description

When updating a ServiceNow resource (e.g. incident) the body is compared to be a subtype of the allowed model. The implementation had a bug that tests "the model is a subtype of the body" - this PR fixes the bug by reversing the order or comparison, i.e. it tests whether the model is a parent/super type of the supplied body.

JIRA Issue: https://issues.apache.org/jira/browse/CAMEL-21877

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

