### PR TITLE
CAMEL-23307: Handle HotRodClientException wrapping IllegalLifecycleStateException in schema registration retry

### DIFF
--- a/components/camel-infinispan/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteManager.java
+++ b/components/camel-infinispan/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteManager.java
@@ -33,7 +33,7 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
-import org.infinispan.client.hotrod.exceptions.RemoteIllegalLifecycleStateException;
+import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.commons.api.BasicCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,7 +143,8 @@ public class InfinispanRemoteManager extends ServiceSupport implements Infinispa
     /**
      * Registers the embedding store schema with retry logic to handle the case where Camel and the remote Infinispan
      * server start up concurrently (e.g., in Kubernetes). The server's internal {@code ___protobuf_metadata} cache may
-     * not be ready yet, causing a {@link RemoteIllegalLifecycleStateException}.
+     * not be ready yet, causing either a {@code RemoteIllegalLifecycleStateException} or a generic
+     * {@link HotRodClientException} wrapping an {@code IllegalLifecycleStateException} in its message.
      */
     private void registerSchemaWithRetry() throws Exception {
         Duration timeout = configuration.getEmbeddingStoreSchemaRegistrationTimeout();
@@ -160,7 +161,10 @@ public class InfinispanRemoteManager extends ServiceSupport implements Infinispa
             try {
                 EmbeddingStoreUtil.registerSchema(configuration, cacheContainer);
                 return true;
-            } catch (RemoteIllegalLifecycleStateException e) {
+            } catch (HotRodClientException e) {
+                if (!isIllegalLifecycleStateException(e)) {
+                    throw e;
+                }
                 if (firstAttempt[0]) {
                     firstAttempt[0] = false;
                     LOG.info("Infinispan server not ready for schema registration, will retry for up to {}: {}",
@@ -177,6 +181,22 @@ public class InfinispanRemoteManager extends ServiceSupport implements Infinispa
                     "Failed to register Infinispan schema after " + timeout
                                             + " of retries. The server may not be fully started.");
         }
+    }
+
+    private static boolean isIllegalLifecycleStateException(HotRodClientException e) {
+        if (e.getClass().getSimpleName().contains("IllegalLifecycleStateException")) {
+            return true;
+        }
+        String message = e.getMessage();
+        if (message != null && message.contains("IllegalLifecycleStateException")) {
+            return true;
+        }
+        for (Throwable cause = e.getCause(); cause != null; cause = cause.getCause()) {
+            if (cause.getClass().getSimpleName().contains("IllegalLifecycleStateException")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteSchemaRegistrationRetryTest.java
+++ b/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteSchemaRegistrationRetryTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.camel.support.task.ForegroundTask;
 import org.apache.camel.support.task.Tasks;
 import org.apache.camel.support.task.budget.Budgets;
+import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.client.hotrod.exceptions.RemoteIllegalLifecycleStateException;
 import org.junit.jupiter.api.Test;
 
@@ -59,7 +60,48 @@ class InfinispanRemoteSchemaRegistrationRetryTest {
                     throw new RemoteIllegalLifecycleStateException("Server not ready", 0, (short) 0, null);
                 }
                 return true;
-            } catch (RemoteIllegalLifecycleStateException e) {
+            } catch (HotRodClientException e) {
+                if (!isIllegalLifecycleStateException(e)) {
+                    throw e;
+                }
+                return false;
+            }
+        });
+
+        assertTrue(registered);
+        assertEquals(failCount + 1, attempts.get());
+    }
+
+    /**
+     * Simulates the retry pattern when the server wraps the lifecycle error in a generic {@link HotRodClientException}
+     * with {@code IllegalLifecycleStateException} in the message text (status=0x85).
+     */
+    @Test
+    void retrySucceedsAfterWrappedLifecycleFailures() {
+        AtomicInteger attempts = new AtomicInteger();
+        int failCount = 2;
+
+        ForegroundTask task = Tasks.foregroundTask()
+                .withName("infinispan-schema-registration")
+                .withBudget(Budgets.iterationTimeBudget()
+                        .withInterval(Duration.ofMillis(50))
+                        .withMaxDuration(Duration.ofSeconds(5))
+                        .build())
+                .build();
+
+        boolean registered = task.run(null, () -> {
+            try {
+                if (attempts.incrementAndGet() <= failCount) {
+                    throw new HotRodClientException(
+                            "Request for messageId=5 returned server error (status=0x85): "
+                                                    + "org.infinispan.commons.IllegalLifecycleStateException: "
+                                                    + "ISPN005066: Cache '___protobuf_metadata' is not ready");
+                }
+                return true;
+            } catch (HotRodClientException e) {
+                if (!isIllegalLifecycleStateException(e)) {
+                    throw e;
+                }
                 return false;
             }
         });
@@ -81,12 +123,44 @@ class InfinispanRemoteSchemaRegistrationRetryTest {
         boolean registered = task.run(null, () -> {
             try {
                 throw new RemoteIllegalLifecycleStateException("Server not ready", 0, (short) 0, null);
-            } catch (RemoteIllegalLifecycleStateException e) {
+            } catch (HotRodClientException e) {
+                if (!isIllegalLifecycleStateException(e)) {
+                    throw e;
+                }
                 return false;
             }
         });
 
         assertFalse(registered);
+    }
+
+    @Test
+    void nonLifecycleHotRodExceptionPropagatesImmediately() {
+        AtomicInteger attempts = new AtomicInteger();
+
+        ForegroundTask task = Tasks.foregroundTask()
+                .withName("infinispan-schema-registration")
+                .withBudget(Budgets.iterationTimeBudget()
+                        .withInterval(Duration.ofMillis(50))
+                        .withMaxDuration(Duration.ofSeconds(5))
+                        .build())
+                .build();
+
+        assertThrows(HotRodClientException.class, () -> {
+            task.run(null, () -> {
+                try {
+                    attempts.incrementAndGet();
+                    throw new HotRodClientException("Authentication failure");
+                } catch (HotRodClientException e) {
+                    if (!isIllegalLifecycleStateException(e)) {
+                        throw e;
+                    }
+                    return false;
+                }
+            });
+        });
+
+        assertEquals(1, attempts.get());
     }
 
     @Test
@@ -109,5 +183,25 @@ class InfinispanRemoteSchemaRegistrationRetryTest {
         });
 
         assertEquals(1, attempts.get());
