### PR TITLE
CAMEL-22083: AWS

### DIFF
--- a/test-infra/camel-test-infra-aws-common/src/main/java/org/apache/camel/test/infra/aws/common/services/AWSInfraService.java
+++ b/test-infra/camel-test-infra-aws-common/src/main/java/org/apache/camel/test/infra/aws/common/services/AWSInfraService.java
@@ -24,4 +24,14 @@ import org.apache.camel.test.infra.common.services.InfrastructureService;
 public interface AWSInfraService extends InfrastructureService {
 
     Properties getConnectionProperties();
+
+    String amazonAWSHost();
+
+    String region();
+
+    String protocol();
+
+    String accessKey();
+
+    String secretKey();
 }

--- a/test-infra/camel-test-infra-aws-v2/src/main/java/org/apache/camel/test/infra/aws2/services/AWSLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-aws-v2/src/main/java/org/apache/camel/test/infra/aws2/services/AWSLocalContainerInfraService.java
@@ -62,16 +62,39 @@ public abstract class AWSLocalContainerInfraService implements AWSInfraService, 
     }
 
     @Override
+    public String amazonAWSHost() {
+        return container.getAmazonHost();
+    }
+
+    @Override
+    public String region() {
+        return Region.US_EAST_1.toString();
+    }
+
+    @Override
+    public String protocol() {
+        return "http";
+    }
+
+    @Override
+    public String accessKey() {
+        return container.getCredentialsProvider().resolveCredentials().accessKeyId();
+    }
+
+    @Override
+    public String secretKey() {
+        return container.getCredentialsProvider().resolveCredentials().secretAccessKey();
+    }
+
+    @Override
     public Properties getConnectionProperties() {
         Properties properties = new Properties();
 
-        AwsCredentials credentials = container.getCredentialsProvider().resolveCredentials();
-
-        properties.put(AWSConfigs.ACCESS_KEY, credentials.accessKeyId());
-        properties.put(AWSConfigs.SECRET_KEY, credentials.secretAccessKey());
-        properties.put(AWSConfigs.REGION, Region.US_EAST_1.toString());
-        properties.put(AWSConfigs.AMAZON_AWS_HOST, container.getAmazonHost());
-        properties.put(AWSConfigs.PROTOCOL, "http");
+        properties.put(AWSConfigs.ACCESS_KEY, accessKey());
+        properties.put(AWSConfigs.SECRET_KEY, secretKey());
+        properties.put(AWSConfigs.REGION, region());
+        properties.put(AWSConfigs.AMAZON_AWS_HOST, amazonAWSHost());
+        properties.put(AWSConfigs.PROTOCOL, protocol());
 
         return properties;
     }

--- a/test-infra/camel-test-infra-aws-v2/src/main/java/org/apache/camel/test/infra/aws2/services/AWSRemoteInfraService.java
+++ b/test-infra/camel-test-infra-aws-v2/src/main/java/org/apache/camel/test/infra/aws2/services/AWSRemoteInfraService.java
@@ -41,6 +41,31 @@ public class AWSRemoteInfraService implements AWSInfraService {
     }
 
     @Override
+    public String amazonAWSHost() {
+        throw new IllegalArgumentException("Not implemented for remote scenario");
+    }
+
+    @Override
+    public String region() {
+        throw new IllegalArgumentException("Not implemented for remote scenario");
+    }
+
+    @Override
+    public String protocol() {
+        throw new IllegalArgumentException("Not implemented for remote scenario");
+    }
+
+    @Override
+    public String accessKey() {
+        throw new IllegalArgumentException("Not implemented for remote scenario");
+    }
+
+    @Override
+    public String secretKey() {
+        throw new IllegalArgumentException("Not implemented for remote scenario");
+    }
+
+    @Override
     public void registerProperties() {
 
     }

--- a/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSServiceFactory.java
+++ b/test-infra/camel-test-infra-aws-v2/src/test/java/org/apache/camel/test/infra/aws2/services/AWSServiceFactory.java
@@ -40,6 +40,31 @@ public final class AWSServiceFactory {
         public Properties getConnectionProperties() {
             return getService().getConnectionProperties();
         }
+
+        @Override
+        public String amazonAWSHost() {
+            return getService().amazonAWSHost();
+        }
+
+        @Override
+        public String region() {
+            return getService().region();
+        }
+
+        @Override
+        public String protocol() {
+            return getService().protocol();
+        }
+
+        @Override
+        public String accessKey() {
+            return getService().accessKey();
+        }
+
+        @Override
+        public String secretKey() {
+            return getService().secretKey();
+        }
     }
 
     public static <T extends AWSService> SimpleTestServiceBuilder<T> builder() {


### PR DESCRIPTION
SQS Example usage:

```
///usr/bin/env jbang "$0" "$@" ; exit $?
//DEPS org.apache.camel:camel-aws2-sqs:4.12.0-SNAPSHOT

import org.apache.camel.builder.RouteBuilder;
import org.apache.camel.Exchange;

public class MyRoute extends RouteBuilder {

    @Override
    public void configure() throws Exception {
        from("timer:java?period=1000")
                .setBody()
                .simple("Hello Camel from ${routeId}")
                .to("aws2-sqs:test?amazonAWSHost=localhost:32775&autoCreateQueue=true&region=us-east-1&protocol=http&accessKey=accessKey&secretKey=secretKey");

        from("aws2-sqs:test?amazonAWSHost=localhost:32775&autoCreateQueue=true&region=us-east-1&protocol=http&accessKey=accessKey&secretKey=secretKey")
                .log("${body}");
    }
}
```

Where `amazonAWSHost`, `region`, `protocol`, `accessKey` and `secretKey` are taken from the console output `camel infra run aws sqs`

```
{
  "accessKey" : "accesskey",
  "amazonAWSHost" : "localhost:32779",
  "getConnectionProperties" : {
    "aws.access.key" : "accesskey",
    "aws.host" : "localhost:32779",
    "aws.protocol" : "http",
    "aws.region" : "us-east-1",
    "aws.secret.key" : "secretkey"
  },
  "protocol" : "http",
  "region" : "us-east-1",
  "secretKey" : "secretkey"
}
```