### PR TITLE
Handle Camel Spring Boot versions that are not equal to Camel

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 import org.apache.camel.dsl.jbang.core.common.RuntimeType;
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
 import org.apache.camel.dsl.jbang.core.common.SourceScheme;
+import org.apache.camel.dsl.jbang.core.common.VersionHelper;
 import org.apache.camel.tooling.maven.MavenGav;
 import org.apache.camel.util.CamelCaseOrderedProperties;
 import org.apache.camel.util.FileUtil;
@@ -113,7 +114,8 @@ public class Export extends ExportBaseCommand {
             this.quarkusGroupId = props.getProperty("camel.jbang.quarkusGroupId", this.quarkusGroupId);
             this.quarkusArtifactId = props.getProperty("camel.jbang.quarkusArtifactId", this.quarkusArtifactId);
             this.quarkusVersion = props.getProperty("camel.jbang.quarkusVersion", this.quarkusVersion);
-            this.camelSpringBootVersion = props.getProperty("camel.jbang.camelSpringBootVersion", this.camelSpringBootVersion);
+            this.camelSpringBootVersion = VersionHelper.getSpringBootVersion(
+                    () -> props.getProperty("camel.jbang.camelSpringBootVersion", this.camelSpringBootVersion));
             this.springBootVersion = props.getProperty("camel.jbang.springBootVersion", this.springBootVersion);
             this.mavenWrapper
                     = "true".equals(props.getProperty("camel.jbang.mavenWrapper", this.mavenWrapper ? "true" : "false"));

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
@@ -51,6 +51,8 @@ class ExportSpringBoot extends Export {
 
     @Override
     public Integer export() throws Exception {
+        this.camelSpringBootVersion = VersionHelper.getSpringBootVersion(null);
+
         String[] ids = gav.split(":");
         if (ids.length != 3) {
             printer().printErr("--gav must be in syntax: groupId:artifactId:version");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -1029,7 +1029,8 @@ public class Run extends CamelCommand {
         eq.gradleWrapper = false;
         eq.springBootVersion = this.springBootVersion;
         eq.camelVersion = this.camelVersion;
-        eq.camelSpringBootVersion = this.camelSpringBootVersion != null ? this.camelSpringBootVersion : this.camelVersion;
+        eq.camelSpringBootVersion = VersionHelper.getSpringBootVersion(
+                () -> this.camelSpringBootVersion != null ? this.camelSpringBootVersion : this.camelVersion);
         eq.kameletsVersion = this.kameletsVersion;
         eq.exportDir = runDir.toString();
         eq.localKameletDir = this.localKameletDir;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/CatalogLoader.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/CatalogLoader.java
@@ -115,7 +115,9 @@ public final class CatalogLoader {
                 throw new IOException("Cannot download org.apache.camel:camel-catalog:" + camelCatalogVersion);
             }
 
-            ma = downloader.downloadArtifact("org.apache.camel.springboot", "camel-catalog-provider-springboot", version);
+            final String camelVersion = version;
+            ma = downloader.downloadArtifact("org.apache.camel.springboot", "camel-catalog-provider-springboot",
+                    VersionHelper.getSpringBootVersion(() -> camelVersion));
             if (ma != null) {
                 cl.addFile(ma.getFile());
             } else {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/VersionHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/VersionHelper.java
@@ -18,6 +18,7 @@ package org.apache.camel.dsl.jbang.core.common;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.function.Supplier;
 
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
@@ -25,6 +26,33 @@ import org.apache.camel.util.StringHelper;
 public final class VersionHelper {
 
     private VersionHelper() {
+    }
+
+    /**
+     * Retrieves the Spring Boot version to use, with support for overriding via system property. This is particularly
+     * useful when the Camel version differs from the Camel Spring Boot version, allowing for explicit version control
+     * in JBang scenarios.
+     *
+     * <p>
+     * The method follows this precedence order:
+     * <ol>
+     * <li>System property {@code camel.jbang.camelSpringBootVersion} if set</li>
+     * <li>Value from the provided supplier if not null</li>
+     * <li>Returns null if neither option is available</li>
+     * </ol>
+     *
+     * @param  supplier a supplier that provides the default Spring Boot version when no system property override is
+     *                  present. May be null.
+     * @return          the Spring Boot version string, or null if no version can be determined
+     */
+    public static String getSpringBootVersion(Supplier<String> supplier) {
+        if (System.getProperty("camel.jbang.camelSpringBootVersion") != null) {
+            return System.getProperty("camel.jbang.camelSpringBootVersion");
+        } else if (supplier != null) {
+            return supplier.get();
+        }
+
+        return null;
     }
 
     public static String getJBangVersion() {


### PR DESCRIPTION
# Description

Bring the resolution of camel-spring-boot version from environment variable over to 4.10.x branch.     

# Target

- [ x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [ x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.


