### PR TITLE
Fix FileConcurrentWriteAppendSameFileTest.testConcurrentAppend() on Windows

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConcurrentWriteAppendSameFileTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConcurrentWriteAppendSameFileTest.java
@@ -16,14 +16,11 @@
  */
 package org.apache.camel.component.file;
 
-import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -36,11 +33,11 @@ import org.junit.jupiter.api.parallel.Isolated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Isolated
 public class FileConcurrentWriteAppendSameFileTest extends ContextTestSupport {
+    private static final String APPENDED_TEXT_STATUS_OK = ":Status=OK";
     private static final String TEST_FILE_NAME = "input" + UUID.randomUUID() + ".txt";
     private static final String TEST_FILE_NAME_RESULT = "result" + UUID.randomUUID() + ".txt";
     private static final Logger LOG = LoggerFactory.getLogger(FileConcurrentWriteAppendSameFileTest.class);
@@ -59,21 +56,6 @@ public class FileConcurrentWriteAppendSameFileTest extends ContextTestSupport {
         data = sb.toString();
     }
 
-    private boolean fileIsOk() {
-        final Path path = testFile("outbox/" + TEST_FILE_NAME_RESULT);
-        if (Files.exists(path)) {
-            try {
-                final long expectedSize = 1790;
-
-                return Files.size(path) == expectedSize;
-            } catch (IOException e) {
-                LOG.error("IOException: {}", e.getMessage(), e);
-            }
-        }
-
-        return false;
-    }
-
     @Test
     public void testConcurrentAppend() throws Exception {
         template.sendBodyAndHeader(fileUri(), data, Exchange.FILE_NAME, TEST_FILE_NAME);
@@ -88,22 +70,16 @@ public class FileConcurrentWriteAppendSameFileTest extends ContextTestSupport {
 
         // we need to wait a bit for our slow CI server to make sure the entire
         // file is written on disc
-        Awaitility.await().atMost(1000, TimeUnit.MILLISECONDS).until(this::fileIsOk);
+        List<String> expectedLines = data.lines().map(line -> {
+            return line + APPENDED_TEXT_STATUS_OK;
+        }).collect(Collectors.toList());
+        Awaitility.await().atMost(1000, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+            List<String> actualLines
+                    = Files.readString(testFile("outbox/" + TEST_FILE_NAME_RESULT)).lines().collect(Collectors.toList());
+            assertThat(actualLines).containsExactlyInAnyOrderElementsOf(expectedLines);
+        });
 
         assertMockEndpointsSatisfied();
-
-        // check the file has correct number of lines
-        String txt = new String(Files.readAllBytes(testFile("outbox/" + TEST_FILE_NAME_RESULT)));
-        assertNotNull(txt);
-
-        String[] lines = txt.split(LS);
-        assertEquals(size, lines.length, "Should be " + size + " lines");
-
-        // should be unique
-        Set<String> rows = new LinkedHashSet<>(Arrays.asList(lines));
-        assertEquals(size, rows.size(), "Should be " + size + " unique lines");
-
-        log.info(txt);
     }
 
     @Override
@@ -113,7 +89,7 @@ public class FileConcurrentWriteAppendSameFileTest extends ContextTestSupport {
             public void configure() {
                 from(fileUri("?initialDelay=0&delay=10")).routeId("foo").autoStartup(false)
                         .split(body().tokenize(LS)).parallelProcessing().streaming()
-                        .setBody(body().append(":Status=OK").append(LS))
+                        .setBody(body().append(APPENDED_TEXT_STATUS_OK).append(LS))
                         .to(fileUri("outbox?fileExist=Append&fileName=" + TEST_FILE_NAME_RESULT)).to("mock:result").end();
             }
         };


### PR DESCRIPTION
a test was made on the exact byte size of the written String, this is dependent on the system, the charset and compression system used. For instance, on my Windows, it was returning 1890 and on Linux 1790. Test is modified to check more precisely the content of the written file and avoid to look for the byte size

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

