### PR TITLE
CAMEL-22174 Enable Stream Download tests, remove try-with-resources from getBodyAsInputStream

### DIFF
--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
@@ -558,19 +558,20 @@ public class SmbOperations implements SmbFileOperations {
 
     public InputStream getBodyAsInputStream(Exchange exchange, String path) {
         connectIfNecessary();
-        try (File shareFile = share.openFile(path, EnumSet.of(AccessMask.GENERIC_READ), null,
-                SMB2ShareAccess.ALL, SMB2CreateDisposition.FILE_OPEN, null)) {
-            InputStream is = shareFile.getInputStream();
+        InputStream is = null;
+        try {
+            File shareFile = share.openFile(path, EnumSet.of(AccessMask.GENERIC_READ), null,
+                    SMB2ShareAccess.ALL, SMB2CreateDisposition.FILE_OPEN, null);
+            is = shareFile.getInputStream();
             exchange.getIn().setHeader(SmbComponent.SMB_FILE_INPUT_STREAM, is);
             exchange.getIn().setHeader(SmbConstants.SMB_UNC_PATH, shareFile.getUncPath());
-            return is;
         } catch (SMBRuntimeException smbre) {
             if (smbre.getCause() instanceof TransportException) {
                 disconnect();
                 throw smbre;
             }
         }
-        return null;
+        return is;
     }
 
     /*

--- a/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbStreamDownloadFalseIT.java
+++ b/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbStreamDownloadFalseIT.java
@@ -19,12 +19,10 @@ package org.apache.camel.component.smb;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-@Disabled("CAMEL-22174")
 public class SmbStreamDownloadFalseIT extends SmbServerTestSupport {
 
     @Override

--- a/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbStreamDownloadIT.java
+++ b/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbStreamDownloadIT.java
@@ -23,12 +23,10 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.util.IOHelper;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@Disabled("CAMEL-22174")
 public class SmbStreamDownloadIT extends SmbServerTestSupport {
 
     @Override

--- a/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbStreamDownloadStreamCacheIT.java
+++ b/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbStreamDownloadStreamCacheIT.java
@@ -20,10 +20,8 @@ import org.apache.camel.Exchange;
 import org.apache.camel.StreamCache;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled("CAMEL-22174")
 public class SmbStreamDownloadStreamCacheIT extends SmbServerTestSupport {
 
     @Override


### PR DESCRIPTION
# Description

https://issues.apache.org/jira/browse/CAMEL-22174

https://github.com/apache/camel/commit/a05a990aa57b632873354e4d21b7eb8c723574c9 broke three stream download integration tests, https://github.com/apache/camel/commit/8d03fa5bc937a6a082abb9550f9e612803b848bc disabled them - re-enable all three tests and remove the try-with-resources in favor of just a try-catch from getBodyAsInputStream as it seems to be too eager to clean up the inputstream

# Target

- [ x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [ x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.


