### PR TITLE
CAMEL-22174  catch SMBRuntimeExceptions on connect and always close connection on disconnect

### DIFF
--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
@@ -97,7 +97,7 @@ public class SmbOperations implements SmbFileOperations {
                 LOG.debug("Connected and logged in to: {}:{}", configuration.getHostname(), configuration.getPort());
                 loggedIn = true;
             }
-        } catch (IOException e) {
+        } catch (SMBRuntimeException | IOException e) {
             disconnect();
             throw new GenericFileOperationFailedException(
                     "Cannot connect to: " + configuration.getHostname() + ":" + configuration.getPort() + " due to: "

--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
@@ -128,6 +128,7 @@ public class SmbOperations implements SmbFileOperations {
         if (session != null) {
             try {
                 session.close();
+                session.getConnection().close();
             } catch (TransportException t) {
                 try {
                     session.getConnection().close(true);


### PR DESCRIPTION
# Description

When the query parameter `disconnect=true` is set, the exception thrown in `connectIfNecessary()` is an `SMBRuntimeException` from `Connection.authenticate()`, instead of an `IOException` from `SMBClient.connect()`. As a result, `disconnect()` is never called, and the consumer fails to recover from the broken connection. 

I also added that the connection is always closed on disconnect, so `disconnect=true` now fully disconnects the connection and not just the session.

@cunningt Could you take a look and see if this makes sense?

Kind regards,
jubar

Example stacktrace:
```
com.hierynomus.smbj.common.SMBRuntimeException: com.hierynomus.protocol.transport.TransportException: java.net.SocketException: Connection reset by peer
	at com.hierynomus.smbj.connection.SMBSessionBuilder.establish(SMBSessionBuilder.java:124) ~[smbj-0.14.0.jar:0.14.0]
	at com.hierynomus.smbj.connection.Connection.authenticate(Connection.java:206) ~[smbj-0.14.0.jar:0.14.0]
	at org.apache.camel.component.smb.SmbOperations.connectIfNecessary(SmbOperations.java:93) ~[camel-smb-4.10.6.jar:4.10.6]
	at org.apache.camel.component.smb.SmbConsumer.prePollCheck(SmbConsumer.java:207) ~[camel-smb-4.10.6.jar:4.10.6]
	at org.apache.camel.component.file.GenericFileConsumer.poll(GenericFileConsumer.java:129) ~[camel-file-4.10.6.jar:4.10.6]
	at org.apache.camel.support.ScheduledPollConsumer.doRun(ScheduledPollConsumer.java:208) ~[camel-support-4.10.6.jar:4.10.6]
	at org.apache.camel.support.ScheduledPollConsumer.run(ScheduledPollConsumer.java:119) ~[camel-support-4.10.6.jar:4.10.6]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[na:na]
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358) ~[na:na]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[na:na]
	at io.opentelemetry.context.Context.lambda$wrap$1(Context.java:241) ~[opentelemetry-context-1.49.0.jar:1.49.0]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]
Caused by: com.hierynomus.protocol.transport.TransportException: java.net.SocketException: Connection reset by peer
	at com.hierynomus.smbj.transport.tcp.direct.DirectTcpTransport.write(DirectTcpTransport.java:86) ~[smbj-0.14.0.jar:0.14.0]
	at com.hierynomus.smbj.connection.Connection.send(Connection.java:242) ~[smbj-0.14.0.jar:0.14.0]
	at com.hierynomus.smbj.connection.Connection.sendAndReceive(Connection.java:247) ~[smbj-0.14.0.jar:0.14.0]
	at com.hierynomus.smbj.connection.SMBSessionBuilder.initiateSessionSetup(SMBSessionBuilder.java:217) ~[smbj-0.14.0.jar:0.14.0]
	at com.hierynomus.smbj.connection.SMBSessionBuilder.setupSession(SMBSessionBuilder.java:136) ~[smbj-0.14.0.jar:0.14.0]
	at com.hierynomus.smbj.connection.SMBSessionBuilder.establish(SMBSessionBuilder.java:119) ~[smbj-0.14.0.jar:0.14.0]
	... 13 common frames omitted
Caused by: java.net.SocketException: Connection reset by peer
	at java.base/sun.nio.ch.SocketDispatcher.write0(Native Method) ~[na:na]
	at java.base/sun.nio.ch.SocketDispatcher.write(SocketDispatcher.java:54) ~[na:na]
	at java.base/sun.nio.ch.NioSocketImpl.tryWrite(NioSocketImpl.java:394) ~[na:na]
	at java.base/sun.nio.ch.NioSocketImpl.implWrite(NioSocketImpl.java:410) ~[na:na]
	at java.base/sun.nio.ch.NioSocketImpl.write(NioSocketImpl.java:440) ~[na:na]
	at java.base/sun.nio.ch.NioSocketImpl$2.write(NioSocketImpl.java:819) ~[na:na]
	at java.base/java.net.Socket$SocketOutputStream.write(Socket.java:1195) ~[na:na]
	at java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:125) ~[na:na]
	at java.base/java.io.BufferedOutputStream.implFlush(BufferedOutputStream.java:252) ~[na:na]
	at java.base/java.io.BufferedOutputStream.flush(BufferedOutputStream.java:240) ~[na:na]
	at com.hierynomus.smbj.transport.tcp.direct.DirectTcpTransport.write(DirectTcpTransport.java:83) ~[smbj-0.14.0.jar:0.14.0]
	... 18 common frames omitted
```

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

