### PR TITLE
Fix Camel Jbang TransformTest on Windows

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -1571,7 +1571,7 @@ public class Run extends CamelCommand {
 
         // cleanup and delete log file
         if (logFile != null) {
-            Files.deleteIfExists(logFile);
+            FileUtil.deleteFile(logFile);
         }
 
         return main.getExitCode();

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/TransformTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/TransformTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class TransformTest {
 
     private Path workingDir;
@@ -75,7 +77,7 @@ class TransformTest {
         String data = Files.readString(outPath);
         String expected
                 = IOHelper.stripLineComments(Paths.get("src/test/resources/blueprint-out.yaml"), "#", true);
-        Assertions.assertEquals(expected, data);
+        assertThat(data).isEqualToIgnoringNewLines(expected);
     }
 
     private TransformRoute createCommand(String[] files, String... args) {


### PR DESCRIPTION
# Description

* one part was a regression for the test introduced with
https://github.com/apache/camel/commit/e732f61286f69bd9aec5802cff8ececf51a78377
. It emphasizes a potential lock remaining on the log file related to
the pid of a process started with Camel Jbang. Solution consists in
reusing the FileUtil method which has been already updated to use
java.nio anyway.
* one part was that it never passed because of end of line not
considered in the test

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

