### PR TITLE
CAMEL-22408: OpenAPI Description showing wrong allowable dates depending on system timezone

### DIFF
--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiSupport.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiSupport.java
@@ -25,6 +25,7 @@ import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -60,7 +61,12 @@ import static org.apache.camel.openapi.RestDefinitionsResolver.JMX_REST_DEFINITI
  */
 public class RestOpenApiSupport {
 
-    public static DateFormat DEFAULT_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+    private static final DateFormat DEFAULT_DATE_FORMAT;
+    static {
+        final SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd");
+        f.setTimeZone(TimeZone.getTimeZone("UTC"));
+        DEFAULT_DATE_FORMAT = f;
+    }
 
     static final String HEADER_X_FORWARDED_PREFIX = "X-Forwarded-Prefix";
     static final String HEADER_X_FORWARDED_HOST = "X-Forwarded-Host";

--- a/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderTest.java
+++ b/components/camel-openapi-java/src/test/java/org/apache/camel/openapi/RestOpenApiReaderTest.java
@@ -16,14 +16,6 @@
  */
 package org.apache.camel.openapi;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.TimeZone;
-
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.swagger.v3.core.util.Json;
-import io.swagger.v3.core.util.Json31;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import org.apache.camel.BindToRegistry;
@@ -240,7 +232,7 @@ public class RestOpenApiReaderTest extends CamelTestSupport {
                 new DefaultClassResolver());
         assertNotNull(openApi);
 
-        String json = getJsonFromOpenAPIAsString(openApi, config);
+        String json = RestOpenApiSupport.getJsonFromOpenAPIAsString(openApi, config);
         log.info(json);
         json = json.replace("\n", " ").replaceAll("\\s+", " ");
 
@@ -276,26 +268,6 @@ public class RestOpenApiReaderTest extends CamelTestSupport {
         assertTrue(json.contains(
                 "\"tags\" : [ { \"name\" : \"/hello\" }, { \"name\" : \"Organisation\" }, { \"name\" : \"Group A\" }, { \"name\" : \"Group B\" } ]"));
         context.stop();
-    }
-
-    /*
-     * set TimeZone as default GMT to eusure this test pass everywhere
-     */
-    private String getJsonFromOpenAPIAsString(OpenAPI openApi, BeanConfig config) {
-        ObjectMapper mapper = config.isOpenApi31() ? Json31.mapper() : Json.mapper();
-        DateFormat origin = mapper.getDateFormat();
-        String result = null;
-        try {
-            DateFormat testDateFormat = new SimpleDateFormat("yyyy-MM-dd");
-            testDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-            mapper.setDateFormat(testDateFormat);
-            result = mapper.writer(new DefaultPrettyPrinter()).writeValueAsString(openApi);
-        } catch (Exception e) {
-            return null;
-        } finally {
-            mapper.setDateFormat(origin);
-        }
-        return result;
     }
 
 }


### PR DESCRIPTION
# Description

See https://issues.apache.org/jira/browse/CAMEL-22408

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] https://issues.apache.org/jira/browse/CAMEL-22408

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.
