### PR TITLE
CAMEL-22174 Catch TransportExceptions and disconnect share calls so we can recover from network outage (#18387)

### DIFF
--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
@@ -28,8 +28,10 @@ import com.hierynomus.msfscc.fileinformation.FileIdBothDirectoryInformation;
 import com.hierynomus.mssmb2.SMB2CreateDisposition;
 import com.hierynomus.mssmb2.SMB2CreateOptions;
 import com.hierynomus.mssmb2.SMB2ShareAccess;
+import com.hierynomus.protocol.transport.TransportException;
 import com.hierynomus.smbj.SMBClient;
 import com.hierynomus.smbj.auth.AuthenticationContext;
+import com.hierynomus.smbj.common.SMBRuntimeException;
 import com.hierynomus.smbj.connection.Connection;
 import com.hierynomus.smbj.session.Session;
 import com.hierynomus.smbj.share.DiskShare;
@@ -126,6 +128,12 @@ public class SmbOperations implements SmbFileOperations {
         if (session != null) {
             try {
                 session.close();
+            } catch (TransportException t) {
+                try {
+                    session.getConnection().close(true);
+                } catch (IOException e) {
+                    // ignore
+                }
             } catch (Exception e) {
                 // ignore
             }
@@ -189,6 +197,11 @@ public class SmbOperations implements SmbFileOperations {
             }
 
             src.deleteOnClose();
+        } catch (SMBRuntimeException smbre) {
+            if (smbre.getCause() instanceof TransportException) {
+                disconnect();
+                throw smbre;
+            }
         }
         return true;
     }
@@ -197,7 +210,15 @@ public class SmbOperations implements SmbFileOperations {
     public boolean buildDirectory(String directory, boolean absolute) throws GenericFileOperationFailedException {
         connectIfNecessary();
         SmbFiles files = new SmbFiles();
-        files.mkdirs(share, normalize(directory));
+
+        try {
+            files.mkdirs(share, normalize(directory));
+        } catch (SMBRuntimeException smbre) {
+            if (smbre.getCause() instanceof TransportException) {
+                disconnect();
+                throw smbre;
+            }
+        }
         return true;
     }
 
@@ -215,7 +236,16 @@ public class SmbOperations implements SmbFileOperations {
 
     public boolean existsFolder(String name) {
         connectIfNecessary();
-        return share.folderExists(name);
+        boolean result = false;
+        try {
+            result = share.folderExists(name);
+        } catch (SMBRuntimeException smbre) {
+            if (smbre.getCause() instanceof TransportException) {
+                disconnect();
+                throw smbre;
+            }
+        }
+        return result;
     }
 
     private boolean retrieveFileToStreamInBody(String name, Exchange exchange) throws GenericFileOperationFailedException {
@@ -242,6 +272,11 @@ public class SmbOperations implements SmbFileOperations {
             }
 
             exchange.getIn().setHeader(SmbConstants.SMB_UNC_PATH, shareFile.getUncPath());
+        } catch (SMBRuntimeException smbre) {
+            if (smbre.getCause() instanceof TransportException) {
+                disconnect();
+                throw smbre;
+            }
         }
         return true;
     }
@@ -490,7 +525,16 @@ public class SmbOperations implements SmbFileOperations {
     public FileIdBothDirectoryInformation[] listFiles(String path, String searchPattern)
             throws GenericFileOperationFailedException {
         connectIfNecessary();
-        return share.list(path, searchPattern).toArray(FileIdBothDirectoryInformation[]::new);
+        FileIdBothDirectoryInformation[] result = null;
+        try {
+            result = share.list(path, searchPattern).toArray(FileIdBothDirectoryInformation[]::new);
+        } catch (SMBRuntimeException smbre) {
+            if (smbre.getCause() instanceof TransportException) {
+                disconnect();
+                throw smbre;
+            }
+        }
+        return result;
     }
 
     public byte[] getBody(String path) {
@@ -503,16 +547,30 @@ public class SmbOperations implements SmbFileOperations {
             } catch (Exception e) {
                 throw new GenericFileOperationFailedException(e.getMessage(), e);
             }
+        } catch (SMBRuntimeException smbre) {
+            if (smbre.getCause() instanceof TransportException) {
+                disconnect();
+                throw smbre;
+            }
         }
+        return null;
     }
 
     public InputStream getBodyAsInputStream(Exchange exchange, String path) {
         connectIfNecessary();
-        File shareFile = share.openFile(path, EnumSet.of(AccessMask.GENERIC_READ), null,
-                SMB2ShareAccess.ALL, SMB2CreateDisposition.FILE_OPEN, null);
-        InputStream is = shareFile.getInputStream();
-        exchange.getIn().setHeader(SmbComponent.SMB_FILE_INPUT_STREAM, is);
-        exchange.getIn().setHeader(SmbConstants.SMB_UNC_PATH, shareFile.getUncPath());
+        InputStream is = null;
+        try {
+            File shareFile = share.openFile(path, EnumSet.of(AccessMask.GENERIC_READ), null,
+                    SMB2ShareAccess.ALL, SMB2CreateDisposition.FILE_OPEN, null);
+            is = shareFile.getInputStream();
+            exchange.getIn().setHeader(SmbComponent.SMB_FILE_INPUT_STREAM, is);
+            exchange.getIn().setHeader(SmbConstants.SMB_UNC_PATH, shareFile.getUncPath());
+        } catch (SMBRuntimeException smbre) {
+            if (smbre.getCause() instanceof TransportException) {
+                disconnect();
+                throw smbre;
+            }
+        }
         return is;
     }
 


### PR DESCRIPTION

# Description

Cherry pick of camel-smb fixes to 4.10.x branch

Commits https://github.com/apache/camel/commit/a05a990aa57b632873354e4d21b7eb8c723574c9 and https://github.com/apache/camel/commit/f57969526cc99fa9b5e423b2e846442b392a8ef1 from upstream rebased into one commit (includes the stream download fix and passes integration tests).

# Target

- [ x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [ x] I checked that each commit in the pull request has a meaningful subject line and body.

- [ x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.


