### PR TITLE
Add title to asciidoc

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/migration-app-note.adoc
+++ b/docs/user-manual/modules/ROOT/pages/migration-app-note.adoc
@@ -1,3 +1,5 @@
+= Migration Note
+
 [NOTE]
 ====
 https://github.com/apache/camel-upgrade-recipes/[The Camel Upgrade Recipes project] provides automated assistance for some common migration tasks.


### PR DESCRIPTION
# Description

The website build currently breaks with the following error which is caused by an asciidoc file not having a title:

```

$ docker top 29ed83b7fd049313455e9b84dfc2ca4c6308b528e0bb286ae3fedb3b6f5e910a -eo pid,comm
--
  |   |   | + cd /home/jenkins/712657a4/workspace/Camel_Camel.website_main/camel-website
  |   |   | + yarn checks
  |   |   | [check:html     ]
  |   |   | [check:html     ] /home/jenkins/712657a4/workspace/Camel_Camel.website_main/camel-website/public/manual/migration-app-note.html
  |   |   | [check:html     ]   1:133  error  Title starts with the `Untitled` make sure that the Asciidoc file starts with level 1 heading  camel/title
  |   |   | [check:html     ]
  |   |   | [check:html     ] ✖ 1 problem (1 error, 0 warnings)
  |   |   | ERROR: "check:html" exited with 1.
```

See: https://ci-builds.apache.org/job/Camel/job/Camel.website/job/main/2126/cloudbees-pipeline-explorer/?line=173