### PR TITLE
fix(datalake): Remove unnecessary log statements

### DIFF
--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/operations/DataLakeFileSystemOperations.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/operations/DataLakeFileSystemOperations.java
@@ -48,14 +48,11 @@ public class DataLakeFileSystemOperations {
     }
 
     public DataLakeOperationResponse createFileSystem(final Exchange exchange) {
-        LOG.info("inside create file system in operation");
         final Map<String, String> metadata = configurationProxy.getMetadata(exchange);
         final PublicAccessType publicAccessType = configurationProxy.getPublicAccessType(exchange);
         final Duration timeout = configurationProxy.getTimeout(exchange);
         final DataLakeExchangeHeaders dataLakeExchangeHeaders
                 = new DataLakeExchangeHeaders().httpHeaders(client.createFileSystem(metadata, publicAccessType, timeout));
-
-        LOG.info("DataLake exchange headers: {}", dataLakeExchangeHeaders);
 
         return new DataLakeOperationResponse(true, dataLakeExchangeHeaders.toMap());
     }


### PR DESCRIPTION
# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

Removes unnecessary info log statements when creating a new filesystem:

```
2025-07-09 14:45:07,292 INFO  [org.apa.cam.com.azu.sto.dat.ope.DataLakeFileSystemOperations] (executor-thread-1) inside create file system in operation
2025-07-09 14:45:07,639 INFO  [org.apa.cam.com.azu.sto.dat.ope.DataLakeFileSystemOperations] (executor-thread-1) DataLake exchange headers: org.apache.camel.component.azure.storage.datalake.DataLakeExchangeHeaders@3db7d96e
```

# Target

- [X] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

