### PR TITLE
[CAMEL-21938] camel-jolt - inputType & outputType can't be set for http uris

### DIFF
--- a/components/camel-jolt/src/main/java/org/apache/camel/component/jolt/JoltComponent.java
+++ b/components/camel-jolt/src/main/java/org/apache/camel/component/jolt/JoltComponent.java
@@ -44,6 +44,7 @@ public class JoltComponent extends DefaultComponent {
         answer.setAllowTemplateFromHeader(allowTemplateFromHeader);
         answer.setContentCache(cache);
         answer.setTransform(transform);
+        setProperties(answer, parameters);
 
         // if its a http resource then append any remaining parameters and update the resource uri
         if (ResourceHelper.isHttpUri(remaining)) {
@@ -71,7 +72,7 @@ public class JoltComponent extends DefaultComponent {
 
     /**
      * Whether to allow to use resource template from header or not (default false).
-     *
+     * <p>
      * Enabling this allows to specify dynamic templates via message header. However this can be seen as a potential
      * security vulnerability if the header is coming from a malicious user, so use this with care.
      */


### PR DESCRIPTION
# Description
Added call to setProperties before appending the remaining params to the http resourceUri.

[CAMEL-21938](https://issues.apache.org/jira/browse/CAMEL-21938)

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

