### PR TITLE
CAMEL-22282: Removes CamelHttpPath header from http producer on bridge

### DIFF
--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
@@ -164,6 +164,8 @@ public class HttpProducer extends DefaultProducer implements LineNumberAware {
             if (queryString != null) {
                 skipRequestHeaders = URISupport.parseQuery(queryString, false, true);
             }
+            //to avoid to append raw http path to the bridged url
+            exchange.getIn().setHeader(HttpConstants.HTTP_PATH, "");
         }
 
         HttpUriRequest httpRequest = createMethod(exchange);


### PR DESCRIPTION
cherry pick for 4.10.x 