### PR TITLE
Add exclude to prevent javax.xml.bind:jaxb-api:jar:2.3.0-b161121.1438 from dependency tree

### DIFF
--- a/components/camel-debezium/camel-debezium-oracle/pom.xml
+++ b/components/camel-debezium/camel-debezium-oracle/pom.xml
@@ -48,6 +48,15 @@
                     <groupId>org.lz4</groupId>
                     <artifactId>lz4-java</artifactId>
                 </exclusion>
+                <!-- ehcache:3.11.1 declares version range [2.2,3) for jaxb-runtime,
+                     resolved to pre-release 2.3.0-b170127.1453 which pulls jaxb-api
+                     from defunct HTTP-only repos (maven.java.net), blocked since
+                     Maven 3.8.1+. Not needed at runtime on Java 11+.
+                     See: https://github.com/ehcache/ehcache3/issues/3215 -->
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
Add exclude to prevent javax.xml.bind:jaxb-api:jar:2.3.0-b161121.1438… from entering dependency tree, see https://github.com/ehcache/ehcache3/issues/3215#event-24373237837 (#22546)

Cherry picked from main, intended for the 4.18.x LTS branch

# Target

- [x ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).


# Apache Camel coding standards and style

- [ x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

