### PR TITLE
fix(core): migrate setStartingRoutes/setLockModel to scoped ContextValue pattern

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.TreeSet;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledExecutorService;
@@ -1131,6 +1132,7 @@ public abstract class AbstractCamelContext extends BaseService
         return Boolean.TRUE.equals(isStartingRoutes.orElse(false));
     }
 
+    @Deprecated(since = "4.20.0")
     public void setStartingRoutes(boolean starting) {
         if (starting) {
             isStartingRoutes.set(true);
@@ -1139,16 +1141,61 @@ public abstract class AbstractCamelContext extends BaseService
         }
     }
 
+    /**
+     * Executes the given operation within a "starting routes" context.
+     */
+    public void startingRoutes(Runnable operation) {
+        ContextValue.where(isStartingRoutes, true, operation);
+    }
+
+    /**
+     * Executes the given operation within a "starting routes" context.
+     */
+    public <T> T startingRoutes(Callable<T> callable) throws Exception {
+        return ContextValue.where(isStartingRoutes, true, () -> {
+            try {
+                return callable.call();
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
     public boolean isLockModel() {
         return Boolean.TRUE.equals(isLockModel.orElse(false));
     }
 
+    @Deprecated(since = "4.20.0")
     public void setLockModel(boolean lockModel) {
         if (lockModel) {
             isLockModel.set(true);
         } else {
             isLockModel.remove();
         }
+    }
+
+    /**
+     * Executes the given operation within a "lock model" context.
+     */
+    public void lockModel(Runnable operation) {
+        ContextValue.where(isLockModel, true, operation);
+    }
+
+    /**
+     * Executes the given operation within a "lock model" context.
+     */
+    public <T> T lockModel(Callable<T> callable) throws Exception {
+        return ContextValue.where(isLockModel, true, () -> {
+            try {
+                return callable.call();
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     public void startAllRoutes() throws Exception {
@@ -3559,14 +3606,7 @@ public abstract class AbstractCamelContext extends BaseService
     public void startRouteService(RouteService routeService, boolean addingRoutes) throws Exception {
         lock.lock();
         try {
-            // we may already be starting routes so remember this, so we can unset
-            // accordingly in finally block
-            boolean alreadyStartingRoutes = isStartingRoutes();
-            if (!alreadyStartingRoutes) {
-                setStartingRoutes(true);
-            }
-
-            try {
+            startingRoutes(() -> {
                 // the route service could have been suspended, and if so then
                 // resume it instead
                 if (routeService.getStatus().isSuspended()) {
@@ -3596,11 +3636,8 @@ public abstract class AbstractCamelContext extends BaseService
                         startupStepRecorder.endStep(step);
                     }
                 }
-            } finally {
-                if (!alreadyStartingRoutes) {
-                    setStartingRoutes(false);
-                }
-            }
+                return null;
+            });
         } finally {
             lock.unlock();
         }

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/InternalRouteController.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/InternalRouteController.java
@@ -87,14 +87,12 @@ class InternalRouteController implements RouteController {
     public void reloadAllRoutes() throws Exception {
         // lock model as we need to preserve the model definitions
         // during removing routes because we need to create new processors from the models
-        abstractCamelContext.setLockModel(true);
-        try {
+        abstractCamelContext.lockModel(() -> {
             abstractCamelContext.removeAllRoutes();
             // remove endpoints, so we can start on a fresh
             abstractCamelContext.getEndpointRegistry().clear();
-        } finally {
-            abstractCamelContext.setLockModel(false);
-        }
+            return null;
+        });
         // remove left-over route created from templates (model should not be locked for templates to be removed)
         abstractCamelContext.removeRouteDefinitionsFromTemplate();
         // start all routes again

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/InternalRouteStartupManager.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/InternalRouteStartupManager.java
@@ -77,8 +77,7 @@ final class InternalRouteStartupManager {
     public void doInitRoutes(AbstractCamelContext camelContext, Map<String, RouteService> routeServices)
             throws Exception {
 
-        camelContext.setStartingRoutes(true);
-        try {
+        camelContext.startingRoutes(() -> {
             for (RouteService routeService : routeServices.values()) {
                 StartupStep step = camelContext.getCamelContextExtension().getStartupStepRecorder().beginStep(Route.class,
                         routeService.getId(),
@@ -95,9 +94,8 @@ final class InternalRouteStartupManager {
                     camelContext.getCamelContextExtension().getStartupStepRecorder().endStep(step);
                 }
             }
-        } finally {
-            camelContext.setStartingRoutes(false);
-        }
+            return null;
+        });
     }
 
     /**
@@ -116,8 +114,7 @@ final class InternalRouteStartupManager {
             Map<String, RouteService> routeServices, boolean checkClash, boolean startConsumer, boolean resumeConsumer,
             boolean addingRoutes)
             throws Exception {
-        camelContext.setStartingRoutes(true);
-        try {
+        camelContext.startingRoutes(() -> {
             // filter out already started routes
             Map<String, RouteService> filtered = new LinkedHashMap<>();
             for (Map.Entry<String, RouteService> entry : routeServices.entrySet()) {
@@ -130,10 +127,8 @@ final class InternalRouteStartupManager {
 
             // the context is in last phase of staring, so lets start the routes
             safelyStartRouteServices(camelContext, checkClash, startConsumer, resumeConsumer, addingRoutes, filtered.values());
-
-        } finally {
-            camelContext.setStartingRoutes(false);
-        }
+            return null;
+        });
     }
 
     private static boolean isStartable(Map.Entry<String, RouteService> entry) {

--- a/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -631,11 +631,13 @@ public class DefaultCamelContext extends SimpleCamelContext implements ModelCame
     public void startRouteDefinitions(List<RouteDefinition> routeDefinitions) throws Exception {
         // indicate we are staring the route using this thread so
         // we are able to query this if needed
-        boolean alreadyStartingRoutes = isStartingRoutes();
-        if (!alreadyStartingRoutes) {
-            setStartingRoutes(true);
-        }
+        startingRoutes(() -> {
+            doStartRouteDefinitions(routeDefinitions);
+            return null;
+        });
+    }
 
+    private void doStartRouteDefinitions(List<RouteDefinition> routeDefinitions) throws Exception {
         PropertiesComponent pc = getCamelContextReference().getPropertiesComponent();
         // route templates supports binding beans that are local for the template only
         // in this local mode then we need to check for side-effects (see further)
@@ -644,157 +646,151 @@ public class DefaultCamelContext extends SimpleCamelContext implements ModelCame
         if (registry instanceof LocalBeanRepositoryAware localBeanRepositoryAware) {
             localBeans = localBeanRepositoryAware;
         }
-        try {
-            RouteDefinitionHelper.forceAssignIds(getCamelContextReference(), routeDefinitions);
-            List<RouteDefinition> routeDefinitionsToRemove = null;
-            for (RouteDefinition routeDefinition : routeDefinitions) {
-                try {
-                    // assign ids to the routes and validate that the id's is all unique
-                    String duplicate = RouteDefinitionHelper.validateUniqueIds(routeDefinition, routeDefinitions,
-                            routeDefinition.getNodePrefixId());
-                    if (duplicate != null) {
-                        throw new FailedToStartRouteException(
-                                routeDefinition.getId(),
-                                "Duplicate id detected: " + duplicate
-                                                         + ". Please correct ids to be unique among all your routes.");
+        RouteDefinitionHelper.forceAssignIds(getCamelContextReference(), routeDefinitions);
+        List<RouteDefinition> routeDefinitionsToRemove = null;
+        for (RouteDefinition routeDefinition : routeDefinitions) {
+            try {
+                // assign ids to the routes and validate that the id's is all unique
+                String duplicate = RouteDefinitionHelper.validateUniqueIds(routeDefinition, routeDefinitions,
+                        routeDefinition.getNodePrefixId());
+                if (duplicate != null) {
+                    throw new FailedToStartRouteException(
+                            routeDefinition.getId(),
+                            "Duplicate id detected: " + duplicate
+                                                     + ". Please correct ids to be unique among all your routes.");
+                }
+
+                // if the route definition was created via a route template then we need to
+                // prepare its parameters when the route is being created and started
+                if (routeDefinition.isTemplate() != null && routeDefinition.isTemplate()
+                        && routeDefinition.getTemplateParameters() != null) {
+
+                    // apply configurer if any present
+                    if (routeDefinition.getRouteTemplateContext().getConfigurer() != null) {
+                        routeDefinition.getRouteTemplateContext().getConfigurer()
+                                .accept(routeDefinition.getRouteTemplateContext());
                     }
 
-                    // if the route definition was created via a route template then we need to
-                    // prepare its parameters when the route is being created and started
-                    if (routeDefinition.isTemplate() != null && routeDefinition.isTemplate()
-                            && routeDefinition.getTemplateParameters() != null) {
+                    // copy parameters/bean repository to not cause side effect
+                    Map<String, Object> params = new HashMap<>(routeDefinition.getTemplateParameters());
+                    LocalBeanRegistry bbr = (LocalBeanRegistry) routeDefinition.getRouteTemplateContext()
+                            .getLocalBeanRepository();
+                    LocalBeanRegistry bbrCopy = new LocalBeanRegistry();
 
-                        // apply configurer if any present
-                        if (routeDefinition.getRouteTemplateContext().getConfigurer() != null) {
-                            routeDefinition.getRouteTemplateContext().getConfigurer()
-                                    .accept(routeDefinition.getRouteTemplateContext());
-                        }
-
-                        // copy parameters/bean repository to not cause side effect
-                        Map<String, Object> params = new HashMap<>(routeDefinition.getTemplateParameters());
-                        LocalBeanRegistry bbr = (LocalBeanRegistry) routeDefinition.getRouteTemplateContext()
-                                .getLocalBeanRepository();
-                        LocalBeanRegistry bbrCopy = new LocalBeanRegistry();
-
-                        // make all bean in the bean repository use unique keys (need to add uuid
-                        // counter)
-                        // so when the route template is used again to create another route, then there
-                        // is
-                        // no side-effect from previously used values that Camel may use in its endpoint
-                        // registry and elsewhere
-                        if (bbr != null && !bbr.isEmpty()) {
-                            for (Map.Entry<String, Object> param : params.entrySet()) {
-                                Object value = param.getValue();
-                                if (value instanceof String oldKey) {
-                                    boolean clash = bbr.keys().stream().anyMatch(k -> k.equals(oldKey));
-                                    if (clash) {
-                                        String newKey = oldKey + "-" + UUID.generateUuid();
-                                        LOG.debug(
-                                                "Route: {} re-assigning local-bean id: {} to: {} to ensure ids are globally unique",
-                                                routeDefinition.getId(), oldKey, newKey);
-                                        bbrCopy.put(newKey, bbr.remove(oldKey));
-                                        param.setValue(newKey);
-                                    }
-                                }
-                            }
-                            // the remainder of the local beans must also have their ids made global unique
-                            for (Map.Entry<String, Map<Class<?>, Object>> entry : bbr.entrySet()) {
-                                String oldKey = entry.getKey();
-                                String newKey = oldKey + "-" + UUID.generateUuid();
-                                LOG.debug(
-                                        "Route: {} re-assigning local-bean id: {} to: {} to ensure ids are globally unique",
-                                        routeDefinition.getId(), oldKey, newKey);
-                                bbrCopy.put(newKey, entry.getValue());
-                                if (!params.containsKey(oldKey)) {
-                                    // if a bean was bound as local bean with a key and it was not defined as
-                                    // template parameter
-                                    // then store it as if it was a template parameter with same key=value which
-                                    // allows us
-                                    // to use this local bean in the route without any problem such as:
-                                    // to("bean:{{myBean}}")
-                                    // and myBean is the local bean id.
-                                    params.put(oldKey, newKey);
+                    // make all bean in the bean repository use unique keys (need to add uuid
+                    // counter)
+                    // so when the route template is used again to create another route, then there
+                    // is
+                    // no side-effect from previously used values that Camel may use in its endpoint
+                    // registry and elsewhere
+                    if (bbr != null && !bbr.isEmpty()) {
+                        for (Map.Entry<String, Object> param : params.entrySet()) {
+                            Object value = param.getValue();
+                            if (value instanceof String oldKey) {
+                                boolean clash = bbr.keys().stream().anyMatch(k -> k.equals(oldKey));
+                                if (clash) {
+                                    String newKey = oldKey + "-" + UUID.generateUuid();
+                                    LOG.debug(
+                                            "Route: {} re-assigning local-bean id: {} to: {} to ensure ids are globally unique",
+                                            routeDefinition.getId(), oldKey, newKey);
+                                    bbrCopy.put(newKey, bbr.remove(oldKey));
+                                    param.setValue(newKey);
                                 }
                             }
                         }
-
-                        OrderedLocationProperties prop = new OrderedLocationProperties();
-                        if (routeDefinition.getTemplateDefaultParameters() != null) {
-                            // need to keep track if a parameter is set as default value or end user
-                            // configured value
-                            params.forEach((k, v) -> {
-                                Object dv = routeDefinition.getTemplateDefaultParameters().get(k);
-                                prop.put(routeDefinition.getLocation(), k, v, dv);
-                            });
-                        } else {
-                            prop.putAll(routeDefinition.getLocation(), params);
-                        }
-                        pc.setLocalProperties(prop);
-
-                        // we need to shadow the bean registry on the CamelContext with the local beans
-                        // from the route template context
-                        if (localBeans != null) {
-                            localBeans.setLocalBeanRepository(bbrCopy);
-                        }
-
-                        // need to reset auto assigned ids, so there is no clash when creating routes
-                        ProcessorDefinitionHelper.resetAllAutoAssignedNodeIds(routeDefinition);
-                        // must re-init parent when created from a template
-                        RouteDefinitionHelper.initParent(routeDefinition);
-                    }
-                    // Check if the route is included
-                    if (includedRoute(routeDefinition)) {
-                        // must ensure route is prepared, before we can start it
-                        if (!routeDefinition.isPrepared()) {
-                            RouteDefinitionHelper.prepareRoute(getCamelContextReference(), routeDefinition);
-                            routeDefinition.markPrepared();
-                        }
-                        // force the creation of ids on all nodes in the route
-                        RouteDefinitionHelper.forceAssignIds(this, routeDefinition.getInput());
-                        RouteDefinitionHelper.forceAssignIds(this, routeDefinition);
-
-                        StartupStepRecorder recorder = getCamelContextReference().getCamelContextExtension()
-                                .getStartupStepRecorder();
-                        StartupStep step = recorder.beginStep(Route.class, routeDefinition.getRouteId(),
-                                "Create Route");
-
-                        getCamelContextExtension().createRoute(routeDefinition.getRouteId(), () -> {
-                            try {
-                                Route route = model.getModelReifierFactory().createRoute(this, routeDefinition);
-                                recorder.endStep(step);
-
-                                RouteService routeService = new RouteService(route);
-                                startRouteService(routeService, true);
-                            } catch (RuntimeException e) {
-                                throw e;
-                            } catch (Exception e) {
-                                throw new RuntimeException(e);
+                        // the remainder of the local beans must also have their ids made global unique
+                        for (Map.Entry<String, Map<Class<?>, Object>> entry : bbr.entrySet()) {
+                            String oldKey = entry.getKey();
+                            String newKey = oldKey + "-" + UUID.generateUuid();
+                            LOG.debug(
+                                    "Route: {} re-assigning local-bean id: {} to: {} to ensure ids are globally unique",
+                                    routeDefinition.getId(), oldKey, newKey);
+                            bbrCopy.put(newKey, entry.getValue());
+                            if (!params.containsKey(oldKey)) {
+                                // if a bean was bound as local bean with a key and it was not defined as
+                                // template parameter
+                                // then store it as if it was a template parameter with same key=value which
+                                // allows us
+                                // to use this local bean in the route without any problem such as:
+                                // to("bean:{{myBean}}")
+                                // and myBean is the local bean id.
+                                params.put(oldKey, newKey);
                             }
+                        }
+                    }
+
+                    OrderedLocationProperties prop = new OrderedLocationProperties();
+                    if (routeDefinition.getTemplateDefaultParameters() != null) {
+                        // need to keep track if a parameter is set as default value or end user
+                        // configured value
+                        params.forEach((k, v) -> {
+                            Object dv = routeDefinition.getTemplateDefaultParameters().get(k);
+                            prop.put(routeDefinition.getLocation(), k, v, dv);
                         });
                     } else {
-                        // Add the definition to the list of definitions to remove as the route is
-                        // excluded
-                        if (routeDefinitionsToRemove == null) {
-                            routeDefinitionsToRemove = new ArrayList<>(routeDefinitions.size());
-                        }
-                        routeDefinitionsToRemove.add(routeDefinition);
+                        prop.putAll(routeDefinition.getLocation(), params);
                     }
-                } finally {
-                    // clear local after the route is created via the reifier
-                    pc.setLocalProperties(null);
+                    pc.setLocalProperties(prop);
+
+                    // we need to shadow the bean registry on the CamelContext with the local beans
+                    // from the route template context
                     if (localBeans != null) {
-                        localBeans.setLocalBeanRepository(null);
+                        localBeans.setLocalBeanRepository(bbrCopy);
                     }
+
+                    // need to reset auto assigned ids, so there is no clash when creating routes
+                    ProcessorDefinitionHelper.resetAllAutoAssignedNodeIds(routeDefinition);
+                    // must re-init parent when created from a template
+                    RouteDefinitionHelper.initParent(routeDefinition);
+                }
+                // Check if the route is included
+                if (includedRoute(routeDefinition)) {
+                    // must ensure route is prepared, before we can start it
+                    if (!routeDefinition.isPrepared()) {
+                        RouteDefinitionHelper.prepareRoute(getCamelContextReference(), routeDefinition);
+                        routeDefinition.markPrepared();
+                    }
+                    // force the creation of ids on all nodes in the route
+                    RouteDefinitionHelper.forceAssignIds(this, routeDefinition.getInput());
+                    RouteDefinitionHelper.forceAssignIds(this, routeDefinition);
+
+                    StartupStepRecorder recorder = getCamelContextReference().getCamelContextExtension()
+                            .getStartupStepRecorder();
+                    StartupStep step = recorder.beginStep(Route.class, routeDefinition.getRouteId(),
+                            "Create Route");
+
+                    getCamelContextExtension().createRoute(routeDefinition.getRouteId(), () -> {
+                        try {
+                            Route route = model.getModelReifierFactory().createRoute(this, routeDefinition);
+                            recorder.endStep(step);
+
+                            RouteService routeService = new RouteService(route);
+                            startRouteService(routeService, true);
+                        } catch (RuntimeException e) {
+                            throw e;
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                } else {
+                    // Add the definition to the list of definitions to remove as the route is
+                    // excluded
+                    if (routeDefinitionsToRemove == null) {
+                        routeDefinitionsToRemove = new ArrayList<>(routeDefinitions.size());
+                    }
+                    routeDefinitionsToRemove.add(routeDefinition);
+                }
+            } finally {
+                // clear local after the route is created via the reifier
+                pc.setLocalProperties(null);
+                if (localBeans != null) {
+                    localBeans.setLocalBeanRepository(null);
                 }
             }
-            if (routeDefinitionsToRemove != null) {
-                // Remove all the excluded routes
-                model.removeRouteDefinitions(routeDefinitionsToRemove);
-            }
-        } finally {
-            if (!alreadyStartingRoutes) {
-                setStartingRoutes(false);
-            }
+        }
+        if (routeDefinitionsToRemove != null) {
+            // Remove all the excluded routes
+            model.removeRouteDefinitions(routeDefinitionsToRemove);
         }
     }
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Federico Mariani_

[CamelVirtualThreadsIT](https://github.com/apache/camel-spring-boot/blob/488c745e38b87f35b5020fc01f44f7e7f8797bba/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/CamelVirtualThreadsIT.java#L58) in camel-spring-boot fails on JDK 25 with `camel.threads.virtual.enabled=true` because `ScopedValueContextValue.set()` throws `UnsupportedOperationException`.

PR #20702 introduced the `ContextValue` abstraction and migrated 3 of 5 internal fields (`isCreateRoute`, `isCreateProcessor`, `isSetupRoutes`) to the scoped `ContextValue.where()` pattern, but left `isStartingRoutes` and `isLockModel` on the imperative `set()`/`remove()` pattern. On JDK 25 with virtual threads, `ContextValue.newInstance()` returns a `ScopedValueContextValue` whose `set()` throws.

This PR completes the migration:

- Add `startingRoutes(Runnable/Callable)` and `lockModel(Runnable/Callable)` scoped methods to `AbstractCamelContext`
- Migrate all callers (`InternalRouteStartupManager`, `InternalRouteController`, `DefaultCamelContext`) to the scoped API
- Deprecate `setStartingRoutes(boolean)` and `setLockModel(boolean)`
- Restore all 5 `ContextValue` fields to `newInstance()` so JDK 25 gets full `ScopedValue` support

Re-entrant call sites (`startRouteService`, `startRouteDefinitions`) that used `alreadyStartingRoutes` guards are simplified — `ContextValue.where()` naturally handles nesting by saving/restoring the previous value.

## Test plan

- [x] `ContextValueTest` — 7/7 pass
- [x] `camel-core` — 6802 tests pass (3 pre-existing file-system flakes)
- [x] camel-spring-boot `CamelVirtualThreadsIT` is successful when both Camel and Camel Spring Boot are built/tested with JDK25 