### PR TITLE
CAMEL-23300: bypass Couchbase 8.0 CPU microarchitecture check

### DIFF
--- a/test-infra/camel-test-infra-couchbase/src/main/java/org/apache/camel/test/infra/couchbase/services/CouchbaseLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-couchbase/src/main/java/org/apache/camel/test/infra/couchbase/services/CouchbaseLocalContainerInfraService.java
@@ -44,6 +44,10 @@ public class CouchbaseLocalContainerInfraService implements CouchbaseInfraServic
         public CustomCouchbaseContainer(String imageName) {
             super(DockerImageName.parse(imageName).asCompatibleSubstituteFor("couchbase/server"));
 
+            // Couchbase 8.0+ validates CPU microarchitecture (requires x86-64-v3 / AVX2).
+            // CI agents may run on older hardware, causing the container to exit immediately.
+            withEnv("COUCHBASE_DO_NOT_VALIDATE_CPU_MICROARCHITECTURE", "1");
+
             boolean fixedPort = ContainerEnvironmentUtil.isFixedPort(CouchbaseLocalContainerInfraService.class);
             final int kvPort = 11210;
             final int managementPort = 8091;


### PR DESCRIPTION
## Summary

- Couchbase Server 8.0 added a startup validation (`validate-cpu-microarchitecture.sh`) that requires **x86-64-v3** CPUs (AVX2, BMI2, FMA, etc.). CI agents running on older hardware (x86-64-v2) cause the container to `exit(1)` after ~2 seconds, before the management API even starts.
- This has broken the **camel-kafka-connector Daily** build since build #345 (8 consecutive failures), with `ContainerLaunchException: Container startup failed`.
- The fix sets `COUCHBASE_DO_NOT_VALIDATE_CPU_MICROARCHITECTURE=1` — an official bypass env var provided by the Couchbase 8.0 entrypoint script — on the test container.

## Test plan

- [ ] Verify camel-kafka-connector Daily build #353+ passes the `CamelSinkCouchbaseITCase` test
- [ ] Verify camel core couchbase integration tests still pass

_Claude Code on behalf of Federico Mariani_