### PR TITLE
Enforce JDK 21+ as minimum build JDK for multi-release JAR support

### DIFF
--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -70,6 +70,10 @@ jobs:
         java: ['17', '21']
         experimental: [ false ]
         include:
+          - java: '17'
+            # JDK 17 is kept for runtime compatibility testing.
+            # Skip the enforcer which requires JDK 21+ (needed to compile JDK 21-specific classes).
+            maven_extra_args: '-Denforcer.phase=none'
           - java: '25'
             experimental: true
 
@@ -90,6 +94,8 @@ jobs:
           cache: 'maven'
       - name: maven build
         if: ${{ !inputs.skip_full_build }}
+        env:
+          MAVEN_EXTRA_ARGS: ${{ matrix.maven_extra_args || '' }}
         run: ./etc/scripts/regen.sh
       - name: Quick dependency build
         if: ${{ inputs.skip_full_build }}

--- a/etc/scripts/regen.sh
+++ b/etc/scripts/regen.sh
@@ -26,7 +26,7 @@ git clean -fdx
 rm -Rf **/src/generated/
 
 # Regenerate everything
-if ./mvnw --batch-mode -Pregen -DskipTests install >> build.log 2>&1; then
+if ./mvnw --batch-mode -Pregen -DskipTests ${MAVEN_EXTRA_ARGS} install >> build.log 2>&1; then
   echo "✅ mvn -Pregen succeeded."
 else
   echo "❌ mvn -Pregen failed. Last 50 lines of build.log:"
@@ -35,7 +35,7 @@ else
 fi
 
 # One additional pass to get the info for the 'others' jars
-if ./mvnw --batch-mode install -f catalog/camel-catalog >> build.log 2>&1; then
+if ./mvnw --batch-mode ${MAVEN_EXTRA_ARGS} install -f catalog/camel-catalog >> build.log 2>&1; then
   echo "✅ mvn install for camel-catalog succeeded."
 else
   echo "❌ mvn install for camel-catalog failed. Last 50 lines of build.log:"

--- a/pom.xml
+++ b/pom.xml
@@ -869,6 +869,23 @@
                             <outputName>${project.artifactId}-${project.version}-sbom</outputName>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-java-version</id>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <version>[25,)</version>
+                                            <message>JDK 25+ is required for releases to ensure all multi-release JAR layers (java-21, java-25) are compiled.</message>
+                                        </requireJavaVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
 
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,14 @@
                     <execution>
                         <id>enforce-java-version</id>
                         <phase>${enforcer.phase}</phase>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[21,)</version>
+                                    <message>JDK 21+ is required to build Apache Camel. JDK 21-specific classes (e.g., virtual thread support in camel-util) are only compiled with JDK 21+. Building with JDK 17 silently omits these classes from the resulting JARs.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary

- Add `requireJavaVersion [21,)` to the existing `enforce-java-version` execution in `maven-enforcer-plugin`
- Update `minimalJavaBuildVersion` from `${jdk.version}` (17) to `21`

## Motivation

`camel-util` uses multi-release JARs with a `java-21-sources` profile activated by `<jdk>[21,)</jdk>`. If Camel is built with JDK 17, the virtual thread classes under `META-INF/versions/21/` are silently omitted — users running on JDK 21 would get JARs without virtual thread support.

`Jenkinsfile.deploy` defaults to `jdk_17_latest`, meaning daily SNAPSHOT deployments were built without virtual thread support.

This does **not** change the runtime requirement — Camel JARs remain Java 17 compatible. It only ensures the build JDK is high enough to compile the multi-release JAR layers.

The enforcer runs only when the `full` profile is active (not with `-Dquickly`), so fast local builds are unaffected. The `Jenkinsfile.deploy` fix ensures SNAPSHOT deployments use JDK 21.

Discussion thread: dev@camel.apache.org "Enforce JDK 21+ for building Camel"