### PR TITLE
Revert "chore(deps-dev): Bump com.google.code.gson:gson from 2.12.1 to 2.13.0"

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -208,7 +208,7 @@
         <grpc-google-auth-library-version>1.33.1</grpc-google-auth-library-version>
         <grpc-java-jwt-version>4.5.0</grpc-java-jwt-version>
         <grpc-netty-tcnative-boringssl-static-version>2.0.59.Final</grpc-netty-tcnative-boringssl-static-version>
-        <gson-version>2.13.0</gson-version>
+        <gson-version>2.12.1</gson-version>
         <guava-version>33.4.7-jre</guava-version>
         <guice3-version>3.0</guice3-version>
         <h2-version>2.3.232</h2-version>


### PR DESCRIPTION
Reverts apache/camel#17742

trying to revert to fix main branch https://ci-builds.apache.org/job/Camel/job/Camel%20Core%20(Build%20and%20test)/job/main/lastCompletedBuild/testReport/org.apache.camel.component.couchdb/CouchDbProducerTest/BuildAndTest___Matrix___JDK_NAME____jdk_17_latest___PLATFORM____s390x____Test___testDeleteResponse/

```
java.lang.NoClassDefFoundError: com/google/gson/internal/$Gson$Types
	at com.ibm.cloud.sdk.core.util.DynamicModelTypeAdapterFactory.getBoundFields(DynamicModelTypeAdapterFactory.java:161)
	at com.ibm.cloud.sdk.core.util.DynamicModelTypeAdapterFactory.create(DynamicModelTypeAdapterFactory.java:108)
	at com.google.gson.Gson.getAdapter(Gson.java:628)
	at com.google.gson.Gson.toJson(Gson.java:928)
	at com.google.gson.Gson.toJson(Gson.java:899)
	at com.google.gson.Gson.toJson(Gson.java:848)
	at com.google.gson.Gson.toJson(Gson.java:825)
	at com.ibm.cloud.sdk.core.service.model.DynamicModel.toString(DynamicModel.java:161)
	at org.apache.camel.component.couchdb.CouchDbProducer.getBodyAsJsonElement(CouchDbProducer.java:101)
	at org.apache.camel.component.couchdb.CouchDbProducer.process(CouchDbProducer.java:48)
	at org.apache.camel.component.couchdb.CouchDbProducerTest.testDeleteResponse(CouchDbProducerTest.java:124)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.ClassNotFoundException: com.google.gson.internal.$Gson$Types
	... 14 more
```