### PR TITLE
CAMEL-21658: Create a fat-jar launcher for Camel JBang

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -6,9 +6,9 @@
         <version>4.17.9</version>
     </extension>
     <extension>
-        <groupId>com.tisonkun.os</groupId>
-        <artifactId>os-detector-maven-plugin</artifactId>
-        <version>0.6.0</version>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension</artifactId>
+        <version>0.4.4</version>
     </extension>
 <!-- Temporarily disabled due to INFRA-26647 -->
 <!--    <extension>-->

--- a/dsl/camel-jbang/camel-jbang-launcher/README.md
+++ b/dsl/camel-jbang/camel-jbang-launcher/README.md
@@ -1,0 +1,56 @@
+# Camel JBang Fat-Jar Launcher
+
+This module provides a self-contained executable JAR that includes all dependencies required to run Camel JBang without the need for the JBang two-step process.
+
+## Building
+
+To build the fat-jar launcher:
+
+```bash
+mvn clean package
+```
+
+This will create:
+1. A fat-jar (`camel-jbang-launcher-<version>.jar`) in the `target` directory
+2. Distribution archives (`camel-jbang-launcher-<version>-bin.zip` and `camel-jbang-launcher-<version>-bin.tar.gz`) in the `target` directory
+
+## Usage
+
+### Using the JAR directly
+
+```bash
+java -jar camel-jbang-launcher-<version>.jar [command] [options]
+```
+
+For example:
+
+```bash
+java -jar camel-jbang-launcher-<version>.jar version
+java -jar camel-jbang-launcher-<version>.jar run hello.java
+```
+
+### Using the distribution
+
+1. Extract the distribution archive:
+   ```bash
+   unzip camel-jbang-launcher-<version>-bin.zip
+   # or
+   tar -xzf camel-jbang-launcher-<version>-bin.tar.gz
+   ```
+
+2. Use the provided scripts:
+   ```bash
+   # On Unix/Linux
+   ./bin/camel.sh [command] [options]
+   
+   # On Windows
+   bin\camel.bat [command] [options]
+   ```
+
+## Benefits
+
+- No need for JBang installation
+- Single executable JAR with all dependencies included
+- Faster startup time (no dependency resolution step)
+- Each fat-jar is its own release, avoiding version complexity
+- Can still be used with JBang if preferred

