### PR TITLE
CAMEL-21087: Add jolokia trait to Camel Jbang Kubernetes plugin

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
@@ -1222,6 +1222,110 @@ spec:
 <6> Service Resource reference
 
 
+=== Jolokia trait options
+
+The Jolokia trait enhances the Kubernetes manifest enabling JMX access to Camel application. This requires jolokia being configured in the Camel Application.
+
+The Jolokia trait provides the following configuration options:
+
+[cols="2m,1m,5a"]
+|===
+|Property | Type | Description
+
+| jolokia.enabled
+| bool
+| Can be used to enable or disable a trait. All traits share this common property. (default `false`).
+
+| jolokia.container-port
+| int
+| To configure a different jolokia port exposed by the container (default `8778`).
+
+| jolokia.container-port-name
+| string
+| To configure a different port name for the port exposed by the container (default `jolokia`).
+
+| jolokia.expose
+| bool
+| Can be used to enable/disable exposure of jolokia via kubernetes Service. (default `false`).
+
+| jolokia.service-port
+| int
+| To configure a different jolokia port exposed by the service (default `8778`). It is applied only when the expose parameter is true.
+
+| jolokia.service-port-name
+| string
+| To configure a different port name for the port exposed by the service (default `jolokia`). It is applied only when the expose parameter is true.
+
+
+|===
+
+The syntax to specify jolokia trait options is as follows:
+
+[source,bash]
+----
+camel kubernetes export Sample.java --trait jolokia.[key]=[value]
+----
+
+You may specify these options with the export command to customize the Container and Service Resource specification for Jolokia.
+
+[source,bash]
+----
+camel kubernetes export Sample.java --trait jolokia.enabled=true --trait jolokia.container-port=8779 --trait jolokia.container-port-name=jolokia-port --trait jolokia.expose=true --trait jolokia.service-port=8779 --trait jolokia.service-port-name=port-jolokia
+----
+
+This results in the following specifications in the Deployment and Service resources.
+
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  ...
+  name: sample
+spec:
+  selector:
+  ...
+  template:
+  ...
+    spec:
+      containers:
+      - name: sample
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 8779 #<1>
+          name: jolokia-port #<2>
+          protocol: TCP
+...
+----
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+...
+  name: sample
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+  - name: jolokia-port #<3>
+    port: 8779 #<4>
+    protocol: TCP
+    targetPort: jolokia-port #<2>
+...
+----
+
+<1> Custom Jolokia container port
+<2> Custom Jolokia container port name
+<3> Custom Jolokia service port name
+<4> Custom Jolokia service port
+
+
 === OpenApi specifications
 
 You can mount OpenAPI specifications to the application container with this trait.

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/JolokiaTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/JolokiaTrait.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.kubernetes.traits;
+
+import java.util.Optional;
+
+import io.fabric8.kubernetes.api.model.IntOrString;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Jolokia;
+import org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model.Traits;
+
+public class JolokiaTrait extends BaseTrait {
+    public static final int JolokiaTrait = 1800;
+
+    public static final int DEFAULT_JOLOKIA_PORT = 8778;
+    public static final String DEFAULT_JOLOKIA_PORT_NAME = "jolokia";
+    public static final String DEFAULT_JOLOKIA_PORT_PROTOCOL = "TCP";
+
+    public JolokiaTrait() {
+        super("jolokia", JolokiaTrait);
+    }
+
+    @Override
+    public boolean configure(Traits traitConfig, TraitContext context) {
+        // must be explicitly enabled
+        if (traitConfig.getJolokia() == null) {
+            return false;
+        } else {
+            return Optional.ofNullable(traitConfig.getJolokia().getEnabled()).orElse(false);
+        }
+    }
+
+    @Override
+    public void apply(Traits traitConfig, TraitContext context) {
+        Jolokia jolokiaTrait = Optional.ofNullable(traitConfig.getJolokia()).orElseGet(Jolokia::new);
+
+        context.doWithDeployments(
+                d -> d.editSpec()
+                        .editTemplate()
+                        .editSpec()
+                        .editFirstContainer()
+                        .addNewPort()
+                        .withName(Optional.ofNullable(jolokiaTrait.getContainerPortName()).orElse(DEFAULT_JOLOKIA_PORT_NAME))
+                        .withContainerPort(Optional.ofNullable(jolokiaTrait.getContainerPort()).map(Long::intValue)
+                                .orElse(DEFAULT_JOLOKIA_PORT))
+                        .withProtocol(DEFAULT_JOLOKIA_PORT_PROTOCOL)
+                        .endPort()
+                        .endContainer()
+                        .endSpec()
+                        .endTemplate()
+                        .endSpec());
+        context.doWithKnativeServices(
+                s -> s.editSpec()
+                        .editTemplate()
+                        .editSpec()
+                        .editFirstContainer()
+                        .addNewPort()
+                        .withName(Optional.ofNullable(jolokiaTrait.getContainerPortName()).orElse(DEFAULT_JOLOKIA_PORT_NAME))
+                        .withContainerPort(Optional.ofNullable(jolokiaTrait.getContainerPort()).map(Long::intValue)
+                                .orElse(DEFAULT_JOLOKIA_PORT))
+                        .withProtocol(DEFAULT_JOLOKIA_PORT_PROTOCOL)
+                        .endPort()
+                        .endContainer()
+                        .endSpec()
+                        .endTemplate()
+                        .endSpec());
+        context.doWithServices(
+                s -> s.editSpec()
+                        .addNewPort()
+                        .withName(Optional.ofNullable(jolokiaTrait.getServicePortName()).orElse(DEFAULT_JOLOKIA_PORT_NAME))
+                        .withPort(Optional.ofNullable(jolokiaTrait.getServicePort()).map(Long::intValue)
+                                .orElse(DEFAULT_JOLOKIA_PORT))
+                        .withTargetPort(new IntOrString(
+                                Optional.ofNullable(jolokiaTrait.getContainerPortName()).orElse(DEFAULT_JOLOKIA_PORT_NAME)))
+                        .endPort()
+                        .endSpec());
+
+    }
+
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitCatalog.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitCatalog.java
@@ -51,6 +51,7 @@ public class TraitCatalog {
         register(new LabelTrait());
         register(new AnnotationTrait());
         register(new CamelTrait());
+        register(new JolokiaTrait());
     }
 
     public List<Trait> allTraits() {

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/model/Jolokia.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/model/Jolokia.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+        "enabled", "containerPort", "containerPortName", "expose", "servicePort", "servicePortName" })
+public class Jolokia {
+    @JsonProperty("enabled")
+    @JsonPropertyDescription("Can be used to enable or disable a trait.")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Boolean enabled;
+    @JsonProperty("containerPort")
+    @JsonPropertyDescription("To configure a different jolokia port exposed by the container (default `8778`).")
+    @JsonSetter(
+                nulls = Nulls.SKIP)
+    private Long containerPort;
+    @JsonProperty("containerPortName")
+    @JsonPropertyDescription("To configure a different jolokia port name for the port exposed by the container. It defaults to `jolokia`.")
+    @JsonSetter(
+                nulls = Nulls.SKIP)
+    private String containerPortName;
+    @JsonProperty("expose")
+    @JsonPropertyDescription("Can be used to enable/disable jolokia exposure via kubernetes Service. Requires Service to be enabled to be applicable.")
+    @JsonSetter(
+                nulls = Nulls.SKIP)
+    private Boolean expose;
+    @JsonProperty("servicePort")
+    @JsonPropertyDescription("To configure a different jolokia port exposed by the service (default `8778`).")
+    @JsonSetter(
+                nulls = Nulls.SKIP)
+    private Long servicePort;
+    @JsonProperty("servicePortName")
+    @JsonPropertyDescription("To configure a different jolokia port name for the port exposed by the service. It defaults to `jolokia`.")
+    @JsonSetter(
+                nulls = Nulls.SKIP)
+    private String servicePortName;
+
+    public Jolokia() {
+    }
+
+    public Boolean getEnabled() {
+        return this.enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Long getContainerPort() {
+        return this.containerPort;
+    }
+
+    public void setContainerPort(Long port) {
+        this.containerPort = port;
+    }
+
+    public String getContainerPortName() {
+        return this.containerPortName;
+    }
+
+    public void setContainerPortName(String portName) {
+        this.containerPortName = portName;
+    }
+
+    public Boolean getExpose() {
+        return this.expose;
+    }
+
+    public void setExpose(Boolean expose) {
+        this.expose = expose;
+    }
+
+    public Long getServicePort() {
+        return this.servicePort;
+    }
+
+    public void setServicePort(Long port) {
+        this.servicePort = port;
+    }
+
+    public String getServicePortName() {
+        return this.servicePortName;
+    }
+
+    public void setServicePortName(String portName) {
+        this.servicePortName = portName;
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/model/JolokiaBuilder.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/model/JolokiaBuilder.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.kubernetes.traits.model;
+
+public final class JolokiaBuilder {
+    private Boolean enabled;
+    private Long containerPort;
+    private String containerPortName;
+    private Boolean expose;
+    private Long servicePort;
+    private String servicePortName;
+
+    private JolokiaBuilder() {
+    }
+
+    public static JolokiaBuilder jolokia() {
+        return new JolokiaBuilder();
+    }
+
+    public JolokiaBuilder withEnabled(Boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public JolokiaBuilder withContainerPort(Long port) {
+        this.containerPort = port;
+        return this;
+    }
+
+    public JolokiaBuilder withContainerPortName(String portName) {
+        this.containerPortName = portName;
+        return this;
+    }
+
+    public JolokiaBuilder withExpose(Boolean expose) {
+        this.expose = expose;
+        return this;
+    }
+
+    public JolokiaBuilder withServicePort(Long port) {
+        this.servicePort = port;
+        return this;
+    }
+
+    public JolokiaBuilder withServicePortName(String portName) {
+        this.servicePortName = portName;
+        return this;
+    }
+
+    public Jolokia build() {
+        Jolokia jolokia = new Jolokia();
+        jolokia.setEnabled(enabled);
+        jolokia.setContainerPort(containerPort);
+        jolokia.setContainerPortName(containerPortName);
+        jolokia.setExpose(expose);
+        jolokia.setServicePort(servicePort);
+        jolokia.setServicePortName(servicePortName);
+        return jolokia;
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/model/Traits.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/model/Traits.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.Nulls;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
         "camel", "container", "environment", "ingress", "knative", "knative-service", "mount", "openapi", "pod", "route",
-        "service", "service-binding" })
+        "service", "service-binding", "jolokia" })
 public class Traits {
 
     @JsonProperty("addons")
@@ -86,10 +86,16 @@ public class Traits {
     @JsonPropertyDescription("The configuration of Service trait")
     @JsonSetter(nulls = Nulls.SKIP)
     private Service service;
+
     @JsonProperty("service-binding")
     @JsonPropertyDescription("The configuration of Service Binding trait")
     @JsonSetter(nulls = Nulls.SKIP)
     private ServiceBinding serviceBinding;
+
+    @JsonProperty("jolokia")
+    @JsonPropertyDescription("The configuration of Jolokia trait")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Jolokia jolokia;
 
     public Map<String, Addons> getAddons() {
         return this.addons;
@@ -169,6 +175,14 @@ public class Traits {
 
     public void setRoute(Route route) {
         this.route = route;
+    }
+
+    public Jolokia getJolokia() {
+        return jolokia;
+    }
+
+    public void setJolokia(Jolokia jolokia) {
+        this.jolokia = jolokia;
     }
 
     public Service getService() {


### PR DESCRIPTION
# Description

Add the Jolokia trait to allow to enrich the kubernetes manifests. It exposes the Jolokia port in the Container and Service.

# Target

- [X] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

