### PR TITLE
docs: add camel-arangodb section to 4.19 upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_19.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_19.adoc
@@ -471,6 +471,30 @@ Previously the context-path would always be used:
 
 The intention is to allow to configure the `base.path` _as is_ in the return API specification.
 
+=== camel-arangodb
+
+The ArangoDB Java driver (upgraded to 7.24+) no longer defaults to `localhost:8529` when no host is configured.
+You must now explicitly set the host and port:
+
+[source,properties]
+----
+camel.component.arangodb.host=localhost
+camel.component.arangodb.port=8529
+----
+
+Or when using the Java API directly:
+
+[source,java]
+----
+ArangoDbConfiguration config = new ArangoDbConfiguration();
+config.setHost("localhost");
+config.setPort(8529);
+----
+
+Additionally, the `RESULT_CLASS_TYPE` header for `FIND_DOCUMENT_BY_KEY` no longer accepts `String.class`
+to retrieve documents. Use the appropriate document type (e.g., `BaseDocument.class`) instead, as Jackson 2.21
+no longer coerces JSON objects into plain Strings.
+
 === camel-as2
 
 Some public constants were deprecated:

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_19.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_19.adoc
@@ -491,10 +491,6 @@ config.setHost("localhost");
 config.setPort(8529);
 ----
 
-Additionally, the `RESULT_CLASS_TYPE` header for `FIND_DOCUMENT_BY_KEY` no longer accepts `String.class`
-to retrieve documents. Use the appropriate document type (e.g., `BaseDocument.class`) instead, as Jackson 2.21
-no longer coerces JSON objects into plain Strings.
-
 === camel-as2
 
 Some public constants were deprecated:


### PR DESCRIPTION
## Summary
- Add `camel-arangodb` section to the 4.19 upgrade guide documenting two breaking changes from the ArangoDB Java driver 7.24+ upgrade:
  - Host/port must now be explicitly configured (driver no longer defaults to `localhost:8529`)

## Context
Found while testing the `camel-spring-boot-examples` arangodb example against Camel 4.19.0. The ArangoDB driver 7.24 added a `"No host has been set!"` validation that did not exist in 7.23. Camel 4.17.0 was the first version to use driver 7.24.2.