### PR TITLE
camel-jbang: pre-compile grep/find patterns and cache SimpleDateFormat - perf improvements

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/ActionBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/ActionBaseCommand.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
@@ -130,6 +131,22 @@ abstract class ActionBaseCommand extends CamelCommand {
             // ignore
         }
         return null;
+    }
+
+    /**
+     * Quotes each element in the given array with {@link Pattern#quote} and compiles a case-insensitive pattern for it.
+     * The array is modified in place (elements are replaced with their quoted form).
+     *
+     * @param  values the raw search terms
+     * @return        compiled patterns ready for matching
+     */
+    static Pattern[] quoteAndCompilePatterns(String[] values) {
+        Pattern[] patterns = new Pattern[values.length];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = Pattern.quote(values[i]);
+            patterns[i] = Pattern.compile("(?i)" + values[i]);
+        }
+        return patterns;
     }
 
     /**

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelLogAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelLogAction.java
@@ -116,9 +116,13 @@ public class CamelLogAction extends ActionBaseCommand {
     String[] grep;
 
     String findAnsi;
+    Pattern[] grepPatterns;
+    Pattern[] findPatterns;
 
     private int nameMaxWidth;
     private boolean prefixShown;
+    private final SimpleDateFormat sdfMain = new SimpleDateFormat(TIMESTAMP_MAIN);
+    private final SimpleDateFormat sdfSB = new SimpleDateFormat(TIMESTAMP_SB);
 
     private final Map<String, Ansi.Color> colors = new HashMap<>();
 
@@ -136,19 +140,11 @@ public class CamelLogAction extends ActionBaseCommand {
             // read existing log files (skip by tail/since)
             if (find != null) {
                 findAnsi = Ansi.ansi().fg(Ansi.Color.BLACK).bg(Ansi.Color.YELLOW).a("$0").reset().toString();
-                for (int i = 0; i < find.length; i++) {
-                    String f = find[i];
-                    f = Pattern.quote(f);
-                    find[i] = f;
-                }
+                findPatterns = quoteAndCompilePatterns(find);
             }
             if (grep != null) {
                 findAnsi = Ansi.ansi().fg(Ansi.Color.BLACK).bg(Ansi.Color.YELLOW).a("$0").reset().toString();
-                for (int i = 0; i < grep.length; i++) {
-                    String f = grep[i];
-                    f = Pattern.quote(f);
-                    grep[i] = f;
-                }
+                grepPatterns = quoteAndCompilePatterns(grep);
             }
             Date limit = null;
             if (since != null) {
@@ -413,14 +409,14 @@ public class CamelLogAction extends ActionBaseCommand {
                 before = StringHelper.before(line, "---");
                 after = StringHelper.after(line, "---", line);
             }
-            if (find != null) {
-                for (String f : find) {
-                    after = after.replaceAll("(?i)" + f, findAnsi);
+            if (findPatterns != null) {
+                for (Pattern p : findPatterns) {
+                    after = p.matcher(after).replaceAll(findAnsi);
                 }
             }
-            if (grep != null) {
-                for (String g : grep) {
-                    after = after.replaceAll("(?i)" + g, findAnsi);
+            if (grepPatterns != null) {
+                for (Pattern p : grepPatterns) {
+                    after = p.matcher(after).replaceAll(findAnsi);
                 }
             }
             line = before != null ? before + "---" + after : after;
@@ -494,7 +490,7 @@ public class CamelLogAction extends ActionBaseCommand {
         // if using spring boot then adjust the timestamp to uniform camel-main style
         String ts = StringHelper.before(line, "  ");
         if (ts != null && ts.contains("T")) {
-            SimpleDateFormat sdf = new SimpleDateFormat(TIMESTAMP_SB);
+            SimpleDateFormat sdf = sdfSB;
             try {
                 // the log can be in color or not so we need to unescape always
                 sdf.parse(unescapeAnsi(ts));
@@ -524,7 +520,7 @@ public class CamelLogAction extends ActionBaseCommand {
         line = unescapeAnsi(line);
         String ts = StringHelper.before(line, "  ");
         if (ts != null && !ts.isBlank()) {
-            SimpleDateFormat sdf = new SimpleDateFormat(TIMESTAMP_MAIN);
+            SimpleDateFormat sdf = sdfMain;
             try {
                 Date row = sdf.parse(ts);
                 return row.compareTo(limit) >= 0;
@@ -542,9 +538,8 @@ public class CamelLogAction extends ActionBaseCommand {
         // the log can be in color or not so we need to unescape always
         line = unescapeAnsi(line);
         String after = StringHelper.after(line, "---", line);
-        for (String g : grep) {
-            boolean m = Pattern.compile("(?i)" + g).matcher(after).find();
-            if (m) {
+        for (Pattern p : grepPatterns) {
+            if (p.matcher(after).find()) {
                 return true;
             }
         }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelReceiveAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelReceiveAction.java
@@ -213,6 +213,8 @@ public class CamelReceiveAction extends ActionBaseCommand {
     private volatile long pid;
 
     String findAnsi;
+    Pattern[] grepPatterns;
+    Pattern[] findPatterns;
     private int nameMaxWidth;
     private boolean prefixShown;
     private MessageTableHelper tableHelper;
@@ -521,19 +523,11 @@ public class CamelReceiveAction extends ActionBaseCommand {
             // read existing received files (skip by tail/since)
             if (find != null) {
                 findAnsi = Ansi.ansi().fg(Ansi.Color.BLACK).bg(Ansi.Color.YELLOW).a("$0").reset().toString();
-                for (int i = 0; i < find.length; i++) {
-                    String f = find[i];
-                    f = Pattern.quote(f);
-                    find[i] = f;
-                }
+                findPatterns = quoteAndCompilePatterns(find);
             }
             if (grep != null) {
                 findAnsi = Ansi.ansi().fg(Ansi.Color.BLACK).bg(Ansi.Color.YELLOW).a("$0").reset().toString();
-                for (int i = 0; i < grep.length; i++) {
-                    String f = grep[i];
-                    f = Pattern.quote(f);
-                    grep[i] = f;
-                }
+                grepPatterns = quoteAndCompilePatterns(grep);
             }
             Date limit = null;
             if (since != null) {
@@ -840,9 +834,8 @@ public class CamelReceiveAction extends ActionBaseCommand {
         if (grep == null) {
             return true;
         }
-        for (String g : grep) {
-            boolean m = Pattern.compile("(?i)" + g).matcher(line).find();
-            if (m) {
+        for (Pattern p : grepPatterns) {
+            if (p.matcher(line).find()) {
                 return true;
             }
         }
@@ -911,14 +904,14 @@ public class CamelReceiveAction extends ActionBaseCommand {
         String[] lines = data.split(System.lineSeparator());
         if (lines.length > 0) {
             for (String line : lines) {
-                if (find != null) {
-                    for (String f : find) {
-                        line = line.replaceAll("(?i)" + f, findAnsi);
+                if (findPatterns != null) {
+                    for (Pattern p : findPatterns) {
+                        line = p.matcher(line).replaceAll(findAnsi);
                     }
                 }
-                if (grep != null) {
-                    for (String g : grep) {
-                        line = line.replaceAll("(?i)" + g, findAnsi);
+                if (grepPatterns != null) {
+                    for (Pattern p : grepPatterns) {
+                        line = p.matcher(line).replaceAll(findAnsi);
                     }
                 }
                 if (nameWithPrefix != null) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelStubAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelStubAction.java
@@ -100,6 +100,8 @@ public class CamelStubAction extends ActionWatchCommand {
 
     private volatile long pid;
     String findAnsi;
+    Pattern[] grepPatterns;
+    Pattern[] findPatterns;
     private MessageTableHelper tableHelper;
     private final Map<String, Ansi.Color> exchangeIdColors = new HashMap<>();
     private int exchangeIdColorsIndex = 1;
@@ -127,8 +129,13 @@ public class CamelStubAction extends ActionWatchCommand {
             }
             return color;
         });
-        if (find != null || grep != null) {
+        if (find != null) {
             findAnsi = Ansi.ansi().fg(Ansi.Color.BLACK).bg(Ansi.Color.YELLOW).a("$0").reset().toString();
+            findPatterns = quoteAndCompilePatterns(find);
+        }
+        if (grep != null) {
+            findAnsi = Ansi.ansi().fg(Ansi.Color.BLACK).bg(Ansi.Color.YELLOW).a("$0").reset().toString();
+            grepPatterns = quoteAndCompilePatterns(grep);
         }
 
         List<Row> rows = new ArrayList<>();
@@ -257,9 +264,8 @@ public class CamelStubAction extends ActionWatchCommand {
         if (grep == null) {
             return true;
         }
-        for (String g : grep) {
-            boolean m = Pattern.compile("(?i)" + g).matcher(line).find();
-            if (m) {
+        for (Pattern p : grepPatterns) {
+            if (p.matcher(line).find()) {
                 return true;
             }
         }
@@ -308,14 +314,14 @@ public class CamelStubAction extends ActionWatchCommand {
                                     printer().println();
                                 }
                                 for (String line : lines) {
-                                    if (find != null) {
-                                        for (String f : find) {
-                                            line = line.replaceAll("(?i)" + f, findAnsi);
+                                    if (findPatterns != null) {
+                                        for (Pattern p : findPatterns) {
+                                            line = p.matcher(line).replaceAll(findAnsi);
                                         }
                                     }
-                                    if (grep != null) {
-                                        for (String g : grep) {
-                                            line = line.replaceAll("(?i)" + g, findAnsi);
+                                    if (grepPatterns != null) {
+                                        for (Pattern p : grepPatterns) {
+                                            line = p.matcher(line).replaceAll(findAnsi);
                                         }
                                     }
                                     printer().print(" ");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelTraceAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelTraceAction.java
@@ -69,6 +69,7 @@ public class CamelTraceAction extends ActionBaseCommand {
 
     private static final int NAME_MAX_WIDTH = 25;
     private static final int NAME_MIN_WIDTH = 10;
+    private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
 
     private CommandHelper.ReadConsoleTask waitUserTask;
 
@@ -186,6 +187,8 @@ public class CamelTraceAction extends ActionBaseCommand {
     boolean pretty;
 
     String findAnsi;
+    Pattern[] grepPatterns;
+    Pattern[] findPatterns;
 
     private int nameMaxWidth;
     private boolean prefixShown;
@@ -195,6 +198,7 @@ public class CamelTraceAction extends ActionBaseCommand {
     private final Map<String, Ansi.Color> nameColors = new HashMap<>();
     private final Map<String, Ansi.Color> exchangeIdColors = new HashMap<>();
     private int exchangeIdColorsIndex = 1;
+    private final SimpleDateFormat sdfTimestamp = new SimpleDateFormat(TIMESTAMP_FORMAT);
 
     public CamelTraceAction(CamelJBangMain main) {
         super(main);
@@ -347,19 +351,11 @@ public class CamelTraceAction extends ActionBaseCommand {
             // read existing trace files (skip by tail/since)
             if (find != null) {
                 findAnsi = Ansi.ansi().fg(Ansi.Color.BLACK).bg(Ansi.Color.YELLOW).a("$0").reset().toString();
-                for (int i = 0; i < find.length; i++) {
-                    String f = find[i];
-                    f = Pattern.quote(f);
-                    find[i] = f;
-                }
+                findPatterns = quoteAndCompilePatterns(find);
             }
             if (grep != null) {
                 findAnsi = Ansi.ansi().fg(Ansi.Color.BLACK).bg(Ansi.Color.YELLOW).a("$0").reset().toString();
-                for (int i = 0; i < grep.length; i++) {
-                    String f = grep[i];
-                    f = Pattern.quote(f);
-                    grep[i] = f;
-                }
+                grepPatterns = quoteAndCompilePatterns(grep);
             }
             Date limit = null;
             if (since != null) {
@@ -709,9 +705,8 @@ public class CamelTraceAction extends ActionBaseCommand {
         if (grep == null) {
             return true;
         }
-        for (String g : grep) {
-            boolean m = Pattern.compile("(?i)" + g).matcher(line).find();
-            if (m) {
+        for (Pattern p : grepPatterns) {
+            if (p.matcher(line).find()) {
                 return true;
             }
         }
@@ -769,7 +764,7 @@ public class CamelTraceAction extends ActionBaseCommand {
             if (ago) {
                 ts = String.format("%12s", TimeUtils.printSince(row.timestamp) + " ago");
             } else {
-                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+                SimpleDateFormat sdf = sdfTimestamp;
                 ts = sdf.format(new Date(row.timestamp));
             }
             if (loggingColor) {
@@ -841,14 +836,14 @@ public class CamelTraceAction extends ActionBaseCommand {
         if (lines.length > 0) {
             printer().println();
             for (String line : lines) {
-                if (find != null) {
-                    for (String f : find) {
-                        line = line.replaceAll("(?i)" + f, findAnsi);
+                if (findPatterns != null) {
+                    for (Pattern fp : findPatterns) {
+                        line = fp.matcher(line).replaceAll(findAnsi);
                     }
                 }
-                if (grep != null) {
-                    for (String g : grep) {
-                        line = line.replaceAll("(?i)" + g, findAnsi);
+                if (grepPatterns != null) {
+                    for (Pattern gp : grepPatterns) {
+                        line = gp.matcher(line).replaceAll(findAnsi);
                     }
                 }
                 if (nameWithPrefix != null) {


### PR DESCRIPTION
## Summary

- Pre-compile `--grep` and `--find` regex patterns once at startup instead of calling `Pattern.compile()` on every log/trace line in the follow loop
- Cache `SimpleDateFormat` instances as fields instead of creating new ones per line
- Add missing `Pattern.quote()` in `CamelStubAction` for consistency with the other 3 action commands
- Extract shared `quoteAndCompilePatterns()` helper into `ActionBaseCommand`

Files changed: `ActionBaseCommand`, `CamelLogAction`, `CamelTraceAction`, `CamelReceiveAction`, `CamelStubAction`

## Benchmark results

I know it is not a huge difference, but better than nothing — these add up when tailing high-throughput logs with `camel log --follow --grep=ERROR`:

```
=== Fix 1: Pattern.compile per-line vs pre-compiled ===

  isValidGrep (500000 iterations, 2 grep terms, 10 log lines):
    OLD (Pattern.compile per line):     296.92 ms  (150000 matches)
    NEW (pre-compiled):                 141.01 ms  (150000 matches)
    Speedup:                              2.11x

  replaceAll highlighting (500000 iterations, 2 patterns):
    OLD (replaceAll per line):           358.34 ms
    NEW (compiled matcher):              161.19 ms
    Speedup:                              2.22x

=== Fix 2: SimpleDateFormat per-line vs cached ===

  SDF.format() (500000 iterations):
    OLD (new SDF per call):              303.78 ms
    NEW (cached SDF):                     94.02 ms
    Speedup:                              3.23x

  SDF.parse() (500000 iterations):
    OLD (new SDF per call):              377.68 ms
    NEW (cached SDF):                    249.19 ms
    Speedup:                              1.52x
```

## Test plan

- [x] `mvn -DskipTests install` in `camel-jbang-core` — compiles clean
- [x] `mvn formatter:format impsort:sort` — no changes needed
- [x] `camel-jbang-core` unit tests pass
- [x] `camel-jbang-it` integration tests pass

_Claude Code on behalf of Federico Mariani_