### PR TITLE
Create template-engines.adoc

### DIFF
--- a/docs/components/modules/others/pages/template-engines.adoc
+++ b/docs/components/modules/others/pages/template-engines.adoc
@@ -1,0 +1,28 @@
+= Template engines
+
+A template engine is a tool that generates text output, such as emails, XML, or code, by combining templates with dynamic data. 
+In Apache Camel, templates are primarily used to create layouts while dynamically using exchange data.
+
+Below is a list of template engines that are provided by Apache Camel.
+
+[cols="1,1,1,3", options="header"]
+|===
+|Template engine |Artifact               |Since |Website
+
+|Chunk           |camel-chunk            |2.10  |https://github.com/tomj74/chunk-templates[github.com/tomj74/chunk-templates]
+|Freemarker      |camel-freemarker       |2.10  |https://freemarker.apache.org/[freemarker.apache.org]
+|JTE             |camel-jte              |4.4   |https://jte.gg/[jte.gg/]
+|MVEL            |camel-mvel             |2.12  |http://mvel.documentnode.com/[mvel.documentnode.com]
+|Mustache        |camel-mustache         |2.12  |https://mustache.github.io/[mustache.github.io]
+|String Template |camel-stringtemplate   |1.2   |https://www.stringtemplate.org/[www.stringtemplate.org]
+|Thymeleaf       |camel-thymeleaf        |4.1   |https://www.thymeleaf.org/[www.thymeleaf.org]
+|Velocity        |camel-velocity         |1.2   |https://velocity.apache.org/[velocity.apache.org]
+|===
+
+=== Which template engine to choose?
+
+Velocity is a mature template engine with long-term support from Camel. It can be used for text generation, such as emails. 
+Mustache can be used for similar purposes and is cross-platform. 
+For templates that require more conditional logic and XML or HTML output, Freemarker, MVEL, and Thymeleaf are good choices. JTE is known to be fast due to its compile-time template processing.
+
+Note: These template engines perform directly on the echange, if you want to template routes, look at xref:manual::route-template.adoc[Route Templates].


### PR DESCRIPTION
Documentation: Create an overview of template engines used by Camel.