### PR TITLE
camel-jbang: Add more tests for run and kubernetes run commands (backport to 4.14.x)

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
@@ -561,6 +561,17 @@ And if you have `jq` installed which can format and output the JSON data in colo
 curl -s -H "Accept: application/json"  http://0.0.0.0:8080/q/dev/top/ | jq
 ----
 
+=== Using properties
+
+To set properties when running a route, you can use the `--property` or `--properties` parameter from `camel run` command:
+
+* `--property`: sets individual parameters, example: `--property=my-key=my-value`, you have to add more `--property` in case you need more parameters.
+* `--properties`: loads a properties file from the local filesystem, example: `--properties=/var/my-app/config.properties`.
+
+NOTE: You have to use the `=` sign right after the `--property`, as in the examples above.
+
+If both parameters are used, the properties will be merged in a single `application.properties` file.
+
 [#_using_profiles]
 === Using profiles
 

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandITCase.java
@@ -70,6 +70,16 @@ public class RunCommandITCase extends JBangTestSupport {
     }
 
     @Test
+    public void runWithProperties() throws IOException {
+        copyResourceInDataFolder("route-props.yaml");
+        copyResourceInDataFolder("route-props.properties");
+        executeBackground(String.format(
+                "run %s/route-props.yaml --property=a=a --property=b=b --properties=%s/route-props.properties",
+                mountPoint(), mountPoint()));
+        checkLogContains("Hello Camel with properties a=a b=b my-key=my-val", 5);
+    }
+
+    @Test
     public void runRoutesFromMultipleFilesUsingWildcardTest() {
         execute("init one.yaml --directory=/tmp/one");
         execute("init two.xml --directory=/tmp/two");

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -218,6 +218,13 @@ public abstract class JBangTestSupport {
                         .contains(contains)));
     }
 
+    protected void checkContainerLogContainsAllOf(int waitForSeconds, String... contains) {
+        Assertions.assertThatNoException().isThrownBy(() -> Awaitility.await()
+                .atMost(waitForSeconds, TimeUnit.SECONDS)
+                .untilAsserted(() -> Assertions.assertThat(getContainerLogs())
+                        .contains(contains)));
+    }
+
     protected void checkLogContains(String contains) {
         checkLogContains(contains, ASSERTION_WAIT_SECONDS);
     }
@@ -282,6 +289,10 @@ public abstract class JBangTestSupport {
         return getLogs(null);
     }
 
+    protected String getContainerLogs() {
+        return containerService.getContainerLogs();
+    }
+
     protected String getLogs(String route) {
         return execute(Optional.ofNullable(route)
                 .map(r -> String.format("log %s --follow=false", r))
@@ -301,6 +312,13 @@ public abstract class JBangTestSupport {
             Files.copy(is, Path.of(containerDataFolder, resource.getName()), StandardCopyOption.REPLACE_EXISTING);
         }
         assertFileInDataFolderExists(resource.getName());
+    }
+
+    protected void copyResourceInDataFolder(String filename) throws IOException {
+        try (InputStream is = JBangTestSupport.class.getResourceAsStream("/jbang/it/" + filename)) {
+            Files.copy(is, Path.of(containerDataFolder, filename), StandardCopyOption.REPLACE_EXISTING);
+        }
+        assertFileInDataFolderExists(filename);
     }
 
     protected void newFileInDataFolder(String fileName, String content) {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/resources/jbang/it/route-props.properties
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/resources/jbang/it/route-props.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+my-key=my-val

--- a/dsl/camel-jbang/camel-jbang-it/src/test/resources/jbang/it/route-props.yaml
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/resources/jbang/it/route-props.yaml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- from:
+    uri: "timer:yaml"
+    parameters:
+      period: "1000"
+    steps:
+      - setBody:
+          constant: "Hello Camel with properties a={{a:default}} b={{b:default}} my-key={{my-key:default}}"
+      - log: "${body}"

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/MountTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/MountTrait.java
@@ -47,6 +47,10 @@ public class MountTrait extends BaseTrait {
             = Pattern.compile("^([\\w.\\-_:]+)(/([\\w.\\-_:]+))?(@([\\w.\\-_:/]+))?$");
 
     public static final int MOUNT_TRAIT_ORDER = ContainerTrait.CONTAINER_TRAIT_ORDER + 10;
+    public static final String CONF_DIR = "/etc/camel/conf.d";
+    public static final String RESOURCES_DIR = "/etc/camel/resources.d";
+    public static final String SECRETS = "/_secrets";
+    public static final String CONFIGMAPS = "/_configmaps";
 
     public MountTrait() {
         super("mount", MOUNT_TRAIT_ORDER);
@@ -206,15 +210,15 @@ public class MountTrait extends BaseTrait {
 
         String baseMountPoint;
         if (mountResource.contentType == MountResource.ContentType.DATA) {
-            baseMountPoint = "/etc/camel/resources.d";
+            baseMountPoint = RESOURCES_DIR;
         } else {
-            baseMountPoint = "/etc/camel/conf.d";
+            baseMountPoint = CONF_DIR;
         }
 
         if (mountResource.storageType == MountResource.StorageType.SECRET) {
-            baseMountPoint += "/_secrets";
+            baseMountPoint += SECRETS;
         } else {
-            baseMountPoint += "/_configmaps";
+            baseMountPoint += CONFIGMAPS;
         }
 
         return Path.of(baseMountPoint, mountResource.name).toString();

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/resources/test-configmap.yaml
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/resources/test-configmap.yaml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: test-config
+data:
+  test-route.properties: |
+    foo.application.custom = my-custom-value
+    foo.myroute.endpoint = http://my-site.com

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/resources/test-multiple-config.yaml
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/resources/test-multiple-config.yaml
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: multiple-config
+data:
+  game.properties: |
+    enemies=aliens
+    lives=3
+    my-key=property from game.properties
+    enemies.cheat=true
+    enemies.cheat.level=noGoodRotten
+    secret.code.passphrase=UUDDLRLRBABAS
+    secret.code.allowed=true
+    secret.code.lives=30
+  ui.properties: |
+    color.good=purple
+    color.bad=yellow
+    allow.textmode=true
+    how.nice.to.look=fairlyNice
+    my-key=property from ui.properties

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/resources/test-secret.yaml
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/resources/test-secret.yaml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+type: Opaque
+data:
+  secret.properties: bXkta2V5PWEgc2ltcGxlIHBhc3N3b3JkIGZyb20gc2VjcmV0LnByb3BlcnRpZXMK

--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliLocalContainerService.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliLocalContainerService.java
@@ -131,8 +131,12 @@ public class CliLocalContainerService implements CliService, ContainerService<Cl
                         execResult.getStderr()));
             }
             if (LOG.isDebugEnabled()) {
-                LOG.debug("result out {}", execResult.getStdout());
-                LOG.debug("result error {}", execResult.getStderr());
+                if (StringUtils.isNotBlank(execResult.getStdout())) {
+                    LOG.debug("result out {}", execResult.getStdout());
+                }
+                if (StringUtils.isNotBlank(execResult.getStderr())) {
+                    LOG.debug("result error {}", execResult.getStderr());
+                }
             }
             return execResult.getStdout();
         } catch (Exception e) {


### PR DESCRIPTION
Fix kubernetes run --config as the it was overwriting previous keys

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