--- a/dsl/camel-jbang/camel-jbang-launcher/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-launcher/pom.xml
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-jbang-parent</artifactId>
+        <version>4.12.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-jbang-launcher</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Camel :: JBang :: Launcher</name>
+    <description>Camel JBang Fat-Jar Launcher</description>
+
+    <properties>
+        <firstVersion>4.12.0</firstVersion>
+        <label>jbang</label>
+        <supportLevel>Preview</supportLevel>
+        <camel-prepare-component>false</camel-prepare-component>
+
+        <!-- Dependency versions -->
+        <camel-kamelets-version>4.11.0</camel-kamelets-version>
+        <maven-version>3.9.9</maven-version>
+        <maven-resolver-version>1.9.23</maven-resolver-version>
+        <plexus-interpolation-version>1.27</plexus-interpolation-version>
+        <plexus-utils-version>4.0.2</plexus-utils-version>
+        <plexus-xml-version>3.0.1</plexus-xml-version>
+        <plexus-sec-dispatcher-version>2.0</plexus-sec-dispatcher-version>
+        <plexus-cipher-version>2.0</plexus-cipher-version>
+        <eclipse-sisu-version>0.9.0.M3</eclipse-sisu-version>
+        <javax-inject-version>1</javax-inject-version>
+        <httpclient-version>4.5.14</httpclient-version>
+        <httpcore-version>4.4.16</httpcore-version>
+        <commons-codec-version>1.18.0</commons-codec-version>
+        <jcl-over-slf4j-version>1.7.36</jcl-over-slf4j-version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-jbang-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.kamelets</groupId>
+            <artifactId>camel-kamelets</artifactId>
+            <version>${camel-kamelets-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${maven-version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${maven-version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model-builder</artifactId>
+            <version>${maven-version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-resolver-provider</artifactId>
+            <version>${maven-version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-builder-support</artifactId>
+            <version>${maven-version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-repository-metadata</artifactId>
+            <version>${maven-version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${maven-version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings-builder</artifactId>
+            <version>${maven-version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
+            <version>${maven-resolver-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-spi</artifactId>
+            <version>${maven-resolver-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-util</artifactId>
+            <version>${maven-resolver-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-impl</artifactId>
+            <version>${maven-resolver-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-connector-basic</artifactId>
+            <version>${maven-resolver-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-transport-file</artifactId>
+            <version>${maven-resolver-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-transport-http</artifactId>
+            <version>${maven-resolver-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-named-locks</artifactId>
+            <version>${maven-resolver-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-interpolation</artifactId>
+            <version>${plexus-interpolation-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus-utils-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-xml</artifactId>
+            <version>${plexus-xml-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-sec-dispatcher</artifactId>
+            <version>${plexus-sec-dispatcher-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-cipher</artifactId>
+            <version>${plexus-cipher-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sisu</groupId>
+            <artifactId>org.eclipse.sisu.inject</artifactId>
+            <version>${eclipse-sisu-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>${javax-inject-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${httpcore-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${jcl-over-slf4j-version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.apache.camel.dsl.jbang.launcher.CamelJBangLauncher</mainClass>
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/services/org/apache/camel/TypeConverterLoader</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/services/org/apache/camel/component.properties</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/services/org/apache/camel/dataformat.properties</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/services/org/apache/camel/language.properties</resource>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/bin.xml</descriptor>
+                    </descriptors>
+                    <tarLongFileMode>posix</tarLongFileMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/dsl/camel-jbang/camel-jbang-launcher/src/examples/hello.java
+++ b/dsl/camel-jbang/camel-jbang-launcher/src/examples/hello.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// camel-k: language=java
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class hello extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("timer:tick?period=1000")
+            .setBody().constant("Hello World!")
+            .log("${body}");
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-launcher/src/examples/simple.yaml
+++ b/dsl/camel-jbang/camel-jbang-launcher/src/examples/simple.yaml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- route:
+    from:
+      uri: "timer:tick"
+      parameters:
+        period: "1000"
+      steps:
+        - setBody:
+            constant: "Hello World!"
+        - log: "${body}"

--- a/dsl/camel-jbang/camel-jbang-launcher/src/main/assembly/bin.xml
+++ b/dsl/camel-jbang/camel-jbang-launcher/src/main/assembly/bin.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+    <id>bin</id>
+    <formats>
+        <format>zip</format>
+        <format>tar.gz</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>README*</include>
+                <include>LICENSE*</include>
+                <include>NOTICE*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>original-*.jar</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/src/main/resources/bin</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>camel.sh</include>
+                <include>camel.bat</include>
+            </includes>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/src/examples</directory>
+            <outputDirectory>examples</outputDirectory>
+            <includes>
+                <include>*.*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/dsl/camel-jbang/camel-jbang-launcher/src/main/java/org/apache/camel/dsl/jbang/launcher/CamelJBangLauncher.java
+++ b/dsl/camel-jbang/camel-jbang-launcher/src/main/java/org/apache/camel/dsl/jbang/launcher/CamelJBangLauncher.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.launcher;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+
+/**
+ * Main class for the Camel JBang Fat-Jar Launcher.
+ * <p>
+ * This launcher provides a self-contained executable JAR that includes all dependencies required to run Camel JBang
+ * without the need for the JBang two-step process.
+ */
+public class CamelJBangLauncher {
+
+    /**
+     * Main entry point for the Camel JBang Fat-Jar Launcher.
+     *
+     * @param args command line arguments to pass to Camel JBang
+     */
+    public static void main(String... args) {
+        CamelJBangMain.run(args);
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-launcher/src/main/resources/bin/camel.bat
+++ b/dsl/camel-jbang/camel-jbang-launcher/src/main/resources/bin/camel.bat
@@ -1,0 +1,72 @@
+@echo off
+@REM
+@REM Licensed to the Apache Software Foundation (ASF) under one or more
+@REM contributor license agreements.  See the NOTICE file distributed with
+@REM this work for additional information regarding copyright ownership.
+@REM The ASF licenses this file to You under the Apache License, Version 2.0
+@REM (the "License"); you may not use this file except in compliance with
+@REM the License.  You may obtain a copy of the License at
+@REM
+@REM      http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+@REM
+
+@REM ----------------------------------------------------------------------------
+@REM Camel JBang Launcher Start Up Batch script
+@REM ----------------------------------------------------------------------------
+
+@REM Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+@REM Find the project base dir
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set BASEDIR=%DIRNAME%
+
+@REM Java command to use
+if "%JAVA_HOME%" == "" goto noJavaHome
+set JAVACMD=%JAVA_HOME%\bin\java.exe
+goto checkJavaCmd
+
+:noJavaHome
+set JAVACMD=java.exe
+
+:checkJavaCmd
+if exist "%JAVACMD%" goto init
+
+echo.
+echo Error: JAVA_HOME is not defined correctly. >&2
+echo Cannot execute "%JAVACMD%" >&2
+echo.
+goto error
+
+:init
+@REM Set JVM options if specified
+if "%JAVA_OPTS%" == "" set JAVA_OPTS=-Xmx512m
+
+@REM Find the JAR file
+dir /b "%BASEDIR%\camel-jbang-launcher-*.jar" > nul 2>&1
+if not errorlevel 1 (
+  for /f "tokens=*" %%j in ('dir /b "%BASEDIR%\camel-jbang-launcher-*.jar"') do set LAUNCHER_JAR=%BASEDIR%\%%j
+) else (
+  for %%i in ("%BASEDIR%\camel-jbang-launcher-*.jar") do set LAUNCHER_JAR=%%i
+)
+
+@REM Execute Camel JBang
+"%JAVACMD%" %JAVA_OPTS% -jar "%LAUNCHER_JAR%" %*
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+set ERROR_CODE=1
+
+:end
+@REM End local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" endlocal
+
+exit /B %ERROR_CODE%

--- a/dsl/camel-jbang/camel-jbang-launcher/src/main/resources/bin/camel.sh
+++ b/dsl/camel-jbang/camel-jbang-launcher/src/main/resources/bin/camel.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+PRGDIR=`dirname "$PRG"`
+BASEDIR=`cd "$PRGDIR" >/dev/null; pwd`
+
+# Reset the REPO variable. If you need to influence this use the environment setup file.
+REPO=
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+case "`uname`" in
+  CYGWIN*) cygwin=true ;;
+  Darwin*) darwin=true
+           if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=`java-config --jre-home`
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# If a specific java binary isn't specified search for the standard 'java' binary
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=`which java`
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." 1>&2
+  echo "  We cannot execute $JAVACMD" 1>&2
+  exit 1
+fi
+
+if [ -z "$REPO" ]
+then
+  REPO="$BASEDIR"
+fi
+
+# Set the classpath to the JAR file
+for f in "$BASEDIR"/camel-jbang-launcher-*.jar; do
+  if [ -f "$f" ]; then
+    CLASSPATH="$f"
+    break
+  fi
+done
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
+  [ -n "$HOME" ] && HOME=`cygpath --path --windows "$HOME"`
+  [ -n "$BASEDIR" ] && BASEDIR=`cygpath --path --windows "$BASEDIR"`
+  [ -n "$REPO" ] && REPO=`cygpath --path --windows "$REPO"`
+fi
+
+# Set JVM options if specified
+if [ -z "$JAVA_OPTS" ]; then
+  JAVA_OPTS="-Xmx512m"
+fi
+
+exec "$JAVACMD" $JAVA_OPTS -jar "$CLASSPATH" "$@"

--- a/dsl/camel-jbang/camel-jbang-launcher/src/test/java/org/apache/camel/dsl/jbang/launcher/CamelJBangLauncherTest.java
+++ b/dsl/camel-jbang/camel-jbang-launcher/src/test/java/org/apache/camel/dsl/jbang/launcher/CamelJBangLauncherTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.launcher;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.common.Printer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for the CamelJBangLauncher.
+ */
+public class CamelJBangLauncherTest {
+
+    /**
+     * A simple PrintStream-based Printer implementation for testing.
+     */
+    static class PrintStreamPrinter implements Printer {
+        private final PrintStream printStream;
+
+        public PrintStreamPrinter(PrintStream printStream) {
+            this.printStream = printStream;
+        }
+
+        @Override
+        public void println() {
+            printStream.println();
+        }
+
+        @Override
+        public void println(String line) {
+            printStream.println(line);
+        }
+
+        @Override
+        public void print(String output) {
+            printStream.print(output);
+        }
+
+        @Override
+        public void printf(String format, Object... args) {
+            printStream.printf(format, args);
+        }
+    }
+
+    @Test
+    public void testLauncherVersion() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+
+        // Create a custom main that doesn't exit
+        CamelJBangMain main = new CamelJBangMain() {
+            @Override
+            public void quit(int exitCode) {
+                // Do nothing to prevent System.exit
+            }
+        };
+
+        // Set a custom printer to capture output
+        main.setOut(new PrintStreamPrinter(ps));
+
+        // Run the version command
+        CamelJBangMain.run(main, "version");
+
+        String output = baos.toString();
+        assertTrue(output.contains("Camel JBang version:"), "Output should contain version information");
+    }
+}

--- a/dsl/camel-jbang/pom.xml
+++ b/dsl/camel-jbang/pom.xml
@@ -40,6 +40,7 @@
         <module>camel-jbang-plugin-generate</module>
         <module>camel-jbang-plugin-edit</module>
         <module>camel-jbang-plugin-kubernetes</module>
+        <module>camel-jbang-launcher</module>
         <module>camel-jbang-it</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,8 @@
         <invoker.skip>${skipTests}</invoker.skip>
 
         <enforcer.phase>none</enforcer.phase><!-- We do not enforce with -Dquickly, the property is overridden in the full profile -->
+
+        <os.detected.classifier>${nisse.os.classifier}</os.detected.classifier>
     </properties>
 
     <!-- Comment out the snapshot repositories as we don't need them now -->


### PR DESCRIPTION
This PR implements a fat-jar launcher for Camel JBang that provides a pre-built distribution with all dependencies included. The launcher eliminates the two-step process where JBang first parses the .java file and then calls camel-jbang.

### Key changes:
- Created a new Maven module `camel-jbang-launcher`
- Implemented a simple launcher class that calls `CamelJBangMain.run()`
- Configured Maven Shade plugin to create a fat-jar with all dependencies
- Created shell and batch scripts for Unix/Linux and Windows
- Configured Maven Assembly plugin to create distribution archives
- Used properties for dependency versions instead of hardcoded values
- Placed scripts in the root folder of the distribution
- Added example files in the examples directory
- Fixed Maven dependency resolution by including all necessary dependencies

### Testing:
- Tested the fat-jar launcher with basic commands like `version` and `--help`
- Tested running Camel routes from YAML and Java files
- Verified that the distribution archive contains the correct files

This PR is in draft mode as it may need further refinement before being ready for review.
