### PR TITLE
CAMEL-22258 Upgrade Apache Directory Server to 2.0.0.AM27

### DIFF
--- a/components/camel-ldif/src/test/java/org/apache/directory/server/core/integ5/DirectoryExtension.java
+++ b/components/camel-ldif/src/test/java/org/apache/directory/server/core/integ5/DirectoryExtension.java
@@ -34,7 +34,6 @@ import org.apache.directory.server.core.factory.DefaultDirectoryServiceFactory;
 import org.apache.directory.server.core.factory.DirectoryServiceFactory;
 import org.apache.directory.server.core.factory.PartitionFactory;
 import org.apache.directory.server.core.security.TlsKeyGenerator;
-import org.apache.directory.server.kerberos.kdc.KdcServer;
 import org.apache.directory.server.ldap.LdapServer;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -68,11 +67,6 @@ public class DirectoryExtension implements BeforeAllCallback, AfterAllCallback, 
      */
     private static final String SET_LDAP_SERVER_METHOD_NAME = "setLdapServer";
 
-    /**
-     * The 'kdcServer' field in the run tests
-     */
-    private static final String SET_KDC_SERVER_METHOD_NAME = "setKdcServer";
-
     public static class State {
         DirectoryService classDirectoryService;
         DirectoryService methodDirectoryService;
@@ -80,9 +74,6 @@ public class DirectoryExtension implements BeforeAllCallback, AfterAllCallback, 
         LdapServer classLdapServer;
         LdapServer methodLdapServer;
         LdapServer ldapServer;
-        KdcServer classKdcServer;
-        KdcServer methodKdcServer;
-        KdcServer kdcServer;
         DirectoryService oldLdapServerDirService;
         DirectoryService oldKdcServerDirService;
         long revision;
@@ -111,8 +102,6 @@ public class DirectoryExtension implements BeforeAllCallback, AfterAllCallback, 
             // check if it has a LdapServerBuilder, then use the DS created above
             classLdapServer = ServerAnnotationProcessor.createLdapServer(description, classDirectoryService);
 
-            classKdcServer = ServerAnnotationProcessor.getKdcServer(description, classDirectoryService);
-
             // print out information which partition factory we use
             DirectoryServiceFactory dsFactory = new DefaultDirectoryServiceFactory();
             PartitionFactory partitionFactory = dsFactory.getPartitionFactory();
@@ -135,8 +124,6 @@ public class DirectoryExtension implements BeforeAllCallback, AfterAllCallback, 
                 directoryService = classDirectoryService;
             } else if (classLdapServer != null) {
                 directoryService = classLdapServer.getDirectoryService();
-            } else if (classKdcServer != null) {
-                directoryService = classKdcServer.getDirectoryService();
             }
             // apply the method LDIFs, and tag for reversion
             revision = getCurrentRevision(directoryService);
@@ -153,35 +140,17 @@ public class DirectoryExtension implements BeforeAllCallback, AfterAllCallback, 
                 ldapServer.setDirectoryService(directoryService);
             }
 
-            methodKdcServer = ServerAnnotationProcessor.getKdcServer(methodDescription, directoryService);
-            if (methodKdcServer != null) {
-                kdcServer = methodKdcServer;
-            } else if (classKdcServer != null) {
-                kdcServer = classKdcServer;
-            }
-            if (kdcServer != null) {
-                oldKdcServerDirService = kdcServer.getDirectoryService();
-                kdcServer.setDirectoryService(directoryService);
-            }
-
             // At this point, we know which services to use, so inject them into the test instance
             inject(context, SET_SERVICE_METHOD_NAME, DirectoryService.class, directoryService);
             inject(context, SET_LDAP_SERVER_METHOD_NAME, LdapServer.class, ldapServer);
-            inject(context, SET_KDC_SERVER_METHOD_NAME, KdcServer.class, kdcServer);
         }
 
         public void afterEach(ExtensionContext context) throws Exception {
             if (oldLdapServerDirService != null) {
                 ldapServer.setDirectoryService(oldLdapServerDirService);
             }
-            if (oldKdcServerDirService != null) {
-                kdcServer.setDirectoryService(oldKdcServerDirService);
-            }
             if (methodLdapServer != null) {
                 methodLdapServer.stop();
-            }
-            if (methodKdcServer != null) {
-                methodKdcServer.stop();
             }
             // Cleanup the methodDS if it has been created
             if (methodDirectoryService != null) {
@@ -197,9 +166,6 @@ public class DirectoryExtension implements BeforeAllCallback, AfterAllCallback, 
         public void afterAll(ExtensionContext context) throws Exception {
             if (classLdapServer != null) {
                 classLdapServer.stop();
-            }
-            if (classKdcServer != null) {
-                classKdcServer.stop();
             }
             if (classDirectoryService != null) {
                 LOG.debug("Shuting down DS for {}", classDirectoryService.getInstanceId());

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -62,7 +62,7 @@
         <allegro-converter-version>0.3.0</allegro-converter-version>
         <amazon-kinesis-client-version>2.6.0</amazon-kinesis-client-version>
         <angus-mail-version>2.0.3</angus-mail-version>
-        <apacheds-version>2.0.0.AM26</apacheds-version>
+        <apacheds-version>2.0.0.AM27</apacheds-version>
         <apache-drill-version>1.22.0</apache-drill-version>
         <arangodb-java-version>7.20.0</arangodb-java-version>
         <as2-lib-version>5.1.5</as2-lib-version>


### PR DESCRIPTION
# Description

Upgrade Apache Directory Server to 2.0.0.AM27.      Between 2.0.0.AM26 and 2.0.0.AM27, Kerberos functionality was removed from Apache Directory Server and moved to a separate project (Apache Kerby) : https://github.com/apache/directory-server/commit/bb6db861681951c930941ed4bb92fd358fa333ec - this commit removes the Kerberos functionality which no longer exists in Apache Directory Server from the camel-ldap tests.

https://issues.apache.org/jira/browse/CAMEL-22258

# Target

- [x ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [ x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

Note : the camel-ldap tests are disabled by default and fail due to an error applying the ldif file.     These tests compile with this change, but still fail with the same error.     