### PR TITLE
CAMEL-24387: Add createSingletonService() and migrate all tests to singletons

### DIFF
--- a/components/camel-ai/camel-chatscript/src/test/java/org/apache/camel/component/ChatScriptComponentIT.java
+++ b/components/camel-ai/camel-chatscript/src/test/java/org/apache/camel/component/ChatScriptComponentIT.java
@@ -37,7 +37,7 @@ public class ChatScriptComponentIT extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(ChatScriptComponentIT.class);
 
     @RegisterExtension
-    public static ChatScriptService service = ChatScriptServiceFactory.createService();
+    public static ChatScriptService service = ChatScriptServiceFactory.createSingletonService();
 
     @Test
     public void testChatScript() throws Exception {

--- a/components/camel-ai/camel-chatscript/src/test/java/org/apache/camel/component/ChatScriptComponentIT.java
+++ b/components/camel-ai/camel-chatscript/src/test/java/org/apache/camel/component/ChatScriptComponentIT.java
@@ -34,7 +34,7 @@ public class ChatScriptComponentIT extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(ChatScriptComponentIT.class);
 
     @RegisterExtension
-    public static ChatScriptService service = ChatScriptServiceFactory.createService();
+    public static ChatScriptService service = ChatScriptServiceFactory.createSingletonService();
 
     @Test
     public void testChatScript() throws Exception {

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/DoclingITestSupport.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/DoclingITestSupport.java
@@ -31,7 +31,7 @@ public abstract class DoclingITestSupport extends CamelTestSupport {
     protected static final Logger LOG = LoggerFactory.getLogger(DoclingITestSupport.class);
 
     @RegisterExtension
-    static DoclingService doclingService = DoclingServiceFactory.createService();
+    static DoclingService doclingService = DoclingServiceFactory.createSingletonService();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/OcrExtractionIT.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/OcrExtractionIT.java
@@ -58,7 +58,7 @@ class OcrExtractionIT extends CamelTestSupport {
     private static final String TEST_TEXT_LINE3 = "OCR Test Document";
 
     @RegisterExtension
-    static DoclingService doclingService = DoclingServiceFactory.createService();
+    static DoclingService doclingService = DoclingServiceFactory.createSingletonService();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {

--- a/components/camel-ai/camel-kserve/src/test/java/org/apache/camel/component/kserve/it/KServeITSupport.java
+++ b/components/camel-ai/camel-kserve/src/test/java/org/apache/camel/component/kserve/it/KServeITSupport.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class KServeITSupport extends CamelTestSupport {
 
     @RegisterExtension
-    static TritonService service = TritonServiceFactory.createService();
+    static TritonService service = TritonServiceFactory.createSingletonService();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {

--- a/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/integration/LangChain4jAgentMcpAndCamelToolsIT.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/integration/LangChain4jAgentMcpAndCamelToolsIT.java
@@ -75,7 +75,7 @@ public class LangChain4jAgentMcpAndCamelToolsIT extends CamelTestSupport {
     static OllamaService OLLAMA = OllamaServiceFactory.createSingletonService();
 
     @RegisterExtension
-    static McpEverythingService MCP_EVERYTHING = McpEverythingServiceFactory.createService();
+    static McpEverythingService MCP_EVERYTHING = McpEverythingServiceFactory.createSingletonService();
 
     @Override
     protected void setupResources() throws Exception {

--- a/components/camel-ai/camel-langchain4j-embeddings/src/test/java/org/apache/camel/component/langchain4j/embeddings/LangChain4jEmbeddingsComponentPgVectorTargetIT.java
+++ b/components/camel-ai/camel-langchain4j-embeddings/src/test/java/org/apache/camel/component/langchain4j/embeddings/LangChain4jEmbeddingsComponentPgVectorTargetIT.java
@@ -48,7 +48,7 @@ public class LangChain4jEmbeddingsComponentPgVectorTargetIT extends CamelTestSup
     public static final String PGVECTOR_URI = "pgvector:embeddings";
 
     @RegisterExtension
-    static PostgresService POSTGRES = PostgresVectorServiceFactory.createService();
+    static PostgresService POSTGRES = PostgresVectorServiceFactory.createSingletonService();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIMcpAdvancedIT.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIMcpAdvancedIT.java
@@ -51,7 +51,7 @@ public class OpenAIMcpAdvancedIT extends OpenAITestSupport {
     private static final String MCP_PROTOCOL_VERSIONS = "2024-11-05,2025-03-26,2025-06-18";
 
     @RegisterExtension
-    static McpEverythingService MCP_EVERYTHING = McpEverythingServiceFactory.createService();
+    static McpEverythingService MCP_EVERYTHING = McpEverythingServiceFactory.createSingletonService();
 
     private String returnDirectEndpointUri;
 

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIMcpConversationStoreIT.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIMcpConversationStoreIT.java
@@ -57,7 +57,7 @@ public class OpenAIMcpConversationStoreIT extends OpenAITestSupport {
     private final Map<String, List<?>> conversationStore = new ConcurrentHashMap<>();
 
     @RegisterExtension
-    static McpEverythingService MCP_EVERYTHING = McpEverythingServiceFactory.createService();
+    static McpEverythingService MCP_EVERYTHING = McpEverythingServiceFactory.createSingletonService();
 
     @Override
     protected RouteBuilder createRouteBuilder() {

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIMcpManualToolLoopIT.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIMcpManualToolLoopIT.java
@@ -51,7 +51,7 @@ public class OpenAIMcpManualToolLoopIT extends OpenAITestSupport {
     private static final String MCP_PROTOCOL_VERSIONS = "2024-11-05,2025-03-26,2025-06-18";
 
     @RegisterExtension
-    static McpEverythingService MCP_EVERYTHING = McpEverythingServiceFactory.createService();
+    static McpEverythingService MCP_EVERYTHING = McpEverythingServiceFactory.createSingletonService();
 
     @Override
     protected RouteBuilder createRouteBuilder() {

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIMcpParallelToolExecutionIT.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIMcpParallelToolExecutionIT.java
@@ -64,7 +64,7 @@ public class OpenAIMcpParallelToolExecutionIT extends OpenAITestSupport {
             = "Add 3 and 4 using the add tool, and echo the word hello using the echo tool. Call both tools now, together.";
 
     @RegisterExtension
-    static McpEverythingService MCP_EVERYTHING = McpEverythingServiceFactory.createService();
+    static McpEverythingService MCP_EVERYTHING = McpEverythingServiceFactory.createSingletonService();
 
     @Override
     protected RouteBuilder createRouteBuilder() {

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIMcpToolsIT.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIMcpToolsIT.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class OpenAIMcpToolsIT extends OpenAITestSupport {
 
     @RegisterExtension
-    static McpEverythingService MCP_EVERYTHING = McpEverythingServiceFactory.createService();
+    static McpEverythingService MCP_EVERYTHING = McpEverythingServiceFactory.createSingletonService();
 
     @Override
     protected RouteBuilder createRouteBuilder() {

--- a/components/camel-ai/camel-pgvector/src/test/java/org/apache/camel/component/pgvector/PgVectorComponentIT.java
+++ b/components/camel-ai/camel-pgvector/src/test/java/org/apache/camel/component/pgvector/PgVectorComponentIT.java
@@ -46,7 +46,7 @@ public class PgVectorComponentIT extends CamelTestSupport {
     private static final int DIMENSION = 3;
 
     @RegisterExtension
-    static PostgresService POSTGRES = PostgresVectorServiceFactory.createService();
+    static PostgresService POSTGRES = PostgresVectorServiceFactory.createSingletonService();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {

--- a/components/camel-ai/camel-tensorflow-serving/src/test/java/org/apache/camel/component/torchserve/it/TensorFlowServingITSupport.java
+++ b/components/camel-ai/camel-tensorflow-serving/src/test/java/org/apache/camel/component/torchserve/it/TensorFlowServingITSupport.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class TensorFlowServingITSupport extends CamelTestSupport {
 
     @RegisterExtension
-    static TensorFlowServingService service = TensorFlowServingServiceFactory.createService();
+    static TensorFlowServingService service = TensorFlowServingServiceFactory.createSingletonService();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {

--- a/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/BaseArangoDb.java
+++ b/components/camel-arangodb/src/test/java/org/apache/camel/component/arangodb/integration/BaseArangoDb.java
@@ -42,7 +42,7 @@ public abstract class BaseArangoDb implements ConfigurableRoute, CamelTestSuppor
 
     @Order(1)
     @RegisterExtension
-    public static ArangoDBService service = ArangoDBServiceFactory.createService();
+    public static ArangoDBService service = ArangoDBServiceFactory.createSingletonService();
     @Order(2)
     @RegisterExtension
     public static final CamelContextExtension camelContextExtension = new TransientCamelContextExtension();

--- a/components/camel-azure/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/Base.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/integration/Base.java
@@ -45,7 +45,7 @@ public class Base extends CamelTestSupport {
     static {
         initCredentials();
 
-        service = AzureStorageBlobServiceFactory.createService();
+        service = AzureStorageBlobServiceFactory.createSingletonService();
     }
 
     /*

--- a/components/camel-azure/camel-azure-storage-datalake/src/test/java/org/apache/camel/component/azure/storage/datalake/integration/Base.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/test/java/org/apache/camel/component/azure/storage/datalake/integration/Base.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class Base extends CamelTestSupport {
 
     @RegisterExtension
-    public AzureService service = AzureStorageDataLakeServiceFactory.createService();
+    public AzureService service = AzureStorageDataLakeServiceFactory.createSingletonService();
 
     protected DataLakeServiceClient serviceClient;
     protected DataLakeConfiguration configuration;

--- a/components/camel-azure/camel-azure-storage-queue/src/test/java/org/apache/camel/component/azure/storage/queue/integration/StorageQueueBase.java
+++ b/components/camel-azure/camel-azure-storage-queue/src/test/java/org/apache/camel/component/azure/storage/queue/integration/StorageQueueBase.java
@@ -43,7 +43,7 @@ public class StorageQueueBase extends CamelTestSupport {
     static {
         initCredentials();
 
-        service = AzureStorageQueueServiceFactory.createService();
+        service = AzureStorageQueueServiceFactory.createSingletonService();
     }
 
     /*

--- a/components/camel-clickhouse/src/test/java/org/apache/camel/component/clickhouse/integration/ClickHouseProducerIT.java
+++ b/components/camel-clickhouse/src/test/java/org/apache/camel/component/clickhouse/integration/ClickHouseProducerIT.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ClickHouseProducerIT extends CamelTestSupport {
 
     @RegisterExtension
-    static ClickHouseService service = ClickHouseServiceFactory.createService();
+    static ClickHouseService service = ClickHouseServiceFactory.createSingletonService();
 
     private static Client client;
 

--- a/components/camel-consul/src/test/java/org/apache/camel/component/consul/ConsulHealthIT.java
+++ b/components/camel-consul/src/test/java/org/apache/camel/component/consul/ConsulHealthIT.java
@@ -29,6 +29,7 @@ import org.apache.camel.test.infra.consul.services.ConsulServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.kiwiproject.consul.AgentClient;
 import org.kiwiproject.consul.Consul;
 import org.kiwiproject.consul.model.agent.ImmutableRegistration;
@@ -38,19 +39,12 @@ import org.kiwiproject.consul.model.health.ServiceHealth;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConsulHealthIT extends CamelTestSupport {
-    /*
-     NOTE: this one is not registered as extension because it requires a different lifecycle. It
-     needs to be started much earlier than usual, so in this test we take care of handling it.
-     */
-    private ConsulService consulService = ConsulServiceFactory.createService();
+    @RegisterExtension
+    static ConsulService consulService = ConsulServiceFactory.createSingletonService();
 
     private AgentClient client;
     private List<Registration> registrations;
     private String service;
-
-    public ConsulHealthIT() {
-        consulService.initialize();
-    }
 
     @BindToRegistry("consul")
     public ConsulComponent getConsulComponent() {

--- a/components/camel-consul/src/test/java/org/apache/camel/component/consul/ConsulRegistryIT.java
+++ b/components/camel-consul/src/test/java/org/apache/camel/component/consul/ConsulRegistryIT.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 public class ConsulRegistryIT implements Serializable {
     @RegisterExtension
-    public static ConsulService consulService = ConsulServiceFactory.createService();
+    public static ConsulService consulService = ConsulServiceFactory.createSingletonService();
 
     private static final long serialVersionUID = -3482971969351609265L;
     private static ConsulRegistry registry;

--- a/components/camel-consul/src/test/java/org/apache/camel/component/consul/ConsulTestSupport.java
+++ b/components/camel-consul/src/test/java/org/apache/camel/component/consul/ConsulTestSupport.java
@@ -31,7 +31,7 @@ import org.kiwiproject.consul.Consul;
 
 public class ConsulTestSupport extends CamelTestSupport {
     @RegisterExtension
-    public static ConsulService service = ConsulServiceFactory.createService();
+    public static ConsulService service = ConsulServiceFactory.createSingletonService();
 
     @RegisterExtension
     @Order(10)

--- a/components/camel-consul/src/test/java/org/apache/camel/component/consul/cluster/ConsulClusterViewIT.java
+++ b/components/camel-consul/src/test/java/org/apache/camel/component/consul/cluster/ConsulClusterViewIT.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ConsulClusterViewIT {
     @RegisterExtension
-    public static ConsulService service = ConsulServiceFactory.createService();
+    public static ConsulService service = ConsulServiceFactory.createSingletonService();
 
     @Test
     public void getLeaderTest() throws Exception {

--- a/components/camel-consul/src/test/java/org/apache/camel/component/consul/cluster/ConsulClusteredRoutePolicyFactoryIT.java
+++ b/components/camel-consul/src/test/java/org/apache/camel/component/consul/cluster/ConsulClusteredRoutePolicyFactoryIT.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 
 public class ConsulClusteredRoutePolicyFactoryIT {
     @RegisterExtension
-    public static ConsulService service = ConsulServiceFactory.createService();
+    public static ConsulService service = ConsulServiceFactory.createSingletonService();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsulClusteredRoutePolicyFactoryIT.class);
     private static final List<String> CLIENTS = IntStream.range(0, 3).mapToObj(Integer::toString).toList();

--- a/components/camel-consul/src/test/java/org/apache/camel/component/consul/cluster/ConsulClusteredRoutePolicyIT.java
+++ b/components/camel-consul/src/test/java/org/apache/camel/component/consul/cluster/ConsulClusteredRoutePolicyIT.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 
 public class ConsulClusteredRoutePolicyIT {
     @RegisterExtension
-    public static ConsulService service = ConsulServiceFactory.createService();
+    public static ConsulService service = ConsulServiceFactory.createSingletonService();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsulClusteredRoutePolicyIT.class);
     private static final List<String> CLIENTS = IntStream.range(0, 3).mapToObj(Integer::toString).toList();

--- a/components/camel-consul/src/test/java/org/apache/camel/component/consul/cluster/ConsulMasterIT.java
+++ b/components/camel-consul/src/test/java/org/apache/camel/component/consul/cluster/ConsulMasterIT.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 public class ConsulMasterIT {
     @RegisterExtension
-    public static ConsulService service = ConsulServiceFactory.createService();
+    public static ConsulService service = ConsulServiceFactory.createSingletonService();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsulMasterIT.class);
     private static final List<String> CLIENTS = IntStream.range(0, 3).mapToObj(Integer::toString).toList();

--- a/components/camel-cyberark-vault/src/test/java/org/apache/camel/component/cyberark/vault/integration/CyberArkTestSupport.java
+++ b/components/camel-cyberark-vault/src/test/java/org/apache/camel/component/cyberark/vault/integration/CyberArkTestSupport.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 abstract class CyberArkTestSupport extends CamelTestSupport {
 
     @RegisterExtension
-    static CyberArkVaultService service = CyberArkVaultServiceFactory.createService();
+    static CyberArkVaultService service = CyberArkVaultServiceFactory.createSingletonService();
 
     static final Logger LOG = LoggerFactory.getLogger(CyberArkTestSupport.class);
 

--- a/components/camel-duckdb/src/test/java/org/apache/camel/component/duckdb/integration/DuckDbProducerIT.java
+++ b/components/camel-duckdb/src/test/java/org/apache/camel/component/duckdb/integration/DuckDbProducerIT.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DuckDbProducerIT extends CamelTestSupport {
 
     @RegisterExtension
-    static DuckDbService service = DuckDbServiceFactory.createService();
+    static DuckDbService service = DuckDbServiceFactory.createSingletonService();
 
     @BeforeEach
     void setUpDatabase() throws Exception {

--- a/components/camel-google/camel-google-pubsub/src/test/java/org/apache/camel/component/google/pubsub/PubsubTestSupport.java
+++ b/components/camel-google/camel-google-pubsub/src/test/java/org/apache/camel/component/google/pubsub/PubsubTestSupport.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 
 public class PubsubTestSupport extends CamelTestSupport {
     @RegisterExtension
-    public static GooglePubSubService service = GooglePubSubServiceFactory.createService();
+    public static GooglePubSubService service = GooglePubSubServiceFactory.createSingletonService();
 
     public static final String PROJECT_ID;
 
@@ -122,17 +122,21 @@ public class PubsubTestSupport extends CamelTestSupport {
 
     public void createTopic(Topic topic) {
         TopicAdminClient topicAdminClient = createTopicAdminClient();
-
-        topicAdminClient.createTopic(topic);
-
+        try {
+            topicAdminClient.createTopic(topic);
+        } catch (com.google.api.gax.rpc.AlreadyExistsException e) {
+            // Topic already exists in shared emulator — safe to ignore
+        }
         topicAdminClient.shutdown();
     }
 
     public void createSubscription(Subscription subscription) {
         SubscriptionAdminClient subscriptionAdminClient = createSubscriptionAdminClient();
-
-        subscriptionAdminClient.createSubscription(subscription);
-
+        try {
+            subscriptionAdminClient.createSubscription(subscription);
+        } catch (com.google.api.gax.rpc.AlreadyExistsException e) {
+            // Subscription already exists in shared emulator — safe to ignore
+        }
         subscriptionAdminClient.shutdown();
     }
 

--- a/components/camel-google/camel-google-pubsub/src/test/java/org/apache/camel/component/google/pubsub/PubsubTestSupport.java
+++ b/components/camel-google/camel-google-pubsub/src/test/java/org/apache/camel/component/google/pubsub/PubsubTestSupport.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
 
 public class PubsubTestSupport extends CamelTestSupport {
     @RegisterExtension
-    public static GooglePubSubService service = GooglePubSubServiceFactory.createService();
+    public static GooglePubSubService service = GooglePubSubServiceFactory.createSingletonService();
 
     public static final String PROJECT_ID;
 
@@ -147,17 +147,21 @@ public class PubsubTestSupport extends CamelTestSupport {
 
     public void createTopic(Topic topic) {
         TopicAdminClient topicAdminClient = createTopicAdminClient();
-
-        topicAdminClient.createTopic(topic);
-
+        try {
+            topicAdminClient.createTopic(topic);
+        } catch (com.google.api.gax.rpc.AlreadyExistsException e) {
+            // Topic already exists in shared emulator — safe to ignore
+        }
         topicAdminClient.shutdown();
     }
 
     public void createSubscription(Subscription subscription) {
         SubscriptionAdminClient subscriptionAdminClient = createSubscriptionAdminClient();
-
-        subscriptionAdminClient.createSubscription(subscription);
-
+        try {
+            subscriptionAdminClient.createSubscription(subscription);
+        } catch (com.google.api.gax.rpc.AlreadyExistsException e) {
+            // Subscription already exists in shared emulator — safe to ignore
+        }
         subscriptionAdminClient.shutdown();
     }
 

--- a/components/camel-google/camel-google-pubsub/src/test/java/org/apache/camel/component/google/pubsub/integration/CustomSerializerIT.java
+++ b/components/camel-google/camel-google-pubsub/src/test/java/org/apache/camel/component/google/pubsub/integration/CustomSerializerIT.java
@@ -31,8 +31,8 @@ import org.junit.jupiter.api.Test;
 
 public class CustomSerializerIT extends PubsubTestSupport {
 
-    private static final String TOPIC_NAME = "typesSend";
-    private static final String SUBSCRIPTION_NAME = "TypesReceive";
+    private static final String TOPIC_NAME = "customTypesSend";
+    private static final String SUBSCRIPTION_NAME = "customTypesReceive";
 
     @EndpointInject("direct:from")
     private Endpoint directIn;

--- a/components/camel-google/camel-google-pubsub/src/test/java/org/apache/camel/component/google/pubsub/integration/DeadLetterIT.java
+++ b/components/camel-google/camel-google-pubsub/src/test/java/org/apache/camel/component/google/pubsub/integration/DeadLetterIT.java
@@ -34,12 +34,12 @@ import org.junit.jupiter.api.Test;
 
 public class DeadLetterIT extends PubsubTestSupport {
 
-    private static final String INPUT_TOPIC_NAME = "camel.input-topic";
-    private static final String INPUT_SUBSCRIPTION_NAME = "camel.input-topic-subscription";
-    private static final String OUTPUT_TOPIC_NAME = "camel.output-topic";
-    private static final String OUTPUT_SUBSCRIPTION_NAME = "camel.output-topic-subscription";
-    private static final String DEAD_LETTER_TOPIC_NAME = "camel.dead-letter-topic";
-    private static final String DEAD_LETTER_SUBSCRIPTION_NAME = "camel.dead-letter-topic-subscription";
+    private static final String INPUT_TOPIC_NAME = "camel.dl-input-topic";
+    private static final String INPUT_SUBSCRIPTION_NAME = "camel.dl-input-topic-subscription";
+    private static final String OUTPUT_TOPIC_NAME = "camel.dl-output-topic";
+    private static final String OUTPUT_SUBSCRIPTION_NAME = "camel.dl-output-topic-subscription";
+    private static final String DEAD_LETTER_TOPIC_NAME = "camel.dl-dead-letter-topic";
+    private static final String DEAD_LETTER_SUBSCRIPTION_NAME = "camel.dl-dead-letter-topic-subscription";
     private static int count = 1;
 
     @EndpointInject("google-pubsub:{{project.id}}:" + INPUT_SUBSCRIPTION_NAME)

--- a/components/camel-google/camel-google-pubsub/src/test/java/org/apache/camel/component/google/pubsub/integration/SingleExchangeRoundAllHeadersIT.java
+++ b/components/camel-google/camel-google-pubsub/src/test/java/org/apache/camel/component/google/pubsub/integration/SingleExchangeRoundAllHeadersIT.java
@@ -36,8 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SingleExchangeRoundAllHeadersIT extends PubsubTestSupport {
 
-    private static final String TOPIC_NAME = "singleSend";
-    private static final String SUBSCRIPTION_NAME = "singleReceive";
+    private static final String TOPIC_NAME = "singleAllHeadersSend";
+    private static final String SUBSCRIPTION_NAME = "singleAllHeadersReceive";
 
     @EndpointInject("direct:from")
     private Endpoint directIn;

--- a/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/HashicorpVaultPropertiesSourceNoEnvTestIT.java
+++ b/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/HashicorpVaultPropertiesSourceNoEnvTestIT.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class HashicorpVaultPropertiesSourceNoEnvTestIT extends CamelTestSupport {
 
     @RegisterExtension
-    public static HashicorpVaultService service = HashicorpServiceFactory.createService();
+    public static HashicorpVaultService service = HashicorpServiceFactory.createSingletonService();
 
     @BeforeAll
     public static void init() {

--- a/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerCreateMultiVersionSecretIT.java
+++ b/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerCreateMultiVersionSecretIT.java
@@ -63,7 +63,8 @@ public class HashicorpProducerCreateMultiVersionSecretIT extends HashicorpVaultB
         exchange = template.request("direct:readSecret", new Processor() {
             @Override
             public void process(Exchange exchange) {
-                exchange.getMessage().setHeader(HashicorpVaultConstants.SECRET_PATH, "test");
+                exchange.getMessage().setHeader(HashicorpVaultConstants.SECRET_PATH,
+                        secretPath());
             }
         });
 
@@ -76,12 +77,13 @@ public class HashicorpProducerCreateMultiVersionSecretIT extends HashicorpVaultB
 
     @Override
     protected RouteBuilder createRouteBuilder() {
+        final String path = secretPath();
         return new RouteBuilder() {
             @Override
             public void configure() {
                 from("direct:createSecret")
-                        .toF("hashicorp-vault://secret?operation=createSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=test",
-                                service.token(), service.host(), service.port())
+                        .toF("hashicorp-vault://secret?operation=createSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=%s",
+                                service.token(), service.host(), service.port(), path)
                         .to("mock:result-write");
 
                 from("direct:readSecret")

--- a/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerCreateSecretIT.java
+++ b/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerCreateSecretIT.java
@@ -59,7 +59,8 @@ public class HashicorpProducerCreateSecretIT extends HashicorpVaultBase {
         template.request("direct:readSecret", new Processor() {
             @Override
             public void process(Exchange exchange) {
-                exchange.getMessage().setHeader(HashicorpVaultConstants.SECRET_PATH, "test");
+                exchange.getMessage().setHeader(HashicorpVaultConstants.SECRET_PATH,
+                        secretPath());
             }
         });
         template.request("direct:readSecretWithPathParam", null);
@@ -83,12 +84,13 @@ public class HashicorpProducerCreateSecretIT extends HashicorpVaultBase {
 
     @Override
     protected RouteBuilder createRouteBuilder() {
+        final String path = secretPath();
         return new RouteBuilder() {
             @Override
             public void configure() {
                 from("direct:createSecret")
-                        .toF("hashicorp-vault://secret?operation=createSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=test",
-                                service.token(), service.host(), service.port())
+                        .toF("hashicorp-vault://secret?operation=createSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=%s",
+                                service.token(), service.host(), service.port(), path)
                         .to("mock:result-write");
 
                 from("direct:readSecret")
@@ -97,8 +99,8 @@ public class HashicorpProducerCreateSecretIT extends HashicorpVaultBase {
                         .to("mock:result-read");
 
                 from("direct:readSecretWithPathParam")
-                        .toF("hashicorp-vault://secret?operation=getSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=test",
-                                service.token(), service.host(), service.port())
+                        .toF("hashicorp-vault://secret?operation=getSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=%s",
+                                service.token(), service.host(), service.port(), path)
                         .to("mock:result-read-with-param");
             }
         };

--- a/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerCreateSecretPOJOIT.java
+++ b/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerCreateSecretPOJOIT.java
@@ -55,7 +55,8 @@ public class HashicorpProducerCreateSecretPOJOIT extends HashicorpVaultBase {
         exchange = template.request("direct:readSecret", new Processor() {
             @Override
             public void process(Exchange exchange) {
-                exchange.getMessage().setHeader(HashicorpVaultConstants.SECRET_PATH, "test");
+                exchange.getMessage().setHeader(HashicorpVaultConstants.SECRET_PATH,
+                        secretPath());
             }
         });
 
@@ -68,12 +69,13 @@ public class HashicorpProducerCreateSecretPOJOIT extends HashicorpVaultBase {
 
     @Override
     protected RouteBuilder createRouteBuilder() {
+        final String path = secretPath();
         return new RouteBuilder() {
             @Override
             public void configure() {
                 from("direct:createSecret")
-                        .toF("hashicorp-vault://secret?operation=createSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=test",
-                                service.token(), service.host(), service.port())
+                        .toF("hashicorp-vault://secret?operation=createSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=%s",
+                                service.token(), service.host(), service.port(), path)
                         .to("mock:result-write");
                 from("direct:readSecret")
                         .toF("hashicorp-vault://secret?operation=getSecret&token=RAW(%s)&host=%s&port=%s&scheme=http",

--- a/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerDeleteSecretIT.java
+++ b/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerDeleteSecretIT.java
@@ -58,17 +58,18 @@ public class HashicorpProducerDeleteSecretIT extends HashicorpVaultBase {
 
     @Override
     protected RouteBuilder createRouteBuilder() {
+        final String path = secretPath();
         return new RouteBuilder() {
             @Override
             public void configure() {
                 from("direct:createSecret")
-                        .toF("hashicorp-vault://secret?operation=createSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=test",
-                                service.token(), service.host(), service.port())
+                        .toF("hashicorp-vault://secret?operation=createSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=%s",
+                                service.token(), service.host(), service.port(), path)
                         .to("mock:result-write");
 
                 from("direct:deleteSecret")
-                        .toF("hashicorp-vault://secret?operation=deleteSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=test",
-                                service.token(), service.host(), service.port())
+                        .toF("hashicorp-vault://secret?operation=deleteSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=%s",
+                                service.token(), service.host(), service.port(), path)
                         .to("mock:result-delete");
             }
         };

--- a/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerListSecretsIT.java
+++ b/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerListSecretsIT.java
@@ -27,7 +27,6 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -69,23 +68,23 @@ public class HashicorpProducerListSecretsIT extends HashicorpVaultBase {
         MockEndpoint.assertIsSatisfied(context);
         Exchange ret = mockRead.getExchanges().get(0);
         assertNotNull(ret);
-        assertTrue(ret.getMessage().getBody(List.class).contains("test"));
-        assertEquals(1, ret.getMessage().getBody(List.class).size());
+        assertTrue(ret.getMessage().getBody(List.class).contains(secretPath()));
     }
 
     @Override
     protected RouteBuilder createRouteBuilder() {
+        final String path = secretPath();
         return new RouteBuilder() {
             @Override
             public void configure() {
                 from("direct:createSecret")
-                        .toF("hashicorp-vault://secret?operation=createSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=test",
-                                service.token(), service.host(), service.port())
+                        .toF("hashicorp-vault://secret?operation=createSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=%s",
+                                service.token(), service.host(), service.port(), path)
                         .to("mock:result-write");
 
                 from("direct:listSecrets")
-                        .toF("hashicorp-vault://secret?operation=listSecrets&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=test",
-                                service.token(), service.host(), service.port())
+                        .toF("hashicorp-vault://secret?operation=listSecrets&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=%s",
+                                service.token(), service.host(), service.port(), path)
                         .to("mock:result-list");
             }
         };

--- a/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerReadMultiVersionedSecretIT.java
+++ b/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerReadMultiVersionedSecretIT.java
@@ -63,7 +63,8 @@ public class HashicorpProducerReadMultiVersionedSecretIT extends HashicorpVaultB
         exchange = template.request("direct:readSecret", new Processor() {
             @Override
             public void process(Exchange exchange) {
-                exchange.getMessage().setHeader(HashicorpVaultConstants.SECRET_PATH, "test");
+                exchange.getMessage().setHeader(HashicorpVaultConstants.SECRET_PATH,
+                        secretPath());
                 exchange.getMessage().setHeader(HashicorpVaultConstants.SECRET_VERSION, "1");
             }
         });
@@ -77,12 +78,13 @@ public class HashicorpProducerReadMultiVersionedSecretIT extends HashicorpVaultB
 
     @Override
     protected RouteBuilder createRouteBuilder() {
+        final String path = secretPath();
         return new RouteBuilder() {
             @Override
             public void configure() {
                 from("direct:createSecret")
-                        .toF("hashicorp-vault://secret?operation=createSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=test",
-                                service.token(), service.host(), service.port())
+                        .toF("hashicorp-vault://secret?operation=createSecret&token=RAW(%s)&host=%s&port=%s&scheme=http&secretPath=%s",
+                                service.token(), service.host(), service.port(), path)
                         .to("mock:result-write");
 
                 from("direct:readSecret")

--- a/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerSecretPathHeaderIT.java
+++ b/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpProducerSecretPathHeaderIT.java
@@ -52,20 +52,21 @@ public class HashicorpProducerSecretPathHeaderIT extends HashicorpVaultBase {
             @Override
             public void process(Exchange exchange) {
                 Message message = exchange.getMessage();
-                message.setHeader(SECRET_PATH, "test");
+                message.setHeader(SECRET_PATH, secretPath());
                 exchange.getMessage().setBody(Map.of("integer", "30"));
             }
         });
         template.request("direct:readSecret", new Processor() {
             @Override
             public void process(Exchange exchange) {
-                exchange.getMessage().setHeader(HashicorpVaultConstants.SECRET_PATH, "test");
+                exchange.getMessage().setHeader(HashicorpVaultConstants.SECRET_PATH,
+                        secretPath());
             }
         });
         template.request("direct:deleteSecret", new Processor() {
             @Override
             public void process(Exchange exchange) {
-                exchange.getMessage().setHeader(SECRET_PATH, "test");
+                exchange.getMessage().setHeader(SECRET_PATH, secretPath());
             }
         });
 

--- a/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpVaultBase.java
+++ b/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/integration/operations/HashicorpVaultBase.java
@@ -24,11 +24,15 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class HashicorpVaultBase extends CamelTestSupport {
     @RegisterExtension
-    public static HashicorpVaultService service = HashicorpServiceFactory.createService();
+    public static HashicorpVaultService service = HashicorpServiceFactory.createSingletonService();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext context = super.createCamelContext();
         return context;
+    }
+
+    protected String secretPath() {
+        return getClass().getSimpleName() + "-test";
     }
 }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastConfigurationTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastConfigurationTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class HazelcastConfigurationTest {
 
     @RegisterExtension
-    public static HazelcastService hazelcastService = HazelcastServiceFactory.createService();
+    public static HazelcastService hazelcastService = HazelcastServiceFactory.createSingletonService();
 
     @RegisterExtension
     public static TestEntityNameGenerator nameGenerator = new TestEntityNameGenerator();

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastListProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastListProducerTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HazelcastListProducerTest extends CamelTestSupport {
 
     @RegisterExtension
-    public static HazelcastService hazelcastService = HazelcastServiceFactory.createService();
+    public static HazelcastService hazelcastService = HazelcastServiceFactory.createSingletonService();
 
     @RegisterExtension
     public static TestEntityNameGenerator nameGenerator = new TestEntityNameGenerator();

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaTransferExchangeTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSedaTransferExchangeTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class HazelcastSedaTransferExchangeTest extends CamelTestSupport {
 
     @RegisterExtension
-    public static HazelcastService hazelcastService = HazelcastServiceFactory.createService();
+    public static HazelcastService hazelcastService = HazelcastServiceFactory.createSingletonService();
 
     @RegisterExtension
     public static TestEntityNameGenerator nameGenerator = new TestEntityNameGenerator();

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSetProducerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSetProducerTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HazelcastSetProducerTest extends CamelTestSupport {
 
     @RegisterExtension
-    public static HazelcastService hazelcastService = HazelcastServiceFactory.createService();
+    public static HazelcastService hazelcastService = HazelcastServiceFactory.createSingletonService();
 
     @RegisterExtension
     public static TestEntityNameGenerator nameGenerator = new TestEntityNameGenerator();

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/policy/HazelcastRoutePolicyIT.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/policy/HazelcastRoutePolicyIT.java
@@ -49,7 +49,7 @@ public class HazelcastRoutePolicyIT {
     private static final List<String> CLIENTS = List.of("0", "1", "2");
 
     @RegisterExtension
-    public static HazelcastService hazelcastService = HazelcastServiceFactory.createService();
+    public static HazelcastService hazelcastService = HazelcastServiceFactory.createSingletonService();
 
     @Test
     @Timeout(value = 2, unit = TimeUnit.MINUTES)

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepositoryCamelTestSupport.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepositoryCamelTestSupport.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class HazelcastAggregationRepositoryCamelTestSupport extends CamelTestSupport {
 
     @RegisterExtension
-    public static HazelcastService hazelcastService = HazelcastServiceFactory.createService();
+    public static HazelcastService hazelcastService = HazelcastServiceFactory.createSingletonService();
 
     @RegisterExtension
     public static TestEntityNameGenerator nameGenerator = new TestEntityNameGenerator();

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/processor/idempotent/hazelcast/HazelcastIdempotentRepositoryTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/processor/idempotent/hazelcast/HazelcastIdempotentRepositoryTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HazelcastIdempotentRepositoryTest extends CamelTestSupport {
 
     @RegisterExtension
-    public static HazelcastService hazelcastService = HazelcastServiceFactory.createService();
+    public static HazelcastService hazelcastService = HazelcastServiceFactory.createSingletonService();
 
     @RegisterExtension
     public static TestEntityNameGenerator nameGenerator = new TestEntityNameGenerator();

--- a/components/camel-iggy/src/test/java/org/apache/camel/component/iggy/IggyTestBase.java
+++ b/components/camel-iggy/src/test/java/org/apache/camel/component/iggy/IggyTestBase.java
@@ -45,7 +45,7 @@ public abstract class IggyTestBase {
 
     @Order(1)
     @RegisterExtension
-    protected static IggyService iggyService = IggyServiceFactory.createService();
+    protected static IggyService iggyService = IggyServiceFactory.createSingletonService();
 
     @Order(2)
     @RegisterExtension

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsComponentIbmMQTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsComponentIbmMQTest.java
@@ -35,7 +35,7 @@ import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknow
 public class JmsComponentIbmMQTest extends CamelTestSupport {
 
     @RegisterExtension
-    public static IbmMQService service = IbmMQServiceFactory.createService();
+    public static IbmMQService service = IbmMQServiceFactory.createSingletonService();
 
     @Test
     public void testSend() throws Exception {

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsComponentIbmMQTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsComponentIbmMQTest.java
@@ -37,7 +37,7 @@ import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknow
 public class JmsComponentIbmMQTest extends CamelTestSupport {
 
     @RegisterExtension
-    public static IbmMQService service = IbmMQServiceFactory.createService();
+    public static IbmMQService service = IbmMQServiceFactory.createSingletonService();
 
     @Test
     public void testSend() throws Exception {

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsReplyToIbmMQTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsReplyToIbmMQTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class JmsReplyToIbmMQTest extends CamelTestSupport {
 
     @RegisterExtension
-    public static IbmMQService service = IbmMQServiceFactory.createService();
+    public static IbmMQService service = IbmMQServiceFactory.createSingletonService();
 
     @Test
     public void testCustomJMSReplyToInOut() {

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsReplyToIbmMQTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsReplyToIbmMQTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class JmsReplyToIbmMQTest extends CamelTestSupport {
 
     @RegisterExtension
-    static IbmMQService service = IbmMQServiceFactory.createService();
+    static IbmMQService service = IbmMQServiceFactory.createSingletonService();
 
     @Test
     void testCustomJMSReplyToInOut() {

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/BaseExclusiveKafkaTestSupport.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/BaseExclusiveKafkaTestSupport.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public abstract class BaseExclusiveKafkaTestSupport implements ConfigurableRoute {
     @Order(1)
     @RegisterExtension
-    protected static KafkaService service = KafkaServiceFactory.createService();
+    protected static KafkaService service = KafkaServiceFactory.createSingletonService();
 
     @Order(2)
     @RegisterExtension

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/health/KafkaHealthCheckTestSupport.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/health/KafkaHealthCheckTestSupport.java
@@ -48,7 +48,7 @@ abstract class KafkaHealthCheckTestSupport implements ConfigurableRoute, Configu
     protected static final Logger LOG = LoggerFactory.getLogger(KafkaConsumerUnresolvableHealthCheckIT.class);
     @Order(1)
     @RegisterExtension
-    protected static KafkaService service = KafkaServiceFactory.createService();
+    protected static KafkaService service = KafkaServiceFactory.createSingletonService();
 
     @Order(2)
     @RegisterExtension

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/KeycloakConsumerIT.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/KeycloakConsumerIT.java
@@ -54,7 +54,7 @@ public class KeycloakConsumerIT extends CamelTestSupport {
     private static final Logger log = LoggerFactory.getLogger(KeycloakConsumerIT.class);
 
     @RegisterExtension
-    static KeycloakService keycloakService = KeycloakServiceFactory.createService();
+    static KeycloakService keycloakService = KeycloakServiceFactory.createSingletonService();
 
     // Test data - use unique names to avoid conflicts
     private static final String TEST_REALM_NAME = "consumer-test-realm-" + UUID.randomUUID().toString().substring(0, 8);

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/KeycloakConsumerIT.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/KeycloakConsumerIT.java
@@ -50,7 +50,7 @@ public class KeycloakConsumerIT extends CamelTestSupport {
     private static final Logger log = LoggerFactory.getLogger(KeycloakConsumerIT.class);
 
     @RegisterExtension
-    static KeycloakService keycloakService = KeycloakServiceFactory.createService();
+    static KeycloakService keycloakService = KeycloakServiceFactory.createSingletonService();
 
     // Test data - use unique names to avoid conflicts
     private static final String TEST_REALM_NAME = "consumer-test-realm-" + UUID.randomUUID().toString().substring(0, 8);

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/KeycloakProducerRevocationIT.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/KeycloakProducerRevocationIT.java
@@ -60,7 +60,7 @@ public class KeycloakProducerRevocationIT extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(KeycloakProducerRevocationIT.class);
 
     @RegisterExtension
-    static KeycloakService keycloakService = KeycloakServiceFactory.createService();
+    static KeycloakService keycloakService = KeycloakServiceFactory.createSingletonService();
 
     private static final String TEST_REALM_NAME = "revocation-realm-" + UUID.randomUUID().toString().substring(0, 8);
     private static final String TEST_CLIENT_ID = "revocation-client-" + UUID.randomUUID().toString().substring(0, 8);

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/KeycloakTestInfraIT.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/KeycloakTestInfraIT.java
@@ -59,7 +59,7 @@ public class KeycloakTestInfraIT extends CamelTestSupport {
     private static final Logger log = LoggerFactory.getLogger(KeycloakTestInfraIT.class);
 
     @RegisterExtension
-    static KeycloakService keycloakService = KeycloakServiceFactory.createService();
+    static KeycloakService keycloakService = KeycloakServiceFactory.createSingletonService();
 
     // Test data - use unique names to avoid conflicts
     private static final String TEST_REALM_NAME = "testinfra-realm-" + UUID.randomUUID().toString().substring(0, 8);

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/KeycloakTestInfraIT.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/KeycloakTestInfraIT.java
@@ -63,7 +63,7 @@ class KeycloakTestInfraIT extends CamelTestSupport {
     private static final Logger log = LoggerFactory.getLogger(KeycloakTestInfraIT.class);
 
     @RegisterExtension
-    static KeycloakService keycloakService = KeycloakServiceFactory.createService();
+    static KeycloakService keycloakService = KeycloakServiceFactory.createSingletonService();
 
     // Test data - use unique names to avoid conflicts
     private static final String TEST_REALM_NAME = "testinfra-realm-" + UUID.randomUUID().toString().substring(0, 8);

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityTestInfraIT.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityTestInfraIT.java
@@ -79,7 +79,7 @@ public class KeycloakSecurityTestInfraIT extends CamelTestSupport {
     private static final Logger log = LoggerFactory.getLogger(KeycloakSecurityTestInfraIT.class);
 
     @RegisterExtension
-    static KeycloakService keycloakService = KeycloakServiceFactory.createService();
+    static KeycloakService keycloakService = KeycloakServiceFactory.createSingletonService();
 
     // Test data - use unique names to avoid conflicts
     private static final String TEST_REALM_NAME = "security-test-realm-" + UUID.randomUUID().toString().substring(0, 8);

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityTestInfraIT.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityTestInfraIT.java
@@ -77,7 +77,7 @@ public class KeycloakSecurityTestInfraIT extends CamelTestSupport {
     private static final Logger log = LoggerFactory.getLogger(KeycloakSecurityTestInfraIT.class);
 
     @RegisterExtension
-    static KeycloakService keycloakService = KeycloakServiceFactory.createService();
+    static KeycloakService keycloakService = KeycloakServiceFactory.createSingletonService();
 
     // Test data - use unique names to avoid conflicts
     private static final String TEST_REALM_NAME = "security-test-realm-" + UUID.randomUUID().toString().substring(0, 8);

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakTokenBindingSecurityIT.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakTokenBindingSecurityIT.java
@@ -69,7 +69,7 @@ public class KeycloakTokenBindingSecurityIT extends CamelTestSupport {
     private static final Logger log = LoggerFactory.getLogger(KeycloakTokenBindingSecurityIT.class);
 
     @RegisterExtension
-    static KeycloakService keycloakService = KeycloakServiceFactory.createService();
+    static KeycloakService keycloakService = KeycloakServiceFactory.createSingletonService();
 
     // Test data - use unique names
     private static final String TEST_REALM_NAME = "token-binding-realm-" + UUID.randomUUID().toString().substring(0, 8);

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakTokenIntrospectionIT.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakTokenIntrospectionIT.java
@@ -73,7 +73,7 @@ public class KeycloakTokenIntrospectionIT extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(KeycloakTokenIntrospectionIT.class);
 
     @RegisterExtension
-    static KeycloakService keycloakService = KeycloakServiceFactory.createService();
+    static KeycloakService keycloakService = KeycloakServiceFactory.createSingletonService();
 
     // Test data - use unique names to avoid conflicts
     private static final String TEST_REALM_NAME = "introspection-realm-" + UUID.randomUUID().toString().substring(0, 8);

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakTokenIntrospectionIT.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakTokenIntrospectionIT.java
@@ -75,7 +75,7 @@ public class KeycloakTokenIntrospectionIT extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(KeycloakTokenIntrospectionIT.class);
 
     @RegisterExtension
-    static KeycloakService keycloakService = KeycloakServiceFactory.createService();
+    static KeycloakService keycloakService = KeycloakServiceFactory.createSingletonService();
 
     // Test data - use unique names to avoid conflicts
     private static final String TEST_REALM_NAME = "introspection-realm-" + UUID.randomUUID().toString().substring(0, 8);

--- a/components/camel-ldif/src/test/java/org/apache/camel/component/ldif/LdifTestSupport.java
+++ b/components/camel-ldif/src/test/java/org/apache/camel/component/ldif/LdifTestSupport.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class LdifTestSupport extends CamelTestSupport {
     @RegisterExtension
-    public static OpenldapService service = OpenldapServiceFactory.createService();
+    public static OpenldapService service = OpenldapServiceFactory.createSingletonService();
 
     protected int port;
 

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/AbstractLRATestSupport.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/AbstractLRATestSupport.java
@@ -43,7 +43,7 @@ import static org.awaitility.Awaitility.await;
 public abstract class AbstractLRATestSupport extends CamelTestSupport {
 
     @RegisterExtension
-    static MicroprofileLRAService service = MicroprofileLRAServiceFactory.createService();
+    static MicroprofileLRAService service = MicroprofileLRAServiceFactory.createSingletonService();
 
     @RegisterExtension
     AvailablePortFinder.Port serverPortHolder = AvailablePortFinder.find();

--- a/components/camel-minio/src/test/java/org/apache/camel/component/minio/integration/MinioIntegrationTestSupport.java
+++ b/components/camel-minio/src/test/java/org/apache/camel/component/minio/integration/MinioIntegrationTestSupport.java
@@ -23,6 +23,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 class MinioIntegrationTestSupport extends CamelTestSupport {
     @RegisterExtension
-    static MinioService service = MinioServiceFactory.createService();
+    static MinioService service = MinioServiceFactory.createSingletonService();
 
 }

--- a/components/camel-mongodb-gridfs/src/test/java/org/apache/camel/component/mongodb/gridfs/integration/AbstractMongoDbITSupport.java
+++ b/components/camel-mongodb-gridfs/src/test/java/org/apache/camel/component/mongodb/gridfs/integration/AbstractMongoDbITSupport.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 public abstract class AbstractMongoDbITSupport extends CamelTestSupport {
     @RegisterExtension
-    public static MongoDBService service = MongoDBServiceFactory.createService();
+    public static MongoDBService service = MongoDBServiceFactory.createSingletonService();
 
     protected static final String FILE_NAME = "filename.for.db.txt";
     protected static final String FILE_DATA = "This is some stuff to go into the db";

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsITSupport.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsITSupport.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 
 public class NatsITSupport extends CamelTestSupport {
     @RegisterExtension
-    static NatsService service = NatsServiceFactory.createService();
+    static NatsService service = NatsServiceFactory.createSingletonService();
 
     static {
         try (InputStream is = NatsITSupport.class.getClassLoader().getResourceAsStream("logging.properties")) {

--- a/components/camel-paho-mqtt5/src/test/java/org/apache/camel/component/paho/mqtt5/integration/PahoMqtt5ITSupport.java
+++ b/components/camel-paho-mqtt5/src/test/java/org/apache/camel/component/paho/mqtt5/integration/PahoMqtt5ITSupport.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 public abstract class PahoMqtt5ITSupport extends CamelTestSupport {
     @RegisterExtension
-    public static MosquittoService service = MosquittoServiceFactory.createService();
+    public static MosquittoService service = MosquittoServiceFactory.createSingletonService();
 
     protected int mqttPort;
 

--- a/components/camel-pqc/src/test/java/org/apache/camel/component/pqc/HashicorpVaultKeyLifecycleIT.java
+++ b/components/camel-pqc/src/test/java/org/apache/camel/component/pqc/HashicorpVaultKeyLifecycleIT.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class HashicorpVaultKeyLifecycleIT extends CamelTestSupport {
 
     @RegisterExtension
-    public static HashicorpVaultService service = HashicorpServiceFactory.createService();
+    public static HashicorpVaultService service = HashicorpServiceFactory.createSingletonService();
 
     private HashicorpVaultKeyLifecycleManager keyManager;
 

--- a/components/camel-pqc/src/test/java/org/apache/camel/component/pqc/HashicorpVaultKeyLifecycleIT.java
+++ b/components/camel-pqc/src/test/java/org/apache/camel/component/pqc/HashicorpVaultKeyLifecycleIT.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class HashicorpVaultKeyLifecycleIT extends CamelTestSupport {
 
     @RegisterExtension
-    public static HashicorpVaultService service = HashicorpServiceFactory.createService();
+    public static HashicorpVaultService service = HashicorpServiceFactory.createSingletonService();
 
     private HashicorpVaultKeyLifecycleManager keyManager;
 

--- a/components/camel-redis/src/test/java/org/apache/camel/component/redis/processor/aggregate/integration/AggregateRedisIT.java
+++ b/components/camel-redis/src/test/java/org/apache/camel/component/redis/processor/aggregate/integration/AggregateRedisIT.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class AggregateRedisIT extends CamelTestSupport {
 
     @RegisterExtension
-    static RedisService service = RedisServiceFactory.createService();
+    static RedisService service = RedisServiceFactory.createSingletonService();
 
     @Test
     public void testABC() throws Exception {

--- a/components/camel-redis/src/test/java/org/apache/camel/component/redis/processor/aggregate/integration/RedisAggregationRepositoryOperationsIT.java
+++ b/components/camel-redis/src/test/java/org/apache/camel/component/redis/processor/aggregate/integration/RedisAggregationRepositoryOperationsIT.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class RedisAggregationRepositoryOperationsIT extends CamelTestSupport {
 
     @RegisterExtension
-    static RedisService service = RedisServiceFactory.createService();
+    static RedisService service = RedisServiceFactory.createSingletonService();
 
     private RedisAggregationRepository createRepo(String mapName, boolean optimistic) {
         RedisAggregationRepository repo = new RedisAggregationRepository(mapName, service.getServiceAddress(), optimistic);

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/integration/SolrTestSupport.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/integration/SolrTestSupport.java
@@ -56,7 +56,7 @@ public abstract class SolrTestSupport implements CamelTestSupportHelper, Configu
 
     @Order(1)
     @RegisterExtension
-    public static final SolrService service = SolrServiceFactory.createService();
+    public static final SolrService service = SolrServiceFactory.createSingletonService();
 
     @Order(2)
     @RegisterExtension

--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/test/java/org/apache/camel/component/springai/chat/SpringAiChatMcpSseIT.java
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/test/java/org/apache/camel/component/springai/chat/SpringAiChatMcpSseIT.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SpringAiChatMcpSseIT extends OllamaTestSupport {
 
     @RegisterExtension
-    static McpEverythingSseService MCP_EVERYTHING = McpEverythingSseServiceFactory.createService();
+    static McpEverythingSseService MCP_EVERYTHING = McpEverythingSseServiceFactory.createSingletonService();
 
     @Test
     public void testMcpEchoTool() {

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQBasicIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQBasicIT.java
@@ -37,11 +37,13 @@ public class RabbitMQBasicIT extends RabbitMQITSupport {
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
         ConnectionProperties connectionProperties = service.connectionProperties();
-        foo = String.format("spring-rabbitmq:%s:%d/foo?username=%s&password=%s", connectionProperties.hostname(),
-                connectionProperties.port(), connectionProperties.username(), connectionProperties.password());
+        foo = String.format("spring-rabbitmq:%s:%d/%s?username=%s&password=%s", connectionProperties.hostname(),
+                connectionProperties.port(), uniqueName("foo"), connectionProperties.username(),
+                connectionProperties.password());
 
-        bar = String.format("spring-rabbitmq:%s:%d/bar?username=%s&password=%s", connectionProperties.hostname(),
-                connectionProperties.port(), connectionProperties.username(), connectionProperties.password());
+        bar = String.format("spring-rabbitmq:%s:%d/%s?username=%s&password=%s", connectionProperties.hostname(),
+                connectionProperties.port(), uniqueName("bar"), connectionProperties.username(),
+                connectionProperties.password());
 
         return new RouteBuilder() {
             @Override

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQComponentNullBodyIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQComponentNullBodyIT.java
@@ -43,8 +43,8 @@ public class RabbitMQComponentNullBodyIT extends RabbitMQITSupport {
     public void testProducer() {
         ConnectionFactory cf = context.getRegistry().lookupByNameAndType("myCF", ConnectionFactory.class);
 
-        Queue q = new Queue("myqueue");
-        TopicExchange t = new TopicExchange("foo");
+        Queue q = new Queue(uniqueName("myqueue"));
+        TopicExchange t = new TopicExchange(uniqueName("foo"));
 
         AmqpAdmin admin = new RabbitAdmin(cf);
         admin.declareQueue(q);
@@ -60,7 +60,7 @@ public class RabbitMQComponentNullBodyIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:foo?routingKey=foo.bar");
+                        .to("spring-rabbitmq:" + uniqueName("foo") + "?routingKey=foo.bar");
             }
         };
     }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQConsumerIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQConsumerIT.java
@@ -40,9 +40,9 @@ public class RabbitMQConsumerIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:foo");
+                        .to("spring-rabbitmq:" + uniqueName("foo"));
 
-                from("spring-rabbitmq:foo")
+                from("spring-rabbitmq:" + uniqueName("foo"))
                         .to("log:result")
                         .to("mock:result");
             }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQConsumerPooledExchangeIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQConsumerPooledExchangeIT.java
@@ -59,9 +59,9 @@ public class RabbitMQConsumerPooledExchangeIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:foo");
+                        .to("spring-rabbitmq:" + uniqueName("foo"));
 
-                from("spring-rabbitmq:foo")
+                from("spring-rabbitmq:" + uniqueName("foo"))
                         .to("log:result")
                         .to("mock:result");
             }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQConsumerQueuesIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQConsumerQueuesIT.java
@@ -106,9 +106,9 @@ public class RabbitMQConsumerQueuesIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:foo");
+                        .to("spring-rabbitmq:" + uniqueName("foo"));
 
-                from("spring-rabbitmq:foo?queues=myqueue")
+                from("spring-rabbitmq:" + uniqueName("foo") + "?queues=" + uniqueName("myqueue"))
                         .to("log:result")
                         .to("mock:result");
             }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQConsumerRoutingKeyIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQConsumerRoutingKeyIT.java
@@ -73,9 +73,9 @@ public class RabbitMQConsumerRoutingKeyIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:foo?routingKey=foo.bar");
+                        .to("spring-rabbitmq:" + uniqueName("foo") + "?routingKey=foo.bar");
 
-                from("spring-rabbitmq:foo?queues=myqueue&routingKey=foo.bar")
+                from("spring-rabbitmq:" + uniqueName("foo") + "?queues=" + uniqueName("myqueue") + "&routingKey=foo.bar")
                         .to("log:result")
                         .to("mock:result");
             }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQConsumerTopicIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQConsumerTopicIT.java
@@ -73,9 +73,10 @@ public class RabbitMQConsumerTopicIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:foo?routingKey=foo.bar");
+                        .to("spring-rabbitmq:" + uniqueName("foo") + "?routingKey=foo.bar");
 
-                from("spring-rabbitmq:foo?exchangeType=topic&queues=myqueue&routingKey=foo.#")
+                from("spring-rabbitmq:" + uniqueName("foo") + "?exchangeType=topic&queues=" + uniqueName("myqueue")
+                     + "&routingKey=foo.#")
                         .to("log:result")
                         .to("mock:result");
             }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQITSupport.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQITSupport.java
@@ -30,9 +30,13 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 public abstract class RabbitMQITSupport extends CamelTestSupport {
 
     @RegisterExtension
-    public static RabbitMQService service = RabbitMQServiceFactory.createService();
+    public static RabbitMQService service = RabbitMQServiceFactory.createSingletonService();
 
     protected Logger log = LoggerFactory.getLogger(getClass());
+
+    protected String uniqueName(String baseName) {
+        return getClass().getSimpleName() + "-" + baseName;
+    }
 
     ConnectionFactory createConnectionFactory(boolean confirm) {
         CachingConnectionFactory cf = new CachingConnectionFactory();

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQInOutIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQInOutIT.java
@@ -56,11 +56,12 @@ public class RabbitMQInOutIT extends RabbitMQITSupport {
                 from("direct:start")
                         .setVariable("global:mycrmb", header(Exchange.BREADCRUMB_ID))
                         .to("log:request")
-                        .to(ExchangePattern.InOut, "spring-rabbitmq:cheese?routingKey=foo.bar")
+                        .to(ExchangePattern.InOut, "spring-rabbitmq:" + uniqueName("cheese") + "?routingKey=foo.bar")
                         .to("log:response")
                         .to("mock:result");
 
-                from("spring-rabbitmq:cheese?queues=myqueue&routingKey=foo.bar")
+                from("spring-rabbitmq:" + uniqueName("cheese") + "?queues=" + uniqueName("myqueue")
+                     + "&routingKey=foo.bar")
                         .to("log:input")
                         .to("mock:input")
                         .transform(body().prepend("Hello "));

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQPollingConsumerIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQPollingConsumerIT.java
@@ -39,8 +39,8 @@ public class RabbitMQPollingConsumerIT extends RabbitMQITSupport {
 
         ConnectionFactory cf = context.getRegistry().lookupByNameAndType("myCF", ConnectionFactory.class);
 
-        Queue q = new Queue("myqueue");
-        DirectExchange t = new DirectExchange("foo");
+        Queue q = new Queue(uniqueName("myqueue"));
+        DirectExchange t = new DirectExchange(uniqueName("foo"));
         AmqpAdmin admin = new RabbitAdmin(cf);
         admin.declareQueue(q);
         admin.declareExchange(t);
@@ -57,8 +57,10 @@ public class RabbitMQPollingConsumerIT extends RabbitMQITSupport {
         // use another thread for polling consumer to demonstrate that we can wait before
         // the message is sent to the queue
         Executors.newSingleThreadExecutor().execute(() -> {
-            String body = consumer.receiveBody("spring-rabbitmq:foo?queues=myqueue&routingKey=mykey", String.class);
-            template.sendBody("spring-rabbitmq:foo?routingKey=mykey2", body + " Claus");
+            String body = consumer.receiveBody(
+                    "spring-rabbitmq:" + uniqueName("foo") + "?queues=" + uniqueName("myqueue") + "&routingKey=mykey",
+                    String.class);
+            template.sendBody("spring-rabbitmq:" + uniqueName("foo") + "?routingKey=mykey2", body + " Claus");
         });
 
         // wait a little to demonstrate we can start poll before we have a msg on the queue
@@ -77,10 +79,12 @@ public class RabbitMQPollingConsumerIT extends RabbitMQITSupport {
         // use another thread for polling consumer to demonstrate that we can wait before
         // the message is sent to the queue
         Executors.newSingleThreadExecutor().execute(() -> {
-            String body = consumer.receiveBody("spring-rabbitmq:foo?queues=myqueue&routingKey=mykey", 100, String.class);
+            String body = consumer.receiveBody(
+                    "spring-rabbitmq:" + uniqueName("foo") + "?queues=" + uniqueName("myqueue") + "&routingKey=mykey",
+                    100, String.class);
             assertNull(body, "Should be null");
 
-            template.sendBody("spring-rabbitmq:foo?routingKey=mykey2", "Hello Claus");
+            template.sendBody("spring-rabbitmq:" + uniqueName("foo") + "?routingKey=mykey2", "Hello Claus");
         });
 
         // wait a little to demonstrate we can start poll before we have a msg on the queue
@@ -99,8 +103,10 @@ public class RabbitMQPollingConsumerIT extends RabbitMQITSupport {
         // use another thread for polling consumer to demonstrate that we can wait before
         // the message is sent to the queue
         Executors.newSingleThreadExecutor().execute(() -> {
-            String body = consumer.receiveBody("spring-rabbitmq:foo?queues=myqueue&routingKey=mykey", 3000, String.class);
-            template.sendBody("spring-rabbitmq:foo?routingKey=mykey2", body + " Claus");
+            String body = consumer.receiveBody(
+                    "spring-rabbitmq:" + uniqueName("foo") + "?queues=" + uniqueName("myqueue") + "&routingKey=mykey",
+                    3000, String.class);
+            template.sendBody("spring-rabbitmq:" + uniqueName("foo") + "?routingKey=mykey2", body + " Claus");
         });
 
         // wait a little to demonstrate we can start poll before we have a msg on the queue
@@ -116,9 +122,11 @@ public class RabbitMQPollingConsumerIT extends RabbitMQITSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("direct:start").log("Sending ${body} to myqueue").to("spring-rabbitmq:foo?routingKey=mykey");
+                from("direct:start").log("Sending ${body} to myqueue")
+                        .to("spring-rabbitmq:" + uniqueName("foo") + "?routingKey=mykey");
 
-                from("spring-rabbitmq:foo?queues=myqueue2&routingKey=mykey2").log("Received ${body} from myqueue2")
+                from("spring-rabbitmq:" + uniqueName("foo") + "?queues=" + uniqueName("myqueue2") + "&routingKey=mykey2")
+                        .log("Received ${body} from myqueue2")
                         .to("mock:result");
             }
         };

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerAutoDeclareIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerAutoDeclareIT.java
@@ -42,7 +42,7 @@ public class RabbitMQProducerAutoDeclareIT extends RabbitMQITSupport {
         template.sendBody("direct:start", "Hello World");
 
         AmqpTemplate template = new RabbitTemplate(cf);
-        String out = (String) template.receiveAndConvert("myqueue");
+        String out = (String) template.receiveAndConvert(uniqueName("myqueue"));
         Assertions.assertEquals("Hello World", out);
     }
 
@@ -53,7 +53,7 @@ public class RabbitMQProducerAutoDeclareIT extends RabbitMQITSupport {
         template.sendBodyAndHeader("direct:start", "Hello World", "cheese", "gouda");
 
         AmqpTemplate template = new RabbitTemplate(cf);
-        Message out = template.receive("myqueue");
+        Message out = template.receive(uniqueName("myqueue"));
 
         byte[] body = out.getBody();
         Assertions.assertNotNull(body, "The body should not be null");
@@ -77,7 +77,7 @@ public class RabbitMQProducerAutoDeclareIT extends RabbitMQITSupport {
         template.sendBody("direct:start", body);
 
         AmqpTemplate template = new RabbitTemplate(cf);
-        Message out = template.receive("myqueue");
+        Message out = template.receive(uniqueName("myqueue"));
         Assertions.assertEquals("foo", new String(out.getBody()));
         Assertions.assertEquals("baz", out.getMessageProperties().getHeader("bar"));
     }
@@ -94,7 +94,7 @@ public class RabbitMQProducerAutoDeclareIT extends RabbitMQITSupport {
                         SpringRabbitMQConstants.PRIORITY, 1));
 
         AmqpTemplate template = new RabbitTemplate(cf);
-        Message out = template.receive("myqueue");
+        Message out = template.receive(uniqueName("myqueue"));
 
         final MessageProperties messageProperties = out.getMessageProperties();
         Assertions.assertNotNull(messageProperties, "The message properties should not be null");
@@ -115,7 +115,9 @@ public class RabbitMQProducerAutoDeclareIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:foo?autoDeclareProducer=true&routingKey=foo.bar.#&queues=myqueue&exchangeType=topic");
+                        .to("spring-rabbitmq:" + uniqueName("foo")
+                            + "?autoDeclareProducer=true&routingKey=foo.bar.#&queues=" + uniqueName("myqueue")
+                            + "&exchangeType=topic");
             }
         };
     }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerIT.java
@@ -57,8 +57,8 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
         // --- 1. AMQP Setup ---
         // Ensures the RabbitMQ queue, exchange, and binding exist before the test.
         ConnectionFactory cf = context.getRegistry().lookupByNameAndType("myCF", ConnectionFactory.class);
-        Queue q = new Queue("myqueue");
-        TopicExchange t = new TopicExchange("foo");
+        Queue q = new Queue(uniqueName("myqueue"));
+        TopicExchange t = new TopicExchange(uniqueName("foo"));
         AmqpAdmin admin = new RabbitAdmin(cf);
         admin.declareQueue(q);
         admin.declareExchange(t);
@@ -115,7 +115,7 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
         StopWatch lastMessageStopWatch = new StopWatch();
         final long idleTimeoutMillis = 2000; // 2 seconds
         while (true) {
-            Object receivedMessage = rabbitConsumerTemplate.receiveAndConvert("myqueue");
+            Object receivedMessage = rabbitConsumerTemplate.receiveAndConvert(uniqueName("myqueue"));
 
             if (receivedMessage != null) {
                 // If we got a message, increment count and reset the idle timer.
@@ -140,8 +140,8 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
     public void testProducer() throws Exception {
         ConnectionFactory cf = context.getRegistry().lookupByNameAndType("myCF", ConnectionFactory.class);
 
-        Queue q = new Queue("myqueue");
-        TopicExchange t = new TopicExchange("foo");
+        Queue q = new Queue(uniqueName("myqueue"));
+        TopicExchange t = new TopicExchange(uniqueName("foo"));
 
         AmqpAdmin admin = new RabbitAdmin(cf);
         admin.declareQueue(q);
@@ -151,7 +151,7 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
         template.sendBody("direct:start", "Hello World");
 
         AmqpTemplate template = new RabbitTemplate(cf);
-        String out = (String) template.receiveAndConvert("myqueue");
+        String out = (String) template.receiveAndConvert(uniqueName("myqueue"));
         Assertions.assertEquals("Hello World", out);
     }
 
@@ -159,8 +159,8 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
     public void testProducerWithHeader() throws Exception {
         ConnectionFactory cf = context.getRegistry().lookupByNameAndType("myCF", ConnectionFactory.class);
 
-        Queue q = new Queue("myqueue");
-        TopicExchange t = new TopicExchange("foo");
+        Queue q = new Queue(uniqueName("myqueue"));
+        TopicExchange t = new TopicExchange(uniqueName("foo"));
 
         AmqpAdmin admin = new RabbitAdmin(cf);
         admin.declareQueue(q);
@@ -170,7 +170,7 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
         template.sendBodyAndHeader("direct:start", "Hello World", "cheese", "gouda");
 
         AmqpTemplate template = new RabbitTemplate(cf);
-        Message out = template.receive("myqueue");
+        Message out = template.receive(uniqueName("myqueue"));
 
         byte[] body = out.getBody();
         Assertions.assertNotNull(body, "The body should not be null");
@@ -182,8 +182,8 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
     public void testProducerWithMessage() throws Exception {
         ConnectionFactory cf = context.getRegistry().lookupByNameAndType("myCF", ConnectionFactory.class);
 
-        Queue q = new Queue("myqueue");
-        TopicExchange t = new TopicExchange("foo");
+        Queue q = new Queue(uniqueName("myqueue"));
+        TopicExchange t = new TopicExchange(uniqueName("foo"));
 
         AmqpAdmin admin = new RabbitAdmin(cf);
         admin.declareQueue(q);
@@ -202,7 +202,7 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
         template.sendBody("direct:start", body);
 
         AmqpTemplate template = new RabbitTemplate(cf);
-        Message out = template.receive("myqueue");
+        Message out = template.receive(uniqueName("myqueue"));
         Assertions.assertEquals("foo", new String(out.getBody()));
         Assertions.assertEquals("baz", out.getMessageProperties().getHeader("bar"));
     }
@@ -211,8 +211,8 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
     public void testProducerWithMessageProperties() throws Exception {
         ConnectionFactory cf = context.getRegistry().lookupByNameAndType("myCF", ConnectionFactory.class);
 
-        Queue q = new Queue("myqueue");
-        TopicExchange t = new TopicExchange("foo");
+        Queue q = new Queue(uniqueName("myqueue"));
+        TopicExchange t = new TopicExchange(uniqueName("foo"));
 
         AmqpAdmin admin = new RabbitAdmin(cf);
         admin.declareQueue(q);
@@ -227,7 +227,7 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
                         SpringRabbitMQConstants.PRIORITY, 1));
 
         AmqpTemplate template = new RabbitTemplate(cf);
-        Message out = template.receive("myqueue");
+        Message out = template.receive(uniqueName("myqueue"));
 
         final MessageProperties messageProperties = out.getMessageProperties();
         Assertions.assertNotNull(messageProperties, "The message properties should not be null");
@@ -246,8 +246,8 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
     public void testProducerWithBreadcrumb() throws Exception {
         ConnectionFactory cf = context.getRegistry().lookupByNameAndType("myCF", ConnectionFactory.class);
 
-        Queue q = new Queue("myqueue");
-        TopicExchange t = new TopicExchange("foo");
+        Queue q = new Queue(uniqueName("myqueue"));
+        TopicExchange t = new TopicExchange(uniqueName("foo"));
 
         AmqpAdmin admin = new RabbitAdmin(cf);
         admin.declareQueue(q);
@@ -259,7 +259,7 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
                         SpringRabbitMQConstants.TYPE, "price", Exchange.BREADCRUMB_ID, "mycrumb123"));
 
         AmqpTemplate template = new RabbitTemplate(cf);
-        Message out = template.receive("myqueue");
+        Message out = template.receive(uniqueName("myqueue"));
 
         final MessageProperties messageProperties = out.getMessageProperties();
         Assertions.assertNotNull(messageProperties, "The message properties should not be null");
@@ -277,7 +277,7 @@ public class RabbitMQProducerIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:foo?routingKey=foo.bar");
+                        .to("spring-rabbitmq:" + uniqueName("foo") + "?routingKey=foo.bar");
             }
         };
     }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerInvalidExchangeIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerInvalidExchangeIT.java
@@ -42,8 +42,8 @@ public class RabbitMQProducerInvalidExchangeIT extends RabbitMQITSupport {
     public void testProducer() {
         ConnectionFactory cf = context.getRegistry().lookupByNameAndType("myCF", ConnectionFactory.class);
 
-        Queue q = new Queue("myqueue");
-        TopicExchange t = new TopicExchange("foo");
+        Queue q = new Queue(uniqueName("myqueue"));
+        TopicExchange t = new TopicExchange(uniqueName("foo"));
 
         AmqpAdmin admin = new RabbitAdmin(cf);
         admin.declareQueue(q);
@@ -61,7 +61,7 @@ public class RabbitMQProducerInvalidExchangeIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:unknown?routingKey=foo.bar");
+                        .to("spring-rabbitmq:" + uniqueName("unknown") + "?routingKey=foo.bar");
             }
         };
     }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerInvalidExchangeIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerInvalidExchangeIT.java
@@ -40,8 +40,8 @@ public class RabbitMQProducerInvalidExchangeIT extends RabbitMQITSupport {
     public void testProducer() {
         ConnectionFactory cf = context.getRegistry().lookupByNameAndType("myCF", ConnectionFactory.class);
 
-        Queue q = new Queue("myqueue");
-        TopicExchange t = new TopicExchange("foo");
+        Queue q = new Queue(uniqueName("myqueue"));
+        TopicExchange t = new TopicExchange(uniqueName("foo"));
 
         AmqpAdmin admin = new RabbitAdmin(cf);
         admin.declareQueue(q);
@@ -59,7 +59,7 @@ public class RabbitMQProducerInvalidExchangeIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:unknown?routingKey=foo.bar");
+                        .to("spring-rabbitmq:" + uniqueName("unknown") + "?routingKey=foo.bar");
             }
         };
     }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerNullBodyIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerNullBodyIT.java
@@ -33,8 +33,8 @@ public class RabbitMQProducerNullBodyIT extends RabbitMQITSupport {
     public void testProducer() {
         ConnectionFactory cf = context.getRegistry().lookupByNameAndType("myCF", ConnectionFactory.class);
 
-        Queue q = new Queue("myqueue");
-        TopicExchange t = new TopicExchange("foo");
+        Queue q = new Queue(uniqueName("myqueue"));
+        TopicExchange t = new TopicExchange(uniqueName("foo"));
 
         AmqpAdmin admin = new RabbitAdmin(cf);
         admin.declareQueue(q);
@@ -50,7 +50,7 @@ public class RabbitMQProducerNullBodyIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:foo?routingKey=foo.bar&allowNullBody=true");
+                        .to("spring-rabbitmq:" + uniqueName("foo") + "?routingKey=foo.bar&allowNullBody=true");
             }
         };
     }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerSimpleIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerSimpleIT.java
@@ -33,7 +33,7 @@ public class RabbitMQProducerSimpleIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:simple");
+                        .to("spring-rabbitmq:" + uniqueName("simple"));
             }
         };
     }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerSimpleIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerSimpleIT.java
@@ -39,7 +39,7 @@ class RabbitMQProducerSimpleIT extends RabbitMQITSupport {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                        .to("spring-rabbitmq:simple");
+                        .to("spring-rabbitmq:" + uniqueName("simple"));
             }
         };
     }

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerToDIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerToDIT.java
@@ -35,26 +35,26 @@ public class RabbitMQProducerToDIT extends RabbitMQITSupport {
     public void testToD() throws Exception {
         ConnectionFactory cf = context.getRegistry().lookupByNameAndType("myCF", ConnectionFactory.class);
 
-        Queue q = new Queue("myqueue");
-        TopicExchange t = new TopicExchange("foo");
+        Queue q = new Queue(uniqueName("myqueue"));
+        TopicExchange t = new TopicExchange(uniqueName("foo"));
 
         AmqpAdmin admin = new RabbitAdmin(cf);
         admin.declareQueue(q);
         admin.declareExchange(t);
         admin.declareBinding(BindingBuilder.bind(q).to(t).with("foo.bar.#"));
 
-        fluentTemplate.to("direct:start").withBody("Hello World").withHeader("whereTo", "foo").withHeader("myKey", "foo.bar")
-                .send();
+        fluentTemplate.to("direct:start").withBody("Hello World").withHeader("whereTo", uniqueName("foo"))
+                .withHeader("myKey", "foo.bar").send();
 
         AmqpTemplate template = new RabbitTemplate(cf);
-        String out = (String) template.receiveAndConvert("myqueue");
+        String out = (String) template.receiveAndConvert(uniqueName("myqueue"));
         Assertions.assertEquals("Hello World", out);
 
-        fluentTemplate.to("direct:start").withBody("Bye World").withHeader("whereTo", "foo").withHeader("myKey", "foo.bar.baz")
-                .send();
+        fluentTemplate.to("direct:start").withBody("Bye World").withHeader("whereTo", uniqueName("foo"))
+                .withHeader("myKey", "foo.bar.baz").send();
 
         template = new RabbitTemplate(cf);
-        out = (String) template.receiveAndConvert("myqueue");
+        out = (String) template.receiveAndConvert(uniqueName("myqueue"));
         Assertions.assertEquals("Bye World", out);
 
         // there should only be 1 rabbit endpoint

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/test/infra/services/RabbitMQServiceFactory.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/test/infra/services/RabbitMQServiceFactory.java
@@ -26,4 +26,8 @@ public final class RabbitMQServiceFactory {
     public static RabbitMQService createService() {
         return org.apache.camel.test.infra.rabbitmq.services.RabbitMQServiceFactory.createService();
     }
+
+    public static RabbitMQService createSingletonService() {
+        return org.apache.camel.test.infra.rabbitmq.services.RabbitMQServiceFactory.createSingletonService();
+    }
 }

--- a/components/camel-spring-parent/camel-spring-redis/src/test/java/org/apache/camel/component/redis/integration/RedisConsumerManualIT.java
+++ b/components/camel-spring-parent/camel-spring-redis/src/test/java/org/apache/camel/component/redis/integration/RedisConsumerManualIT.java
@@ -33,7 +33,7 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 public class RedisConsumerManualIT extends RedisTestSupport {
 
     @RegisterExtension
-    static RedisService service = RedisServiceFactory.createService();
+    static RedisService service = RedisServiceFactory.createSingletonService();
 
     private static final RedisMessageListenerContainer LISTENER_CONTAINER = new RedisMessageListenerContainer();
     private static JedisConnectionFactory jedisConnectionFactory;

--- a/components/camel-spring-parent/camel-spring-redis/src/test/java/org/apache/camel/component/redis/integration/RedisProducerManualIT.java
+++ b/components/camel-spring-parent/camel-spring-redis/src/test/java/org/apache/camel/component/redis/integration/RedisProducerManualIT.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class RedisProducerManualIT extends RedisTestSupport {
 
     @RegisterExtension
-    static RedisService service = RedisServiceFactory.createService();
+    static RedisService service = RedisServiceFactory.createSingletonService();
     private static JedisConnectionFactory connectionFactory;
 
     @BeforeAll

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/ClusteredPostgresAggregationRepositoryIT.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/ClusteredPostgresAggregationRepositoryIT.java
@@ -49,7 +49,7 @@ public class ClusteredPostgresAggregationRepositoryIT {
     private static final String REPO_NAME = "camel_clu_agg_it";
 
     @RegisterExtension
-    public static PostgresService service = PostgresServiceFactory.createService();
+    public static PostgresService service = PostgresServiceFactory.createSingletonService();
 
     private CamelContext context;
     private DataSource dataSource;

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/PostgresAggregationRepositoryIT.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/PostgresAggregationRepositoryIT.java
@@ -49,7 +49,7 @@ public class PostgresAggregationRepositoryIT {
     private static final String REPO_NAME_TEXT = "camel_agg_text_it";
 
     @RegisterExtension
-    public static PostgresService service = PostgresServiceFactory.createService();
+    public static PostgresService service = PostgresServiceFactory.createSingletonService();
 
     private CamelContext context;
     private DataSource dataSource;

--- a/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/integration/XmppBaseIT.java
+++ b/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/integration/XmppBaseIT.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 @DisabledOnOs(value = OS.AIX, disabledReason = "has problem with all the new reconnection stuff and whatnot")
 public class XmppBaseIT extends CamelTestSupport {
     @RegisterExtension
-    static XmppService service = XmppServiceFactory.createService();
+    static XmppService service = XmppServiceFactory.createSingletonService();
 
     static {
         try (InputStream is = XmppBaseIT.class.getClassLoader().getResourceAsStream("logging.properties")) {

--- a/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/MasterEndpointIT.java
+++ b/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/MasterEndpointIT.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class MasterEndpointIT {
 
     @RegisterExtension
-    static ZooKeeperService service = ZooKeeperServiceFactory.createService();
+    static ZooKeeperService service = ZooKeeperServiceFactory.createSingletonService();
 
     @Autowired
     protected CamelContext camelContext;

--- a/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/MasterQuartzEndpointIT.java
+++ b/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/MasterQuartzEndpointIT.java
@@ -31,7 +31,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration
 public class MasterQuartzEndpointIT {
     @RegisterExtension
-    static ZooKeeperService service = ZooKeeperServiceFactory.createService();
+    static ZooKeeperService service = ZooKeeperServiceFactory.createSingletonService();
 
     @Autowired
     protected CamelContext camelContext;

--- a/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/group/GroupIT.java
+++ b/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/group/GroupIT.java
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GroupIT {
     @RegisterExtension
-    static ZooKeeperService service = ZooKeeperServiceFactory.createService();
+    static ZooKeeperService service = ZooKeeperServiceFactory.createSingletonService();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GroupIT.class);
 

--- a/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/integration/MasterEndpointFailoverIT.java
+++ b/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/integration/MasterEndpointFailoverIT.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 public class MasterEndpointFailoverIT {
     @RegisterExtension
-    static ZooKeeperService service = ZooKeeperServiceFactory.createService();
+    static ZooKeeperService service = ZooKeeperServiceFactory.createSingletonService();
 
     private static final transient Logger LOG = LoggerFactory.getLogger(MasterEndpointFailoverIT.class);
 

--- a/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/integration/MasterEndpointFailoverIT.java
+++ b/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/integration/MasterEndpointFailoverIT.java
@@ -43,7 +43,7 @@ import static org.awaitility.Awaitility.await;
 
 public class MasterEndpointFailoverIT {
     @RegisterExtension
-    static ZooKeeperService service = ZooKeeperServiceFactory.createService();
+    static ZooKeeperService service = ZooKeeperServiceFactory.createSingletonService();
 
     private static final transient Logger LOG = LoggerFactory.getLogger(MasterEndpointFailoverIT.class);
 

--- a/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/cluster/integration/ZooKeeperClusteredRoutePolicyFactoryIT.java
+++ b/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/cluster/integration/ZooKeeperClusteredRoutePolicyFactoryIT.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ZooKeeperClusteredRoutePolicyFactoryIT {
     @RegisterExtension
-    static ZooKeeperService service = ZooKeeperServiceFactory.createService();
+    static ZooKeeperService service = ZooKeeperServiceFactory.createSingletonService();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ZooKeeperClusteredRoutePolicyFactoryIT.class);
     private static final List<String> CLIENTS = IntStream.range(0, 3).mapToObj(Integer::toString).toList();

--- a/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/cluster/integration/ZooKeeperClusteredRoutePolicyIT.java
+++ b/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/cluster/integration/ZooKeeperClusteredRoutePolicyIT.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ZooKeeperClusteredRoutePolicyIT {
     @RegisterExtension
-    static ZooKeeperService service = ZooKeeperServiceFactory.createService();
+    static ZooKeeperService service = ZooKeeperServiceFactory.createSingletonService();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ZooKeeperClusteredRoutePolicyIT.class);
     private static final List<String> CLIENTS = IntStream.range(0, 3).mapToObj(Integer::toString).toList();

--- a/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/cluster/integration/ZooKeeperMasterIT.java
+++ b/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/cluster/integration/ZooKeeperMasterIT.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ZooKeeperMasterIT {
     @RegisterExtension
-    static ZooKeeperService service = ZooKeeperServiceFactory.createService();
+    static ZooKeeperService service = ZooKeeperServiceFactory.createSingletonService();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ZooKeeperMasterIT.class);
     private static final List<String> CLIENTS = IntStream.range(0, 3).mapToObj(Integer::toString).toList();

--- a/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/integration/ConsumeDataIT.java
+++ b/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/integration/ConsumeDataIT.java
@@ -64,7 +64,7 @@ public class ConsumeDataIT extends ZooKeeperITSupport {
         updateNode(10);
 
         delay(500);
-        client.delete("/camel");
+        client.deleteAll("/camel");
 
         MockEndpoint.assertIsSatisfied(30, TimeUnit.SECONDS);
 
@@ -90,7 +90,7 @@ public class ConsumeDataIT extends ZooKeeperITSupport {
         delay(500);
 
         // by now we are back waiting for a change so delete the node
-        client.delete("/camel");
+        client.deleteAll("/camel");
 
         // recreate and update a number of times.
         createCamelNode();
@@ -98,7 +98,7 @@ public class ConsumeDataIT extends ZooKeeperITSupport {
 
         MockEndpoint.assertIsSatisfied(30, TimeUnit.SECONDS);
 
-        client.delete("/camel");
+        client.deleteAll("/camel");
     }
 
     private void updateNode(int times) throws Exception {

--- a/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/integration/ZooKeeperITSupport.java
+++ b/components/camel-zookeeper/src/test/java/org/apache/camel/component/zookeeper/integration/ZooKeeperITSupport.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ZooKeeperITSupport extends CamelTestSupport {
     @RegisterExtension
-    static ZooKeeperService service = ZooKeeperServiceFactory.createService();
+    static ZooKeeperService service = ZooKeeperServiceFactory.createSingletonService();
 
     protected String testPayload = "This is a test";
     protected byte[] testPayloadBytes = testPayload.getBytes();

--- a/docs/user-manual/modules/ROOT/pages/test-infra.adoc
+++ b/docs/user-manual/modules/ROOT/pages/test-infra.adoc
@@ -176,8 +176,35 @@ On the test class, add a member variable for the service and annotate it with th
 [source,java]
 ----
 @RegisterExtension
-static MyService service = MyServiceServiceFactory.createService();
+static MyService service = MyServiceServiceFactory.createSingletonService();
 ----
+
+==== Singleton Services
+
+Most service factories provide a `createSingletonService()` method that returns a JVM-wide singleton instance.
+This is the **recommended** approach for integration tests. The singleton ensures that the Testcontainers service
+(or embedded service) is started only once per JVM and reused across all test classes, rather than starting a
+new container for each test class.
+
+Benefits of singleton services:
+
+* **Faster test execution** — containers start once and are reused, avoiding repeated startup overhead.
+* **Parallel test support** — when running tests in parallel (e.g., with https://github.com/apache/maven-mvnd[mvnd]),
+  singletons prevent multiple test classes from starting conflicting containers on the same ports.
+* **Lower resource usage** — a single container instance serves all test classes instead of each class managing its own.
+
+The singleton is backed by a lazy holder idiom and includes a JVM shutdown hook that stops the container when
+the JVM exits. JUnit's `@RegisterExtension` lifecycle calls to `shutdown()` are treated as no-ops on a
+singleton, so the service stays alive across test classes.
+
+[NOTE]
+====
+When using singleton services, tests must be careful about shared state. For example, use unique topic or
+queue names per test class, or clean up data between tests to avoid interference.
+====
+
+Use `createService()` only when a test genuinely needs its own isolated service instance (e.g., it reconfigures
+the container in a way that would break other tests).
 
 More complex test services can be created using something similar to:
 

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -60,7 +60,7 @@ public abstract class JBangTestSupport {
     protected Logger logger = LoggerFactory.getLogger(getClass());
 
     @RegisterExtension
-    protected static CliService containerService = CliServiceFactory.createService();
+    protected static CliService containerService = CliServiceFactory.createSingletonService();
 
     private static final String DATA_FOLDER = System.getProperty(CliProperties.DATA_FOLDER);
 
@@ -111,7 +111,8 @@ public abstract class JBangTestSupport {
         FORMATS_MAPPING_DATA("data.csv", "/jbang/it/data-mapping/data-formats/data.csv"),
         STUB_ROUTE("StubRoute.java", "/jbang/it/StubRoute.java"),
         HISTORY_ROUTE("HistoryRoute.java", "/jbang/it/HistoryRoute.java"),
-        USER_SOURCE_KAMELET("user-source.kamelet.yaml", "/jbang/it/user-source.kamelet.yaml");
+        USER_SOURCE_KAMELET("user-source.kamelet.yaml", "/jbang/it/user-source.kamelet.yaml"),
+        GROUP_ROUTE("GroupRoute.java", "/jbang/it/GroupRoute.java");
 
         private String name;
         private String resPath;

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -60,7 +60,7 @@ public abstract class JBangTestSupport {
     protected Logger logger = LoggerFactory.getLogger(getClass());
 
     @RegisterExtension
-    protected static CliService containerService = CliServiceFactory.createService();
+    protected static CliService containerService = CliServiceFactory.createSingletonService();
 
     private static final String DATA_FOLDER = System.getProperty(CliProperties.DATA_FOLDER);
 

--- a/test-infra/camel-test-infra-azure-storage-blob/src/main/java/org/apache/camel/test/infra/azure/storage/blob/services/AzureStorageBlobServiceFactory.java
+++ b/test-infra/camel-test-infra-azure-storage-blob/src/main/java/org/apache/camel/test/infra/azure/storage/blob/services/AzureStorageBlobServiceFactory.java
@@ -17,10 +17,45 @@
 
 package org.apache.camel.test.infra.azure.storage.blob.services;
 
+import org.apache.camel.test.infra.azure.common.AzureCredentialsHolder;
 import org.apache.camel.test.infra.azure.common.services.AzureService;
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class AzureStorageBlobServiceFactory {
+
+    private static class SingletonAzureStorageBlobService extends SingletonService<AzureService>
+            implements AzureService {
+        public SingletonAzureStorageBlobService(AzureService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public AzureCredentialsHolder azureCredentials() {
+            return getService().azureCredentials();
+        }
+
+        @Override
+        public String accountName() {
+            return getService().accountName();
+        }
+
+        @Override
+        public String accessKey() {
+            return getService().accessKey();
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+    }
+
     private AzureStorageBlobServiceFactory() {
 
     }
@@ -34,6 +69,21 @@ public final class AzureStorageBlobServiceFactory {
                 .addLocalMapping(AzureStorageBlobLocalContainerService::new)
                 .addRemoteMapping(AzureStorageBlobRemoteService::new)
                 .build();
+    }
+
+    public static AzureService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final AzureService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<AzureService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonAzureStorageBlobService(new AzureStorageBlobLocalContainerService(), "azure"))
+                    .addRemoteMapping(AzureStorageBlobRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     static class AzureStorageBlobLocalContainerService extends AzureStorageBlobLocalContainerInfraService

--- a/test-infra/camel-test-infra-azure-storage-datalake/src/main/java/org/apache/camel/test/infra/azure/storage/datalake/services/AzureStorageDataLakeServiceFactory.java
+++ b/test-infra/camel-test-infra-azure-storage-datalake/src/main/java/org/apache/camel/test/infra/azure/storage/datalake/services/AzureStorageDataLakeServiceFactory.java
@@ -17,10 +17,44 @@
 
 package org.apache.camel.test.infra.azure.storage.datalake.services;
 
+import org.apache.camel.test.infra.azure.common.AzureCredentialsHolder;
 import org.apache.camel.test.infra.azure.common.services.AzureService;
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class AzureStorageDataLakeServiceFactory {
+
+    private static class SingletonAzureStorageDataLakeService extends SingletonService<AzureService>
+            implements AzureService {
+        public SingletonAzureStorageDataLakeService(AzureService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public AzureCredentialsHolder azureCredentials() {
+            return getService().azureCredentials();
+        }
+
+        @Override
+        public String accountName() {
+            return getService().accountName();
+        }
+
+        @Override
+        public String accessKey() {
+            return getService().accessKey();
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+    }
 
     private AzureStorageDataLakeServiceFactory() {
 
@@ -34,6 +68,19 @@ public final class AzureStorageDataLakeServiceFactory {
         return builder()
                 .addRemoteMapping(AzureStorageDataLakeRemoteService::new)
                 .build();
+    }
+
+    public static AzureService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final AzureService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<AzureService> instance = builder();
+            instance.addRemoteMapping(AzureStorageDataLakeRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     static class AzureStorageDataLakeRemoteService extends AzureStorageDataLakeRemoteInfraService implements AzureService {

--- a/test-infra/camel-test-infra-azure-storage-queue/src/main/java/org/apache/camel/test/infra/azure/storage/queue/services/AzureStorageQueueServiceFactory.java
+++ b/test-infra/camel-test-infra-azure-storage-queue/src/main/java/org/apache/camel/test/infra/azure/storage/queue/services/AzureStorageQueueServiceFactory.java
@@ -17,10 +17,45 @@
 
 package org.apache.camel.test.infra.azure.storage.queue.services;
 
+import org.apache.camel.test.infra.azure.common.AzureCredentialsHolder;
 import org.apache.camel.test.infra.azure.common.services.AzureService;
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class AzureStorageQueueServiceFactory {
+
+    private static class SingletonAzureStorageQueueService extends SingletonService<AzureService>
+            implements AzureService {
+        public SingletonAzureStorageQueueService(AzureService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public AzureCredentialsHolder azureCredentials() {
+            return getService().azureCredentials();
+        }
+
+        @Override
+        public String accountName() {
+            return getService().accountName();
+        }
+
+        @Override
+        public String accessKey() {
+            return getService().accessKey();
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+    }
+
     private AzureStorageQueueServiceFactory() {
 
     }
@@ -34,6 +69,21 @@ public final class AzureStorageQueueServiceFactory {
                 .addLocalMapping(AzureStorageQueueLocalContainerService::new)
                 .addRemoteMapping(AzureStorageQueueRemoteService::new)
                 .build();
+    }
+
+    public static AzureService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final AzureService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<AzureService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonAzureStorageQueueService(new AzureStorageQueueLocalContainerService(), "azure"))
+                    .addRemoteMapping(AzureStorageQueueRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class AzureStorageQueueLocalContainerService extends AzureStorageQueueLocalContainerInfraService

--- a/test-infra/camel-test-infra-cassandra/src/main/java/org/apache/camel/test/infra/cassandra/services/CassandraServiceFactory.java
+++ b/test-infra/camel-test-infra-cassandra/src/main/java/org/apache/camel/test/infra/cassandra/services/CassandraServiceFactory.java
@@ -17,8 +17,36 @@
 package org.apache.camel.test.infra.cassandra.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class CassandraServiceFactory {
+
+    private static class SingletonCassandraService extends SingletonService<CassandraService> implements CassandraService {
+        public SingletonCassandraService(CassandraService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public int getCQL3Port() {
+            return getService().getCQL3Port();
+        }
+
+        @Override
+        public String getCassandraHost() {
+            return getService().getCassandraHost();
+        }
+
+        @Override
+        public String hosts() {
+            return getService().hosts();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+    }
+
     private CassandraServiceFactory() {
 
     }
@@ -41,6 +69,21 @@ public final class CassandraServiceFactory {
                 .addLocalMapping(CassandraLocalContainerService::new)
                 .addRemoteMapping(RemoteCassandraService::new)
                 .build();
+    }
+
+    public static CassandraService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final CassandraService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<CassandraService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonCassandraService(new CassandraLocalContainerService(), "cassandra"))
+                    .addRemoteMapping(RemoteCassandraService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class RemoteCassandraService extends RemoteCassandraInfraService implements CassandraService {

--- a/test-infra/camel-test-infra-chatscript/src/main/java/org/apache/camel/test/infra/chatscript/services/ChatScriptServiceFactory.java
+++ b/test-infra/camel-test-infra-chatscript/src/main/java/org/apache/camel/test/infra/chatscript/services/ChatScriptServiceFactory.java
@@ -17,8 +17,21 @@
 package org.apache.camel.test.infra.chatscript.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class ChatScriptServiceFactory {
+
+    private static class SingletonChatScriptService extends SingletonService<ChatScriptService>
+            implements ChatScriptService {
+        public SingletonChatScriptService(ChatScriptService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String serviceAddress() {
+            return getService().serviceAddress();
+        }
+    }
 
     private ChatScriptServiceFactory() {
 
@@ -33,6 +46,21 @@ public final class ChatScriptServiceFactory {
                 .addLocalMapping(ChatScriptLocalContainerTestService::new)
                 .addRemoteMapping(ChatScriptRemoteTestService::new)
                 .build();
+    }
+
+    public static ChatScriptService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final ChatScriptService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<ChatScriptService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonChatScriptService(new ChatScriptLocalContainerTestService(), "chatscript"))
+                    .addRemoteMapping(ChatScriptRemoteTestService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class ChatScriptLocalContainerTestService extends ChatScriptLocalContainerInfraService

--- a/test-infra/camel-test-infra-cli/src/main/java/org/apache/camel/test/infra/cli/services/CliServiceFactory.java
+++ b/test-infra/camel-test-infra-cli/src/main/java/org/apache/camel/test/infra/cli/services/CliServiceFactory.java
@@ -16,9 +16,89 @@
  */
 package org.apache.camel.test.infra.cli.services;
 
+import java.util.stream.Stream;
+
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class CliServiceFactory {
+
+    private static class SingletonCliService extends SingletonService<CliService> implements CliService {
+        public SingletonCliService(CliService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String execute(String command) {
+            return getService().execute(command);
+        }
+
+        @Override
+        public String execute(String command, Boolean getError, Boolean expectFail) {
+            return getService().execute(command, getError, expectFail);
+        }
+
+        @Override
+        public String executeBackground(String command) {
+            return getService().executeBackground(command);
+        }
+
+        @Override
+        public String executeGenericCommand(String command) {
+            return getService().executeGenericCommand(command);
+        }
+
+        @Override
+        public String executeGenericCommand(String command, Boolean getError, Boolean expectFail) {
+            return getService().executeGenericCommand(command, getError, expectFail);
+        }
+
+        @Override
+        public void copyFileInternally(String source, String destination) {
+            getService().copyFileInternally(source, destination);
+        }
+
+        @Override
+        public String getMountPoint() {
+            return getService().getMountPoint();
+        }
+
+        @Override
+        public String getContainerLogs() {
+            return getService().getContainerLogs();
+        }
+
+        @Override
+        public int getDevConsolePort() {
+            return getService().getDevConsolePort();
+        }
+
+        @Override
+        public Stream<String> listDirectory(String directoryPath) {
+            return getService().listDirectory(directoryPath);
+        }
+
+        @Override
+        public String id() {
+            return getService().id();
+        }
+
+        @Override
+        public String version() {
+            return getService().version();
+        }
+
+        @Override
+        public int getSshPort() {
+            return getService().getSshPort();
+        }
+
+        @Override
+        public String getSshPassword() {
+            return getService().getSshPassword();
+        }
+    }
+
     private CliServiceFactory() {
 
     }
@@ -32,5 +112,23 @@ public final class CliServiceFactory {
                 .addLocalMapping(CliLocalContainerService::new)
                 .addMapping("local-camel-cli-process", CliLocalProcessService::new)
                 .build();
+    }
+
+    public static CliService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final CliService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<CliService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonCliService(new CliLocalContainerService(), CliLocalContainerService.CONTAINER_NAME))
+                    .addMapping("local-camel-cli-process",
+                            () -> new SingletonCliService(
+                                    new CliLocalProcessService(),
+                                    CliLocalContainerService.CONTAINER_NAME));
+            INSTANCE = instance.build();
+        }
     }
 }

--- a/test-infra/camel-test-infra-common/src/main/java/org/apache/camel/test/infra/common/services/SingletonService.java
+++ b/test-infra/camel-test-infra-common/src/main/java/org/apache/camel/test/infra/common/services/SingletonService.java
@@ -78,8 +78,7 @@ public class SingletonService<T extends InfrastructureService>
 
     @Override
     public final void shutdown() {
-        LOG.error("Singleton services must not be shutdown manually");
-        throw new IllegalArgumentException("Singleton services must not be shutdown manually");
+        LOG.debug("Ignoring shutdown request for singleton service {}: will be shutdown via JVM shutdown hook", name);
     }
 
     @Override

--- a/test-infra/camel-test-infra-consul/src/main/java/org/apache/camel/test/infra/consul/services/ConsulServiceFactory.java
+++ b/test-infra/camel-test-infra-consul/src/main/java/org/apache/camel/test/infra/consul/services/ConsulServiceFactory.java
@@ -17,8 +17,30 @@
 package org.apache.camel.test.infra.consul.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class ConsulServiceFactory {
+
+    private static class SingletonConsulService extends SingletonService<ConsulService> implements ConsulService {
+        public SingletonConsulService(ConsulService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String getConsulUrl() {
+            return getService().getConsulUrl();
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+    }
 
     private ConsulServiceFactory() {
     }
@@ -32,6 +54,21 @@ public final class ConsulServiceFactory {
                 .addLocalMapping(ConsulLocalContainerTestService::new)
                 .addRemoteMapping(ConsulRemoteTestService::new)
                 .build();
+    }
+
+    public static ConsulService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final ConsulService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<ConsulService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonConsulService(new ConsulLocalContainerTestService(), "consul"))
+                    .addRemoteMapping(ConsulRemoteTestService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class ConsulLocalContainerTestService extends ConsulLocalContainerInfraService implements ConsulService {

--- a/test-infra/camel-test-infra-cyberark-vault/src/main/java/org/apache/camel/test/infra/cyberark/vault/services/CyberArkVaultServiceFactory.java
+++ b/test-infra/camel-test-infra-cyberark-vault/src/main/java/org/apache/camel/test/infra/cyberark/vault/services/CyberArkVaultServiceFactory.java
@@ -17,8 +17,42 @@
 package org.apache.camel.test.infra.cyberark.vault.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class CyberArkVaultServiceFactory {
+
+    private static class SingletonCyberArkVaultService extends SingletonService<CyberArkVaultService>
+            implements CyberArkVaultService {
+        public SingletonCyberArkVaultService(CyberArkVaultService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String account() {
+            return getService().account();
+        }
+
+        @Override
+        public String username() {
+            return getService().username();
+        }
+
+        @Override
+        public String apiKey() {
+            return getService().apiKey();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+    }
+
     private CyberArkVaultServiceFactory() {
 
     }
@@ -31,6 +65,20 @@ public final class CyberArkVaultServiceFactory {
         return builder()
                 .addLocalMapping(CyberArkVaultLocalContainerService::new)
                 .build();
+    }
+
+    public static CyberArkVaultService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final CyberArkVaultService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<CyberArkVaultService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonCyberArkVaultService(new CyberArkVaultLocalContainerService(), "cyberark-vault"));
+            INSTANCE = instance.build();
+        }
     }
 
     public static class CyberArkVaultLocalContainerService extends CyberArkVaultLocalContainerInfraService

--- a/test-infra/camel-test-infra-docling/src/main/java/org/apache/camel/test/infra/docling/services/DoclingServiceFactory.java
+++ b/test-infra/camel-test-infra-docling/src/main/java/org/apache/camel/test/infra/docling/services/DoclingServiceFactory.java
@@ -17,8 +17,21 @@
 package org.apache.camel.test.infra.docling.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class DoclingServiceFactory {
+
+    private static class SingletonDoclingService extends SingletonService<DoclingService> implements DoclingService {
+        public SingletonDoclingService(DoclingService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String doclingServerUrl() {
+            return getService().doclingServerUrl();
+        }
+    }
+
     private DoclingServiceFactory() {
 
     }
@@ -31,6 +44,20 @@ public final class DoclingServiceFactory {
         return builder()
                 .addLocalMapping(DoclingLocalContainerService::new)
                 .build();
+    }
+
+    public static DoclingService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final DoclingService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<DoclingService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonDoclingService(new DoclingLocalContainerService(), "docling"));
+            INSTANCE = instance.build();
+        }
     }
 
     public static class DoclingLocalContainerService extends DoclingLocalContainerInfraService

--- a/test-infra/camel-test-infra-duckdb/src/main/java/org/apache/camel/test/infra/duckdb/services/DuckDbServiceFactory.java
+++ b/test-infra/camel-test-infra-duckdb/src/main/java/org/apache/camel/test/infra/duckdb/services/DuckDbServiceFactory.java
@@ -17,8 +17,25 @@
 package org.apache.camel.test.infra.duckdb.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class DuckDbServiceFactory {
+
+    private static class SingletonDuckDbService extends SingletonService<DuckDbService> implements DuckDbService {
+        public SingletonDuckDbService(DuckDbService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String getJdbcUrl() {
+            return getService().getJdbcUrl();
+        }
+
+        @Override
+        public String getDatabasePath() {
+            return getService().getDatabasePath();
+        }
+    }
 
     private DuckDbServiceFactory() {
     }
@@ -32,6 +49,21 @@ public final class DuckDbServiceFactory {
                 .addLocalMapping(DuckDbEmbeddedService::new)
                 .addRemoteMapping(DuckDbRemoteService::new)
                 .build();
+    }
+
+    public static DuckDbService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final DuckDbService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<DuckDbService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonDuckDbService(new DuckDbEmbeddedService(), "duckdb"))
+                    .addRemoteMapping(DuckDbRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class DuckDbRemoteService extends RemoteDuckDbInfraService implements DuckDbService {

--- a/test-infra/camel-test-infra-google-pubsub/src/main/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubServiceFactory.java
+++ b/test-infra/camel-test-infra-google-pubsub/src/main/java/org/apache/camel/test/infra/google/pubsub/services/GooglePubSubServiceFactory.java
@@ -17,8 +17,22 @@
 package org.apache.camel.test.infra.google.pubsub.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class GooglePubSubServiceFactory {
+
+    private static class SingletonGooglePubSubService extends SingletonService<GooglePubSubService>
+            implements GooglePubSubService {
+        public SingletonGooglePubSubService(GooglePubSubService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String getServiceAddress() {
+            return getService().getServiceAddress();
+        }
+    }
+
     private GooglePubSubServiceFactory() {
 
     }
@@ -32,6 +46,21 @@ public final class GooglePubSubServiceFactory {
                 .addLocalMapping(GooglePubSubLocalContainerService::new)
                 .addRemoteMapping(GooglePubSubRemoteService::new)
                 .build();
+    }
+
+    public static GooglePubSubService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final GooglePubSubService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<GooglePubSubService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonGooglePubSubService(new GooglePubSubLocalContainerService(), "google"))
+                    .addRemoteMapping(GooglePubSubRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class GooglePubSubLocalContainerService extends GooglePubSubLocalContainerInfraService

--- a/test-infra/camel-test-infra-hashicorp-vault/src/main/java/org/apache/camel/test/infra/hashicorp/vault/services/HashicorpServiceFactory.java
+++ b/test-infra/camel-test-infra-hashicorp-vault/src/main/java/org/apache/camel/test/infra/hashicorp/vault/services/HashicorpServiceFactory.java
@@ -17,8 +17,32 @@
 package org.apache.camel.test.infra.hashicorp.vault.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class HashicorpServiceFactory {
+
+    private static class SingletonHashicorpVaultService extends SingletonService<HashicorpVaultService>
+            implements HashicorpVaultService {
+        public SingletonHashicorpVaultService(HashicorpVaultService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String token() {
+            return getService().token();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+    }
+
     private HashicorpServiceFactory() {
 
     }
@@ -31,6 +55,20 @@ public final class HashicorpServiceFactory {
         return builder()
                 .addLocalMapping(HashicorpVaultLocalContainerService::new)
                 .build();
+    }
+
+    public static HashicorpVaultService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final HashicorpVaultService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<HashicorpVaultService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonHashicorpVaultService(new HashicorpVaultLocalContainerService(), "hashicorp-vault"));
+            INSTANCE = instance.build();
+        }
     }
 
     public static class HashicorpVaultLocalContainerService extends HashicorpVaultLocalContainerInfraService

--- a/test-infra/camel-test-infra-hazelcast/src/main/java/org/apache/camel/test/infra/hazelcast/services/HazelcastServiceFactory.java
+++ b/test-infra/camel-test-infra-hazelcast/src/main/java/org/apache/camel/test/infra/hazelcast/services/HazelcastServiceFactory.java
@@ -16,9 +16,22 @@
  */
 package org.apache.camel.test.infra.hazelcast.services;
 
+import com.hazelcast.config.Config;
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class HazelcastServiceFactory {
+
+    private static class SingletonHazelcastService extends SingletonService<HazelcastService> implements HazelcastService {
+        public SingletonHazelcastService(HazelcastService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public Config createConfiguration(String name, int port, String instanceName, String componentName) {
+            return getService().createConfiguration(name, port, instanceName, componentName);
+        }
+    }
 
     private HazelcastServiceFactory() {
 
@@ -32,6 +45,20 @@ public final class HazelcastServiceFactory {
         return builder()
                 .addLocalMapping(HazelcastEmbeddedService::new)
                 .build();
+    }
+
+    public static HazelcastService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final HazelcastService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<HazelcastService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonHazelcastService(new HazelcastEmbeddedService(), "hazelcast"));
+            INSTANCE = instance.build();
+        }
     }
 
     public static class HazelcastEmbeddedService extends HazelcastEmbeddedInfraService implements HazelcastService {

--- a/test-infra/camel-test-infra-ibmmq/src/main/java/org/apache/camel/test/infra/ibmmq/services/IbmMQServiceFactory.java
+++ b/test-infra/camel-test-infra-ibmmq/src/main/java/org/apache/camel/test/infra/ibmmq/services/IbmMQServiceFactory.java
@@ -17,8 +17,30 @@
 package org.apache.camel.test.infra.ibmmq.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public class IbmMQServiceFactory {
+
+    private static class SingletonIbmMQService extends SingletonService<IbmMQService> implements IbmMQService {
+        public SingletonIbmMQService(IbmMQService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String channel() {
+            return getService().channel();
+        }
+
+        @Override
+        public String queueManager() {
+            return getService().queueManager();
+        }
+
+        @Override
+        public int listenerPort() {
+            return getService().listenerPort();
+        }
+    }
 
     private IbmMQServiceFactory() {
 
@@ -32,6 +54,20 @@ public class IbmMQServiceFactory {
         return builder()
                 .addLocalMapping(IbmMQLocalContainerService::new)
                 .build();
+    }
+
+    public static IbmMQService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final IbmMQService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<IbmMQService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonIbmMQService(new IbmMQLocalContainerService(), "ibm-mq"));
+            INSTANCE = instance.build();
+        }
     }
 
     public static class IbmMQLocalContainerService extends IbmMQLocalContainerInfraService

--- a/test-infra/camel-test-infra-iggy/src/main/java/org/apache/camel/test/infra/iggy/services/IggyServiceFactory.java
+++ b/test-infra/camel-test-infra-iggy/src/main/java/org/apache/camel/test/infra/iggy/services/IggyServiceFactory.java
@@ -17,8 +17,36 @@
 package org.apache.camel.test.infra.iggy.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class IggyServiceFactory {
+
+    private static class SingletonIggyService extends SingletonService<IggyService> implements IggyService {
+        public SingletonIggyService(IggyService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+
+        @Override
+        public String username() {
+            return getService().username();
+        }
+
+        @Override
+        public String password() {
+            return getService().password();
+        }
+    }
+
     private IggyServiceFactory() {
 
     }
@@ -32,6 +60,21 @@ public final class IggyServiceFactory {
                 .addLocalMapping(IggyLocalContainerService::new)
                 .addRemoteMapping(IggyRemoteService::new)
                 .build();
+    }
+
+    public static IggyService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final IggyService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<IggyService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonIggyService(new IggyLocalContainerService(), "iggy"))
+                    .addRemoteMapping(IggyRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class IggyRemoteService extends IggyRemoteInfraService implements IggyService {

--- a/test-infra/camel-test-infra-ignite/src/main/java/org/apache/camel/test/infra/ignite/services/IgniteServiceFactory.java
+++ b/test-infra/camel-test-infra-ignite/src/main/java/org/apache/camel/test/infra/ignite/services/IgniteServiceFactory.java
@@ -17,8 +17,21 @@
 package org.apache.camel.test.infra.ignite.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
+import org.apache.ignite.configuration.IgniteConfiguration;
 
 public final class IgniteServiceFactory {
+
+    private static class SingletonIgniteService extends SingletonService<IgniteService> implements IgniteService {
+        public SingletonIgniteService(IgniteService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public IgniteConfiguration createConfiguration() {
+            return getService().createConfiguration();
+        }
+    }
 
     private IgniteServiceFactory() {
 
@@ -32,6 +45,20 @@ public final class IgniteServiceFactory {
         return builder()
                 .addLocalMapping(IgniteEmbeddedService::new)
                 .build();
+    }
+
+    public static IgniteService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final IgniteService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<IgniteService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonIgniteService(new IgniteEmbeddedService(), "ignite"));
+            INSTANCE = instance.build();
+        }
     }
 
     public static class IgniteEmbeddedService extends IgniteEmbeddedInfraService implements IgniteService {

--- a/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerServiceFactory.java
+++ b/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerServiceFactory.java
@@ -17,11 +17,39 @@
 package org.apache.camel.test.infra.jaeger.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 /**
  * @since 4.21
  */
 public final class JaegerServiceFactory {
+
+    private static class SingletonJaegerService extends SingletonService<JaegerService> implements JaegerService {
+        public SingletonJaegerService(JaegerService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int collectorGrpcPort() {
+            return getService().collectorGrpcPort();
+        }
+
+        @Override
+        public int collectorHttpPort() {
+            return getService().collectorHttpPort();
+        }
+
+        @Override
+        public int queryUiPort() {
+            return getService().queryUiPort();
+        }
+    }
+
     private JaegerServiceFactory() {
     }
 
@@ -34,6 +62,21 @@ public final class JaegerServiceFactory {
                 .addLocalMapping(JaegerLocalContainerService::new)
                 .addRemoteMapping(JaegerRemoteService::new)
                 .build();
+    }
+
+    public static JaegerService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final JaegerService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<JaegerService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonJaegerService(new JaegerLocalContainerService(), "jaeger"))
+                    .addRemoteMapping(JaegerRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class JaegerRemoteService extends JaegerRemoteInfraService implements JaegerService {

--- a/test-infra/camel-test-infra-keycloak/src/main/java/org/apache/camel/test/infra/keycloak/services/KeycloakServiceFactory.java
+++ b/test-infra/camel-test-infra-keycloak/src/main/java/org/apache/camel/test/infra/keycloak/services/KeycloakServiceFactory.java
@@ -17,8 +17,42 @@
 package org.apache.camel.test.infra.keycloak.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
+import org.keycloak.admin.client.Keycloak;
 
 public final class KeycloakServiceFactory {
+
+    private static class SingletonKeycloakService extends SingletonService<KeycloakService> implements KeycloakService {
+        public SingletonKeycloakService(KeycloakService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String getKeycloakServerUrl() {
+            return getService().getKeycloakServerUrl();
+        }
+
+        @Override
+        public String getKeycloakRealm() {
+            return getService().getKeycloakRealm();
+        }
+
+        @Override
+        public String getKeycloakUsername() {
+            return getService().getKeycloakUsername();
+        }
+
+        @Override
+        public String getKeycloakPassword() {
+            return getService().getKeycloakPassword();
+        }
+
+        @Override
+        public Keycloak getKeycloakAdminClient() {
+            return getService().getKeycloakAdminClient();
+        }
+    }
+
     private KeycloakServiceFactory() {
 
     }
@@ -31,6 +65,20 @@ public final class KeycloakServiceFactory {
         return builder()
                 .addLocalMapping(KeycloakLocalContainerService::new)
                 .build();
+    }
+
+    public static KeycloakService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final KeycloakService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<KeycloakService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonKeycloakService(new KeycloakLocalContainerService(), "keycloak"));
+            INSTANCE = instance.build();
+        }
     }
 
     public static class KeycloakLocalContainerService extends KeycloakLocalContainerInfraService

--- a/test-infra/camel-test-infra-mcp-everything/src/main/java/org/apache/camel/test/infra/mcp/everything/services/McpEverythingServiceFactory.java
+++ b/test-infra/camel-test-infra-mcp-everything/src/main/java/org/apache/camel/test/infra/mcp/everything/services/McpEverythingServiceFactory.java
@@ -17,8 +17,26 @@
 package org.apache.camel.test.infra.mcp.everything.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class McpEverythingServiceFactory {
+
+    private static class SingletonMcpEverythingService extends SingletonService<McpEverythingService>
+            implements McpEverythingService {
+        public SingletonMcpEverythingService(McpEverythingService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+    }
 
     private McpEverythingServiceFactory() {
     }
@@ -31,6 +49,20 @@ public final class McpEverythingServiceFactory {
         return builder()
                 .addLocalMapping(McpEverythingLocalContainerService::new)
                 .build();
+    }
+
+    public static McpEverythingService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final McpEverythingService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<McpEverythingService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonMcpEverythingService(new McpEverythingLocalContainerService(), "mcp-everything"));
+            INSTANCE = instance.build();
+        }
     }
 
     public static class McpEverythingLocalContainerService extends McpEverythingLocalContainerInfraService

--- a/test-infra/camel-test-infra-mcp-everything/src/main/java/org/apache/camel/test/infra/mcp/everything/services/McpEverythingSseServiceFactory.java
+++ b/test-infra/camel-test-infra-mcp-everything/src/main/java/org/apache/camel/test/infra/mcp/everything/services/McpEverythingSseServiceFactory.java
@@ -17,8 +17,26 @@
 package org.apache.camel.test.infra.mcp.everything.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class McpEverythingSseServiceFactory {
+
+    private static class SingletonMcpEverythingSseService extends SingletonService<McpEverythingSseService>
+            implements McpEverythingSseService {
+        public SingletonMcpEverythingSseService(McpEverythingSseService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+    }
 
     private McpEverythingSseServiceFactory() {
     }
@@ -31,6 +49,22 @@ public final class McpEverythingSseServiceFactory {
         return builder()
                 .addLocalMapping(McpEverythingSseLocalContainerService::new)
                 .build();
+    }
+
+    public static McpEverythingSseService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final McpEverythingSseService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<McpEverythingSseService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonMcpEverythingSseService(
+                            new McpEverythingSseLocalContainerService(),
+                            "mcp-everything-sse"));
+            INSTANCE = instance.build();
+        }
     }
 
     public static class McpEverythingSseLocalContainerService extends McpEverythingSseLocalContainerInfraService

--- a/test-infra/camel-test-infra-microprofile-lra/src/main/java/org/apache/camel/test/infra/microprofile/lra/services/MicroprofileLRAServiceFactory.java
+++ b/test-infra/camel-test-infra-microprofile-lra/src/main/java/org/apache/camel/test/infra/microprofile/lra/services/MicroprofileLRAServiceFactory.java
@@ -17,8 +17,32 @@
 package org.apache.camel.test.infra.microprofile.lra.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class MicroprofileLRAServiceFactory {
+
+    private static class SingletonMicroprofileLRAService extends SingletonService<MicroprofileLRAService>
+            implements MicroprofileLRAService {
+        public SingletonMicroprofileLRAService(MicroprofileLRAService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+
+        @Override
+        public String callbackHost() {
+            return getService().callbackHost();
+        }
+    }
+
     private MicroprofileLRAServiceFactory() {
 
     }
@@ -32,6 +56,23 @@ public final class MicroprofileLRAServiceFactory {
                 .addLocalMapping(MicroprofileLRALocalContainerService::new)
                 .addRemoteMapping(MicroprofileLRARemoteService::new)
                 .build();
+    }
+
+    public static MicroprofileLRAService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final MicroprofileLRAService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<MicroprofileLRAService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonMicroprofileLRAService(
+                            new MicroprofileLRALocalContainerService(),
+                            "microprofile-lra"))
+                    .addRemoteMapping(MicroprofileLRARemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class MicroprofileLRALocalContainerService extends MicroprofileLRALocalContainerInfraService

--- a/test-infra/camel-test-infra-minio/src/main/java/org/apache/camel/test/infra/minio/services/MinioServiceFactory.java
+++ b/test-infra/camel-test-infra-minio/src/main/java/org/apache/camel/test/infra/minio/services/MinioServiceFactory.java
@@ -17,8 +17,51 @@
 package org.apache.camel.test.infra.minio.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class MinioServiceFactory {
+
+    private static class SingletonMinioService extends SingletonService<MinioService> implements MinioService {
+        public SingletonMinioService(MinioService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String secretKey() {
+            return getService().secretKey();
+        }
+
+        @Override
+        public String accessKey() {
+            return getService().accessKey();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int consolePort() {
+            return getService().consolePort();
+        }
+
+        @Override
+        public String consoleUsername() {
+            return getService().consoleUsername();
+        }
+
+        @Override
+        public String consolePassword() {
+            return getService().consolePassword();
+        }
+    }
+
     private MinioServiceFactory() {
 
     }
@@ -32,6 +75,21 @@ public final class MinioServiceFactory {
                 .addLocalMapping(MinioLocalContainerService::new)
                 .addRemoteMapping(MinioRemoteService::new)
                 .build();
+    }
+
+    public static MinioService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final MinioService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<MinioService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonMinioService(new MinioLocalContainerService(), "minio"))
+                    .addRemoteMapping(MinioRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class MinioLocalContainerService extends MinioLocalContainerInfraService implements MinioService {

--- a/test-infra/camel-test-infra-mosquitto/src/main/java/org/apache/camel/test/infra/mosquitto/services/MosquittoServiceFactory.java
+++ b/test-infra/camel-test-infra-mosquitto/src/main/java/org/apache/camel/test/infra/mosquitto/services/MosquittoServiceFactory.java
@@ -17,8 +17,21 @@
 package org.apache.camel.test.infra.mosquitto.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class MosquittoServiceFactory {
+
+    private static class SingletonMosquittoService extends SingletonService<MosquittoService> implements MosquittoService {
+        public SingletonMosquittoService(MosquittoService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public Integer getPort() {
+            return getService().getPort();
+        }
+    }
+
     private MosquittoServiceFactory() {
 
     }
@@ -34,4 +47,18 @@ public final class MosquittoServiceFactory {
                 .build();
     }
 
+    public static MosquittoService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final MosquittoService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<MosquittoService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonMosquittoService(new MosquittoLocalContainerService(), "mosquitto"))
+                    .addRemoteMapping(MosquittoRemoteService::new);
+            INSTANCE = instance.build();
+        }
+    }
 }

--- a/test-infra/camel-test-infra-nats/src/main/java/org/apache/camel/test/infra/nats/services/NatsServiceFactory.java
+++ b/test-infra/camel-test-infra-nats/src/main/java/org/apache/camel/test/infra/nats/services/NatsServiceFactory.java
@@ -17,8 +17,21 @@
 package org.apache.camel.test.infra.nats.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class NatsServiceFactory {
+
+    private static class SingletonNatsService extends SingletonService<NatsService> implements NatsService {
+        public SingletonNatsService(NatsService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String getServiceAddress() {
+            return getService().getServiceAddress();
+        }
+    }
+
     private NatsServiceFactory() {
 
     }
@@ -31,6 +44,21 @@ public final class NatsServiceFactory {
         return builder().addLocalMapping(NatsLocalContainerService::new)
                 .addRemoteMapping(NatsRemoteService::new)
                 .build();
+    }
+
+    public static NatsService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final NatsService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<NatsService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonNatsService(new NatsLocalContainerService(), "nats"))
+                    .addRemoteMapping(NatsRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class NatsRemoteService extends NatsRemoteInfraService implements NatsService {

--- a/test-infra/camel-test-infra-openldap/src/main/java/org/apache/camel/test/infra/openldap/services/OpenldapServiceFactory.java
+++ b/test-infra/camel-test-infra-openldap/src/main/java/org/apache/camel/test/infra/openldap/services/OpenldapServiceFactory.java
@@ -17,8 +17,31 @@
 package org.apache.camel.test.infra.openldap.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class OpenldapServiceFactory {
+
+    private static class SingletonOpenldapService extends SingletonService<OpenldapService> implements OpenldapService {
+        public SingletonOpenldapService(OpenldapService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public Integer getPort() {
+            return getService().getPort();
+        }
+
+        @Override
+        public Integer getSslPort() {
+            return getService().getSslPort();
+        }
+
+        @Override
+        public String getHost() {
+            return getService().getHost();
+        }
+    }
+
     private OpenldapServiceFactory() {
 
     }
@@ -32,6 +55,21 @@ public final class OpenldapServiceFactory {
                 .addLocalMapping(OpenldapLocalContainerService::new)
                 .addRemoteMapping(OpenldapRemoteService::new)
                 .build();
+    }
+
+    public static OpenldapService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final OpenldapService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<OpenldapService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonOpenldapService(new OpenldapLocalContainerService(), "openldap"))
+                    .addRemoteMapping(OpenldapRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class OpenldapLocalContainerService extends OpenldapLocalContainerInfraService implements OpenldapService {

--- a/test-infra/camel-test-infra-postgres/src/main/java/org/apache/camel/test/infra/postgres/services/PostgresServiceFactory.java
+++ b/test-infra/camel-test-infra-postgres/src/main/java/org/apache/camel/test/infra/postgres/services/PostgresServiceFactory.java
@@ -17,8 +17,40 @@
 package org.apache.camel.test.infra.postgres.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class PostgresServiceFactory {
+
+    private static class SingletonPostgresService extends SingletonService<PostgresService> implements PostgresService {
+        public SingletonPostgresService(PostgresService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+
+        @Override
+        public String userName() {
+            return getService().userName();
+        }
+
+        @Override
+        public String password() {
+            return getService().password();
+        }
+
+        @Override
+        public String getServiceAddress() {
+            return getService().getServiceAddress();
+        }
+    }
 
     private PostgresServiceFactory() {
     }
@@ -31,6 +63,21 @@ public final class PostgresServiceFactory {
         return builder().addLocalMapping(PostgresLocalContainerService::new)
                 .addRemoteMapping(PostgresRemoteService::new)
                 .build();
+    }
+
+    public static PostgresService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final PostgresService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<PostgresService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonPostgresService(new PostgresLocalContainerService(), "postgres"))
+                    .addRemoteMapping(PostgresRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class PostgresRemoteService extends PostgresRemoteInfraService implements PostgresService {

--- a/test-infra/camel-test-infra-postgres/src/main/java/org/apache/camel/test/infra/postgres/services/PostgresVectorServiceFactory.java
+++ b/test-infra/camel-test-infra-postgres/src/main/java/org/apache/camel/test/infra/postgres/services/PostgresVectorServiceFactory.java
@@ -17,8 +17,40 @@
 package org.apache.camel.test.infra.postgres.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class PostgresVectorServiceFactory {
+
+    private static class SingletonPostgresVectorService extends SingletonService<PostgresService> implements PostgresService {
+        public SingletonPostgresVectorService(PostgresService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+
+        @Override
+        public String userName() {
+            return getService().userName();
+        }
+
+        @Override
+        public String password() {
+            return getService().password();
+        }
+
+        @Override
+        public String getServiceAddress() {
+            return getService().getServiceAddress();
+        }
+    }
 
     private PostgresVectorServiceFactory() {
     }
@@ -31,5 +63,20 @@ public final class PostgresVectorServiceFactory {
         return builder().addLocalMapping(PostgresVectorLocalContainerService::new)
                 .addRemoteMapping(PostgresServiceFactory.PostgresRemoteService::new)
                 .build();
+    }
+
+    public static PostgresService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final PostgresService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<PostgresService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonPostgresVectorService(new PostgresVectorLocalContainerService(), "postgres-vector"))
+                    .addRemoteMapping(PostgresServiceFactory.PostgresRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 }

--- a/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQServiceFactory.java
+++ b/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQServiceFactory.java
@@ -18,8 +18,41 @@
 package org.apache.camel.test.infra.rabbitmq.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class RabbitMQServiceFactory {
+
+    private static class SingletonRabbitMQService extends SingletonService<RabbitMQService> implements RabbitMQService {
+        public SingletonRabbitMQService(RabbitMQService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public ConnectionProperties connectionProperties() {
+            return getService().connectionProperties();
+        }
+
+        @Override
+        public int getHttpPort() {
+            return getService().getHttpPort();
+        }
+
+        @Override
+        public String managementUsername() {
+            return getService().managementUsername();
+        }
+
+        @Override
+        public String managementPassword() {
+            return getService().managementPassword();
+        }
+
+        @Override
+        public String managementUri() {
+            return getService().managementUri();
+        }
+    }
+
     private RabbitMQServiceFactory() {
 
     }
@@ -33,6 +66,21 @@ public final class RabbitMQServiceFactory {
                 .addLocalMapping(RabbitMQLocalContainerService::new)
                 .addRemoteMapping(RabbitMQRemoteService::new)
                 .build();
+    }
+
+    public static RabbitMQService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final RabbitMQService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<RabbitMQService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonRabbitMQService(new RabbitMQLocalContainerService(), "rabbitmq"))
+                    .addRemoteMapping(RabbitMQRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class RabbitMQLocalContainerService extends RabbitMQLocalContainerInfraService implements RabbitMQService {

--- a/test-infra/camel-test-infra-redis/src/main/java/org/apache/camel/test/infra/redis/services/RedisServiceFactory.java
+++ b/test-infra/camel-test-infra-redis/src/main/java/org/apache/camel/test/infra/redis/services/RedisServiceFactory.java
@@ -17,8 +17,26 @@
 package org.apache.camel.test.infra.redis.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class RedisServiceFactory {
+
+    private static class SingletonRedisService extends SingletonService<RedisService> implements RedisService {
+        public SingletonRedisService(RedisService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+    }
+
     private RedisServiceFactory() {
 
     }
@@ -32,6 +50,21 @@ public final class RedisServiceFactory {
                 .addLocalMapping(RedisLocalContainerService::new)
                 .addRemoteMapping(RedisRemoteService::new)
                 .build();
+    }
+
+    public static RedisService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final RedisService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<RedisService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonRedisService(new RedisLocalContainerService(), "redis"))
+                    .addRemoteMapping(RedisRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class RedisRemoteService extends RedisRemoteInfraService implements RedisService {

--- a/test-infra/camel-test-infra-solr/src/main/java/org/apache/camel/test/infra/solr/services/SolrServiceFactory.java
+++ b/test-infra/camel-test-infra-solr/src/main/java/org/apache/camel/test/infra/solr/services/SolrServiceFactory.java
@@ -17,8 +17,26 @@
 package org.apache.camel.test.infra.solr.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class SolrServiceFactory {
+
+    private static class SingletonSolrService extends SingletonService<SolrService> implements SolrService {
+        public SingletonSolrService(SolrService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public int getPort() {
+            return getService().getPort();
+        }
+
+        @Override
+        public String getSolrHost() {
+            return getService().getSolrHost();
+        }
+    }
+
     private SolrServiceFactory() {
 
     }
@@ -32,6 +50,21 @@ public final class SolrServiceFactory {
                 .addLocalMapping(SolrLocalContainerService::new)
                 .addRemoteMapping(SolrRemoteService::new)
                 .build();
+    }
+
+    public static SolrService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final SolrService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<SolrService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonSolrService(new SolrLocalContainerService(), SolrContainer.CONTAINER_NAME))
+                    .addRemoteMapping(SolrRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class SolrRemoteService extends SolrRemoteInfraService implements SolrService {

--- a/test-infra/camel-test-infra-tensorflow-serving/src/main/java/org/apache/camel/test/infra/tensorflow/serving/services/TensorFlowServingServiceFactory.java
+++ b/test-infra/camel-test-infra-tensorflow-serving/src/main/java/org/apache/camel/test/infra/tensorflow/serving/services/TensorFlowServingServiceFactory.java
@@ -17,8 +17,27 @@
 package org.apache.camel.test.infra.tensorflow.serving.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class TensorFlowServingServiceFactory {
+
+    private static class SingletonTensorFlowServingService extends SingletonService<TensorFlowServingService>
+            implements TensorFlowServingService {
+        public SingletonTensorFlowServingService(TensorFlowServingService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public int grpcPort() {
+            return getService().grpcPort();
+        }
+
+        @Override
+        public int restPort() {
+            return getService().restPort();
+        }
+    }
+
     private TensorFlowServingServiceFactory() {
     }
 
@@ -31,5 +50,22 @@ public final class TensorFlowServingServiceFactory {
                 .addLocalMapping(TensorFlowServingLocalContainerService::new)
                 .addRemoteMapping(TensorFlowServingRemoteService::new)
                 .build();
+    }
+
+    public static TensorFlowServingService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final TensorFlowServingService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<TensorFlowServingService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonTensorFlowServingService(
+                            new TensorFlowServingLocalContainerService(),
+                            "tensorflow-serving"))
+                    .addRemoteMapping(TensorFlowServingRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 }

--- a/test-infra/camel-test-infra-triton/src/main/java/org/apache/camel/test/infra/triton/services/TritonServiceFactory.java
+++ b/test-infra/camel-test-infra-triton/src/main/java/org/apache/camel/test/infra/triton/services/TritonServiceFactory.java
@@ -17,8 +17,31 @@
 package org.apache.camel.test.infra.triton.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class TritonServiceFactory {
+
+    private static class SingletonTritonService extends SingletonService<TritonService> implements TritonService {
+        public SingletonTritonService(TritonService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public int httpPort() {
+            return getService().httpPort();
+        }
+
+        @Override
+        public int grpcPort() {
+            return getService().grpcPort();
+        }
+
+        @Override
+        public int metricsPort() {
+            return getService().metricsPort();
+        }
+    }
+
     private TritonServiceFactory() {
     }
 
@@ -31,6 +54,21 @@ public final class TritonServiceFactory {
                 .addLocalMapping(TritonLocalContainerService::new)
                 .addRemoteMapping(TritonRemoteService::new)
                 .build();
+    }
+
+    public static TritonService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final TritonService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<TritonService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonTritonService(new TritonLocalContainerService(), "triton"))
+                    .addRemoteMapping(TritonRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class TritonLocalContainerService extends TritonLocalContainerInfraService

--- a/test-infra/camel-test-infra-xmpp/src/main/java/org/apache/camel/test/infra/xmpp/services/XmppServiceFactory.java
+++ b/test-infra/camel-test-infra-xmpp/src/main/java/org/apache/camel/test/infra/xmpp/services/XmppServiceFactory.java
@@ -17,8 +17,31 @@
 package org.apache.camel.test.infra.xmpp.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
+import org.apache.camel.test.infra.common.services.SingletonService;
 
 public final class XmppServiceFactory {
+
+    private static class SingletonXmppService extends SingletonService<XmppService> implements XmppService {
+        public SingletonXmppService(XmppService service, String name) {
+            super(service, name);
+        }
+
+        @Override
+        public String host() {
+            return getService().host();
+        }
+
+        @Override
+        public int port() {
+            return getService().port();
+        }
+
+        @Override
+        public String getUrl() {
+            return getService().getUrl();
+        }
+    }
+
     private XmppServiceFactory() {
 
     }
@@ -32,6 +55,21 @@ public final class XmppServiceFactory {
                 .addLocalMapping(XmppLocalContainerService::new)
                 .addRemoteMapping(XmppRemoteService::new)
                 .build();
+    }
+
+    public static XmppService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final XmppService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<XmppService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonXmppService(new XmppLocalContainerService(), "xmpp"))
+                    .addRemoteMapping(XmppRemoteService::new);
+            INSTANCE = instance.build();
+        }
     }
 
     public static class XmppLocalContainerService extends XmppLocalContainerInfraService implements XmppService {

--- a/test-infra/camel-test-infra-zookeeper/src/main/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperServiceFactory.java
+++ b/test-infra/camel-test-infra-zookeeper/src/main/java/org/apache/camel/test/infra/zookeeper/services/ZooKeeperServiceFactory.java
@@ -47,6 +47,21 @@ public final class ZooKeeperServiceFactory {
                 .addRemoteMapping(ZooKeeperRemoteService::new)
                 .build();
     }
+
+    public static ZooKeeperService createSingletonService() {
+        return SingletonServiceHolder.INSTANCE;
+    }
+
+    private static class SingletonServiceHolder {
+        static final ZooKeeperService INSTANCE;
+        static {
+            SimpleTestServiceBuilder<ZooKeeperService> instance = builder();
+            instance.addLocalMapping(
+                    () -> new SingletonZooKeeperService(new ZooKeeperLocalContainerService(), "zookeeper"))
+                    .addRemoteMapping(ZooKeeperRemoteService::new);
+            INSTANCE = instance.build();
+        }
+    }
 }
 
 class ZooKeeperLocalContainerService extends ZooKeeperLocalContainerInfraService


### PR DESCRIPTION
## Summary

Add `createSingletonService()` to 32 test-infra service factories and migrate all integration tests to use them. This ensures each Testcontainers service is started only once per JVM, enabling parallel test execution via mvnd without container conflicts.

### Commit 1: Add createSingletonService() to 32 test-infra service factories
- Add a `createSingletonService()` method to all test-infra service factories, returning a JVM-wide singleton backed by `SingletonService` with lazy initialization (holder idiom) and JVM shutdown hook cleanup
- Each factory's singleton wrapper delegates all service-specific interface methods to the underlying instance
- Change `SingletonService.shutdown()` from throwing `IllegalArgumentException` to a debug-level no-op, since JUnit's `@RegisterExtension` lifecycle calls `shutdown()` after each test class

### Commit 2: Migrate all test classes from createService() to createSingletonService()
- Switch all integration test classes to use the new singleton service factories
- Test isolation fixes for shared singleton instances:
  - ZooKeeper `ConsumeDataIT`: use `deleteAll()` instead of `delete()` to handle nodes with children
  - Google PubSub: catch `AlreadyExistsException` for topics/subscriptions in shared emulator
  - Hashicorp Vault: use per-class `secretPath()` to avoid data collisions
  - Consul `ConsulHealthIT`: use `@RegisterExtension` instead of manual lifecycle
  - Google PubSub ITs: use unique topic/subscription names per test class

## Test plan
- [x] CI passes with all tests using singleton services
- [ ] Verify no test isolation issues in parallel execution (mvnd)