### PR TITLE
Align properties for camel infra command

### DIFF
--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQITSupport.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQITSupport.java
@@ -39,7 +39,7 @@ public abstract class RabbitMQITSupport extends CamelTestSupport {
         if (confirm) {
             cf.setPublisherConfirmType(CachingConnectionFactory.ConfirmType.CORRELATED);
         }
-        cf.setUri(service.getAmqpUrl());
+        cf.setUri(service.uri());
         return cf;
     }
 

--- a/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/FtpInfraService.java
+++ b/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/FtpInfraService.java
@@ -32,7 +32,13 @@ public interface FtpInfraService extends InfrastructureService {
 
     int port();
 
+    @Deprecated
+    // use host
     default String hostname() {
+        return "localhost";
+    }
+
+    default String host() {
         return "localhost";
     }
 

--- a/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/FtpEmbeddedInfraService.java
+++ b/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/FtpEmbeddedInfraService.java
@@ -26,6 +26,7 @@ import java.util.function.BiConsumer;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.services.AbstractService;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.ftp.common.FtpProperties;
 import org.apache.camel.test.infra.ftp.services.FtpInfraService;
 import org.apache.commons.io.FileUtils;
@@ -132,7 +133,11 @@ public class FtpEmbeddedInfraService extends AbstractService implements FtpInfra
         serverFactory.setConnectionConfig(new ConnectionConfigFactory().createConnectionConfig());
 
         ListenerFactory factory = new ListenerFactory();
-        factory.setPort(port);
+        if (ContainerEnvironmentUtil.isFixedPort(this.getClass())) {
+            factory.setPort(2221);
+        } else {
+            factory.setPort(port);
+        }
         factory.setServerAddress(embeddedConfiguration.getServerAddress());
 
         final Listener listener = factory.createListener();

--- a/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/SftpEmbeddedInfraService.java
+++ b/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/SftpEmbeddedInfraService.java
@@ -29,6 +29,7 @@ import java.util.function.BiConsumer;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.services.AbstractService;
+import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.ftp.common.FtpProperties;
 import org.apache.camel.test.infra.ftp.services.FtpInfraService;
 import org.apache.sshd.common.NamedFactory;
@@ -88,7 +89,11 @@ public class SftpEmbeddedInfraService extends AbstractService implements FtpInfr
 
     public void setUpServer() throws Exception {
         sshd = SshServer.setUpDefaultServer();
-        sshd.setPort(port);
+        if (ContainerEnvironmentUtil.isFixedPort(this.getClass())) {
+            sshd.setPort(2222);
+        } else {
+            sshd.setPort(port);
+        }
 
         sshd.setKeyPairProvider(new FileKeyPairProvider(Paths.get(embeddedConfiguration.getKeyPairFile())));
         sshd.setSubsystemFactories(Collections.singletonList(new SftpSubsystemFactory()));

--- a/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/ConfluentInfraService.java
+++ b/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/ConfluentInfraService.java
@@ -60,6 +60,11 @@ public class ConfluentInfraService implements KafkaInfraService, ContainerServic
     }
 
     @Override
+    public String brokers() {
+        return getBootstrapServers();
+    }
+
+    @Override
     public void registerProperties() {
         System.setProperty(KafkaProperties.KAFKA_BOOTSTRAP_SERVERS, getBootstrapServers());
     }

--- a/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaInfraService.java
+++ b/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaInfraService.java
@@ -66,6 +66,11 @@ public class ContainerLocalKafkaInfraService implements KafkaInfraService, Conta
     }
 
     @Override
+    public String brokers() {
+        return getBootstrapServers();
+    }
+
+    @Override
     public void registerProperties() {
         System.setProperty(KafkaProperties.KAFKA_BOOTSTRAP_SERVERS, getBootstrapServers());
     }

