### PR TITLE
CAMEL-22116 and CAMEL-22117: camel-openapi-validator fixes

### DIFF
--- a/components/camel-openapi-validator/src/main/java/org/apache/camel/component/rest/openapi/validator/client/OpenApiRestClientRequestValidator.java
+++ b/components/camel-openapi-validator/src/main/java/org/apache/camel/component/rest/openapi/validator/client/OpenApiRestClientRequestValidator.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.rest.openapi.validator.client;
 
+import java.util.Map.Entry;
+
 import com.atlassian.oai.validator.OpenApiInteractionValidator;
 import com.atlassian.oai.validator.model.SimpleRequest;
 import com.atlassian.oai.validator.report.JsonValidationReportFormat;
@@ -62,6 +64,28 @@ public class OpenApiRestClientRequestValidator implements RestClientRequestValid
         }
         if (body != null) {
             builder.withBody(body);
+        }
+        // Use all non-Camel headers
+        for (Entry<String, Object> header : exchange.getMessage().getHeaders().entrySet()) {
+            boolean isCamelHeader = header.getKey().startsWith("Camel")
+                    || header.getKey().startsWith("camel")
+                    || header.getKey().startsWith("org.apache.camel.");
+            if (!isCamelHeader) {
+                builder.withHeader(header.getKey(), header.getValue().toString());
+            }
+        }
+        // Use query parameters, if present
+        String query = exchange.getMessage().getHeader(Exchange.HTTP_QUERY, String.class);
+        if (query != null) {
+            String[] params = query.split("&");
+            for (String param : params) {
+                String[] keyValue = param.split("=");
+                if (keyValue.length == 2) {
+                    builder.withQueryParam(keyValue[0], keyValue[1]);
+                } else if (keyValue.length == 1) {
+                    builder.withQueryParam(keyValue[0], "");
+                }
+            }
         }
 
         OpenApiInteractionValidator validator = OpenApiInteractionValidator.createFor(openAPI).build();

--- a/components/camel-openapi-validator/src/test/java/org/apache/camel/component/rest/openapi/validator/client/OpenApiRestClientRequestValidatorTest.java
+++ b/components/camel-openapi-validator/src/test/java/org/apache/camel/component/rest/openapi/validator/client/OpenApiRestClientRequestValidatorTest.java
@@ -16,10 +16,11 @@
  */
 package org.apache.camel.component.rest.openapi.validator.client;
 
+import java.io.IOException;
+
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
-import java.io.IOException;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.RestClientRequestValidator;
 import org.apache.camel.test.junit5.ExchangeTestSupport;
@@ -75,8 +76,8 @@ public class OpenApiRestClientRequestValidatorTest extends ExchangeTestSupport {
         exchange.getMessage().setBody("");
 
         RestClientRequestValidator.ValidationError error
-            = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
-            "application/json", "application/json", true, null, null, null, null));
+                = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
+                        "application/json", "application/json", true, null, null, null, null));
 
         Assertions.assertNotNull(error);
         Assertions.assertTrue(error.body().contains("Query parameter 'status' is required"));
@@ -84,7 +85,7 @@ public class OpenApiRestClientRequestValidatorTest extends ExchangeTestSupport {
         exchange.getMessage().setHeader(Exchange.HTTP_QUERY, "status=available");
 
         error = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
-            "application/json", "application/json", true, null, null, null, null));
+                "application/json", "application/json", true, null, null, null, null));
         Assertions.assertNull(error);
     }
 
@@ -98,8 +99,8 @@ public class OpenApiRestClientRequestValidatorTest extends ExchangeTestSupport {
         exchange.getMessage().setBody("");
 
         RestClientRequestValidator.ValidationError error
-            = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
-            "application/json", "application/json", true, null, null, null, null));
+                = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
+                        "application/json", "application/json", true, null, null, null, null));
 
         Assertions.assertNotNull(error);
         Assertions.assertTrue(error.body().contains("Header parameter 'tags' is required"));
@@ -107,7 +108,7 @@ public class OpenApiRestClientRequestValidatorTest extends ExchangeTestSupport {
         exchange.getMessage().setHeader("tags", "dog");
 
         error = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
-            "application/json", "application/json", true, null, null, null, null));
+                "application/json", "application/json", true, null, null, null, null));
         Assertions.assertNull(error);
     }
 
