### PR TITLE
Resource leak in RouteWatcherReloadStrategy

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/RouteWatcherReloadStrategy.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/RouteWatcherReloadStrategy.java
@@ -174,8 +174,11 @@ public class RouteWatcherReloadStrategy extends FileWatcherResourceReloadStrateg
             // load the properties, so we can update (remember location)
             InputStream is = resource.getInputStream();
             OrderedProperties tmp = new OrderedProperties();
-            tmp.load(is);
-            IOHelper.close(is);
+            try {
+                tmp.load(is);
+            } finally {
+                IOHelper.close(is);
+            }
             changed = new OrderedLocationProperties();
             changed.putAll(resource.getLocation(), tmp);
             // filter to only keep changed properties


### PR DESCRIPTION
RESOURCE_LEAK (CWE-404)

If _OrderedProperties#load_ throws (_IOException_, _IllegalArgumentException_), _is_ variable leaks.