### PR TITLE
CAMEL-22217: Fix browse related ClassCastException where CamelMessageTimestamp header is not present

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileEndpoint.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileEndpoint.java
@@ -504,8 +504,8 @@ public abstract class GenericFileEndpoint<T> extends ScheduledPollEndpoint imple
         long ts = 0;
         long ts2 = 0;
         if (!list.isEmpty()) {
-            ts = list.get(0).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0, long.class);
-            ts2 = list.get(list.size() - 1).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0, long.class);
+            ts = list.get(0).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0L, long.class);
+            ts2 = list.get(list.size() - 1).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0L, long.class);
         }
         return new BrowseStatus(list.size(), ts, ts2);
     }

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/QueueBrowseStrategy.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/QueueBrowseStrategy.java
@@ -41,8 +41,8 @@ public interface QueueBrowseStrategy {
         long ts = 0;
         long ts2 = 0;
         if (!list.isEmpty()) {
-            ts = list.get(0).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0, long.class);
-            ts2 = list.get(list.size() - 1).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0, long.class);
+            ts = list.get(0).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0L, long.class);
+            ts2 = list.get(list.size() - 1).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0L, long.class);
         }
         return new BrowsableEndpoint.BrowseStatus(list.size(), ts, ts2);
     }

--- a/core/camel-api/src/main/java/org/apache/camel/spi/BrowsableEndpoint.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/BrowsableEndpoint.java
@@ -60,8 +60,8 @@ public interface BrowsableEndpoint extends Endpoint {
         long ts = 0;
         long ts2 = 0;
         if (!list.isEmpty()) {
-            ts = list.get(0).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0, long.class);
-            ts2 = list.get(list.size() - 1).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0, long.class);
+            ts = list.get(0).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0L, long.class);
+            ts2 = list.get(list.size() - 1).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0L, long.class);
         }
         return new BrowseStatus(list.size(), ts, ts2);
     }


### PR DESCRIPTION
Follow up to https://github.com/apache/camel/pull/18537. There are a few other potential `ClassCastException` I noticed when setting  `dump=false` on `BrowseDevConsole`.