### PR TITLE
Update event-notifier.adoc for using timestamps

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/event-notifier.adoc
+++ b/docs/user-manual/modules/ROOT/pages/event-notifier.adoc
@@ -136,3 +136,14 @@ stepCollector.setIgnoreStepEvents(false);
 //Add the Event Notifier to the Camel Context
 context.getManagementStrategy().addEventNotifier(stepCollector);
 ----
+
+== Event Timestamps
+
+By default, event timestamps are not included and the getTimestamp() method returns 0. 
+
+Timestamps can be enabled from the CamelContext as follows:
+
+[source,java]
+----
+context.getManagementStrategy().getEventFactory().setTimestampEnabled(true);
+----


### PR DESCRIPTION
Clarified that timestamps by default are not included, and need to be enabled explicitly.