### PR TITLE
CAMEL-21893: EnvVar settings should overwrite default Kamelet properties

### DIFF
--- a/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultModel.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultModel.java
@@ -485,12 +485,12 @@ public class DefaultModel implements Model {
             StringJoiner missingParameters = new StringJoiner(", ");
 
             for (RouteTemplateParameterDefinition temp : target.getTemplateParameters()) {
-                if (temp.getDefaultValue() != null) {
-                    addProperty(prop, temp.getName(), temp.getDefaultValue());
-                    addProperty(propDefaultValues, temp.getName(), temp.getDefaultValue());
-                } else if (routeTemplateContext.hasEnvironmentVariable(temp.getName())) {
+                if (routeTemplateContext.hasEnvironmentVariable(temp.getName())) {
                     // property is configured via environment variables
                     addProperty(prop, temp.getName(), routeTemplateContext.getEnvironmentVariable(temp.getName()));
+                } else if (temp.getDefaultValue() != null) {
+                    addProperty(prop, temp.getName(), temp.getDefaultValue());
+                    addProperty(propDefaultValues, temp.getName(), temp.getDefaultValue());
                 } else if (temp.isRequired() && !routeTemplateContext.hasParameter(temp.getName())) {
                     // this is a required parameter which is missing
                     missingParameters.add(temp.getName());


### PR DESCRIPTION
# Description

- Make sure to use the property set via environment variables when the Kamelet property has a default value
- Only use the default Kamelet property value as a fallback when not set explicitly

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

See CAMEL-21893

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

