### PR TITLE
minor: Replaced get() with getProperty() for type safety and clarity

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
@@ -86,7 +86,7 @@ class ExportTest {
         Assertions.assertEquals("route", model.getArtifactId());
         Assertions.assertEquals("1.0.0", model.getVersion());
         // Reproducible build
-        Assertions.assertNotNull(model.getProperties().get("project.build.outputTimestamp"));
+        Assertions.assertNotNull(model.getProperties().getProperty("project.build.outputTimestamp"));
     }
 
     @ParameterizedTest
@@ -107,7 +107,7 @@ class ExportTest {
         Assertions.assertEquals("route", model.getArtifactId());
         Assertions.assertEquals("1.0.0", model.getVersion());
         // Reproducible build
-        Assertions.assertNotNull(model.getProperties().get("project.build.outputTimestamp"));
+        Assertions.assertNotNull(model.getProperties().getProperty("project.build.outputTimestamp"));
 
         if (rt == RuntimeType.main) {
             assertThat(model.getDependencyManagement().getDependencies())


### PR DESCRIPTION
Replaced get() with getProperty() for config access.
get() comes from Hashtable and returns a generic Object, while getProperty() is type-safe and clearer.
This improves readability and avoids unnecessary casting.

