### PR TITLE
CAMEL-22276: camel-http OAuth2.0 body authentication

### DIFF
--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpConfiguration.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpConfiguration.java
@@ -57,7 +57,7 @@ public class HttpConfiguration implements Serializable {
                             "If you set this parameter to too small value, you can get 4xx http errors because camel will think that the received token is still valid, while in reality the token is expired for the Authentication server.")
     private long oauth2CachedTokensExpirationMarginSeconds = 5L;
     @UriParam(label = "producer,security", defaultValue = "false",
-            description = "Whether to use OAuth2 body authentication.")
+              description = "Whether to use OAuth2 body authentication.")
     private boolean oauth2BodyAuthentication;
     @Metadata(label = "producer,security", description = "Authentication domain to use with NTLM")
     @Deprecated
@@ -349,6 +349,7 @@ public class HttpConfiguration implements Serializable {
     public void setOauth2ResourceIndicator(final String oauth2ResourceIndicator) {
         this.oauth2ResourceIndicator = oauth2ResourceIndicator;
     }
+
     public boolean isOauth2BodyAuthentication() {
         return oauth2BodyAuthentication;
     }

--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpConfiguration.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpConfiguration.java
@@ -56,6 +56,9 @@ public class HttpConfiguration implements Serializable {
                             +
                             "If you set this parameter to too small value, you can get 4xx http errors because camel will think that the received token is still valid, while in reality the token is expired for the Authentication server.")
     private long oauth2CachedTokensExpirationMarginSeconds = 5L;
+    @UriParam(label = "producer,security", defaultValue = "false",
+            description = "Whether to use OAuth2 body authentication.")
+    private boolean oauth2BodyAuthentication;
     @Metadata(label = "producer,security", description = "Authentication domain to use with NTLM")
     @Deprecated
     private String authDomain;
@@ -345,5 +348,15 @@ public class HttpConfiguration implements Serializable {
      */
     public void setOauth2ResourceIndicator(final String oauth2ResourceIndicator) {
         this.oauth2ResourceIndicator = oauth2ResourceIndicator;
+    }
+    public boolean isOauth2BodyAuthentication() {
+        return oauth2BodyAuthentication;
+    }
+
+    /**
+     * Whether to use OAuth2 body authentication.
+     */
+    public void setOauth2BodyAuthentication(boolean oauth2BodyAuthentication) {
+        this.oauth2BodyAuthentication = oauth2BodyAuthentication;
     }
 }

--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpComponent.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpComponent.java
@@ -257,7 +257,11 @@ public class HttpComponent extends HttpCommonComponent implements RestProducerFa
                 "oauth2CachedTokensExpirationMarginSeconds",
                 long.class,
                 configDefaults.getOauth2CachedTokensExpirationMarginSeconds());
-
+        boolean useBodyAuthentication = getParameter(
+                parameters,
+                "oauth2BodyAuthentication",
+                boolean.class,
+                configDefaults.isOauth2BodyAuthentication());
         if (clientId != null && clientSecret != null && tokenEndpoint != null) {
             return CompositeHttpConfigurer.combineConfigurers(configurer,
                     new OAuth2ClientConfigurer(
@@ -268,7 +272,8 @@ public class HttpComponent extends HttpCommonComponent implements RestProducerFa
                             scope,
                             cacheTokens,
                             cachedTokensDefaultExpirySeconds,
-                            cachedTokensExpirationMarginSeconds));
+                            cachedTokensExpirationMarginSeconds,
+                            useBodyAuthentication));
         }
         return configurer;
     }

--- a/components/camel-http/src/main/java/org/apache/camel/component/http/OAuth2ClientConfigurer.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/OAuth2ClientConfigurer.java
@@ -58,7 +58,8 @@ public class OAuth2ClientConfigurer extends ServiceSupport implements HttpClient
 
     public OAuth2ClientConfigurer(String clientId, String clientSecret, String tokenEndpoint, String resourceIndicator,
                                   String scope, boolean cacheTokens,
-                                  long cachedTokensDefaultExpirySeconds, long cachedTokensExpirationMarginSeconds, boolean useBodyAuthentication) {
+                                  long cachedTokensDefaultExpirySeconds, long cachedTokensExpirationMarginSeconds,
+                                  boolean useBodyAuthentication) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.tokenEndpoint = tokenEndpoint;

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpOAuth2AuthenticationTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpOAuth2AuthenticationTest.java
@@ -97,20 +97,23 @@ public class HttpOAuth2AuthenticationTest extends BaseHttpTest {
         assertExchange(exchange);
 
     }
