### PR TITLE
[CAMEL-21981] camel-jbang: when running in shell mode, plugins cannot be used

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/PluginHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/PluginHelper.java
@@ -84,7 +84,7 @@ public final class PluginHelper {
                 final String firstVersion = properties.getOrDefault("firstVersion", "").toString();
 
                 // only load the plugin if the command-line is calling this plugin
-                if (target != null && !target.equals(command)) {
+                if (target != null && !"shell".equals(target) && !target.equals(command)) {
                     continue;
                 }
 


### PR DESCRIPTION
JIRA issue: [CAMEL-21981](https://issues.apache.org/jira/browse/CAMEL-21981)

When invoking the shell command, commands from plugins are ignored.

