### PR TITLE
CAMEL-22359 Fix MDN multipart/report parsing issue with no Content-Type

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/EntityParser.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/entity/EntityParser.java
@@ -678,9 +678,12 @@ public final class EntityParser {
                     textReportContentTransferEncoding = header.getValue();
                 }
             }
+
+            // If Content-Type is not defined, should be considered as "text/plain; charset=us-ascii" (RFC 2045 - 5.2)
             if (textReportContentType == null) {
-                throw new HttpException("Failed to find Content-Type header in EDI message body part");
+                textReportContentType = ContentType.parse("text/plain").withCharset(StandardCharsets.US_ASCII.name());
             }
+
             if (!textReportContentType.getMimeType().equalsIgnoreCase(AS2MimeType.TEXT_PLAIN)) {
                 throw new HttpException(
                         "Invalid content type '" + textReportContentType.getMimeType()


### PR DESCRIPTION
JIRA : https://issues.apache.org/jira/browse/CAMEL-22359

We use Apache Camel AS2 libraries in our application to receive and process AS2 messages.

Currently, we tracked down an issue where a client message's signature fails to be validated.

It turns out that the message content contains CRLF line endings in the mime part body, while the original message has LF only.

We were able to verify that replacement LF->CRLF is carried out in CanonicalOutputStream, which is used in AS2 implementation to marshal the signed entity in SigningUtils::isValid into a byte array.

```
Caused by: org.apache.hc.core5.http.ParseException: failed to parse text entity
	at org.apache.camel.component.as2.api.entity.EntityParser.parseMultipartSignedEntityBody(EntityParser.java:449) ~[classes/:na]
	at org.apache.camel.component.as2.api.entity.EntityParser.parseMultipartSignedEntity(EntityParser.java:274) ~[classes/:na]
	at org.apache.camel.component.as2.api.entity.EntityParser.parseByMimeType(EntityParser.java:368) ~[classes/:na]
	at org.apache.camel.component.as2.api.entity.EntityParser.doParseAS2MessageEntity(EntityParser.java:357) ~[classes/:na]
	at org.apache.camel.component.as2.api.entity.EntityParser.parseAS2MessageEntity(EntityParser.java:336) ~[classes/:na]
	at org.apache.camel.component.as2.api.io.AS2BHttpClientConnection.receiveResponseEntity(AS2BHttpClientConnection.java:126) ~[camel-as2-api-4.10.6.jar:4.10.6]
	at org.apache.hc.core5.http.impl.io.HttpRequestExecutor.execute(HttpRequestExecutor.java:192) ~[httpcore5-5.2.5.jar:5.2.5]
	at org.apache.hc.core5.http.impl.io.HttpRequestExecutor.execute(HttpRequestExecutor.java:218) ~[httpcore5-5.2.5.jar:5.2.5]
	at org.apache.camel.component.as2.api.AS2ClientConnection$2.execute(AS2ClientConnection.java:205) ~[camel-as2-api-4.10.6.jar:4.10.6]
	at org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager$InternalConnectionEndpoint.execute(PoolingHttpClientConnectionManager.java:717) ~[httpclient5-5.3.1.jar:5.3.1]
	at org.apache.camel.component.as2.api.AS2ClientConnection.send(AS2ClientConnection.java:211) ~[camel-as2-api-4.10.6.jar:4.10.6]
	at org.apache.camel.component.as2.api.AS2ClientManager.sendRequest(AS2ClientManager.java:331) ~[camel-as2-api-4.10.6.jar:4.10.6]
	at org.apache.camel.component.as2.api.AS2ClientManager.send(AS2ClientManager.java:322) ~[camel-as2-api-4.10.6.jar:4.10.6]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	at org.apache.camel.support.component.ApiMethodHelper.invokeMethod(ApiMethodHelper.java:521) ~[camel-support-4.10.6.jar:4.10.6]
	... 9 common frames omitted
Caused by: org.apache.hc.core5.http.ParseException: failed to parse EDI entity
	at org.apache.camel.component.as2.api.entity.EntityParser.parseEntityBody(EntityParser.java:634) ~[classes/:na]
	at org.apache.camel.component.as2.api.entity.EntityParser.parseMultipartSignedEntityBody(EntityParser.java:419) ~[classes/:na]
	... 24 common frames omitted
Caused by: org.apache.hc.core5.http.ParseException: failed to parse text entity
	at org.apache.camel.component.as2.api.entity.EntityParser.parseMultipartReportEntityBody(EntityParser.java:520) ~[classes/:na]
	at org.apache.camel.component.as2.api.entity.EntityParser.parseEntityBody(EntityParser.java:616) ~[classes/:na]
	... 25 common frames omitted
Caused by: org.apache.hc.core5.http.HttpException: Failed to find Content-Type header in EDI message body part
	at org.apache.camel.component.as2.api.entity.EntityParser.parseMultipartReportEntityBody(EntityParser.java:486) ~[classes/:na]
	... 26 common frames omitted
```