### PR TITLE
Align versions to spring-boot 3.4.4

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -278,7 +278,7 @@
         <jcr-version>2.0</jcr-version>
         <jedis-client-version>5.2.0</jedis-client-version>
         <jetcd-version>0.8.4</jetcd-version>
-        <jetty-version>12.0.16</jetty-version>
+        <jetty-version>12.0.18</jetty-version>
         <jetty-for-solr-version>10.0.20</jetty-for-solr-version>
         <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
         <jetty-runner-groupId>org.eclipse.jetty</jetty-runner-groupId>
@@ -381,7 +381,7 @@
         <narayana-version>5.13.1.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
         <neo4j-version>5.28.1</neo4j-version>
-        <netty-version>4.1.118.Final</netty-version>
+        <netty-version>4.1.119.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.5.5</networknt-json-schema-validator-version>
         <nimbus-jose-jwt>10.0.1</nimbus-jose-jwt>
@@ -463,14 +463,14 @@
         <solr-zookeeper-version>3.9.3</solr-zookeeper-version>
         <splunk-version>1.9.5_1</splunk-version>
         <spock-version>2.3-groovy-4.0</spock-version>
-        <spring-batch-version>5.2.1</spring-batch-version>
-        <spring-data-redis-version>3.4.2</spring-data-redis-version>
+        <spring-batch-version>5.2.2</spring-batch-version>
+        <spring-data-redis-version>3.4.4</spring-data-redis-version>
         <spring-ldap-version>3.2.11</spring-ldap-version>
         <spring-vault-core-version>3.1.2</spring-vault-core-version>
-        <spring-version>6.2.3</spring-version>
-        <spring-rabbitmq-version>3.2.2</spring-rabbitmq-version>
-        <spring-security-version>6.4.3</spring-security-version>
-        <spring-ws-version>4.0.11</spring-ws-version>
+        <spring-version>6.2.5</spring-version>
+        <spring-rabbitmq-version>3.2.4</spring-rabbitmq-version>
+        <spring-security-version>6.4.4</spring-security-version>
+        <spring-ws-version>4.0.12</spring-ws-version>
         <sql-maven-plugin-version>3.0.0</sql-maven-plugin-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>
         <squareup-okio-version>1.17.5</squareup-okio-version>


### PR DESCRIPTION
# Description

Align important versions (netty/jetty/spring-*) to the versions in spring-boot 3.4.4 for the camel-4.10.x LTS branch.    https://github.com/apache/camel-spring-boot/pull/1405 is the corresponding commit on camel-spring-boot-4.10.x LTS branch to align it to spring-boot 3.4.4.
