### PR TITLE
health-check: Fixes Camel context health check

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/impl/health/ContextHealthCheckTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/health/ContextHealthCheckTest.java
@@ -1,0 +1,50 @@
+package org.apache.camel.impl.health;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ServiceStatus;
+import org.apache.camel.health.HealthCheck;
+import org.apache.camel.health.HealthCheckResultBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class ContextHealthCheckTest {
+
+    @Test
+    public void testOverallStatusOnceTheContextIsStarted() {
+        CamelContext context = new DefaultCamelContext();
+        context.start();
+
+        ContextHealthCheck check = new ContextHealthCheck();
+        check.setCamelContext(context);
+
+        HealthCheck.Result result = check.call();
+
+        assertEquals(HealthCheck.State.UP, result.getState());
+        assertFalse(result.getMessage().isPresent());
+        assertFalse(result.getDetails().containsKey(AbstractHealthCheck.CHECK_ENABLED));
+        assertEquals(ServiceStatus.Started, result.getDetails().get("context.status"));
+    }
+
+    @Test
+    public void testOverallStatusOnceTheContextIsSuspended() {
+        CamelContext context = new DefaultCamelContext();
+        context.suspend();
+
+        ContextHealthCheck check = new ContextHealthCheck();
+        check.setCamelContext(context);
+
+        HealthCheck.Result result = check.call();
+
+        assertEquals(HealthCheck.State.DOWN, result.getState());
+        assertTrue(result.getMessage().isPresent());
+        assertFalse(result.getDetails().containsKey(AbstractHealthCheck.CHECK_ENABLED));
+        assertEquals(ServiceStatus.Suspended, result.getDetails().get("context.status"));
+    }
+
+
+}

--- a/core/camel-health/src/main/java/org/apache/camel/impl/health/ContextHealthCheck.java
+++ b/core/camel-health/src/main/java/org/apache/camel/impl/health/ContextHealthCheck.java
@@ -71,6 +71,7 @@ public final class ContextHealthCheck extends AbstractHealthCheck {
                     break;
                 case Started:
                     builder.up();
+                    break;
                 case Stopping:
                 case Stopped:
                 case Suspending:
@@ -78,6 +79,7 @@ public final class ContextHealthCheck extends AbstractHealthCheck {
                     builder.message("Camel Context '" + name + "' is shutting down. Status: '" + status + "', Phase: '" + phase
                                     + "'. Please check the debug log");
                     builder.down();
+                    break;
                 default:
                     builder.message("Camel Context '" + name + "' has unknown Status: " + status);
                     builder.down();


### PR DESCRIPTION
Fixes the health check once the Camel context has started, otherwise the result was DOWN even if the status is started