### PR TITLE
CAMEL-22466 Clean up spring-boot / quarkus version references

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-core/pom.xml
@@ -215,6 +215,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>templating-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>filter-src</id>
+                        <goals>
+                            <goal>filter-sources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java-templates/org/apache/camel/dsl/jbang/core/common/RuntimeType.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java-templates/org/apache/camel/dsl/jbang/core/common/RuntimeType.java
@@ -26,8 +26,8 @@ public enum RuntimeType {
     quarkus,
     main;
 
-    public static final String QUARKUS_VERSION = "3.26.4";
-    public static final String SPRING_BOOT_VERSION = "3.5.5";
+    public static final String QUARKUS_VERSION = "${quarkus-version}";
+    public static final String SPRING_BOOT_VERSION = "${spring-boot-version}";
 
     public static RuntimeType fromValue(String value) {
         value = value.toLowerCase(Locale.ROOT);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -444,6 +444,7 @@
         <qpid-broker-version>9.2.1</qpid-broker-version>
         <qpid-proton-j-version>0.34.1</qpid-proton-j-version>
         <qpid-jms-client-version>2.9.0</qpid-jms-client-version>
+        <quarkus-version>3.26.4</quarkus-version>
         <quartz-version>2.5.0</quartz-version>
         <quickfixj-version>2.3.2</quickfixj-version>
         <reactive-streams-version>1.0.4</reactive-streams-version>
@@ -480,6 +481,7 @@
         <spock-version>2.3-groovy-4.0</spock-version>
         <spring-cloud-config-version>4.3.0</spring-cloud-config-version>
         <spring-batch-version>5.2.3</spring-batch-version>
+        <spring-boot-version>3.5.6</spring-boot-version>
         <spring-data-redis-version>3.5.4</spring-data-redis-version>
         <spring-ldap-version>3.3.3</spring-ldap-version>
         <spring-vault-core-version>3.2.0</spring-vault-core-version>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@
         <maven-release-plugin-version>3.1.1</maven-release-plugin-version>
         <maven-remote-resources-plugin-version>3.3.0</maven-remote-resources-plugin-version>
         <maven-surefire-plugin-version>3.5.4</maven-surefire-plugin-version>
+        <templating-maven-plugin-version>3.0.0</templating-maven-plugin-version>
         <versions-maven-plugin-version>2.19.1</versions-maven-plugin-version>
 
         <camel.javadoc.offline>false</camel.javadoc.offline>
@@ -571,6 +572,12 @@
                         <arguments>-Prelease</arguments>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                     </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>templating-maven-plugin</artifactId>
+                    <version>${templating-maven-plugin-version}</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
# Description

`dsl/camel-jbang/camel-jbang-core/src/main/java-templates/org/apache/camel/dsl/jbang/core/common/RuntimeType.java
` has hardcoded versions of quarkus and spring-boot included in it that are hard to maintain - they won't be picked up by dependabot updates.

This is an attempt to manage the spring-boot / quarkus versions for RuntimeType.java consistently with how camel manages other third party versions - add them to parent/pom.xml, and then filter the versions into the source.

Looking for some feedback here - this compiles with no issues for me locally - templating-maven-plugin is executed pre-compile in maven, but I am not sure how IDEs will handle this.   References to RuntimeType might be marked as missing, I'm not sure if IDEs know to look in the `java-templates` directory for sources.      Another strategy might be to filter the versions into a property file and then read that file in RuntimeType for the quarkus/spring-boot versions - I could change to that if that's preferable?

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.
