### PR TITLE
camel-groovy: Set application context ClassLoader as GroovyScriptClassLoader parent if present

### DIFF
--- a/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/DefaultGroovyScriptCompiler.java
+++ b/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/DefaultGroovyScriptCompiler.java
@@ -159,7 +159,12 @@ public class DefaultGroovyScriptCompiler extends ServiceSupport
             // use existing class loader if available
             classLoader = (GroovyScriptClassLoader) context.getClassResolver().getClassLoader("GroovyScriptClassLoader");
             if (classLoader == null) {
-                classLoader = new GroovyScriptClassLoader();
+                ClassLoader applicationContextClassLoader = context.getApplicationContextClassLoader();
+                if (applicationContextClassLoader != null) {
+                    classLoader = new GroovyScriptClassLoader(applicationContextClassLoader);
+                } else {
+                    classLoader = new GroovyScriptClassLoader();
+                }
                 context.getClassResolver().addClassLoader(classLoader);
                 // make classloader available for groovy language
                 context.getCamelContextExtension().addContextPlugin(GroovyScriptClassLoader.class, classLoader);

--- a/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyScriptClassLoader.java
+++ b/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyScriptClassLoader.java
@@ -33,6 +33,10 @@ public class GroovyScriptClassLoader extends ClassLoader implements Closeable {
         super(GroovyScriptClassLoader.class.getClassLoader());
     }
 
+    public GroovyScriptClassLoader(ClassLoader parent) {
+        super(parent);
+    }
+
     @Override
     public String getName() {
         return "GroovyScriptClassLoader";


### PR DESCRIPTION
Fixes a failure in the Camel Quarkus test suite due to the wrong ClassLoader being used.