### PR TITLE
CAMEL-22087: Make name and port camel CLI option working on CSB and CEQ

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -115,6 +115,10 @@ public abstract class ExportBaseCommand extends CamelCommand {
                         description = "The integration name. Use this when the name should not get derived otherwise.")
     protected String name;
 
+    @CommandLine.Option(names = { "--port" },
+                        description = "Embeds a local HTTP server on this port", defaultValue = "8080")
+    int port;
+
     @CommandLine.Option(names = { "--gav" }, description = "The Maven group:artifact:version")
     protected String gav;
 
@@ -335,6 +339,8 @@ public abstract class ExportBaseCommand extends CamelCommand {
         // need to declare the profile to use for run
         run.dependencies = dependencies;
         run.files = files;
+        run.name = name;
+        run.port = port;
         run.excludes = excludes;
         run.openapi = openapi;
         run.download = download;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
@@ -105,6 +105,14 @@ class ExportQuarkus extends Export {
             if (!hasModeline(settings)) {
                 prop.remove("camel.main.modeline");
             }
+            // are we using http then enable embedded HTTP server (if not explicit configured already)
+            int port = httpServerPort(settings);
+            if (port == -1) {
+                port = 8080;
+            }
+            if (port != -1 && port != 8080) {
+                prop.put("quarkus.http.port", port);
+            }
             return prop;
         });
         // copy docker files

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
@@ -120,6 +120,14 @@ class ExportSpringBoot extends Export {
             if (!http) {
                 prop.put("camel.springboot.main-run-controller", "true");
             }
+            // are we using http then enable embedded HTTP server (if not explicit configured already)
+            int port = httpServerPort(settings);
+            if (port == -1 && http) {
+                port = 8080;
+            }
+            if (port != -1 && port != 8080) {
+                prop.put("server.port", port);
+            }
             return prop;
         });
         if ("maven".equals(buildTool)) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -1030,6 +1030,8 @@ public class Run extends CamelCommand {
         eq.filePaths = this.filePaths;
         eq.files = this.files;
         eq.name = this.name;
+        eq.verbose = this.verbose;
+        eq.port = this.port;
         eq.gav = this.gav;
         if (eq.gav == null) {
             if (eq.name == null) {
@@ -1111,6 +1113,8 @@ public class Run extends CamelCommand {
         eq.filePaths = this.filePaths;
         eq.files = this.files;
         eq.name = this.name;
+        eq.verbose = this.verbose;
+        eq.port = this.port;
         eq.gav = this.gav;
         eq.repositories = this.repositories;
         if (eq.gav == null) {


### PR DESCRIPTION
# Description

This should fix https://issues.apache.org/jira/browse/CAMEL-22087

`--verbose` option should be fixed too

# Target

- [main] 

