### PR TITLE
CAMEL-22282: Removes CamelHttpPath header from http producer on bridge

### DIFF
--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
@@ -168,6 +168,8 @@ public class HttpProducer extends DefaultProducer implements LineNumberAware {
             if (queryString != null) {
                 skipRequestHeaders = URISupport.parseQuery(queryString, false, true);
             }
+            //to avoid to append raw http path to the bridged url
+            exchange.getIn().setHeader(HttpConstants.HTTP_PATH, "");
         }
 
         HttpUriRequest httpRequest = createMethod(exchange);


### PR DESCRIPTION
In case of spring boot binding the raw http path is appended to the bridged endpoint