### PR TITLE
CAMEL-23334: (backport 4.18.x) Add preferLocal mode to avoid remote checks for cached plugin artifacts

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/PluginHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/PluginHelper.java
@@ -219,6 +219,8 @@ public final class PluginHelper {
         if (repos != null && !repos.isBlank()) {
             downloader.setRepositories(repos);
         }
+        // prefer resolving from local Maven repository to avoid expensive remote SNAPSHOT metadata checks
+        downloader.setPreferLocal(true);
         downloader.start();
         // downloads and adds to the classpath
         downloader.downloadDependencyWithParent("org.apache.camel:camel-jbang-parent:pom:" + camelVersion, group,

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DependencyDownloader.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DependencyDownloader.java
@@ -66,6 +66,17 @@ public interface DependencyDownloader extends CamelContextAware, StaticService {
      */
     boolean isDownload();
 
+    /**
+     * When enabled, prefer resolving from local Maven repository before checking remote repositories. Falls back to
+     * normal resolution if offline resolution fails. Useful for CLI tools where artifacts are typically already cached.
+     */
+    void setPreferLocal(boolean preferLocal);
+
+    /**
+     * Whether prefer-local mode is enabled.
+     */
+    boolean isPreferLocal();
+
     boolean isFresh();
 
     /**

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/MavenDependencyDownloader.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/MavenDependencyDownloader.java
@@ -75,6 +75,7 @@ public class MavenDependencyDownloader extends ServiceSupport implements Depende
     private KnownReposResolver knownReposResolver;
     private VersionResolver versionResolver;
     private boolean download = true;
+    private boolean preferLocal;
 
     // all maven-resolver work is delegated to camel-tooling-maven
     private MavenDownloader mavenDownloader;
@@ -181,6 +182,16 @@ public class MavenDependencyDownloader extends ServiceSupport implements Depende
 
     public void setDownload(boolean download) {
         this.download = download;
+    }
+
+    @Override
+    public boolean isPreferLocal() {
+        return preferLocal;
+    }
+
+    @Override
+    public void setPreferLocal(boolean preferLocal) {
+        this.preferLocal = preferLocal;
     }
 
     @Override
@@ -549,6 +560,7 @@ public class MavenDependencyDownloader extends ServiceSupport implements Depende
         mavenDownloaderImpl.setRepos(repositories);
         mavenDownloaderImpl.setFresh(fresh);
         mavenDownloaderImpl.setOffline(!download);
+        mavenDownloaderImpl.setPreferLocal(preferLocal);
         // use listener to keep track of which JARs was downloaded from a remote Maven repo (and how long time it took)
         mavenDownloaderImpl.setRemoteArtifactDownloadListener(new RemoteArtifactDownloadListener() {
             @Override

--- a/tooling/camel-tooling-maven/src/main/java/org/apache/camel/tooling/maven/MavenDownloader.java
+++ b/tooling/camel-tooling-maven/src/main/java/org/apache/camel/tooling/maven/MavenDownloader.java
@@ -86,6 +86,19 @@ public interface MavenDownloader extends Service {
     void setOffline(boolean offline);
 
     /**
+     * When enabled, resolution will first check if artifacts exist in the local Maven repository and attempt offline
+     * resolution to avoid remote repository checks. Falls back to normal resolution if offline resolution fails. This
+     * is useful for CLI tools where artifacts are typically already cached and remote SNAPSHOT metadata checks add
+     * significant latency.
+     */
+    void setPreferLocal(boolean preferLocal);
+
+    /**
+     * Whether prefer-local resolution mode is enabled.
+     */
+    boolean isPreferLocal();
+
+    /**
      * Configure comma-separated list of repositories to use (in addition to the ones discovered from Maven settings).
      */
     void setRepos(String repos);

--- a/tooling/camel-tooling-maven/src/main/java/org/apache/camel/tooling/maven/MavenDownloaderImpl.java
+++ b/tooling/camel-tooling-maven/src/main/java/org/apache/camel/tooling/maven/MavenDownloaderImpl.java
@@ -268,6 +268,7 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
     private String repos;
     private boolean fresh;
     private boolean offline;
+    private boolean preferLocal;
     private RemoteArtifactDownloadListener remoteArtifactDownloadListener;
     private boolean apacheSnapshotsIncluded;
     private AtomicInteger customRepositoryCounter = new AtomicInteger(1);
@@ -384,7 +385,35 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
             List<String> dependencyGAVs, Set<String> extraRepositories,
             boolean transitively, boolean useApacheSnapshots)
             throws MavenResolutionException {
-        ArtifactTypeRegistry artifactTypeRegistry = repositorySystemSession.getArtifactTypeRegistry();
+
+        // When preferLocal is enabled and not already offline, try offline resolution first
+        // if the requested artifacts exist in the local Maven repository. This avoids expensive
+        // remote SNAPSHOT metadata checks for artifacts that are already cached locally.
+        if (preferLocal && !offline && existsInLocalRepo(dependencyGAVs)) {
+            try {
+                DefaultRepositorySystemSession offlineSession
+                        = new DefaultRepositorySystemSession(repositorySystemSession);
+                offlineSession.setOffline(true);
+                return doResolveArtifacts(rootGav, dependencyGAVs, extraRepositories,
+                        transitively, useApacheSnapshots, offlineSession);
+            } catch (MavenResolutionException e) {
+                LOG.debug("Offline resolution failed for locally cached artifacts, "
+                          + "falling back to online: {}",
+                        e.getMessage());
+            }
+        }
+
+        return doResolveArtifacts(rootGav, dependencyGAVs, extraRepositories,
+                transitively, useApacheSnapshots, repositorySystemSession);
+    }
+
+    private List<MavenArtifact> doResolveArtifacts(
+            String rootGav,
+            List<String> dependencyGAVs, Set<String> extraRepositories,
+            boolean transitively, boolean useApacheSnapshots,
+            RepositorySystemSession session)
+            throws MavenResolutionException {
+        ArtifactTypeRegistry artifactTypeRegistry = session.getArtifactTypeRegistry();
 
         final List<ArtifactRequest> requests = new ArrayList<>(dependencyGAVs.size());
         CollectRequest collectRequest = new CollectRequest();
@@ -395,7 +424,7 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
             // read them
             configureRepositories(extraRemoteRepositories, extraRepositories);
             // proxy/mirror them
-            repositories.addAll(repositorySystem.newResolutionRepositories(repositorySystemSession,
+            repositories.addAll(repositorySystem.newResolutionRepositories(session,
                     extraRemoteRepositories));
         }
         if (mavenApacheSnapshotEnabled && useApacheSnapshots && !apacheSnapshotsIncluded) {
@@ -427,8 +456,8 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
             //collectRequest.addManagedDependency(...);
         }
 
-        if (remoteArtifactDownloadListener != null && repositorySystemSession instanceof DefaultRepositorySystemSession) {
-            DefaultRepositorySystemSession drss = (DefaultRepositorySystemSession) repositorySystemSession;
+        if (remoteArtifactDownloadListener != null && session instanceof DefaultRepositorySystemSession) {
+            DefaultRepositorySystemSession drss = (DefaultRepositorySystemSession) session;
             drss.setRepositoryListener(new AbstractRepositoryListener() {
                 private final StopWatch watch = new StopWatch();
 
@@ -469,7 +498,7 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
             DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, new AcceptAllDependencyFilter());
             try {
                 DependencyResult dependencyResult
-                        = repositorySystem.resolveDependencies(repositorySystemSession, dependencyRequest);
+                        = repositorySystem.resolveDependencies(session, dependencyRequest);
 
                 return dependencyResult.getArtifactResults().stream()
                         .map(dr -> {
@@ -487,7 +516,7 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
         } else {
             try {
                 List<ArtifactResult> artifactResults
-                        = repositorySystem.resolveArtifacts(repositorySystemSession, requests);
+                        = repositorySystem.resolveArtifacts(session, requests);
 
                 return artifactResults.stream()
                         .map(dr -> {
@@ -503,6 +532,33 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
                 throw mre;
             }
         }
+    }
+
+    /**
+     * Checks if all the given dependency artifacts exist in the local Maven repository. For each artifact, verifies
+     * that the version directory exists and contains at least one JAR file. This handles both locally-installed
+     * SNAPSHOTs (artifact-version.jar) and remotely-downloaded SNAPSHOTs (artifact-timestamp-buildnumber.jar).
+     */
+    private boolean existsInLocalRepo(List<String> dependencyGAVs) {
+        File basedir = repositorySystemSession.getLocalRepository().getBasedir();
+        for (String gav : dependencyGAVs) {
+            MavenGav mg = MavenGav.parseGav(gav);
+            Path versionDir = basedir.toPath()
+                    .resolve(mg.getGroupId().replace('.', File.separatorChar))
+                    .resolve(mg.getArtifactId())
+                    .resolve(mg.getVersion());
+            if (!java.nio.file.Files.isDirectory(versionDir)) {
+                return false;
+            }
+            try (var stream = java.nio.file.Files.list(versionDir)) {
+                if (stream.noneMatch(p -> p.getFileName().toString().endsWith(".jar"))) {
+                    return false;
+                }
+            } catch (java.io.IOException e) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
@@ -1363,6 +1419,16 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
     @Override
     public void setOffline(boolean offline) {
         this.offline = offline;
+    }
+
+    @Override
+    public void setPreferLocal(boolean preferLocal) {
+        this.preferLocal = preferLocal;
+    }
+
+    @Override
+    public boolean isPreferLocal() {
+        return preferLocal;
     }
 
     @Override


### PR DESCRIPTION
Backport of #22651 to `camel-4.18.x`.

## Summary

- Adds a `preferLocal` flag to `MavenDownloader` / `MavenDownloaderImpl` that, when enabled, checks if requested artifacts exist in the local Maven repository and attempts offline resolution first, skipping remote repository checks (especially SNAPSHOT metadata). Falls back to normal online resolution if offline fails.
- `PluginHelper.downloadPlugin()` opts in to this mode, reducing JBang plugin resolution from ~30-90s to ~2-3s on every CLI invocation when the plugin is already cached locally.
- Default behavior (`preferLocal=false`) is unchanged for all existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)