### PR TITLE
CAMEL-22340: Fix env var documentation for camel-jbang-kubernetes

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
@@ -386,7 +386,8 @@ The environment trait provides the following configuration options:
 | environment.vars
 | []string
 | A list of environment variables to be added to the integration container.
-The syntax is KEY=VALUE, e.g., `MY_VAR="my value"`.
+The syntax is KEY=VALUE separated by a comma, e.g., `'MY_VAR="my value"','MY_OTHER_VAR="my value"'` .
+
 These take precedence over the previously defined environment variables.
 
 |===

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
@@ -552,7 +552,9 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
     @ParameterizedTest
     @MethodSource("runtimeProvider")
     public void shouldAddEnvVars(RuntimeType rt) throws Exception {
-        KubernetesExport command = createCommand(new String[] { "classpath:route.yaml" }, "--runtime=" + rt.runtime());
+        KubernetesExport command
+                = createCommand(new String[] { "classpath:route.yaml", "src/test/resources/application.properties", },
+                        "--runtime=" + rt.runtime());
         command.envVars = new String[] { "CAMEL_FOO=bar", "MY_ENV=foo" };
         var exit = command.doCall();
         Assertions.assertEquals(0, exit);
@@ -560,15 +562,19 @@ class KubernetesExportTest extends KubernetesExportBaseTest {
         Deployment deployment = getDeployment(rt);
         Assertions.assertEquals("route", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertEquals(2, deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().size());
-        Assertions.assertEquals("CAMEL_FOO",
+        Assertions.assertEquals(4, deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().size());
+        Assertions.assertEquals("MY_VAR",
                 deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().get(0).getName());
-        Assertions.assertEquals("bar",
+        Assertions.assertEquals("\"my value\"",
                 deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().get(0).getValue());
         Assertions.assertEquals("MY_ENV",
                 deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().get(1).getName());
-        Assertions.assertEquals("foo",
+        Assertions.assertEquals("fuzz",
                 deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().get(1).getValue());
+        Assertions.assertEquals("CAMEL_FOO",
+                deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().get(2).getName());
+        Assertions.assertEquals("bar",
+                deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().get(2).getValue());
     }
 
     @ParameterizedTest

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/resources/application.properties
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/resources/application.properties
@@ -16,3 +16,5 @@
 ## ---------------------------------------------------------------------------
 
 camel.jbang.trait.ingress.enabled = true
+
+camel.jbang.trait.environment.vars='MY_VAR="my value"','MY_ENV=fuzz'


### PR DESCRIPTION
# Description

Fix env var documentation formating issue for camel-jbang-kubernetes and improve test.

# Target

- [X] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

