### PR TITLE
CAMEL-22151 Standardize disables based on ci.test.env to test for .* (whether the property is defined or not, not apache.org / github.com)

### DIFF
--- a/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCollectionDeleteIT.java
+++ b/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCollectionDeleteIT.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @DisabledIfSystemProperties({
-        @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+        @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                                   disabledReason = "Apache CI nodes are too resource constrained for this test"),
         @DisabledIfSystemProperty(named = "arangodb.tests.disable", matches = "true",
                                   disabledReason = "Manually disabled tests")

--- a/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCollectionFindByKeyIT.java
+++ b/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCollectionFindByKeyIT.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledIfSystemProperties({
-        @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+        @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                                   disabledReason = "Apache CI nodes are too resource constrained for this test"),
         @DisabledIfSystemProperty(named = "arangodb.tests.disable", matches = "true",
                                   disabledReason = "Manually disabled tests")

--- a/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCollectionQueryIT.java
+++ b/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCollectionQueryIT.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledIfSystemProperties({
-        @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+        @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                                   disabledReason = "Apache CI nodes are too resource constrained for this test"),
         @DisabledIfSystemProperty(named = "arangodb.tests.disable", matches = "true",
                                   disabledReason = "Manually disabled tests")

--- a/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCollectionSaveIT.java
+++ b/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCollectionSaveIT.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledIfSystemProperties({
-        @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+        @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                                   disabledReason = "Apache CI nodes are too resource constrained for this test"),
         @DisabledIfSystemProperty(named = "arangodb.tests.disable", matches = "true",
                                   disabledReason = "Manually disabled tests")

--- a/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCollectionUpdateIT.java
+++ b/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCollectionUpdateIT.java
@@ -28,7 +28,7 @@ import static org.apache.camel.component.arangodb.ArangoDbConstants.ARANGO_KEY;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DisabledIfSystemProperties({
-        @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+        @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                                   disabledReason = "Apache CI nodes are too resource constrained for this test"),
         @DisabledIfSystemProperty(named = "arangodb.tests.disable", matches = "true",
                                   disabledReason = "Manually disabled tests")

--- a/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCustomVertxIT.java
+++ b/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoCustomVertxIT.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledIfSystemProperties({
-        @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+        @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                                   disabledReason = "Apache CI nodes are too resource constrained for this test"),
         @DisabledIfSystemProperty(named = "arangodb.tests.disable", matches = "true",
                                   disabledReason = "Manually disabled tests")

--- a/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoGraphEdgeIT.java
+++ b/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoGraphEdgeIT.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledIfSystemProperties({
-        @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+        @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                                   disabledReason = "Apache CI nodes are too resource constrained for this test"),
         @DisabledIfSystemProperty(named = "arangodb.tests.disable", matches = "true",
                                   disabledReason = "Manually disabled tests")

--- a/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoGraphQueriesIT.java
+++ b/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoGraphQueriesIT.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledIfSystemProperties({
-        @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+        @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                                   disabledReason = "Apache CI nodes are too resource constrained for this test"),
         @DisabledIfSystemProperty(named = "arangodb.tests.disable", matches = "true",
                                   disabledReason = "Manually disabled tests")

--- a/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoGraphVertexIT.java
+++ b/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/ArangoGraphVertexIT.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledIfSystemProperties({
-        @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+        @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                                   disabledReason = "Apache CI nodes are too resource constrained for this test"),
         @DisabledIfSystemProperty(named = "arangodb.tests.disable", matches = "true",
                                   disabledReason = "Manually disabled tests")

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerCreateSecretProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerCreateSecretProducerLocalstackIT.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SecretsManagerCreateSecretProducerLocalstackIT extends AwsSecretsManagerBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerDescribeSecretProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerDescribeSecretProducerLocalstackIT.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SecretsManagerDescribeSecretProducerLocalstackIT extends AwsSecretsManagerBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerProducerListSecretsLocalstackIT.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerProducerListSecretsLocalstackIT.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SecretsManagerProducerListSecretsLocalstackIT extends AwsSecretsManagerBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerPutSecretValueProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerPutSecretValueProducerLocalstackIT.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.services.secretsmanager.model.PutSecretValueRespon
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SecretsManagerPutSecretValueProducerLocalstackIT extends AwsSecretsManagerBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerRotateSecretProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerRotateSecretProducerLocalstackIT.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SecretsManagerRotateSecretProducerLocalstackIT extends AwsSecretsManagerBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerUpdateSecretProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerUpdateSecretProducerLocalstackIT.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SecretsManagerUpdateSecretProducerLocalstackIT extends AwsSecretsManagerBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws2-kinesis/src/test/java/org/apache/camel/component/aws2/kinesis/Kinesis2ConsumerHealthCustomClientIT.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/test/java/org/apache/camel/component/aws2/kinesis/Kinesis2ConsumerHealthCustomClientIT.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.awaitility.Awaitility.await;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class Kinesis2ConsumerHealthCustomClientIT extends CamelTestSupport {

--- a/components/camel-aws/camel-aws2-kms/src/test/java/org/apache/camel/component/aws2/kms/localstack/KmsCreateKeyIT.java
+++ b/components/camel-aws/camel-aws2-kms/src/test/java/org/apache/camel/component/aws2/kms/localstack/KmsCreateKeyIT.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.services.kms.model.CreateKeyResponse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class KmsCreateKeyIT extends Aws2KmsBase {
 
     @EndpointInject

--- a/components/camel-aws/camel-aws2-kms/src/test/java/org/apache/camel/component/aws2/kms/localstack/KmsDisableKeyIT.java
+++ b/components/camel-aws/camel-aws2-kms/src/test/java/org/apache/camel/component/aws2/kms/localstack/KmsDisableKeyIT.java
@@ -31,7 +31,7 @@ import software.amazon.awssdk.services.kms.model.ListKeysResponse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class KmsDisableKeyIT extends Aws2KmsBase {
 
     @EndpointInject

--- a/components/camel-aws/camel-aws2-kms/src/test/java/org/apache/camel/component/aws2/kms/localstack/KmsListKeysIT.java
+++ b/components/camel-aws/camel-aws2-kms/src/test/java/org/apache/camel/component/aws2/kms/localstack/KmsListKeysIT.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.services.kms.model.ListKeysResponse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class KmsListKeysIT extends Aws2KmsBase {
 
     @EndpointInject

--- a/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaAliasesIT.java
+++ b/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaAliasesIT.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.services.lambda.model.ListAliasesResponse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class LambdaAliasesIT extends Aws2LambdaBase {
 
     @Test

--- a/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaDeleteFunctionIT.java
+++ b/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaDeleteFunctionIT.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.services.lambda.model.DeleteFunctionResponse;
 
 import static org.junit.Assert.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class LambdaDeleteFunctionIT extends Aws2LambdaBase {
 
     @EndpointInject

--- a/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaListFunctionsIT.java
+++ b/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaListFunctionsIT.java
@@ -34,7 +34,7 @@ import software.amazon.awssdk.services.lambda.model.ListFunctionsResponse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class LambdaListFunctionsIT extends Aws2LambdaBase {
 
     @EndpointInject

--- a/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsTopicProducerBatchIT.java
+++ b/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsTopicProducerBatchIT.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.services.sns.model.PublishBatchResponse;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SnsTopicProducerBatchIT extends Aws2SNSBase {
 
     @RegisterExtension

--- a/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsTopicProducerIT.java
+++ b/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsTopicProducerIT.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SnsTopicProducerIT extends Aws2SNSBase {
 
     @RegisterExtension

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
@@ -39,7 +39,7 @@ import static org.apache.camel.test.junit5.TestSupport.assertListSize;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class GrpcProducerStreamingTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProducerStreamingTest.class);

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueConsumerPollTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastQueueConsumerPollTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class HazelcastQueueConsumerPollTest extends HazelcastCamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(HazelcastQueueConsumerPollTest.class);
 

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpNoConnectionTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpNoConnectionTest.java
@@ -31,7 +31,7 @@ import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class HttpNoConnectionTest extends BaseHttpTest {
 
     private HttpServer localServer;

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/InterfacesTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/InterfacesTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org", disabledReason = "Slow test")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Slow test")
 public class InterfacesTest extends BaseJettyTest {
 
     private static final boolean isMacOS = System.getProperty("os.name").startsWith("Mac");

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsMultipleConsumersQueueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsMultipleConsumersQueueTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class JmsMultipleConsumersQueueTest extends AbstractJMSTest {
 
     @Order(2)

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsMultipleConsumersTopicTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsMultipleConsumersTopicTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class JmsMultipleConsumersTopicTest extends AbstractJMSTest {
 
     @Order(2)

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/ManagedJmsEndpointTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/ManagedJmsEndpointTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tags({ @Tag("not-parallel") })
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class ManagedJmsEndpointTest extends AbstractPersistentJMSTest {
 
     private final String uuid = new ShortUuidGenerator().generateUuid();

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/consumers/TwoConsumerOnSameQueueIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/consumers/TwoConsumerOnSameQueueIT.java
@@ -69,7 +69,7 @@ public class TwoConsumerOnSameQueueIT extends CamelTestSupport {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+    @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
     public void testStopAndStartOneRoute() throws Exception {
         sendTwoMessagesWhichShouldReceivedOnBothEndpointsAndAssert();
 
@@ -97,7 +97,7 @@ public class TwoConsumerOnSameQueueIT extends CamelTestSupport {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+    @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
     public void testRemoveOneRoute() throws Exception {
         sendTwoMessagesWhichShouldReceivedOnBothEndpointsAndAssert();
 

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/temp/TemporaryQueueRouteTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/temp/TemporaryQueueRouteTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class TemporaryQueueRouteTest extends AbstractJMSTest {
     @Order(2)
     @RegisterExtension

--- a/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNativeQueryTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNativeQueryTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Timeout(30)
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                           disabledReason = "Apache CI is hanging on this test")
 public class JpaWithNativeQueryTest extends JpaWithNamedQueryTest {
 

--- a/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNativeQueryWithResultClassTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNativeQueryWithResultClassTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                           disabledReason = "Apache CI is hanging on this test")
 public class JpaWithNativeQueryWithResultClassTest extends JpaWithNamedQueryTest {
 

--- a/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithQueryTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithQueryTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Timeout(30)
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                           disabledReason = "Apache CI is hanging on this test")
 public class JpaWithQueryTest extends JpaWithNamedQueryTest {
 

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerAuthInvalidIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerAuthInvalidIT.java
@@ -64,7 +64,7 @@ import static org.junit.jupiter.api.Assertions.fail;
                                  disabledReason = "Requires Kafka 3.x"),
         @EnabledIfSystemProperty(named = "kafka.instance.type", matches = "kafka", disabledReason = "Requires Kafka 3.x")
 })
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class KafkaConsumerAuthInvalidIT {
     public static final String TOPIC = "test-auth-invalid-it";

--- a/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpTcpClientProducerConnectionErrorTest.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpTcpClientProducerConnectionErrorTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class MllpTcpClientProducerConnectionErrorTest extends CamelTestSupport {
 
     @RegisterExtension

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerIT.java
@@ -23,7 +23,7 @@ import org.apache.camel.component.nats.NatsConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class NatsConsumerIT extends NatsITSupport {
 
     @EndpointInject("mock:result")

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerMaxMessagesIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerMaxMessagesIT.java
@@ -22,7 +22,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class NatsConsumerMaxMessagesIT extends NatsITSupport {
 
     @EndpointInject("mock:result")

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerReplyToIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerReplyToIT.java
@@ -23,7 +23,7 @@ import org.apache.camel.component.nats.NatsConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class NatsConsumerReplyToIT extends NatsITSupport {
 
     @EndpointInject("mock:result")

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsProducerReplyToIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsProducerReplyToIT.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class NatsProducerReplyToIT extends NatsITSupport {
 
     protected String startUri = "direct:start";

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsProducerReplyToTimeoutIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsProducerReplyToTimeoutIT.java
@@ -26,7 +26,7 @@ import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class NatsProducerReplyToTimeoutIT extends NatsITSupport {
 
     protected String startUri = "direct:start";

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/SjmsToDTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/SjmsToDTest.java
@@ -22,7 +22,7 @@ import org.apache.camel.component.sjms.support.JmsTestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SjmsToDTest extends JmsTestSupport {
 
     @Test

--- a/components/camel-stomp/src/test/java/org/apache/camel/component/stomp/StompConsumerHeaderFilterStrategyTest.java
+++ b/components/camel-stomp/src/test/java/org/apache/camel/component/stomp/StompConsumerHeaderFilterStrategyTest.java
@@ -34,7 +34,7 @@ import static org.fusesource.stomp.client.Constants.DESTINATION;
 import static org.fusesource.stomp.client.Constants.MESSAGE_ID;
 import static org.fusesource.stomp.client.Constants.SEND;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class StompConsumerHeaderFilterStrategyTest extends StompBaseTest {
 
     @BindToRegistry("customHeaderFilterStrategy")

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsConsumerRouteTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsConsumerRouteTest.java
@@ -163,7 +163,7 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
         testClient2.close();
     }
 
-    @DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+    @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
     @Test
     public void echo() throws Exception {
         WebsocketTestClient wsclient1 = new WebsocketTestClient("ws://localhost:" + getPort() + "/app3", 2);

--- a/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/XmppDeferredConnectionIT.java
+++ b/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/XmppDeferredConnectionIT.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * the server is not available upon route initialization. Also verify that these endpoints will then deliver messages as
  * expected.
  */
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com",
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                           disabledReason = "Github environment has trouble running the XMPP test container and/or component")
 public class XmppDeferredConnectionIT extends XmppBaseContainerTest {
     private static final Logger LOG = LoggerFactory.getLogger(XmppDeferredConnectionIT.class);

--- a/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/integration/XmppMultiUserChatIT.java
+++ b/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/integration/XmppMultiUserChatIT.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com",
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                           disabledReason = "Github environment has trouble running the XMPP test container and/or component")
 class XmppMultiUserChatIT extends XmppBaseIT {
 

--- a/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/integration/XmppProducerConcurrentIT.java
+++ b/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/integration/XmppProducerConcurrentIT.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.apache.camel.test.junit5.TestSupport.body;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com",
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                           disabledReason = "Github environment has trouble running the XMPP test container and/or component")
 public class XmppProducerConcurrentIT extends XmppBaseIT {
 

--- a/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/integration/XmppRouteChatIT.java
+++ b/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/integration/XmppRouteChatIT.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com",
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                           disabledReason = "Github environment has trouble running the XMPP test container and/or component")
 public class XmppRouteChatIT extends XmppBaseIT {
 

--- a/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/integration/XmppRouteIT.java
+++ b/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/integration/XmppRouteIT.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com",
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                           disabledReason = "Github environment has trouble running the XMPP test container and/or component")
 public class XmppRouteIT extends XmppBaseIT {
 

--- a/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/integration/XmppRouteMultipleProducersSingleConsumerIT.java
+++ b/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/integration/XmppRouteMultipleProducersSingleConsumerIT.java
@@ -22,7 +22,7 @@ import org.apache.camel.component.xmpp.XmppConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com",
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                           disabledReason = "Github environment has trouble running the XMPP test container and/or component")
 public class XmppRouteMultipleProducersSingleConsumerIT extends XmppBaseIT {
     protected MockEndpoint goodEndpoint;

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentKeyNameAndSizeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerIdempotentKeyNameAndSizeTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 /**
  * Unit test for the idempotentKey option.
  */
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class FileConsumerIdempotentKeyNameAndSizeTest extends FileConsumerIdempotentTest {
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerMoveFailureTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerMoveFailureTest.java
@@ -24,7 +24,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class FileConsumerMoveFailureTest extends ContextTestSupport {
 
     @Test

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPollStrategyStopOnRollbackTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumerPollStrategyStopOnRollbackTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Unit test for poll strategy
  */
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class FileConsumerPollStrategyStopOnRollbackTest extends ContextTestSupport {
 
     private static int counter;

--- a/core/camel-core/src/test/java/org/apache/camel/impl/StopTimeoutRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/StopTimeoutRouteTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class StopTimeoutRouteTest extends ContextTestSupport {
 
     private final CountDownLatch latch = new CountDownLatch(1);

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/CamelPostProcessorHelperSedaConsumePredicateTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/CamelPostProcessorHelperSedaConsumePredicateTest.java
@@ -23,7 +23,7 @@ import org.apache.camel.ContextTestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class CamelPostProcessorHelperSedaConsumePredicateTest extends ContextTestSupport {
 
     @Test

--- a/core/camel-core/src/test/java/org/apache/camel/issues/AggregatorWithBatchConsumingIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/AggregatorWithBatchConsumingIssueTest.java
@@ -25,7 +25,7 @@ import org.apache.camel.processor.BodyInAggregatingStrategy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class AggregatorWithBatchConsumingIssueTest extends ContextTestSupport {
 
     @Test

--- a/core/camel-core/src/test/java/org/apache/camel/processor/MulticastParallelStreamingTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/MulticastParallelStreamingTimeoutTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 @DisabledOnOs(architectures = { "s390x" },
               disabledReason = "This test does not run reliably on s390x (see CAMEL-21438)")
 public class MulticastParallelStreamingTimeoutTest extends ContextTestSupport {

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateLostGroupIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateLostGroupIssueTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 /**
  * Based on user forum issue
  */
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class AggregateLostGroupIssueTest extends ContextTestSupport {
 
     private int messageIndex;

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateProcessorTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateProcessorTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 @Isolated
 public class AggregateProcessorTest extends ContextTestSupport {
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AlbertoAggregatorTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AlbertoAggregatorTest.java
@@ -31,7 +31,7 @@ import org.apache.camel.model.AggregateDefinition;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class AlbertoAggregatorTest extends ContextTestSupport {
     private static final String SURNAME_HEADER = "surname";
     private static final String TYPE_HEADER = "type";

--- a/core/camel-core/src/test/java/org/apache/camel/processor/async/AsyncProcessorAwaitManagerInterruptWithRedeliveryTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/async/AsyncProcessorAwaitManagerInterruptWithRedeliveryTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class AsyncProcessorAwaitManagerInterruptWithRedeliveryTest extends ContextTestSupport {
 
     private MyBean bean;

--- a/core/camel-core/src/test/java/org/apache/camel/processor/throttle/concurrent/ConcurrentRequestsThrottlerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/throttle/concurrent/ConcurrentRequestsThrottlerTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 // time-bound that does not run well in shared environments
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 @EnabledOnOs(value = { OS.LINUX, OS.MAC, OS.FREEBSD, OS.OPENBSD },
              architectures = { "amd64", "aarch64", "ppc64le" },
              disabledReason = "This test does not run reliably multiple platforms (see CAMEL-21438)")

--- a/core/camel-core/src/test/java/org/apache/camel/processor/throttle/requests/ThrottlerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/throttle/requests/ThrottlerTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // time-bound that does not run well in shared environments
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 @EnabledOnOs(value = { OS.LINUX, OS.MAC, OS.FREEBSD, OS.OPENBSD },
              architectures = { "amd64", "aarch64", "ppc64le" },
              disabledReason = "This test does not run reliably multiple platforms (see CAMEL-21438)")

--- a/core/camel-core/src/test/java/org/apache/camel/support/DefaultTimeoutMapTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/DefaultTimeoutMapTest.java
@@ -35,7 +35,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Isolated("Depends on precise timing that may be hard to achieve if the system is under pressure")
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class DefaultTimeoutMapTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultTimeoutMapTest.class);

--- a/core/camel-core/src/test/java/org/apache/camel/support/cache/SimpleLRUCacheTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/cache/SimpleLRUCacheTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * The test class for {@link SimpleLRUCache}.
  */
 @Isolated("Some of these tests creates a lot of threads")
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                           disabledReason = "Apache CI nodes are too resource constrained for this test")
 class SimpleLRUCacheTest {
 

--- a/core/camel-core/src/test/java/org/apache/camel/support/jsse/TrustManagersParametersTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/jsse/TrustManagersParametersTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 @Isolated("This test is regularly flaky")
 public class TrustManagersParametersTest extends AbstractJsseParametersTest {
 

--- a/core/camel-management/src/test/java/org/apache/camel/management/AbstractManagedThrottlerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/AbstractManagedThrottlerTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledOnOs(OS.AIX)
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public abstract class AbstractManagedThrottlerTest extends ManagementTestSupport {
 
     protected Long runTestManageThrottler() throws Exception {

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedAggregateControllerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedAggregateControllerTest.java
@@ -38,7 +38,7 @@ import static org.apache.camel.management.DefaultManagementObjectNameStrategy.TY
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on Github CI")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 @DisabledOnOs(OS.AIX)
 public class ManagedAggregateControllerTest extends ManagementTestSupport {
 

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedConcurrentThrottlerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedConcurrentThrottlerTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.condition.OS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledOnOs(OS.AIX)
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class ManagedConcurrentThrottlerTest extends AbstractManagedThrottlerTest {
 
     @Test

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedThrottlerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedThrottlerTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.condition.OS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledOnOs(OS.AIX)
-@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com", disabledReason = "Flaky on GitHub Actions")
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class ManagedThrottlerTest extends AbstractManagedThrottlerTest {
 
     @Test


### PR DESCRIPTION
…
# Description

Standardize disables based on ci.test.env to test for .* (whether the property is defined or not, not apache.org / github.com)

# Target

- [ x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

