### PR TITLE
Enable ppc64le Support for Camel-optaplanner

### DIFF
--- a/components/camel-optaplanner/pom.xml
+++ b/components/camel-optaplanner/pom.xml
@@ -33,8 +33,6 @@
 
     <properties>
         <camel.surefire.forkTimeout>1800</camel.surefire.forkTimeout>
-        <!-- Needs to be investigated: crashes on CI on ppc64le -->
-        <skipTests.ppc64le>true</skipTests.ppc64le>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
# Description
Enabling support for camel-optaplanner on power
Test Results :
[ppc64le_optaplanner_build.txt](https://github.com/user-attachments/files/19905736/ppc64le_optaplanner_build.txt)
[x86optaplanner_build.txt](https://github.com/user-attachments/files/19905738/x86optaplanner_build.txt)

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

