### PR TITLE
Upgrade reactor-netty to 1.1.28 to match the version of netty in camel (4.1.119.Final)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -423,7 +423,7 @@
         <quickfixj-version>2.3.2</quickfixj-version>
         <reactive-streams-version>1.0.4</reactive-streams-version>
         <reactor-version>3.6.9</reactor-version>
-        <reactor-netty-version>1.1.22</reactor-netty-version>
+        <reactor-netty-version>1.1.28</reactor-netty-version>
         <redisson-version>3.35.0</redisson-version>
         <resilience4j-version>2.2.0</resilience4j-version>
         <rest-assured-version>5.5.0</rest-assured-version>


### PR DESCRIPTION
# Description

On 4.8.x branch, netty version is set to 4.1.119.Final, but reactor-netty 1.1.22 points to netty 4.1.118.Final.    Upgrade reactor-netty version to 1.1.28 (most recent) to match netty 4.1.119.Final.