### PR TITLE
Camel-Console is not needed in production, make it provided

### DIFF
--- a/components/camel-kafka/pom.xml
+++ b/components/camel-kafka/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-console</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- kafka java client -->

--- a/dsl/camel-kamelet-main/pom.xml
+++ b/dsl/camel-kamelet-main/pom.xml
@@ -55,6 +55,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-console</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/dsl/camel-kamelet-main/pom.xml
+++ b/dsl/camel-kamelet-main/pom.xml
@@ -55,7 +55,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-console</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>


### PR DESCRIPTION
I think that the best practice here, would be that users create a `dev` maven profile with camel-console dependency.

I do not think we need documentation here since in camel-console documentation there is already
```
== Using Camel Console

The `camel-console` must be added to the classpath, and enabled either via...
...
```

But if this PR makes sense, and is merged, I'll open a jira issue for the release notes 