+    }
+
+    /**
+     * Mirrors the logic in {@link InfinispanRemoteManager} to check whether a {@link HotRodClientException} is caused
+     * by an {@code IllegalLifecycleStateException}.
+     */
+    private static boolean isIllegalLifecycleStateException(HotRodClientException e) {
+        if (e.getClass().getSimpleName().contains("IllegalLifecycleStateException")) {
+            return true;
+        }
+        String message = e.getMessage();
+        if (message != null && message.contains("IllegalLifecycleStateException")) {
+            return true;
+        }
+        for (Throwable cause = e.getCause(); cause != null; cause = cause.getCause()) {
+            if (cause.getClass().getSimpleName().contains("IllegalLifecycleStateException")) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
[CAMEL-23307](https://issues.apache.org/jira/browse/CAMEL-23307)

## Summary

The retry logic added in CAMEL-23255 catches `RemoteIllegalLifecycleStateException`, which works when Infinispan throws that specific subclass. However, there is a second code path in the Hot Rod client where the server returns a generic error (status `0x85`) and the client wraps it as a plain `HotRodClientException` with `IllegalLifecycleStateException` only in the message text — not as the exception type itself:

```
org.infinispan.client.hotrod.exceptions.HotRodClientException:
Request for messageId=5 returned server error (status=0x85):
org.infinispan.commons.IllegalLifecycleStateException:
ISPN005066: Cache '___protobuf_metadata' is not ready
```

This PR **broadens** the catch from `RemoteIllegalLifecycleStateException` to its parent `HotRodClientException`, and adds a guard (`isIllegalLifecycleStateException()`) that checks the exception class name, message text, and cause chain. Non-lifecycle `HotRodClientException`s (e.g. auth failures) are still rethrown immediately.

## Changes

- Catch `HotRodClientException` instead of `RemoteIllegalLifecycleStateException` in `registerSchemaWithRetry()`
- Add `isIllegalLifecycleStateException()` helper to distinguish retryable lifecycle errors from other Hot Rod errors
- Add test for the wrapped `HotRodClientException` scenario and for verifying non-lifecycle exception propagation

## Test plan

- [x] Existing `retrySucceedsAfterTransientLifecycleFailures` passes with broadened catch
- [x] New `retrySucceedsAfterWrappedLifecycleFailures` verifies retry on generic `HotRodClientException` containing `IllegalLifecycleStateException` in the message
- [x] New `nonLifecycleHotRodExceptionPropagatesImmediately` verifies non-lifecycle `HotRodClientException` is not retried
- [x] `retryExhaustedWhenServerNeverBecomesReady` and `nonLifecycleExceptionPropagatesImmediately` continue to pass

_Claude Code on behalf of Guillaume Nodet_