### PR TITLE
Fix several Camel Jbang functionalities on Windows when classpath url is

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_12.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_12.adoc
@@ -236,10 +236,17 @@ The `camel-jetty-starter` has been deprecated in favor of `camel-platform-http-s
 
 The `camel-undertow-starter` has been deprecated in favor of `camel-platform-http-starter` to use the HTTP server from Spring Boot.
 
-
 == camel-langchain4j-tokenizer
 
 The code was upgraded to LangChain4j version 1.0.0, which brings a few breaking changes:
 
 - By default, tokenization now uses segment sizes
 - To tokenize by tokens, the model used in the system must be provided
+
+== Known regressions
+
+On Windows, Camel Jbang export is no more working out of the box. A workaround consists in providing `--maven-wrapper=false`.
+
+On Windows, when using an URL starting with `classpath:` with Camel JBang, most of the actions are not working.
+
+Both are fixed in Camel 4.13.

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -1871,9 +1871,11 @@ public class Run extends CamelCommand {
         }
 
         // skip dirs
-        Path path = Paths.get(name);
-        if (Files.exists(path) && Files.isDirectory(path)) {
-            return true;
+        if (!name.startsWith("classpath:")) {
+            Path path = Path.of(name);
+            if (Files.exists(path) && Files.isDirectory(path)) {
+                return true;
+            }
         }
 
         if (FileUtil.onlyExt(name) == null) {


### PR DESCRIPTION
used

* Checking if the path starts with classpath: before using it with Path.of
* Use Path.of instead of Paths.get as the javadoc is recommending it this way

it allows to get down from 34 failures and 2 errors to 2 errors and 2 failures on Windows

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

