### PR TITLE
chore(deps): Bump tika-version from 2.9.3 to 2.9.4 (#17973)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -486,7 +486,7 @@
         <tahu-version>1.0.13</tahu-version>
         <testcontainers-version>1.20.4</testcontainers-version>
         <thymeleaf-version>3.1.3.RELEASE</thymeleaf-version>
-        <tika-version>2.9.3</tika-version>
+        <tika-version>2.9.4</tika-version>
         <twilio-version>10.6.8</twilio-version>
         <twitter4j-version>4.1.2</twitter4j-version>
         <undertow-version>2.3.18.Final</undertow-version>


### PR DESCRIPTION
Bumps `tika-version` from 2.9.3 to 2.9.4.

# Description

Cherry pick of tika upgrade from 2.9.3->2.9.4 from main

# Target

- [ x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.
