### PR TITLE
CAMEL-21903: camel-jbang: Adjustable container image name on Kubernetes export

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
@@ -276,22 +276,13 @@ public class KubernetesExport extends Export {
             openapi = null;
         }
         TraitHelper.configureContainerImage(traitsSpec, image,
-                resolvedImageRegistry, resolvedImageGroup, projectName, getVersion());
+                resolvedImageRegistry, resolvedImageGroup, projectName, getVersion(), buildProperties);
         TraitHelper.configureEnvVars(traitsSpec, envVars);
         TraitHelper.configureConnects(traitsSpec, connects);
 
         Container container = traitsSpec.getContainer();
-
-        buildProperties.add("jkube.image.name=%s".formatted(container.getImage()));
-        buildProperties.add("jkube.container-image.name=%s".formatted(container.getImage()));
-
         if (container.getName() != null && !container.getName().equals(projectName)) {
             printer().printf("Custom container name '%s' not supported%n".formatted(container.getName()));
-        }
-
-        if (container.getImagePullPolicy() != null) {
-            var imagePullPolicy = container.getImagePullPolicy().getValue();
-            buildProperties.add("jkube.container-image.imagePullPolicy=%s".formatted(imagePullPolicy));
         }
 
         buildProperties.add("jkube.skip.push=%b".formatted(!imagePush));

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/ContainerTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/ContainerTrait.java
@@ -25,6 +25,7 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Container;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Traits;
+import org.apache.camel.util.ObjectHelper;
 
 public class ContainerTrait extends BaseTrait {
 
@@ -48,8 +49,11 @@ public class ContainerTrait extends BaseTrait {
         Container containerTrait = Optional.ofNullable(traitConfig.getContainer()).orElseGet(Container::new);
 
         ContainerBuilder container = new ContainerBuilder()
-                .withName(Optional.ofNullable(containerTrait.getName()).orElse(context.getName()))
-                .withImage(containerTrait.getImage());
+                .withName(Optional.ofNullable(containerTrait.getName()).orElse(context.getName()));
+
+        if (ObjectHelper.isNotEmpty(containerTrait.getImage())) {
+            container.withImage(containerTrait.getImage());
+        }
 
         if (containerTrait.getImagePullPolicy() != null) {
             container.withImagePullPolicy(containerTrait.getImagePullPolicy().getValue());

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
@@ -64,6 +64,7 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
 
         Properties props = model.getProperties();
         Assertions.assertEquals("examples/route:1.0.0", props.get("jkube.image.name"));
+        Assertions.assertEquals("examples/route:1.0.0", props.get("jkube.container-image.name"));
         Assertions.assertEquals("eclipse-temurin:17", props.get("jkube.container-image.from"));
         Assertions.assertEquals("jib", props.get("jkube.build.strategy"));
         Assertions.assertNull(props.get("jkube.docker.push.registry"));
@@ -106,6 +107,7 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
 
         Properties props = model.getProperties();
         Assertions.assertEquals("quay.io/camel-riders/route:1.0-SNAPSHOT", props.get("jkube.image.name"));
+        Assertions.assertEquals("quay.io/camel-riders/route:1.0-SNAPSHOT", props.get("jkube.container-image.name"));
         Assertions.assertEquals("mirror.gcr.io/my-base-image:latest", props.get("jkube.container-image.from"));
         Assertions.assertEquals("docker", props.get("jkube.build.strategy"));
         Assertions.assertEquals("quay.io", props.get("jkube.docker.push.registry"));
@@ -130,7 +132,16 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
         Assertions.assertEquals("route", labels.get(BaseTrait.KUBERNETES_LABEL_NAME));
         Assertions.assertEquals("route", containers.get(0).getName());
         Assertions.assertEquals("route", matchLabels.get(BaseTrait.KUBERNETES_LABEL_NAME));
-        Assertions.assertEquals("quay.io/camel-test/route:1.0-SNAPSHOT", containers.get(0).getImage());
+        Assertions.assertNull(containers.get(0).getImage());
+
+        Model model = readMavenModel();
+        Assertions.assertEquals("org.example.project", model.getGroupId());
+        Assertions.assertEquals("route", model.getArtifactId());
+        Assertions.assertEquals("1.0-SNAPSHOT", model.getVersion());
+
+        Properties props = model.getProperties();
+        Assertions.assertEquals("quay.io/camel-test/route:1.0-SNAPSHOT", props.get("jkube.image.name"));
+        Assertions.assertEquals("quay.io/camel-test/route:1.0-SNAPSHOT", props.get("jkube.container-image.name"));
 
         Assertions.assertTrue(hasService(rt));
         Assertions.assertFalse(hasKnativeService(rt));
@@ -155,7 +166,16 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
         Assertions.assertEquals("route", labels.get(BaseTrait.KUBERNETES_LABEL_NAME));
         Assertions.assertEquals("route", containers.get(0).getName());
         Assertions.assertEquals("route", matchLabels.get(BaseTrait.KUBERNETES_LABEL_NAME));
-        Assertions.assertEquals("camel-test/route:1.0-SNAPSHOT", containers.get(0).getImage());
+        Assertions.assertNull(containers.get(0).getImage());
+
+        Model model = readMavenModel();
+        Assertions.assertEquals("org.example.project", model.getGroupId());
+        Assertions.assertEquals("route", model.getArtifactId());
+        Assertions.assertEquals("1.0-SNAPSHOT", model.getVersion());
+
+        Properties props = model.getProperties();
+        Assertions.assertEquals("camel-test/route:1.0-SNAPSHOT", props.get("jkube.image.name"));
+        Assertions.assertEquals("camel-test/route:1.0-SNAPSHOT", props.get("jkube.container-image.name"));
 
         Assertions.assertTrue(hasService(rt));
         Assertions.assertFalse(hasKnativeService(rt));
@@ -187,10 +207,19 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
         Assertions.assertEquals("route", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertEquals("route:1.0-SNAPSHOT", container.getImage());
+        Assertions.assertNull(container.getImage());
         Assertions.assertEquals(1, container.getPorts().size());
         Assertions.assertEquals("http", container.getPorts().get(0).getName());
         Assertions.assertEquals(8080, container.getPorts().get(0).getContainerPort());
+
+        Model model = readMavenModel();
+        Assertions.assertEquals("org.example.project", model.getGroupId());
+        Assertions.assertEquals("route", model.getArtifactId());
+        Assertions.assertEquals("1.0-SNAPSHOT", model.getVersion());
+
+        Properties props = model.getProperties();
+        Assertions.assertEquals("route:1.0-SNAPSHOT", props.get("jkube.image.name"));
+        Assertions.assertEquals("route:1.0-SNAPSHOT", props.get("jkube.container-image.name"));
 
         Service service = getService(rt);
         List<ServicePort> ports = service.getSpec().getPorts();
@@ -218,10 +247,19 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
         Assertions.assertEquals("route-service", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertEquals("route-service:1.0-SNAPSHOT", container.getImage());
+        Assertions.assertNull(container.getImage());
         Assertions.assertEquals(1, container.getPorts().size());
         Assertions.assertEquals("http", container.getPorts().get(0).getName());
         Assertions.assertEquals(8080, container.getPorts().get(0).getContainerPort());
+
+        Model model = readMavenModel();
+        Assertions.assertEquals("org.example.project", model.getGroupId());
+        Assertions.assertEquals("route-service", model.getArtifactId());
+        Assertions.assertEquals("1.0-SNAPSHOT", model.getVersion());
+
+        Properties props = model.getProperties();
+        Assertions.assertEquals("route-service:1.0-SNAPSHOT", props.get("jkube.image.name"));
+        Assertions.assertEquals("route-service:1.0-SNAPSHOT", props.get("jkube.container-image.name"));
 
         Service service = getService(rt);
         List<ServicePort> ports = service.getSpec().getPorts();
@@ -258,10 +296,19 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
         Assertions.assertEquals("route-service", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertEquals("route-service:1.0-SNAPSHOT", container.getImage());
+        Assertions.assertNull(container.getImage());
         Assertions.assertEquals(1, container.getPorts().size());
         Assertions.assertEquals("http", container.getPorts().get(0).getName());
         Assertions.assertEquals(8080, container.getPorts().get(0).getContainerPort());
+
+        Model model = readMavenModel();
+        Assertions.assertEquals("org.example.project", model.getGroupId());
+        Assertions.assertEquals("route-service", model.getArtifactId());
+        Assertions.assertEquals("1.0-SNAPSHOT", model.getVersion());
+
+        Properties props = model.getProperties();
+        Assertions.assertEquals("route-service:1.0-SNAPSHOT", props.get("jkube.image.name"));
+        Assertions.assertEquals("route-service:1.0-SNAPSHOT", props.get("jkube.container-image.name"));
 
         Ingress ingress = getIngress(rt);
         Assertions.assertEquals("route-service", ingress.getMetadata().getName());
@@ -307,10 +354,19 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
         Assertions.assertEquals("route-service", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertEquals("route-service:1.0-SNAPSHOT", container.getImage());
+        Assertions.assertNull(container.getImage());
         Assertions.assertEquals(1, container.getPorts().size());
         Assertions.assertEquals("http", container.getPorts().get(0).getName());
         Assertions.assertEquals(8080, container.getPorts().get(0).getContainerPort());
+
+        Model model = readMavenModel();
+        Assertions.assertEquals("org.example.project", model.getGroupId());
+        Assertions.assertEquals("route-service", model.getArtifactId());
+        Assertions.assertEquals("1.0-SNAPSHOT", model.getVersion());
+
+        Properties props = model.getProperties();
+        Assertions.assertEquals("route-service:1.0-SNAPSHOT", props.get("jkube.image.name"));
+        Assertions.assertEquals("route-service:1.0-SNAPSHOT", props.get("jkube.container-image.name"));
 
         Route route = getRoute(rt);
         Assertions.assertEquals("route-service", route.getMetadata().getName());
@@ -359,8 +415,7 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
         Deployment deployment = getDeployment(rt);
         Assertions.assertEquals("route-service", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertEquals("camel-test/route-service:1.0.0",
-                deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
+        Assertions.assertNull(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
         Assertions.assertEquals("IfNotPresent",
                 deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().size());
@@ -380,6 +435,15 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
         Assertions.assertEquals("512Mi",
                 deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getResources().getLimits().get("memory")
                         .toString());
+
+        Model model = readMavenModel();
+        Assertions.assertEquals("camel-test", model.getGroupId());
+        Assertions.assertEquals("route-service", model.getArtifactId());
+        Assertions.assertEquals("1.0.0", model.getVersion());
+
+        Properties props = model.getProperties();
+        Assertions.assertEquals("camel-test/route-service:1.0.0", props.get("jkube.image.name"));
+        Assertions.assertEquals("camel-test/route-service:1.0.0", props.get("jkube.container-image.name"));
 
         Service service = getService(rt);
         Assertions.assertEquals("route-service", service.getMetadata().getName());
@@ -553,7 +617,15 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
         Deployment deployment = getDeployment(rt);
         Assertions.assertEquals("demo-app", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertEquals("quay.io/camel/demo-app:1.0",
-                deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
+        Assertions.assertNull(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
+
+        Model model = readMavenModel();
+        Assertions.assertEquals("org.example.project", model.getGroupId());
+        Assertions.assertEquals("demo-app", model.getArtifactId());
+        Assertions.assertEquals("1.0", model.getVersion());
+
+        Properties props = model.getProperties();
+        Assertions.assertEquals("quay.io/camel/demo-app:1.0", props.get("jkube.image.name"));
+        Assertions.assertEquals("quay.io/camel/demo-app:1.0", props.get("jkube.container-image.name"));
     }
 }


### PR DESCRIPTION
# Description

- Do not set container image name on Kubernetes deployment
- Use `jkube.container-image.name` setting in the generated Maven project instead
- Allows users to overwrite the container image name in Maven builds (e.g. when using a CI/CD pipeline)

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

See CAMEL-21903

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