@@ -123,8 +124,8 @@ public class OpenApiRestClientRequestValidatorTest extends ExchangeTestSupport {
         exchange.getMessage().setBody("{ some body here }");
 
         RestClientRequestValidator.ValidationError error
-            = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
-            "application/json", "application/json", true, null, null, null, null));
+                = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
+                        "application/json", "application/json", true, null, null, null, null));
         Assertions.assertNull(error);
     }
 }

--- a/components/camel-openapi-validator/src/test/java/org/apache/camel/component/rest/openapi/validator/client/OpenApiRestClientRequestValidatorTest.java
+++ b/components/camel-openapi-validator/src/test/java/org/apache/camel/component/rest/openapi/validator/client/OpenApiRestClientRequestValidatorTest.java
@@ -66,6 +66,52 @@ public class OpenApiRestClientRequestValidatorTest extends ExchangeTestSupport {
     }
 
     @Test
+    public void testValidateQueryParam() {
+        exchange.setProperty(Exchange.REST_OPENAPI, openAPI);
+        exchange.setProperty(Exchange.CONTENT_TYPE, "application/json");
+        exchange.getMessage().setHeader(Exchange.HTTP_METHOD, "GET");
+        exchange.getMessage().setHeader(Exchange.HTTP_PATH, "pet/findByStatus");
+        exchange.getMessage().setHeader("Accept", "application/json");
+        exchange.getMessage().setBody("");
+
+        RestClientRequestValidator.ValidationError error
+            = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
+            "application/json", "application/json", true, null, null, null, null));
+
+        Assertions.assertNotNull(error);
+        Assertions.assertTrue(error.body().contains("Query parameter 'status' is required"));
+
+        exchange.getMessage().setHeader(Exchange.HTTP_QUERY, "status=available");
+
+        error = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
+            "application/json", "application/json", true, null, null, null, null));
+        Assertions.assertNull(error);
+    }
+
+    @Test
+    public void testValidateHeader() {
+        exchange.setProperty(Exchange.REST_OPENAPI, openAPI);
+        exchange.setProperty(Exchange.CONTENT_TYPE, "application/json");
+        exchange.getMessage().setHeader(Exchange.HTTP_METHOD, "GET");
+        exchange.getMessage().setHeader(Exchange.HTTP_PATH, "pet/findByTags");
+        exchange.getMessage().setHeader("Accept", "application/json");
+        exchange.getMessage().setBody("");
+
+        RestClientRequestValidator.ValidationError error
+            = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
+            "application/json", "application/json", true, null, null, null, null));
+
+        Assertions.assertNotNull(error);
+        Assertions.assertTrue(error.body().contains("Header parameter 'tags' is required"));
+
+        exchange.getMessage().setHeader("tags", "dog");
+
+        error = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
+            "application/json", "application/json", true, null, null, null, null));
+        Assertions.assertNull(error);
+    }
+
+    @Test
     public void testEmptyPathHeader() {
         exchange.setProperty(Exchange.REST_OPENAPI, openAPI);
         exchange.setProperty(Exchange.CONTENT_TYPE, "application/json");

--- a/components/camel-openapi-validator/src/test/resources/petstore-v3.json
+++ b/components/camel-openapi-validator/src/test/resources/petstore-v3.json
@@ -180,7 +180,7 @@
             "name": "status",
             "in": "query",
             "description": "Status values that need to be considered for filter",
-            "required": false,
+            "required": true,
             "explode": true,
             "schema": {
               "type": "string",
@@ -240,9 +240,9 @@
         "parameters": [
           {
             "name": "tags",
-            "in": "query",
+            "in": "header",
             "description": "Tags to filter by",
-            "required": false,
+            "required": true,
             "explode": true,
             "schema": {
               "type": "array",


### PR DESCRIPTION
# Description

## Fix for CAMEL-22116

camel-openapi-validator is broken with a contract-first api's, due to CamelHttpPath being set to ''. This fix computes the path from HTTP_URI and CamelPlatformHttpContextPath, if not correctly set.

## Fix for CAMEL-22117

camel-openapi-validator fails validating query params and headers. This fix includes query params and headers in the validation context.

# Target

- [X] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.
