### PR TITLE
[CAMEL-21862] camel-spring-boot - Remove deprecated camel.springboot. config prefix

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
@@ -118,7 +118,7 @@ class ExportSpringBoot extends Export {
             // ensure spring-boot keeps running if no HTTP server included
             boolean http = deps.stream().anyMatch(s -> s.contains("mvn:org.apache.camel:camel-platform-http"));
             if (!http) {
-                prop.put("camel.springboot.main-run-controller", "true");
+                prop.put("camel.main.run-controller", "true");
             }
             // are we using http then enable embedded HTTP server (if not explicit configured already)
             int port = httpServerPort(settings);

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
@@ -391,8 +391,8 @@ class ExportTest {
                         "should not contain camel.main.routes-include-pattern property, was " + content);
             }
             if (rt == RuntimeType.springBoot) {
-                Assertions.assertTrue(content.contains("camel.springboot.main-run-controller=true"),
-                        "should contain camel.springboot.main-run-controller property, was " + content);
+                Assertions.assertTrue(content.contains("camel.main.run-controller=true"),
+                        "should contain camel.main.run-controller property, was " + content);
             }
         }
     }


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-21862

Together with https://github.com/apache/camel-spring-boot-examples/pull/158 
and 
