### PR TITLE
Use JDK21 when deploying SNAPSHOT

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 def AGENT_LABEL = env.AGENT_LABEL ?: 'ubuntu'
-def JDK_NAME = env.JDK_NAME ?: 'jdk_17_latest'
+def JDK_NAME = env.JDK_NAME ?: 'jdk_21_latest'
 
 def MAVEN_PARAMS = "-U -B -e -fae -V -Dnoassembly -Dmaven.compiler.fork=true "
 


### PR DESCRIPTION
with jdk 17 the multi jar deployment for virtual threads does not work, use jdk21 instead.
