### PR TITLE
Add debugging info to incremental_build.sh and allow other projects (like camel-spring-boot) to override the exclusion list

### DIFF
--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -696,6 +696,10 @@ main() {
   # This needs to install, not just test, otherwise test-infra will fail due to jandex maven plugin
   # Exclusion list is only needed with -amd (to prevent testing generated/meta modules);
   # without -amd, only the explicitly listed modules are built.
+  echo ""
+  echo "============================================================"
+  echo "Starting Maven build (logging to $log)..."
+  echo "============================================================"
   if [[ "$use_amd" = true ]]; then
     local filtered_exclusions
     filtered_exclusions=$(filterExclusions "$build_pl" "$EXCLUSION_LIST")
@@ -703,10 +707,18 @@ main() {
     if [ -n "$filtered_exclusions" ]; then
       build_pl_with_exclusions="${build_pl},${filtered_exclusions}"
     fi
+    echo "Command: $mavenBinary $MVND_OPTS install -pl \"$build_pl_with_exclusions\" -amd"
+    echo ""
     $mavenBinary -l "$log" $MVND_OPTS install -pl "$build_pl_with_exclusions" -amd || ret=$?
   else
+    echo "Command: $mavenBinary $MVND_OPTS install -pl \"$build_pl\""
+    echo ""
     $mavenBinary -l "$log" $MVND_OPTS install -pl "$build_pl" || ret=$?
   fi
+  echo ""
+  echo "Maven build completed with exit code: $ret"
+  echo "============================================================"
+  echo ""
 
   # ── Step 5: Write comment and summary ──
   local comment_file="incremental-test-comment.md"
@@ -776,11 +788,49 @@ main() {
   fi
 
   if [[ ${ret} -ne 0 ]]; then
-    echo "Processing surefire and failsafe reports to create the summary"
-    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-      echo -e "| Failed Test | Duration | Failure Type |\n| --- | --- | --- |" >> "$GITHUB_STEP_SUMMARY"
+    echo ""
+    echo "============================================================"
+    echo "BUILD FAILED with exit code $ret"
+    echo "============================================================"
+
+    # Show end of build log
+    if [[ -f "$log" ]]; then
+      echo ""
+      echo "Last 50 lines of build log:"
+      echo "------------------------------------------------------------"
+      tail -50 "$log"
+      echo "------------------------------------------------------------"
+      echo ""
+    else
+      echo "WARNING: Build log not found at $log"
+      echo ""
     fi
-    find . -path '*target/*-reports*' -iname '*.txt' -exec .github/actions/incremental-build/parse_errors.sh {} \;
+
+    echo "Processing surefire and failsafe reports to create the summary"
+
+    # Find test reports
+    local report_files
+    report_files=$(find . -path '*target/*-reports*' -iname '*.txt' 2>/dev/null || true)
+
+    if [[ -z "$report_files" ]]; then
+      echo ""
+      echo "WARNING: No test report files found!"
+      echo "This means tests never ran - build failed before test execution"
+      echo ""
+    else
+      local report_count
+      report_count=$(echo "$report_files" | wc -l)
+      echo "Found $report_count test report files"
+      echo ""
+
+      if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        echo -e "| Failed Test | Duration | Failure Type |\n| --- | --- | --- |" >> "$GITHUB_STEP_SUMMARY"
+      fi
+
+      echo "Invoking parse_errors.sh on each report file..."
+      find . -path '*target/*-reports*' -iname '*.txt' -exec .github/actions/incremental-build/parse_errors.sh {} \;
+      echo "Done processing test reports"
+    fi
   fi
 
   exit $ret

--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -37,6 +37,13 @@ maxNumberOfTestableProjects=50
 # Modules excluded from targeted testing (generated code, meta-modules, etc.)
 EXCLUSION_LIST="!:camel-allcomponents,!:dummy-component,!:camel-catalog,!:camel-catalog-console,!:camel-catalog-lucene,!:camel-catalog-maven,!:camel-catalog-suggest,!:camel-route-parser,!:camel-csimple-maven-plugin,!:camel-report-maven-plugin,!:camel-endpointdsl,!:camel-componentdsl,!:camel-endpointdsl-support,!:camel-yaml-dsl,!:camel-kamelet-main,!:camel-yaml-dsl-deserializers,!:camel-yaml-dsl-maven-plugin,!:camel-jbang-core,!:camel-jbang-main,!:camel-jbang-plugin-generate,!:camel-jbang-plugin-edit,!:camel-jbang-plugin-kubernetes,!:camel-jbang-plugin-test,!:camel-launcher,!:camel-jbang-it,!:camel-itest,!:docs,!:apache-camel,!:coverage"
 
+# Allow projects to override the exclusion list
+# (e.g., camel-spring-boot has different modules than main Camel)
+if [[ -f ".github/actions/incremental-build/exclusions.sh" ]]; then
+  echo "Loading project-specific exclusions from .github/actions/incremental-build/exclusions.sh"
+  source .github/actions/incremental-build/exclusions.sh
+fi
+
 # ── Utility functions ──────────────────────────────────────────────────
 
 # Walk up from a file path to find the nearest directory containing a pom.xml


### PR DESCRIPTION
# Description

camel-spring-boot CI is failing on incremental_build.sh but we aren't reaching the parse_errors.sh script.    

The incremental_build.sh script from camel is used by camel-spring-boot, so we need to make changes here.    Add some debugging to incremental_build.sh to help us understand what is failing and allow camel-spring-boot to override the EXCLUSION_LIST, which contains a list of camel components which do not exist in camel-spring-boot.     I'm not positive because we need more debugging info to go off of, but it looks like this EXCLUSION_LIST is what is causing failures in camel-spring-boot CI (https://github.com/apache/camel-spring-boot/pull/1750 and https://github.com/apache/camel-spring-boot/pull/1747)

# Target

- [x ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x ] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.


