### PR TITLE
CAMEL-23306: Add missing sample-placeholder route to Spring XML test config

### DIFF
--- a/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringSamplingThrottlerTest.java
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringSamplingThrottlerTest.java
@@ -48,6 +48,11 @@ public class SpringSamplingThrottlerTest extends SamplingThrottlerTest {
     }
 
     @Override
+    public void testSamplingWithPropertyPlaceholder() throws Exception {
+        super.testSamplingWithPropertyPlaceholder();
+    }
+
+    @Override
     public void testSamplingUsingMessageFrequency() throws Exception {
         super.testSamplingUsingMessageFrequency();
     }

--- a/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/processor/samplingThrottler.xml
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/processor/samplingThrottler.xml
@@ -41,6 +41,11 @@
             <sample messageFrequency="5"/>
             <to uri="mock:result"/>
         </route>
+        <route>
+            <from uri="direct:sample-placeholder"/>
+            <sample samplePeriod="{{sample.period}}"/>
+            <to uri="mock:result"/>
+        </route>
         <!-- END SNIPPET: e1 -->
 
     </camelContext>


### PR DESCRIPTION
[CAMEL-23306](https://issues.apache.org/jira/browse/CAMEL-23306)

## Summary

- Add the missing `direct:sample-placeholder` route with property placeholder to `samplingThrottler.xml`
- Add `testSamplingWithPropertyPlaceholder()` override in `SpringSamplingThrottlerTest`

The parent test `SamplingThrottlerTest` added `testSamplingWithPropertyPlaceholder()` and its corresponding route in commit 06629602fe6a (CAMEL-23279), but the Spring XML config and Spring test subclass were not updated, causing the inherited test to always fail with a 30-second timeout.

_Claude Code on behalf of Guillaume Nodet_