### PR TITLE
Resource leak in JBang Run

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -1111,7 +1111,11 @@ public class Run extends CamelCommand {
 
         // prepare spring-boot for logging to file
         InputStream is = Run.class.getClassLoader().getResourceAsStream("spring-boot-logback.xml");
-        eq.safeCopy(is, new File(eq.exportDir + "/src/main/resources/logback.xml"));
+        try {
+            eq.safeCopy(is, new File(eq.exportDir + "/src/main/resources/logback.xml"));
+        } finally {
+            IOHelper.close(is);
+        }
 
         // run spring-boot via maven
         ProcessBuilder pb = new ProcessBuilder();


### PR DESCRIPTION
RESOURCE_LEAK (CWE-404)

Resource leak. Input stream _is_ is not closed after use.

