### PR TITLE
INFRA-26918 - clean whole .m2 org/apache/camel on Jenkins slave

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
                     stage('Clean workspace') {
                         steps {
                             cleanWs()
-                            sh 'rm -rv /home/jenkins/.m2/repository/org/apache/camel/camel-buildtools'
+                            sh 'rm -rv /home/jenkins/.m2/repository/org/apache/camel'
                             checkout scm
                         }
                     }


### PR DESCRIPTION
as unfortunately, it seems that corrupted repo can happen on different Camel metadata files, the new one:

```
Caused by: org.eclipse.aether.RepositoryException: Could not parse
metadata /home/jenkins/.m2/repository/org/apache/camel/camel-util/maven-metadata-local.xml:
in epilog non whitespace content is not allowed but got a (position:
END_TAG seen ...</metadata>\na... @34:2)
```

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

