### PR TITLE
chore(deps): Bump logback-version from 1.5.17 to 1.5.18 (#17495)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -329,7 +329,7 @@
         <!-- virtual dependency only used by Eclipse m2e -->
         <lifecycle-mapping-version>1.0.0</lifecycle-mapping-version>
         <log4j2-version>2.21.1</log4j2-version>
-        <logback-version>1.5.16</logback-version>
+        <logback-version>1.5.18</logback-version>
         <lucene-version>9.12.0</lucene-version>
         <lightcouch-version>0.2.0</lightcouch-version>
         <littleproxy-version>2.4.0</littleproxy-version>


### PR DESCRIPTION
(cherry pick of logback upgrade -> 1.5.18 from main -> camel-4.10.x branch)
Ran mvn -DskipTests clean install

Bumps `logback-version` from 1.5.17 to 1.5.18.

Updates `ch.qos.logback:logback-core` from 1.5.17 to 1.5.18
- [Release notes](https://github.com/qos-ch/logback/releases)
- [Commits](https://github.com/qos-ch/logback/compare/v_1.5.17...v_1.5.18)

Updates `ch.qos.logback:logback-classic` from 1.5.17 to 1.5.18
- [Release notes](https://github.com/qos-ch/logback/releases)
- [Commits](https://github.com/qos-ch/logback/compare/v_1.5.17...v_1.5.18)

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-core dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: ch.qos.logback:logback-classic dependency-type: direct:production update-type: version-update:semver-patch ...

