### PR TITLE
CAMEL-22261 Reuse existing transaction if already transacted

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
@@ -532,14 +532,16 @@ public class KafkaProducer extends DefaultAsyncProducer implements RouteIdAware 
 
         if (uow.isTransactedBy(transactionId)) {
             if (LOG.isDebugEnabled()) {
-            	LOG.debug("Not starting kafka transaction {} with exchange {} (UOW hash code {}) since one is already started.", transactionId, exchange.getExchangeId(), uow.hashCode());
+                LOG.debug("Not starting kafka transaction {} with exchange {} (UOW hash code {}) since one is already started.",
+                        transactionId, exchange.getExchangeId(), uow.hashCode());
             }
-    		return;
-		} else if (LOG.isDebugEnabled()) {
-        	LOG.debug("Starting kafka transaction {} with exchange {} (UOW hash code {})", transactionId, exchange.getExchangeId(), uow.hashCode());
-		}
+            return;
+        } else if (LOG.isDebugEnabled()) {
+            LOG.debug("Starting kafka transaction {} with exchange {} (UOW hash code {})", transactionId,
+                    exchange.getExchangeId(), uow.hashCode());
+        }
 
-    	uow.beginTransactedBy(transactionId);
+        uow.beginTransactedBy(transactionId);
         kafkaProducer.beginTransaction();
         uow.addSynchronization(new KafkaTransactionSynchronization(transactionId, kafkaProducer));
     }

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
@@ -41,6 +41,7 @@ import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
 import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.UnitOfWork;
 import org.apache.camel.support.DefaultAsyncProducer;
 import org.apache.camel.util.KeyValueHolder;
 import org.apache.camel.util.ObjectHelper;
@@ -527,9 +528,20 @@ public class KafkaProducer extends DefaultAsyncProducer implements RouteIdAware 
     }
 
     private void startKafkaTransaction(Exchange exchange) {
-        exchange.getUnitOfWork().beginTransactedBy(transactionId);
+        UnitOfWork uow = exchange.getUnitOfWork();
+
+        if (uow.isTransactedBy(transactionId)) {
+            if (LOG.isDebugEnabled()) {
+            	LOG.debug("Not starting kafka transaction {} with exchange {} (UOW hash code {}) since one is already started.", transactionId, exchange.getExchangeId(), uow.hashCode());
+            }
+    		return;
+		} else if (LOG.isDebugEnabled()) {
+        	LOG.debug("Starting kafka transaction {} with exchange {} (UOW hash code {})", transactionId, exchange.getExchangeId(), uow.hashCode());
+		}
+
+    	uow.beginTransactedBy(transactionId);
         kafkaProducer.beginTransaction();
-        exchange.getUnitOfWork().addSynchronization(new KafkaTransactionSynchronization(transactionId, kafkaProducer));
+        uow.addSynchronization(new KafkaTransactionSynchronization(transactionId, kafkaProducer));
     }
 
     @Override

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaProducerMultipleMessagesInTransactionWithSplitTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaProducerMultipleMessagesInTransactionWithSplitTest.java
@@ -1,9 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.component.kafka;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.mockito.ArgumentMatchers.any;
 
 import java.util.Properties;
 
