### PR TITLE
Use AsyncEmbeddedEngine replacing deprecated EmbeddedEngine for Debezium

### DIFF
--- a/components/camel-debezium/camel-debezium-common/camel-debezium-common-component/src/main/java/org/apache/camel/component/debezium/configuration/EmbeddedDebeziumConfiguration.java
+++ b/components/camel-debezium/camel-debezium-common/camel-debezium-common-component/src/main/java/org/apache/camel/component/debezium/configuration/EmbeddedDebeziumConfiguration.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
-import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.embedded.async.AsyncEmbeddedEngine;
 import io.debezium.engine.spi.OffsetCommitPolicy;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.debezium.DebeziumConstants;
@@ -163,19 +163,19 @@ public abstract class EmbeddedDebeziumConfiguration implements Cloneable {
     private Configuration createDebeziumEmbeddedEngineConfiguration() {
         final Configuration.Builder configBuilder = Configuration.create();
 
-        addPropertyIfNotNull(configBuilder, EmbeddedEngine.ENGINE_NAME, name);
-        addPropertyIfNotNull(configBuilder, EmbeddedEngine.CONNECTOR_CLASS, connectorClass.getName());
-        addPropertyIfNotNull(configBuilder, EmbeddedEngine.OFFSET_STORAGE, offsetStorage);
-        addPropertyIfNotNull(configBuilder, EmbeddedEngine.OFFSET_STORAGE_FILE_FILENAME,
+        addPropertyIfNotNull(configBuilder, AsyncEmbeddedEngine.ENGINE_NAME, name);
+        addPropertyIfNotNull(configBuilder, AsyncEmbeddedEngine.CONNECTOR_CLASS, connectorClass.getName());
+        addPropertyIfNotNull(configBuilder, AsyncEmbeddedEngine.OFFSET_STORAGE, offsetStorage);
+        addPropertyIfNotNull(configBuilder, AsyncEmbeddedEngine.OFFSET_STORAGE_FILE_FILENAME,
                 offsetStorageFileName);
-        addPropertyIfNotNull(configBuilder, EmbeddedEngine.OFFSET_STORAGE_KAFKA_TOPIC, offsetStorageTopic);
-        addPropertyIfNotNull(configBuilder, EmbeddedEngine.OFFSET_STORAGE_KAFKA_PARTITIONS,
+        addPropertyIfNotNull(configBuilder, AsyncEmbeddedEngine.OFFSET_STORAGE_KAFKA_TOPIC, offsetStorageTopic);
+        addPropertyIfNotNull(configBuilder, AsyncEmbeddedEngine.OFFSET_STORAGE_KAFKA_PARTITIONS,
                 offsetStoragePartitions);
-        addPropertyIfNotNull(configBuilder, EmbeddedEngine.OFFSET_STORAGE_KAFKA_REPLICATION_FACTOR,
+        addPropertyIfNotNull(configBuilder, AsyncEmbeddedEngine.OFFSET_STORAGE_KAFKA_REPLICATION_FACTOR,
                 offsetStorageReplicationFactor);
-        addPropertyIfNotNull(configBuilder, EmbeddedEngine.OFFSET_COMMIT_POLICY, offsetCommitPolicy);
-        addPropertyIfNotNull(configBuilder, EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, offsetFlushIntervalMs);
-        addPropertyIfNotNull(configBuilder, EmbeddedEngine.OFFSET_COMMIT_TIMEOUT_MS, offsetCommitTimeoutMs);
+        addPropertyIfNotNull(configBuilder, AsyncEmbeddedEngine.OFFSET_COMMIT_POLICY, offsetCommitPolicy);
+        addPropertyIfNotNull(configBuilder, AsyncEmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, offsetFlushIntervalMs);
+        addPropertyIfNotNull(configBuilder, AsyncEmbeddedEngine.OFFSET_COMMIT_TIMEOUT_MS, offsetCommitTimeoutMs);
 
         if (internalKeyConverter != null && internalValueConverter != null) {
             configBuilder.with("internal.key.converter", internalKeyConverter);

--- a/components/camel-debezium/camel-debezium-common/camel-debezium-common-component/src/test/java/org/apache/camel/component/debezium/configuration/EmbeddedDebeziumConfigurationTest.java
+++ b/components/camel-debezium/camel-debezium-common/camel-debezium-common-component/src/test/java/org/apache/camel/component/debezium/configuration/EmbeddedDebeziumConfigurationTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.debezium.configuration;
 import java.util.Collections;
 
 import io.debezium.config.Configuration;
-import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.embedded.async.AsyncEmbeddedEngine;
 import org.apache.camel.component.debezium.DebeziumConstants;
 import org.junit.jupiter.api.Test;
 
@@ -38,13 +38,14 @@ public class EmbeddedDebeziumConfigurationTest {
 
         final Configuration dbzEmbeddedConfiguration = configuration.createDebeziumConfiguration();
 
-        assertEquals("test_config", dbzEmbeddedConfiguration.getString(EmbeddedEngine.ENGINE_NAME), "Expect the same name");
+        assertEquals("test_config", dbzEmbeddedConfiguration.getString(AsyncEmbeddedEngine.ENGINE_NAME),
+                "Expect the same name");
         assertEquals(2, dbzEmbeddedConfiguration
-                .getInteger(EmbeddedEngine.OFFSET_STORAGE_KAFKA_REPLICATION_FACTOR));
+                .getInteger(AsyncEmbeddedEngine.OFFSET_STORAGE_KAFKA_REPLICATION_FACTOR));
         assertEquals(DebeziumConstants.DEFAULT_OFFSET_STORAGE,
-                dbzEmbeddedConfiguration.getString(EmbeddedEngine.OFFSET_STORAGE));
+                dbzEmbeddedConfiguration.getString(AsyncEmbeddedEngine.OFFSET_STORAGE));
         assertEquals("test_field", configuration.getTestField());
-        assertEquals(Class.class.getName(), dbzEmbeddedConfiguration.getString(EmbeddedEngine.CONNECTOR_CLASS));
+        assertEquals(Class.class.getName(), dbzEmbeddedConfiguration.getString(AsyncEmbeddedEngine.CONNECTOR_CLASS));
     }
 
     @Test

--- a/components/camel-debezium/camel-debezium-db2/src/test/java/org/apache/camel/component/debezium/db2/configuration/Db2ConnectorEmbeddedDebeziumConfigurationTest.java
+++ b/components/camel-debezium/camel-debezium-db2/src/test/java/org/apache/camel/component/debezium/db2/configuration/Db2ConnectorEmbeddedDebeziumConfigurationTest.java
@@ -21,7 +21,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.db2.Db2Connector;
 import io.debezium.connector.db2.Db2ConnectorConfig;
-import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.embedded.async.AsyncEmbeddedEngine;
 import org.apache.camel.component.debezium.DebeziumConstants;
 import org.apache.camel.component.debezium.configuration.ConfigurationValidation;
 import org.junit.jupiter.api.Test;
@@ -42,12 +42,12 @@ public class Db2ConnectorEmbeddedDebeziumConfigurationTest {
 
         final Configuration dbzConfigurations = configuration.createDebeziumConfiguration();
 
-        assertEquals("test_config", dbzConfigurations.getString(EmbeddedEngine.ENGINE_NAME));
+        assertEquals("test_config", dbzConfigurations.getString(AsyncEmbeddedEngine.ENGINE_NAME));
         assertEquals("test_user", dbzConfigurations.getString(Db2ConnectorConfig.USER));
         assertEquals(1212, dbzConfigurations.getInteger(CommonConnectorConfig.MAX_QUEUE_SIZE));
-        assertEquals(Db2Connector.class.getName(), dbzConfigurations.getString(EmbeddedEngine.CONNECTOR_CLASS));
+        assertEquals(Db2Connector.class.getName(), dbzConfigurations.getString(AsyncEmbeddedEngine.CONNECTOR_CLASS));
         assertEquals(DebeziumConstants.DEFAULT_OFFSET_STORAGE,
-                dbzConfigurations.getString(EmbeddedEngine.OFFSET_STORAGE));
+                dbzConfigurations.getString(AsyncEmbeddedEngine.OFFSET_STORAGE));
     }
 
     @Test

--- a/components/camel-debezium/camel-debezium-mongodb/src/test/java/org/apache/camel/component/debezium/mongodb/configuration/MongodbConnectorEmbeddedDebeziumConfigurationTest.java
+++ b/components/camel-debezium/camel-debezium-mongodb/src/test/java/org/apache/camel/component/debezium/mongodb/configuration/MongodbConnectorEmbeddedDebeziumConfigurationTest.java
@@ -20,7 +20,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mongodb.MongoDbConnector;
 import io.debezium.connector.mongodb.MongoDbConnectorConfig;
-import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.embedded.async.AsyncEmbeddedEngine;
 import org.apache.camel.component.debezium.DebeziumConstants;
 import org.apache.camel.component.debezium.configuration.ConfigurationValidation;
 import org.junit.jupiter.api.Test;
@@ -40,12 +40,12 @@ public class MongodbConnectorEmbeddedDebeziumConfigurationTest {
 
         final Configuration dbzConfigurations = configuration.createDebeziumConfiguration();
 
-        assertEquals("test_config", dbzConfigurations.getString(EmbeddedEngine.ENGINE_NAME));
+        assertEquals("test_config", dbzConfigurations.getString(AsyncEmbeddedEngine.ENGINE_NAME));
         assertEquals("test_user", dbzConfigurations.getString(MongoDbConnectorConfig.USER));
         assertEquals(1212, dbzConfigurations.getInteger(CommonConnectorConfig.MAX_QUEUE_SIZE));
-        assertEquals(MongoDbConnector.class.getName(), dbzConfigurations.getString(EmbeddedEngine.CONNECTOR_CLASS));
+        assertEquals(MongoDbConnector.class.getName(), dbzConfigurations.getString(AsyncEmbeddedEngine.CONNECTOR_CLASS));
         assertEquals(DebeziumConstants.DEFAULT_OFFSET_STORAGE,
-                dbzConfigurations.getString(EmbeddedEngine.OFFSET_STORAGE));
+                dbzConfigurations.getString(AsyncEmbeddedEngine.OFFSET_STORAGE));
     }
 
     @Test

--- a/components/camel-debezium/camel-debezium-mysql/src/test/java/org/apache/camel/component/debezium/mysql/configuration/MySqlConnectorEmbeddedDebeziumConfigurationTest.java
+++ b/components/camel-debezium/camel-debezium-mysql/src/test/java/org/apache/camel/component/debezium/mysql/configuration/MySqlConnectorEmbeddedDebeziumConfigurationTest.java
@@ -20,7 +20,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnector;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
-import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.embedded.async.AsyncEmbeddedEngine;
 import org.apache.camel.component.debezium.DebeziumConstants;
 import org.apache.camel.component.debezium.configuration.ConfigurationValidation;
 import org.junit.jupiter.api.Test;
@@ -41,16 +41,16 @@ public class MySqlConnectorEmbeddedDebeziumConfigurationTest {
 
         final Configuration dbzMysqlConfigurations = configuration.createDebeziumConfiguration();
 
-        assertEquals("test_config", dbzMysqlConfigurations.getString(EmbeddedEngine.ENGINE_NAME));
+        assertEquals("test_config", dbzMysqlConfigurations.getString(AsyncEmbeddedEngine.ENGINE_NAME));
         assertEquals("test_user", dbzMysqlConfigurations.getString(MySqlConnectorConfig.USER));
         assertTrue(dbzMysqlConfigurations.getBoolean(MySqlConnectorConfig.INCLUDE_SQL_QUERY));
         assertEquals(1212, dbzMysqlConfigurations.getInteger(CommonConnectorConfig.MAX_QUEUE_SIZE));
         assertEquals(30000,
                 dbzMysqlConfigurations.getLong(MySqlConnectorConfig.CONNECTION_TIMEOUT_MS));
-        assertEquals(MySqlConnector.class.getName(), dbzMysqlConfigurations.getString(EmbeddedEngine.CONNECTOR_CLASS));
+        assertEquals(MySqlConnector.class.getName(), dbzMysqlConfigurations.getString(AsyncEmbeddedEngine.CONNECTOR_CLASS));
         assertTrue(dbzMysqlConfigurations.getBoolean(MySqlConnectorConfig.INCLUDE_SQL_QUERY));
         assertEquals(DebeziumConstants.DEFAULT_OFFSET_STORAGE,
-                dbzMysqlConfigurations.getString(EmbeddedEngine.OFFSET_STORAGE));
+                dbzMysqlConfigurations.getString(AsyncEmbeddedEngine.OFFSET_STORAGE));
         assertEquals(30000,
                 dbzMysqlConfigurations.getLong(MySqlConnectorConfig.CONNECTION_TIMEOUT_MS));
     }

--- a/components/camel-debezium/camel-debezium-oracle/src/test/java/org/apache/camel/component/debezium/oracle/configuration/OracleConnectorEmbeddedDebeziumConfigurationTest.java
+++ b/components/camel-debezium/camel-debezium-oracle/src/test/java/org/apache/camel/component/debezium/oracle/configuration/OracleConnectorEmbeddedDebeziumConfigurationTest.java
@@ -21,7 +21,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnector;
 import io.debezium.connector.oracle.OracleConnectorConfig;
-import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.embedded.async.AsyncEmbeddedEngine;
 import org.apache.camel.component.debezium.DebeziumConstants;
 import org.apache.camel.component.debezium.configuration.ConfigurationValidation;
 import org.junit.jupiter.api.Test;
@@ -42,12 +42,12 @@ public class OracleConnectorEmbeddedDebeziumConfigurationTest {
 
         final Configuration dbzConfigurations = configuration.createDebeziumConfiguration();
 
-        assertEquals("test_config", dbzConfigurations.getString(EmbeddedEngine.ENGINE_NAME));
+        assertEquals("test_config", dbzConfigurations.getString(AsyncEmbeddedEngine.ENGINE_NAME));
         assertEquals("test_user", dbzConfigurations.getString(OracleConnectorConfig.USER));
         assertEquals(1212, dbzConfigurations.getInteger(CommonConnectorConfig.MAX_QUEUE_SIZE));
-        assertEquals(OracleConnector.class.getName(), dbzConfigurations.getString(EmbeddedEngine.CONNECTOR_CLASS));
+        assertEquals(OracleConnector.class.getName(), dbzConfigurations.getString(AsyncEmbeddedEngine.CONNECTOR_CLASS));
         assertEquals(DebeziumConstants.DEFAULT_OFFSET_STORAGE,
-                dbzConfigurations.getString(EmbeddedEngine.OFFSET_STORAGE));
+                dbzConfigurations.getString(AsyncEmbeddedEngine.OFFSET_STORAGE));
     }
 
     @Test

