### PR TITLE
CAMEL-21926 camel-attachment fix inconsistent behaviour when last attachment is removed

### DIFF
--- a/components/camel-attachments/src/main/java/org/apache/camel/attachment/DefaultAttachmentMessage.java
+++ b/components/camel-attachments/src/main/java/org/apache/camel/attachment/DefaultAttachmentMessage.java
@@ -212,7 +212,11 @@ public final class DefaultAttachmentMessage implements AttachmentMessage {
 
     @Override
     public void removeAttachment(String id) {
-        getAttachmentsMap().remove(id);
+        Map<String, Object> attachmentsMap = getAttachmentsMap();
+        attachmentsMap.remove(id);
+        if (attachmentsMap.isEmpty()) {
+            removeTrait(MessageTrait.ATTACHMENTS);
+        }
     }
 
     @Override

--- a/components/camel-attachments/src/test/java/org/apache/camel/attachment/AttachmentRemovalTest.java
+++ b/components/camel-attachments/src/test/java/org/apache/camel/attachment/AttachmentRemovalTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.attachment;
+
+import jakarta.activation.DataHandler;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AttachmentRemovalTest extends CamelTestSupport {
+
+    @Test
+    public void testRemoval() throws Exception {
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        template.sendBody("direct:start", "");
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        Exchange e1 = getMockEndpoint("mock:result").getReceivedExchanges().get(0);
+
+        AttachmentMessage am1 = e1.getMessage(AttachmentMessage.class);
+
+        Assertions.assertFalse(am1.hasAttachments());
+        Assertions.assertEquals(0, am1.getAttachmentNames().size());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start")
+                        .process(exchange -> {
+                            AttachmentMessage message = exchange.getMessage(AttachmentMessage.class);
+                            byte[] data = exchange.getMessage().getBody(byte[].class);
+                            String attachmentName = "myfile.txt";
+                            String mimeType = "text/plain";
+                            DataHandler dataHandler = new DataHandler(data, mimeType);
+                            message.addAttachment(attachmentName, dataHandler);
+                            message.removeAttachment(attachmentName);
+                        })
+                        .to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
…

# Description
Updated the remove attachment logic: remove ATTACHMENTS trait when last attachment is removed.
<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