--- a/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/KafkaInfraService.java
+++ b/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/KafkaInfraService.java
@@ -31,4 +31,6 @@ public interface KafkaInfraService extends InfrastructureService {
      */
     String getBootstrapServers();
 
+    String brokers();
+
 }

--- a/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/RedpandaInfraService.java
+++ b/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/RedpandaInfraService.java
@@ -61,6 +61,11 @@ public class RedpandaInfraService implements KafkaInfraService, ContainerService
     }
 
     @Override
+    public String brokers() {
+        return getBootstrapServers();
+    }
+
+    @Override
     public void registerProperties() {
         System.setProperty(KafkaProperties.KAFKA_BOOTSTRAP_SERVERS, getBootstrapServers());
     }

--- a/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/RemoteKafkaInfraService.java
+++ b/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/RemoteKafkaInfraService.java
@@ -30,6 +30,11 @@ public class RemoteKafkaInfraService implements KafkaInfraService {
     }
 
     @Override
+    public String brokers() {
+        return getBootstrapServers();
+    }
+
+    @Override
     public void registerProperties() {
         // NO-OP
     }

--- a/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/StrimziInfraService.java
+++ b/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/StrimziInfraService.java
@@ -69,6 +69,11 @@ public class StrimziInfraService implements KafkaInfraService, ContainerService<
     }
 
     @Override
+    public String brokers() {
+        return getBootstrapServers();
+    }
+
+    @Override
     public void registerProperties() {
         System.setProperty(KafkaProperties.KAFKA_BOOTSTRAP_SERVERS, getBootstrapServers());
     }

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalAuthKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/ContainerLocalAuthKafkaService.java
@@ -76,6 +76,11 @@ public class ContainerLocalAuthKafkaService implements KafkaService, ContainerSe
     }
 
     @Override
+    public String brokers() {
+        return getBootstrapServers();
+    }
+
+    @Override
     public void registerProperties() {
         System.setProperty(KafkaProperties.KAFKA_BOOTSTRAP_SERVERS, getBootstrapServers());
     }

--- a/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/KafkaServiceFactory.java
+++ b/test-infra/camel-test-infra-kafka/src/test/java/org/apache/camel/test/infra/kafka/services/KafkaServiceFactory.java
@@ -36,6 +36,11 @@ public final class KafkaServiceFactory {
         }
 
         @Override
+        public String brokers() {
+            return getService().brokers();
+        }
+
+        @Override
         public final void beforeAll(ExtensionContext extensionContext) {
             super.beforeAll(extensionContext);
         }

--- a/test-infra/camel-test-infra-milvus/src/main/java/org/apache/camel/test/infra/milvus/services/MilvusInfraService.java
+++ b/test-infra/camel-test-infra-milvus/src/main/java/org/apache/camel/test/infra/milvus/services/MilvusInfraService.java
@@ -25,7 +25,17 @@ public interface MilvusInfraService extends InfrastructureService {
 
     String getMilvusEndpointUrl();
 
-    String getMilvusHost();
+    @Deprecated
+    default String getMilvusHost() {
+        return host();
+    }
 
-    int getMilvusPort();
+    @Deprecated
+    default int getMilvusPort() {
+        return port();
+    }
+
+    String host();
+
+    int port();
 }

--- a/test-infra/camel-test-infra-milvus/src/main/java/org/apache/camel/test/infra/milvus/services/MilvusLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-milvus/src/main/java/org/apache/camel/test/infra/milvus/services/MilvusLocalContainerInfraService.java
@@ -100,7 +100,7 @@ public class MilvusLocalContainerInfraService implements MilvusInfraService, Con
     }
 
     @Override
