### PR TITLE
(chores): fix SonarCloud S1871 duplicate branch violations

### DIFF
--- a/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/ModelPredictorProducer.java
+++ b/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/ModelPredictorProducer.java
@@ -195,11 +195,9 @@ public final class ModelPredictorProducer {
             return new CustomNlpPredictor<Classifications>(endpoint);
         } else if (WORD_EMBEDDING.getPath().equals(applicationPath)) {
             return new CustomWordEmbeddingPredictor(endpoint);
-        } else if (TEXT_GENERATION.getPath().equals(applicationPath)) {
-            return new CustomNlpPredictor<String>(endpoint);
-        } else if (MACHINE_TRANSLATION.getPath().equals(applicationPath)) {
-            return new CustomNlpPredictor<String>(endpoint);
-        } else if (MULTIPLE_CHOICE.getPath().equals(applicationPath)) {
+        } else if (TEXT_GENERATION.getPath().equals(applicationPath)
+                || MACHINE_TRANSLATION.getPath().equals(applicationPath)
+                || MULTIPLE_CHOICE.getPath().equals(applicationPath)) {
             return new CustomNlpPredictor<String>(endpoint);
         } else if (TEXT_EMBEDDING.getPath().equals(applicationPath)) {
             return new CustomNlpPredictor<NDArray>(endpoint);

--- a/components/camel-aws/camel-aws-xray/src/test/java/org/apache/camel/component/aws/xray/json/JsonParser.java
+++ b/components/camel-aws/camel-aws-xray/src/test/java/org/apache/camel/component/aws/xray/json/JsonParser.java
@@ -114,9 +114,8 @@ public final class JsonParser {
                     if ('"' == c && (curToken.isEmpty() || curToken.charAt(curToken.length() - 1) != '\\')) {
                         inWord = !inWord;
                     }
-                    if (!inWord && !doNotIncludeSymbols.contains(String.valueOf(c))) {
-                        curToken.append(c);
-                    } else if ('"' != c || (!curToken.isEmpty() && curToken.charAt(curToken.length() - 1) == '\\')) {
+                    if ((!inWord && !doNotIncludeSymbols.contains(String.valueOf(c)))
+                            || ('"' != c || (!curToken.isEmpty() && curToken.charAt(curToken.length() - 1) == '\\'))) {
                         curToken.append(c);
                     }
             }

--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -1096,11 +1096,7 @@ public class BeanInfo {
         Iterator<MethodInfo> it = methods.iterator();
         while (it.hasNext()) {
             MethodInfo info = it.next();
-            if (isGetter(info.getMethod())) {
-                // skip getters
-                it.remove();
-            } else if (isSetter(info.getMethod())) {
-                // skip setters
+            if (isGetter(info.getMethod()) || isSetter(info.getMethod())) {
                 it.remove();
             }
         }

--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/MethodsFilter.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/MethodsFilter.java
@@ -61,12 +61,8 @@ class MethodsFilter {
 
                 boolean registeredMethodIsPublic = Modifier.isPublic(alreadyRegistered.getDeclaringClass().getModifiers());
 
-                if (overridden && !registeredMethodIsPublic) {
-                    // Retain the overridden method from a public class
-                    methods.set(i, proposedMethod);
-                    return;
-                } else if (overridding) {
-                    // Retain the override from a public class
+                if ((overridden && !registeredMethodIsPublic) || overridding) {
+                    // Retain the overridden/overriding method from a public class
                     methods.set(i, proposedMethod);
                     return;
                 }

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyFixedLengthFactory.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyFixedLengthFactory.java
@@ -494,15 +494,12 @@ public class BindyFixedLengthFactory extends BindyAbstractFactory implements Bin
                                 padChar = padCharField;
                             }
 
-                            if (align.contains("R")) {
+                            if (align.contains("R") || align.contains("B")) {
                                 temp.append(generatePaddingChars(padChar, fieldLength, result.length()));
                                 temp.append(result);
                             } else if (align.contains("L")) {
                                 temp.append(result);
                                 temp.append(generatePaddingChars(padChar, fieldLength, result.length()));
-                            } else if (align.contains("B")) {
-                                temp.append(generatePaddingChars(padChar, fieldLength, result.length()));
-                                temp.append(result);
                             } else {
                                 throw new IllegalArgumentException(
                                         "Alignment for the field: " + field.getName()

--- a/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/feature/AbstractDataFormatFeature.java
+++ b/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/feature/AbstractDataFormatFeature.java
@@ -76,10 +76,7 @@ public abstract class AbstractDataFormatFeature extends AbstractFeature {
             List<Interceptor<? extends Message>> interceptors, Set<String> needToBeKept,
             PhaseInterceptor<? extends Message> p) {
         // To support the old API
-        if (needToBeKept == null) {
-            getLogger().info("removing the interceptor {}", p);
-            interceptors.remove(p);
-        } else if (!needToBeKept.contains(p.getClass().getName())) {
+        if (needToBeKept == null || !needToBeKept.contains(p.getClass().getName())) {
             getLogger().info("removing the interceptor {}", p);
             interceptors.remove(p);
         }

--- a/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/util/CxfUtilsTestHelper.java
+++ b/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/util/CxfUtilsTestHelper.java
@@ -103,10 +103,9 @@ public final class CxfUtilsTestHelper {
             } else {
                 if ("xmlns".equals(name) && attrPrefix.isEmpty()) {
                     writer.writeNamespace("", attr.getNodeValue());
-                    if (attr.getNodeValue().equals(ns)) {
-                        declareNamespace = false;
-                    } else if (StringUtils.isEmpty(attr.getNodeValue())
-                            && StringUtils.isEmpty(ns)) {
+                    if (attr.getNodeValue().equals(ns)
+                            || (StringUtils.isEmpty(attr.getNodeValue())
+                                    && StringUtils.isEmpty(ns))) {
                         declareNamespace = false;
                     }
                 } else {

--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/util/CxfUtilsTestHelper.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/util/CxfUtilsTestHelper.java
@@ -103,10 +103,9 @@ public final class CxfUtilsTestHelper {
             } else {
                 if ("xmlns".equals(name) && attrPrefix.isEmpty()) {
                     writer.writeNamespace("", attr.getNodeValue());
-                    if (attr.getNodeValue().equals(ns)) {
-                        declareNamespace = false;
-                    } else if (StringUtils.isEmpty(attr.getNodeValue())
-                            && StringUtils.isEmpty(ns)) {
+                    if (attr.getNodeValue().equals(ns)
+                            || (StringUtils.isEmpty(attr.getNodeValue())
+                                    && StringUtils.isEmpty(ns))) {
                         declareNamespace = false;
                     }
                 } else {

--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
@@ -675,22 +675,13 @@ public class HttpProducer extends DefaultProducer implements LineNumberAware {
     }
 
     private boolean isCreateNewURL(Exchange exchange) {
-        boolean create = false;
         Message in = exchange.getIn();
-        if (in.getHeader(HttpConstants.REST_HTTP_URI) != null) {
-            create = true;
-        } else if (in.getHeader(HttpConstants.HTTP_URI) != null && !getEndpoint().isBridgeEndpoint()) {
-            create = true;
-        } else if (in.getHeader(HttpConstants.HTTP_PATH) != null) {
-            create = true;
-        } else if (in.getHeader(HttpConstants.REST_HTTP_QUERY) != null) {
-            create = true;
-        } else if (in.getHeader(HttpConstants.HTTP_RAW_QUERY) != null) {
-            create = true;
-        } else if (in.getHeader(HttpConstants.HTTP_QUERY) != null) {
-            create = true;
-        }
-        return create;
+        return in.getHeader(HttpConstants.REST_HTTP_URI) != null
+                || (in.getHeader(HttpConstants.HTTP_URI) != null && !getEndpoint().isBridgeEndpoint())
+                || in.getHeader(HttpConstants.HTTP_PATH) != null
+                || in.getHeader(HttpConstants.REST_HTTP_QUERY) != null
+                || in.getHeader(HttpConstants.HTTP_RAW_QUERY) != null
+                || in.getHeader(HttpConstants.HTTP_QUERY) != null;
     }
 
     /**

--- a/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400PgmProducer.java
+++ b/components/camel-jt400/src/main/java/org/apache/camel/component/jt400/Jt400PgmProducer.java
@@ -128,20 +128,18 @@ public class Jt400PgmProducer extends DefaultProducer {
             if (input) {
                 if (param != null) {
                     AS400DataType typeConverter;
-                    if (param instanceof CharSequence) {
-                        param = param.toString();
-                        typeConverter = new AS400Text(length, iSeries);
-                    } else if (param instanceof char[]) {
-                        param = new String((char[]) param);
-                        typeConverter = new AS400Text(length, iSeries);
-                    } else if (param instanceof Integer) {
+                    if (param instanceof Integer) {
                         typeConverter = new AS400Bin4();
                     } else if (param instanceof Long) {
                         typeConverter = new AS400Bin8();
                     } else if (param instanceof byte[]) {
                         typeConverter = new AS400ByteArray(length);
                     } else {
-                        param = param.toString(); // must be a String for AS400Text class
+                        if (param instanceof char[]) {
+                            param = new String((char[]) param);
+                        } else {
+                            param = param.toString();
+                        }
                         typeConverter = new AS400Text(length, iSeries);
                     }
                     inputData = typeConverter.toBytes(param);

--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailBinding.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailBinding.java
@@ -917,14 +917,9 @@ public class MailBinding {
      * Is the given key a mime message recipient header (To, CC or BCC)
      */
     private static boolean isRecipientHeader(String key) {
-        if (Message.RecipientType.TO.toString().equalsIgnoreCase(key)) {
-            return true;
-        } else if (Message.RecipientType.CC.toString().equalsIgnoreCase(key)) {
-            return true;
-        } else if (Message.RecipientType.BCC.toString().equalsIgnoreCase(key)) {
-            return true;
-        }
-        return false;
+        return Message.RecipientType.TO.toString().equalsIgnoreCase(key)
+                || Message.RecipientType.CC.toString().equalsIgnoreCase(key)
+                || Message.RecipientType.BCC.toString().equalsIgnoreCase(key);
     }
 
     /**

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/AbstractMiloServerTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/AbstractMiloServerTest.java
@@ -146,9 +146,8 @@ public abstract class AbstractMiloServerTest extends CamelTestSupport {
             if (dot != -1) {
                 version = version.substring(0, dot);
             }
-            if (version.equalsIgnoreCase("16-ea")) {
-                return true;
-            } else if (Integer.parseInt(version) >= requiredVersion) {
+            if (version.equalsIgnoreCase("16-ea")
+                    || Integer.parseInt(version) >= requiredVersion) {
                 return true;
             }
         }

--- a/components/camel-mllp/src/test/java/org/apache/camel/test/stub/tcp/SocketOutputStreamStub.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/test/stub/tcp/SocketOutputStreamStub.java
@@ -29,9 +29,7 @@ public class SocketOutputStreamStub extends OutputStream {
 
     @Override
     public void write(int b) throws IOException {
-        if (failOnWrite) {
-            throw new IOException("Faking write failure");
-        } else if (writeFailOn != null && writeFailOn == b) {
+        if (failOnWrite || (writeFailOn != null && writeFailOn == b)) {
             throw new IOException("Faking write failure");
         }
 

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/SecurityConstraintMapping.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/SecurityConstraintMapping.java
@@ -70,11 +70,7 @@ public class SecurityConstraintMapping implements SecurityConstraint {
         if (inclusions != null && !inclusions.isEmpty()) {
             for (String constraint : inclusions.keySet()) {
                 if (PatternHelper.matchPattern(url, constraint)) {
-                    if (candidate == null) {
-                        candidate = constraint;
-                    } else if (constraint.length() > candidate.length()) {
-                        // we want the constraint that has the longest context-path matching as its
-                        // the most explicit for the target url
+                    if (candidate == null || constraint.length() > candidate.length()) {
                         candidate = constraint;
                     }
                 }

--- a/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceProcessor.java
+++ b/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceProcessor.java
@@ -29,7 +29,6 @@ import java.util.function.Supplier;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
-import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
@@ -732,16 +731,8 @@ public class ResilienceProcessor extends BaseProcessorSupport
                         exchange.setException(throwable);
                     }
                     return exchange;
-                } else if (throwable instanceof BulkheadFullException) {
-                    // the circuit breaker bulkhead is full
-                    exchange.setProperty(ExchangePropertyKey.CIRCUIT_BREAKER_RESPONSE_SUCCESSFUL_EXECUTION, false);
-                    exchange.setProperty(ExchangePropertyKey.CIRCUIT_BREAKER_RESPONSE_FROM_FALLBACK, false);
-                    exchange.setProperty(ExchangePropertyKey.CIRCUIT_BREAKER_RESPONSE_SHORT_CIRCUITED, true);
-                    exchange.setProperty(ExchangePropertyKey.CIRCUIT_BREAKER_RESPONSE_REJECTED, true);
-                    exchange.setException(throwable);
-                    return exchange;
                 } else {
-                    // other kind of exception
+                    // the circuit breaker bulkhead is full, or other kind of exception
                     exchange.setProperty(ExchangePropertyKey.CIRCUIT_BREAKER_RESPONSE_SUCCESSFUL_EXECUTION, false);
                     exchange.setProperty(ExchangePropertyKey.CIRCUIT_BREAKER_RESPONSE_FROM_FALLBACK, false);
                     exchange.setProperty(ExchangePropertyKey.CIRCUIT_BREAKER_RESPONSE_SHORT_CIRCUITED, true);

--- a/components/camel-saxon/src/main/java/org/apache/camel/component/xquery/XQueryBuilder.java
+++ b/components/camel-saxon/src/main/java/org/apache/camel/component/xquery/XQueryBuilder.java
@@ -593,13 +593,8 @@ public abstract class XQueryBuilder implements Expression, Predicate, NamespaceA
             return false;
         }
 
-        if (payload instanceof Source) {
-            return false;
-        } else if (payload instanceof String) {
-            return false;
-        } else if (payload instanceof byte[]) {
-            return false;
-        } else if (payload instanceof Node) {
+        if (payload instanceof Source || payload instanceof String
+                || payload instanceof byte[] || payload instanceof Node) {
             return false;
         }
 

--- a/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringCustomPredicateTest.java
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringCustomPredicateTest.java
@@ -47,13 +47,7 @@ public class SpringCustomPredicateTest extends SpringTestSupport {
         @Override
         public boolean matches(Exchange exchange) {
             String body = exchange.getIn().getBody(String.class);
-            if (body.contains("Camel")) {
-                return true;
-            } else if (body.startsWith("Secret")) {
-                return true;
-            }
-
-            return false;
+            return body.contains("Camel") || body.startsWith("Secret");
         }
     }
 }

--- a/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlHelper.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/component/sql/SqlHelper.java
@@ -98,17 +98,16 @@ public final class SqlHelper {
         Map<?, ?> headersMap = safeMap(exchange.getIn().getHeaders());
         Map<?, ?> variablesMap = safeMap(exchange.getVariables());
 
-        if ((nextParam.startsWith("$simple{") || nextParam.startsWith("${")) && nextParam.endsWith("}")) {
-            return true;
-        } else if (bodyMap.containsKey(nextParam)) {
-            return true;
-        } else if (headersMap.containsKey(nextParam)) {
-            return true;
-        } else if (variablesMap.containsKey(nextParam)) {
+        if (isSimpleExpression(nextParam)) {
             return true;
         }
+        return bodyMap.containsKey(nextParam)
+                || headersMap.containsKey(nextParam)
+                || variablesMap.containsKey(nextParam);
+    }
 
-        return false;
+    private static boolean isSimpleExpression(String param) {
+        return (param.startsWith("$simple{") || param.startsWith("${")) && param.endsWith("}");
     }
 
     private static Map<?, ?> safeMap(Map<?, ?> map) {

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowComponent.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowComponent.java
@@ -251,11 +251,7 @@ public class UndertowComponent extends DefaultComponent
         boolean explicitOptions = restrict.contains("OPTIONS");
         boolean cors = config.isEnableCORS();
 
-        if (cors) {
-            // allow HTTP Options as we want to handle CORS in rest-dsl
-            map.put("optionsEnabled", "true");
-        } else if (explicitOptions) {
-            // the rest-dsl is using OPTIONS
+        if (cors || explicitOptions) {
             map.put("optionsEnabled", "true");
         }
 

--- a/core/camel-api/src/main/java/org/apache/camel/health/HealthCheckHelper.java
+++ b/core/camel-api/src/main/java/org/apache/camel/health/HealthCheckHelper.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -337,39 +338,19 @@ public final class HealthCheckHelper {
      * @param  key the key
      * @return     true if reserved, false otherwise
      */
+    private static final Set<String> RESERVED_KEYS = Set.of(
+            HealthCheck.CHECK_ID, HealthCheck.CHECK_GROUP,
+            HealthCheck.CHECK_KIND, HealthCheck.CHECK_ENABLED,
+            HealthCheck.INVOCATION_COUNT, HealthCheck.INVOCATION_TIME,
+            HealthCheck.FAILURE_COUNT, HealthCheck.FAILURE_START_TIME,
+            HealthCheck.FAILURE_TIME, HealthCheck.FAILURE_ERROR_COUNT,
+            HealthCheck.SUCCESS_COUNT, HealthCheck.SUCCESS_START_TIME,
+            HealthCheck.SUCCESS_TIME);
+
     public static boolean isReservedKey(String key) {
         if (key == null) {
             return false;
         }
-
-        if (HealthCheck.CHECK_ID.equals(key)) {
-            return true;
-        } else if (HealthCheck.CHECK_GROUP.equals(key)) {
-            return true;
-        } else if (HealthCheck.CHECK_KIND.equals(key)) {
-            return true;
-        } else if (HealthCheck.CHECK_ENABLED.equals(key)) {
-            return true;
-        } else if (HealthCheck.INVOCATION_COUNT.equals(key)) {
-            return true;
-        } else if (HealthCheck.INVOCATION_TIME.equals(key)) {
-            return true;
-        } else if (HealthCheck.FAILURE_COUNT.equals(key)) {
-            return true;
-        } else if (HealthCheck.FAILURE_START_TIME.equals(key)) {
-            return true;
-        } else if (HealthCheck.FAILURE_TIME.equals(key)) {
-            return true;
-        } else if (HealthCheck.FAILURE_ERROR_COUNT.equals(key)) {
-            return true;
-        } else if (HealthCheck.SUCCESS_COUNT.equals(key)) {
-            return true;
-        } else if (HealthCheck.SUCCESS_START_TIME.equals(key)) {
-            return true;
-        } else if (HealthCheck.SUCCESS_TIME.equals(key)) {
-            return true;
-        }
-
-        return false;
+        return RESERVED_KEYS.contains(key);
     }
 }

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultStreamCachingStrategy.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultStreamCachingStrategy.java
@@ -277,13 +277,8 @@ public class DefaultStreamCachingStrategy extends ServiceSupport implements Came
         // try convert to stream cache
         if (body != null) {
             // fast skip some common types that should never be converted
-            if (body instanceof String) {
-                return null;
-            } else if (body instanceof byte[]) {
-                return null;
-            } else if (body instanceof Boolean) {
-                return null;
-            } else if (body instanceof Number) {
+            if (body instanceof String || body instanceof byte[]
+                    || body instanceof Boolean || body instanceof Number) {
                 return null;
             }
             Class<?> type = body.getClass();

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/IntrospectionSupport.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/IntrospectionSupport.java
@@ -371,9 +371,8 @@ final class IntrospectionSupport {
             methods.addAll(Arrays.asList(type.getMethods()));
             for (Method m : methods) {
                 if (isGetter(m)) {
-                    if (m.getName().startsWith("is") && m.getName().substring(2).equalsIgnoreCase(propertyName)) {
-                        return m;
-                    } else if (m.getName().startsWith("get") && m.getName().substring(3).equalsIgnoreCase(propertyName)) {
+                    if ((m.getName().startsWith("is") && m.getName().substring(2).equalsIgnoreCase(propertyName))
+                            || (m.getName().startsWith("get") && m.getName().substring(3).equalsIgnoreCase(propertyName))) {
                         return m;
                     }
                 }

--- a/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/AbstractCamelCatalog.java
+++ b/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/AbstractCamelCatalog.java
@@ -1281,9 +1281,8 @@ public abstract class AbstractCamelCatalog {
             if (!optionPlaceholder && !lookup && javaType != null
                     && (javaType.startsWith("java.util.Map") || javaType.startsWith("java.util.Properties"))) {
                 // there must be a valid suffix
-                if (isValidSuffix(suffix)) {
-                    result.addInvalidMap(longKey, value);
-                } else if (suffix.startsWith("[") && !suffix.contains("]")) {
+                if (isValidSuffix(suffix)
+                        || (suffix.startsWith("[") && !suffix.contains("]"))) {
                     result.addInvalidMap(longKey, value);
                 }
             }

--- a/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultModel.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultModel.java
@@ -590,13 +590,7 @@ public class DefaultModel implements Model {
             final String key = entry.getKey();
             final String templateId = target.getId();
 
-            if ("*".equals(key) || templateId.equals(key)) {
-                converter = entry.getValue();
-                break;
-            } else if (AntPathMatcher.INSTANCE.match(key, templateId)) {
-                converter = entry.getValue();
-                break;
-            } else if (templateId.matches(key)) {
+            if (matchesTemplateKey(key, templateId)) {
                 converter = entry.getValue();
                 break;
             }
@@ -652,6 +646,12 @@ public class DefaultModel implements Model {
         // add route and return the id it was assigned
         addRouteDefinition(def);
         return def.getId();
+    }
+
+    private static boolean matchesTemplateKey(String key, String templateId) {
+        return "*".equals(key) || templateId.equals(key)
+                || AntPathMatcher.INSTANCE.match(key, templateId)
+                || templateId.matches(key);
     }
 
     private static void addProperty(Map<String, Object> prop, String key, Object value) {

--- a/core/camel-core-model/src/main/java/org/apache/camel/builder/AdviceWithTasks.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/builder/AdviceWithTasks.java
@@ -461,13 +461,10 @@ public final class AdviceWithTasks {
         }
         // for intercept/onException/onCompletion then we want to work on the
         // route outputs as they are top-level
-        if (node instanceof InterceptDefinition) {
-            return route.getOutputs();
-        } else if (node instanceof InterceptSendToEndpointDefinition) {
-            return route.getOutputs();
-        } else if (node instanceof OnExceptionDefinition) {
-            return route.getOutputs();
-        } else if (node instanceof OnCompletionDefinition) {
+        if (node instanceof InterceptDefinition
+                || node instanceof InterceptSendToEndpointDefinition
+                || node instanceof OnExceptionDefinition
+                || node instanceof OnCompletionDefinition) {
             return route.getOutputs();
         }
 

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
@@ -814,12 +814,9 @@ public class AggregateProcessor extends BaseProcessorSupport
         }
 
         Exchange answer;
-        if (fromTimeout && isDiscardOnCompletionTimeout()) {
+        if ((fromTimeout && isDiscardOnCompletionTimeout())
+                || (aggregateFailed && isDiscardOnAggregationFailure())) {
             discard(key, aggregated);
-            answer = null;
-        } else if (aggregateFailed && isDiscardOnAggregationFailure()) {
-            discard(key, aggregated);
-            // the completion was failed during aggregation and we should just discard it
             answer = null;
         } else {
             // the aggregated exchange should be published (sent out)

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/errorhandler/RedeliveryErrorHandler.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/errorhandler/RedeliveryErrorHandler.java
@@ -1742,10 +1742,7 @@ public abstract class RedeliveryErrorHandler extends ErrorHandlerSupport
 
             LoggingLevel newLogLevel;
             boolean logStackTrace;
-            if (exchange.isRollbackOnly() || exchange.isRollbackOnlyLast()) {
-                newLogLevel = currentRedeliveryPolicy.getRetriesExhaustedLogLevel();
-                logStackTrace = currentRedeliveryPolicy.isLogStackTrace();
-            } else if (shouldRedeliver) {
+            if (shouldRedeliver && !exchange.isRollbackOnly() && !exchange.isRollbackOnlyLast()) {
                 newLogLevel = currentRedeliveryPolicy.getRetryAttemptedLogLevel();
                 logStackTrace = currentRedeliveryPolicy.isLogRetryStackTrace();
             } else {

--- a/core/camel-health/src/main/java/org/apache/camel/impl/health/DefaultHealthCheckRegistry.java
+++ b/core/camel-health/src/main/java/org/apache/camel/impl/health/DefaultHealthCheckRegistry.java
@@ -317,10 +317,7 @@ public class DefaultHealthCheckRegistry extends ServiceSupport implements Health
             if (id.startsWith("route:")) {
                 id = id.substring(6);
                 return PatternHelper.matchPatterns(id, s);
-            } else if (id.startsWith("consumer:")) {
-                id = id.substring(9);
-                return PatternHelper.matchPatterns(id, s);
-            } else if (id.startsWith("producer:")) {
+            } else if (id.startsWith("consumer:") || id.startsWith("producer:")) {
                 id = id.substring(9);
                 return PatternHelper.matchPatterns(id, s);
             }

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedRouteGroup.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedRouteGroup.java
@@ -169,9 +169,7 @@ public class ManagedRouteGroup extends ManagedPerformanceCounter implements Time
         for (Route route : context.getRoutesByGroup(group)) {
             var e = route.getLastError();
             if (e != null) {
-                if (last == null) {
-                    last = e;
-                } else if (e.getDate().compareTo(last.getDate()) > 0) {
+                if (last == null || e.getDate().compareTo(last.getDate()) > 0) {
                     last = e;
                 }
             }

--- a/core/camel-support/src/main/java/org/apache/camel/support/MessageHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/MessageHelper.java
@@ -702,11 +702,8 @@ public final class MessageHelper {
             Object value = entry.getValue();
 
             if (target.getHeader(key) == null || override) {
-                if (strategy == null) {
-                    target.setHeader(key, value);
-                } else if (!strategy.applyFilterToExternalHeaders(key, value, target.getExchange())) {
-                    // Just make sure we don't copy the protocol headers to
-                    // target
+                if (strategy == null
+                        || !strategy.applyFilterToExternalHeaders(key, value, target.getExchange())) {
                     target.setHeader(key, value);
                 }
             }

--- a/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/PropertyBindingSupport.java
@@ -2042,9 +2042,8 @@ public final class PropertyBindingSupport {
             // so we can remove the corresponding key from the original map
             Set<String> toBeRemoved = new HashSet<>();
             originalMap.forEach((k, v) -> {
-                if (startsWithIgnoreCase(k, optionPrefix)) {
-                    toBeRemoved.add(k);
-                } else if (startsWithIgnoreCase(k, "?" + optionPrefix)) {
+                if (startsWithIgnoreCase(k, optionPrefix)
+                        || startsWithIgnoreCase(k, "?" + optionPrefix)) {
                     toBeRemoved.add(k);
                 }
             });

--- a/core/camel-support/src/main/java/org/apache/camel/support/builder/PredicateBuilder.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/builder/PredicateBuilder.java
@@ -350,11 +350,9 @@ public class PredicateBuilder {
         return new BinaryPredicateSupport(left, right) {
 
             protected boolean matches(Exchange exchange, Object leftValue, Object rightValue) {
-                if (leftValue == null && rightValue == null) {
-                    // they are equal
-                    return false;
-                } else if (leftValue == null || rightValue == null) {
-                    // only one of them is null so they are not equal
+                if (leftValue == null || rightValue == null) {
+                    // if both are null they are equal (not greater);
+                    // if only one is null they are not equal (not greater)
                     return false;
                 }
 

--- a/core/camel-util/src/main/java/org/apache/camel/util/ObjectHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/ObjectHelper.java
@@ -982,20 +982,12 @@ public final class ObjectHelper {
      * Is the give type numeric
      */
     public static boolean isNumericType(Class<?> type) {
-        if (type == int.class || type == Integer.class) {
-            return true;
-        } else if (type == long.class || type == Long.class) {
-            return true;
-        } else if (type == double.class || type == Double.class) {
-            return true;
-        } else if (type == float.class || type == Float.class) {
-            return true;
-        } else if (type == short.class || type == Short.class) {
-            return true;
-        } else if (type == byte.class || type == Byte.class) {
-            return true;
-        }
-        return false;
+        return type == int.class || type == Integer.class
+                || type == long.class || type == Long.class
+                || type == double.class || type == Double.class
+                || type == float.class || type == Float.class
+                || type == short.class || type == Short.class
+                || type == byte.class || type == Byte.class;
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/StringHelper.java
@@ -1085,9 +1085,7 @@ public final class StringHelper {
         for (int i = 0; i < newLines.length; i++) {
             String newLine = newLines[i];
             String oldLine = i < oldLines.length ? oldLines[i] : null;
-            if (oldLine == null) {
-                changed.add(i);
-            } else if (!newLine.equals(oldLine)) {
+            if (oldLine == null || !newLine.equals(oldLine)) {
                 changed.add(i);
             }
         }

--- a/core/camel-util/src/main/java/org/apache/camel/util/backoff/BackOffTimerTask.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/backoff/BackOffTimerTask.java
@@ -241,10 +241,8 @@ public final class BackOffTimerTask implements BackOffTimer.Task, Runnable {
 
             currentAttempts++;
 
-            if (currentAttempts > backOff.getMaxAttempts()) {
-                currentDelay = BackOff.NEVER;
-                status = Status.Exhausted;
-            } else if (currentElapsedTime > backOff.getMaxElapsedTime().toMillis()) {
+            if (currentAttempts > backOff.getMaxAttempts()
+                    || currentElapsedTime > backOff.getMaxElapsedTime().toMillis()) {
                 currentDelay = BackOff.NEVER;
                 status = Status.Exhausted;
             } else {

--- a/core/camel-xml-io/src/main/java/org/apache/camel/xml/io/MXParser.java
+++ b/core/camel-xml-io/src/main/java/org/apache/camel/xml/io/MXParser.java
@@ -780,10 +780,7 @@ public class MXParser implements XmlPullParser {
     }
 
     public String getNamespace() {
-        if (eventType == START_TAG) {
-            // return processNamespaces ? elUri[ depth - 1 ] : NO_NAMESPACE;
-            return processNamespaces ? elUri[depth] : NO_NAMESPACE;
-        } else if (eventType == END_TAG) {
+        if (eventType == START_TAG || eventType == END_TAG) {
             return processNamespaces ? elUri[depth] : NO_NAMESPACE;
         }
         return null;
@@ -827,10 +824,7 @@ public class MXParser implements XmlPullParser {
     }
 
     public String getPrefix() {
-        if (eventType == START_TAG) {
-            // return elPrefix[ depth - 1 ] ;
-            return elPrefix[depth];
-        } else if (eventType == END_TAG) {
+        if (eventType == START_TAG || eventType == END_TAG) {
             return elPrefix[depth];
         }
         return null;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -344,12 +344,7 @@ public class Run extends CamelCommand {
         if (exportRun) {
             return false;
         }
-        if (RuntimeType.quarkus == runtime) {
-            return true;
-        } else if (RuntimeType.springBoot == runtime) {
-            return true;
-        }
-        return false;
+        return RuntimeType.quarkus == runtime || RuntimeType.springBoot == runtime;
     }
 
     @Override

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/TransformTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/TransformTools.java
@@ -320,9 +320,8 @@ public class TransformTools {
                     String key = line.substring(0, colonPos).trim();
                     String value = line.substring(colonPos + 1).trim();
 
-                    if (value.startsWith("\"") && value.endsWith("\"")) {
-                        value = value.substring(1, value.length() - 1);
-                    } else if (value.startsWith("'") && value.endsWith("'")) {
+                    if ((value.startsWith("\"") && value.endsWith("\""))
+                            || (value.startsWith("'") && value.endsWith("'"))) {
                         value = value.substring(1, value.length() - 1);
                     }
 

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/util/ExtraFilesClassLoader.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/util/ExtraFilesClassLoader.java
@@ -54,9 +54,8 @@ public final class ExtraFilesClassLoader extends ClassLoader {
         for (String f : files) {
             String source = f;
             // deal with adding files to classpath that are in src/main/resources
-            if (source.startsWith("src/main/resources/")) {
-                source = source.substring(19);
-            } else if (source.startsWith("src\\main\\resources\\")) {
+            if (source.startsWith("src/main/resources/")
+                    || source.startsWith("src\\main\\resources\\")) {
                 source = source.substring(19);
             }
             if (name.equals(source)) {

--- a/tooling/camel-util-json/src/main/java/org/apache/camel/util/json/JsonArray.java
+++ b/tooling/camel-util-json/src/main/java/org/apache/camel/util/json/JsonArray.java
@@ -394,9 +394,7 @@ public class JsonArray extends ArrayList<Object> implements Jsonable {
      */
     public String getString(final int index) {
         Object returnable = this.get(index);
-        if (returnable instanceof Boolean) {
-            returnable = returnable.toString();
-        } else if (returnable instanceof Number) {
+        if (returnable instanceof Boolean || returnable instanceof Number) {
             returnable = returnable.toString();
         }
         return (String) returnable;

--- a/tooling/camel-util-json/src/main/java/org/apache/camel/util/json/JsonObject.java
+++ b/tooling/camel-util-json/src/main/java/org/apache/camel/util/json/JsonObject.java
@@ -76,9 +76,7 @@ public class JsonObject extends LinkedHashMap<String, Object> implements Jsonabl
      */
     public String pathString(final String path) {
         Object returnable = path(path);
-        if (returnable instanceof Boolean) {
-            returnable = returnable.toString();
-        } else if (returnable instanceof Number) {
+        if (returnable instanceof Boolean || returnable instanceof Number) {
             returnable = returnable.toString();
         }
         return (String) returnable;
@@ -966,9 +964,7 @@ public class JsonObject extends LinkedHashMap<String, Object> implements Jsonabl
      */
     public String getString(final String key) {
         Object returnable = this.get(key);
-        if (returnable instanceof Boolean) {
-            returnable = returnable.toString();
-        } else if (returnable instanceof Number) {
+        if (returnable instanceof Boolean || returnable instanceof Number) {
             returnable = returnable.toString();
         }
         return (String) returnable;
@@ -989,9 +985,7 @@ public class JsonObject extends LinkedHashMap<String, Object> implements Jsonabl
         } else {
             return defaultValue;
         }
-        if (returnable instanceof Boolean) {
-            returnable = returnable.toString();
-        } else if (returnable instanceof Number) {
+        if (returnable instanceof Boolean || returnable instanceof Number) {
             returnable = returnable.toString();
         }
         return (String) returnable;

--- a/tooling/maven/camel-maven-plugin/src/main/java/org/apache/camel/maven/RunMojo.java
+++ b/tooling/maven/camel-maven-plugin/src/main/java/org/apache/camel/maven/RunMojo.java
@@ -757,17 +757,16 @@ public class RunMojo extends AbstractExecMojo {
         Set<Artifact> artifacts = new HashSet<>(this.pluginDependencies);
         for (Artifact artifact : artifacts) {
             // add these loggers in the beginning so they are first
-            if (artifact.getArtifactId().equals("jansi")) {
-                // jansi for logging in color
-                classpath.add(0, artifact);
-            } else if (artifact.getGroupId().equals("org.apache.logging.log4j")) {
-                // add log4j as this is needed
-                classpath.add(0, artifact);
-            } else if (artifact.getArtifactId().equals("camel-maven-plugin")) {
-                // add ourselves
+            if (isConsoleLogDependency(artifact)) {
                 classpath.add(0, artifact);
             }
         }
+    }
+
+    private static boolean isConsoleLogDependency(Artifact artifact) {
+        return artifact.getArtifactId().equals("jansi")
+                || artifact.getGroupId().equals("org.apache.logging.log4j")
+                || artifact.getArtifactId().equals("camel-maven-plugin");
     }
 
     /**

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointSchemaGeneratorMojo.java
@@ -1075,9 +1075,8 @@ public class EndpointSchemaGeneratorMojo extends AbstractGeneratorMojo {
                         componentModel.isProducerOnly());
                 // filter out consumer/producer only
                 boolean accept = !excludes.contains(name);
-                if (componentModel.isConsumerOnly() && "producer".equals(group)) {
-                    accept = false;
-                } else if (componentModel.isProducerOnly() && "consumer".equals(group)) {
+                if ((componentModel.isConsumerOnly() && "producer".equals(group))
+                        || (componentModel.isProducerOnly() && "consumer".equals(group))) {
                     accept = false;
                 }
                 if (accept) {

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/SchemaHelper.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/SchemaHelper.java
@@ -87,12 +87,9 @@ public final class SchemaHelper {
             }
             if (ch == '-' || ch == '_') {
                 answer.append("-");
-            } else if (Character.isUpperCase(ch) && prev != null && !Character.isUpperCase(prev)) {
-                if (prev != '-' && prev != '_') {
-                    answer.append("-");
-                }
-                answer.append(ch);
-            } else if (Character.isUpperCase(ch) && prev != null && next != null && Character.isLowerCase(next)) {
+            } else if (Character.isUpperCase(ch) && prev != null
+                    && (!Character.isUpperCase(prev)
+                            || (next != null && Character.isLowerCase(next)))) {
                 if (prev != '-' && prev != '_') {
                     answer.append("-");
                 }

--- a/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/MethodBodySourceCodeEmitter.java
+++ b/tooling/openapi-rest-dsl-generator/src/main/java/org/apache/camel/generator/openapi/MethodBodySourceCodeEmitter.java
@@ -99,14 +99,10 @@ class MethodBodySourceCodeEmitter implements CodeEmitter<MethodSpec> {
             case "options":
                 return 1;
             case "param":
-                indentIntentStack.push(3);
-                return 2;
-            case "endParam":
-                indentIntentStack.pop();
-                return 2;
             case "route":
                 indentIntentStack.push(3);
                 return 2;
+            case "endParam":
             case "endRest":
                 indentIntentStack.pop();
                 return 2;


### PR DESCRIPTION
## Summary

- Merge duplicate conditional branches (S1871) across 45 files in core, components, tooling, and DSL modules
- Combine if-else branches returning identical results using `||` operators
- Extract helper methods where combining conditions would be too complex (e.g., `matchesTemplateKey()`, `isConsoleLogDependency()`, `isSimpleExpression()`)
- Use `Set`-based lookup for `HealthCheckHelper.isReservedKey()` replacing 13 duplicate branches
- Consolidate switch case fall-throughs in `MethodBodySourceCodeEmitter`

## Test plan

- [x] Core modules compile successfully (`mvn -DskipTests install`)
- [x] All modules formatted with `mvn formatter:format impsort:sort`
- [ ] CI build validates all changes compile and tests pass

_Claude Code on behalf of Otavio R. Piske_