### PR TITLE
CAMEL-22210: Add UUIDv4 option to simple uuid function

### DIFF
--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/simple-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/simple-language.adoc
@@ -291,7 +291,7 @@ includes the route stack-trace). This can be used if you do not want to
 log sensitive data from the message itself.
 
 |uuid(type) |String |Returns a UUID using the Camel `UuidGenerator`.
-You can choose between `default`, `classic`, `short` and `simple` as the type.
+You can choose between `default`, `classic`, `short`, `simple` and `random` as the type.
 If no type is given, the default is used. It is also possible to use a custom `UuidGenerator`
 and bind the bean to the xref:manual::registry.adoc[Registry] with an id. For example `${uuid(myGenerator)}`
 where the ID is _myGenerator_.

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleExpressionBuilder.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleExpressionBuilder.java
@@ -46,6 +46,7 @@ import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.ExpressionAdapter;
 import org.apache.camel.support.LanguageHelper;
 import org.apache.camel.support.MessageHelper;
+import org.apache.camel.support.RandomUuidGenerator;
 import org.apache.camel.support.ShortUuidGenerator;
 import org.apache.camel.support.SimpleUuidGenerator;
 import org.apache.camel.support.builder.ExpressionBuilder;
@@ -525,6 +526,8 @@ public final class SimpleExpressionBuilder {
                     uuid = new ShortUuidGenerator();
                 } else if ("simple".equals(generator)) {
                     uuid = new SimpleUuidGenerator();
+                } else if ("random".equals(generator)) {
+                    uuid = new RandomUuidGenerator();
                 } else if (generator == null || "default".equals(generator)) {
                     uuid = new DefaultUuidGenerator();
                 } else {

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/SimpleFunctionExpression.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/ast/SimpleFunctionExpression.java
@@ -2058,6 +2058,9 @@ public class SimpleFunctionExpression extends LiteralExpression {
             } else if ("default".equals(generator)) {
                 sb.append("    UuidGenerator uuid = new org.apache.camel.support.DefaultUuidGenerator();\n");
                 sb.append("return uuid.generateUuid();");
+            } else if ("random".equals(generator)) {
+                sb.append("    UuidGenerator uuid = new org.apache.camel.support.RandomUuidGenerator();\n");
+                sb.append("return uuid.generateUuid();");
             } else {
                 generator = StringQuoteHelper.doubleQuote(generator);
                 sb.append("if (uuid == null) uuid = customUuidGenerator(exchange, ").append(generator)

--- a/core/camel-core/src/test/java/org/apache/camel/impl/RandomUuidGeneratorTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/RandomUuidGeneratorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl;
+
+import org.apache.camel.spi.UuidGenerator;
+import org.apache.camel.support.RandomUuidGenerator;
+import org.apache.camel.util.StopWatch;
+import org.apache.camel.util.TimeUtils;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+public class RandomUuidGeneratorTest {
+    private static final Logger LOG = LoggerFactory.getLogger(RandomUuidGeneratorTest.class);
+
+    @Test
+    public void testGenerateUUID() {
+        UuidGenerator uuidGenerator = new RandomUuidGenerator();
+
+        String firstUUID = uuidGenerator.generateUuid();
+        String secondUUID = uuidGenerator.generateUuid();
+
+        assertNotSame(firstUUID, secondUUID);
+    }
+
+    @Test
+    public void testPerformance() {
+        UuidGenerator uuidGenerator = new RandomUuidGenerator();
+        StopWatch watch = new StopWatch();
+
+        LOG.info("First id: {}", uuidGenerator.generateUuid());
+        for (int i = 0; i < 500000; i++) {
+            uuidGenerator.generateUuid();
+        }
+        LOG.info("Last id: {}", uuidGenerator.generateUuid());
+
+        LOG.info("Took {}", TimeUtils.printDuration(watch.taken(), true));
+    }
+
+}

--- a/core/camel-support/src/main/java/org/apache/camel/support/RandomUuidGenerator.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/RandomUuidGenerator.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.support;
+
+import java.util.UUID;
+
+import org.apache.camel.spi.UuidGenerator;
+
+/**
+ * Random {@link UuidGenerator} type 4 (pseudo randomly generated) UUID. 
+ * The UUID is generated using a cryptographically strong pseudo random number generator.
+ */
+public class RandomUuidGenerator implements UuidGenerator {
+
+    @Override
+    public String generateUuid() {
+        return UUID.randomUUID().toString();
+    }
+
+}

--- a/core/camel-support/src/main/java/org/apache/camel/support/RandomUuidGenerator.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/RandomUuidGenerator.java
@@ -21,8 +21,8 @@ import java.util.UUID;
 import org.apache.camel.spi.UuidGenerator;
 
 /**
- * Random {@link UuidGenerator} type 4 (pseudo randomly generated) UUID. 
- * The UUID is generated using a cryptographically strong pseudo random number generator.
+ * Random {@link UuidGenerator} type 4 (pseudo randomly generated) UUID. The UUID is generated using a cryptographically
+ * strong pseudo random number generator.
  */
 public class RandomUuidGenerator implements UuidGenerator {
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_13.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_13.adoc
@@ -89,7 +89,3 @@ which is standard across all runtimes.
 === camel-fury
 
 Camel Fury dataformat has been renamed camel-fory, this is valid for all the component elements: scheme, DSL and documentation.
-
-=== camel-simple
-
-Camel Simple has added a new uuid generator type named `random` which implements type 4 (pseudo randomly generated) UUID.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_13.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_13.adoc
@@ -89,3 +89,7 @@ which is standard across all runtimes.
 === camel-fury
 
 Camel Fury dataformat has been renamed camel-fory, this is valid for all the component elements: scheme, DSL and documentation.
+
+=== camel-simple
+
+Camel Simple has added a new uuid generator type named `random` which implements type 4 (pseudo randomly generated) UUID.

--- a/docs/user-manual/modules/ROOT/pages/uuidgenerator.adoc
+++ b/docs/user-manual/modules/ROOT/pages/uuidgenerator.adoc
@@ -43,3 +43,5 @@ Camel comes with the following implementations out of the box:
 * `org.apache.camel.support.SimpleUuidGenerator`: This implementation uses
 internally a `java.util.concurrent.atomic.AtomicLong` and increases the
 ID for every call by one. Starting with 1 as the first id.
+* `org.apache.camel.support.RandomUuidGenerator`: type 4 (pseudo randomly generated) UUID. 
+The UUID is generated using a cryptographically strong pseudo random number generator.


### PR DESCRIPTION
Add a new uuid generator type named random which implements type 4 (pseudo randomly generated) UUID. Base on java utils package UUID.
 
As discussed in Zulip Channel https://camel.zulipchat.com/#narrow/channel/257298-camel/topic/Simple.20UUID.20Generator/with/526396456 