### PR TITLE
chore: upgrade Pulsar client to 4.2.0 and fix V1 topic names in tests

### DIFF
--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/integration/PulsarConsumerInIT.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/integration/PulsarConsumerInIT.java
@@ -38,7 +38,7 @@ public class PulsarConsumerInIT extends PulsarITSupport {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PulsarConsumerInIT.class);
 
-    private static final String TOPIC_URI = "persistent://public/default/camel-topic/PulsarConsumerInIT";
+    private static final String TOPIC_URI = "persistent://public/default/camel-topic-PulsarConsumerInIT";
     private static final String PRODUCER = "camel-producer-1";
 
     @EndpointInject("pulsar:" + TOPIC_URI + "?numberOfConsumers=1&subscriptionType=Exclusive"

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/integration/PulsarConsumerInURIClientIT.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/integration/PulsarConsumerInURIClientIT.java
@@ -36,7 +36,7 @@ public class PulsarConsumerInURIClientIT extends PulsarITSupport {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PulsarConsumerInURIClientIT.class);
 
-    private static final String TOPIC_URI = "persistent://public/default/camel-topic/PulsarConsumerInURIClientIT";
+    private static final String TOPIC_URI = "persistent://public/default/camel-topic-PulsarConsumerInURIClientIT";
     private static final String PRODUCER = "camel-producer-1";
     private static final String URI_ENDPOINT = "pulsar:" + TOPIC_URI + "?numberOfConsumers=1&subscriptionType=Exclusive"
                                                + "&subscriptionName=camel-subscription&consumerQueueSize=1&consumerName=camel-consumer&serviceUrl="

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/integration/PulsarConsumerPatternInIT.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/integration/PulsarConsumerPatternInIT.java
@@ -38,9 +38,9 @@ public class PulsarConsumerPatternInIT extends PulsarITSupport {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PulsarConsumerPatternInIT.class);
 
-    private static final String TOPIC_URI = "persistent://public/default/PulsarConsumerPatternInIT/camel-foo";
-    private static final String TOPIC_TWO_URI = "persistent://public/default/PulsarConsumerPatternInIT/camel-bar";
-    private static final String TOPIC_PATTERN_URI = "persistent://public/default/PulsarConsumerPatternInIT/camel-.*";
+    private static final String TOPIC_URI = "persistent://public/default/PulsarConsumerPatternInIT-camel-foo";
+    private static final String TOPIC_TWO_URI = "persistent://public/default/PulsarConsumerPatternInIT-camel-bar";
+    private static final String TOPIC_PATTERN_URI = "persistent://public/default/PulsarConsumerPatternInIT-camel-.*";
     private static final String PRODUCER = "camel-producer-1";
 
     @EndpointInject("pulsar:" + TOPIC_PATTERN_URI + "?topicsPattern=true"

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/integration/PulsarCustomMessageReceiptIT.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/integration/PulsarCustomMessageReceiptIT.java
@@ -49,7 +49,7 @@ public class PulsarCustomMessageReceiptIT extends PulsarITSupport {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PulsarCustomMessageReceiptIT.class);
 
-    private static final String TOPIC_URI = "persistent://public/default/camel-topic/PulsarCustomMessageReceiptIT";
+    private static final String TOPIC_URI = "persistent://public/default/camel-topic-PulsarCustomMessageReceiptIT";
     private static final String PRODUCER = "camel-producer-1";
 
     public PulsarMessageReceiptFactory mockPulsarMessageReceiptFactory = mock(PulsarMessageReceiptFactory.class);

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_20.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_20.adoc
@@ -1,0 +1,27 @@
+= Apache Camel 4.x Upgrade Guide
+
+This document is for helping you upgrade your Apache Camel application
+from Camel 4.x to 4.y. For example, if you are upgrading Camel 4.0 to 4.2, then you should follow the guides
+from both 4.0 to 4.1 and 4.1 to 4.2.
+
+[NOTE]
+====
+https://github.com/apache/camel-upgrade-recipes/[The Camel Upgrade Recipes project] provides automated assistance for some common migration tasks.
+Note that manual migration is still required.
+See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
+====
+
+== Upgrading Camel 4.19 to 4.20
+
+=== camel-pulsar
+
+The Apache Pulsar client library has been upgraded from 4.1.3 to 4.2.0.
+
+Pulsar 4.2.0 removes support for V1 topic names via https://github.com/apache/pulsar/pull/25304[PIP-457].
+Topic names must now use the V2 format (`persistent://tenant/namespace/topic`) with exactly three path
+segments after the scheme. The V1 format (`persistent://tenant/cluster/namespace/topic`) with four path
+segments is no longer accepted and will result in an `InvalidTopicNameException`.
+
+If your Camel routes use topic URIs with extra `/` characters in the topic name portion
+(e.g., `pulsar:persistent://public/default/my-topic/sub-path`), you must replace the extra `/` with
+another separator such as `-` (e.g., `pulsar:persistent://public/default/my-topic-sub-path`).

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -478,7 +478,7 @@
         <protonpack-version>1.8</protonpack-version>
         <prowide-version>SRU2025-10.3.5</prowide-version>
         <pubnub-version>13.1.1</pubnub-version>
-        <pulsar-version>4.1.3</pulsar-version>
+        <pulsar-version>4.2.0</pulsar-version>
         <qdrant-client-version>1.17.0</qdrant-client-version>
         <qpid-broker-version>10.0.1</qpid-broker-version>
         <qpid-proton-j-version>0.34.1</qpid-proton-j-version>

--- a/test-infra/camel-test-infra-pulsar/src/main/java/org/apache/camel/test/infra/pulsar/services/PulsarLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-pulsar/src/main/java/org/apache/camel/test/infra/pulsar/services/PulsarLocalContainerInfraService.java
@@ -61,6 +61,11 @@ public class PulsarLocalContainerInfraService implements PulsarInfraService, Con
 
                 withStartupTimeout(Duration.ofMinutes(3L));
 
+                // Pulsar 4.2.0 standalone no longer defaults advertisedAddress to localhost,
+                // causing the broker to advertise the container hostname which is unreachable
+                // from the test host. Explicitly set it to localhost for testcontainer usage.
+                withEnv("PULSAR_PREFIX_advertisedAddress", "localhost");
+
                 ContainerEnvironmentUtil.configurePorts(this, fixedPort,
                         ContainerEnvironmentUtil.PortConfig.primary(6650),
                         ContainerEnvironmentUtil.PortConfig.secondary(8080));


### PR DESCRIPTION
Pulsar 4.2.0 (PIP-457) removed V1 topic name support. Fix test topic URIs that used slashes in the topic name portion, and document the change in the migration guide.

Pulsar 4.2.0 standalone no longer defaults advertisedAddress to localhost, causing the broker to advertise the container hostname. Set PULSAR_PREFIX_advertisedAddress=localhost in the test container.

