### PR TITLE
Use parent/pom.xml defined property for postgresql version

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/pom.xml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/pom.xml
@@ -239,7 +239,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.7</version>
+            <version>${pgjdbc-driver-version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
# Description

parent/pom.xml has a ${pgjdbc-driver-version} for the postgresql version - should use that rather than a hardcoded value.    ${pgjdbc-driver-version} is 42.7.7 currently, so no change of version for this artifact.

# Target

- [x ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

