### PR TITLE
ci: fix incremental build exclusion conflict with primary modules

### DIFF
--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -54,6 +54,38 @@ findProjectRoot() {
   echo "$path"
 }
 
+# Remove exclusion entries that conflict with explicitly included modules.
+# When -amd pulls in dependents, the EXCLUSION_LIST prevents testing generated/meta
+# modules.  But when those modules are the *primary* changed modules, excluding them
+# cancels them out of the reactor and breaks the build.
+filterExclusions() {
+  local build_pl="$1"
+  local exclusions="$2"
+
+  # Collect artifact IDs from build_pl (path → basename, :id → id)
+  local included_ids=","
+  for mod in $(echo "$build_pl" | tr ',' '\n'); do
+    if [[ "$mod" == :* ]]; then
+      included_ids="${included_ids}${mod#:},"
+    else
+      included_ids="${included_ids}$(basename "$mod"),"
+    fi
+  done
+
+  # Keep only exclusions whose artifact ID is not in the included set
+  local result=""
+  for excl in $(echo "$exclusions" | tr ',' '\n'); do
+    local excl_id="${excl#!:}"
+    if [[ "$included_ids" == *",${excl_id},"* ]]; then
+      echo "  Removing exclusion ${excl} (conflicts with explicitly included module)" >&2
+    else
+      result="${result:+${result},}${excl}"
+    fi
+  done
+
+  echo "$result"
+}
+
 # Check whether a PR label exists
 hasLabel() {
   local issueNumber=${1}
@@ -215,7 +247,7 @@ runScalpelDetection() {
   # - fullBuildTriggers="": override .mvn/** default (Scalpel lives in .mvn/extensions.xml)
   # - alsoMake/alsoMakeDependents=false: we only want directly affected modules
   #   (our script handles -amd expansion separately)
-  local scalpel_args="-Dscalpel.mode=report -Dscalpel.fullBuildTriggers= -Dscalpel.alsoMake=false -Dscalpel.alsoMakeDependents=false"
+  local scalpel_args="-Dscalpel.enabled=true -Dscalpel.mode=report -Dscalpel.fullBuildTriggers= -Dscalpel.alsoMake=false -Dscalpel.alsoMakeDependents=false"
   # For workflow_dispatch, GITHUB_BASE_REF may not be set
   if [ -z "${GITHUB_BASE_REF:-}" ]; then
     scalpel_args="$scalpel_args -Dscalpel.baseBranch=origin/main"
@@ -665,7 +697,13 @@ main() {
   # Exclusion list is only needed with -amd (to prevent testing generated/meta modules);
   # without -amd, only the explicitly listed modules are built.
   if [[ "$use_amd" = true ]]; then
-    $mavenBinary -l "$log" $MVND_OPTS install -pl "${build_pl},${EXCLUSION_LIST}" -amd || ret=$?
+    local filtered_exclusions
+    filtered_exclusions=$(filterExclusions "$build_pl" "$EXCLUSION_LIST")
+    local build_pl_with_exclusions="$build_pl"
+    if [ -n "$filtered_exclusions" ]; then
+      build_pl_with_exclusions="${build_pl},${filtered_exclusions}"
+    fi
+    $mavenBinary -l "$log" $MVND_OPTS install -pl "$build_pl_with_exclusions" -amd || ret=$?
   else
     $mavenBinary -l "$log" $MVND_OPTS install -pl "$build_pl" || ret=$?
   fi

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -23,6 +23,6 @@
     <extension>
         <groupId>eu.maveniverse.maven.scalpel</groupId>
         <artifactId>extension3</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0</version>
     </extension>
 </extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Daether.remoteRepositoryFilter.groupId=true
 -Daether.remoteRepositoryFilter.groupId.basedir=${session.rootDirectory}/.mvn/rrf/
+-Dscalpel.enabled=false


### PR DESCRIPTION
## Summary

Fix two interacting bugs in `incremental-build.sh` that cause the incremental test build to fail when a PR changes modules listed in the `EXCLUSION_LIST` (e.g. `camel-yaml-dsl`, `docs`).

### Bug 1: Include/exclude conflict
When Maven resolves a path like `-pl dsl/camel-yaml-dsl/camel-yaml-dsl`, it maps it to artifact ID `camel-yaml-dsl`. The exclusion `!:camel-yaml-dsl` in the `EXCLUSION_LIST` then removes it from the reactor — the module is both included and excluded.

**Fix:** Add `filterExclusions()` to remove exclusion entries that conflict with explicitly included modules.

### Bug 2: Scalpel reactor trimming
Scalpel (Maven extension in `.mvn/extensions.xml`) defaults to `trim` mode, which removes modules from the reactor that the `EXCLUSION_LIST` references (e.g. `camel-allcomponents`), causing `Could not find the selected project in the reactor` errors. Previously this didn't surface because Scalpel couldn't find the merge base in the shallow CI clone.

**Fix:** Upgrade Scalpel from 0.1.0 to 0.2.0. Disable Scalpel by default in `.mvn/maven.config` (`-Dscalpel.enabled=false`) and explicitly enable it only in the `runScalpelDetection` step (`-Dscalpel.enabled=true`).

**Introduced in:** ba3dd16f36e6 (#22247, March 27 2026).

## Changes

- `.github/actions/incremental-build/incremental-build.sh`: add `filterExclusions()`, use it before `-amd` build, pass `-Dscalpel.enabled=true` in detection step
- `.mvn/extensions.xml`: upgrade Scalpel 0.1.0 → 0.2.0
- `.mvn/maven.config`: add `-Dscalpel.enabled=false` (disabled by default)

## Test plan

- [x] Tested `filterExclusions()` locally with multiple scenarios (path-style, artifact-style, no conflicts, all conflicts)
- [x] CI validation with pre-resolve approach passed: [run 24227903849](https://github.com/apache/camel/actions/runs/24227903849) — all 3 JDKs green
- [ ] CI validation with `scalpel.enabled=false` approach (this push)