### PR TITLE
Add SpanKind parameter to telemetry API to support proper span type

### DIFF
--- a/components/camel-micrometer-observability/src/main/java/org/apache/camel/micrometer/observability/MicrometerObservabilityTracer.java
+++ b/components/camel-micrometer-observability/src/main/java/org/apache/camel/micrometer/observability/MicrometerObservabilityTracer.java
@@ -32,10 +32,7 @@ import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.spi.Configurer;
 import org.apache.camel.spi.annotations.JdkService;
 import org.apache.camel.support.CamelContextHelper;
-import org.apache.camel.telemetry.Span;
-import org.apache.camel.telemetry.SpanContextPropagationExtractor;
-import org.apache.camel.telemetry.SpanContextPropagationInjector;
-import org.apache.camel.telemetry.SpanLifecycleManager;
+import org.apache.camel.telemetry.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -126,7 +123,9 @@ public class MicrometerObservabilityTracer extends org.apache.camel.telemetry.Tr
         }
 
         @Override
-        public Span create(String spanName, Span parent, SpanContextPropagationExtractor extractor) {
+        public Span create(
+                String spanName, SpanKind kind, Span parent,
+                SpanContextPropagationExtractor extractor) {
             io.micrometer.tracing.Span span;
             if (parent != null) {
                 MicrometerObservabilitySpanAdapter microObsParentSpan = (MicrometerObservabilitySpanAdapter) parent;
@@ -139,6 +138,9 @@ public class MicrometerObservabilityTracer extends org.apache.camel.telemetry.Tr
                 span = builder.start();
             }
             span.name(spanName);
+            // Note: Micrometer determines span kind through Observation context types,
+            // not through direct span.kind() calls. The kind parameter is accepted
+            // for API compatibility but not used in this implementation.
 
             return new MicrometerObservabilitySpanAdapter(span);
         }

--- a/components/camel-opentelemetry2/src/main/java/org/apache/camel/opentelemetry2/OpenTelemetryTracer.java
+++ b/components/camel-opentelemetry2/src/main/java/org/apache/camel/opentelemetry2/OpenTelemetryTracer.java
@@ -28,10 +28,7 @@ import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.spi.Configurer;
 import org.apache.camel.spi.annotations.JdkService;
 import org.apache.camel.support.CamelContextHelper;
-import org.apache.camel.telemetry.Span;
-import org.apache.camel.telemetry.SpanContextPropagationExtractor;
-import org.apache.camel.telemetry.SpanContextPropagationInjector;
-import org.apache.camel.telemetry.SpanLifecycleManager;
+import org.apache.camel.telemetry.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,8 +93,11 @@ public class OpenTelemetryTracer extends org.apache.camel.telemetry.Tracer {
         }
 
         @Override
-        public Span create(String spanName, Span parent, SpanContextPropagationExtractor extractor) {
+        public Span create(
+                String spanName, SpanKind kind, Span parent,
+                SpanContextPropagationExtractor extractor) {
             SpanBuilder builder = tracer.spanBuilder(spanName);
+            builder = builder.setSpanKind(mapToSpanKind(kind));
             Baggage baggage = null;
 
             if (parent != null) {
@@ -169,6 +169,16 @@ public class OpenTelemetryTracer extends org.apache.camel.telemetry.Tracer {
                 injector.put(org.apache.camel.telemetry.Tracer.TRACE_HEADER, otelSpan.getSpan().getSpanContext().getTraceId());
                 injector.put(org.apache.camel.telemetry.Tracer.SPAN_HEADER, otelSpan.getSpan().getSpanContext().getSpanId());
             }
+        }
+
+        private io.opentelemetry.api.trace.SpanKind mapToSpanKind(org.apache.camel.telemetry.SpanKind kind) {
+            return switch (kind) {
+                case CLIENT -> io.opentelemetry.api.trace.SpanKind.CLIENT;
+                case SERVER -> io.opentelemetry.api.trace.SpanKind.SERVER;
+                case PRODUCER -> io.opentelemetry.api.trace.SpanKind.PRODUCER;
+                case CONSUMER -> io.opentelemetry.api.trace.SpanKind.CONSUMER;
+                case INTERNAL -> io.opentelemetry.api.trace.SpanKind.INTERNAL;
+            };
         }
 
     }

--- a/components/camel-telemetry-dev/src/main/java/org/apache/camel/telemetrydev/TelemetryDevTracer.java
+++ b/components/camel-telemetry-dev/src/main/java/org/apache/camel/telemetrydev/TelemetryDevTracer.java
@@ -25,6 +25,7 @@ import org.apache.camel.spi.annotations.JdkService;
 import org.apache.camel.telemetry.Span;
 import org.apache.camel.telemetry.SpanContextPropagationExtractor;
 import org.apache.camel.telemetry.SpanContextPropagationInjector;
+import org.apache.camel.telemetry.SpanKind;
 import org.apache.camel.telemetry.SpanLifecycleManager;
 import org.apache.camel.telemetry.Tracer;
 import org.slf4j.Logger;
@@ -87,7 +88,9 @@ public class TelemetryDevTracer extends Tracer {
         }
 
         @Override
-        public Span create(String spanName, Span parent, SpanContextPropagationExtractor extractor) {
+        public Span create(
+                String spanName, SpanKind kind, Span parent,
+                SpanContextPropagationExtractor extractor) {
             Span span = DevSpanAdapter.buildSpan(spanName);
             String traceId = UUID.randomUUID().toString().replaceAll("-", "");
             if (parent != null) {
@@ -101,6 +104,7 @@ public class TelemetryDevTracer extends Tracer {
                         LOG.error("TRACE ERROR: wrong format, could not split traceparent {}", upstreamTraceParent);
                         span.setTag("traceid", traceId);
                         span.setTag("spanid", UUID.randomUUID().toString().replaceAll("-", ""));
+                        span.setTag("kind", kind.toString());
                         return span;
                     }
                     traceId = split[0];
@@ -110,6 +114,7 @@ public class TelemetryDevTracer extends Tracer {
             }
             span.setTag("traceid", traceId);
             span.setTag("spanid", UUID.randomUUID().toString().replaceAll("-", ""));
+            span.setTag("kind", kind.toString());
             return span;
         }
 

--- a/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/DisableEndpointTest.java
+++ b/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/DisableEndpointTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.telemetrydev;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -47,9 +46,9 @@ public class DisableEndpointTest extends TelemetryDevTracerTestSupport {
     }
 
     @Test
-    void testProcessorsTraceRequest() throws IOException {
+    void testProcessorsTraceRequest() {
         template.sendBody("direct:start", "my-body");
-        Map<String, DevTrace> traces = tracesFromLog();
+        Map<String, DevTrace> traces = awaitTracesFromLog(1);
         assertEquals(1, traces.size());
         checkTrace(traces.values().iterator().next());
     }

--- a/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/EnableProcessorsTest.java
+++ b/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/EnableProcessorsTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.telemetrydev;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -46,9 +45,9 @@ public class EnableProcessorsTest extends TelemetryDevTracerTestSupport {
     }
 
     @Test
-    void testProcessorsTraceRequest() throws IOException {
+    void testProcessorsTraceRequest() {
         template.sendBody("direct:start", "my-body");
-        Map<String, DevTrace> traces = tracesFromLog();
+        Map<String, DevTrace> traces = awaitTracesFromLog(1);
         assertEquals(1, traces.size());
         checkTrace(traces.values().iterator().next());
     }

--- a/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/MDCHeadersTraceTest.java
+++ b/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/MDCHeadersTraceTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.telemetrydev;
 
-import java.io.IOException;
 import java.util.Map;
 
 import org.apache.camel.CamelContext;
@@ -44,11 +43,11 @@ public class MDCHeadersTraceTest extends TelemetryDevTracerTestSupport {
     }
 
     @Test
-    void testProcessorsTraceRequest() throws InterruptedException, IOException {
+    void testProcessorsTraceRequest() throws InterruptedException {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
         template.sendBody("direct:start", "my-body");
-        Map<String, DevTrace> traces = tracesFromLog();
+        Map<String, DevTrace> traces = awaitTracesFromLog(1);
         assertEquals(1, traces.size());
         mock.assertIsSatisfied();
         Map<String, Object> headers = mock.getExchanges().get(0).getIn().getHeaders();

--- a/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/SpanPropagationUpstreamTest.java
+++ b/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/SpanPropagationUpstreamTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.telemetrydev;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -41,10 +40,10 @@ public class SpanPropagationUpstreamTest extends TelemetryDevTracerTestSupport {
     }
 
     @Test
-    void testPropagateUpstreamTraceRequest() throws IOException {
+    void testPropagateUpstreamTraceRequest() {
         template.requestBodyAndHeader("direct:start", "sample body",
                 "traceparent", "123456789-123456");
-        Map<String, DevTrace> traces = tracesFromLog();
+        Map<String, DevTrace> traces = awaitTracesFromLog(1);
         assertEquals(1, traces.size());
         checkTrace(traces.values().iterator().next());
     }

--- a/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/TelemetryDevTracerTest.java
+++ b/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/TelemetryDevTracerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.telemetrydev;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -45,21 +44,21 @@ public class TelemetryDevTracerTest extends TelemetryDevTracerTestSupport {
     }
 
     @Test
-    void testRouteSingleRequest() throws IOException {
+    void testRouteSingleRequest() {
         Exchange result = template.request("direct:start", null);
         // Make sure the trace is propagated downstream
         assertNotNull(result.getIn().getHeader("traceparent"));
-        Map<String, DevTrace> traces = tracesFromLog();
+        Map<String, DevTrace> traces = awaitTracesFromLog(1);
         assertEquals(1, traces.size());
         checkTrace(traces.values().iterator().next(), null);
     }
 
     @Test
-    void testRouteMultipleRequests() throws IOException {
+    void testRouteMultipleRequests() {
         for (int i = 1; i <= 10; i++) {
             context.createProducerTemplate().sendBody("direct:start", "Hello!");
         }
-        Map<String, DevTrace> traces = tracesFromLog();
+        Map<String, DevTrace> traces = awaitTracesFromLog(10);
         // Each trace should have a unique trace id. It is enough to assert that
         // the number of elements in the map is the same of the requests to prove
         // all traces have been generated uniquely.

--- a/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/TelemetryDevTracerTestSupport.java
+++ b/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/TelemetryDevTracerTestSupport.java
@@ -23,6 +23,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.telemetry.Op;
@@ -32,14 +33,32 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.awaitility.Awaitility.await;
 
 public class TelemetryDevTracerTestSupport extends ExchangeTestSupport {
 
     private final ObjectMapper mapper = new ObjectMapper();
 
+    /*
+     * Clear the log traces before each test to prevent flaky tests from leftover data
+     */
+    @BeforeEach
+    public synchronized void clearLogTracesBeforeTest() throws IOException {
+        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        RollingFileAppender appender = (RollingFileAppender) ctx.getConfiguration().getAppenders().get("file2");
+        if (appender != null) {
+            appender.getManager().rollover();
+        }
+    }
+
     protected Map<String, DevTrace> tracesFromLog() throws IOException {
         Map<String, DevTrace> answer = new HashMap<>();
         Path path = Paths.get("target/telemetry-traces.log");
+        if (!Files.exists(path)) {
+            return answer;
+        }
         List<String> allTraces = Files.readAllLines(path);
         for (String trace : allTraces) {
             DevTrace st = mapper.readValue(trace, DevTrace.class);
@@ -55,6 +74,28 @@ public class TelemetryDevTracerTestSupport extends ExchangeTestSupport {
         }
 
         return answer;
+    }
+
+    /**
+     * Wait for the expected number of traces to be written to the log file. Uses Awaitility to avoid flaky tests from
+     * timing issues.
+     */
+    protected Map<String, DevTrace> awaitTracesFromLog(int expectedCount) {
+        await().atMost(10, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .until(() -> {
+                    try {
+                        Map<String, DevTrace> traces = tracesFromLog();
+                        return traces.size() >= expectedCount;
+                    } catch (IOException e) {
+                        return false;
+                    }
+                });
+        try {
+            return tracesFromLog();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read traces from log", e);
+        }
     }
 
     /*

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/SpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/SpanDecorator.java
@@ -38,4 +38,12 @@ public interface SpanDecorator {
 
     SpanContextPropagationInjector getInjector(Exchange exchange);
 
+    /**
+     * This method returns the SpanKind for a given operation.
+     *
+     * @param  op The operation type
+     * @return    The span kind to use for this operation
+     */
+    SpanKind getSpanKind(Op op);
+
 }

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/SpanKind.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/SpanKind.java
@@ -17,18 +17,23 @@
 package org.apache.camel.telemetry;
 
 /**
- * This interface is used to manage the lifecycle of a Span.
+ * Span kind constants for telemetry tracing.
+ * <p>
+ * These values describe the relationship between the span and its parent:
+ * <ul>
+ * <li>CLIENT - The span covers a client-side call to a remote service</li>
+ * <li>SERVER - The span covers server-side handling of a remote request</li>
+ * <li>PRODUCER - The span covers the production of a message to a remote system (e.g., message broker, queue, HTTP
+ * endpoint)</li>
+ * <li>CONSUMER - The span covers the consumption of a message from a remote system (e.g., message broker, queue, HTTP
+ * endpoint)</li>
+ * <li>INTERNAL - The span represents internal operations with no remote interaction</li>
+ * </ul>
  */
-public interface SpanLifecycleManager {
-
-    Span create(String spanName, SpanKind kind, Span parent, SpanContextPropagationExtractor extractor);
-
-    void activate(Span span);
-
-    void deactivate(Span span);
-
-    void close(Span span);
-
-    void inject(Span span, SpanContextPropagationInjector injector, boolean includeTracing);
-
+public enum SpanKind {
+    CLIENT,
+    SERVER,
+    PRODUCER,
+    CONSUMER,
+    INTERNAL
 }

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/Tracer.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/Tracer.java
@@ -270,7 +270,8 @@ public abstract class Tracer extends ServiceSupport implements CamelTracingServi
         SpanDecorator spanDecorator = spanDecoratorManager.get(endpoint);
         Span parentSpan = spanStorageManager.peek(exchange);
         String spanName = spanDecorator.getOperationName(exchange, endpoint);
-        Span span = spanLifecycleManager.create(spanName, parentSpan, spanDecorator.getExtractor(exchange));
+        SpanKind spanKind = spanDecorator.getSpanKind(op);
+        Span span = spanLifecycleManager.create(spanName, spanKind, parentSpan, spanDecorator.getExtractor(exchange));
         span.setTag(TagConstants.OP, op.toString());
         spanDecorator.beforeTracingEvent(span, exchange, endpoint);
         spanLifecycleManager.activate(span);
@@ -286,7 +287,8 @@ public abstract class Tracer extends ServiceSupport implements CamelTracingServi
             // there is some inconsistency
             LOG.warn("Processor tracing parent should not be null!");
         }
-        Span span = spanLifecycleManager.create(processorName, parentSpan, spanDecorator.getExtractor(exchange));
+        SpanKind spanKind = spanDecorator.getSpanKind(Op.EVENT_PROCESS);
+        Span span = spanLifecycleManager.create(processorName, spanKind, parentSpan, spanDecorator.getExtractor(exchange));
         span.setTag(TagConstants.OP, Op.EVENT_PROCESS.toString());
         spanDecorator.beforeTracingEvent(span, exchange, null);
         spanLifecycleManager.activate(span);

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AbstractHttpSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AbstractHttpSpanDecorator.java
@@ -19,7 +19,9 @@ package org.apache.camel.telemetry.decorators;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.telemetry.Op;
 import org.apache.camel.telemetry.Span;
+import org.apache.camel.telemetry.SpanKind;
 import org.apache.camel.telemetry.TagConstants;
 
 public abstract class AbstractHttpSpanDecorator extends AbstractSpanDecorator {
@@ -104,5 +106,14 @@ public abstract class AbstractHttpSpanDecorator extends AbstractSpanDecorator {
                 span.setTag(TagConstants.HTTP_STATUS, responseCode.toString());
             }
         }
+    }
+
+    @Override
+    public SpanKind getSpanKind(Op op) {
+        return switch (op) {
+            case EVENT_SENT -> SpanKind.CLIENT;
+            case EVENT_RECEIVED -> SpanKind.SERVER;
+            case EVENT_PROCESS -> SpanKind.INTERNAL;
+        };
     }
 }

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AbstractMessagingSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AbstractMessagingSpanDecorator.java
@@ -18,7 +18,9 @@ package org.apache.camel.telemetry.decorators;
 
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Op;
 import org.apache.camel.telemetry.Span;
+import org.apache.camel.telemetry.SpanKind;
 import org.apache.camel.telemetry.TagConstants;
 
 public abstract class AbstractMessagingSpanDecorator extends AbstractSpanDecorator {
@@ -58,6 +60,15 @@ public abstract class AbstractMessagingSpanDecorator extends AbstractSpanDecorat
      */
     protected String getMessageId(Exchange exchange) {
         return null;
+    }
+
+    @Override
+    public SpanKind getSpanKind(Op op) {
+        return switch (op) {
+            case EVENT_SENT -> SpanKind.PRODUCER;
+            case EVENT_RECEIVED -> SpanKind.CONSUMER;
+            case EVENT_PROCESS -> SpanKind.INTERNAL;
+        };
     }
 
 }

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AbstractSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AbstractSpanDecorator.java
@@ -21,10 +21,12 @@ import java.util.*;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.EndpointServiceLocation;
+import org.apache.camel.telemetry.Op;
 import org.apache.camel.telemetry.Span;
 import org.apache.camel.telemetry.SpanContextPropagationExtractor;
 import org.apache.camel.telemetry.SpanContextPropagationInjector;
 import org.apache.camel.telemetry.SpanDecorator;
+import org.apache.camel.telemetry.SpanKind;
 import org.apache.camel.telemetry.TagConstants;
 import org.apache.camel.telemetry.propagation.CamelHeadersSpanContextPropagationExtractor;
 import org.apache.camel.telemetry.propagation.CamelHeadersSpanContextPropagationInjector;
@@ -174,5 +176,11 @@ public abstract class AbstractSpanDecorator implements SpanDecorator {
     @Override
     public SpanContextPropagationInjector getInjector(Exchange exchange) {
         return new CamelHeadersSpanContextPropagationInjector(exchange.getIn().getHeaders());
+    }
+
+    @Override
+    public SpanKind getSpanKind(Op op) {
+        // Default to INTERNAL for all operations
+        return SpanKind.INTERNAL;
     }
 }

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/mock/MockTracer.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/mock/MockTracer.java
@@ -24,11 +24,7 @@ import java.util.UUID;
 import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.spi.Configurer;
 import org.apache.camel.spi.annotations.JdkService;
-import org.apache.camel.telemetry.Span;
-import org.apache.camel.telemetry.SpanContextPropagationExtractor;
-import org.apache.camel.telemetry.SpanContextPropagationInjector;
-import org.apache.camel.telemetry.SpanLifecycleManager;
-import org.apache.camel.telemetry.Tracer;
+import org.apache.camel.telemetry.*;
 
 @JdkService("mock-tracer")
 @Configurer
@@ -53,7 +49,9 @@ public class MockTracer extends Tracer {
         Map<String, Span> inMemoryStorageMap = new HashMap<>();
 
         @Override
-        public Span create(String spanName, Span parentSpan, SpanContextPropagationExtractor extractor) {
+        public Span create(
+                String spanName, SpanKind kind, Span parentSpan,
+                SpanContextPropagationExtractor extractor) {
             Span span = MockSpanAdapter.buildSpan(spanName);
             String traceId = UUID.randomUUID().toString().replaceAll("-", "");
             if (parentSpan != null) {
@@ -69,6 +67,7 @@ public class MockTracer extends Tracer {
             }
             span.setTag("traceid", traceId);
             span.setTag("spanid", UUID.randomUUID().toString().replaceAll("-", ""));
+            span.setTag("kind", kind.toString());
             return span;
         }
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_20.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_20.adoc
@@ -25,3 +25,85 @@ segments is no longer accepted and will result in an `InvalidTopicNameException`
 If your Camel routes use topic URIs with extra `/` characters in the topic name portion
 (e.g., `pulsar:persistent://public/default/my-topic/sub-path`), you must replace the extra `/` with
 another separator such as `-` (e.g., `pulsar:persistent://public/default/my-topic-sub-path`).
+
+=== camel-telemetry
+
+The telemetry API has been enhanced to support proper span type classification through the introduction
+of the `SpanKind` enum. This affects custom implementations of telemetry tracers and span decorators.
+
+==== SpanKind API Changes
+
+The `SpanLifecycleManager.create()` method signature has been updated to accept a `SpanKind` parameter:
+
+Before:
+[source,java]
+----
+Span create(Exchange exchange, String spanName);
+----
+
+After:
+[source,java]
+----
+Span create(Exchange exchange, String spanName, SpanKind kind);
+----
+
+==== Impact on Custom Implementations
+
+If you have implemented custom tracer or span decorator classes, you need to update them:
+
+**Custom Tracer Implementations**
+
+If you implemented the `org.apache.camel.telemetry.Tracer` interface, update your `createSpan()` method:
+
+Before:
+[source,java]
+----
+@Override
+public Span createSpan(Exchange exchange, String spanName) {
+    return spanLifecycleManager.create(exchange, spanName);
+}
+----
+
+After:
+[source,java]
+----
+@Override
+public Span createSpan(Exchange exchange, String spanName, SpanKind kind) {
+    return spanLifecycleManager.create(exchange, spanName, kind);
+}
+----
+
+**Custom SpanDecorator Implementations**
+
+If you implemented custom `SpanDecorator` classes, you must now provide span kind information by implementing
+the new `getSpanKind()` method:
+
+[source,java]
+----
+@Override
+public SpanKind getSpanKind() {
+    // Return appropriate span kind based on your component's behavior:
+    // - CLIENT: for outbound calls to remote services
+    // - SERVER: for handling incoming requests
+    // - PRODUCER: for sending messages/data to remote systems
+    // - CONSUMER: for receiving messages/data from remote systems
+    // - INTERNAL: for internal operations with no remote interaction
+    return SpanKind.PRODUCER;
+}
+----
+
+==== MockTracer Test Utilities
+
+If you use `MockTracer` in tests, update calls to `createSpan()`:
+
+Before:
+[source,java]
+----
+mockTracer.createSpan(exchange, "test-span");
+----
+
+After:
+[source,java]
+----
+mockTracer.createSpan(exchange, "test-span", SpanKind.INTERNAL);
+----


### PR DESCRIPTION
  fixes https://issues.apache.org/jira/browse/CAMEL-23312
    
  Adds SpanKind parameter to the Camel telemetry API to enable proper span type classification
  (CLIENT, SERVER, PRODUCER, CONSUMER, INTERNAL) across different observability backends.            
   
  Changes:                                                                                           
  - Introduces org.apache.camel.telemetry.SpanKind enum
  - Updates SpanLifecycleManager.create() signature to accept span kind                              
  - Implements span kind mapping in tracer implementations:            
    - OpenTelemetry2: Maps to native io.opentelemetry.api.trace.SpanKind                             
    - Micrometer: Accepts parameter for API compatibility (kind determined by Observation context)  without using it
    - TelemetryDev: Stores as span tag                                                               
  - Extends SpanDecorator and decorator implementations to provide span kind information             
  - Migrates test code from Thread.sleep() to Awaitility for more reliable async testing             
                                                                                                     
  Impact: Enables proper span classification in distributed traces, improving observability for      
  messaging and HTTP components.


# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

