### PR TITLE
Prefix note file with underscore to prevent standalone publication

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/_migration-app-note.adoc
+++ b/docs/user-manual/modules/ROOT/pages/_migration-app-note.adoc
@@ -1,5 +1,3 @@
-= Migration Note
-
 [NOTE]
 ====
 https://github.com/apache/camel-upgrade-recipes/[The Camel Upgrade Recipes project] provides automated assistance for some common migration tasks.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_1.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_1.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading Camel 4.0 to 4.1
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_10.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_10.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading from 4.10.5 to 4.10.7
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_11.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_11.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading Camel 4.10 to 4.11
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_12.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_12.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading Camel 4.11 to 4.12
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_13.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_13.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading Camel 4.12 to 4.13
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading Camel 4.13 to 4.14
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_15.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_15.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading Camel 4.14 to 4.15
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_2.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_2.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading Camel 4.1 to 4.2
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_3.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_3.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading Camel 4.2 to 4.3
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_4.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_4.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading from 4.4.4 to 4.4.5
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_5.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_5.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading Camel 4.4 to 4.5
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_6.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_6.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading Camel 4.5 to 4.6
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_7.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_7.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading Camel 4.6 to 4.7
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_8.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_8.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading from 4.8.4 to 4.8.7
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_9.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_9.adoc
@@ -4,7 +4,7 @@ This document is for helping you upgrade your Apache Camel application
 from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
 from both 4.0 to 4.1 and 4.1 to 4.2.
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 
 == Upgrading Camel 4.8 to 4.9
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide.adoc
@@ -25,5 +25,5 @@ You can find the upgrade guide for each release in the following pages:
 - xref:camel-4x-upgrade-guide-4_14.adoc[Upgrade guide 4.13 -> 4.14]
 - xref:camel-4x-upgrade-guide-4_15.adoc[Upgrade guide 4.14 -> 4.15]
 
-include::migration-app-note.adoc[]
+include::_migration-app-note.adoc[]
 


### PR DESCRIPTION
# Description

Fix for the following documentation build error:

```

[build:antora  ] [build:antora-perf] (node:189) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
--
  |   |   | [build:antora  ] [build:antora-perf] (Use `node --trace-deprecation ...` to show where the warning was created)
  |   |   | [build:antora  ] [build:antora-perf] [08:20:19.781] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_1.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:19.879] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_10.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:19.948] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_11.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:19.992] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_12.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:20.047] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_13.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:20.079] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:20.115] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_15.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:20.154] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_2.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:20.189] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_3.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:20.229] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_5.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:20.291] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_4.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:20.344] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_7.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:20.402] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_6.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:20.448] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_8.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:20.482] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_9.adoc:7
  |   |   | [build:antora  ] [build:antora-perf] [08:20:20.523] ERROR (asciidoctor): level 0 sections can only be used when doctype is book
  |   |   | [build:antora  ] [build:antora-perf]     file: docs/user-manual/modules/ROOT/pages/migration-app-note.adoc:1
  |   |   | [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel.git (branch: main \| start path: docs/user-manual)
  |   |   | [build:antora  ] [build:antora-perf]     stack:
  |   |   | [build:antora  ] [build:antora-perf]         file: docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide.adoc:28
  |   |   | [build:antora  ] ERROR: "build:antora-perf" exited with 1.
  |   |   | ERROR: "build:antora" exited with 1.
  |   |   | The command failed for workspaces that are depended upon by other workspaces; can't satisfy the dependency graph
  |   |   | Failed with errors in 11m 42s
```

See: https://ci-builds.apache.org/job/Camel/job/Camel.website/job/main/2127/cloudbees-pipeline-explorer/