### PR TITLE
CAMEL-22184 - avoid IndexOutBoundException in Camel Jbang update list

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/update/UpdateList.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/update/UpdateList.java
@@ -136,13 +136,15 @@ public class UpdateList extends CamelCommand {
             recipesVersions.quarkusUpdateRecipes().forEach(l -> {
                 List<String[]> runtimeVersions = recipesVersions.qVersions().stream().filter(v -> v[1].startsWith(l.version()))
                         .collect(Collectors.toList());
-                runtimeVersions.sort(Comparator.comparing(o -> o[1]));
-                String[] runtimeVersion = runtimeVersions.get(runtimeVersions.size() - 1);
-                // Quarkus may release patches independently, therefore, we do not know the real micro version
-                String quarkusVersion = runtimeVersion[1];
-                quarkusVersion = quarkusVersion.substring(0, quarkusVersion.lastIndexOf('.')) + ".x";
+                if (!runtimeVersions.isEmpty()) {
+                    runtimeVersions.sort(Comparator.comparing(o -> o[1]));
+                    String[] runtimeVersion = runtimeVersions.get(runtimeVersions.size() - 1);
+                    // Quarkus may release patches independently, therefore, we do not know the real micro version
+                    String quarkusVersion = runtimeVersion[1];
+                    quarkusVersion = quarkusVersion.substring(0, quarkusVersion.lastIndexOf('.')) + ".x";
 
-                rows.add(new Row(runtimeVersion[0], "Camel Quarkus", quarkusVersion, l.description()));
+                    rows.add(new Row(runtimeVersion[0], "Camel Quarkus", quarkusVersion, l.description()));
+                }
             });
         }
 


### PR DESCRIPTION
it doesn't fix the potential root cause, so maybe an update version will be missing but at least it avoids to break existing feature when the list of upgrade recipes is modified (in some ways that I have not defined yet)

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

