### PR TITLE
Enforce JDK 21+ as minimum build JDK for multi-release JAR support

### DIFF
--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -41,11 +41,13 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        java: ['17']
+        java: ['17', '21']
         experimental: [ false ]
         include:
-          - java: '21'
-            experimental: true
+          - java: '17'
+            # JDK 17 is kept for runtime compatibility testing.
+            # Skip the enforcer which requires JDK 21+ (needed for multi-release JAR compilation).
+            maven_extra_args: '-Denforcer.phase=none'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -62,6 +64,8 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: maven build
+        env:
+          MAVEN_EXTRA_ARGS: ${{ matrix.maven_extra_args || '' }}
         run: ./etc/scripts/regen.sh
       - name: archive logs
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 def AGENT_LABEL = env.AGENT_LABEL ?: 'ubuntu'
-def JDK_NAME = env.JDK_NAME ?: 'jdk_17_latest'
+def JDK_NAME = env.JDK_NAME ?: 'jdk_21_latest'
 
 def MAVEN_PARAMS = "-U -B -e -fae -V -Dnoassembly -Dmaven.compiler.fork=true "
 

--- a/etc/scripts/regen.sh
+++ b/etc/scripts/regen.sh
@@ -26,7 +26,7 @@ git clean -fdx
 rm -Rf **/src/generated/
 
 # Regenerate everything
-if ./mvnw --batch-mode -Pregen -DskipTests install >> build.log 2>&1; then
+if ./mvnw --batch-mode -Pregen -DskipTests ${MAVEN_EXTRA_ARGS} install >> build.log 2>&1; then
   echo "✅ mvn -Pregen succeeded."
 else
   echo "❌ mvn -Pregen failed. Last 50 lines of build.log:"
@@ -35,7 +35,7 @@ else
 fi
 
 # One additional pass to get the info for the 'others' jars
-if ./mvnw --batch-mode install -f catalog/camel-catalog >> build.log 2>&1; then
+if ./mvnw --batch-mode ${MAVEN_EXTRA_ARGS} install -f catalog/camel-catalog >> build.log 2>&1; then
   echo "✅ mvn install for camel-catalog succeeded."
 else
   echo "❌ mvn install for camel-catalog failed. Last 50 lines of build.log:"

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <maven.compiler.source>${jdk.version}</maven.compiler.source>
         <maven.compiler.target>${jdk.version}</maven.compiler.target>
         <maven.compiler.release>${jdk.version}</maven.compiler.release>
-        <minimalJavaBuildVersion>${jdk.version}</minimalJavaBuildVersion>
+        <minimalJavaBuildVersion>21</minimalJavaBuildVersion>
 
         <!-- reproducible builds: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
         <project.build.outputTimestamp>2026-03-23T15:25:22Z</project.build.outputTimestamp>
@@ -190,6 +190,14 @@
                     <execution>
                         <id>enforce-java-version</id>
                         <phase>${enforcer.phase}</phase>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[21,)</version>
+                                    <message>JDK 21+ is required to build Apache Camel. The multi-release JAR in camel-util requires JDK 21+ to compile virtual thread support. Building with JDK 17 produces JARs without virtual thread support.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary

- Add `requireJavaVersion [21,)` to the existing `enforce-java-version` execution in `maven-enforcer-plugin`
- Change `Jenkinsfile.deploy` default JDK from `jdk_17_latest` to `jdk_21_latest`
- Update `minimalJavaBuildVersion` from `${jdk.version}` (17) to `21`

## Motivation

`camel-util` uses multi-release JARs with a `java-21-sources` profile activated by `<jdk>[21,)</jdk>`. If Camel is built with JDK 17, the virtual thread classes under `META-INF/versions/21/` are silently omitted — users running on JDK 21 would get JARs without virtual thread support.

`Jenkinsfile.deploy` defaults to `jdk_17_latest`, meaning daily SNAPSHOT deployments were built without virtual thread support.

This does **not** change the runtime requirement — Camel JARs remain Java 17 compatible. It only ensures the build JDK is high enough to compile the multi-release JAR layers.

The enforcer runs only when the `full` profile is active (not with `-Dquickly`), so fast local builds are unaffected. The `Jenkinsfile.deploy` fix ensures SNAPSHOT deployments use JDK 21.

Backport of https://github.com/apache/camel/pull/22608

Discussion thread: dev@camel.apache.org "[DISCUSS] Enforce JDK 21+ for building Camel"