### PR TITLE
Copy paste typo fix

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
@@ -2178,7 +2178,7 @@ public abstract class BaseMainSupport extends BaseService {
                 src.setBackOffMaxAttempts(config.getBackOffMaxAttempts());
             }
             if (config.getBackOffMaxDelay() > 0) {
-                src.setBackOffMaxDelay(config.getBackOffDelay());
+                src.setBackOffMaxDelay(config.getBackOffMaxDelay());
             }
             if (config.getBackOffMaxElapsedTime() > 0) {
                 src.setBackOffMaxElapsedTime(config.getBackOffMaxElapsedTime());


### PR DESCRIPTION
COPY_PASTE_ERROR (CWE-398)

Looks like there is a wrong value used when copying configuration.


