### PR TITLE
Align spring* versions to the versions used in spring-boot 3.4.6

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -464,12 +464,12 @@
         <splunk-version>1.9.5_1</splunk-version>
         <spock-version>2.3-groovy-4.0</spock-version>
         <spring-batch-version>5.2.2</spring-batch-version>
-        <spring-data-redis-version>3.4.5</spring-data-redis-version>
+        <spring-data-redis-version>3.4.6</spring-data-redis-version>
         <spring-ldap-version>3.2.12</spring-ldap-version>
-        <spring-vault-core-version>3.1.2</spring-vault-core-version>
+        <spring-vault-core-version>3.1.3</spring-vault-core-version>
         <spring-version>6.2.7</spring-version>
-        <spring-rabbitmq-version>3.2.4</spring-rabbitmq-version>
-        <spring-security-version>6.4.5</spring-security-version>
+        <spring-rabbitmq-version>3.2.5</spring-rabbitmq-version>
+        <spring-security-version>6.4.6</spring-security-version>
         <spring-ws-version>4.0.13</spring-ws-version>
         <sql-maven-plugin-version>3.0.0</sql-maven-plugin-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>


### PR DESCRIPTION
# Description

This commit on camel-spring-boot-4.10.x upgraded spring-boot to 3.4.6 - https://github.com/apache/camel-spring-boot/commit/71af2bb0c679920ead0ff12aae8b16c64859a6d3 

Align the spring-* versions in camel to the versions used in spring-boot 3.4.6