### PR TITLE
fix: deactivate ElasticSearch IT tests on ppc64le

### DIFF
--- a/components/camel-elasticsearch/pom.xml
+++ b/components/camel-elasticsearch/pom.xml
@@ -35,6 +35,8 @@
     <properties>
         <!-- Elasticsearch container is not available on these platforms -->
         <skipITs.s390x>true</skipITs.s390x>
+        <!-- The image for ElasticSearch 9.x for ppc64le architecture is not yet available -->
+        <skipITs.ppc64le>true</skipITs.ppc64le>
 
         <camel.surefire.reuseForks>false</camel.surefire.reuseForks>
     </properties>

--- a/test-infra/camel-test-infra-elasticsearch/src/main/resources/org/apache/camel/test/infra/elasticsearch/services/container.properties
+++ b/test-infra/camel-test-infra-elasticsearch/src/main/resources/org/apache/camel/test/infra/elasticsearch/services/container.properties
@@ -15,4 +15,5 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 elasticsearch.container=docker.elastic.co/elasticsearch/elasticsearch:9.0.1
+# IT tests are currently deactivated on ppc64le until  an image for 9.x is available
 elasticsearch.container.ppc64le=icr.io/ppc64le-oss/elasticsearch-ppc64le:8.3.3


### PR DESCRIPTION
ElasticSearch has been upgraded to 9.x but the image on ppc64le is not yet available.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

