### PR TITLE
Fix camel.jbang.repo option

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -959,7 +959,7 @@ public abstract class ExportBaseCommand extends CamelCommand {
     protected String getMavenRepositories(Path settings, Properties prop, String camelVersion) throws Exception {
         Set<String> answer = new LinkedHashSet<>();
 
-        String propRepositories = prop.getProperty(CLASSPATH_FILES);
+        String propRepositories = prop.getProperty(REPOS);
         if (propRepositories != null) {
             answer.add(propRepositories);
         }


### PR DESCRIPTION
# Description

Related to [jbang options support](https://github.com/camel-tooling/camel-language-server/issues/1323), the repository property should be fixed

# Target

- I checked that the commit is targeting the correct branch (Camel 4 uses the `camel-4.14.x` branch)