--- a/components/camel-debezium/camel-debezium-postgres/src/test/java/org/apache/camel/component/debezium/postgres/configuration/PostgresConnectorEmbeddedDebeziumConfigurationTest.java
+++ b/components/camel-debezium/camel-debezium-postgres/src/test/java/org/apache/camel/component/debezium/postgres/configuration/PostgresConnectorEmbeddedDebeziumConfigurationTest.java
@@ -20,7 +20,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnector;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
-import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.embedded.async.AsyncEmbeddedEngine;
 import org.apache.camel.component.debezium.DebeziumConstants;
 import org.apache.camel.component.debezium.configuration.ConfigurationValidation;
 import org.junit.jupiter.api.Test;
@@ -41,12 +41,12 @@ public class PostgresConnectorEmbeddedDebeziumConfigurationTest {
 
         final Configuration dbzConfigurations = configuration.createDebeziumConfiguration();
 
-        assertEquals("test_config", dbzConfigurations.getString(EmbeddedEngine.ENGINE_NAME));
+        assertEquals("test_config", dbzConfigurations.getString(AsyncEmbeddedEngine.ENGINE_NAME));
         assertEquals("test_user", dbzConfigurations.getString(PostgresConnectorConfig.USER));
         assertEquals(1212, dbzConfigurations.getInteger(CommonConnectorConfig.MAX_QUEUE_SIZE));
-        assertEquals(PostgresConnector.class.getName(), dbzConfigurations.getString(EmbeddedEngine.CONNECTOR_CLASS));
+        assertEquals(PostgresConnector.class.getName(), dbzConfigurations.getString(AsyncEmbeddedEngine.CONNECTOR_CLASS));
         assertEquals(DebeziumConstants.DEFAULT_OFFSET_STORAGE,
-                dbzConfigurations.getString(EmbeddedEngine.OFFSET_STORAGE));
+                dbzConfigurations.getString(AsyncEmbeddedEngine.OFFSET_STORAGE));
     }
 
     @Test

