### PR TITLE
Align spring-*, jetty, http-* versions to the versions used in spring-boot 3.4.10

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeType.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/RuntimeType.java
@@ -25,7 +25,7 @@ public enum RuntimeType {
     main;
 
     public static final String QUARKUS_VERSION = "3.18.4";
-    public static final String SPRING_BOOT_VERSION = "3.4.7";
+    public static final String SPRING_BOOT_VERSION = "3.4.10";
 
     public static RuntimeType fromValue(String value) {
         return switch (value) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -221,8 +221,8 @@
         <hk2-version>2.6.1</hk2-version>
         <hsqldb-version>2.7.4</hsqldb-version>
         <httpunit-version>1.7</httpunit-version>
-        <httpcore-version>5.3.4</httpcore-version>
-        <httpclient-version>5.4.3</httpclient-version>
+        <httpcore-version>5.3.5</httpcore-version>
+        <httpclient-version>5.4.4</httpclient-version>
         <httpcore4-version>4.4.16</httpcore4-version>
         <httpclient4-version>4.5.14</httpclient4-version>
         <httpasyncclient-version>4.1.5</httpasyncclient-version>
@@ -278,7 +278,7 @@
         <jcr-version>2.0</jcr-version>
         <jedis-client-version>5.2.0</jedis-client-version>
         <jetcd-version>0.8.4</jetcd-version>
-        <jetty-version>12.0.26</jetty-version>
+        <jetty-version>12.0.27</jetty-version>
         <jetty-for-solr-version>10.0.20</jetty-for-solr-version>
         <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
         <jetty-runner-groupId>org.eclipse.jetty</jetty-runner-groupId>
@@ -463,13 +463,13 @@
         <solr-zookeeper-version>3.9.3</solr-zookeeper-version>
         <splunk-version>1.9.5_1</splunk-version>
         <spock-version>2.3-groovy-4.0</spock-version>
-        <spring-batch-version>5.2.2</spring-batch-version>
+        <spring-batch-version>5.2.3</spring-batch-version>
         <spring-data-redis-version>3.4.9</spring-data-redis-version>
         <spring-ldap-version>3.2.14</spring-ldap-version>
         <spring-vault-core-version>3.1.3</spring-vault-core-version>
-        <spring-version>6.2.10</spring-version>
-        <spring-rabbitmq-version>3.2.5</spring-rabbitmq-version>
-        <spring-security-version>6.4.9</spring-security-version>
+        <spring-version>6.2.11</spring-version>
+        <spring-rabbitmq-version>3.2.7</spring-rabbitmq-version>
+        <spring-security-version>6.4.11</spring-security-version>
         <spring-ws-version>4.0.15</spring-ws-version>
         <sql-maven-plugin-version>3.0.0</sql-maven-plugin-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>


### PR DESCRIPTION
# Description

Alignment to spring-boot 3.4.10 for the camel-4.10.x branch

# Target

- [x ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.
