### PR TITLE
[CAMEL-WHATSAPP] Update whatsapp parameter to allow payload buttons

### DIFF
--- a/components/camel-whatsapp/src/main/java/org/apache/camel/component/whatsapp/model/Parameter.java
+++ b/components/camel-whatsapp/src/main/java/org/apache/camel/component/whatsapp/model/Parameter.java
@@ -28,6 +28,7 @@ public class Parameter {
     private MediaMessage image;
     private MediaMessage document;
     private MediaMessage video;
+    private String payload;
 
     public Parameter() {
     }
@@ -86,6 +87,14 @@ public class Parameter {
 
     public void setVideo(MediaMessage video) {
         this.video = video;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
     }
 
 }


### PR DESCRIPTION
# Description

According to the documentation https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-message-templates/#interactive a template message could have some buttons with a payload parameter. To accomplish this, is necessary to add the payload attribute in the model

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

