### PR TITLE
CAMEL-23309: Camel-Jbang: Upgrade to Camel-Kamelets 4.18.1

### DIFF
--- a/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
@@ -21,7 +21,7 @@
 //REPOS central=https://repo1.maven.org/maven2,apache-snapshot=https://repository.apache.org/content/groups/snapshots/
 //DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.18.0}@pom
 //DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.18.0}
-//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.18.0}
+//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.18.1}
 
 package main;
 

--- a/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
@@ -19,8 +19,8 @@
 
 //JAVA 17+
 //REPOS central=https://repo1.maven.org/maven2,apache-snapshot=https://repository.apache.org/content/groups/snapshots/
-//DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.18.0}@pom
-//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.18.0}
+//DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.18.1}@pom
+//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.18.1}
 //DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.18.1}
 
 package main;

--- a/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
@@ -21,7 +21,7 @@
 //REPOS central=https://repo1.maven.org/maven2,apache-snapshot=https://repository.apache.org/content/groups/snapshots/
 //DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.18.0}@pom
 //DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.18.0}
-//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.18.0}
+//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.18.1}
 
 package main;
 

--- a/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
@@ -19,8 +19,8 @@
 
 //JAVA 17+
 //REPOS central=https://repo1.maven.org/maven2,apache-snapshot=https://repository.apache.org/content/groups/snapshots/
-//DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.18.0}@pom
-//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.18.0}
+//DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.18.1}@pom
+//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.18.1}
 //DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.18.1}
 
 package main;

--- a/dsl/camel-jbang/camel-launcher/pom.xml
+++ b/dsl/camel-jbang/camel-launcher/pom.xml
@@ -41,7 +41,7 @@
         <camel-prepare-component>false</camel-prepare-component>
 
         <!-- Dependency versions -->
-        <camel-kamelets-version>4.18.0</camel-kamelets-version>
+        <camel-kamelets-version>4.18.1</camel-kamelets-version>
         <maven-version>3.9.12</maven-version>
         <maven-resolver-version>1.9.25</maven-resolver-version>
         <plexus-interpolation-version>1.29</plexus-interpolation-version>


### PR DESCRIPTION
## Summary

Upgrades `camel-kamelets` and `camel.jbang.version` fallbacks from 4.18.0 to 4.18.1 in `camel-jbang` on the `camel-4.18.x` branch. Picks up the latest patch releases on the 4.18.x line.

Jira: [CAMEL-23309](https://issues.apache.org/jira/browse/CAMEL-23309)

## Changes

- `dsl/camel-jbang/camel-launcher/pom.xml` — bumps `camel-kamelets-version` 4.18.0 → 4.18.1
- `dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java` — bumps `camel-bom`, `camel-jbang-core` and `camel-kamelets` `//DEPS` fallbacks 4.18.0 → 4.18.1
- `dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java` — same

The `CAMEL_VERSION` in `dsl/camel-jbang/camel-jbang-container/Dockerfile` and `camel-kamelets-catalog-version` in `parent/pom.xml` are intentionally **not** touched — the Dockerfile Camel version is managed separately during release cuts, and the JBang kamelets catalog artifact is a separate dependency that should be handled in its own task.

This mirrors the pattern used in `CAMEL-23055` ("Camel-Jbang: Upgrade to Camel-Kamelets 4.18.0"), scoped to the 4.18.1 bits.

## Verification

- `camel-kamelets:4.18.1` confirmed available on Maven Central.
- Full `dsl/camel-jbang/camel-launcher` build chain compiles clean with the new version (`mvn -DskipTests install` from root, 242 modules, BUILD SUCCESS).
- `camel-launcher` unit test passes:
  ```
  Running org.apache.camel.dsl.jbang.launcher.CamelLauncherTest
  Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
  ```

## Review feedback

- @davsclaus suggested bumping the other `//DEPS` lines (`camel-bom`, `camel-jbang-core`) to 4.18.1 as well — addressed in commit `d698c1c`.

## Test plan

- [ ] CI build passes on `camel-4.18.x`
- [ ] `camel-launcher` shaded jar builds with the new kamelets + jbang versions

---

_Claude Code on behalf of Andrea Cosentino_