### PR TITLE
chore(deps): Bump undertow-version from 2.3.18.Final to 2.3.19.Final …

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -489,7 +489,7 @@
         <tika-version>2.9.3</tika-version>
         <twilio-version>10.6.8</twilio-version>
         <twitter4j-version>4.1.2</twitter4j-version>
-        <undertow-version>2.3.18.Final</undertow-version>
+        <undertow-version>2.3.19.Final</undertow-version>
         <univocity-parsers-version>2.10.1</univocity-parsers-version>
         <validation-api-version>2.0.1.Final</validation-api-version>
         <vavr-version>0.10.6</vavr-version>


### PR DESCRIPTION

Bumps `undertow-version` from 2.3.18.Final to 2.3.19.Final.

# Description

Cherry pick of undertow version upgrade from main to the camel-4.10.x branch

# Target

- [ x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.
