### PR TITLE
CAMEL-22083: FTP

### DIFF
--- a/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/FtpInfraService.java
+++ b/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/FtpInfraService.java
@@ -24,7 +24,27 @@ import org.apache.camel.test.infra.common.services.InfrastructureService;
  * Test infra service for Ftp
  */
 public interface FtpInfraService extends InfrastructureService {
+    @Deprecated
+    // Use port
     int getPort();
 
     Path getFtpRootDir();
+
+    int port();
+
+    default String hostname() {
+        return "localhost";
+    }
+
+    default String username() {
+        return "admin";
+    }
+
+    default String password() {
+        return "admin";
+    }
+
+    default String directoryName() {
+        return "myTestDirectory";
+    }
 }

--- a/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/FtpEmbeddedInfraService.java
+++ b/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/FtpEmbeddedInfraService.java
@@ -184,6 +184,11 @@ public class FtpEmbeddedInfraService extends AbstractService implements FtpInfra
         return rootDir;
     }
 
+    @Override
+    public int port() {
+        return port;
+    }
+
     public void resume() {
         ftpServer.resume();
         port = getListenerPort();

--- a/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/SftpEmbeddedInfraService.java
+++ b/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/SftpEmbeddedInfraService.java
@@ -177,4 +177,9 @@ public class SftpEmbeddedInfraService extends AbstractService implements FtpInfr
     public int getPort() {
         return port;
     }
+
+    @Override
+    public int port() {
+        return port;
+    }
 }


### PR DESCRIPTION
When using `camel infra run $SERVICE` the resulting json properties should match the Camel ones. For example, right now `camel infra run ftp` print
```
{
  "getFtpRootDir" : "file:///private/tmp/test/target/ftp/camel-test-infra-test-directory/camel-test-infra-configuration-test-directory",
  "getPort" : 49894
} 
```
This json has some issues:

* Wrong naming convention, getPort should be port to match the property in Camel
* The hostname is missing (in this case can be a constant, localhost)
* The directoryName is missing as well (any constant string would be ok)
* Username and password are needed as well since the underlying implementation needs those.

This way, the command will be tool-friendly and tools may automagically configure routes for fast prototyping.

With the fix, the following is printed:

```
{
  "directoryName" : "myTestDirectory",
  "getFtpRootDir" : "file:///Users/fmariani/Repositories/croway/camel/target/ftp/camel-test-infra-test-directory/camel-test-infra-configuration-test-directory",
  "getPort" : 54556,
  "hostname" : "localhost",
  "password" : "admin",
  "port" : 54556,
  "username" : "admin"
}
```