### PR TITLE
Allow empty credentials in DHIS2 component

### DIFF
--- a/components/camel-dhis2/camel-dhis2-component/src/main/java/org/apache/camel/component/dhis2/Dhis2Component.java
+++ b/components/camel-dhis2/camel-dhis2-component/src/main/java/org/apache/camel/component/dhis2/Dhis2Component.java
@@ -26,6 +26,8 @@ import org.apache.camel.support.component.AbstractApiComponent;
 import org.hisp.dhis.integration.sdk.Dhis2ClientBuilder;
 import org.hisp.dhis.integration.sdk.api.Dhis2Client;
 
+import static org.apache.camel.util.ObjectHelper.isNotEmpty;
+
 @org.apache.camel.spi.annotations.Component("dhis2")
 public class Dhis2Component extends AbstractApiComponent<Dhis2ApiName, Dhis2Configuration, Dhis2ApiCollection> {
     @Metadata(label = "advanced")
@@ -82,18 +84,19 @@ public class Dhis2Component extends AbstractApiComponent<Dhis2ApiName, Dhis2Conf
                 if (endpointConfiguration.getBaseApiUrl() != null || endpointConfiguration.getPersonalAccessToken() != null
                         || endpointConfiguration.getUsername() != null || endpointConfiguration.getPassword() != null) {
                     throw new RuntimeCamelException(
-                            "Bad DHIS2 endpoint configuration: client option is mutually exclusive to baseApiUrl, username, password, and personalAccessToken. Either set `client`, or `baseApiUrl` and `username` and `password`, or `baseApiUrl` and `personalAccessToken`");
+                            "Bad DHIS2 endpoint configuration: client option is mutually exclusive to baseApiUrl, username, password, and personalAccessToken. Either set (1) `client`, or (2) `baseApiUrl` and `username` and `password`, or (3) `baseApiUrl` and `personalAccessToken`");
                 }
 
                 return endpointConfiguration.getClient();
             } else {
-                if (endpointConfiguration.getPersonalAccessToken() != null
-                        && (endpointConfiguration.getUsername() != null || endpointConfiguration.getPassword() != null)) {
+                if (isNotEmpty(endpointConfiguration.getPersonalAccessToken())
+                        && (isNotEmpty(endpointConfiguration.getUsername())
+                                || isNotEmpty(endpointConfiguration.getPassword()))) {
                     throw new RuntimeCamelException(
                             "Bad DHIS2 authentication configuration: Personal access token authentication and basic authentication are mutually exclusive. Either set `personalAccessToken` or both `username` and `password`");
                 }
 
-                if (endpointConfiguration.getPersonalAccessToken() != null) {
+                if (isNotEmpty(endpointConfiguration.getPersonalAccessToken())) {
                     return Dhis2ClientBuilder.newClient(endpointConfiguration.getBaseApiUrl(),
                             endpointConfiguration.getPersonalAccessToken()).build();
                 } else {

--- a/components/camel-dhis2/camel-dhis2-component/src/test/java/org/apache/camel/component/dhis2/Dhis2ComponentTestCase.java
+++ b/components/camel-dhis2/camel-dhis2-component/src/test/java/org/apache/camel/component/dhis2/Dhis2ComponentTestCase.java
@@ -19,9 +19,10 @@ package org.apache.camel.component.dhis2;
 import org.apache.camel.RuntimeCamelException;
 import org.hisp.dhis.integration.sdk.Dhis2ClientBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Dhis2ComponentTestCase {
     @Test
@@ -35,7 +36,41 @@ public class Dhis2ComponentTestCase {
         RuntimeCamelException runtimeCamelException
                 = assertThrows(RuntimeCamelException.class, () -> dhis2Component.getClient(dhis2Configuration));
         assertEquals(
-                "Bad DHIS2 endpoint configuration: client option is mutually exclusive to baseApiUrl, username, password, and personalAccessToken. Either set `client`, or `baseApiUrl` and `username` and `password`, or `baseApiUrl` and `personalAccessToken`",
+                "Bad DHIS2 endpoint configuration: client option is mutually exclusive to baseApiUrl, username, password, and personalAccessToken. Either set (1) `client`, or (2) `baseApiUrl` and `username` and `password`, or (3) `baseApiUrl` and `personalAccessToken`",
                 runtimeCamelException.getMessage());
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "admin,district,secret", ",district,secret", "admin,,secret" })
+    public void testGetClientThrowsExceptionGivenDhis2ConfigurationWithNonEmptyMutuallyExclusiveCredentials(
+            String username, String password, String personalAccessToken) {
+        Dhis2Configuration dhis2Configuration = new Dhis2Configuration();
+        dhis2Configuration.setBaseApiUrl("https://play.dhis2.org/40.2.2/api");
+        dhis2Configuration.setUsername(username);
+        dhis2Configuration.setPassword(password);
+        dhis2Configuration.setPersonalAccessToken(personalAccessToken);
+
+        Dhis2Component dhis2Component = new Dhis2Component();
+        RuntimeCamelException runtimeCamelException
+                = assertThrows(RuntimeCamelException.class, () -> dhis2Component.getClient(dhis2Configuration));
+        assertEquals(
+                "Bad DHIS2 authentication configuration: Personal access token authentication and basic authentication are mutually exclusive. Either set `personalAccessToken` or both `username` and `password`",
+                runtimeCamelException.getMessage());
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = { "admin,district,' '", "' ',' ',secret" })
+    public void testGetClientDoesNotThrowExceptionGivenDhis2ConfigurationWithEmptyMutuallyExclusiveCredentials(
+            String username, String password, String personalAccessToken) {
+        Dhis2Configuration dhis2Configuration = new Dhis2Configuration();
+        dhis2Configuration.setBaseApiUrl("https://play.dhis2.org/40.2.2/api");
+        dhis2Configuration.setUsername(username);
+        dhis2Configuration.setPassword(password);
+        dhis2Configuration.setPersonalAccessToken(personalAccessToken);
+
+        Dhis2Component dhis2Component = new Dhis2Component();
+        assertDoesNotThrow(() -> {
+            dhis2Component.getClient(dhis2Configuration);
+        });
     }
 }


### PR DESCRIPTION
# Description

Allow empty credentials in DHIS2 component since it's possible that one set of credentials defaults to an empty string when the auth type is not known ahead of time

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

