### PR TITLE
Expose UncPath for backward compatibility

### DIFF
--- a/components/camel-smb/src/main/docs/smb-component.adoc
+++ b/components/camel-smb/src/main/docs/smb-component.adoc
@@ -101,6 +101,8 @@ public void configure() {
 Beware that the File object provided is not a `java.io.File` instance, but, instead a `org.apache.camel.component.smb.SmbFile` instance that extends Camel's `GenericFile`.
 Relying on the underlying implementation may make your code more susceptible to problems between version upgrades of the library
 used to implement this component.
+
+To maintain backward compatibility, a new Camel Header `CamelSmbUncPath` has been introduced that provides the full absolute path when a File is consumed from the SMB server.
 ====
 
 

--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbConstants.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbConstants.java
@@ -81,4 +81,5 @@ public class SmbConstants {
               javaType = "org.apache.camel.component.file.GenericFileExist")
     @Deprecated
     public static final String SMB_FILE_EXISTS = "CamelSmbFileExists";
+    public static final String SMB_UNC_PATH = "CamelSmbUncPath";
 }

--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
@@ -293,6 +293,8 @@ public class SmbOperations implements SmbFileOperations {
                     // store content as a file in the local work directory in the temp handle
                     java.nio.file.Files.copy(is, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 }
+
+                exchange.getIn().setHeader(SmbConstants.SMB_UNC_PATH, shareFile.getUncPath());
             }
         } catch (IOException e) {
 
@@ -510,6 +512,7 @@ public class SmbOperations implements SmbFileOperations {
                 SMB2ShareAccess.ALL, SMB2CreateDisposition.FILE_OPEN, null);
         InputStream is = shareFile.getInputStream();
         exchange.getIn().setHeader(SmbComponent.SMB_FILE_INPUT_STREAM, is);
+        exchange.getIn().setHeader(SmbConstants.SMB_UNC_PATH, shareFile.getUncPath());
         return is;
     }
 

--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
@@ -240,6 +240,8 @@ public class SmbOperations implements SmbFileOperations {
                     throw new GenericFileOperationFailedException(e.getMessage(), e);
                 }
             }
+
+            exchange.getIn().setHeader(SmbConstants.SMB_UNC_PATH, shareFile.getUncPath());
         }
         return true;
     }

--- a/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbComponentIT.java
+++ b/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbComponentIT.java
@@ -48,6 +48,7 @@ public class SmbComponentIT extends CamelTestSupport {
     public void testSmbRead() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(100);
+        mock.expectedHeaderValuesReceivedInAnyOrder("CamelSmbUncPath", "\\\\localhost\\data-rw\\1.txt");
 
         mock.assertIsSatisfied();
     }


### PR DESCRIPTION
The previous smb implementation was providing more information wrt the absolute path, for example, if camel-smb is connected to a share `localhost/data-rw`, and files are created under data-rw, a Camel consumer absolute path would be `/fileName` without data-rw, and there is no way to retrieve that information from the GenericFile, the previous implementation was handing smbj.File and that information was there.

Does it make sense to add a header with that information?