### PR TITLE
Fix text block for Camel URI in Java file on Windows

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.apache.camel.util.CamelURIParser.URI_ALREADY_NORMALIZED;
 
@@ -47,10 +48,6 @@ public final class URISupport {
     public static final String RAW_TOKEN_PREFIX = "RAW";
     public static final char[] RAW_TOKEN_START = { '(', '{' };
     public static final char[] RAW_TOKEN_END = { ')', '}' };
-
-    // Java 17 text blocks have new lines with optional white space
-    private static final String TEXT_BLOCK_MARKER = System.lineSeparator();
-    private static final Pattern TEXT_BLOCK_PATTERN = Pattern.compile("\n\\s*");
 
     // Match any key-value pair in the URI query string whose key contains
     // "passphrase" or "password" or secret key (case-insensitive).
@@ -97,10 +94,9 @@ public final class URISupport {
     }
 
     public static String textBlockToSingleLine(String uri) {
-        // text blocks
-        if (uri != null && uri.contains(TEXT_BLOCK_MARKER)) {
-            uri = TEXT_BLOCK_PATTERN.matcher(uri).replaceAll("");
-            uri = uri.trim();
+        // Java 17 text blocks have new lines with optional white space
+        if (uri != null) {
+            uri = uri.lines().map(String::trim).collect(Collectors.joining());
         }
         return uri;
     }


### PR DESCRIPTION
The end of line of the Java file can be written with different end of line style, this can not follow the System default line separator. it can happen depending when files are created on one system and consumed on another.

So instead of looking for the system line separator, use built-in Collectors.joining to avoid this kind of problem

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

