### PR TITLE
[backport camel-4.14.x] CAMEL-23322: Add deserialization filtering to camel-infinispan remote aggregation repository

### DIFF
--- a/components/camel-infinispan/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/remote/protostream/DefaultExchangeHolderUtils.java
+++ b/components/camel-infinispan/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/remote/protostream/DefaultExchangeHolderUtils.java
@@ -19,16 +19,27 @@ package org.apache.camel.component.infinispan.remote.protostream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.camel.support.DefaultExchangeHolder;
 import org.apache.camel.util.ClassLoadingAwareObjectInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utilities for {@link DefaultExchangeHolder} and the Infinispan Protostream marshaller.
  */
 final class DefaultExchangeHolderUtils {
+
+    /**
+     * Default deserialization filter that restricts which classes can be deserialized. Allows standard Java types and
+     * Apache Camel types. Can be overridden via the JVM system property {@code jdk.serialFilter}.
+     */
+    static final String DEFAULT_DESERIALIZATION_FILTER = "java.**;javax.**;org.apache.camel.**;!*";
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultExchangeHolderUtils.class);
 
     private DefaultExchangeHolderUtils() {
         // Utility class
@@ -46,6 +57,14 @@ final class DefaultExchangeHolderUtils {
     static DefaultExchangeHolder deserialize(byte[] bytes) {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
              ObjectInputStream ois = new ClassLoadingAwareObjectInputStream(bais)) {
+            ObjectInputFilter jvmFilter = ObjectInputFilter.Config.getSerialFilter();
+            if (jvmFilter != null) {
+                ois.setObjectInputFilter(jvmFilter);
+            } else {
+                LOG.debug("No JVM-wide deserialization filter set, applying default Camel filter: {}",
+                        DEFAULT_DESERIALIZATION_FILTER);
+                ois.setObjectInputFilter(ObjectInputFilter.Config.createFilter(DEFAULT_DESERIALIZATION_FILTER));
+            }
             return (DefaultExchangeHolder) ois.readObject();
         } catch (IOException | ClassNotFoundException e) {
             throw new RuntimeException(e);

--- a/components/camel-infinispan/camel-infinispan/src/test/java/com/example/external/NotAllowedSerializable.java
+++ b/components/camel-infinispan/camel-infinispan/src/test/java/com/example/external/NotAllowedSerializable.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.external;
+
+import java.io.Serializable;
+
+/**
+ * Serializable type living outside the {@code java.**}, {@code javax.**} and {@code org.apache.camel.**} packages, used
+ * to verify that the default deserialization allowlist rejects unknown classes.
+ */
+public final class NotAllowedSerializable implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String value;
+
+    public NotAllowedSerializable(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/protostream/DefaultExchangeHolderUtilsTest.java
+++ b/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/protostream/DefaultExchangeHolderUtilsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.infinispan.remote.protostream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+import com.example.external.NotAllowedSerializable;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.apache.camel.support.DefaultExchangeHolder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DefaultExchangeHolderUtilsTest {
+
+    @Test
+    public void testDeserializeAcceptsDefaultExchangeHolder() {
+        DefaultCamelContext context = new DefaultCamelContext();
+        DefaultExchange exchange = new DefaultExchange(context);
+        exchange.getIn().setBody("hello");
+
+        DefaultExchangeHolder holder = DefaultExchangeHolder.marshal(exchange, true);
+        byte[] bytes = DefaultExchangeHolderUtils.serialize(holder);
+
+        DefaultExchangeHolder roundTripped = DefaultExchangeHolderUtils.deserialize(bytes);
+        assertNotNull(roundTripped);
+
+        DefaultExchange restored = new DefaultExchange(context);
+        DefaultExchangeHolder.unmarshal(restored, roundTripped);
+        assertEquals("hello", restored.getIn().getBody());
+    }
+
+    @Test
+    public void testDeserializeRejectsUnlistedType() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(new NotAllowedSerializable("blocked"));
+        }
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> DefaultExchangeHolderUtils.deserialize(baos.toByteArray()));
+        Throwable cause = thrown.getCause();
+        assertNotNull(cause);
+    }
+}


### PR DESCRIPTION
## Backport of #22599

Cherry-pick of #22599 onto `camel-4.14.x`.

**Original PR:** #22599 - CAMEL-23322: Add deserialization filtering to camel-infinispan remote aggregation repository
**Original author:** @oscerd
**Target branch:** `camel-4.14.x`
**Jira:** https://issues.apache.org/jira/browse/CAMEL-23322

> :warning: **Hold for source PR.** Source PR #22599 on `main` is still open at the time this backport was raised. Please do not merge this backport until #22599 is merged. If the source PR is modified during review, this backport branch will be re-cherry-picked from the final merge commit before merging here.

### Change

`DefaultExchangeHolderUtils.deserialize()` now configures a filter on the
`ObjectInputStream` before calling `readObject()`:

- If a JVM-wide filter is set via `-Djdk.serialFilter` (or
  `ObjectInputFilter.Config.setSerialFilter`), that filter is applied.
- Otherwise a default Camel allowlist is applied:
  `java.**;javax.**;org.apache.camel.**;!*`.

### Tests

- `DefaultExchangeHolderUtilsTest.testDeserializeAcceptsDefaultExchangeHolder`
  verifies that a normal `DefaultExchangeHolder` still round-trips through
  the ProtoStream path.
- `DefaultExchangeHolderUtilsTest.testDeserializeRejectsUnlistedType`
  verifies that a type outside the allowlist is rejected.

Cherry-pick applied cleanly against the `camel-4.14.x` baseline (same context as `main`). Local verification on `main` and `camel-4.18.x` was green; CI will validate the 4.14.x build.

_Claude Code on behalf of Andrea Cosentino_