### PR TITLE
fix(components): add break of fallthrough comment

### DIFF
--- a/components/camel-as2/camel-as2-component/src/main/java/org/apache/camel/component/as2/AS2Endpoint.java
+++ b/components/camel-as2/camel-as2-component/src/main/java/org/apache/camel/component/as2/AS2Endpoint.java
@@ -300,6 +300,7 @@ public class AS2Endpoint extends AbstractApiEndpoint<AS2ApiName, AS2Configuratio
                 break;
             case RECEIPT:
                 apiProxy = new AS2AsyncMDNServerManager(getAS2AsyncMDNServerConnection());
+                break;
             default:
                 throw new IllegalArgumentException("Invalid API name " + apiName);
         }

--- a/components/camel-aws/camel-aws-xray/src/test/java/org/apache/camel/component/aws/xray/json/JsonParser.java
+++ b/components/camel-aws/camel-aws-xray/src/test/java/org/apache/camel/component/aws/xray/json/JsonParser.java
@@ -54,6 +54,7 @@ public final class JsonParser {
                         stack.push(newNode);
                         break;
                     }
+                    // Fall-through to default
                 case '}':
                     if (!inWord) {
                         // JsonObject end
@@ -69,6 +70,7 @@ public final class JsonParser {
                         }
                         break;
                     }
+                    // Fall-through to default
                 case '[':
                     if (!inWord) {
                         // JsonArray start
@@ -78,6 +80,7 @@ public final class JsonParser {
                         stack.push(newArray);
                         break;
                     }
+                    // Fall-through to default
                 case ']':
                     if (!inWord) {
                         // JsonArray end
@@ -86,6 +89,7 @@ public final class JsonParser {
                         }
                         break;
                     }
+                    // Fall-through to default
                 case ':':
                     if (!inWord) {
                         // Element start
@@ -93,6 +97,7 @@ public final class JsonParser {
                         curToken.delete(0, curToken.length());
                         break;
                     }
+                    // Fall-through to default
                 case ',':
                     if (!inWord) {
                         // Element separator
@@ -104,6 +109,7 @@ public final class JsonParser {
                         keyName = null;
                         break;
                     }
+                    // Fall-through to default
                 default:
                     if ('"' == c && (curToken.isEmpty() || curToken.charAt(curToken.length() - 1) != '\\')) {
                         inWord = !inWord;


### PR DESCRIPTION
Relates various security code scanning alerts

Fixes https://github.com/apache/camel/security/code-scanning/5710
Fixes https://github.com/apache/camel/security/code-scanning/5711
Fixes https://github.com/apache/camel/security/code-scanning/5712
Fixes https://github.com/apache/camel/security/code-scanning/5713
Fixes https://github.com/apache/camel/security/code-scanning/5714
Fixes https://github.com/apache/camel/security/code-scanning/5715

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

