### PR TITLE
Upgrade versions to align with spring-boot 3.3.13

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -400,7 +400,7 @@
         <parquet-common-version>1.14.3</parquet-common-version>
         <parquet-avro-version>1.14.4</parquet-avro-version>
         <pdfbox-version>3.0.3</pdfbox-version>
-        <pgjdbc-driver-version>42.7.4</pgjdbc-driver-version>
+        <pgjdbc-driver-version>42.7.7</pgjdbc-driver-version>
         <pgjdbc-ng-driver-version>0.8.9</pgjdbc-ng-driver-version>
         <picocli-version>4.7.6</picocli-version>
         <pinecone-client-version>1.2.2</pinecone-client-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -99,8 +99,8 @@
         <chunk-templates-version>3.6.2</chunk-templates-version>
         <classgraph-version>4.8.175</classgraph-version>
         <cloudant-version>0.9.1</cloudant-version>
-        <cometd-java-client-version>8.0.4</cometd-java-client-version>
-        <cometd-java-server-version>8.0.4</cometd-java-server-version>
+        <cometd-java-client-version>8.0.8</cometd-java-client-version>
+        <cometd-java-server-version>8.0.8</cometd-java-server-version>
         <commons-beanutils-version>1.9.4</commons-beanutils-version>
         <commons-codec-version>1.17.1</commons-codec-version>
         <commons-collections-version>3.2.2</commons-collections-version>
@@ -199,7 +199,7 @@
         <graphql-java-version>22.3</graphql-java-version>
         <greenmail-version>2.0.1</greenmail-version>
         <grizzly-websockets-version>2.4.4</grizzly-websockets-version>
-        <groovy-version>4.0.26</groovy-version>
+        <groovy-version>4.0.27</groovy-version>
         <grpc-version>1.66.0</grpc-version>
         <grpc-google-auth-library-version>1.24.1</grpc-google-auth-library-version>
         <grpc-java-jwt-version>4.4.0</grpc-java-jwt-version>
@@ -274,7 +274,7 @@
         <jcr-version>2.0</jcr-version>
         <jedis-client-version>5.1.5</jedis-client-version>
         <jetcd-version>0.8.3</jetcd-version>
-        <jetty-version>12.0.19</jetty-version>
+        <jetty-version>12.0.22</jetty-version>
 		<jetty-for-solr-version>10.0.20</jetty-for-solr-version>        
         <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
         <jetty-runner-groupId>org.eclipse.jetty</jetty-runner-groupId>
@@ -375,7 +375,7 @@
         <mybatis-version>3.5.16</mybatis-version>
         <narayana-version>5.13.1.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
-        <netty-version>4.1.119.Final</netty-version>
+        <netty-version>4.1.122.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.5.1</networknt-json-schema-validator-version>
         <nimbus-jose-jwt>9.40</nimbus-jose-jwt>
@@ -453,13 +453,13 @@
         <splunk-version>1.9.5_1</splunk-version>
         <spock-version>2.3-groovy-4.0</spock-version>
         <spring-batch-version>5.1.3</spring-batch-version>
-        <spring-data-redis-version>3.3.10</spring-data-redis-version>
-        <spring-ldap-version>3.2.12</spring-ldap-version>
+        <spring-data-redis-version>3.3.13</spring-data-redis-version>
+        <spring-ldap-version>3.2.13</spring-ldap-version>
         <spring-vault-core-version>3.1.2</spring-vault-core-version>
         <spring-version>6.1.21</spring-version>
         <spring-rabbitmq-version>3.1.7</spring-rabbitmq-version>
-        <spring-security-version>6.3.9</spring-security-version>
-        <spring-ws-version>4.0.13</spring-ws-version>
+        <spring-security-version>6.3.10</spring-security-version>
+        <spring-ws-version>4.0.15</spring-ws-version>
         <sql-maven-plugin-version>3.0.0</sql-maven-plugin-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>
         <squareup-okio-version>1.17.5</squareup-okio-version>


### PR DESCRIPTION
# Description

camel-4.8.x branch

Upgrade spring.* versions to align with spring-boot 3.3.13 - most are spring.* version upgrades but other notable updates here to align with spring-boot 3.3.13 versions are jetty 12.0.19 -> 12.0.22 and cometd update to match jetty update, groovy from 4.0.26->4.0.27 and netty 4.1.119 -> 4.1.122.   

# Target

- [ x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

