### PR TITLE
CAMEL-22216: Fix ZipIterator using apache.commons.compress

### DIFF
--- a/components/camel-zipfile/pom.xml
+++ b/components/camel-zipfile/pom.xml
@@ -43,6 +43,11 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-file</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons-compress-version}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipSplitAggregateTransactedStreamingIssueTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/processor/aggregate/zipfile/ZipSplitAggregateTransactedStreamingIssueTest.java
@@ -33,7 +33,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled("")
+
 public class ZipSplitAggregateTransactedStreamingIssueTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZipSplitAggregateTransactedStreamingIssueTest.class);
@@ -78,7 +78,7 @@ public class ZipSplitAggregateTransactedStreamingIssueTest extends CamelTestSupp
                 getContext().getRegistry().bind("transacted", springTransactionPolicy);
                 getContext().getRegistry().bind("zipSplitter", new ZipSplitter());
 
-                from("direct:start").streamCache(false)
+                from("direct:start").streamCache(true)
                         .transacted("transacted")
                         .setBody().simple(zipArchiveWithTwoFiles)
                         .unmarshal().base64()


### PR DESCRIPTION
Ticket: https://issues.apache.org/jira/browse/CAMEL-22216

It is about the camel-zipfile component. The changes which have been added for this ticket: https://issues.apache.org/jira/browse/CAMEL-22147 are causing this problem.

A transacted route with ZipSplitter and Aggregation Strategy in streaming mode does not aggregate the last zip file entry.

Changes: Using the apache.commons.compress for the Zip handling, change the availableDataInCurrentEntry to check if the currantEntry is not null, Re-enable the test ZipSplitAggregateTransactedStreamingIssueTest in stream caching mode, To have unified ZIP handling align ZipFileDataFormat using apache.commons.compress

