### PR TITLE
CAMEL-22465 Allow multiple occurrences with SolrParam.x headers

### DIFF
--- a/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrProducer.java
+++ b/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrProducer.java
@@ -136,8 +136,8 @@ public class SolrProducer extends DefaultAsyncProducer {
                 .forEach(entry -> {
                     String paramName = entry.getKey().substring(SolrConstants.HEADER_PARAM_PREFIX.length());
                     Object value = entry.getValue();
-                    if(value instanceof Iterable<?> iterable) {
-                        for(Object val : iterable) {
+                    if (value instanceof Iterable<?> iterable) {
+                        for (Object val : iterable) {
                             modifiableSolrParams.add(paramName, val.toString());
                         }
                     } else {

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/integration/SolrPingAndSearchTest.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/integration/SolrPingAndSearchTest.java
@@ -33,7 +33,6 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.SolrPingResponse;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.ModifiableSolrParams;
-import org.apache.solr.common.params.SolrParams;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.component.solr.SolrConstants.HEADER_PARAM_PREFIX;
@@ -115,11 +114,13 @@ class SolrPingAndSearchTest extends SolrTestSupport {
     @Test
     void testQueryWithMultipleFilters() {
         // this indexes 5 documents with ids 1-5
-        List<Map<String, String>> content = IntStream.range(1, 6).mapToObj(i -> Map.of("id", ""+ i, "content", "content" + i)).toList();
+        List<Map<String, String>> content
+                = IntStream.range(1, 6).mapToObj(i -> Map.of("id", "" + i, "content", "content" + i)).toList();
         template.requestBodyAndHeaders("direct:index", content, SolrUtils.getHeadersForCommit());
 
         // we can construct a ModifiableSolrParams object to send 2 filter queries to solr
-        ModifiableSolrParams msp = new ModifiableSolrParams(Map.of("fq", new String[] { "-content:content1", "-content:content4" }));
+        ModifiableSolrParams msp
+                = new ModifiableSolrParams(Map.of("fq", new String[] { "-content:content1", "-content:content4" }));
         SolrDocumentList sdl = executeSolrQuery("direct:search", "*:*", Map.of(PARAM_SOLR_PARAMS, msp)).getResults();
 
         assertEquals(3, sdl.size());

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/integration/SolrTestSupport.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/integration/SolrTestSupport.java
@@ -219,8 +219,8 @@ public abstract class SolrTestSupport implements CamelTestSupportHelper, Configu
                 .withHeader(SolrConstants.PARAM_OPERATION, SolrOperation.SEARCH)
                 .withHeader(SolrConstants.PARAM_QUERY_STRING, queryString)
                 .withHeader(SolrConstants.PARAM_REQUEST_HANDLER, null);
-        if(additionalExchangeHeaders != null) {
-            for(var entry : additionalExchangeHeaders.entrySet()) {
+        if (additionalExchangeHeaders != null) {
+            for (var entry : additionalExchangeHeaders.entrySet()) {
                 exchangeBuilder.withHeader(entry.getKey(), entry.getValue());
             }
         }


### PR DESCRIPTION
While it is convenient to build a request using the SolrParam.x header convention, this only allows a single value. Yet Solr often takes multiple occurrences for the same value. For instance fq. Camel-Solr should allow multiple values.  See https://issues.apache.org/jira/browse/CAMEL-22465

- [x ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

- [x ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

- [ x] I checked that each commit in the pull request has a meaningful subject line and body.

- [ x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