--- a/components/camel-debezium/camel-debezium-sqlserver/src/test/java/org/apache/camel/component/debezium/sqlserver/configuration/SqlserverConnectorEmbeddedDebeziumConfigurationTest.java
+++ b/components/camel-debezium/camel-debezium-sqlserver/src/test/java/org/apache/camel/component/debezium/sqlserver/configuration/SqlserverConnectorEmbeddedDebeziumConfigurationTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.debezium.sqlserver.configuration;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.sqlserver.SqlServerConnector;
-import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.embedded.async.AsyncEmbeddedEngine;
 import org.apache.camel.component.debezium.DebeziumConstants;
 import org.apache.camel.component.debezium.configuration.ConfigurationValidation;
 import org.junit.jupiter.api.Test;
@@ -40,12 +40,12 @@ public class SqlserverConnectorEmbeddedDebeziumConfigurationTest {
 
         final Configuration dbzConfigurations = configuration.createDebeziumConfiguration();
 
-        assertEquals("test_config", dbzConfigurations.getString(EmbeddedEngine.ENGINE_NAME));
+        assertEquals("test_config", dbzConfigurations.getString(AsyncEmbeddedEngine.ENGINE_NAME));
         assertEquals("test_user", dbzConfigurations.getString("database.user"));
         assertEquals(1212, dbzConfigurations.getInteger(CommonConnectorConfig.MAX_QUEUE_SIZE));
-        assertEquals(SqlServerConnector.class.getName(), dbzConfigurations.getString(EmbeddedEngine.CONNECTOR_CLASS));
+        assertEquals(SqlServerConnector.class.getName(), dbzConfigurations.getString(AsyncEmbeddedEngine.CONNECTOR_CLASS));
         assertEquals(DebeziumConstants.DEFAULT_OFFSET_STORAGE,
-                dbzConfigurations.getString(EmbeddedEngine.OFFSET_STORAGE));
+                dbzConfigurations.getString(AsyncEmbeddedEngine.OFFSET_STORAGE));
     }
 
     @Test


### PR DESCRIPTION
based on https://debezium.io/releases/3.2/release-notes

The mentioned class EmbeddedEngine will be removed https://issues.redhat.com/browse/DBZ-8029 in 3.2 (after being deprecated for several versions)

needs to use AsyncEmbeddedEngine instead
https://github.com/debezium/debezium/pull/5645/files

Doing the update here will allow an easier transition between Debezium 3.1 and 3.2 and alignment with Quarkus

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

