### PR TITLE
Resource leak in FileInputStreamCache

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/converter/stream/FileInputStreamCache.java
+++ b/core/camel-support/src/main/java/org/apache/camel/converter/stream/FileInputStreamCache.java
@@ -331,6 +331,7 @@ public final class FileInputStreamCache extends InputStream implements StreamCac
                         ciphers = new CipherPair(strategy.getSpoolCipher());
                     }
                 } catch (GeneralSecurityException e) {
+                    IOHelper.close(out);
                     throw new IOException(e.getMessage(), e);
                 }
                 out = new CipherOutputStream(out, ciphers.getEncryptor()) {


### PR DESCRIPTION
RESOURCE_LEAK (CWE-404)

The out variable leaks if exception GeneralSecurityException is thrown
