### PR TITLE
Make Camel Infra command more tool friendly

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraPs.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraPs.java
@@ -31,6 +31,9 @@ import picocli.CommandLine;
                      showDefaultValues = true)
 public class InfraPs extends InfraBaseCommand {
 
+    @CommandLine.Parameters(description = "Service name", arity = "0..1")
+    private List<String> serviceName;
+
     public InfraPs(CamelJBangMain main) {
         super(main);
     }
@@ -46,7 +49,13 @@ public class InfraPs extends InfraBaseCommand {
         Set<String> runningAliases = new HashSet<>();
         try {
             List<Path> pidFiles = Files.list(CommandLineHelper.getCamelDir())
-                    .filter(p -> p.getFileName().toString().startsWith("infra-"))
+                    .filter(p -> {
+                        if (serviceName == null) {
+                            return p.getFileName().toString().startsWith("infra-");
+                        } else {
+                            return p.getFileName().toString().startsWith("infra-" + serviceName.get(0));
+                        }
+                    })
                     .toList();
 
             for (Path pidFile : pidFiles) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraRun.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraRun.java
@@ -184,7 +184,7 @@ public class InfraRun extends InfraBaseCommand {
             }
         }
 
-        String jsonProperties = jsonMapper.writeValueAsString(properties);
+        String jsonProperties = jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(properties);
         printer().println(jsonProperties);
 
         String name = getLogFileName(testService, RuntimeUtil.getPid());
@@ -192,7 +192,7 @@ public class InfraRun extends InfraBaseCommand {
 
         String jsonName = getJsonFileName(testService, RuntimeUtil.getPid());
         Path jsonFile = createFile(jsonName);
-        Files.write(jsonFile, jsonProperties.getBytes());
+        Files.write(jsonFile, jsonMapper.writeValueAsString(properties).getBytes());
 
         if (Arrays.stream(actualService.getClass().getInterfaces()).anyMatch(c -> c.getName().contains("ContainerService"))) {
             Object containerLogConsumer = cl.loadClass("org.apache.camel.test.infra.common.CamelLogConsumer")


### PR DESCRIPTION
- Add a `camel infra ps $SERVICE` command to filter out list
- Include the service data JSON in the ps output. This way when running an infra service with --background, the service data can be retrieved. 