### PR TITLE
Use a fixed port (default one) when running services via camel infra

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraBaseCommand.java
@@ -60,6 +60,7 @@ public abstract class InfraBaseCommand extends CamelCommand {
         jsonMapper.enable(SerializationFeature.INDENT_OUTPUT);
         jsonMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
         jsonMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        jsonMapper.configure(MapperFeature.REQUIRE_HANDLERS_FOR_JAVA8_OPTIONALS, false);
     }
 
     protected List<TestInfraService> getMetadata() throws IOException {

--- a/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisAllInfraService.java
+++ b/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisAllInfraService.java
@@ -35,7 +35,7 @@ public class ArtemisAllInfraService implements ArtemisInfraService, ContainerSer
     }
 
     protected ArtemisContainer initContainer() {
-        return new ArtemisContainer();
+        return ArtemisContainer.withFixedPort();
     }
 
     @Override

--- a/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisContainer.java
+++ b/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisContainer.java
@@ -43,6 +43,16 @@ public class ArtemisContainer extends GenericContainer<ArtemisContainer> impleme
                 .waitingFor(Wait.forListeningPort());
     }
 
+    public static ArtemisContainer withFixedPort() {
+        ArtemisContainer container = new ArtemisContainer();
+        container.addFixedExposedPort(DEFAULT_MQTT_PORT, DEFAULT_MQTT_PORT);
+        container.addFixedExposedPort(DEFAULT_AMQP_PORT, DEFAULT_AMQP_PORT);
+        container.addFixedExposedPort(DEFAULT_ADMIN_PORT, DEFAULT_ADMIN_PORT);
+        container.addFixedExposedPort(DEFAULT_ACCEPTOR_PORT, DEFAULT_ACCEPTOR_PORT);
+
+        return container;
+    }
+
     /**
      * Gets the port number used for exchanging messages using the AMQP protocol
      *

--- a/test-infra/camel-test-infra-aws-v2/src/main/java/org/apache/camel/test/infra/aws2/services/AWSContainer.java
+++ b/test-infra/camel-test-infra-aws-v2/src/main/java/org/apache/camel/test/infra/aws2/services/AWSContainer.java
@@ -51,11 +51,11 @@ public class AWSContainer extends GenericContainer<AWSContainer> {
         super(imageName);
     }
 
-    public AWSContainer(String imageName, Service... services) {
+    public AWSContainer(String imageName, boolean fixedPort, Service... services) {
         super(imageName);
 
         setupServices(services);
-        setupContainer();
+        setupContainer(fixedPort);
     }
 
     @Deprecated
@@ -63,7 +63,7 @@ public class AWSContainer extends GenericContainer<AWSContainer> {
         super(imageName);
 
         setupServices(serviceList);
-        setupContainer();
+        setupContainer(false);
     }
 
     public void setupServices(Service... services) {
@@ -80,9 +80,14 @@ public class AWSContainer extends GenericContainer<AWSContainer> {
         withEnv("SERVICE", serviceList);
     }
 
-    protected void setupContainer() {
-        withExposedPorts(SERVICE_PORT)
-                .waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
+    protected void setupContainer(boolean fixedPort) {
+        if (fixedPort) {
+            addFixedExposedPort(SERVICE_PORT, SERVICE_PORT);
+        } else {
+            withExposedPorts(SERVICE_PORT);
+        }
+
+        waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
     }
 
     public AwsCredentialsProvider getCredentialsProvider() {

--- a/test-infra/camel-test-infra-aws-v2/src/main/java/org/apache/camel/test/infra/aws2/services/AWSLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-aws-v2/src/main/java/org/apache/camel/test/infra/aws2/services/AWSLocalContainerInfraService.java
@@ -49,7 +49,8 @@ public abstract class AWSLocalContainerInfraService implements AWSInfraService, 
     }
 
     protected AWSContainer initContainer(String imageName, Service... services) {
-        return new AWSContainer(imageName, services);
+        boolean fixedPort = !this.getClass().getName().contains("TestService");
+        return new AWSContainer(imageName, fixedPort, services);
     }
 
     private String getAmazonHost() {

--- a/test-infra/camel-test-infra-azure-common/src/main/java/org/apache/camel/test/infra/azure/common/services/AzureStorageInfraService.java
+++ b/test-infra/camel-test-infra-azure-common/src/main/java/org/apache/camel/test/infra/azure/common/services/AzureStorageInfraService.java
@@ -20,6 +20,7 @@ package org.apache.camel.test.infra.azure.common.services;
 import org.apache.camel.test.infra.azure.common.AzureConfigs;
 import org.apache.camel.test.infra.azure.common.AzureProperties;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +42,7 @@ public abstract class AzureStorageInfraService implements AzureInfraService, Con
     }
 
     protected AzuriteContainer initContainer(String imageName) {
-        return new AzuriteContainer(imageName);
+        return new AzuriteContainer(imageName, ContainerEnvironmentUtil.isFixedPort(this.getClass()));
     }
 
     public AzuriteContainer getContainer() {

--- a/test-infra/camel-test-infra-azure-common/src/main/java/org/apache/camel/test/infra/azure/common/services/AzuriteContainer.java
+++ b/test-infra/camel-test-infra-azure-common/src/main/java/org/apache/camel/test/infra/azure/common/services/AzuriteContainer.java
@@ -34,11 +34,17 @@ public class AzuriteContainer extends GenericContainer<AzuriteContainer> {
                 AzureProperties.AZURE_CONTAINER);
     }
 
-    public AzuriteContainer(String containerName) {
+    public AzuriteContainer(String containerName, boolean fixedPort) {
         super(containerName);
 
-        withExposedPorts(AzureServices.BLOB_SERVICE, AzureServices.QUEUE_SERVICE)
-                .waitingFor(Wait.forListeningPort());
+        if (fixedPort) {
+            addFixedExposedPort(AzureServices.BLOB_SERVICE, AzureServices.BLOB_SERVICE);
+            addFixedExposedPort(AzureServices.QUEUE_SERVICE, AzureServices.QUEUE_SERVICE);
+        } else {
+            withExposedPorts(AzureServices.BLOB_SERVICE, AzureServices.QUEUE_SERVICE);
+        }
+
+        waitingFor(Wait.forListeningPort());
     }
 
     public AzureCredentialsHolder azureCredentials() {

--- a/test-infra/camel-test-infra-common/src/main/java/org/apache/camel/test/infra/common/services/ContainerEnvironmentUtil.java
+++ b/test-infra/camel-test-infra-common/src/main/java/org/apache/camel/test/infra/common/services/ContainerEnvironmentUtil.java
@@ -56,4 +56,14 @@ public final class ContainerEnvironmentUtil {
         int startupAttempts = Integer.valueOf(System.getProperty(property, String.valueOf(defaultValue)));
         container.setStartupAttempts(startupAttempts);
     }
+
+    public static boolean isFixedPort(Class cls) {
+        for (Class<?> i : cls.getInterfaces()) {
+            if (i.getName().contains("InfraService")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/test-infra/camel-test-infra-google-pubsub/src/main/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-google-pubsub/src/main/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubLocalContainerInfraService.java
@@ -18,6 +18,7 @@ package org.apache.camel.test.infra.google.pubsub.services;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.google.pubsub.common.GooglePubSubProperties;
 import org.slf4j.Logger;
@@ -35,6 +36,7 @@ public class GooglePubSubLocalContainerInfraService
     public static final String PROJECT_ID;
     private static final Logger LOG = LoggerFactory.getLogger(GooglePubSubLocalContainerInfraService.class);
     private static final String DEFAULT_PROJECT_ID = "test-project";
+    private static final int PORT = 8085;
 
     static {
         PROJECT_ID = System.getProperty(GooglePubSubProperties.PROJECT_ID, DEFAULT_PROJECT_ID);
@@ -57,7 +59,18 @@ public class GooglePubSubLocalContainerInfraService
     }
 
     protected PubSubEmulatorContainer initContainer(String imageName) {
-        return new PubSubEmulatorContainer(DockerImageName.parse(imageName));
+        class TestInfraPubSubEmulatorContainer extends PubSubEmulatorContainer {
+            public TestInfraPubSubEmulatorContainer(boolean fixedPort) {
+                super(DockerImageName.parse(imageName));
+
+                if (fixedPort) {
+                    addFixedExposedPort(PORT, PORT);
+                } else {
+                    addExposedPort(PORT);
+                }
+            }
+        }
+        return new TestInfraPubSubEmulatorContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()));
     }
 
     @Override

--- a/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaInfraService.java
+++ b/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaInfraService.java
@@ -19,6 +19,7 @@ package org.apache.camel.test.infra.kafka.services;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.kafka.common.KafkaProperties;
 import org.slf4j.Logger;
@@ -46,9 +47,18 @@ public class ContainerLocalKafkaInfraService implements KafkaInfraService, Conta
     }
 
     protected KafkaContainer initContainer() {
-        return new KafkaContainer(
-                DockerImageName.parse(System.getProperty(KafkaProperties.KAFKA_CONTAINER, KAFKA3_IMAGE_NAME))
+        class TestInfraKafkaContainer extends KafkaContainer {
+            public TestInfraKafkaContainer(boolean fixedPort) {
+                super(DockerImageName.parse(System.getProperty(KafkaProperties.KAFKA_CONTAINER, KAFKA3_IMAGE_NAME))
                         .asCompatibleSubstituteFor("apache/kafka"));
+
+                if (fixedPort) {
+                    addFixedExposedPort(9092, 9092);
+                }
+            }
+        }
+
+        return new TestInfraKafkaContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()));
     }
 
     public String getBootstrapServers() {

--- a/test-infra/camel-test-infra-mosquitto/src/main/java/org/apache/camel/test/infra/mosquitto/services/MosquittoLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-mosquitto/src/main/java/org/apache/camel/test/infra/mosquitto/services/MosquittoLocalContainerInfraService.java
@@ -18,6 +18,7 @@ package org.apache.camel.test.infra.mosquitto.services;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.mosquitto.common.MosquittoProperties;
 import org.slf4j.Logger;
@@ -52,7 +53,11 @@ public class MosquittoLocalContainerInfraService implements MosquittoInfraServic
     }
 
     public MosquittoLocalContainerInfraService(String imageName) {
-        container = initContainer(imageName, null);
+        if (ContainerEnvironmentUtil.isFixedPort(this.getClass())) {
+            container = initContainer(imageName, CONTAINER_PORT);
+        } else {
+            container = initContainer(imageName, null);
+        }
     }
 
     public MosquittoLocalContainerInfraService(GenericContainer container) {

--- a/test-infra/camel-test-infra-ollama/src/main/java/org/apache/camel/test/infra/ollama/services/OllamaLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-ollama/src/main/java/org/apache/camel/test/infra/ollama/services/OllamaLocalContainerInfraService.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.ollama.commons.OllamaProperties;
 import org.slf4j.Logger;
@@ -59,9 +60,18 @@ public class OllamaLocalContainerInfraService implements OllamaInfraService, Con
     }
 
     protected OllamaContainer initContainer() {
-        return new OllamaContainer(
-                DockerImageName.parse(CONTAINER_NAME)
+        class TestInfraOllamaContainer extends OllamaContainer {
+            public TestInfraOllamaContainer(boolean fixedPort) {
+                super(DockerImageName.parse(CONTAINER_NAME)
                         .asCompatibleSubstituteFor("ollama/ollama"));
+
+                if (fixedPort) {
+                    addFixedExposedPort(11434, 11434);
+                }
+            }
+        }
+
+        return new TestInfraOllamaContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()));
     }
 
     @Override

--- a/test-infra/camel-test-infra-openldap/src/main/java/org/apache/camel/test/infra/openldap/services/OpenLdapContainer.java
+++ b/test-infra/camel-test-infra-openldap/src/main/java/org/apache/camel/test/infra/openldap/services/OpenLdapContainer.java
@@ -26,11 +26,16 @@ public class OpenLdapContainer extends GenericContainer<OpenLdapContainer> {
     public static final int CONTAINER_PORT_LDAP = 389;
     public static final int CONTAINER_PORT_LDAP_OVER_SSL = 636;
 
-    public OpenLdapContainer() {
+    public OpenLdapContainer(boolean fixedPort) {
         super(LocalPropertyResolver.getProperty(OpenldapLocalContainerInfraService.class,
                 OpenldapProperties.OPENLDAP_CONTAINER));
 
-        this.withExposedPorts(CONTAINER_PORT_LDAP, CONTAINER_PORT_LDAP_OVER_SSL)
-                .withNetworkAliases(CONTAINER_NAME);
+        if (fixedPort) {
+            this.addFixedExposedPort(CONTAINER_PORT_LDAP, CONTAINER_PORT_LDAP);
+            this.addFixedExposedPort(CONTAINER_PORT_LDAP_OVER_SSL, CONTAINER_PORT_LDAP_OVER_SSL);
+        } else {
+            this.withExposedPorts(CONTAINER_PORT_LDAP, CONTAINER_PORT_LDAP_OVER_SSL)
+                    .withNetworkAliases(CONTAINER_NAME);
+        }
     }
 }

--- a/test-infra/camel-test-infra-openldap/src/main/java/org/apache/camel/test/infra/openldap/services/OpenldapLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-openldap/src/main/java/org/apache/camel/test/infra/openldap/services/OpenldapLocalContainerInfraService.java
@@ -17,6 +17,7 @@
 package org.apache.camel.test.infra.openldap.services;
 
 import org.apache.camel.spi.annotations.InfraService;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.openldap.common.OpenldapProperties;
 import org.slf4j.Logger;
@@ -34,7 +35,7 @@ public class OpenldapLocalContainerInfraService implements OpenldapInfraService,
     private final OpenLdapContainer container;
 
     public OpenldapLocalContainerInfraService() {
-        container = new OpenLdapContainer();
+        container = new OpenLdapContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()));
     }
 
     @Override

--- a/test-infra/camel-test-infra-pinecone/src/main/java/org/apache/camel/test/infra/pinecone/services/PineconeIndexContainer.java
+++ b/test-infra/camel-test-infra-pinecone/src/main/java/org/apache/camel/test/infra/pinecone/services/PineconeIndexContainer.java
@@ -31,10 +31,10 @@ public class PineconeIndexContainer extends GenericContainer<PineconeIndexContai
             "ghcr.io/pinecone-io/pinecone-index");
 
     public PineconeIndexContainer(String dockerImageName) {
-        this(DockerImageName.parse(dockerImageName));
+        this(DockerImageName.parse(dockerImageName), false);
     }
 
-    public PineconeIndexContainer(DockerImageName dockerImageName) {
+    public PineconeIndexContainer(DockerImageName dockerImageName, boolean fixedPort) {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
         withEnv("PINECONE_HOST", "localhost");
@@ -43,7 +43,11 @@ public class PineconeIndexContainer extends GenericContainer<PineconeIndexContai
         withEnv("INDEX_TYPE", "serverless");
         withEnv("METRIC", "cosine");
         withEnv("PORT", String.valueOf(CLIENT_PORT));
-        withExposedPorts(CLIENT_PORT);
+        if (fixedPort) {
+            addFixedExposedPort(CLIENT_PORT, CLIENT_PORT);
+        } else {
+            withExposedPorts(CLIENT_PORT);
+        }
     }
 
     public String getEndpoint() {

--- a/test-infra/camel-test-infra-postgres/src/main/java/org/apache/camel/test/infra/postgres/services/PostgresLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-postgres/src/main/java/org/apache/camel/test/infra/postgres/services/PostgresLocalContainerInfraService.java
@@ -18,6 +18,7 @@ package org.apache.camel.test.infra.postgres.services;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.postgres.common.PostgresProperties;
 import org.slf4j.Logger;
@@ -48,8 +49,18 @@ public class PostgresLocalContainerInfraService implements PostgresInfraService,
     }
 
     protected PostgreSQLContainer initContainer(String imageName) {
-        return new PostgreSQLContainer(
-                DockerImageName.parse(imageName).asCompatibleSubstituteFor("postgres"));
+        class TestInfraPostgreSQLContainer extends PostgreSQLContainer {
+            public TestInfraPostgreSQLContainer(boolean fixedPort) {
+                super(DockerImageName.parse(imageName)
+                        .asCompatibleSubstituteFor("postgres"));
+
+                if (fixedPort) {
+                    addFixedExposedPort(5432, 5432);
+                }
+            }
+        }
+
+        return new TestInfraPostgreSQLContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()));
     }
 
     @Override

--- a/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQLocalContainerInfraService.java
@@ -19,6 +19,7 @@ package org.apache.camel.test.infra.rabbitmq.services;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.rabbitmq.common.RabbitMQProperties;
 import org.slf4j.Logger;
@@ -48,7 +49,20 @@ public class RabbitMQLocalContainerInfraService implements RabbitMQInfraService,
     }
 
     protected RabbitMQContainer initContainer(String imageName) {
-        return new RabbitMQContainer(DockerImageName.parse(imageName).asCompatibleSubstituteFor("rabbitmq"));
+        class TestInfraRabbitMQContainer extends RabbitMQContainer {
+            public TestInfraRabbitMQContainer(boolean fixedPort) {
+                super(DockerImageName.parse(imageName).asCompatibleSubstituteFor("rabbitmq"));
+
+                if (fixedPort) {
+                    addFixedExposedPort(5672, 5672);
+                    addFixedExposedPort(5671, 5671);
+                    addFixedExposedPort(15671, 15671);
+                    addFixedExposedPort(15672, 15672);
+                }
+            }
+        }
+
+        return new TestInfraRabbitMQContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()));
     }
 
     @Override

--- a/test-infra/camel-test-infra-redis/src/main/java/org/apache/camel/test/infra/redis/services/RedisContainer.java
+++ b/test-infra/camel-test-infra-redis/src/main/java/org/apache/camel/test/infra/redis/services/RedisContainer.java
@@ -38,7 +38,20 @@ public class RedisContainer extends GenericContainer<RedisContainer> {
         super(DockerImageName.parse(imageName));
     }
 
-    public static RedisContainer initContainer(String imageName, String networkAlias) {
+    public static RedisContainer initContainer(String imageName, String networkAlias, boolean fixedPort) {
+        class TestInfraRedisContainer extends RedisContainer {
+            public TestInfraRedisContainer() {
+                super(imageName);
+                waitingFor(Wait.forListeningPort());
+
+                if (fixedPort) {
+                    addFixedExposedPort(RedisProperties.DEFAULT_PORT, RedisProperties.DEFAULT_PORT);
+                } else {
+                    withNetworkAliases(networkAlias)
+                            .withExposedPorts(RedisProperties.DEFAULT_PORT);
+                }
+            }
+        }
         return new RedisContainer(imageName)
                 .withNetworkAliases(networkAlias)
                 .withExposedPorts(RedisProperties.DEFAULT_PORT)

--- a/test-infra/camel-test-infra-redis/src/main/java/org/apache/camel/test/infra/redis/services/RedisLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-redis/src/main/java/org/apache/camel/test/infra/redis/services/RedisLocalContainerInfraService.java
@@ -17,6 +17,7 @@
 package org.apache.camel.test.infra.redis.services;
 
 import org.apache.camel.spi.annotations.InfraService;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.redis.common.RedisProperties;
 import org.slf4j.Logger;
@@ -35,7 +36,8 @@ public class RedisLocalContainerInfraService implements RedisInfraService, Conta
     }
 
     public RedisLocalContainerInfraService(String imageName) {
-        container = RedisContainer.initContainer(imageName, RedisContainer.CONTAINER_NAME);
+        container = RedisContainer.initContainer(imageName, RedisContainer.CONTAINER_NAME,
+                ContainerEnvironmentUtil.isFixedPort(this.getClass()));
     }
 
     @Override

--- a/test-infra/camel-test-infra-rocketmq/src/main/java/org/apache/camel/test/infra/rocketmq/services/RocketMQBrokerContainer.java
+++ b/test-infra/camel-test-infra-rocketmq/src/main/java/org/apache/camel/test/infra/rocketmq/services/RocketMQBrokerContainer.java
@@ -26,13 +26,19 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public class RocketMQBrokerContainer extends GenericContainer<RocketMQBrokerContainer> {
 
-    public RocketMQBrokerContainer(Network network, String confName) {
+    public RocketMQBrokerContainer(Network network, String confName, boolean fixedPort) {
         super(RocketMQContainerInfraService.ROCKETMQ_IMAGE);
 
-        withNetwork(network);
-        withExposedPorts(RocketMQProperties.ROCKETMQ_BROKER3_PORT,
-                RocketMQProperties.ROCKETMQ_BROKER2_PORT,
-                RocketMQProperties.ROCKETMQ_BROKER1_PORT);
+        if (fixedPort) {
+            addFixedExposedPort(RocketMQProperties.ROCKETMQ_BROKER3_PORT, RocketMQProperties.ROCKETMQ_BROKER3_PORT);
+            addFixedExposedPort(RocketMQProperties.ROCKETMQ_BROKER2_PORT, RocketMQProperties.ROCKETMQ_BROKER2_PORT);
+            addFixedExposedPort(RocketMQProperties.ROCKETMQ_BROKER1_PORT, RocketMQProperties.ROCKETMQ_BROKER1_PORT);
+        } else {
+            withNetwork(network);
+            withExposedPorts(RocketMQProperties.ROCKETMQ_BROKER3_PORT,
+                    RocketMQProperties.ROCKETMQ_BROKER2_PORT,
+                    RocketMQProperties.ROCKETMQ_BROKER1_PORT);
+        }
         withEnv("NAMESRV_ADDR", "nameserver:9876");
         withClasspathResourceMapping(confName + "/" + confName + ".conf",
                 "/opt/rocketmq-" + RocketMQContainerInfraService.ROCKETMQ_VERSION + "/conf/broker.conf",

--- a/test-infra/camel-test-infra-rocketmq/src/main/java/org/apache/camel/test/infra/rocketmq/services/RocketMQContainerInfraService.java
+++ b/test-infra/camel-test-infra-rocketmq/src/main/java/org/apache/camel/test/infra/rocketmq/services/RocketMQContainerInfraService.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.rocketmq.common.RocketMQProperties;
 import org.awaitility.Awaitility;
@@ -49,7 +50,8 @@ public class RocketMQContainerInfraService implements RocketMQInfraService, Cont
 
         nameserverContainer = new RocketMQNameserverContainer(network);
 
-        brokerContainer1 = new RocketMQBrokerContainer(network, "broker1");
+        brokerContainer1
+                = new RocketMQBrokerContainer(network, "broker1", ContainerEnvironmentUtil.isFixedPort(this.getClass()));
     }
 
     @Override

--- a/test-infra/camel-test-infra-smb/src/main/java/org/apache/camel/test/infra/smb/services/SmbContainer.java
+++ b/test-infra/camel-test-infra-smb/src/main/java/org/apache/camel/test/infra/smb/services/SmbContainer.java
@@ -27,13 +27,18 @@ public class SmbContainer extends GenericContainer<SmbContainer> {
     public static final String DEFAULT_USER = "camel";
     public static final String DEFAULT_PASSWORD = "camelTester123";
 
-    public SmbContainer() {
+    public SmbContainer(boolean fixedPort) {
         super(new ImageFromDockerfile("localhost/samba:camel", false)
                 .withFileFromClasspath(".",
                         "org/apache/camel/test/infra/smb/services/"));
 
-        super.withExposedPorts(SMB_PORT_DEFAULT)
-                .waitingFor(Wait.forListeningPort());
+        if (fixedPort) {
+            addFixedExposedPort(SMB_PORT_DEFAULT, SMB_PORT_DEFAULT);
+        } else {
+            super.withExposedPorts(SMB_PORT_DEFAULT);
+        }
+
+        waitingFor(Wait.forListeningPort());
     }
 
     public String getUser() {

--- a/test-infra/camel-test-infra-smb/src/main/java/org/apache/camel/test/infra/smb/services/SmbLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-smb/src/main/java/org/apache/camel/test/infra/smb/services/SmbLocalContainerInfraService.java
@@ -17,6 +17,7 @@
 package org.apache.camel.test.infra.smb.services;
 
 import org.apache.camel.spi.annotations.InfraService;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.util.IOHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +27,7 @@ import org.slf4j.LoggerFactory;
               serviceAlias = "smb")
 public class SmbLocalContainerInfraService implements SmbInfraService {
     protected static final Logger LOG = LoggerFactory.getLogger(SmbLocalContainerInfraService.class);
-    protected final SmbContainer container = new SmbContainer();
+    protected final SmbContainer container = new SmbContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()));
 
     public SmbLocalContainerInfraService() {
     }

--- a/test-infra/camel-test-infra-solr/src/main/java/org/apache/camel/test/infra/solr/services/SolrContainer.java
+++ b/test-infra/camel-test-infra-solr/src/main/java/org/apache/camel/test/infra/solr/services/SolrContainer.java
@@ -48,16 +48,23 @@ public class SolrContainer extends GenericContainer<SolrContainer> {
         super(DockerImageName.parse(imageName));
     }
 
-    public static SolrContainer initContainer(String networkAlias) {
-        return new SolrContainer()
+    public static SolrContainer initContainer(String networkAlias, boolean fixedPort) {
+        SolrContainer solrContainer = new SolrContainer()
                 .withNetworkAliases(networkAlias)
                 .withEnv("SOLR_OPTS", "-Dsolr.environment=test,label=camel-solr-test-infra,color=sandybrown")
                 .withEnv("GC_LOG_OPTS", "-verbose:")
                 .withAccessToHost(true)
                 .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix(CONTAINER_NAME))
-                .withExposedPorts(SolrProperties.DEFAULT_PORT)
                 .withCommand(SOLR_CONTAINER_COMMANDS)
                 .waitingFor(Wait.forHttp("/solr/" + SOLR_DFT_COLLECTION + "/admin/ping?docker-ping"));
+
+        if (fixedPort) {
+            solrContainer.addFixedExposedPort(SolrProperties.DEFAULT_PORT, SolrProperties.DEFAULT_PORT);
+        } else {
+            solrContainer.withExposedPorts(SolrProperties.DEFAULT_PORT);
+        }
+
+        return solrContainer;
     }
 
 }

--- a/test-infra/camel-test-infra-solr/src/main/java/org/apache/camel/test/infra/solr/services/SolrLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-solr/src/main/java/org/apache/camel/test/infra/solr/services/SolrLocalContainerInfraService.java
@@ -17,6 +17,7 @@
 package org.apache.camel.test.infra.solr.services;
 
 import org.apache.camel.spi.annotations.InfraService;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.solr.common.SolrProperties;
 import org.slf4j.Logger;
@@ -31,7 +32,8 @@ public class SolrLocalContainerInfraService implements SolrInfraService, Contain
     private final SolrContainer container;
 
     public SolrLocalContainerInfraService() {
-        container = SolrContainer.initContainer(SolrContainer.CONTAINER_NAME);
+        container = SolrContainer.initContainer(SolrContainer.CONTAINER_NAME,
+                ContainerEnvironmentUtil.isFixedPort(this.getClass()));
     }
 
     @Override

--- a/test-infra/camel-test-infra-xmpp/src/main/java/org/apache/camel/test/infra/xmpp/services/XmppLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-xmpp/src/main/java/org/apache/camel/test/infra/xmpp/services/XmppLocalContainerInfraService.java
@@ -18,6 +18,7 @@ package org.apache.camel.test.infra.xmpp.services;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.xmpp.common.XmppProperties;
 import org.slf4j.Logger;
@@ -44,7 +45,7 @@ public class XmppLocalContainerInfraService implements XmppInfraService, Contain
     }
 
     protected XmppServerContainer initContainer(String imageName) {
-        return new XmppServerContainer();
+        return new XmppServerContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()));
     }
 
     @Override

--- a/test-infra/camel-test-infra-xmpp/src/main/java/org/apache/camel/test/infra/xmpp/services/XmppServerContainer.java
+++ b/test-infra/camel-test-infra-xmpp/src/main/java/org/apache/camel/test/infra/xmpp/services/XmppServerContainer.java
@@ -43,6 +43,14 @@ public class XmppServerContainer extends GenericContainer<XmppServerContainer> {
                 .waitingFor(Wait.forLogMessage(".*Started Application in.*", 1));
     }
 
+    public XmppServerContainer(boolean fixedPort) {
+        this();
+        if (fixedPort) {
+            addFixedExposedPort(XmppProperties.PORT_DEFAULT, XmppProperties.PORT_DEFAULT);
+            addFixedExposedPort(8088, PORT_REST);
+        }
+    }
+
     public String getUrl() {
         return String.format("%s:%d", this.getHost(), this.getMappedPort(XmppProperties.PORT_DEFAULT));
     }


### PR DESCRIPTION
For example:
```
➜  camel git:(main) ✗ camel infra run aws sqs
Starting service aws with implementation sqs
{
  "accessKey" : "accesskey",
  "amazonAWSHost" : "localhost:4566",
  "getConnectionProperties" : {
    "aws.access.key" : "accesskey",
    "aws.host" : "localhost:4566",
    "aws.protocol" : "http",
    "aws.region" : "us-east-1",
    "aws.secret.key" : "secretkey"
  },
  "protocol" : "http",
  "region" : "us-east-1",
  "secretKey" : "secretkey"
}
```
This way, a default port is always used instead of the random one picked by testcontainers (Camel tests keep using the random one).