+
     @Test
     public void bodyAuthenticationIsPresent() {
         String tokenEndpoint = "http://localhost:" + localServer.getLocalPort() + "/token";
 
         Exchange exchange
                 = template.request("http://localhost:" + localServer.getLocalPort() + "/post?httpMethod=POST&oauth2ClientId="
-                        + clientId + "&oauth2ClientSecret=" + clientSecret + "&oauth2TokenEndpoint=" + tokenEndpoint +
-                "&oauth2BodyAuthentication=true",
-                exchange1 -> {
-                });
+                                   + clientId + "&oauth2ClientSecret=" + clientSecret + "&oauth2TokenEndpoint=" + tokenEndpoint
+                                   +
+                                   "&oauth2BodyAuthentication=true",
+                        exchange1 -> {
+                        });
 
         assertExchange(exchange);
 
     }
+
     protected void assertHeaders(Map<String, Object> headers) {
         assertEquals(HttpStatus.SC_OK, headers.get(Exchange.HTTP_RESPONSE_CODE));
     }

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpOAuth2AuthenticationTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpOAuth2AuthenticationTest.java
@@ -97,7 +97,20 @@ public class HttpOAuth2AuthenticationTest extends BaseHttpTest {
         assertExchange(exchange);
 
     }
+    @Test
+    public void bodyAuthenticationIsPresent() {
+        String tokenEndpoint = "http://localhost:" + localServer.getLocalPort() + "/token";
 
+        Exchange exchange
+                = template.request("http://localhost:" + localServer.getLocalPort() + "/post?httpMethod=POST&oauth2ClientId="
+                        + clientId + "&oauth2ClientSecret=" + clientSecret + "&oauth2TokenEndpoint=" + tokenEndpoint +
+                "&oauth2BodyAuthentication=true",
+                exchange1 -> {
+                });
+
+        assertExchange(exchange);
+
+    }
     protected void assertHeaders(Map<String, Object> headers) {
         assertEquals(HttpStatus.SC_OK, headers.get(Exchange.HTTP_RESPONSE_CODE));
     }

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/handler/OAuth2TokenRequestHandler.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/handler/OAuth2TokenRequestHandler.java
@@ -58,7 +58,7 @@ public class OAuth2TokenRequestHandler implements HttpRequestHandler {
         Map<String, String> bodyCredentials = new HashMap<>();
         WWWFormCodec.parse(requestBody, StandardCharsets.UTF_8).stream()
                 .filter(pair -> pair.getName().equals("client_id") || pair.getName().equals("client_secret"))
-                .forEach( pair -> bodyCredentials.put(pair.getName(), pair.getValue()));
+                .forEach(pair -> bodyCredentials.put(pair.getName(), pair.getValue()));
 
         if (!hasValidHeaderAuthentication(request) && !hasValidBodyAuthentication(bodyCredentials))
             throw new HttpException("Invalid credentials");
@@ -73,7 +73,8 @@ public class OAuth2TokenRequestHandler implements HttpRequestHandler {
         return request.containsHeader(HttpHeaders.AUTHORIZATION) && request.getHeader(HttpHeaders.AUTHORIZATION).getValue()
                 .equals(HttpCredentialsHelper.generateBasicAuthHeader(clientId, clientSecret));
     }
-    private boolean hasValidBodyAuthentication(Map<String,String> credentials) {
+
+    private boolean hasValidBodyAuthentication(Map<String, String> credentials) {
         if (null == credentials || credentials.isEmpty())
             return false;
         return clientId.equals(credentials.get("client_id")) && clientSecret.equals(credentials.get("client_secret"));


### PR DESCRIPTION
# Description

Adds a toggle for authentication using the POST body method defined in [rfc6749 section-2.3.1](https://www.rfc-editor.org/rfc/rfc6749.html#section-2.3.1) for OAuth 2.0. This enables camel-http to speak to OAuth2 authorization servers requiring the client credentials in the HTTP body.


# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).


# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

