### PR TITLE
CAMEL-20367: Adds Camel watch and Route DSL transformation tests

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/TransformMessageITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/TransformMessageITCase.java
@@ -53,6 +53,14 @@ public class TransformMessageITCase extends JBangTestSupport {
         checkOutputFile("[[Jack Dalton,  115,  mad at Averell]");
     }
 
+    @Test
+    public void testTransformRouteDSL() throws IOException {
+        copyResourceInDataFolder(TestResources.ROUTE2);
+        execute(String.format("transform route --format=xml %s/route2.yaml --output=%s/route2.xml", mountPoint(),
+                mountPoint()));
+        assertFileInDataFolderContains("route2.xml", "<constant>Hello Camel from custom integration</constant>");
+    }
+
     private void runTransformation(String command) {
         checkCommandOutputs(command, "Camel Main: transform (state: Running)");
     }


### PR DESCRIPTION
Adds tests for [watching camel integrations](https://camel.apache.org/manual/camel-jbang.html#_watching_local_camel_integrations) and [transforming route DSL](https://camel.apache.org/manual/camel-jbang.html#_transforming_routes_dsl)