### PR TITLE
Align versions to spring-boot 3.4.7 versions

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -381,7 +381,7 @@
         <narayana-version>5.13.1.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
         <neo4j-version>5.28.1</neo4j-version>
-        <netty-version>4.1.119.Final</netty-version>
+        <netty-version>4.1.122.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.5.5</networknt-json-schema-validator-version>
         <nimbus-jose-jwt>10.0.1</nimbus-jose-jwt>
@@ -405,7 +405,7 @@
         <parquet-common-version>1.15.0</parquet-common-version>
         <parquet-avro-version>1.15.0</parquet-avro-version>
         <pdfbox-version>3.0.4</pdfbox-version>
-        <pgjdbc-driver-version>42.7.5</pgjdbc-driver-version>
+        <pgjdbc-driver-version>42.7.7</pgjdbc-driver-version>
         <pgjdbc-ng-driver-version>0.8.9</pgjdbc-ng-driver-version>
         <picocli-version>4.7.6</picocli-version>
         <pinecone-client-version>3.1.0</pinecone-client-version>
@@ -464,13 +464,13 @@
         <splunk-version>1.9.5_1</splunk-version>
         <spock-version>2.3-groovy-4.0</spock-version>
         <spring-batch-version>5.2.2</spring-batch-version>
-        <spring-data-redis-version>3.4.6</spring-data-redis-version>
-        <spring-ldap-version>3.2.12</spring-ldap-version>
+        <spring-data-redis-version>3.4.7</spring-data-redis-version>
+        <spring-ldap-version>3.2.13</spring-ldap-version>
         <spring-vault-core-version>3.1.3</spring-vault-core-version>
         <spring-version>6.2.8</spring-version>
         <spring-rabbitmq-version>3.2.5</spring-rabbitmq-version>
-        <spring-security-version>6.4.6</spring-security-version>
-        <spring-ws-version>4.0.14</spring-ws-version>
+        <spring-security-version>6.4.7</spring-security-version>
+        <spring-ws-version>4.0.15</spring-ws-version>
         <sql-maven-plugin-version>3.0.0</sql-maven-plugin-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>
         <squareup-okio-version>1.17.5</squareup-okio-version>


### PR DESCRIPTION
# Description

Align spring-* versions and a few others to the versions used in spring-boot 3.4.7.       In the camel-spring-boot project, https://github.com/apache/camel-spring-boot/pull/1452 changes the spring-boot version to 3.4.7 in the camel-spring-boot-4.10.x branch.

# Target

- [x ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

(not a large change, no JIRA)

- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.


