### PR TITLE
Use parent/pom.xml defined property for postgresql version (#18734)

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/pom.xml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/pom.xml
@@ -239,7 +239,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.5</version>
+            <version>${pgjdbc-driver-version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
# Description

Cherry pick from main - use the parent/pom.xml defined property for postgresql version