### PR TITLE
CAMEL-22356: Allow Google PubSub consumer pass exception through error handler

### DIFF
--- a/components/camel-google/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubConsumer.java
+++ b/components/camel-google/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubConsumer.java
@@ -142,11 +142,16 @@ public class GooglePubsubConsumer extends DefaultConsumer {
                 }
 
                 localLog.debug("Exit run for subscription {}", subscriptionName);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                localLog.error("Failure getting messages from PubSub", e);
             } catch (Exception e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
                 localLog.error("Failure getting messages from PubSub", e);
+
+                // allow camel error handler to be aware
+                if (endpoint.isBridgeErrorHandler()) {
+                    getExceptionHandler().handleException(e);
+                }
             }
         }
 
@@ -161,6 +166,11 @@ public class GooglePubsubConsumer extends DefaultConsumer {
                     subscriber.awaitTerminated();
                 } catch (Exception e) {
                     localLog.error("Failure getting messages from PubSub", e);
+
+                    // allow camel error handler to be aware
+                    if (endpoint.isBridgeErrorHandler()) {
+                        getExceptionHandler().handleException(e);
+                    }
                 } finally {
                     localLog.debug("Stopping async subscriber {}", subscriptionName);
                     subscriber.stopAsync();


### PR DESCRIPTION
# Description

Downstream currently has no way to know when Google PubSub consumer fails as exception is simply logged and ignored. This change will let Google PubSub consumer to pass exception through bridge error handler (when enabled) to allow downstream to react to the exception. 

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [CAMEL-22356](https://issues.apache.org/jira/browse/CAMEL-22356) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

