### PR TITLE
CAMEL-21845: camel-sql - Only commit/rollback if auto commit has been true

### DIFF
--- a/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlProducer.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlProducer.java
@@ -159,7 +159,7 @@ public class SqlProducer extends DefaultProducer {
                     boolean restoreAutoCommit = true;
 
                     if (batch) {
-                        if (manualCommit) {
+                        if (!exchange.isTransacted() && manualCommit) {
                             // optimize batch by turning off auto-commit
                             restoreAutoCommit = ps.getConnection().getAutoCommit();
                             ps.getConnection().setAutoCommit(false);
@@ -171,18 +171,18 @@ public class SqlProducer extends DefaultProducer {
                                 total += count;
                             }
                             exchange.getIn().setHeader(SqlConstants.SQL_UPDATE_COUNT, total);
-                            if (manualCommit) {
+                            if (!exchange.isTransacted() && manualCommit) {
                                 // optimize batch by commit after done
                                 ps.getConnection().commit();
                             }
                         } catch (Exception e) {
-                            if (manualCommit) {
+                            if (!exchange.isTransacted() && manualCommit) {
                                 // we failed so rollback
                                 ps.getConnection().rollback();
                             }
                             throw e;
                         } finally {
-                            if (manualCommit && restoreAutoCommit) {
+                            if (!exchange.isTransacted() && manualCommit && restoreAutoCommit) {
                                 // restore auto commit on connection as it may be used
                                 // in another kind of query (connection pooling)
                                 ps.getConnection().setAutoCommit(true);


### PR DESCRIPTION
Add-on to the optimization from CAMEL-21845. Commit or rollback should only be called if auto commit has not been set to false before. This might be intended to control the transaction for whatever reason! In cases of XA transactions, for example, calling commit or rollback would cause exceptions.