-    public String getMilvusHost() {
+    public String host() {
         URL url = null;
         try {
             url = new URL(container.getEndpoint());
@@ -111,7 +111,7 @@ public class MilvusLocalContainerInfraService implements MilvusInfraService, Con
     }
 
     @Override
-    public int getMilvusPort() {
+    public int port() {
         URL url = null;
         try {
             url = new URL(container.getEndpoint());

--- a/test-infra/camel-test-infra-milvus/src/main/java/org/apache/camel/test/infra/milvus/services/MilvusRemoteInfraService.java
+++ b/test-infra/camel-test-infra-milvus/src/main/java/org/apache/camel/test/infra/milvus/services/MilvusRemoteInfraService.java
@@ -41,12 +41,12 @@ public class MilvusRemoteInfraService implements MilvusInfraService {
     }
 
     @Override
-    public String getMilvusHost() {
+    public String host() {
         return System.getProperty(MilvusProperties.MILVUS_ENDPOINT_HOST);
     }
 
     @Override
-    public int getMilvusPort() {
+    public int port() {
         return Integer.parseInt(System.getProperty(MilvusProperties.MILVUS_ENDPOINT_PORT));
     }
 }

--- a/test-infra/camel-test-infra-milvus/src/test/java/org/apache/camel/test/infra/milvus/services/MilvusServiceFactory.java
+++ b/test-infra/camel-test-infra-milvus/src/test/java/org/apache/camel/test/infra/milvus/services/MilvusServiceFactory.java
@@ -44,6 +44,16 @@ public final class MilvusServiceFactory {
         public int getMilvusPort() {
             return getService().getMilvusPort();
         }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
     }
 
     public static SimpleTestServiceBuilder<MilvusService> builder() {

--- a/test-infra/camel-test-infra-qdrant/src/main/java/org/apache/camel/test/infra/qdrant/services/QdrantInfraService.java
+++ b/test-infra/camel-test-infra-qdrant/src/main/java/org/apache/camel/test/infra/qdrant/services/QdrantInfraService.java
@@ -30,9 +30,19 @@ public interface QdrantInfraService extends InfrastructureService {
 
     int getHttpPort();
 
-    String getGrpcHost();
+    @Deprecated
+    default String getGrpcHost() {
+        return host();
+    }
 
-    int getGrpcPort();
+    @Deprecated
+    default int getGrpcPort() {
+        return port();
+    }
+
+    String host();
+
+    int port();
 
     default HttpResponse<byte[]> put(String path, Map<Object, Object> body) throws Exception {
         final String reqPath = !path.startsWith("/") ? "/" + path : path;

--- a/test-infra/camel-test-infra-qdrant/src/main/java/org/apache/camel/test/infra/qdrant/services/QdrantLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-qdrant/src/main/java/org/apache/camel/test/infra/qdrant/services/QdrantLocalContainerInfraService.java
@@ -106,12 +106,12 @@ public class QdrantLocalContainerInfraService implements QdrantInfraService, Con
     }
 
     @Override
-    public String getGrpcHost() {
+    public String host() {
         return container.getHost();
     }
 
     @Override
-    public int getGrpcPort() {
+    public int port() {
         return container.getMappedPort(GRPC_PORT);
     }
 }

--- a/test-infra/camel-test-infra-qdrant/src/main/java/org/apache/camel/test/infra/qdrant/services/QdrantRemoteInfraService.java
+++ b/test-infra/camel-test-infra-qdrant/src/main/java/org/apache/camel/test/infra/qdrant/services/QdrantRemoteInfraService.java
@@ -46,12 +46,12 @@ public class QdrantRemoteInfraService implements QdrantInfraService {
     }
 
     @Override
-    public String getGrpcHost() {
+    public String host() {
         return System.getProperty(QdrantProperties.QDRANT_GRPC_HOST);
     }
 
     @Override
-    public int getGrpcPort() {
+    public int port() {
         return Integer.getInteger(QdrantProperties.QDRANT_GRPC_PORT);
     }
 }

--- a/test-infra/camel-test-infra-qdrant/src/test/java/org/apache/camel/test/infra/qdrant/services/QdrantServiceFactory.java
+++ b/test-infra/camel-test-infra-qdrant/src/test/java/org/apache/camel/test/infra/qdrant/services/QdrantServiceFactory.java
@@ -54,6 +54,16 @@ public final class QdrantServiceFactory {
         }
 
         @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+
+        @Override
         public HttpResponse<byte[]> put(String path, Map<Object, Object> body) throws Exception {
             return getService().put(path, body);
         }

--- a/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQInfraService.java
+++ b/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQInfraService.java
@@ -33,9 +33,9 @@ public interface RabbitMQInfraService extends InfrastructureService {
      *
      * @return the connection URI in the format amqp://host:port
      */
+    @Deprecated
     default String getAmqpUrl() {
-        ConnectionProperties properties = connectionProperties();
-        return String.format("amqp://%s:%s", properties.hostname(), properties.port());
+        return uri();
     }
 
     /**
@@ -54,4 +54,15 @@ public interface RabbitMQInfraService extends InfrastructureService {
      * Shuts down the service after the test has completed
      */
     void shutdown();
+
+    default String uri() {
+        ConnectionProperties properties = connectionProperties();
+        return String.format("amqp://%s:%s", properties.hostname(), properties.port());
+    }
+
+    String managementUsername();
+
+    String managementPassword();
+
+    String managementUri();
 }

--- a/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQLocalContainerInfraService.java
@@ -128,4 +128,19 @@ public class RabbitMQLocalContainerInfraService implements RabbitMQInfraService,
     public void shutdown() {
         container.stop();
     }
+
+    @Override
+    public String managementUsername() {
+        return container.getAdminUsername();
+    }
+
+    @Override
+    public String managementPassword() {
+        return container.getAdminPassword();
+    }
+
+    @Override
+    public String managementUri() {
+        return String.format("http://%s:%s", container.getHost(), container.getHttpPort());
+    }
 }

--- a/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQRemoteInfraService.java
+++ b/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQRemoteInfraService.java
@@ -69,4 +69,19 @@ public class RabbitMQRemoteInfraService implements RabbitMQInfraService {
     public void shutdown() {
 
     }
+
+    @Override
+    public String managementUsername() {
+        return connectionProperties().username();
+    }
+
+    @Override
+    public String managementPassword() {
+        return connectionProperties().password();
+    }
+
+    @Override
+    public String managementUri() {
+        return String.format("http://%s:%s", connectionProperties().hostname(), getHttpPort());
+    }
 }

--- a/test-infra/camel-test-infra-rabbitmq/src/main/resources/org/apache/camel/test/infra/rabbitmq/services/container.properties
+++ b/test-infra/camel-test-infra-rabbitmq/src/main/resources/org/apache/camel/test/infra/rabbitmq/services/container.properties
@@ -14,4 +14,4 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-rabbitmq.container=mirror.gcr.io/rabbitmq:3.13
+rabbitmq.container=mirror.gcr.io/rabbitmq:3.13-management


### PR DESCRIPTION
```
$ camel infra run rabbitmq --json
{
  "connectionProperties" : { },
  "getAmqpUrl" : "amqp://localhost:5672",
  "getHttpPort" : 15672,
  "initialize" : null,
  "managementPassword" : "guest",
  "managementUri" : "http://localhost:15672",
  "managementUsername" : "guest",
  "shutdown" : null,
  "uri" : "amqp://localhost:5672"
}
```

```
        CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory();
        cachingConnectionFactory.setUri("amqp://localhost:5672");
        getCamelContext().getRegistry().bind("rabbitConnectionFactory", cachingConnectionFactory);

        from("timer:java?period=1000")
                .setBody()
                .simple("Hello Camel from ${routeId}")
                .to("spring-rabbitmq:cheese?routingKey=cheese");

        from("spring-rabbitmq:cheese?routingKey=cheese")
                .log("${body}");
```

The Management GUI is accessible at managementUri, and managementUsername and managementPassword can be used to log in to it.