### PR TITLE
CAMEL-23334: Add preferLocal mode to avoid remote checks for cached plugin artifacts

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/PluginHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/PluginHelper.java
@@ -219,6 +219,8 @@ public final class PluginHelper {
         if (repos != null && !repos.isBlank()) {
             downloader.setRepositories(repos);
         }
+        // prefer resolving from local Maven repository to avoid expensive remote SNAPSHOT metadata checks
+        downloader.setPreferLocal(true);
         downloader.start();
         // downloads and adds to the classpath
         downloader.downloadDependencyWithParent("org.apache.camel:camel-jbang-parent:pom:" + camelVersion, group,

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DependencyDownloader.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DependencyDownloader.java
@@ -66,6 +66,17 @@ public interface DependencyDownloader extends CamelContextAware, StaticService {
      */
     boolean isDownload();
 
+    /**
+     * When enabled, prefer resolving from local Maven repository before checking remote repositories. Falls back to
+     * normal resolution if offline resolution fails. Useful for CLI tools where artifacts are typically already cached.
+     */
+    void setPreferLocal(boolean preferLocal);
+
+    /**
+     * Whether prefer-local mode is enabled.
+     */
+    boolean isPreferLocal();
+
     boolean isFresh();
 
     /**

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/MavenDependencyDownloader.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/MavenDependencyDownloader.java
@@ -75,6 +75,7 @@ public class MavenDependencyDownloader extends ServiceSupport implements Depende
     private KnownReposResolver knownReposResolver;
     private VersionResolver versionResolver;
     private boolean download = true;
+    private boolean preferLocal;
 
     // all maven-resolver work is delegated to camel-tooling-maven
     private MavenDownloader mavenDownloader;
@@ -181,6 +182,16 @@ public class MavenDependencyDownloader extends ServiceSupport implements Depende
 
     public void setDownload(boolean download) {
         this.download = download;
+    }
+
+    @Override
+    public boolean isPreferLocal() {
+        return preferLocal;
+    }
+
+    @Override
+    public void setPreferLocal(boolean preferLocal) {
+        this.preferLocal = preferLocal;
     }
 
     @Override
@@ -549,6 +560,7 @@ public class MavenDependencyDownloader extends ServiceSupport implements Depende
         mavenDownloaderImpl.setRepos(repositories);
         mavenDownloaderImpl.setFresh(fresh);
         mavenDownloaderImpl.setOffline(!download);
+        mavenDownloaderImpl.setPreferLocal(preferLocal);
         // use listener to keep track of which JARs was downloaded from a remote Maven repo (and how long time it took)
         mavenDownloaderImpl.setRemoteArtifactDownloadListener(new RemoteArtifactDownloadListener() {
             @Override

--- a/tooling/camel-tooling-maven/src/main/java/org/apache/camel/tooling/maven/MavenDownloader.java
+++ b/tooling/camel-tooling-maven/src/main/java/org/apache/camel/tooling/maven/MavenDownloader.java
@@ -86,6 +86,19 @@ public interface MavenDownloader extends Service {
     void setOffline(boolean offline);
 
     /**
+     * When enabled, resolution will first check if artifacts exist in the local Maven repository and attempt offline
+     * resolution to avoid remote repository checks. Falls back to normal resolution if offline resolution fails. This
+     * is useful for CLI tools where artifacts are typically already cached and remote SNAPSHOT metadata checks add
+     * significant latency.
+     */
+    void setPreferLocal(boolean preferLocal);
+
+    /**
+     * Whether prefer-local resolution mode is enabled.
+     */
+    boolean isPreferLocal();
+
+    /**
      * Configure comma-separated list of repositories to use (in addition to the ones discovered from Maven settings).
      */
     void setRepos(String repos);

--- a/tooling/camel-tooling-maven/src/main/java/org/apache/camel/tooling/maven/MavenDownloaderImpl.java
+++ b/tooling/camel-tooling-maven/src/main/java/org/apache/camel/tooling/maven/MavenDownloaderImpl.java
@@ -18,11 +18,13 @@ package org.apache.camel.tooling.maven;
 
 import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -96,6 +98,7 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
     private String repos;
     private boolean fresh;
     private boolean offline;
+    private boolean preferLocal;
     private RemoteArtifactDownloadListener remoteArtifactDownloadListener;
     private RepositoryResolver repositoryResolver;
 
@@ -516,6 +519,34 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
             boolean transitively, boolean useApacheSnapshots)
             throws MavenResolutionException {
 
+        // When preferLocal is enabled and not already offline, try offline resolution first
+        // if the requested artifacts exist in the local Maven repository. This avoids expensive
+        // remote SNAPSHOT metadata checks for artifacts that are already cached locally.
+        if (preferLocal && !offline && existsInLocalRepo(dependencyGAVs)) {
+            try {
+                DefaultRepositorySystemSession offlineSession
+                        = new DefaultRepositorySystemSession(repositorySystemSession);
+                offlineSession.setOffline(true);
+                return doResolveArtifacts(rootGav, dependencyGAVs, extraRepositories,
+                        transitively, useApacheSnapshots, offlineSession);
+            } catch (MavenResolutionException e) {
+                LOG.debug("Offline resolution failed for locally cached artifacts, "
+                          + "falling back to online: {}",
+                        e.getMessage());
+            }
+        }
+
+        return doResolveArtifacts(rootGav, dependencyGAVs, extraRepositories,
+                transitively, useApacheSnapshots, repositorySystemSession);
+    }
+
+    private List<MavenArtifact> doResolveArtifacts(
+            String rootGav,
+            List<String> dependencyGAVs, Set<String> extraRepositories,
+            boolean transitively, boolean useApacheSnapshots,
+            RepositorySystemSession session)
+            throws MavenResolutionException {
+
         StopWatch watch = new StopWatch();
 
         List<RemoteRepository> repositories = new ArrayList<>(remoteRepositories);
@@ -528,7 +559,7 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
             List<RemoteRepository> extraRepos = new ArrayList<>();
             configureRepositories(extraRepos, extraRepositories);
             List<RemoteRepository> resolvedExtraRepos = repositorySystem.newResolutionRepositories(
-                    repositorySystemSession, extraRepos);
+                    session, extraRepos);
             repositories.addAll(resolvedExtraRepos);
         }
 
@@ -553,8 +584,8 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
 
                 // Add download listener if configured
                 if (remoteArtifactDownloadListener != null) {
-                    DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(repositorySystemSession);
-                    session.setRepositoryListener(new AbstractRepositoryListener() {
+                    DefaultRepositorySystemSession listenerSession = new DefaultRepositorySystemSession(session);
+                    listenerSession.setRepositoryListener(new AbstractRepositoryListener() {
                         @Override
                         public void artifactDownloading(RepositoryEvent event) {
                             Artifact artifact = event.getArtifact();
@@ -581,11 +612,12 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
                         }
                     });
 
-                    DependencyResult dependencyResult = repositorySystem.resolveDependencies(session, dependencyRequest);
+                    DependencyResult dependencyResult
+                            = repositorySystem.resolveDependencies(listenerSession, dependencyRequest);
                     dependencyResult.getArtifactResults().forEach(ar -> result.add(toMavenArtifact(ar)));
                 } else {
-                    DependencyResult dependencyResult = repositorySystem.resolveDependencies(repositorySystemSession,
-                            dependencyRequest);
+                    DependencyResult dependencyResult
+                            = repositorySystem.resolveDependencies(session, dependencyRequest);
                     dependencyResult.getArtifactResults().forEach(ar -> result.add(toMavenArtifact(ar)));
                 }
             } else {
@@ -598,7 +630,7 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
                     requests.add(request);
                 }
 
-                List<ArtifactResult> results = repositorySystem.resolveArtifacts(repositorySystemSession, requests);
+                List<ArtifactResult> results = repositorySystem.resolveArtifacts(session, requests);
                 results.forEach(ar -> result.add(toMavenArtifact(ar)));
             }
 
@@ -610,6 +642,33 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
             repositories.forEach(r -> mre.getRepositories().add(r.getUrl()));
             throw mre;
         }
