### PR TITLE
Align spring-security with spring-boot 3.5.5

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -484,7 +484,7 @@
         <spring-vault-core-version>3.2.0</spring-vault-core-version>
         <spring-version>6.2.10</spring-version>
         <spring-rabbitmq-version>3.2.6</spring-rabbitmq-version>
-        <spring-security-version>6.5.2</spring-security-version>
+        <spring-security-version>6.5.3</spring-security-version>
         <spring-ws-version>4.1.1</spring-ws-version>
         <sql-maven-plugin-version>3.0.0</sql-maven-plugin-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>


### PR DESCRIPTION
# Description

Align versions with spring-boot 3.5.5 (camel-4.14.x branch)- the only version spring-* version I could find that needed upgrading was spring-security (6.5.2 -> 6.5.3)

# Target

- [ x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.
