### PR TITLE
Revert "CAMEL-22265 camel-jbang infra run: Set the container name to a fixed name"

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraRun.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraRun.java
@@ -110,7 +110,7 @@ public class InfraRun extends InfraBaseCommand {
             printer().println("Starting service " + testService + prefix);
         }
 
-        Object actualService = cl.loadClass(serviceImpl).getDeclaredConstructor().newInstance();
+        Object actualService = cl.loadClass(serviceImpl).newInstance();
 
         // Make sure the actualService can be run with initialize method
         boolean actualServiceIsAnInfrastructureService = false;

--- a/test-infra/camel-test-infra-arangodb/src/main/java/org/apache/camel/test/infra/arangodb/services/ArangoDBLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-arangodb/src/main/java/org/apache/camel/test/infra/arangodb/services/ArangoDBLocalContainerInfraService.java
@@ -39,7 +39,6 @@ public class ArangoDBLocalContainerInfraService implements ArangoDBInfraService,
 
     public ArangoDBLocalContainerInfraService(String imageName) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public ArangoDBLocalContainerInfraService(ArangoDbContainer container) {

--- a/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisAllInfraService.java
+++ b/test-infra/camel-test-infra-artemis/src/main/java/org/apache/camel/test/infra/artemis/services/ArtemisAllInfraService.java
@@ -18,7 +18,6 @@ package org.apache.camel.test.infra.artemis.services;
 
 import org.apache.activemq.artemis.core.server.QueueQueryResult;
 import org.apache.camel.spi.annotations.InfraService;
-import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +32,6 @@ public class ArtemisAllInfraService implements ArtemisInfraService, ContainerSer
 
     public ArtemisAllInfraService() {
         container = initContainer();
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     protected ArtemisContainer initContainer() {

--- a/test-infra/camel-test-infra-aws-v2/src/main/java/org/apache/camel/test/infra/aws2/services/AWSLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-aws-v2/src/main/java/org/apache/camel/test/infra/aws2/services/AWSLocalContainerInfraService.java
@@ -24,7 +24,6 @@ import org.apache.camel.test.infra.aws.common.AWSConfigs;
 import org.apache.camel.test.infra.aws.common.AWSProperties;
 import org.apache.camel.test.infra.aws.common.services.AWSInfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
-import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +44,7 @@ public abstract class AWSLocalContainerInfraService implements AWSInfraService, 
 
     public AWSLocalContainerInfraService(String imageName, Service... services) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
+
         container.setupServices(services);
     }
 

--- a/test-infra/camel-test-infra-azure-common/src/main/java/org/apache/camel/test/infra/azure/common/services/AzureStorageInfraService.java
+++ b/test-infra/camel-test-infra-azure-common/src/main/java/org/apache/camel/test/infra/azure/common/services/AzureStorageInfraService.java
@@ -35,7 +35,6 @@ public abstract class AzureStorageInfraService implements AzureInfraService, Con
 
     public AzureStorageInfraService(String imageName) {
         this.container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public AzureStorageInfraService(AzuriteContainer container) {

--- a/test-infra/camel-test-infra-azure-common/src/main/java/org/apache/camel/test/infra/azure/common/services/AzuriteContainer.java
+++ b/test-infra/camel-test-infra-azure-common/src/main/java/org/apache/camel/test/infra/azure/common/services/AzuriteContainer.java
@@ -18,6 +18,8 @@
 package org.apache.camel.test.infra.azure.common.services;
 
 import org.apache.camel.test.infra.azure.common.AzureCredentialsHolder;
+import org.apache.camel.test.infra.azure.common.AzureProperties;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
@@ -25,6 +27,12 @@ public class AzuriteContainer extends GenericContainer<AzuriteContainer> {
     public static final String DEFAULT_ACCOUNT_NAME = "devstoreaccount1";
     public static final String DEFAULT_ACCOUNT_KEY
             = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+    public AzuriteContainer() {
+        LocalPropertyResolver.getProperty(
+                AzuriteContainer.class,
+                AzureProperties.AZURE_CONTAINER);
+    }
 
     public AzuriteContainer(String containerName, boolean fixedPort) {
         super(containerName);

--- a/test-infra/camel-test-infra-cassandra/src/main/java/org/apache/camel/test/infra/cassandra/services/CassandraLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-cassandra/src/main/java/org/apache/camel/test/infra/cassandra/services/CassandraLocalContainerInfraService.java
@@ -19,11 +19,10 @@ package org.apache.camel.test.infra.cassandra.services;
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.cassandra.common.CassandraProperties;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
-import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.cassandra.CassandraContainer;
+import org.testcontainers.containers.CassandraContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -45,7 +44,6 @@ public class CassandraLocalContainerInfraService implements CassandraInfraServic
 
     public CassandraLocalContainerInfraService(String imageName) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public CassandraLocalContainerInfraService(CassandraContainer container) {
@@ -73,7 +71,7 @@ public class CassandraLocalContainerInfraService implements CassandraInfraServic
 
     @Override
     public int port() {
-        return container.getContactPoint().getPort();
+        return container.getMappedPort(CassandraContainer.CQL_PORT);
     }
 
     @Override

--- a/test-infra/camel-test-infra-chatscript/src/main/java/org/apache/camel/test/infra/chatscript/services/ChatScriptLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-chatscript/src/main/java/org/apache/camel/test/infra/chatscript/services/ChatScriptLocalContainerInfraService.java
@@ -19,7 +19,6 @@ package org.apache.camel.test.infra.chatscript.services;
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.chatscript.common.ChatScriptProperties;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
-import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +39,6 @@ public class ChatScriptLocalContainerInfraService implements ChatScriptInfraServ
 
         container = new GenericContainer<>(containerName)
                 .withExposedPorts(SERVICE_PORT)
-                .withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())))
                 .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withTty(true));
     }
 

--- a/test-infra/camel-test-infra-common/src/main/java/org/apache/camel/test/infra/common/services/ContainerEnvironmentUtil.java
+++ b/test-infra/camel-test-infra-common/src/main/java/org/apache/camel/test/infra/common/services/ContainerEnvironmentUtil.java
@@ -17,7 +17,6 @@
 
 package org.apache.camel.test.infra.common.services;
 
-import org.apache.camel.spi.annotations.InfraService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.DockerClientFactory;
@@ -58,7 +57,7 @@ public final class ContainerEnvironmentUtil {
         container.setStartupAttempts(startupAttempts);
     }
 
-    public static boolean isFixedPort(@SuppressWarnings("rawtypes") Class cls) {
+    public static boolean isFixedPort(Class cls) {
         for (Class<?> i : cls.getInterfaces()) {
             if (i.getName().contains("InfraService")) {
                 return true;
@@ -66,15 +65,5 @@ public final class ContainerEnvironmentUtil {
         }
 
         return false;
-    }
-
-    @SuppressWarnings("unchecked")
-    public static String containerName(Class cls) {
-        InfraService annotation = (InfraService) cls.getAnnotation(InfraService.class);
-        String name = "camel-" + annotation.serviceAlias()[0];
-        if (annotation.serviceImplementationAlias().length > 0) {
-            name += "-" + annotation.serviceImplementationAlias()[0];
-        }
-        return name;
     }
 }

--- a/test-infra/camel-test-infra-couchbase/src/main/java/org/apache/camel/test/infra/couchbase/services/CouchbaseLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-couchbase/src/main/java/org/apache/camel/test/infra/couchbase/services/CouchbaseLocalContainerInfraService.java
@@ -27,7 +27,6 @@ import com.couchbase.client.java.manager.view.View;
 import com.couchbase.client.java.view.DesignDocumentNamespace;
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
-import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.couchbase.common.CouchbaseProperties;
 import org.slf4j.Logger;
@@ -78,7 +77,6 @@ public class CouchbaseLocalContainerInfraService implements CouchbaseInfraServic
 
     public CouchbaseLocalContainerInfraService(String imageName) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public CouchbaseLocalContainerInfraService(CouchbaseContainer container) {

--- a/test-infra/camel-test-infra-couchdb/src/main/java/org/apache/camel/test/infra/couchdb/services/CouchDbLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-couchdb/src/main/java/org/apache/camel/test/infra/couchdb/services/CouchDbLocalContainerInfraService.java
@@ -30,12 +30,12 @@ import org.testcontainers.utility.DockerImageName;
 @InfraService(service = CouchDbInfraService.class,
               description = "SQL Clustered database CouchDB",
               serviceAlias = { "couchdb" })
-public class CouchDbLocalContainerInfraService implements CouchDbInfraService, ContainerService<GenericContainer<?>> {
+public class CouchDbLocalContainerInfraService implements CouchDbInfraService, ContainerService<GenericContainer> {
     public static final String CONTAINER_NAME = "couchdb";
 
     private static final Logger LOG = LoggerFactory.getLogger(CouchDbLocalContainerInfraService.class);
 
-    private final GenericContainer<?> container;
+    private final GenericContainer container;
 
     public CouchDbLocalContainerInfraService() {
         this(LocalPropertyResolver.getProperty(
@@ -45,14 +45,13 @@ public class CouchDbLocalContainerInfraService implements CouchDbInfraService, C
 
     public CouchDbLocalContainerInfraService(String imageName) {
         container = initContainer(imageName, CONTAINER_NAME);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
-    public CouchDbLocalContainerInfraService(GenericContainer<?> container) {
+    public CouchDbLocalContainerInfraService(GenericContainer container) {
         this.container = container;
     }
 
-    protected GenericContainer<?> initContainer(String imageName, String containerName) {
+    protected GenericContainer initContainer(String imageName, String containerName) {
         class CouchDBContainer extends GenericContainer<CouchDBContainer> {
             public CouchDBContainer(boolean fixedPort) {
                 super(DockerImageName.parse(imageName));
@@ -93,7 +92,7 @@ public class CouchDbLocalContainerInfraService implements CouchDbInfraService, C
     }
 
     @Override
-    public GenericContainer<?> getContainer() {
+    public GenericContainer getContainer() {
         return container;
     }
 

--- a/test-infra/camel-test-infra-elasticsearch/src/main/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-elasticsearch/src/main/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchLocalContainerInfraService.java
@@ -58,7 +58,6 @@ public class ElasticSearchLocalContainerInfraService
 
     public ElasticSearchLocalContainerInfraService(String imageName) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public ElasticSearchLocalContainerInfraService(ElasticsearchContainer container) {

--- a/test-infra/camel-test-infra-fhir/src/main/java/org/apache/camel/test/infra/fhir/services/FhirLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-fhir/src/main/java/org/apache/camel/test/infra/fhir/services/FhirLocalContainerInfraService.java
@@ -31,13 +31,13 @@ import org.testcontainers.containers.wait.strategy.Wait;
 @InfraService(service = FhirInfraService.class,
               description = "HAPI FHIR RESTful test server",
               serviceAlias = { "fhir" })
-public class FhirLocalContainerInfraService implements FhirInfraService, ContainerService<GenericContainer<?>> {
+public class FhirLocalContainerInfraService implements FhirInfraService, ContainerService<GenericContainer> {
     // needs https://github.com/hapifhir/hapi-fhir-jpaserver-starter/commit/54120f374eea5084634830d34c99a9137b22a310
     public static final String CONTAINER_NAME = "fhir";
 
     private static final Logger LOG = LoggerFactory.getLogger(FhirLocalContainerInfraService.class);
 
-    private final GenericContainer<?> container;
+    private final GenericContainer container;
 
     public FhirLocalContainerInfraService() {
         this(LocalPropertyResolver.getProperty(
@@ -47,14 +47,13 @@ public class FhirLocalContainerInfraService implements FhirInfraService, Contain
 
     public FhirLocalContainerInfraService(String imageName) {
         container = initContainer(imageName, CONTAINER_NAME);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
-    public FhirLocalContainerInfraService(GenericContainer<?> container) {
+    public FhirLocalContainerInfraService(GenericContainer container) {
         this.container = container;
     }
 
-    protected GenericContainer<?> initContainer(String imageName, String containerName) {
+    protected GenericContainer initContainer(String imageName, String containerName) {
         class FhirContainer extends GenericContainer<FhirContainer> {
             public FhirContainer(boolean fixedPort) {
                 super(imageName);
@@ -100,7 +99,7 @@ public class FhirLocalContainerInfraService implements FhirInfraService, Contain
     }
 
     @Override
-    public GenericContainer<?> getContainer() {
+    public GenericContainer getContainer() {
         return container;
     }
 

--- a/test-infra/camel-test-infra-google-pubsub/src/main/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-google-pubsub/src/main/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubLocalContainerInfraService.java
@@ -52,7 +52,6 @@ public class GooglePubSubLocalContainerInfraService
 
     public GooglePubSubLocalContainerInfraService(String imageName) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public GooglePubSubLocalContainerInfraService(PubSubEmulatorContainer container) {

--- a/test-infra/camel-test-infra-hashicorp-vault/src/main/java/org/apache/camel/test/infra/hashicorp/vault/services/HashicorpVaultLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-hashicorp-vault/src/main/java/org/apache/camel/test/infra/hashicorp/vault/services/HashicorpVaultLocalContainerInfraService.java
@@ -58,7 +58,7 @@ public class HashicorpVaultLocalContainerInfraService
 
     private static final Logger LOG = LoggerFactory.getLogger(HashicorpVaultLocalContainerInfraService.class);
 
-    private final GenericContainer<?> container;
+    private final GenericContainer container;
 
     public HashicorpVaultLocalContainerInfraService() {
         this(LocalPropertyResolver.getProperty(
@@ -68,14 +68,13 @@ public class HashicorpVaultLocalContainerInfraService
 
     public HashicorpVaultLocalContainerInfraService(String containerImage) {
         container = initContainer(containerImage, CONTAINER_NAME);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
-    public HashicorpVaultLocalContainerInfraService(GenericContainer<?> container) {
+    public HashicorpVaultLocalContainerInfraService(GenericContainer container) {
         this.container = container;
     }
 
-    protected GenericContainer<?> initContainer(String imageName, String containerName) {
+    protected GenericContainer initContainer(String imageName, String containerName) {
         final Logger containerLog = LoggerFactory.getLogger("container." + containerName);
         final Consumer<OutputFrame> logConsumer = new Slf4jLogConsumer(containerLog);
 
@@ -128,7 +127,7 @@ public class HashicorpVaultLocalContainerInfraService
     }
 
     @Override
-    public GenericContainer<?> getContainer() {
+    public GenericContainer getContainer() {
         return container;
     }
 

--- a/test-infra/camel-test-infra-hivemq/src/main/java/org/apache/camel/test/infra/hivemq/services/AbstractLocalHiveMQService.java
+++ b/test-infra/camel-test-infra-hivemq/src/main/java/org/apache/camel/test/infra/hivemq/services/AbstractLocalHiveMQService.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.test.infra.hivemq.services;
 
-import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.hivemq.common.HiveMQProperties;
 import org.slf4j.Logger;
@@ -39,8 +38,7 @@ public abstract class AbstractLocalHiveMQService<T extends AbstractLocalHiveMQSe
     protected AbstractLocalHiveMQService(String imageName) {
         container = initContainer(imageName)
                 .withExposedPorts(MQTT_PORT_DEFAULT, WEBSOCKET_PORT_DEFAULT)
-                .waitingFor(Wait.forListeningPort())
-                .withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
+                .waitingFor(Wait.forListeningPort());
     }
 
     @Override

--- a/test-infra/camel-test-infra-hivemq/src/main/java/org/apache/camel/test/infra/hivemq/services/LocalHiveMQInfraService.java
+++ b/test-infra/camel-test-infra-hivemq/src/main/java/org/apache/camel/test/infra/hivemq/services/LocalHiveMQInfraService.java
@@ -27,13 +27,11 @@ import org.testcontainers.utility.DockerImageName;
               serviceAlias = "hive-mq")
 public class LocalHiveMQInfraService extends AbstractLocalHiveMQService<LocalHiveMQInfraService> {
 
-    public LocalHiveMQInfraService() {
+    LocalHiveMQInfraService() {
         super(LocalPropertyResolver.getProperty(LocalHiveMQInfraService.class, HiveMQProperties.HIVEMQ_CONTAINER));
     }
 
     protected HiveMQContainer initContainer(String imageName) {
-        return new HiveMQContainer(
-                DockerImageName.parse(imageName)
-                        .asCompatibleSubstituteFor("hivemq/hivemq-ce"));
+        return new HiveMQContainer(DockerImageName.parse(imageName));
     }
 }

--- a/test-infra/camel-test-infra-hivemq/src/main/java/org/apache/camel/test/infra/hivemq/services/LocalHiveMQSparkplugTCKInfraService.java
+++ b/test-infra/camel-test-infra-hivemq/src/main/java/org/apache/camel/test/infra/hivemq/services/LocalHiveMQSparkplugTCKInfraService.java
@@ -30,7 +30,7 @@ import org.testcontainers.utility.DockerImageName;
               serviceImplementationAlias = "sparkplug")
 public class LocalHiveMQSparkplugTCKInfraService extends AbstractLocalHiveMQService<LocalHiveMQSparkplugTCKInfraService> {
 
-    public LocalHiveMQSparkplugTCKInfraService() {
+    LocalHiveMQSparkplugTCKInfraService() {
         super(LocalPropertyResolver.getProperty(LocalHiveMQSparkplugTCKInfraService.class,
                 HiveMQProperties.HIVEMQ_SPARKPLUG_CONTAINER));
     }

--- a/test-infra/camel-test-infra-infinispan/src/main/java/org/apache/camel/test/infra/infinispan/services/InfinispanLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-infinispan/src/main/java/org/apache/camel/test/infra/infinispan/services/InfinispanLocalContainerInfraService.java
@@ -41,7 +41,7 @@ public class InfinispanLocalContainerInfraService implements InfinispanInfraServ
 
     private static final Logger LOG = LoggerFactory.getLogger(InfinispanLocalContainerInfraService.class);
 
-    private final GenericContainer<?> container;
+    private final GenericContainer container;
     private final boolean isNetworkHost;
 
     public InfinispanLocalContainerInfraService() {
@@ -53,15 +53,14 @@ public class InfinispanLocalContainerInfraService implements InfinispanInfraServ
     public InfinispanLocalContainerInfraService(String containerImage) {
         isNetworkHost = isHostNetworkMode();
         container = initContainer(containerImage, CONTAINER_NAME);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
-    public InfinispanLocalContainerInfraService(GenericContainer<?> container) {
+    public InfinispanLocalContainerInfraService(GenericContainer container) {
         isNetworkHost = isHostNetworkMode();
         this.container = container;
     }
 
-    protected GenericContainer<?> initContainer(String imageName, String containerName) {
+    protected GenericContainer initContainer(String imageName, String containerName) {
         final Logger containerLog = LoggerFactory.getLogger("container." + containerName);
         final Consumer<OutputFrame> logConsumer = new Slf4jLogConsumer(containerLog);
 
@@ -123,7 +122,7 @@ public class InfinispanLocalContainerInfraService implements InfinispanInfraServ
     }
 
     @Override
-    public GenericContainer<?> getContainer() {
+    public GenericContainer getContainer() {
         return container;
     }
 

--- a/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaInfraService.java
+++ b/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/ContainerLocalKafkaInfraService.java
@@ -40,7 +40,6 @@ public class ContainerLocalKafkaInfraService implements KafkaInfraService, Conta
 
     public ContainerLocalKafkaInfraService() {
         kafka = initContainer();
-        kafka.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public ContainerLocalKafkaInfraService(KafkaContainer kafka) {

--- a/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/RedpandaInfraService.java
+++ b/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/RedpandaInfraService.java
@@ -18,7 +18,6 @@ package org.apache.camel.test.infra.kafka.services;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.TestUtils;
-import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.kafka.common.KafkaProperties;
 import org.slf4j.Logger;
@@ -42,8 +41,6 @@ public class RedpandaInfraService implements KafkaInfraService, ContainerService
         Network network = Network.newNetwork();
 
         redpandaContainer = initRedpandaContainer(network, redpandaInstanceName);
-        redpandaContainer
-                .withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public RedpandaInfraService(RedpandaContainer redpandaContainer) {

--- a/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/StrimziContainer.java
+++ b/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/StrimziContainer.java
@@ -54,6 +54,7 @@ public class StrimziContainer extends GenericContainer<StrimziContainer> {
 
     private void setupContainer(String name, CreateContainerCmd createContainerCmd) {
         createContainerCmd.withHostName(name);
+        createContainerCmd.withName(name);
     }
 
     public int getKafkaPort() {

--- a/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/StrimziInfraService.java
+++ b/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/StrimziInfraService.java
@@ -19,7 +19,6 @@ package org.apache.camel.test.infra.kafka.services;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.TestUtils;
-import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.kafka.common.KafkaProperties;
 import org.slf4j.Logger;
@@ -45,8 +44,6 @@ public class StrimziInfraService implements KafkaInfraService, ContainerService<
 
         zookeeperContainer = initZookeeperContainer(network, zookeeperInstanceName);
         strimziContainer = initStrimziContainer(network, strimziInstanceName, zookeeperInstanceName);
-        strimziContainer
-                .withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public StrimziInfraService(ZookeeperContainer zookeeperContainer, StrimziContainer strimziContainer) {

--- a/test-infra/camel-test-infra-kafka/src/main/resources/org/apache/camel/test/infra/kafka/services/container.properties
+++ b/test-infra/camel-test-infra-kafka/src/main/resources/org/apache/camel/test/infra/kafka/services/container.properties
@@ -17,4 +17,3 @@
 kafka3.container=mirror.gcr.io/apache/kafka:3.9.1
 redpanda.container.image=mirror.gcr.io/redpandadata/redpanda:v24.1.16
 strimzi.container.image=quay.io/strimzi/kafka:latest-kafka-3.9.1
-confluent.container.image=mirror.gcr.io/confluentinc/cp-kafka:7.9.2

--- a/test-infra/camel-test-infra-microprofile-lra/src/main/java/org/apache/camel/test/infra/microprofile/lra/services/MicroprofileLRALocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-microprofile-lra/src/main/java/org/apache/camel/test/infra/microprofile/lra/services/MicroprofileLRALocalContainerInfraService.java
@@ -35,12 +35,12 @@ import org.testcontainers.utility.DockerImageName;
               serviceAlias = { "microprofile" },
               serviceImplementationAlias = "lra")
 public class MicroprofileLRALocalContainerInfraService
-        implements MicroprofileLRAInfraService, ContainerService<GenericContainer<?>> {
+        implements MicroprofileLRAInfraService, ContainerService<GenericContainer> {
     public static final String CONTAINER_NAME = "microprofile-lra";
 
     private static final Logger LOG = LoggerFactory.getLogger(MicroprofileLRALocalContainerInfraService.class);
 
-    private final GenericContainer<?> container;
+    private final GenericContainer container;
 
     public MicroprofileLRALocalContainerInfraService() {
         this(LocalPropertyResolver.getProperty(
@@ -50,14 +50,13 @@ public class MicroprofileLRALocalContainerInfraService
 
     public MicroprofileLRALocalContainerInfraService(String imageName) {
         container = initContainer(imageName, CONTAINER_NAME);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
-    public MicroprofileLRALocalContainerInfraService(GenericContainer<?> container) {
+    public MicroprofileLRALocalContainerInfraService(GenericContainer container) {
         this.container = container;
     }
 
-    public GenericContainer<?> initContainer(String imageName, String networkAlias) {
+    public GenericContainer initContainer(String imageName, String networkAlias) {
         class MicroprofileLRAContainer extends GenericContainer<MicroprofileLRAContainer> {
             public MicroprofileLRAContainer(boolean fixedPort) {
                 super(DockerImageName.parse(imageName));
@@ -100,7 +99,7 @@ public class MicroprofileLRALocalContainerInfraService
     }
 
     @Override
-    public GenericContainer<?> getContainer() {
+    public GenericContainer getContainer() {
         return container;
     }
 

--- a/test-infra/camel-test-infra-milvus/src/main/java/org/apache/camel/test/infra/milvus/services/MilvusLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-milvus/src/main/java/org/apache/camel/test/infra/milvus/services/MilvusLocalContainerInfraService.java
@@ -45,7 +45,6 @@ public class MilvusLocalContainerInfraService implements MilvusInfraService, Con
 
     public MilvusLocalContainerInfraService(String imageName) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public MilvusLocalContainerInfraService(MilvusContainer container) {

--- a/test-infra/camel-test-infra-minio/src/main/java/org/apache/camel/test/infra/minio/services/MinioLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-minio/src/main/java/org/apache/camel/test/infra/minio/services/MinioLocalContainerInfraService.java
@@ -31,7 +31,7 @@ import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 @InfraService(service = MinioInfraService.class,
               description = "MinIO Object Storage, S3 compatible",
               serviceAlias = { "minio" })
-public class MinioLocalContainerInfraService implements MinioInfraService, ContainerService<GenericContainer<?>> {
+public class MinioLocalContainerInfraService implements MinioInfraService, ContainerService<GenericContainer> {
     public static final String CONTAINER_NAME = "minio";
     private static final String ACCESS_KEY;
     private static final String SECRET_KEY;
@@ -44,7 +44,7 @@ public class MinioLocalContainerInfraService implements MinioInfraService, Conta
         SECRET_KEY = System.getProperty(MinioProperties.SECRET_KEY, "testSecretKey");
     }
 
-    private final GenericContainer<?> container;
+    private final GenericContainer container;
 
     public MinioLocalContainerInfraService() {
         this(LocalPropertyResolver.getProperty(MinioLocalContainerInfraService.class, MinioProperties.MINIO_CONTAINER));
@@ -52,14 +52,13 @@ public class MinioLocalContainerInfraService implements MinioInfraService, Conta
 
     public MinioLocalContainerInfraService(String containerName) {
         container = initContainer(containerName, CONTAINER_NAME);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
-    public MinioLocalContainerInfraService(GenericContainer<?> container) {
+    public MinioLocalContainerInfraService(GenericContainer container) {
         this.container = container;
     }
 
-    protected GenericContainer<?> initContainer(String imageName, String containerName) {
+    protected GenericContainer initContainer(String imageName, String containerName) {
 
         class MinioContainer extends GenericContainer<MinioContainer> {
             public MinioContainer(boolean fixedPort) {
@@ -109,7 +108,7 @@ public class MinioLocalContainerInfraService implements MinioInfraService, Conta
     }
 
     @Override
-    public GenericContainer<?> getContainer() {
+    public GenericContainer getContainer() {
         return container;
     }
 

--- a/test-infra/camel-test-infra-mongodb/src/main/java/org/apache/camel/test/infra/mongodb/services/MongoDBLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-mongodb/src/main/java/org/apache/camel/test/infra/mongodb/services/MongoDBLocalContainerInfraService.java
@@ -41,7 +41,6 @@ public class MongoDBLocalContainerInfraService implements MongoDBInfraService, C
 
     public MongoDBLocalContainerInfraService(String imageName) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public MongoDBLocalContainerInfraService(MongoDBContainer container) {
@@ -51,6 +50,10 @@ public class MongoDBLocalContainerInfraService implements MongoDBInfraService, C
     protected MongoDBContainer initContainer(String imageName) {
 
         class TestInfraMongoDBContainer extends MongoDBContainer {
+            public TestInfraMongoDBContainer(boolean fixedPort) {
+                super();
+                addPort(fixedPort);
+            }
 
             public TestInfraMongoDBContainer(boolean fixedPort, String imageName) {
                 super(DockerImageName.parse(imageName).asCompatibleSubstituteFor("mongo"));
@@ -65,7 +68,12 @@ public class MongoDBLocalContainerInfraService implements MongoDBInfraService, C
                 }
             }
         }
-        return new TestInfraMongoDBContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()), imageName);
+
+        if (imageName == null || imageName.isEmpty()) {
+            return new TestInfraMongoDBContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()));
+        } else {
+            return new TestInfraMongoDBContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()), imageName);
+        }
     }
 
     @Override

--- a/test-infra/camel-test-infra-mosquitto/src/main/java/org/apache/camel/test/infra/mosquitto/services/MosquittoLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-mosquitto/src/main/java/org/apache/camel/test/infra/mosquitto/services/MosquittoLocalContainerInfraService.java
@@ -31,13 +31,13 @@ import org.testcontainers.containers.wait.strategy.Wait;
 @InfraService(service = MosquittoInfraService.class,
               description = "Mosquitto is a message broker that implements MQTT protocol",
               serviceAlias = { "mosquitto" })
-public class MosquittoLocalContainerInfraService implements MosquittoInfraService, ContainerService<GenericContainer<?>> {
+public class MosquittoLocalContainerInfraService implements MosquittoInfraService, ContainerService<GenericContainer> {
     public static final String CONTAINER_NAME = "mosquitto";
     public static final int CONTAINER_PORT = 1883;
 
     private static final Logger LOG = LoggerFactory.getLogger(MosquittoLocalContainerInfraService.class);
 
-    private final GenericContainer<?> container;
+    private final GenericContainer container;
 
     public MosquittoLocalContainerInfraService() {
         this(LocalPropertyResolver.getProperty(MosquittoLocalContainerInfraService.class,
@@ -60,19 +60,19 @@ public class MosquittoLocalContainerInfraService implements MosquittoInfraServic
         }
     }
 
-    public MosquittoLocalContainerInfraService(GenericContainer<?> container) {
+    public MosquittoLocalContainerInfraService(GenericContainer container) {
         this.container = container;
     }
 
-    protected GenericContainer<?> initContainer(String imageName, Integer port) {
-        GenericContainer<?> ret;
+    protected GenericContainer initContainer(String imageName, Integer port) {
+        GenericContainer ret;
 
         if (port == null) {
             ret = new GenericContainer(imageName)
                     .withExposedPorts(CONTAINER_PORT);
         } else {
             @SuppressWarnings("deprecation")
-            GenericContainer<?> fixedPortContainer = new FixedHostPortGenericContainer(imageName)
+            GenericContainer fixedPortContainer = new FixedHostPortGenericContainer(imageName)
                     .withFixedExposedPort(port, CONTAINER_PORT);
             ret = fixedPortContainer;
         }
@@ -81,7 +81,7 @@ public class MosquittoLocalContainerInfraService implements MosquittoInfraServic
                 .withClasspathResourceMapping("mosquitto.conf", "/mosquitto/config/mosquitto.conf", BindMode.READ_ONLY)
                 .waitingFor(Wait.forLogMessage(".* mosquitto version .* running", 1))
                 .waitingFor(Wait.forListeningPort());
-        ret.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
+
         return ret;
     }
 
@@ -106,7 +106,7 @@ public class MosquittoLocalContainerInfraService implements MosquittoInfraServic
     }
 
     @Override
-    public GenericContainer<?> getContainer() {
+    public GenericContainer getContainer() {
         return container;
     }
 

--- a/test-infra/camel-test-infra-nats/src/main/java/org/apache/camel/test/infra/nats/services/NatsLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-nats/src/main/java/org/apache/camel/test/infra/nats/services/NatsLocalContainerInfraService.java
@@ -29,12 +29,12 @@ import org.testcontainers.containers.wait.strategy.Wait;
 @InfraService(service = NatsInfraService.class,
               description = "Messaging Platform NATS",
               serviceAlias = { "nats" })
-public class NatsLocalContainerInfraService implements NatsInfraService, ContainerService<GenericContainer<?>> {
+public class NatsLocalContainerInfraService implements NatsInfraService, ContainerService<GenericContainer> {
     public static final String CONTAINER_NAME = "nats";
     private static final int PORT = 4222;
 
     private static final Logger LOG = LoggerFactory.getLogger(NatsLocalContainerInfraService.class);
-    private final GenericContainer<?> container;
+    private final GenericContainer container;
 
     public NatsLocalContainerInfraService() {
         this(LocalPropertyResolver.getProperty(NatsLocalContainerInfraService.class, NatsProperties.NATS_CONTAINER));
@@ -42,10 +42,9 @@ public class NatsLocalContainerInfraService implements NatsInfraService, Contain
 
     public NatsLocalContainerInfraService(String imageName) {
         container = initContainer(imageName, CONTAINER_NAME);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
-    protected GenericContainer<?> initContainer(String imageName, String containerName) {
+    protected GenericContainer initContainer(String imageName, String containerName) {
         class NatsContainer extends GenericContainer<NatsContainer> {
             public NatsContainer(boolean fixedPort) {
                 super(imageName);
@@ -85,7 +84,7 @@ public class NatsLocalContainerInfraService implements NatsInfraService, Contain
     }
 
     @Override
-    public GenericContainer<?> getContainer() {
+    public GenericContainer getContainer() {
         return container;
     }
 

--- a/test-infra/camel-test-infra-ollama/src/main/java/org/apache/camel/test/infra/ollama/services/OllamaLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-ollama/src/main/java/org/apache/camel/test/infra/ollama/services/OllamaLocalContainerInfraService.java
@@ -50,6 +50,7 @@ public class OllamaLocalContainerInfraService implements OllamaInfraService, Con
 
     public OllamaLocalContainerInfraService() {
         container = initContainer();
+
         configuration = new DefaultServiceConfiguration();
     }
 
@@ -67,8 +68,6 @@ public class OllamaLocalContainerInfraService implements OllamaInfraService, Con
                 if (fixedPort) {
                     addFixedExposedPort(11434, 11434);
                 }
-                withCreateContainerCmdModifier(cmd -> cmd
-                        .withName(ContainerEnvironmentUtil.containerName(OllamaLocalContainerInfraService.this.getClass())));
             }
         }
 

--- a/test-infra/camel-test-infra-openldap/src/main/java/org/apache/camel/test/infra/openldap/services/OpenldapLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-openldap/src/main/java/org/apache/camel/test/infra/openldap/services/OpenldapLocalContainerInfraService.java
@@ -36,7 +36,6 @@ public class OpenldapLocalContainerInfraService implements OpenldapInfraService,
 
     public OpenldapLocalContainerInfraService() {
         container = new OpenLdapContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()));
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     @Override

--- a/test-infra/camel-test-infra-postgres/src/main/java/org/apache/camel/test/infra/postgres/services/PostgresLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-postgres/src/main/java/org/apache/camel/test/infra/postgres/services/PostgresLocalContainerInfraService.java
@@ -29,12 +29,12 @@ import org.testcontainers.utility.DockerImageName;
 @InfraService(service = PostgresInfraService.class,
               description = "Postgres SQL Database",
               serviceAlias = { "postgres" })
-public class PostgresLocalContainerInfraService implements PostgresInfraService, ContainerService<PostgreSQLContainer<?>> {
+public class PostgresLocalContainerInfraService implements PostgresInfraService, ContainerService<PostgreSQLContainer> {
     public static final String DEFAULT_POSTGRES_CONTAINER
             = LocalPropertyResolver.getProperty(PostgresLocalContainerInfraService.class,
                     PostgresProperties.POSTGRES_CONTAINER);
     private static final Logger LOG = LoggerFactory.getLogger(PostgresLocalContainerInfraService.class);
-    private final PostgreSQLContainer<?> container;
+    private final PostgreSQLContainer container;
 
     public PostgresLocalContainerInfraService() {
         this(DEFAULT_POSTGRES_CONTAINER);
@@ -42,14 +42,13 @@ public class PostgresLocalContainerInfraService implements PostgresInfraService,
 
     public PostgresLocalContainerInfraService(String imageName) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
-    public PostgresLocalContainerInfraService(PostgreSQLContainer<?> container) {
+    public PostgresLocalContainerInfraService(PostgreSQLContainer container) {
         this.container = container;
     }
 
-    protected PostgreSQLContainer<?> initContainer(String imageName) {
+    protected PostgreSQLContainer initContainer(String imageName) {
         class TestInfraPostgreSQLContainer extends PostgreSQLContainer {
             public TestInfraPostgreSQLContainer(boolean fixedPort) {
                 super(DockerImageName.parse(imageName)
@@ -89,7 +88,7 @@ public class PostgresLocalContainerInfraService implements PostgresInfraService,
     }
 
     @Override
-    public PostgreSQLContainer<?> getContainer() {
+    public PostgreSQLContainer getContainer() {
         return container;
     }
 

--- a/test-infra/camel-test-infra-pulsar/src/main/java/org/apache/camel/test/infra/pulsar/services/PulsarLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-pulsar/src/main/java/org/apache/camel/test/infra/pulsar/services/PulsarLocalContainerInfraService.java
@@ -43,7 +43,6 @@ public class PulsarLocalContainerInfraService implements PulsarInfraService, Con
 
     public PulsarLocalContainerInfraService(String imageName) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public PulsarLocalContainerInfraService(PulsarContainer container) {

--- a/test-infra/camel-test-infra-qdrant/src/main/java/org/apache/camel/test/infra/qdrant/services/QdrantLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-qdrant/src/main/java/org/apache/camel/test/infra/qdrant/services/QdrantLocalContainerInfraService.java
@@ -44,7 +44,6 @@ public class QdrantLocalContainerInfraService implements QdrantInfraService, Con
 
     public QdrantLocalContainerInfraService(String imageName) {
         this.container = initContainer(imageName, ContainerEnvironmentUtil.isFixedPort(this.getClass()));
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public QdrantLocalContainerInfraService(QdrantContainer container) {

--- a/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQLocalContainerInfraService.java
@@ -42,7 +42,6 @@ public class RabbitMQLocalContainerInfraService implements RabbitMQInfraService,
 
     public RabbitMQLocalContainerInfraService(String imageName) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public RabbitMQLocalContainerInfraService(RabbitMQContainer container) {

--- a/test-infra/camel-test-infra-redis/src/main/java/org/apache/camel/test/infra/redis/services/RedisLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-redis/src/main/java/org/apache/camel/test/infra/redis/services/RedisLocalContainerInfraService.java
@@ -33,13 +33,11 @@ public class RedisLocalContainerInfraService implements RedisInfraService, Conta
 
     public RedisLocalContainerInfraService() {
         container = new RedisContainer();
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public RedisLocalContainerInfraService(String imageName) {
         container = RedisContainer.initContainer(imageName, RedisContainer.CONTAINER_NAME,
                 ContainerEnvironmentUtil.isFixedPort(this.getClass()));
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     @Override

--- a/test-infra/camel-test-infra-rocketmq/src/main/java/org/apache/camel/test/infra/rocketmq/services/RocketMQBrokerContainer.java
+++ b/test-infra/camel-test-infra-rocketmq/src/main/java/org/apache/camel/test/infra/rocketmq/services/RocketMQBrokerContainer.java
@@ -50,5 +50,6 @@ public class RocketMQBrokerContainer extends GenericContainer<RocketMQBrokerCont
                 "-c", "/opt/rocketmq-" + RocketMQContainerInfraService.ROCKETMQ_VERSION + "/conf/broker.conf");
 
         waitingFor(Wait.forListeningPort());
+        withCreateContainerCmdModifier(cmd -> cmd.withName(confName));
     }
 }

--- a/test-infra/camel-test-infra-rocketmq/src/main/java/org/apache/camel/test/infra/rocketmq/services/RocketMQContainerInfraService.java
+++ b/test-infra/camel-test-infra-rocketmq/src/main/java/org/apache/camel/test/infra/rocketmq/services/RocketMQContainerInfraService.java
@@ -52,8 +52,6 @@ public class RocketMQContainerInfraService implements RocketMQInfraService, Cont
 
         brokerContainer1
                 = new RocketMQBrokerContainer(network, "broker1", ContainerEnvironmentUtil.isFixedPort(this.getClass()));
-        brokerContainer1
-                .withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     @Override

--- a/test-infra/camel-test-infra-smb/src/main/java/org/apache/camel/test/infra/smb/services/SmbLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-smb/src/main/java/org/apache/camel/test/infra/smb/services/SmbLocalContainerInfraService.java
@@ -30,7 +30,6 @@ public class SmbLocalContainerInfraService implements SmbInfraService {
     protected final SmbContainer container = new SmbContainer(ContainerEnvironmentUtil.isFixedPort(this.getClass()));
 
     public SmbLocalContainerInfraService() {
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     @Override

--- a/test-infra/camel-test-infra-solr/src/main/java/org/apache/camel/test/infra/solr/services/SolrLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-solr/src/main/java/org/apache/camel/test/infra/solr/services/SolrLocalContainerInfraService.java
@@ -34,7 +34,6 @@ public class SolrLocalContainerInfraService implements SolrInfraService, Contain
     public SolrLocalContainerInfraService() {
         container = SolrContainer.initContainer(SolrContainer.CONTAINER_NAME,
                 ContainerEnvironmentUtil.isFixedPort(this.getClass()));
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     @Override

--- a/test-infra/camel-test-infra-torchserve/src/main/java/org/apache/camel/test/infra/torchserve/services/TorchServeLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-torchserve/src/main/java/org/apache/camel/test/infra/torchserve/services/TorchServeLocalContainerInfraService.java
@@ -49,7 +49,6 @@ public class TorchServeLocalContainerInfraService implements TorchServeInfraServ
                 TorchServeProperties.TORCHSERVE_CONTAINER);
 
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     @SuppressWarnings("resource")

--- a/test-infra/camel-test-infra-xmpp/src/main/java/org/apache/camel/test/infra/xmpp/services/XmppLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-xmpp/src/main/java/org/apache/camel/test/infra/xmpp/services/XmppLocalContainerInfraService.java
@@ -38,7 +38,6 @@ public class XmppLocalContainerInfraService implements XmppInfraService, Contain
 
     public XmppLocalContainerInfraService(String imageName) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public XmppLocalContainerInfraService(XmppServerContainer container) {

--- a/test-infra/camel-test-infra-zookeeper/src/main/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-zookeeper/src/main/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperLocalContainerInfraService.java
@@ -18,7 +18,6 @@ package org.apache.camel.test.infra.zookeeper.services;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
-import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.zookeeper.common.ZooKeeperProperties;
 import org.slf4j.Logger;
@@ -39,7 +38,6 @@ public class ZooKeeperLocalContainerInfraService implements ZooKeeperInfraServic
 
     public ZooKeeperLocalContainerInfraService(String imageName) {
         container = initContainer(imageName);
-        container.withCreateContainerCmdModifier(cmd -> cmd.withName(ContainerEnvironmentUtil.containerName(this.getClass())));
     }
 
     public ZooKeeperLocalContainerInfraService(ZooKeeperContainer container) {


### PR DESCRIPTION
Reverts apache/camel#18702

Given that it i causing thousands of test failing and the Ci to hang for several hours, I propose to revert for now and this can be reworked later on

most of them are failing with this kind of error:
```
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.camel.spi.annotations.InfraService.serviceAlias()" because "annotation" is null
	at org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil.containerName(ContainerEnvironmentUtil.java:74)
	at org.apache.camel.test.infra.chatscript.services.ChatScriptLocalContainerInfraService.lambda$new$0(ChatScriptLocalContainerInfraService.java:43)
	at org.testcontainers.containers.GenericContainer.lambda$withCreateContainerCmdModifier$22(GenericContainer.java:1451)
```