### PR TITLE
CAMEL-21907: Set OAuth2 scope on request body

### DIFF
--- a/components/camel-http/src/main/java/org/apache/camel/component/http/OAuth2ClientConfigurer.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/OAuth2ClientConfigurer.java
@@ -101,16 +101,11 @@ public class OAuth2ClientConfigurer extends ServiceSupport implements HttpClient
 
     private JsonObject getAccessTokenResponse(HttpClient httpClient) throws IOException {
         String bodyStr = "grant_type=client_credentials";
-        String url = tokenEndpoint;
         if (scope != null) {
-            String sep = "?";
-            if (url.contains("?")) {
-                sep = "&";
-            }
-            url = url + sep + "scope=" + scope;
+            bodyStr += "&scope=" + scope;
         }
 
-        final HttpPost httpPost = new HttpPost(url);
+        final HttpPost httpPost = new HttpPost(tokenEndpoint);
 
         httpPost.addHeader(HttpHeaders.AUTHORIZATION,
                 HttpCredentialsHelper.generateBasicAuthHeader(clientId, clientSecret));

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpOAuth2ScopeTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpOAuth2ScopeTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.http;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.component.http.handler.HeaderValidationHandler;
+import org.apache.camel.component.http.handler.OAuth2ScopeRequestHandler;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.impl.bootstrap.HttpServer;
+import org.apache.hc.core5.http.impl.bootstrap.ServerBootstrap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HttpOAuth2ScopeTest extends BaseHttpTest {
+
+    private static final String FAKE_TOKEN = "xxx.yyy.zzz";
+    private static final String clientId = "test-client";
+    private static final String clientSecret = "test-secret";
+    private static final String scope = "test-scope";
+
+    private final OAuth2ScopeRequestHandler handler = new OAuth2ScopeRequestHandler(FAKE_TOKEN, clientId, clientSecret, scope);
+
+    @Override
+    public void setupResources() throws Exception {
+    }
+
+    @Test
+    public void scopeIsAddedToRequestBody() throws Exception {
+        try (var localServer = createLocalServer()) {
+            String tokenEndpoint = "http://localhost:" + localServer.getLocalPort() + "/token";
+            String requestUrl = "http://localhost:" + localServer.getLocalPort() + "/post?httpMethod=POST&oauth2ClientId="
+                                + clientId + "&oauth2ClientSecret=" + clientSecret + "&oauth2TokenEndpoint=" + tokenEndpoint
+                                + "&oauth2Scope=" + scope;
+
+            template.request(requestUrl,
+                    exchange1 -> {
+                    });
+            Exchange exchange
+                    = template.request(requestUrl,
+                            exchange1 -> {
+                            });
+
+            localServer.close();
+
+            assertExchange(exchange);
+        }
+    }
+
+    protected void assertHeaders(Map<String, Object> headers) {
+        assertEquals(HttpStatus.SC_OK, headers.get(Exchange.HTTP_RESPONSE_CODE));
+    }
+
+    protected String getExpectedContent() {
+        return "";
+    }
+
+    private HttpServer createLocalServer() throws Exception {
+        Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("Authorization", "Bearer " + FAKE_TOKEN);
+
+        var localServer = ServerBootstrap.bootstrap()
+                .setCanonicalHostName("localhost").setHttpProcessor(getBasicHttpProcessor())
+                .setConnectionReuseStrategy(getConnectionReuseStrategy()).setResponseFactory(getHttpResponseFactory())
+                .setSslContext(getSSLContext())
+                .register("/token", handler)
+                .register("/post",
+                        new HeaderValidationHandler(
+                                "POST",
+                                null,
+                                null,
+                                null,
+                                expectedHeaders))
+                .create();
+
+        localServer.start();
+        return localServer;
+    }
+}

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/handler/OAuth2ScopeRequestHandler.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/handler/OAuth2ScopeRequestHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.http.handler;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.component.http.HttpCredentialsHelper;
+import org.apache.camel.util.json.Jsoner;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.io.HttpRequestHandler;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.net.WWWFormCodec;
+
+public class OAuth2ScopeRequestHandler implements HttpRequestHandler {
+
+    private final String clientId;
+    private final String clientSecret;
+    private final String expectedToken;
+    private final String scope;
+
+    public OAuth2ScopeRequestHandler(String expectedToken, String clientId, String clientSecret, String scope) {
+        this.expectedToken = expectedToken;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.scope = scope;
+    }
+
+    @Override
+    public void handle(ClassicHttpRequest request, ClassicHttpResponse response, HttpContext context)
+            throws HttpException, IOException {
+        String requestBody = EntityUtils.toString(request.getEntity());
+        WWWFormCodec.parse(requestBody, StandardCharsets.UTF_8).stream()
+                .filter(pair -> pair.getName().equals("scope") && pair.getValue().equals(scope))
+                .findAny().orElseThrow(() -> new HttpException("Invalid or missing scope"));
+
+        if (request.getHeader(HttpHeaders.AUTHORIZATION) == null || !request.getHeader(HttpHeaders.AUTHORIZATION).getValue()
+                .equals(HttpCredentialsHelper.generateBasicAuthHeader(clientId, clientSecret)))
+            throw new HttpException("Invalid credentials");
+
+        Map<String, String> responseEntity = new HashMap<>();
+        responseEntity.put("access_token", expectedToken);
+
+        response.setEntity(new StringEntity(Jsoner.serialize(responseEntity), ContentType.APPLICATION_JSON));
+    }
+
+}


### PR DESCRIPTION
# Description

Updated OAuth2ClientConfigurer to set the parameter values for oauth2Scope on the request body instead of a query parameter when using client_credentials as grant_type. This should be done according to OAuth2 [documentation](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow) provided by Microsoft.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

