### PR TITLE
fix:Add ordinal to groupInstanceId (3.22.3)

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaConsumer.java
@@ -99,7 +99,7 @@ public class KafkaConsumer extends DefaultConsumer
         return UUID.randomUUID().toString();
     }
 
-    Properties getProps() {
+    Properties getProps(int i) {
         KafkaConfiguration configuration = endpoint.getConfiguration();
 
         Properties props = configuration.createConsumerProperties();
@@ -112,7 +112,7 @@ public class KafkaConsumer extends DefaultConsumer
         props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
 
         ObjectHelper.ifNotEmpty(configuration.getGroupInstanceId(),
-                v -> props.put(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, v));
+                v -> props.put(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, (configuration.getConsumersCount() > 1? v+"-"+i : v)));
 
         return props;
     }
@@ -157,7 +157,7 @@ public class KafkaConsumer extends DefaultConsumer
         BridgeExceptionHandlerToErrorHandler bridge = new BridgeExceptionHandlerToErrorHandler(this);
         for (int i = 0; i < endpoint.getConfiguration().getConsumersCount(); i++) {
             KafkaFetchRecords task = new KafkaFetchRecords(
-                    this, bridge, topic, pattern, i + "", getProps(), consumerListener);
+                    this, bridge, topic, pattern, i + "", getProps(i), consumerListener);
 
             executor.submit(task);
 

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaConsumerTest.java
@@ -51,7 +51,7 @@ public class KafkaConsumerTest {
         when(clientFactory.getBrokers(any())).thenThrow(new IllegalArgumentException());
         final KafkaConsumer kafkaConsumer = new KafkaConsumer(endpoint, processor);
 
-        assertThrows(IllegalArgumentException.class, () -> kafkaConsumer.getProps());
+        assertThrows(IllegalArgumentException.class, () -> kafkaConsumer.getProps(0));
     }
 
     @Test


### PR DESCRIPTION
# Description

[... only one instance with this ID is allowed in the consumer group ...](https://kafka.apache.org/documentation/#consumerconfigs_group.instance.id)

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

