### PR TITLE
fix(jira): Fix querying issues on jira cloud instance

### DIFF
--- a/components/camel-jira/src/main/java/org/apache/camel/component/jira/consumer/AbstractJiraConsumer.java
+++ b/components/camel-jira/src/main/java/org/apache/camel/component/jira/consumer/AbstractJiraConsumer.java
@@ -26,6 +26,7 @@ import com.atlassian.jira.rest.client.api.RestClientException;
 import com.atlassian.jira.rest.client.api.SearchRestClient;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.SearchResult;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousCloudSearchRestClient;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePropertyKey;
 import org.apache.camel.Processor;
@@ -125,18 +126,26 @@ public abstract class AbstractJiraConsumer extends ScheduledBatchPollingConsumer
         Set<Issue> issues = new LinkedHashSet<>();
         while (true) {
             SearchRestClient searchRestClient = endpoint.getClient().getSearchClient();
-            SearchResult searchResult = searchRestClient.searchJql(jql, maxPerQuery, start, null).claim();
+            // *navigable should be the default value, but it does not seem to be true with 6.0.2 client
+            SearchResult searchResult = searchRestClient.searchJql(jql, maxPerQuery, start, Set.of("*navigable")).claim();
 
             for (Issue issue : searchResult.getIssues()) {
                 issues.add(issue);
             }
 
-            // Note: #getTotal == the total # the query would return *without* pagination, effectively telling us
+            // Note: the total # the query would return *without* pagination, effectively telling us
             // we've reached the end. Also exit early if we're limiting the # of results or
             // if total # of returned issues is lower than the actual page size.
-            if (maxPerQuery >= searchResult.getTotal() ||
-                    start >= searchResult.getTotal() ||
-                    maxResults > 0 && issues.size() >= maxResults) {
+            int total;
+            if (searchRestClient instanceof AsynchronousCloudSearchRestClient) {
+                // calling searchResult.getTotal() on AsynchronousCloudSearchRestClient throws an exception:
+                // Total is not available in the Cloud version of the new Search API response.
+                // Please use `SearchRestClient.totalCount` instead to fetch the estimated count of the issues for a given JQL
+                total = searchRestClient.totalCount(jql).claim().getCount();
+            } else {
+                total = searchResult.getTotal();
+            }
+            if (maxPerQuery >= total || start >= total || maxResults > 0 && issues.size() >= maxResults) {
                 break;
             }
 


### PR DESCRIPTION
# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

After upgrading the jira client to 6.0.2, it stopped working when querying issues on jira cloud instance. In 6.0.2 they created a [new client](https://bitbucket.org/atlassian/jira-rest-java-client/pull-requests/159/diff) specifically for the jira cloud that seems to work slightly differently:

1. when using `null` as the fields, it did not return any fields at all, resulting in:
```
Caused by: org.codehaus.jettison.json.JSONException: JSONObject["fields"] not found.
	at org.codehaus.jettison.json.JSONObject.get(JSONObject.java:426)
	at org.codehaus.jettison.json.JSONObject.getJSONObject(JSONObject.java:526)
	at com.atlassian.jira.rest.client.internal.json.IssueJsonParser.parse(IssueJsonParser.java:216)
	at com.atlassian.jira.rest.client.internal.json.IssueJsonParser.parse(IssueJsonParser.java:90)
	at com.atlassian.jira.rest.client.internal.json.GenericJsonArrayParser.parse(GenericJsonArrayParser.java:39)
	at com.atlassian.jira.rest.client.internal.json.SearchResultJsonParser.parseIssues(SearchResultJsonParser.java:43)
	at com.atlassian.jira.rest.client.internal.json.EnhancedSearchResultJsonParser.parse(EnhancedSearchResultJsonParser.java:14)
	at com.atlassian.jira.rest.client.internal.json.EnhancedSearchResultJsonParser.parse(EnhancedSearchResultJsonParser.java:9)
	at com.atlassian.jira.rest.client.internal.async.AbstractAsynchronousRestClient$1.handle(AbstractAsynchronousRestClient.java:153)
	at com.atlassian.jira.rest.client.internal.async.AbstractAsynchronousRestClient$3.apply(AbstractAsynchronousRestClient.java:202)
	... 15 more
```

2. `searchResult.getTotal()` is not available when running against jira cloud:

```
2025-07-01 13:09:51,878 WARN  [org.apa.cam.com.jir.con.NewIssuesConsumer] (Camel (camel-1) thread #1 - jira://newIssues) Failed polling endpoint: jira://newIssues?jiraUrl=https%3A%2F%2Ffuseqe2025.atlassian.net&jql=project%3DFUQT2&password=xxxxxx&username=xxxxxx. Will try again at next poll. Caused by: [java.lang.UnsupportedOperationException - Total is not available in the Cloud version of the new Search API response. Please use `SearchRestClient.totalCount` instead to fetch the estimated count of the issues for a given JQL.]: java.lang.UnsupportedOperationException: Total is not available in the Cloud version of the new Search API response. Please use `SearchRestClient.totalCount` instead to fetch the estimated count of the issues for a given JQL.
	at com.atlassian.jira.rest.client.api.domain.SearchResult.getTotal(SearchResult.java:80)
	at org.apache.camel.component.jira.consumer.AbstractJiraConsumer.getIssues(AbstractJiraConsumer.java:145)
	at org.apache.camel.component.jira.consumer.AbstractJiraConsumer.getIssues(AbstractJiraConsumer.java:114)
	at org.apache.camel.component.jira.consumer.AbstractJiraConsumer.getIssues(AbstractJiraConsumer.java:110)
	at org.apache.camel.component.jira.consumer.NewIssuesConsumer.getNewIssues(NewIssuesConsumer.java:92)
	at org.apache.camel.component.jira.consumer.NewIssuesConsumer.doPoll(NewIssuesConsumer.java:75)
	at org.apache.camel.component.jira.consumer.AbstractJiraConsumer.poll(AbstractJiraConsumer.java:65)
	at org.apache.camel.support.ScheduledPollConsumer.doRun(ScheduledPollConsumer.java:208)
	at org.apache.camel.support.ScheduledPollConsumer.run(ScheduledPollConsumer.java:119)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

# Target

- [X] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

