### PR TITLE
[CAMEL-22077] Provide syntax highlighting for came-jbang shell commands

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Nano.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Nano.java
@@ -21,7 +21,9 @@ import java.nio.file.Paths;
 import java.util.Stack;
 import java.util.function.Supplier;
 
+import org.jline.builtins.ClasspathResourceUtil;
 import org.jline.builtins.Commands;
+import org.jline.builtins.ConfigurationPath;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import picocli.CommandLine;
@@ -44,7 +46,9 @@ public class Nano extends CamelCommand {
     public Integer doCall() throws Exception {
         Supplier<Path> workDir = () -> Paths.get(System.getProperty("user.dir"));
         try (Terminal terminal = TerminalBuilder.builder().build()) {
-            Commands.nano(terminal, System.out, System.err, workDir.get(), new String[] { file }, null);
+            Path appConfig = ClasspathResourceUtil.getResourcePath("/nano/jnanorc", getClass()).getParent();
+            ConfigurationPath configPath = new ConfigurationPath(appConfig, null);
+            Commands.nano(terminal, System.out, System.err, workDir.get(), new String[] { file }, configPath);
         }
         return 0;
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Shell.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Shell.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Supplier;
 
+import org.jline.builtins.ClasspathResourceUtil;
 import org.jline.builtins.ConfigurationPath;
 import org.jline.console.SystemRegistry;
 import org.jline.console.impl.Builtins;
@@ -57,7 +58,8 @@ public class Shell extends CamelCommand {
     public Integer doCall() throws Exception {
         Supplier<Path> workDir = () -> Paths.get(System.getProperty("user.dir"));
         // set up JLine built-in commands
-        Builtins builtins = new Builtins(workDir, new ConfigurationPath(workDir.get(), workDir.get()), null) {
+        Path appConfig = ClasspathResourceUtil.getResourcePath("/nano/jnanorc", getClass()).getParent();
+        Builtins builtins = new Builtins(workDir, new ConfigurationPath(appConfig, workDir.get()), null) {
             @Override
             public String name() {
                 return "built-in";

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/asciidoc.nanorc
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/asciidoc.nanorc
@@ -1,0 +1,64 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+syntax "AsciiDoc" "\.(asc|asciidoc|adoc)$"
+
+# main header
+color brightred "^=[[:space:]].+$"
+# h1
+color red "^==[[:space:]].*$"
+color red "^----+$"
+# h2
+color magenta "^===[[:space:]].*$"
+color magenta "^~~~~+$"
+# h4
+color green "^====[[:space:]].*$"
+color green "^\^\^\^\^+$"
+# h5
+color brightblue "^=====[[:space:]].*$"
+color brightblue "^\+\+\+\++$"
+
+# attributes
+color brightgreen ":.*:"
+color brightred "\{[a-z0-9]*\}"
+color red "\\\{[a-z0-9]*\}"
+color red "\+\+\+\{[a-z0-9]*\}\+\+\+"
+
+# Paragraph Title
+color yellow "^\..*$"
+
+# source
+color magenta "^\[(source,.+|NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]"
+
+# Other markup
+color yellow ".*[[:space:]]\+$"
+color yellow "_[^_]+_"
+color yellow "\*[^\*]+\*"
+color yellow "\+[^\+]+\+"
+color yellow "`[^`]+`"
+color yellow "\^[^\^]+\^"
+color yellow "~[^~]+~"
+color yellow "'[^']+'"
+
+color cyan "`{1,2}[^']+'{1,2}"
+
+# bullets
+color brightmagenta "^[[:space:]]*[\*\.-]{1,5}[[:space:]]"
+
+# anchors
+color brightwhite "\[\[.*\]\]"
+color brightwhite "<<.*>>"

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/java.nanorc
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/java.nanorc
@@ -1,0 +1,38 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+syntax "Java" "\.java$"
+magic "Java "
+comment "//"
+
+color green "\<(boolean|byte|char|double|float|int|long|new|short|this|transient|void)\>"
+color red "\<(break|case|catch|continue|default|do|else|finally|for|if|return|switch|throw|try|while)\>"
+color cyan "\<(abstract|class|extends|final|implements|import|instanceof|interface|native|package|private|protected|public|static|strictfp|super|synchronized|throws|volatile)\>"
+color red ""[^"]*""
+color yellow "\<(true|false|null)\>"
+icolor yellow "\b(([1-9][0-9]+)|0+)\.[0-9]+\b" "\b[1-9][0-9]*\b" "\b0[0-7]*\b" "\b0x[1-9a-f][0-9a-f]*\b"
+color blue "//.*"
+color blue start="^\s*/\*" end="\*/"
+color brightblue start="/\*\*" end="\*/"
+color brightwhite,yellow "\<(FIXME|TODO|XXX)\>"
+
+# Highlighting for javadoc stuff
+color magenta "@param [a-zA-Z_][a-z0-9A-Z_]+"
+color magenta "@return"
+color magenta "@author.*"
+
+color ,green "[[:space:]]+$"

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/jnanorc
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/jnanorc
@@ -1,0 +1,24 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+include "./asciidoc.nanorc"
+include "./java.nanorc"
+include "./json.nanorc"
+include "./markdown.nanorc"
+include "./properties.nanorc"
+include "./xml.nanorc"
+include "./yaml.nanorc"

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/json.nanorc
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/json.nanorc
@@ -1,0 +1,30 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+syntax "JSON" "\.json$"
+header "^\{$"
+# You can't add a comment to JSON.
+comment ""
+
+color blue   "\<[-]?[1-9][0-9]*([Ee][+-]?[0-9]+)?\>"  "\<[-]?[0](\.[0-9]+)?\>"
+color cyan  "\<null\>"
+color brightcyan "\<(true|false)\>"
+color yellow ""(\\.|[^"])*"|'(\\.|[^'])*'"
+color brightyellow "\"(\\"|[^"])*\"[[:space:]]*:"  "'(\'|[^'])*'[[:space:]]*:"
+color magenta   "\\u[0-9a-fA-F]{4}|\\[bfnrt'"/\\]"
+color ,green "[[:space:]]+$"
+color ,red "	+ +| +	+"

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/markdown.nanorc
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/markdown.nanorc
@@ -1,0 +1,68 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+syntax "Markdown" "\.(md|mkd|mkdn|markdown|mdx|mdown)$"
+
+# Tables (Github extension)
+color cyan ".*[ :]\|[ :].*"
+
+# quotes
+color brightblack  start="^>" end="^$"
+color brightblack  "^>.*"
+
+# Emphasis
+color green "(^|[[:space:]])(_[^ ][^_]*_|\*[^ ][^*]*\*)"
+
+# Strong emphasis
+color brightgreen "(^|[[:space:]])(__[^ ][^_]*__|\*\*[^ ][^*]*\*\*)"
+
+# strike-through
+color red "(^|[[:space:]])~~[^ ][^~]*~~"
+
+# horizontal rules
+color brightmagenta "^(---+|===+|___+|\*\*\*+)\s*$"
+
+# headlines
+color brightwhite "^#{1,6} .*"
+
+# lists
+color brightblue   "^[[:space:]]*[\*+-] |^[[:space:]]*[0-9]+\. "
+
+# leading whitespace
+color black    "^[[:space:]]+"
+
+# misc
+color magenta   "\(([CcRr]|[Tt][Mm])\)" "\.{3}" "(^|[[:space:]])\-\-($|[[:space:]])"
+
+# links
+color brightblue "\[[^]]+\]"
+color brightblue "\[([^][]|\[[^]]*\])*\]\([^)]+\)"
+
+# images
+color magenta "!\[[^][]*\](\([^)]+\)|\[[^]]+\])"
+
+# urls
+color brightyellow "https?://[^ )>]+"
+
+# code
+color yellow   "`[^`]*`|^ {4}[^-+*].*"
+# code blocks
+color yellow start="^```[^$]" end="^```$"
+color yellow "^```$"
+
+## Trailing spaces
+color ,green "[[:space:]]+$"

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/properties.nanorc
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/properties.nanorc
@@ -1,0 +1,23 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+syntax "properties" "\.properties$"
+# property key
+icolor green "^[^:=]+[:=]"
+
+# comments
+icolor blue "([[:space:]])*[#!].*$"

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/xml.nanorc
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/xml.nanorc
@@ -1,0 +1,40 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+syntax "XML" "\.([jrsx]html?|xml|sgml?|rng|vue|mei|musicxml)$"
+header "<\?xml.*version=.*\?>"
+magic "(XML|SGML) (sub)?document"
+comment "<!--|-->"
+
+color white "^.+$"
+# Attributes
+color green  start="<" end=">"
+color brightgreen "=\"[^\"]*\""
+# Opening tags
+color brightcyan   "<[^/][^> ]*"
+color brightcyan   ">"
+# Closing tags
+color cyan "</[^> ]*>"
+# Self-closing part
+color cyan "/>"
+color yellow start="<!DOCTYPE" end="[/]?>"
+color yellow start="<!--" end="-->"
+color brightwhite,yellow "\<(FIXME|TODO|XXX)\>"
+color red    "&[^;]*;"
+
+## Trailing spaces
+color ,green "[[:space:]]+$"

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/yaml.nanorc
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/nano/yaml.nanorc
@@ -1,0 +1,42 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+syntax "yaml" "\.ya?ml$"
+#comment "#"
+header "^---" "%YAML"
+tabgives "  "
+
+# Values
+color green "(:|^|\s)+\S+"
+
+# Keys
+color red "(^|\s+).*+\s*:(\s|$)"
+
+# Special values
+color yellow "[:-]\s+(true|false|null)\s*$"
+color yellow "[:-]\s+[0-9]+\.?[0-9]*(\s*($|#))"
+color yellow "(^| )!!(binary|bool|float|int|map|null|omap|seq|set|str) "
+
+# Separator
+color brightwhite "^\s*-"
+color brightwhite ":(\s|$)"
+
+# Comments
+color brightblue "(^|[[:space:]])#.*$"
+
+# Trailing whitespace
+color ,red "[[:space:]]+$"

--- a/dsl/camel-jbang/camel-jbang-plugin-edit/src/main/java/org/apache/camel/dsl/jbang/core/commands/edit/EditCommand.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-edit/src/main/java/org/apache/camel/dsl/jbang/core/commands/edit/EditCommand.java
@@ -23,6 +23,8 @@ import java.util.function.Supplier;
 
 import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.jline.builtins.ClasspathResourceUtil;
+import org.jline.builtins.ConfigurationPath;
 import org.jline.builtins.Nano;
 import org.jline.builtins.Options;
 import org.jline.terminal.Terminal;
@@ -51,8 +53,10 @@ public class EditCommand extends CamelCommand {
                 throw new Options.HelpException(opt.usage());
             } else {
                 Path currentDir = workDir.get();
+                Path appConfig = ClasspathResourceUtil.getResourcePath("/nano/jnanorc", getClass()).getParent();
+                ConfigurationPath configPath = new ConfigurationPath(appConfig, null);
                 CamelNanoLspEditor edit
-                        = new CamelNanoLspEditor(terminal, currentDir, opt, null);
+                        = new CamelNanoLspEditor(terminal, currentDir, opt, configPath);
                 edit.open(opt.args());
                 edit.run();
             }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -294,7 +294,7 @@
         <jgroups-raft-leveldbjni-version>1.8</jgroups-raft-leveldbjni-version>
         <jgroups-raft-mapdb-version>1.0.8</jgroups-raft-mapdb-version>
         <jira-rest-client-api-version>6.0.2</jira-rest-client-api-version>
-        <jline-version>3.30.1</jline-version>
+        <jline-version>3.30.2</jline-version>
         <libthrift-version>0.21.0</libthrift-version>
         <jodatime2-version>2.14.0</jodatime2-version>
         <jolokia-version>2.2.9</jolokia-version>

--- a/pom.xml
+++ b/pom.xml
@@ -376,12 +376,14 @@
                             <javamail.providers>CAMEL_PROPERTIES_STYLE</javamail.providers>
                             <jaxb.index>CAMEL_PROPERTIES_STYLE</jaxb.index>
                             <jj>DOUBLESLASH_STYLE</jj>
+                            <jnanorc>CAMEL_PROPERTIES_STYLE</jnanorc>
                             <jsh>SLASHSTAR_STYLE</jsh>
                             <kts>SLASHSTAR_STYLE</kts>
                             <ldif>LDIF_STYLE</ldif>
                             <libsonnet>SLASHSTAR_STYLE</libsonnet>
                             <motd>SCRIPT_STYLE</motd>
                             <mvel>MVEL_STYLE</mvel>
+                            <nanorc>CAMEL_PROPERTIES_STYLE</nanorc>
                             <properties>CAMEL_PROPERTIES_STYLE</properties>
                             <proto>SLASHSTAR_STYLE</proto>
                             <qf.cfg>CAMEL_PROPERTIES_STYLE</qf.cfg>


### PR DESCRIPTION
JIRA issue: [CAMEL-22077](https://issues.apache.org/jira/browse/CAMEL-22077)

This PR provides syntax highlighting for the nano, less and edit commands with support for: asciidoc, java, json, markdown, properties, xml and yaml languages.

The coloring could be modified and enhanced (I don't like much the xml syntax coloring fwiw).

