### PR TITLE
CAMEL-23253: Increase Infinispan Hot Rod client and test timeouts

### DIFF
--- a/components/camel-ai/camel-langchain4j-embeddings/src/test/java/org/apache/camel/component/langchain4j/embeddings/LangChain4jEmbeddingsComponentInfinispanTargetIT.java
+++ b/components/camel-ai/camel-langchain4j-embeddings/src/test/java/org/apache/camel/component/langchain4j/embeddings/LangChain4jEmbeddingsComponentInfinispanTargetIT.java
@@ -206,7 +206,7 @@ public class LangChain4jEmbeddingsComponentInfinispanTargetIT extends CamelTestS
         if (cacheContainer == null) {
             cacheContainer = getCacheContainer();
             final IterationBoundedBudget budget
-                    = Budgets.iterationBudget().withInterval(Duration.ofSeconds(1)).withMaxIterations(10).build();
+                    = Budgets.iterationBudget().withInterval(Duration.ofSeconds(1)).withMaxIterations(30).build();
             final ForegroundTask task = Tasks.foregroundTask()
                     .withBudget(budget).build();
 
@@ -226,6 +226,9 @@ public class LangChain4jEmbeddingsComponentInfinispanTargetIT extends CamelTestS
     private boolean createCache() {
         try {
             getOrCreateCache();
+            // Verify protobuf metadata cache is accessible to avoid
+            // IllegalLifecycleStateException during route startup
+            cacheContainer.getCache("___protobuf_metadata");
             return true;
         } catch (Exception e) {
             return false;

--- a/components/camel-ai/camel-langchain4j-embeddings/src/test/java/org/apache/camel/component/langchain4j/embeddings/LangChain4jEmbeddingsComponentInfinispanTargetIT.java
+++ b/components/camel-ai/camel-langchain4j-embeddings/src/test/java/org/apache/camel/component/langchain4j/embeddings/LangChain4jEmbeddingsComponentInfinispanTargetIT.java
@@ -252,7 +252,10 @@ public class LangChain4jEmbeddingsComponentInfinispanTargetIT extends CamelTestS
                 .host(service.host())
                 .port(service.port());
 
-        clientBuilder.security()
+        clientBuilder
+                .socketTimeout(15000)
+                .connectionTimeout(15000)
+                .security()
                 .authentication()
                 .username(service.username())
                 .password(service.password())

--- a/components/camel-ai/camel-langchain4j-embeddings/src/test/java/org/apache/camel/component/langchain4j/embeddings/LangChain4jEmbeddingsComponentInfinispanTargetIT.java
+++ b/components/camel-ai/camel-langchain4j-embeddings/src/test/java/org/apache/camel/component/langchain4j/embeddings/LangChain4jEmbeddingsComponentInfinispanTargetIT.java
@@ -227,7 +227,7 @@ public class LangChain4jEmbeddingsComponentInfinispanTargetIT extends CamelTestS
         try {
             getOrCreateCache();
             // Verify protobuf metadata cache is accessible to avoid
-            // IllegalLifecycleStateException during route startup
+            // IllegalLifecycleStateException during route startup (CAMEL-23307)
             cacheContainer.getCache("___protobuf_metadata");
             return true;
         } catch (Exception e) {

--- a/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteConfigurationIT.java
+++ b/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteConfigurationIT.java
@@ -49,7 +49,7 @@ public class InfinispanRemoteConfigurationIT {
         try (CamelContext context = new DefaultCamelContext();
              InfinispanRemoteManager manager = new InfinispanRemoteManager(context, configuration)) {
             manager.start();
-            InfinispanRemoteTestSupport.waitForCacheReady(manager.getCacheContainer(), "misc_cache", 5000);
+            InfinispanRemoteTestSupport.waitForCacheReady(manager.getCacheContainer(), "misc_cache", 30000);
 
             BasicCache<Object, Object> cache = manager.getCache("misc_cache");
             assertNotNull(cache);
@@ -91,7 +91,7 @@ public class InfinispanRemoteConfigurationIT {
         try (CamelContext context = new DefaultCamelContext();
              InfinispanRemoteManager manager = new InfinispanRemoteManager(context, configuration)) {
             manager.start();
-            InfinispanRemoteTestSupport.waitForCacheReady(manager.getCacheContainer(), "misc_cache", 5000);
+            InfinispanRemoteTestSupport.waitForCacheReady(manager.getCacheContainer(), "misc_cache", 30000);
 
             BasicCache<Object, Object> cache = manager.getCache("misc_cache");
             assertNotNull(cache);

--- a/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteTestSupport.java
+++ b/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteTestSupport.java
@@ -121,6 +121,8 @@ public class InfinispanRemoteTestSupport extends InfinispanTestSupport {
 
         // add security info
         clientBuilder
+                .socketTimeout(15000)
+                .connectionTimeout(15000)
                 .security()
                 .authentication()
                 .username(service.username())

--- a/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/cluster/InfinispanRemoteClusteredViewIT.java
+++ b/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/cluster/InfinispanRemoteClusteredViewIT.java
@@ -45,7 +45,7 @@ public class InfinispanRemoteClusteredViewIT {
         Configuration configuration = createConfiguration(service);
 
         try (RemoteCacheManager cacheContainer = new RemoteCacheManager(configuration)) {
-            InfinispanRemoteTestSupport.waitForCacheReady(cacheContainer, viewName, 5000);
+            InfinispanRemoteTestSupport.waitForCacheReady(cacheContainer, viewName, 30000);
 
             InfinispanRemoteClusterService clusterService = new InfinispanRemoteClusterService();
             clusterService.setCacheContainer(cacheContainer);

--- a/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/spring/SpringInfinispanRemoteIdempotentRepositoryTestSupport.java
+++ b/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/spring/SpringInfinispanRemoteIdempotentRepositoryTestSupport.java
@@ -66,7 +66,7 @@ public abstract class SpringInfinispanRemoteIdempotentRepositoryTestSupport exte
 
         RemoteCacheManager manager = new RemoteCacheManager(clientBuilder.create());
         MarshallerRegistration.init(MarshallerUtil.getSerializationContext(manager));
-        InfinispanRemoteTestSupport.waitForCacheReady(manager, "idempotent", 5000);
+        InfinispanRemoteTestSupport.waitForCacheReady(manager, "idempotent", 30000);
         RemoteCache<Object, Object> cache = manager.administration().getOrCreateCache("idempotent", (String) null);
         assertNotNull(cache);
     }


### PR DESCRIPTION
[CAMEL-23253](https://issues.apache.org/jira/browse/CAMEL-23253)

## Summary

- Increase Hot Rod client `socketTimeout` and `connectionTimeout` from the default 2000ms to 15000ms in `LangChain4jEmbeddingsComponentInfinispanTargetIT` and `InfinispanRemoteTestSupport`
- Increase `waitForCacheReady` Awaitility timeout from 5s to 30s in all callers — the previous 5-second budget was too short when connection timeouts are 15 seconds, as a single failed attempt could exhaust the entire wait
- Increase retry budget from 10 to 30 iterations in `LangChain4jEmbeddingsComponentInfinispanTargetIT.setupResources()`
- Wait for `___protobuf_metadata` internal cache readiness during test setup — workaround for [CAMEL-23307](https://issues.apache.org/jira/browse/CAMEL-23307) where the component retry logic does not catch `HotRodClientException` wrapping `IllegalLifecycleStateException`

## Test plan

- [x] Both modules compile successfully
- [x] CI passes on JDK 17, 21, and 25 (run 3)
- [ ] CI passes after final cleanup (run 4)