### PR TITLE
fix(ci): exit on error 

### DIFF
--- a/etc/scripts/regen.sh
+++ b/etc/scripts/regen.sh
@@ -26,6 +26,19 @@ git clean -fdx
 rm -Rf **/src/generated/
 
 # Regenerate everything
-./mvnw --batch-mode -Pregen -DskipTests install >> build.log 2>&1
+if ./mvnw --batch-mode -Pregen -DskipTests install >> build.log 2>&1; then
+  echo "✅ mvn -Pregen succeeded."
+else
+  echo "❌ mvn -Pregen failed. Last 50 lines of build.log:"
+  tail -n 50 build.log
+  exit 1
+fi
+
 # One additional pass to get the info for the 'others' jars
-./mvnw --batch-mode install -f catalog/camel-catalog >> build.log 2>&1
+if ./mvnw --batch-mode install -f catalog/camel-catalog >> build.log 2>&1; then
+  echo "✅ mvn install for camel-catalog succeeded."
+else
+  echo "❌ mvn install for camel-catalog failed. Last 50 lines of build.log:"
+  tail -n 50 build.log
+  exit 1
+fi

--- a/etc/scripts/regen.sh
+++ b/etc/scripts/regen.sh
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+set -e
+
 # Move to top directory
 cd `dirname "$0"`/../..
 


### PR DESCRIPTION
# Description

This script is used during github check. When the first maven execution fails, it continues to the second. It is convenient to stop immediately instead.
Additionally with this PR avoid the developer to download the build log file in case of error. He can now have a sneak peak at the workflow log to understand what was wrong.

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

