### PR TITLE
Align spring properties and jetty to match versions in spring-boot-dependencies

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -199,7 +199,7 @@
         <graphql-java-version>22.3</graphql-java-version>
         <greenmail-version>2.0.1</greenmail-version>
         <grizzly-websockets-version>2.4.4</grizzly-websockets-version>
-        <groovy-version>4.0.25</groovy-version>
+        <groovy-version>4.0.26</groovy-version>
         <grpc-version>1.66.0</grpc-version>
         <grpc-google-auth-library-version>1.24.1</grpc-google-auth-library-version>
         <grpc-java-jwt-version>4.4.0</grpc-java-jwt-version>
@@ -274,7 +274,7 @@
         <jcr-version>2.0</jcr-version>
         <jedis-client-version>5.1.5</jedis-client-version>
         <jetcd-version>0.8.3</jetcd-version>
-        <jetty-version>12.0.18</jetty-version>
+        <jetty-version>12.0.19</jetty-version>
 		<jetty-for-solr-version>10.0.20</jetty-for-solr-version>        
         <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
         <jetty-runner-groupId>org.eclipse.jetty</jetty-runner-groupId>
@@ -454,9 +454,9 @@
         <spock-version>2.3-groovy-4.0</spock-version>
         <spring-batch-version>5.1.3</spring-batch-version>
         <spring-data-redis-version>3.3.10</spring-data-redis-version>
-        <spring-ldap-version>3.2.11</spring-ldap-version>
+        <spring-ldap-version>3.2.12</spring-ldap-version>
         <spring-vault-core-version>3.1.2</spring-vault-core-version>
-        <spring-version>6.1.18</spring-version>
+        <spring-version>6.1.19</spring-version>
         <spring-rabbitmq-version>3.1.7</spring-rabbitmq-version>
         <spring-security-version>6.3.9</spring-security-version>
         <spring-ws-version>4.0.13</spring-ws-version>


### PR DESCRIPTION
# Description

camel-4.8.x LTS branch change - align camel spring versions to the versions in spring-boot 3.3.11.     camel-spring-boot-4.8.x was upgraded to spring-boot 3.3.11 in this commit : https://github.com/apache/camel-spring-boot/commit/d6c7b984d56f1ad77ec58dbf8d2b0e5329621bc1

A large number of files were refreshed in the mvn -DskipTests clean install

parent/pom.xml versions changed here --
groovy 4.0.25 -> 4.0.26
jetty 12.0.18 -> 12.0.19
spring-ldap 3.2.11 -> 3.2.12
spring 6.1.18 -> 6.1.19 

# Target

- [x ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

