### PR TITLE
CAMEL-23323 - avoid all tests hanging when building with Maven

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4467,8 +4467,16 @@
                                     junit.jupiter.execution.parallel.mode.classes.default = concurrent
                                     junit.jupiter.execution.parallel.config.strategy = ${camel.surefire.parallel.strategy}
                                     junit.jupiter.execution.parallel.config.dynamic.factor = ${camel.surefire.parallel.factor}
+                                    junit.jupiter.execution.timeout.default = 10 m
                                 </configurationParameters>
                             </properties>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <argLine>@{camel.failsafe.fork.vmargs} @{argLine} -Djunit.jupiter.execution.timeout.default=10m</argLine>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
it will avoid build taking several hours and being aborted on Jenkins CI

note that it doesn't solve the root cause of why the test hangs

# Description

Previously we used this same property in junit-platform.properties for jms tests. Given that similar issue occurs with other tests, I propose to try to configure it in the maven build level so it can be applied on all kind of tests. I think 10 minutes is in theory enough for all tests

more information on test timeout here https://docs.junit.org/6.0.3/writing-tests/timeouts.html#default-timeouts

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

