### PR TITLE
Resource leak in PackageHelper

### DIFF
--- a/tooling/camel-tooling-util/src/main/java/org/apache/camel/tooling/util/PackageHelper.java
+++ b/tooling/camel-tooling-util/src/main/java/org/apache/camel/tooling/util/PackageHelper.java
@@ -51,7 +51,9 @@ public final class PackageHelper {
     }
 
     public static String loadText(Path file) throws IOException {
-        return loadText(Files.newInputStream(file));
+        try (InputStream is = Files.newInputStream(file)) {
+            return loadText(is);
+        }
     }
 
     public static void writeText(File file, String text) throws IOException {


### PR DESCRIPTION
RESOURCE_LEAK (CWE-404)

Input stream is not closed anywhere. @davsclaus is this solution ok, or do you prefer closing with _IOHelper_?
