### PR TITLE
[backport camel-4.14.x] CAMEL-23313: HeaderFilter Strategies - add lowerCase where it's not present - JMS, SJMS, CoAP, Google PubSub

### DIFF
--- a/components/camel-coap/src/main/java/org/apache/camel/coap/CoAPHeaderFilterStrategy.java
+++ b/components/camel-coap/src/main/java/org/apache/camel/coap/CoAPHeaderFilterStrategy.java
@@ -27,6 +27,7 @@ import org.apache.camel.support.DefaultHeaderFilterStrategy;
 public class CoAPHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
 
     public CoAPHeaderFilterStrategy() {
+        setLowerCase(true);
         setOutFilterStartsWith(CAMEL_FILTER_STARTS_WITH);
         setInFilterStartsWith(CAMEL_FILTER_STARTS_WITH);
     }

--- a/components/camel-google/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubHeaderFilterStrategy.java
+++ b/components/camel-google/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubHeaderFilterStrategy.java
@@ -25,6 +25,7 @@ public class GooglePubsubHeaderFilterStrategy extends DefaultHeaderFilterStrateg
     }
 
     public GooglePubsubHeaderFilterStrategy(boolean includeAllGoogleProperties) {
+        setLowerCase(true);
         setOutFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH);
         setInFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH);
         // Filter authorization on both directions for security

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/ClassicJmsHeaderFilterStrategy.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/ClassicJmsHeaderFilterStrategy.java
@@ -29,6 +29,7 @@ public class ClassicJmsHeaderFilterStrategy extends DefaultHeaderFilterStrategy 
     }
 
     public ClassicJmsHeaderFilterStrategy(boolean includeAllJMSXProperties) {
+        setLowerCase(true);
         if (!includeAllJMSXProperties) {
             initialize();
         }

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsHeaderFilterStrategy.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsHeaderFilterStrategy.java
@@ -25,6 +25,7 @@ public class JmsHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
     }
 
     public JmsHeaderFilterStrategy(boolean includeAllJMSXProperties) {
+        setLowerCase(true);
         setOutFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH);
         setInFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH);
         if (!includeAllJMSXProperties) {

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsHeaderFilterStrategy.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/SjmsHeaderFilterStrategy.java
@@ -25,6 +25,7 @@ public class SjmsHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
     }
 
     public SjmsHeaderFilterStrategy(boolean includeAllJMSXProperties) {
+        setLowerCase(true);
         setOutFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH);
         setInFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH);
         if (!includeAllJMSXProperties) {


### PR DESCRIPTION
## Backport of #22569 to `camel-4.14.x`

Parallel PR (not a cherry-pick — source PR #22569 is still open on `main`).

Adds `setLowerCase(true)` to five `HeaderFilterStrategy` implementations for consistency with the other components that already call it:

- `camel-jms`: `JmsHeaderFilterStrategy`, `ClassicJmsHeaderFilterStrategy`
- `camel-sjms`: `SjmsHeaderFilterStrategy`
- `camel-coap`: `CoAPHeaderFilterStrategy`
- `camel-google-pubsub`: `GooglePubsubHeaderFilterStrategy`

**Source PR:** #22569
**Sibling backport:** #22575 (camel-4.18.x)
**Target branch:** `camel-4.14.x`
**JIRA:** [CAMEL-23313](https://issues.apache.org/jira/browse/CAMEL-23313)

## Test plan

- [x] Verified `DefaultHeaderFilterStrategy.setLowerCase(boolean)` exists on this branch
- [x] Changes are byte-identical to those validated on \`main\` (#22569) where local unit tests pass
- [ ] Full local build skipped on 4.14.x due to an unrelated pre-existing JAXB schema-gen issue in \`camel-spring-xml\`; CI will exercise the JMS/SJMS integration tests and full build

---
_Claude Code on behalf of Andrea Cosentino_