### PR TITLE
camel-smb: Align last modified timestamp in SmbConsumer with camel-file component behavior

### DIFF
--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbConsumer.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbConsumer.java
@@ -318,7 +318,7 @@ public class SmbConsumer extends GenericFileConsumer<FileIdBothDirectoryInformat
         genericFile.setHostname(configuration.getHostname());
         genericFile.setFile(file);
         genericFile.setEndpointPath(endpointPath);
-        genericFile.setLastModified(file.getChangeTime().toEpochMillis());
+        genericFile.setLastModified(file.getLastWriteTime().toEpochMillis());
         genericFile.setCharset(charset);
         genericFile.setFileNameOnly(file.getFileName());
         genericFile.setDirectory(isDirectory(file));


### PR DESCRIPTION
During debugging, I noticed that asGenericFile() in SmbConsumer sets a different last modified timestamp compared to the camel-file component for the same file.
The Java File API's lastModified() returns the LastWriteTime field, which is also the timestamp displayed in Windows Explorer, so i aligned the SmbConsumer to use the same timestamp as the FileConsumer.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

