### PR TITLE
Camel 22083 couchbase

### DIFF
--- a/components/camel-couchbase/src/main/java/org/apache/camel/component/couchbase/CouchbaseEndpoint.java
+++ b/components/camel-couchbase/src/main/java/org/apache/camel/component/couchbase/CouchbaseEndpoint.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.ClusterOptions;
+import com.couchbase.client.java.codec.DefaultJsonSerializer;
 import com.couchbase.client.java.env.ClusterEnvironment;
 import org.apache.camel.CamelException;
 import org.apache.camel.Category;
@@ -548,6 +549,7 @@ public class CouchbaseEndpoint extends ScheduledPollEndpoint implements Endpoint
         }
 
         ClusterEnvironment.Builder cfb = ClusterEnvironment.builder();
+        cfb.jsonSerializer(DefaultJsonSerializer.create());
         if (queryTimeout != DEFAULT_QUERY_TIMEOUT) {
             cfb.timeoutConfig()
                     .connectTimeout(Duration.ofMillis(connectTimeout))

--- a/test-infra/camel-test-infra-couchbase/pom.xml
+++ b/test-infra/camel-test-infra-couchbase/pom.xml
@@ -40,6 +40,11 @@
             <version>${project.version}</version>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>com.couchbase.client</groupId>
+            <artifactId>java-client</artifactId>
+            <version>${couchbase-client-version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/test-infra/camel-test-infra-couchbase/src/main/java/org/apache/camel/test/infra/couchbase/common/CouchbaseProperties.java
+++ b/test-infra/camel-test-infra-couchbase/src/main/java/org/apache/camel/test/infra/couchbase/common/CouchbaseProperties.java
@@ -23,6 +23,7 @@ public final class CouchbaseProperties {
     public static final String COUCHBASE_HOSTNAME = "couchbase.hostname";
     public static final String COUCHBASE_PORT = "couchbase.port";
     public static final String COUCHBASE_CONTAINER = "couchbase.container";
+    public static final String COUCHBASE_PROTOCOL = "couchbase.protocol";
 
     private CouchbaseProperties() {
 

--- a/test-infra/camel-test-infra-couchbase/src/main/java/org/apache/camel/test/infra/couchbase/services/CouchbaseInfraService.java
+++ b/test-infra/camel-test-infra-couchbase/src/main/java/org/apache/camel/test/infra/couchbase/services/CouchbaseInfraService.java
@@ -23,11 +23,35 @@ public interface CouchbaseInfraService extends InfrastructureService {
 
     String getConnectionString();
 
+    // Use username
+    @Deprecated
     String getUsername();
 
+    // Use password
+    @Deprecated
     String getPassword();
 
+    // Use hostname
+    @Deprecated
     String getHostname();
 
+    // Use port
+    @Deprecated
     int getPort();
+
+    String protocol();
+
+    String hostname();
+
+    int port();
+
+    String username();
+
+    String password();
+
+    String bucket();
+
+    String viewName();
+
+    String designDocumentName();
 }

--- a/test-infra/camel-test-infra-couchbase/src/main/java/org/apache/camel/test/infra/couchbase/services/CouchbaseRemoteInfraService.java
+++ b/test-infra/camel-test-infra-couchbase/src/main/java/org/apache/camel/test/infra/couchbase/services/CouchbaseRemoteInfraService.java
@@ -49,6 +49,48 @@ public class CouchbaseRemoteInfraService implements CouchbaseInfraService {
     }
 
     @Override
+    public String protocol() {
+        return System.getProperty(CouchbaseProperties.COUCHBASE_PROTOCOL, "http");
+    }
+
+    @Override
+    public String hostname() {
+        return System.getProperty(CouchbaseProperties.COUCHBASE_HOSTNAME);
+    }
+
+    @Override
+    public int port() {
+        String portValue = System.getProperty(CouchbaseProperties.COUCHBASE_PORT, "8091");
+
+        return Integer.parseInt(portValue);
+    }
+
+    @Override
+    public String username() {
+        return System.getProperty(CouchbaseProperties.COUCHBASE_USERNAME, "Administrator");
+    }
+
+    @Override
+    public String password() {
+        return System.getProperty(CouchbaseProperties.COUCHBASE_PASSWORD);
+    }
+
+    @Override
+    public String bucket() {
+        throw new IllegalArgumentException("CouchbaseRemoteInfraService does not support bucket creation");
+    }
+
+    @Override
+    public String viewName() {
+        throw new IllegalArgumentException("CouchbaseRemoteInfraService does not support view creation");
+    }
+
+    @Override
+    public String designDocumentName() {
+        throw new IllegalArgumentException("CouchbaseRemoteInfraService does not support design document creation");
+    }
+
+    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseServiceFactory.java
+++ b/test-infra/camel-test-infra-couchbase/src/test/java/org/apache/camel/test/infra/couchbase/services/CouchbaseServiceFactory.java
@@ -50,6 +50,46 @@ public final class CouchbaseServiceFactory {
         public int getPort() {
             return getService().getPort();
         }
+
+        @Override
+        public String protocol() {
+            return getService().protocol();
+        }
+
+        @Override
+        public String hostname() {
+            return getService().hostname();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+
+        @Override
+        public String username() {
+            return getService().username();
+        }
+
+        @Override
+        public String password() {
+            return getService().password();
+        }
+
+        @Override
+        public String bucket() {
+            return getService().bucket();
+        }
+
+        @Override
+        public String viewName() {
+            return getService().viewName();
+        }
+
+        @Override
+        public String designDocumentName() {
+            return getService().designDocumentName();
+        }
     }
 
     private CouchbaseServiceFactory() {


### PR DESCRIPTION
Output from `camel infra run couchbase`

```
{
  "bucket" : "myBucket",
  "designDocumentName" : "myDesignDocument",
  "getConnectionString" : "couchbase://localhost:11210",
  "getHostname" : "localhost",
  "getPassword" : "password",
  "getPort" : 8091,
  "getUsername" : "Administrator",
  "hostname" : "localhost",
  "password" : "password",
  "port" : 8091,
  "protocol" : "http",
  "username" : "Administrator",
  "viewName" : "myView"
}
```

Route used for test

```
///usr/bin/env jbang "$0" "$@" ; exit $?
//DEPS org.apache.camel:camel-couchbase:4.12.0-SNAPSHOT

import org.apache.camel.builder.RouteBuilder;
import org.apache.camel.Exchange;

public class MyRoute extends RouteBuilder {

    @Override
    public void configure() throws Exception {
        from("timer:java?period=1000&includeMetadata=true")
                .setBody()
                    .simple("Hello Camel from ${routeId}")
                .setHeader(org.apache.camel.component.couchbase.CouchbaseConstants.HEADER_ID, simple("SimpleDocument_${header.CamelMessageTimestamp}"))
                .to("couchbase:http://localhost:8091?username=Administrator&password=password&bucket=myBucket");

        from("couchbase:http://localhost:8091?username=Administrator&password=password&bucket=myBucket&viewName=myView&designDocumentName=myDesignDocument")
                .log("${headers}")
                .log("${body}");
    }
}
```

This https://github.com/apache/camel/commit/ea69a4cc032d6ebbab9e8bf77c09b32f22009429 is a workaround due to https://issues.apache.org/jira/browse/CAMEL-22090