@@ -22,112 +33,118 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.mockito.Mockito;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class KafkaProducerMultipleMessagesInTransactionWithSplitTest extends CamelTestSupport {
-	@EndpointInject("mock:done")
-	protected MockEndpoint doneEndpoint;
-	
-	private MockProducer<String, String> mockProducer = new MockProducer<>(true, new StringSerializer(), new StringSerializer());
-			
-	@Override
-	protected CamelContext createCamelContext() throws Exception {
-		CamelContext context = super.createCamelContext();
-		
-		KafkaClientFactory kcf = Mockito.mock(KafkaClientFactory.class);
-		Mockito.when(kcf.getProducer(any(Properties.class))).thenReturn(mockProducer);
-		
-		KafkaComponent kafka = new KafkaComponent(); 
-	    kafka.getConfiguration().setBrokers("broker1:1234,broker2:4567");
-	    kafka.getConfiguration().setRecordMetadata(true);
-	    kafka.setKafkaClientFactory(kcf);
-	    		
-		context.addComponent("kafka", kafka);
-		
-		return context;
-	}
+    @EndpointInject("mock:done")
+    protected MockEndpoint doneEndpoint;
 
-	/**
-	 * In a Split EIP sends messages with transactional.id to Kafka.
-	 */
-	@Test
-	public void test01_HappySplitPath() throws Exception {
-		StringBuilder sb = new StringBuilder();
-		int messageCount = 5;
-	
-		doneEndpoint.expectedMessageCount(1);
-	
-		for (int i = 0; i < messageCount; i++) {
-			sb.append(String.format("test%02d\n", i + 1));
-		}
-		
-		template.sendBody("direct:split", sb.toString());			
-	
-		MockEndpoint.assertIsSatisfied(context);
-	
-		assertEquals(messageCount, mockProducer.history().size());
-		assertEquals(1, mockProducer.commitCount());
-	}
+    private MockProducer<String, String> mockProducer
+            = new MockProducer<>(true, new StringSerializer(), new StringSerializer());
 
-	/**
-	 * Using the same route as in test01_HappySplitPath but will throw a
-	 * RuntimeException on the last iteration.
-	 */
-	@Test
-	public void test02_OnExceptionWithSplitPath() throws Exception {
-		StringBuilder sb = new StringBuilder();
-		Exception exceptionCaught = null;
-		int throwExeptionOnIndex = 4;
-		
-		for (int i = 0; i < throwExeptionOnIndex+1; i++) {
-			sb.append(String.format("test%02d\n", i + 1));
-		}
-		
-		try {
-			template.sendBodyAndHeader("direct:split", sb.toString(), "ThrowExeptionOnIndex", throwExeptionOnIndex);			
-		} catch (CamelExecutionException e) {
-			exceptionCaught = e;
-		}
-	
-		assertNotNull(exceptionCaught);
-		assertInstanceOf(CamelExchangeException.class, exceptionCaught.getCause());
-		assertInstanceOf(RuntimeException.class, exceptionCaught.getCause().getCause());
-		assertEquals("Failing with Index: "+throwExeptionOnIndex, exceptionCaught.getCause().getCause().getMessage());
-	
-		assertEquals(0, mockProducer.history().size());
-		assertEquals(0, mockProducer.commitCount());
-	}
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
 
-	@Override
-	protected RoutesBuilder createRouteBuilder() throws Exception {
-				
-		return new RouteBuilder() {
-			@Override
-			public void configure() throws Exception {
-				from("direct:split")
-					.id("split")
-					.setVariable("ThrowExeptionOnIndex", 
-							header("ThrowExeptionOnIndex").convertTo(Integer.class))
-					.split(body().tokenize("\n")).shareUnitOfWork(true).stopOnException()
-						.choice().when(exchange -> {
-							Integer throwExeptionOnIndex = exchange.getVariable("ThrowExeptionOnIndex", Integer.class);
-							Integer camelSplitIndex = exchange.getProperty("CamelSplitIndex", Integer.class);
-	
-							if (null != throwExeptionOnIndex && throwExeptionOnIndex == camelSplitIndex) {
-								return true;
-							} else {
-								System.out.printf("***** Sending message to Kafka from Split exchange with id '%s' and UnitOfWork: %s%n",
-									exchange.getExchangeId(), exchange.getUnitOfWork().hashCode());
-	
-								return false;
-							}
-						})
-							.throwException(RuntimeException.class, "Failing with Index: ${exchangeProperty.CamelSplitIndex}")
-						.otherwise()
-							.to("kafka:split?additional-properties[transactional.id]=45678&additional-properties[enable.idempotence]=true&additional-properties[retries]=5")
-						.end() // .choice
-					.end() // .split
-					.to("mock:done");
-			}
-		};
-	}
+        KafkaClientFactory kcf = Mockito.mock(KafkaClientFactory.class);
+        Mockito.when(kcf.getProducer(any(Properties.class))).thenReturn(mockProducer);
+
+        KafkaComponent kafka = new KafkaComponent();
+        kafka.getConfiguration().setBrokers("broker1:1234,broker2:4567");
+        kafka.getConfiguration().setRecordMetadata(true);
+        kafka.setKafkaClientFactory(kcf);
+
+        context.addComponent("kafka", kafka);
+
+        return context;
+    }
+
+    /**
+     * In a Split EIP sends messages with transactional.id to Kafka.
+     */
+    @Test
+    public void test01_HappySplitPath() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        int messageCount = 5;
+
+        doneEndpoint.expectedMessageCount(1);
+
+        for (int i = 0; i < messageCount; i++) {
+            sb.append(String.format("test%02d\n", i + 1));
+        }
+
+        template.sendBody("direct:split", sb.toString());
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        assertEquals(messageCount, mockProducer.history().size());
+        assertEquals(1, mockProducer.commitCount());
+    }
+
+    /**
+     * Using the same route as in test01_HappySplitPath but will throw a RuntimeException on the last iteration.
+     */
+    @Test
+    public void test02_OnExceptionWithSplitPath() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        Exception exceptionCaught = null;
+        int throwExeptionOnIndex = 4;
+
+        for (int i = 0; i < throwExeptionOnIndex + 1; i++) {
+            sb.append(String.format("test%02d\n", i + 1));
+        }
+
+        try {
+            template.sendBodyAndHeader("direct:split", sb.toString(), "ThrowExeptionOnIndex", throwExeptionOnIndex);
+        } catch (CamelExecutionException e) {
+            exceptionCaught = e;
+        }
+
+        assertNotNull(exceptionCaught);
+        assertInstanceOf(CamelExchangeException.class, exceptionCaught.getCause());
+        assertInstanceOf(RuntimeException.class, exceptionCaught.getCause().getCause());
+        assertEquals("Failing with Index: " + throwExeptionOnIndex, exceptionCaught.getCause().getCause().getMessage());
+
+        assertEquals(0, mockProducer.history().size());
+        assertEquals(0, mockProducer.commitCount());
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() throws Exception {
+
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:split")
+                        .id("split")
+                        .setVariable("ThrowExeptionOnIndex",
+                                header("ThrowExeptionOnIndex").convertTo(Integer.class))
+                        .split(body().tokenize("\n")).shareUnitOfWork(true).stopOnException()
+                        .choice().when(exchange -> {
+                            Integer throwExeptionOnIndex = exchange.getVariable("ThrowExeptionOnIndex", Integer.class);
+                            Integer camelSplitIndex = exchange.getProperty("CamelSplitIndex", Integer.class);
+
+                            if (null != throwExeptionOnIndex && throwExeptionOnIndex == camelSplitIndex) {
+                                return true;
+                            } else {
+                                System.out.printf(
+                                        "***** Sending message to Kafka from Split exchange with id '%s' and UnitOfWork: %s%n",
+                                        exchange.getExchangeId(), exchange.getUnitOfWork().hashCode());
+
+                                return false;
+                            }
+                        })
+                        .throwException(RuntimeException.class, "Failing with Index: ${exchangeProperty.CamelSplitIndex}")
+                        .otherwise()
+                        .to("kafka:split?additional-properties[transactional.id]=45678&additional-properties[enable.idempotence]=true&additional-properties[retries]=5")
+                        .end() // .choice
+                        .end() // .split
+                        .to("mock:done");
+            }
+        };
+    }
 }

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaProducerMultipleMessagesInTransactionWithSplitTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaProducerMultipleMessagesInTransactionWithSplitTest.java
@@ -1,0 +1,133 @@
+package org.apache.camel.component.kafka;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.Properties;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelExchangeException;
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.Mockito;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class KafkaProducerMultipleMessagesInTransactionWithSplitTest extends CamelTestSupport {
+	@EndpointInject("mock:done")
+	protected MockEndpoint doneEndpoint;
+	
+	private MockProducer<String, String> mockProducer = new MockProducer<>(true, new StringSerializer(), new StringSerializer());
+			
+	@Override
+	protected CamelContext createCamelContext() throws Exception {
+		CamelContext context = super.createCamelContext();
+		
+		KafkaClientFactory kcf = Mockito.mock(KafkaClientFactory.class);
+		Mockito.when(kcf.getProducer(any(Properties.class))).thenReturn(mockProducer);
+		
+		KafkaComponent kafka = new KafkaComponent(); 
+	    kafka.getConfiguration().setBrokers("broker1:1234,broker2:4567");
+	    kafka.getConfiguration().setRecordMetadata(true);
+	    kafka.setKafkaClientFactory(kcf);
+	    		
+		context.addComponent("kafka", kafka);
+		
+		return context;
+	}
+
+	/**
+	 * In a Split EIP sends messages with transactional.id to Kafka.
+	 */
+	@Test
+	public void test01_HappySplitPath() throws Exception {
+		StringBuilder sb = new StringBuilder();
+		int messageCount = 5;
+	
+		doneEndpoint.expectedMessageCount(1);
+	
+		for (int i = 0; i < messageCount; i++) {
+			sb.append(String.format("test%02d\n", i + 1));
+		}
+		
+		template.sendBody("direct:split", sb.toString());			
+	
+		MockEndpoint.assertIsSatisfied(context);
+	
+		assertEquals(messageCount, mockProducer.history().size());
+		assertEquals(1, mockProducer.commitCount());
+	}
+
+	/**
+	 * Using the same route as in test01_HappySplitPath but will throw a
+	 * RuntimeException on the last iteration.
+	 */
+	@Test
+	public void test02_OnExceptionWithSplitPath() throws Exception {
+		StringBuilder sb = new StringBuilder();
+		Exception exceptionCaught = null;
+		int throwExeptionOnIndex = 4;
+		
+		for (int i = 0; i < throwExeptionOnIndex+1; i++) {
+			sb.append(String.format("test%02d\n", i + 1));
+		}
+		
+		try {
+			template.sendBodyAndHeader("direct:split", sb.toString(), "ThrowExeptionOnIndex", throwExeptionOnIndex);			
+		} catch (CamelExecutionException e) {
+			exceptionCaught = e;
+		}
+	
+		assertNotNull(exceptionCaught);
+		assertInstanceOf(CamelExchangeException.class, exceptionCaught.getCause());
+		assertInstanceOf(RuntimeException.class, exceptionCaught.getCause().getCause());
+		assertEquals("Failing with Index: "+throwExeptionOnIndex, exceptionCaught.getCause().getCause().getMessage());
+	
+		assertEquals(0, mockProducer.history().size());
+		assertEquals(0, mockProducer.commitCount());
+	}
+
+	@Override
+	protected RoutesBuilder createRouteBuilder() throws Exception {
+				
+		return new RouteBuilder() {
+			@Override
+			public void configure() throws Exception {
+				from("direct:split")
+					.id("split")
+					.setVariable("ThrowExeptionOnIndex", 
+							header("ThrowExeptionOnIndex").convertTo(Integer.class))
+					.split(body().tokenize("\n")).shareUnitOfWork(true).stopOnException()
+						.choice().when(exchange -> {
+							Integer throwExeptionOnIndex = exchange.getVariable("ThrowExeptionOnIndex", Integer.class);
+							Integer camelSplitIndex = exchange.getProperty("CamelSplitIndex", Integer.class);
+	
+							if (null != throwExeptionOnIndex && throwExeptionOnIndex == camelSplitIndex) {
+								return true;
+							} else {
+								System.out.printf("***** Sending message to Kafka from Split exchange with id '%s' and UnitOfWork: %s%n",
+									exchange.getExchangeId(), exchange.getUnitOfWork().hashCode());
+	
+								return false;
+							}
+						})
+							.throwException(RuntimeException.class, "Failing with Index: ${exchangeProperty.CamelSplitIndex}")
+						.otherwise()
+							.to("kafka:split?additional-properties[transactional.id]=45678&additional-properties[enable.idempotence]=true&additional-properties[retries]=5")
+						.end() // .choice
+					.end() // .split
+					.to("mock:done");
+			}
+		};
+	}
+}


### PR DESCRIPTION
# Description

This PR fix an issue with sending multiple messages from a Split EIP to Kafka with a transaction as a fix form issue [CAMEL-22261](https://issues.apache.org/jira/browse/CAMEL-22261).

Before fix of issue [CAMEL-22259](https://issues.apache.org/jira/browse/CAMEL-22259) this cased messages to be sent in separate transaction. After applying fix for CAMEL-22259 this caused a IllegalStateException with message "Transaction already started"

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

