### PR TITLE
Camel 22083 artemis

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
@@ -296,15 +296,6 @@
   "artifactId" : "camel-test-infra-couchdb",
   "version" : "4.12.0-SNAPSHOT"
 }, {
-  "service" : "org.apache.camel.test.infra.artemis.services.ArtemisInfraService",
-  "description" : "Apache Artemis is an open source message broker",
-  "implementation" : "org.apache.camel.test.infra.artemis.services.ArtemisVMInfraService",
-  "alias" : [ "artemis" ],
-  "aliasImplementation" : [ ],
-  "groupId" : "org.apache.camel",
-  "artifactId" : "camel-test-infra-artemis",
-  "version" : "4.12.0-SNAPSHOT"
-}, {
   "service" : "org.apache.camel.test.infra.hivemq.services.HiveMQInfraService",
   "description" : "MQTT Platform HiveMQ",
   "implementation" : "org.apache.camel.test.infra.hivemq.services.LocalHiveMQInfraService",
@@ -350,15 +341,6 @@
   "artifactId" : "camel-test-infra-openldap",
   "version" : "4.12.0-SNAPSHOT"
 }, {
-  "service" : "org.apache.camel.test.infra.artemis.services.ArtemisInfraService",
-  "description" : "Apache Artemis is an open source message broker",
-  "implementation" : "org.apache.camel.test.infra.artemis.services.ArtemisPersistentVMInfraService",
-  "alias" : [ "artemis" ],
-  "aliasImplementation" : [ "persistent" ],
-  "groupId" : "org.apache.camel",
-  "artifactId" : "camel-test-infra-artemis",
-  "version" : "4.12.0-SNAPSHOT"
-}, {
   "service" : "org.apache.camel.test.infra.xmpp.services.XmppInfraService",
   "description" : "Test XMPP Server",
   "implementation" : "org.apache.camel.test.infra.xmpp.services.XmppLocalContainerInfraService",
@@ -366,15 +348,6 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-xmpp",
-  "version" : "4.12.0-SNAPSHOT"
-}, {
-  "service" : "org.apache.camel.test.infra.artemis.services.ArtemisInfraService",
-  "description" : "Apache Artemis is an open source message broker",
-  "implementation" : "org.apache.camel.test.infra.artemis.services.ArtemisMQTTInfraService",
-  "alias" : [ "artemis" ],
-  "aliasImplementation" : [ "mqtt" ],
-  "groupId" : "org.apache.camel",
-  "artifactId" : "camel-test-infra-artemis",
   "version" : "4.12.0-SNAPSHOT"
 }, {
   "service" : "org.apache.camel.test.infra.pulsar.services.PulsarInfraService",

--- a/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
+++ b/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
@@ -296,15 +296,6 @@
   "artifactId" : "camel-test-infra-couchdb",
   "version" : "4.12.0-SNAPSHOT"
 }, {
-  "service" : "org.apache.camel.test.infra.artemis.services.ArtemisInfraService",
-  "description" : "Apache Artemis is an open source message broker",
-  "implementation" : "org.apache.camel.test.infra.artemis.services.ArtemisVMInfraService",
-  "alias" : [ "artemis" ],
-  "aliasImplementation" : [ ],
-  "groupId" : "org.apache.camel",
-  "artifactId" : "camel-test-infra-artemis",
-  "version" : "4.12.0-SNAPSHOT"
-}, {
   "service" : "org.apache.camel.test.infra.hivemq.services.HiveMQInfraService",
   "description" : "MQTT Platform HiveMQ",
   "implementation" : "org.apache.camel.test.infra.hivemq.services.LocalHiveMQInfraService",
@@ -350,15 +341,6 @@
   "artifactId" : "camel-test-infra-openldap",
   "version" : "4.12.0-SNAPSHOT"
 }, {
-  "service" : "org.apache.camel.test.infra.artemis.services.ArtemisInfraService",
-  "description" : "Apache Artemis is an open source message broker",
-  "implementation" : "org.apache.camel.test.infra.artemis.services.ArtemisPersistentVMInfraService",
-  "alias" : [ "artemis" ],
-  "aliasImplementation" : [ "persistent" ],
-  "groupId" : "org.apache.camel",
-  "artifactId" : "camel-test-infra-artemis",
-  "version" : "4.12.0-SNAPSHOT"
-}, {
   "service" : "org.apache.camel.test.infra.xmpp.services.XmppInfraService",
   "description" : "Test XMPP Server",
   "implementation" : "org.apache.camel.test.infra.xmpp.services.XmppLocalContainerInfraService",
@@ -366,15 +348,6 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-xmpp",
-  "version" : "4.12.0-SNAPSHOT"
-}, {
-  "service" : "org.apache.camel.test.infra.artemis.services.ArtemisInfraService",
-  "description" : "Apache Artemis is an open source message broker",
-  "implementation" : "org.apache.camel.test.infra.artemis.services.ArtemisMQTTInfraService",
-  "alias" : [ "artemis" ],
-  "aliasImplementation" : [ "mqtt" ],
-  "groupId" : "org.apache.camel",
-  "artifactId" : "camel-test-infra-artemis",
   "version" : "4.12.0-SNAPSHOT"
 }, {
   "service" : "org.apache.camel.test.infra.pulsar.services.PulsarInfraService",

--- a/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisAMQPInfraService.java
+++ b/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisAMQPInfraService.java
@@ -103,6 +103,11 @@ public class ArtemisAMQPInfraService extends AbstractArtemisEmbeddedService {
     }
 
     @Override
+    public String remoteURI() {
+        return "amqp://0.0.0.0:" + amqpPort;
+    }
+
+    @Override
     public int brokerPort() {
         return amqpPort;
     }

--- a/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisInfraService.java
+++ b/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisInfraService.java
@@ -30,6 +30,10 @@ public interface ArtemisInfraService extends InfrastructureService {
 
     int brokerPort();
 
+    default String remoteURI() {
+        throw new IllegalArgumentException("Remote URI is not supported");
+    }
+
     default void registerProperties() {
         // For compatibility with the previous format used by camel-sjms tests
         System.setProperty(ArtemisProperties.SERVICE_ADDRESS, serviceAddress());

--- a/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisMQTTInfraService.java
+++ b/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisMQTTInfraService.java
@@ -19,12 +19,8 @@ package org.apache.camel.test.infra.artemis.services;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.artemis.common.ArtemisRunException;
 
-@InfraService(service = ArtemisInfraService.class,
-              description = "Apache Artemis is an open source message broker",
-              serviceAlias = "artemis", serviceImplementationAlias = "mqtt")
 public class ArtemisMQTTInfraService extends AbstractArtemisEmbeddedService {
 
     private String brokerURL;
@@ -61,6 +57,11 @@ public class ArtemisMQTTInfraService extends AbstractArtemisEmbeddedService {
 
     @Override
     public String serviceAddress() {
+        return brokerURL;
+    }
+
+    @Override
+    public String remoteURI() {
         return brokerURL;
     }
 

--- a/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisPersistentVMInfraService.java
+++ b/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisPersistentVMInfraService.java
@@ -21,12 +21,8 @@ import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.artemis.common.ArtemisRunException;
 
-@InfraService(service = ArtemisInfraService.class,
-              description = "Apache Artemis is an open source message broker",
-              serviceAlias = "artemis", serviceImplementationAlias = "persistent")
 public class ArtemisPersistentVMInfraService extends AbstractArtemisEmbeddedService {
 
     private String brokerURL;

--- a/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisVMInfraService.java
+++ b/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisVMInfraService.java
@@ -20,14 +20,10 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.artemis.common.ArtemisRunException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@InfraService(service = ArtemisInfraService.class,
-              description = "Apache Artemis is an open source message broker",
-              serviceAlias = "artemis")
 public class ArtemisVMInfraService extends AbstractArtemisEmbeddedService {
     private static final Logger LOG = LoggerFactory.getLogger(ArtemisVMInfraService.class);
 


### PR DESCRIPTION
AMQP usage where `amqp://0.0.0.0:56142` is `remoteURI`:
```
///usr/bin/env jbang "$0" "$@" ; exit $?
//DEPS org.apache.camel:camel-amqp:4.12.0-SNAPSHOT
//DEPS org.apache.qpid:qpid-jms-client:2.7.0

import org.apache.camel.builder.RouteBuilder;
import org.apache.camel.Exchange;

public class MyRoute extends RouteBuilder {

    @Override
    public void configure() throws Exception {
        org.apache.qpid.jms.JmsConnectionFactory connectionFactory =
                new org.apache.qpid.jms.JmsConnectionFactory("amqp://0.0.0.0:56142");

        getCamelContext().getRegistry().bind("connectionFactory", connectionFactory);

        from("timer:java?period=1000")
                .setBody()
                .simple("Hello Camel from ${routeId}")
                .to("amqp:test?connectionFactory=#connectionFactory");

        from("amqp:test?connectionFactory=#connectionFactory")
                .log("${body}");
    }
}
```