### PR TITLE
CAMEL-21892 Added fix for Stopped producer in DefaultProducerCache.la…

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/cache/DefaultProducerCache.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/cache/DefaultProducerCache.java
@@ -351,6 +351,8 @@ public class DefaultProducerCache extends ServiceSupport implements ProducerCach
     @Override
     protected void doStop() throws Exception {
         ServiceHelper.stopService(producers);
+        // Clearing lastUsedProducer to remove reference to potentially stopped Producer
+        lastUsedProducer = null;
     }
 
     @Override


### PR DESCRIPTION
…stUsedProducer

# Description

We have found that the lastUsedProducer field in org.apache.camel.support.cache.DefaultProducerCache may reference a stopped producer that case a java.util.concurrent.RejectedExecutionException if re-used after stop/start of a route where it is used.

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

