### PR TITLE
CAMEL-21904: Use cluster specific labels on Kubernetes deployment

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
@@ -240,11 +240,13 @@ public class KubernetesExport extends Export {
         // app.kubernetes.io/name
         // app.kubernetes.io/version
         //
-        addLabel("app.kubernetes.io/runtime", "camel");
-        context.addLabels(Arrays.stream(labels)
-                .map(item -> item.split("="))
-                .filter(parts -> parts.length == 2)
-                .collect(Collectors.toMap(parts -> parts[0], parts -> parts[1])));
+        context.addLabel("app.kubernetes.io/runtime", "camel");
+        if (labels != null) {
+            context.addLabels(Arrays.stream(labels)
+                    .map(item -> item.split("="))
+                    .filter(parts -> parts.length == 2)
+                    .collect(Collectors.toMap(parts -> parts[0], parts -> parts[1])));
+        }
 
         if (clusterType != null) {
             context.setClusterType(ClusterType.valueOf(clusterType.toUpperCase()));
@@ -297,6 +299,9 @@ public class KubernetesExport extends Export {
         buildProperties.add("jkube.skip.push=%b".formatted(!imagePush));
 
         if (ClusterType.OPENSHIFT.isEqualTo(clusterType)) {
+            // Displays the Camel logo as part the deployment
+            context.addLabel("app.openshift.io/runtime", "camel");
+
             if (!"docker".equals(imageBuilder)) {
                 printer().printf("OpenShift forcing --image-builder=docker%n");
                 imageBuilder = "docker";
@@ -426,16 +431,6 @@ public class KubernetesExport extends Export {
         if (!envList.contains(envEntry)) {
             envList.add(envEntry);
             envVars = envList.toArray(new String[0]);
-        }
-    }
-
-    private void addLabel(String key, String value) {
-        var labelArray = Optional.ofNullable(labels).orElse(new String[0]);
-        var labelList = new ArrayList<>(Arrays.asList(labelArray));
-        var labelEntry = "%s=%s".formatted(key, value);
-        if (!labelList.contains(labelEntry)) {
-            labelList.add(labelEntry);
-            labels = labelList.toArray(new String[0]);
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitContext.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitContext.java
@@ -186,6 +186,10 @@ public class TraitContext {
                 .collect(Collectors.toList());
     }
 
+    public void addLabel(String name, String value) {
+        this.labels.put(name, value);
+    }
+
     public void addLabels(Map<String, String> labels) {
         this.labels.putAll(labels);
     }


### PR DESCRIPTION
# Description

- Add OpenShift specific runtime label on Kubernetes deployment when doing the Camel JBang project export to OpenShift cluster
- Makes sure to display the Camel logo as part of the Deployment in OpenShift

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

