### PR TITLE
chore: fix build for Maven 4

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -6,9 +6,9 @@
         <version>4.17.9</version>
     </extension>
     <extension>
-        <groupId>com.tisonkun.os</groupId>
-        <artifactId>os-detector-maven-plugin</artifactId>
-        <version>0.6.0</version>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension</artifactId>
+        <version>0.4.4</version>
     </extension>
 <!-- Temporarily disabled due to INFRA-26647 -->
 <!--    <extension>-->

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,8 @@
         <invoker.skip>${skipTests}</invoker.skip>
 
         <enforcer.phase>none</enforcer.phase><!-- We do not enforce with -Dquickly, the property is overridden in the full profile -->
+
+        <os.detected.classifier>${nisse.os.classifier}</os.detected.classifier>
     </properties>
 
     <!-- Comment out the snapshot repositories as we don't need them now -->


### PR DESCRIPTION
Switch to Nisse extension and make sure the `os.detected.classifier` is a project property, so that it can be overriden by profiles (as user properties cannot).
