### PR TITLE
Fix export condition for Camel Spring Boot

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
@@ -405,7 +405,7 @@ class ExportSpringBoot extends Export {
             // skip "camel.server." or "camel.management." as this is for camel-main only
             return null;
         }
-        boolean camel44orOlder = camelSpringBootVersion != null && VersionHelper.isLE("4.4.0", camelSpringBootVersion);
+        boolean camel44orOlder = camelSpringBootVersion != null && VersionHelper.isGE("4.4.0", camelSpringBootVersion);
         if (camel44orOlder) {
             // camel.main.x should be renamed to camel.springboot.x (for camel 4.4.x or older)
             if (key.startsWith("camel.main.")) {


### PR DESCRIPTION
Apply camel.springboot only if source (4.4.0) is greater than the actual version (not lower)