### PR TITLE
CAMEL-22062: Using JsonNode for output when outputType is Jackson

### DIFF
--- a/components/camel-jsonata/src/main/java/org/apache/camel/component/jsonata/JsonataEndpoint.java
+++ b/components/camel-jsonata/src/main/java/org/apache/camel/component/jsonata/JsonataEndpoint.java
@@ -127,7 +127,6 @@ public class JsonataEndpoint extends ResourceEndpoint {
             });
         }
 
-        Object output = null;
         Jsonata expression = null;
         try (InputStreamReader inputStreamReader
                 = new InputStreamReader(getResourceAsInputStream(), StandardCharsets.UTF_8);
@@ -139,15 +138,20 @@ public class JsonataEndpoint extends ResourceEndpoint {
         }
 
         Jsonata.Frame frame = expression.createFrame();
-        if (frameBinding != null)
+        if (frameBinding != null) {
             frameBinding.bindToFrame(frame);
-        output = expression.evaluate(input, frame);
+        }
+        Object outputLib = expression.evaluate(input, frame);
+        String bodyAsString = mapper.writeValueAsString(outputLib);
 
         // now lets output the results to the exchange
-        Object body = output;
+        final Object output;
         if (getOutputType() == JsonataInputOutputType.JsonString) {
-            body = mapper.writeValueAsString(output);
+            output = bodyAsString;
+        } else {
+            output = mapper.readTree(bodyAsString);
         }
-        ExchangeHelper.setInOutBodyPatternAware(exchange, body);
+        ExchangeHelper.setInOutBodyPatternAware(exchange, output);
     }
+
 }

--- a/components/camel-jsonata/src/test/java/org/apache/camel/component/jsonata/JsonataJacksonOutputTest.java
+++ b/components/camel-jsonata/src/test/java/org/apache/camel/component/jsonata/JsonataJacksonOutputTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jsonata;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.support.ResourceHelper;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.util.IOHelper;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test based on the first sample test from the JSONata project.
+ */
+class JsonataJacksonOutputTest extends CamelTestSupport {
+
+    @Test
+    void testFirstSampleJsonata() throws Exception {
+        getMockEndpoint("mock:result").expectedBodiesReceived(
+                IOHelper.loadText(
+                        ResourceHelper.resolveMandatoryResourceAsInputStream(
+                                context, "org/apache/camel/component/jsonata/firstSample/output.json"))
+                        .trim() // Remove the last newline added by IOHelper.loadText()
+        );
+
+        sendBody("direct://start",
+                ResourceHelper.resolveMandatoryResourceAsInputStream(
+                        context, "org/apache/camel/component/jsonata/firstSample/input.json"));
+
+        MockEndpoint.assertIsSatisfied(context);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        final Processor processor = exchange -> {
+            Map<String, String> contextMap = new HashMap<>();
+            contextMap.put("contextB", "bb");
+
+            exchange.getIn().setHeader(JsonataConstants.JSONATA_CONTEXT, contextMap);
+        };
+
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct://start")
+                        .process(processor)
+                        .to("jsonata:org/apache/camel/component/jsonata/firstSample/expressions.spec?inputType=JsonString&outputType=Jackson")
+                        .to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
# Description

Changing the body output type to JsonNode when jsonata component output type is Jackson.

# Target

- [ ]X I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