+    }
+
+    /**
+     * Checks if all the given dependency artifacts exist in the local Maven repository. For each artifact, verifies
+     * that the version directory exists and contains at least one JAR file. This handles both locally-installed
+     * SNAPSHOTs (artifact-version.jar) and remotely-downloaded SNAPSHOTs (artifact-timestamp-buildnumber.jar).
+     */
+    private boolean existsInLocalRepo(List<String> dependencyGAVs) {
+        File basedir = repositorySystemSession.getLocalRepository().getBasedir();
+        for (String gav : dependencyGAVs) {
+            MavenGav mg = MavenGav.parseGav(gav);
+            Path versionDir = basedir.toPath()
+                    .resolve(mg.getGroupId().replace('.', File.separatorChar))
+                    .resolve(mg.getArtifactId())
+                    .resolve(mg.getVersion());
+            if (!Files.isDirectory(versionDir)) {
+                return false;
+            }
+            try (var stream = Files.list(versionDir)) {
+                if (stream.noneMatch(p -> p.getFileName().toString().endsWith(".jar"))) {
+                    return false;
+                }
+            } catch (IOException e) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
@@ -698,6 +757,16 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
 
     public void setOffline(boolean offline) {
         this.offline = offline;
+    }
+
+    @Override
+    public void setPreferLocal(boolean preferLocal) {
+        this.preferLocal = preferLocal;
+    }
+
+    @Override
+    public boolean isPreferLocal() {
+        return preferLocal;
     }
 
     public void setMavenCentralEnabled(boolean mavenCentralEnabled) {

--- a/tooling/camel-tooling-maven/src/test/java/org/apache/camel/tooling/maven/MavenDownloaderImplTest.java
+++ b/tooling/camel-tooling-maven/src/test/java/org/apache/camel/tooling/maven/MavenDownloaderImplTest.java
@@ -285,6 +285,74 @@ class MavenDownloaderImplTest {
 
     @Test
     @EnabledIfSystemProperty(named = "enableMavenDownloaderTests", matches = "true")
+    void testPreferLocalResolvesFromCache() throws Exception {
+        File customLocalRepo = new File(tempDir, "prefer-local-repo");
+        Files.createDirectories(customLocalRepo.toPath());
+
+        // First, download the artifact into the custom local repo (online)
+        try (MavenDownloaderImpl downloader = new MavenDownloaderImpl()) {
+            downloader.build();
+
+            MavenDownloader customDownloader = downloader.customize(
+                    customLocalRepo.getAbsolutePath(), 5000, 10000);
+
+            customDownloader.resolveArtifacts(
+                    List.of("org.apache.commons:commons-lang3:3.12.0"),
+                    null, false, false);
+        }
+
+        // Verify artifact is in custom local repo
+        File cachedJar = new File(
+                customLocalRepo,
+                "org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar");
+        assertTrue(cachedJar.exists(), "Artifact should have been downloaded to custom local repo");
+
+        // Now create a new downloader with preferLocal=true, Maven Central disabled,
+        // and a non-existent fake repo. Without preferLocal, this would fail because
+        // there are no reachable remote repos. With preferLocal, it should succeed
+        // by resolving from the local cache via offline-first resolution.
+        try (MavenDownloaderImpl downloader = new MavenDownloaderImpl()) {
+            downloader.setPreferLocal(true);
+            downloader.setMavenCentralEnabled(false);
+            downloader.setMavenApacheSnapshotEnabled(false);
+            downloader.setMavenSettingsLocation("false"); // disable settings.xml repos
+            downloader.setRepos("http://localhost:1/non-existent-repo"); // unreachable repo
+            downloader.build();
+
+            MavenDownloader customDownloader = downloader.customize(
+                    customLocalRepo.getAbsolutePath(), 1000, 1000);
+
+            List<MavenArtifact> artifacts = customDownloader.resolveArtifacts(
+                    List.of("org.apache.commons:commons-lang3:3.12.0"),
+                    null, false, false);
+
+            assertEquals(1, artifacts.size());
+            assertTrue(artifacts.get(0).getFile().exists());
+            LOG.info("preferLocal resolved artifact from local cache without contacting remote repos");
+        }
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "enableMavenDownloaderTests", matches = "true")
+    void testPreferLocalFallsBackToOnline() throws Exception {
+        // With preferLocal=true, if the artifact is NOT in the local repo,
+        // it should fall back to online resolution and succeed
+        try (MavenDownloaderImpl downloader = new MavenDownloaderImpl()) {
+            downloader.setPreferLocal(true);
+            downloader.build();
+
+            List<MavenArtifact> artifacts = downloader.resolveArtifacts(
+                    List.of("org.apache.commons:commons-lang3:3.12.0"),
+                    null, false, false);
+
+            assertEquals(1, artifacts.size());
+            assertTrue(artifacts.get(0).getFile().exists());
+            LOG.info("preferLocal fell back to online resolution for non-cached artifact");
+        }
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "enableMavenDownloaderTests", matches = "true")
     void testDisableMavenCentral() throws Exception {
         try (MavenDownloaderImpl downloader = new MavenDownloaderImpl()) {
             downloader.setMavenCentralEnabled(false);


### PR DESCRIPTION
I have been facing usability issues with the Forage plugin, in particular, when using the SNAPSHOT, but the same applies for the released version, every time a camel command is executed, the plugin's remote repository was checked, even if the plugin was already present in the local repo. With slow repositories (even sonatype), the camel CLI was not usable (20-30 sec for each command).

## Summary

- Adds a `preferLocal` flag to `MavenDownloader` / `MavenDownloaderImpl` that, when enabled, checks if requested artifacts exist in the local Maven repository and attempts offline resolution first, skipping remote repository checks (especially SNAPSHOT metadata). Falls back to normal online resolution if offline fails.
- `PluginHelper.downloadPlugin()` opts in to this mode, reducing JBang plugin resolution from ~30-90s to ~2-3s on every CLI invocation when the plugin is already cached locally.
- Default behavior (`preferLocal=false`) is unchanged for all existing callers.

## Test plan

- [x] New tests `testPreferLocalResolvesFromCache` and `testPreferLocalFallsBackToOnline` in `MavenDownloaderImplTest`
- [x] Existing `camel-tooling-maven` and `camel-jbang-core` tests pass
- [x] Manual testing: `camel version` with a 3rd-party SNAPSHOT plugin installed completes in ~2s (vs ~90s before)
