### PR TITLE
Move smooks-edi-cartridge dependency from test scope.

### DIFF
--- a/components/camel-smooks/pom.xml
+++ b/components/camel-smooks/pom.xml
@@ -66,7 +66,6 @@
         <dependency>
             <groupId>org.smooks.cartridges.edi</groupId>
             <artifactId>smooks-edi-cartridge</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.smooks</groupId>


### PR DESCRIPTION
# Description

<!--
-  Camel doc says EDI support : https://camel.apache.org/components/4.10.x/smooks-component.html but **smooks-edi-cartridge** is on test scope moving it from test scope similar to **smooks-javabean-cartridge**
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

