### PR TITLE
CAMEL-22117: Include query params and headers in validation context.

### DIFF
--- a/components/camel-openapi-validator/src/main/java/org/apache/camel/component/rest/openapi/validator/client/OpenApiRestClientRequestValidator.java
+++ b/components/camel-openapi-validator/src/main/java/org/apache/camel/component/rest/openapi/validator/client/OpenApiRestClientRequestValidator.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.component.rest.openapi.validator.client;
 
-import java.util.Map.Entry;
-
 import com.atlassian.oai.validator.OpenApiInteractionValidator;
 import com.atlassian.oai.validator.model.SimpleRequest;
 import com.atlassian.oai.validator.report.JsonValidationReportFormat;
@@ -57,12 +55,9 @@ public class OpenApiRestClientRequestValidator implements RestClientRequestValid
             builder.withBody(body);
         }
         // Use all non-Camel headers
-        for (Entry<String, Object> header : exchange.getMessage().getHeaders().entrySet()) {
-            boolean isCamelHeader = header.getKey().startsWith("Camel")
-                    || header.getKey().startsWith("camel")
-                    || header.getKey().startsWith("org.apache.camel.");
-            if (!isCamelHeader) {
-                builder.withHeader(header.getKey(), header.getValue().toString());
+        for (String header : exchange.getMessage().getHeaders().keySet()) {
+            if (!startsWithIgnoreCase(header, "Camel")) {
+                builder.withHeader(header, exchange.getMessage().getHeader(header, String.class));
             }
         }
         // Use query parameters, if present
@@ -93,4 +88,7 @@ public class OpenApiRestClientRequestValidator implements RestClientRequestValid
         return null;
     }
 
+    boolean startsWithIgnoreCase(String s, String prefix) {
+        return s.regionMatches(true, 0, prefix, 0, prefix.length());
+    }
 }

--- a/components/camel-openapi-validator/src/test/java/org/apache/camel/component/rest/openapi/validator/client/OpenApiRestClientRequestValidatorTest.java
+++ b/components/camel-openapi-validator/src/test/java/org/apache/camel/component/rest/openapi/validator/client/OpenApiRestClientRequestValidatorTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.rest.openapi.validator.client;
 
+import java.io.IOException;
+
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
@@ -24,25 +26,31 @@ import org.apache.camel.spi.RestClientRequestValidator;
 import org.apache.camel.test.junit5.ExchangeTestSupport;
 import org.apache.camel.util.IOHelper;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class OpenApiRestClientRequestValidatorTest extends ExchangeTestSupport {
 
-    @Test
-    public void testValidator() throws Exception {
+    static OpenAPI openAPI;
+    static OpenApiRestClientRequestValidator validator;
+
+    @BeforeAll
+    static void setup() throws IOException {
         String data = IOHelper.loadText(OpenApiRestClientRequestValidatorTest.class.getResourceAsStream("/petstore-v3.json"));
         OpenAPIV3Parser parser = new OpenAPIV3Parser();
         SwaggerParseResult out = parser.readContents(data);
-        OpenAPI openAPI = out.getOpenAPI();
+        openAPI = out.getOpenAPI();
+        validator = new OpenApiRestClientRequestValidator();
+    }
 
+    @Test
+    public void testValidateBody() {
         exchange.setProperty(Exchange.REST_OPENAPI, openAPI);
         exchange.setProperty(Exchange.CONTENT_TYPE, "application/json");
         exchange.getMessage().setHeader(Exchange.HTTP_METHOD, "PUT");
         exchange.getMessage().setHeader(Exchange.HTTP_PATH, "pet");
         exchange.getMessage().setHeader("Accept", "application/json");
         exchange.getMessage().setBody("");
-
-        OpenApiRestClientRequestValidator validator = new OpenApiRestClientRequestValidator();
 
         RestClientRequestValidator.ValidationError error
                 = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
@@ -52,6 +60,52 @@ public class OpenApiRestClientRequestValidatorTest extends ExchangeTestSupport {
         Assertions.assertTrue(error.body().contains("A request body is required but none found"));
 
         exchange.getMessage().setBody("{ some body here }");
+
+        error = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
+                "application/json", "application/json", true, null, null, null, null));
+        Assertions.assertNull(error);
+    }
+
+    @Test
+    public void testValidateQueryParam() {
+        exchange.setProperty(Exchange.REST_OPENAPI, openAPI);
+        exchange.setProperty(Exchange.CONTENT_TYPE, "application/json");
+        exchange.getMessage().setHeader(Exchange.HTTP_METHOD, "GET");
+        exchange.getMessage().setHeader(Exchange.HTTP_PATH, "pet/findByStatus");
+        exchange.getMessage().setHeader("Accept", "application/json");
+        exchange.getMessage().setBody("");
+
+        RestClientRequestValidator.ValidationError error
+                = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
+                        "application/json", "application/json", true, null, null, null, null));
+
+        Assertions.assertNotNull(error);
+        Assertions.assertTrue(error.body().contains("Query parameter 'status' is required"));
+
+        exchange.getMessage().setHeader(Exchange.HTTP_QUERY, "status=available");
+
+        error = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
+                "application/json", "application/json", true, null, null, null, null));
+        Assertions.assertNull(error);
+    }
+
+    @Test
+    public void testValidateHeader() {
+        exchange.setProperty(Exchange.REST_OPENAPI, openAPI);
+        exchange.setProperty(Exchange.CONTENT_TYPE, "application/json");
+        exchange.getMessage().setHeader(Exchange.HTTP_METHOD, "GET");
+        exchange.getMessage().setHeader(Exchange.HTTP_PATH, "pet/findByTags");
+        exchange.getMessage().setHeader("Accept", "application/json");
+        exchange.getMessage().setBody("");
+
+        RestClientRequestValidator.ValidationError error
+                = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
+                        "application/json", "application/json", true, null, null, null, null));
+
+        Assertions.assertNotNull(error);
+        Assertions.assertTrue(error.body().contains("Header parameter 'tags' is required"));
+
+        exchange.getMessage().setHeader("tags", "dog");
 
         error = validator.validate(exchange, new RestClientRequestValidator.ValidationContext(
                 "application/json", "application/json", true, null, null, null, null));

--- a/components/camel-openapi-validator/src/test/resources/petstore-v3.json
+++ b/components/camel-openapi-validator/src/test/resources/petstore-v3.json
@@ -180,7 +180,7 @@
             "name": "status",
             "in": "query",
             "description": "Status values that need to be considered for filter",
-            "required": false,
+            "required": true,
             "explode": true,
             "schema": {
               "type": "string",
@@ -240,9 +240,9 @@
         "parameters": [
           {
             "name": "tags",
-            "in": "query",
+            "in": "header",
             "description": "Tags to filter by",
-            "required": false,
+            "required": true,
             "explode": true,
             "schema": {
               "type": "array",


### PR DESCRIPTION
# Description

Fix for CAMEL-22117: camel-openapi-validator doesn't use query params or headers for validation

# Target

- [X] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.