### PR TITLE
[4.10.x] camel-jbang: fix export not respecting --quarkus-group-id parameter (#17665)

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -335,6 +335,7 @@ public abstract class ExportBaseCommand extends CamelCommand {
         run.camelVersion = camelVersion;
         run.camelSpringBootVersion = camelSpringBootVersion;
         run.quarkusVersion = quarkusVersion;
+        run.quarkusGroupId = quarkusGroupId;
         run.springBootVersion = springBootVersion;
         run.kameletsVersion = kameletsVersion;
         run.localKameletDir = localKameletDir;


### PR DESCRIPTION
Backport of cf951d735ec51a38e7b1c9addd8893809dc270be