### PR TITLE
CAMEL-22083: ArangoDB

### DIFF
--- a/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCustomVertxIT.java
+++ b/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCustomVertxIT.java
@@ -55,7 +55,7 @@ public class ArangoCustomVertxIT extends BaseArangoDb {
             public void configure() {
                 from("direct:query")
                         .toF("arangodb:{{arangodb.testDb}}?host=%s&port=%d&operation=AQL_QUERY",
-                                service.getHost(), service.getPort());
+                                service.host(), service.port());
             }
         };
     }

--- a/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/BaseArangoDb.java
+++ b/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/BaseArangoDb.java
@@ -64,7 +64,7 @@ public abstract class BaseArangoDb implements ConfigurableRoute, CamelTestSuppor
 
     @ContextFixture
     public void createCamelContext(CamelContext ctx) {
-        arangoDb = new ArangoDB.Builder().host(service.getHost(), service.getPort()).build();
+        arangoDb = new ArangoDB.Builder().host(service.host(), service.port()).build();
 
         // drop any existing database to start clean
         if (arangoDb.getDatabases().contains(DATABASE_NAME)) {

--- a/test-infra/camel-test-infra-arangodb/pom.xml
+++ b/test-infra/camel-test-infra-arangodb/pom.xml
@@ -41,6 +41,11 @@
             <version>${project.version}</version>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>com.arangodb</groupId>
+            <artifactId>arangodb-java-driver</artifactId>
+            <version>${arangodb-java-version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/test-infra/camel-test-infra-arangodb/src/main/java/org/apache/camel/test/infra/arangodb/services/ArangoDBInfraService.java
+++ b/test-infra/camel-test-infra-arangodb/src/main/java/org/apache/camel/test/infra/arangodb/services/ArangoDBInfraService.java
@@ -16,15 +16,38 @@
  */
 package org.apache.camel.test.infra.arangodb.services;
 
+import com.arangodb.ArangoDB;
 import org.apache.camel.test.infra.common.services.InfrastructureService;
 
 public interface ArangoDBInfraService extends InfrastructureService {
 
+    // User port
+    @Deprecated
     int getPort();
 
+    int port();
+
+    String host();
+
+    // User host
+    @Deprecated
     String getHost();
 
     default String getServiceAddress() {
         return String.format("%s:%d", getHost(), getPort());
+    }
+
+    default String database() {
+        String database = "myDatabase";
+        ArangoDB arangoDB = new ArangoDB.Builder().host(host(), port()).build();
+
+        arangoDB.createDatabase(database);
+        arangoDB.db(database).createCollection(documentCollection());
+
+        return database;
+    }
+
+    default String documentCollection() {
+        return "myCollection";
     }
 }

--- a/test-infra/camel-test-infra-arangodb/src/main/java/org/apache/camel/test/infra/arangodb/services/ArangoDBLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-arangodb/src/main/java/org/apache/camel/test/infra/arangodb/services/ArangoDBLocalContainerInfraService.java
@@ -55,6 +55,16 @@ public class ArangoDBLocalContainerInfraService implements ArangoDBInfraService,
     }
 
     @Override
+    public int port() {
+        return container.getServicePort();
+    }
+
+    @Override
+    public String host() {
+        return container.getHost();
+    }
+
+    @Override
     public String getHost() {
         return container.getHost();
     }

--- a/test-infra/camel-test-infra-arangodb/src/main/java/org/apache/camel/test/infra/arangodb/services/ArangoDBRemoteInfraService.java
+++ b/test-infra/camel-test-infra-arangodb/src/main/java/org/apache/camel/test/infra/arangodb/services/ArangoDBRemoteInfraService.java
@@ -22,12 +22,22 @@ public class ArangoDBRemoteInfraService implements ArangoDBInfraService {
 
     @Override
     public int getPort() {
+        return port();
+    }
+
+    @Override
+    public int port() {
         return Integer.valueOf(System.getProperty(ArangoDBProperties.ARANGODB_PORT));
     }
 
     @Override
-    public String getHost() {
+    public String host() {
         return System.getProperty(ArangoDBProperties.ARANGODB_HOST);
+    }
+
+    @Override
+    public String getHost() {
+        return host();
     }
 
     @Override

--- a/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBServiceFactory.java
+++ b/test-infra/camel-test-infra-arangodb/src/test/java/org/apache/camel/test/infra/arangodb/services/ArangoDBServiceFactory.java
@@ -35,6 +35,16 @@ public final class ArangoDBServiceFactory {
         public String getHost() {
             return getService().getHost();
         }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
     }
 
     private ArangoDBServiceFactory() {


### PR DESCRIPTION
Creates a database and a collection during `camel infra run arangodb` startup resulting in:

```
{
  "database" : "myDatabase",
  "documentCollection" : "myCollection",
  "getHost" : "localhost",
  "getPort" : 8529,
  "getServiceAddress" : "localhost:8529",
  "host" : "localhost",
  "port" : 8529
}
```

that can be used as:

```
from("timer:java?period=1000")
                .process(ex -> {
                    com.arangodb.entity.BaseDocument myObject = new com.arangodb.entity.BaseDocument();
                    myObject.addAttribute("a", "Foo");
                    myObject.addAttribute("b", 42);

                    ex.getIn().setBody(myObject);
                })
            .to("arangodb:myDatabase?documentCollection=myCollection&operation=SAVE_DOCUMENT&host=localhost&port=8529")
            .log("${body}");
```