### PR TITLE
CAMEL-21896: camel-jbang - Allow configuration preset per directory

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
@@ -3894,7 +3894,25 @@ Now, the run command picks the user configuration:
 camel run *
 ----
 
-The user configuration file is stored in `~/.camel-jbang-user.properties`
+=== Configuration Locations
+
+Camel JBang uses two possible configuration files:
+
+- Global configuration: ~/.camel-jbang-user.properties
+- Local configuration: ./camel-jbang-user.properties
+
+=== Configuration Precedence
+
+When both files exist, the local configuration takes precedence over the global configuration.
+
+=== Using Configuration Commands
+
+All camel config commands target the global configuration by default. To work with the local configuration instead, add the `--global=false` flag:
+[source,bash]
+----
+camel config <command> --global=false
+----
+This directs all configuration changes to the local ./camel-jbang-user.properties file.
 
 IMPORTANT: You cannot use both a set version via `camel config set` and also a version specified via `--camel-version` option,
 i.e., the following is not possible:

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelCommand.java
@@ -17,6 +17,8 @@
 package org.apache.camel.dsl.jbang.core.commands;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -129,8 +131,17 @@ public abstract class CamelCommand implements Callable<Integer> {
 
     protected void printConfigurationValues(String header) {
         if (spec != null) {
-            final Properties configProperties = new Properties();
-            CommandLineHelper.loadProperties(configProperties::putAll);
+            Properties configProperties = new Properties();
+            Path userConfigInCurrentDirectory = Path.of(CommandLineHelper.USER_CONFIG);
+            if (main.isMergeUserConfigurations()) {
+                CommandLineHelper.loadProperties(configProperties::putAll, false);
+                if (Files.exists(userConfigInCurrentDirectory)) {
+                    CommandLineHelper.loadProperties(configProperties::putAll, true);
+                }
+            } else {
+                boolean isLocalConfiguration = Files.exists(userConfigInCurrentDirectory);
+                CommandLineHelper.loadProperties(configProperties::putAll, isLocalConfiguration);
+            }
             List<String> lines = new ArrayList<>();
             spec.options().forEach(opt -> {
                 if (Arrays.stream(opt.names()).anyMatch(name ->

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelCommand.java
@@ -17,8 +17,6 @@
 package org.apache.camel.dsl.jbang.core.commands;
 
 import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -131,17 +129,8 @@ public abstract class CamelCommand implements Callable<Integer> {
 
     protected void printConfigurationValues(String header) {
         if (spec != null) {
-            Properties configProperties = new Properties();
-            Path userConfigInCurrentDirectory = Path.of(CommandLineHelper.USER_CONFIG);
-            if (main.isMergeUserConfigurations()) {
-                CommandLineHelper.loadProperties(configProperties::putAll, false);
-                if (Files.exists(userConfigInCurrentDirectory)) {
-                    CommandLineHelper.loadProperties(configProperties::putAll, true);
-                }
-            } else {
-                boolean isLocalConfiguration = Files.exists(userConfigInCurrentDirectory);
-                CommandLineHelper.loadProperties(configProperties::putAll, isLocalConfiguration);
-            }
+            final Properties configProperties = new Properties();
+            CommandLineHelper.loadProperties(configProperties::putAll);
             List<String> lines = new ArrayList<>();
             spec.options().forEach(opt -> {
                 if (Arrays.stream(opt.names()).anyMatch(name ->

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelJBangMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelJBangMain.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.dsl.jbang.core.commands;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.apache.camel.catalog.CamelCatalog;
@@ -73,8 +71,6 @@ public class CamelJBangMain implements Callable<Integer> {
     public static void run(String... args) {
         run(new CamelJBangMain(), args);
     }
-
-    private static boolean mergeUserConfigurations;
 
     public static void run(CamelJBangMain main, String... args) {
         // set pid as system property as logging ${sys:pid} needs to be resolved on windows
@@ -196,32 +192,9 @@ public class CamelJBangMain implements Callable<Integer> {
             return new String[] { v };
         });
 
-        List<String> arguments = new ArrayList<>(args.length);
-        mergeUserConfigurations = isMergeUserConfigurations(args, mergeUserConfigurations, arguments);
-        args = arguments.toArray(new String[0]);
-        CommandLineHelper.augmentWithUserConfiguration(commandLine, mergeUserConfigurations);
+        CommandLineHelper.augmentWithUserConfiguration(commandLine);
         int exitCode = commandLine.execute(args);
         main.quit(exitCode);
-    }
-
-    /**
-     * The option --mergeConfigurations is used only during PicoCLI UserConfigDefaultProvider initialization if args
-     * contains the string --mergeConfigurations, it is removed, this way, it won't mess with PicoCLI @CommandLine.*
-     *
-     * @param  args
-     * @param  mergeConfigurations
-     * @param  arguments
-     * @return
-     */
-    private static boolean isMergeUserConfigurations(String[] args, boolean mergeConfigurations, List<String> arguments) {
-        for (String arg : args) {
-            if ("--mergeConfigurations".equals(arg)) {
-                mergeConfigurations = true;
-            } else {
-                arguments.add(arg);
-            }
-        }
-        return mergeConfigurations;
     }
 
     /**
@@ -270,9 +243,5 @@ public class CamelJBangMain implements Callable<Integer> {
 
     public static CommandLine getCommandLine() {
         return commandLine;
-    }
-
-    public boolean isMergeUserConfigurations() {
-        return mergeUserConfigurations;
     }
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelJBangMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelJBangMain.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.dsl.jbang.core.commands;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.apache.camel.catalog.CamelCatalog;
@@ -71,6 +73,8 @@ public class CamelJBangMain implements Callable<Integer> {
     public static void run(String... args) {
         run(new CamelJBangMain(), args);
     }
+
+    private static boolean mergeUserConfigurations;
 
     public static void run(CamelJBangMain main, String... args) {
         // set pid as system property as logging ${sys:pid} needs to be resolved on windows
@@ -192,9 +196,32 @@ public class CamelJBangMain implements Callable<Integer> {
             return new String[] { v };
         });
 
-        CommandLineHelper.augmentWithUserConfiguration(commandLine, args);
+        List<String> arguments = new ArrayList<>(args.length);
+        mergeUserConfigurations = isMergeUserConfigurations(args, mergeUserConfigurations, arguments);
+        args = arguments.toArray(new String[0]);
+        CommandLineHelper.augmentWithUserConfiguration(commandLine, mergeUserConfigurations);
         int exitCode = commandLine.execute(args);
         main.quit(exitCode);
+    }
+
+    /**
+     * The option --mergeConfigurations is used only during PicoCLI UserConfigDefaultProvider initialization if args
+     * contains the string --mergeConfigurations, it is removed, this way, it won't mess with PicoCLI @CommandLine.*
+     *
+     * @param  args
+     * @param  mergeConfigurations
+     * @param  arguments
+     * @return
+     */
+    private static boolean isMergeUserConfigurations(String[] args, boolean mergeConfigurations, List<String> arguments) {
+        for (String arg : args) {
+            if ("--mergeConfigurations".equals(arg)) {
+                mergeConfigurations = true;
+            } else {
+                arguments.add(arg);
+            }
+        }
+        return mergeConfigurations;
     }
 
     /**
@@ -243,5 +270,9 @@ public class CamelJBangMain implements Callable<Integer> {
 
     public static CommandLine getCommandLine() {
         return commandLine;
+    }
+
+    public boolean isMergeUserConfigurations() {
+        return mergeUserConfigurations;
     }
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigGet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigGet.java
@@ -30,6 +30,9 @@ public class ConfigGet extends CamelCommand {
     @CommandLine.Parameters(description = "Configuration key", arity = "1")
     String key;
 
+    @CommandLine.Option(names = { "--local" }, description = "Retrieve configurations from current directory")
+    boolean local;
+
     public ConfigGet(CamelJBangMain main) {
         super(main);
     }
@@ -43,7 +46,7 @@ public class ConfigGet extends CamelCommand {
             } else {
                 printer().println(key + " key not found");
             }
-        });
+        }, local);
 
         return 0;
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigGet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigGet.java
@@ -30,8 +30,8 @@ public class ConfigGet extends CamelCommand {
     @CommandLine.Parameters(description = "Configuration key", arity = "1")
     String key;
 
-    @CommandLine.Option(names = { "--local" }, description = "Retrieve configurations from current directory")
-    boolean local;
+    @CommandLine.Option(names = { "--global" }, description = "Use global or local configuration")
+    boolean global = true;
 
     public ConfigGet(CamelJBangMain main) {
         super(main);
@@ -46,7 +46,7 @@ public class ConfigGet extends CamelCommand {
             } else {
                 printer().println(key + " key not found");
             }
-        }, local);
+        }, !global);
 
         return 0;
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigList.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigList.java
@@ -24,8 +24,8 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "list", description = "Displays user configuration", sortOptions = false, showDefaultValues = true)
 public class ConfigList extends CamelCommand {
 
-    @CommandLine.Option(names = { "--local" }, description = "Retrieve configurations from current directory")
-    boolean local;
+    @CommandLine.Option(names = { "--global" }, description = "Use global or local configuration")
+    boolean global = true;
 
     public ConfigList(CamelJBangMain main) {
         super(main);
@@ -33,13 +33,26 @@ public class ConfigList extends CamelCommand {
 
     @Override
     public Integer doCall() throws Exception {
+        listConfigurations(true);
+        if (!global) {
+            return 0;
+        }
+
+        listConfigurations(false);
+        return 0;
+    }
+
+    private void listConfigurations(boolean local) {
         CommandLineHelper
                 .loadProperties(p -> {
+                    if (!p.stringPropertyNames().isEmpty()) {
+                        String configurationType = local ? "Local" : "Global";
+                        printer().println("----- " + configurationType + " -----");
+                    }
                     for (String k : p.stringPropertyNames()) {
                         String v = p.getProperty(k);
                         printer().printf("%s = %s%n", k, v);
                     }
                 }, local);
-        return 0;
     }
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigSet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigSet.java
@@ -29,13 +29,16 @@ public class ConfigSet extends CamelCommand {
     @CommandLine.Parameters(description = "Configuration parameter (ex. key=value)", arity = "1")
     String configuration;
 
+    @CommandLine.Option(names = { "--local" }, description = "Retrieve configurations from current directory")
+    boolean local;
+
     public ConfigSet(CamelJBangMain main) {
         super(main);
     }
 
     @Override
     public Integer doCall() throws Exception {
-        CommandLineHelper.createPropertyFile();
+        CommandLineHelper.createPropertyFile(local);
 
         if (configuration.split("=").length == 1) {
             printer().println("Configuration parameter not in key=value format");
@@ -46,8 +49,8 @@ public class ConfigSet extends CamelCommand {
             String key = StringHelper.before(configuration, "=").trim();
             String value = StringHelper.after(configuration, "=").trim();
             properties.put(key, value);
-            CommandLineHelper.storeProperties(properties, printer());
-        });
+            CommandLineHelper.storeProperties(properties, printer(), local);
+        }, local);
 
         return 0;
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigSet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigSet.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.dsl.jbang.core.commands.config;
 
+import java.io.IOException;
+
 import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
@@ -29,8 +31,8 @@ public class ConfigSet extends CamelCommand {
     @CommandLine.Parameters(description = "Configuration parameter (ex. key=value)", arity = "1")
     String configuration;
 
-    @CommandLine.Option(names = { "--local" }, description = "Retrieve configurations from current directory")
-    boolean local;
+    @CommandLine.Option(names = { "--global" }, description = "Use global or local configuration")
+    boolean global = true;
 
     public ConfigSet(CamelJBangMain main) {
         super(main);
@@ -38,6 +40,10 @@ public class ConfigSet extends CamelCommand {
 
     @Override
     public Integer doCall() throws Exception {
+        return setConfiguration(!global);
+    }
+
+    private int setConfiguration(boolean local) throws IOException {
         CommandLineHelper.createPropertyFile(local);
 
         if (configuration.split("=").length == 1) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnset.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnset.java
@@ -28,8 +28,8 @@ public class ConfigUnset extends CamelCommand {
     @CommandLine.Parameters(description = "Configuration key", arity = "1")
     String key;
 
-    @CommandLine.Option(names = { "--local" }, description = "Retrieve configurations from current directory")
-    boolean local;
+    @CommandLine.Option(names = { "--global" }, description = "Use global or local configurations")
+    boolean global = true;
 
     public ConfigUnset(CamelJBangMain main) {
         super(main);
@@ -39,8 +39,8 @@ public class ConfigUnset extends CamelCommand {
     public Integer doCall() throws Exception {
         CommandLineHelper.loadProperties(properties -> {
             properties.remove(key);
-            CommandLineHelper.storeProperties(properties, printer(), local);
-        }, local);
+            CommandLineHelper.storeProperties(properties, printer(), !global);
+        }, !global);
 
         return 0;
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnset.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnset.java
@@ -28,6 +28,9 @@ public class ConfigUnset extends CamelCommand {
     @CommandLine.Parameters(description = "Configuration key", arity = "1")
     String key;
 
+    @CommandLine.Option(names = { "--local" }, description = "Retrieve configurations from current directory")
+    boolean local;
+
     public ConfigUnset(CamelJBangMain main) {
         super(main);
     }
@@ -36,8 +39,8 @@ public class ConfigUnset extends CamelCommand {
     public Integer doCall() throws Exception {
         CommandLineHelper.loadProperties(properties -> {
             properties.remove(key);
-            CommandLineHelper.storeProperties(properties, printer());
-        });
+            CommandLineHelper.storeProperties(properties, printer(), local);
+        }, local);
 
         return 0;
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionGet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionGet.java
@@ -28,6 +28,9 @@ import picocli.CommandLine;
                      showDefaultValues = true)
 public class VersionGet extends CamelCommand {
 
+    @CommandLine.Option(names = { "--local" }, description = "Retrieve configurations from current directory")
+    boolean local;
+
     public VersionGet(CamelJBangMain main) {
         super(main);
     }
@@ -63,7 +66,7 @@ public class VersionGet extends CamelCommand {
                     printer().println("    repos = " + repos);
                 }
             }
-        });
+        }, local);
 
         return 0;
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionGet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionGet.java
@@ -28,8 +28,8 @@ import picocli.CommandLine;
                      showDefaultValues = true)
 public class VersionGet extends CamelCommand {
 
-    @CommandLine.Option(names = { "--local" }, description = "Retrieve configurations from current directory")
-    boolean local;
+    @CommandLine.Option(names = { "--global" }, description = "Use global or local configuration")
+    boolean global = true;
 
     public VersionGet(CamelJBangMain main) {
         super(main);
@@ -66,7 +66,7 @@ public class VersionGet extends CamelCommand {
                     printer().println("    repos = " + repos);
                 }
             }
-        }, local);
+        }, !global);
 
         return 0;
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionSet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionSet.java
@@ -43,8 +43,8 @@ public class VersionSet extends CamelCommand {
     @CommandLine.Option(names = { "--reset" }, description = "Reset by removing any custom version settings")
     boolean reset;
 
-    @CommandLine.Option(names = { "--local" }, description = "Retrieve configurations from current directory")
-    boolean local;
+    @CommandLine.Option(names = { "--global" }, description = "Use global or local configuration")
+    boolean global = true;
 
     public VersionSet(CamelJBangMain main) {
         super(main);
@@ -52,6 +52,7 @@ public class VersionSet extends CamelCommand {
 
     @Override
     public Integer doCall() throws Exception {
+        boolean local = !global;
         CommandLineHelper.createPropertyFile(local);
 
         CommandLineHelper.loadProperties(properties -> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionSet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionSet.java
@@ -43,13 +43,16 @@ public class VersionSet extends CamelCommand {
     @CommandLine.Option(names = { "--reset" }, description = "Reset by removing any custom version settings")
     boolean reset;
 
+    @CommandLine.Option(names = { "--local" }, description = "Retrieve configurations from current directory")
+    boolean local;
+
     public VersionSet(CamelJBangMain main) {
         super(main);
     }
 
     @Override
     public Integer doCall() throws Exception {
-        CommandLineHelper.createPropertyFile();
+        CommandLineHelper.createPropertyFile(local);
 
         CommandLineHelper.loadProperties(properties -> {
             if (reset) {
@@ -67,8 +70,8 @@ public class VersionSet extends CamelCommand {
                     properties.put("runtime", runtime.runtime());
                 }
             }
-            CommandLineHelper.storeProperties(properties, printer());
-        });
+            CommandLineHelper.storeProperties(properties, printer(), local);
+        }, local);
 
         return 0;
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/CommandLineHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/CommandLineHelper.java
@@ -37,6 +37,7 @@ public final class CommandLineHelper {
 
     private static volatile String homeDir = System.getProperty("user.home");
     public static final String USER_CONFIG = ".camel-jbang-user.properties";
+    public static final String LOCAL_USER_CONFIG = "camel-jbang-user.properties";
     public static final String CAMEL_DIR = ".camel";
     public static final String CAMEL_JBANG_WORK_DIR = ".camel-jbang";
 
@@ -44,15 +45,11 @@ public final class CommandLineHelper {
         super();
     }
 
-    public static void augmentWithUserConfiguration(CommandLine commandLine, boolean mergeConfigurations) {
+    public static void augmentWithUserConfiguration(CommandLine commandLine) {
         File file = getUserConfigurationFile();
         if (file.isFile() && file.exists()) {
             Properties properties = new Properties();
             try {
-                if (mergeConfigurations) {
-                    properties.load(new FileReader(getUserPropertyFile(false)));
-                }
-
                 properties.load(new FileReader(file));
             } catch (IOException e) {
                 commandLine.setDefaultValueProvider(new CamelUserConfigDefaultValueProvider(file));
@@ -64,8 +61,8 @@ public final class CommandLineHelper {
 
     private static File getUserConfigurationFile() {
         File file;
-        if (Files.exists(Path.of(USER_CONFIG))) {
-            file = new File(USER_CONFIG);
+        if (Files.exists(Path.of(LOCAL_USER_CONFIG))) {
+            file = new File(LOCAL_USER_CONFIG);
         } else {
             file = getUserPropertyFile(false);
         }
@@ -109,7 +106,7 @@ public final class CommandLineHelper {
                 throw new RuntimeException(ex);
             }
         } else {
-            printer.println(USER_CONFIG + " does not exist");
+            printer.println(file.getName() + " does not exist");
         }
     }
 
@@ -121,7 +118,7 @@ public final class CommandLineHelper {
      */
     private static File getUserPropertyFile(boolean local) {
         if (local) {
-            return new File(USER_CONFIG);
+            return new File(LOCAL_USER_CONFIG);
         } else {
             return new File(homeDir, USER_CONFIG);
         }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/UserConfigHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/UserConfigHelper.java
@@ -37,6 +37,7 @@ public final class UserConfigHelper {
 
     public static void createUserConfig(String content, boolean local) throws IOException {
         Path userConfigDir;
+        String configFileName = CommandLineHelper.USER_CONFIG;
         if (!local) {
             CommandLineHelper.useHomeDir("target");
             userConfigDir = Paths.get("target");
@@ -45,9 +46,10 @@ public final class UserConfigHelper {
             }
         } else {
             userConfigDir = Paths.get(".");
+            configFileName = CommandLineHelper.LOCAL_USER_CONFIG;
         }
 
-        Files.writeString(userConfigDir.resolve(CommandLineHelper.USER_CONFIG), content,
+        Files.writeString(userConfigDir.resolve(configFileName), content,
                 StandardOpenOption.CREATE,
                 StandardOpenOption.WRITE,
                 StandardOpenOption.TRUNCATE_EXISTING);

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/UserConfigHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/UserConfigHelper.java
@@ -32,10 +32,19 @@ public final class UserConfigHelper {
     }
 
     public static void createUserConfig(String content) throws IOException {
-        CommandLineHelper.useHomeDir("target");
-        Path userConfigDir = Paths.get("target");
-        if (!userConfigDir.toFile().exists()) {
-            userConfigDir.toFile().mkdirs();
+        createUserConfig(content, false);
+    }
+
+    public static void createUserConfig(String content, boolean local) throws IOException {
+        Path userConfigDir;
+        if (!local) {
+            CommandLineHelper.useHomeDir("target");
+            userConfigDir = Paths.get("target");
+            if (!userConfigDir.toFile().exists()) {
+                userConfigDir.toFile().mkdirs();
+            }
+        } else {
+            userConfigDir = Paths.get(".");
         }
 
         Files.writeString(userConfigDir.resolve(CommandLineHelper.USER_CONFIG), content,

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/BaseConfigTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/BaseConfigTest.java
@@ -28,6 +28,6 @@ public class BaseConfigTest extends CamelCommandBaseTest {
 
     @AfterEach
     void removeLocalConfigFile() throws IOException {
-        Files.deleteIfExists(Paths.get(CommandLineHelper.USER_CONFIG));
+        Files.deleteIfExists(Paths.get(CommandLineHelper.LOCAL_USER_CONFIG));
     }
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/BaseConfigTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/BaseConfigTest.java
@@ -16,30 +16,18 @@
  */
 package org.apache.camel.dsl.jbang.core.commands.config;
 
-import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
-import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTest;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
-import picocli.CommandLine;
+import org.junit.jupiter.api.AfterEach;
 
-@CommandLine.Command(name = "list", description = "Displays user configuration", sortOptions = false, showDefaultValues = true)
-public class ConfigList extends CamelCommand {
+public class BaseConfigTest extends CamelCommandBaseTest {
 
-    @CommandLine.Option(names = { "--local" }, description = "Retrieve configurations from current directory")
-    boolean local;
-
-    public ConfigList(CamelJBangMain main) {
-        super(main);
-    }
-
-    @Override
-    public Integer doCall() throws Exception {
-        CommandLineHelper
-                .loadProperties(p -> {
-                    for (String k : p.stringPropertyNames()) {
-                        String v = p.getProperty(k);
-                        printer().printf("%s = %s%n", k, v);
-                    }
-                }, local);
-        return 0;
+    @AfterEach
+    void removeLocalConfigFile() throws IOException {
+        Files.deleteIfExists(Paths.get(CommandLineHelper.USER_CONFIG));
     }
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigGetTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigGetTest.java
@@ -52,7 +52,7 @@ class ConfigGetTest extends BaseConfigTest {
 
         ConfigGet command = new ConfigGet(new CamelJBangMain().withPrinter(printer));
         command.key = "foo";
-        command.local = true;
+        command.global = false;
         command.doCall();
 
         Assertions.assertEquals("bar", printer.getOutput());

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigGetTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigGetTest.java
@@ -17,13 +17,12 @@
 
 package org.apache.camel.dsl.jbang.core.commands.config;
 
-import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTest;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.commands.UserConfigHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class ConfigGetTest extends CamelCommandBaseTest {
+class ConfigGetTest extends BaseConfigTest {
 
     @Test
     public void shouldGetConfig() throws Exception {
@@ -45,6 +44,18 @@ class ConfigGetTest extends CamelCommandBaseTest {
         command.doCall();
 
         Assertions.assertEquals("foo key not found", printer.getOutput());
+    }
+
+    @Test
+    public void shouldGetLocalConfig() throws Exception {
+        UserConfigHelper.createUserConfig("foo=bar", true);
+
+        ConfigGet command = new ConfigGet(new CamelJBangMain().withPrinter(printer));
+        command.key = "foo";
+        command.local = true;
+        command.doCall();
+
+        Assertions.assertEquals("bar", printer.getOutput());
     }
 
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigListTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigListTest.java
@@ -48,10 +48,11 @@ class ConfigListTest extends BaseConfigTest {
         command.doCall();
 
         List<String> lines = printer.getLines();
-        Assertions.assertEquals(3, lines.size());
-        Assertions.assertEquals("camel-version = latest", lines.get(0));
-        Assertions.assertEquals("kamelets-version = greatest", lines.get(1));
-        Assertions.assertEquals("foo = bar", lines.get(2));
+        Assertions.assertEquals(4, lines.size());
+        Assertions.assertEquals("----- Global -----", lines.get(0));
+        Assertions.assertEquals("camel-version = latest", lines.get(1));
+        Assertions.assertEquals("kamelets-version = greatest", lines.get(2));
+        Assertions.assertEquals("foo = bar", lines.get(3));
     }
 
     @Test
@@ -62,12 +63,33 @@ class ConfigListTest extends BaseConfigTest {
                 """, true);
 
         ConfigList command = new ConfigList(new CamelJBangMain().withPrinter(printer));
-        command.local = true;
+        command.global = false;
         command.doCall();
 
         List<String> lines = printer.getLines();
-        Assertions.assertEquals(2, lines.size());
-        Assertions.assertEquals("camel-version = local", lines.get(0));
-        Assertions.assertEquals("kamelets-version = local", lines.get(1));
+        Assertions.assertEquals(3, lines.size());
+        Assertions.assertEquals("----- Local -----", lines.get(0));
+        Assertions.assertEquals("camel-version = local", lines.get(1));
+        Assertions.assertEquals("kamelets-version = local", lines.get(2));
+    }
+
+    @Test
+    public void shouldListGlobalAndLocalUserConfig() throws Exception {
+        UserConfigHelper.createUserConfig("""
+                camel-version=local
+                """, true);
+        UserConfigHelper.createUserConfig("""
+                kamelets-version=global
+                """);
+
+        ConfigList command = new ConfigList(new CamelJBangMain().withPrinter(printer));
+        command.doCall();
+
+        List<String> lines = printer.getLines();
+        Assertions.assertEquals(4, lines.size());
+        Assertions.assertEquals("----- Local -----", lines.get(0));
+        Assertions.assertEquals("camel-version = local", lines.get(1));
+        Assertions.assertEquals("----- Global -----", lines.get(2));
+        Assertions.assertEquals("kamelets-version = global", lines.get(3));
     }
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigListTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigListTest.java
@@ -19,13 +19,12 @@ package org.apache.camel.dsl.jbang.core.commands.config;
 
 import java.util.List;
 
-import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTest;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.commands.UserConfigHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class ConfigListTest extends CamelCommandBaseTest {
+class ConfigListTest extends BaseConfigTest {
 
     @Test
     public void shouldHandleEmptyConfig() throws Exception {
@@ -55,4 +54,20 @@ class ConfigListTest extends CamelCommandBaseTest {
         Assertions.assertEquals("foo = bar", lines.get(2));
     }
 
+    @Test
+    public void shouldListLocalUserConfig() throws Exception {
+        UserConfigHelper.createUserConfig("""
+                camel-version=local
+                kamelets-version=local
+                """, true);
+
+        ConfigList command = new ConfigList(new CamelJBangMain().withPrinter(printer));
+        command.local = true;
+        command.doCall();
+
+        List<String> lines = printer.getLines();
+        Assertions.assertEquals(2, lines.size());
+        Assertions.assertEquals("camel-version = local", lines.get(0));
+        Assertions.assertEquals("kamelets-version = local", lines.get(1));
+    }
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigSetTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigSetTest.java
@@ -61,7 +61,7 @@ class ConfigSetTest extends BaseConfigTest {
     public void setLocalConfig() throws Exception {
         ConfigSet command = new ConfigSet(new CamelJBangMain().withPrinter(printer));
         command.configuration = "foo=local";
-        command.local = true;
+        command.global = false;
         command.doCall();
 
         Assertions.assertEquals("", printer.getOutput());

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigSetTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigSetTest.java
@@ -17,14 +17,13 @@
 
 package org.apache.camel.dsl.jbang.core.commands.config;
 
-import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTest;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.commands.UserConfigHelper;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class ConfigSetTest extends CamelCommandBaseTest {
+class ConfigSetTest extends BaseConfigTest {
 
     @Test
     public void shouldSetConfig() throws Exception {
@@ -56,6 +55,21 @@ class ConfigSetTest extends CamelCommandBaseTest {
             Assertions.assertEquals(1, properties.size());
             Assertions.assertEquals("baz", properties.get("foo"));
         });
+    }
+
+    @Test
+    public void setLocalConfig() throws Exception {
+        ConfigSet command = new ConfigSet(new CamelJBangMain().withPrinter(printer));
+        command.configuration = "foo=local";
+        command.local = true;
+        command.doCall();
+
+        Assertions.assertEquals("", printer.getOutput());
+
+        CommandLineHelper.loadProperties(properties -> {
+            Assertions.assertEquals(1, properties.size());
+            Assertions.assertEquals("local", properties.get("foo"));
+        }, true);
     }
 
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnsetTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnsetTest.java
@@ -75,7 +75,7 @@ class ConfigUnsetTest extends BaseConfigTest {
 
         ConfigUnset command = new ConfigUnset(new CamelJBangMain().withPrinter(printer));
         command.key = "foo";
-        command.local = true;
+        command.global = false;
         command.doCall();
 
         Assertions.assertEquals("", printer.getOutput());

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnsetTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnsetTest.java
@@ -17,14 +17,13 @@
 
 package org.apache.camel.dsl.jbang.core.commands.config;
 
-import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTest;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.commands.UserConfigHelper;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class ConfigUnsetTest extends CamelCommandBaseTest {
+class ConfigUnsetTest extends BaseConfigTest {
 
     @Test
     public void shouldUnsetConfig() throws Exception {
@@ -67,4 +66,23 @@ class ConfigUnsetTest extends CamelCommandBaseTest {
         });
     }
 
+    @Test
+    public void unsetLocalConfig() throws Exception {
+        UserConfigHelper.createUserConfig("""
+                camel-version=local
+                foo=bar
+                """, true);
+
+        ConfigUnset command = new ConfigUnset(new CamelJBangMain().withPrinter(printer));
+        command.key = "foo";
+        command.local = true;
+        command.doCall();
+
+        Assertions.assertEquals("", printer.getOutput());
+
+        CommandLineHelper.loadProperties(properties -> {
+            Assertions.assertEquals(1, properties.size());
+            Assertions.assertEquals("local", properties.get("camel-version"));
+        }, true);
+    }
 }

--- a/test-infra/camel-test-infra-cli/src/test/resources/org/apache/camel/test/infra/cli/services/Dockerfile
+++ b/test-infra/camel-test-infra-cli/src/test/resources/org/apache/camel/test/infra/cli/services/Dockerfile
@@ -39,7 +39,7 @@ ADD 99-ssh-jbang.conf /etc/ssh/sshd_config.d/
 RUN	sed -i "s|#auth		sufficient	pam_wheel.so trust use_uid|auth		sufficient	pam_wheel.so trust use_uid|g" /etc/pam.d/su
 
 #create new user
-RUN groupadd -g $CUSTOM_GID jbang \
+RUN groupadd -f -g $CUSTOM_GID jbang \
     && useradd -u $CUSTOM_UID -g $CUSTOM_GID -s /bin/bash jbang
 
 #to avoid prompt su - root password


### PR DESCRIPTION
Added the following options:

* `--mergeConfigurations` loads the configurations default one _~/.camel-jbang-user.properties_ and the one in the current directory (if exists) _./.camel-jbang-user.properties_, the latter is prioritized. This config is a bit hacky, it is used to preload the configuration before the actual picocli execution, if the argument mergeConfigurations exists, the configurations are merged, and the argument removed before passing the args to Picocli.
* `--local` Use the configuration in current directory (to be used with `camel config` commands) 