### PR TITLE
ci: pass maven-extra-args to incremental build for JDK 17 enforcer skip

### DIFF
--- a/.github/actions/incremental-build/action.yaml
+++ b/.github/actions/incremental-build/action.yaml
@@ -37,6 +37,10 @@ inputs:
     description: 'Additional modules to test (comma-separated paths, e.g. from /component-test)'
     required: false
     default: ''
+  maven-extra-args:
+    description: 'Extra Maven arguments to pass to the build (e.g. -Denforcer.phase=none)'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -50,5 +54,6 @@ runs:
         PR_ID: ${{ inputs.pr-id }}
         GITHUB_REPO: ${{ inputs.github-repo }}
         EXTRA_MODULES: ${{ inputs.extra-modules }}
+        MAVEN_EXTRA_ARGS: ${{ inputs.maven-extra-args }}
       shell: bash
       run: ${{ github.action_path }}/incremental-build.sh ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd "$PR_ID" "$GITHUB_REPO" "$EXTRA_MODULES"

--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -31,6 +31,7 @@
 set -euo pipefail
 
 echo "Using MVND_OPTS=$MVND_OPTS"
+echo "Using MAVEN_EXTRA_ARGS=${MAVEN_EXTRA_ARGS:-}"
 
 maxNumberOfTestableProjects=50
 
@@ -261,7 +262,7 @@ runScalpelDetection() {
   fi
 
   echo "  Scalpel: running mvn validate (report mode)..."
-  ./mvnw -B -q validate $scalpel_args -l /tmp/scalpel-validate.log 2>/dev/null || {
+  ./mvnw -B -q validate $scalpel_args ${MAVEN_EXTRA_ARGS:-} -l /tmp/scalpel-validate.log 2>/dev/null || {
     echo "  WARNING: Scalpel detection failed (exit $?), skipping"
     grep -i "scalpel" /tmp/scalpel-validate.log 2>/dev/null | head -5 || true
     return
@@ -742,13 +743,13 @@ main() {
     if [ -n "$filtered_exclusions" ]; then
       build_pl_with_exclusions="${build_pl},${filtered_exclusions}"
     fi
-    echo "Command: $mavenBinary $MVND_OPTS install -pl \"$build_pl_with_exclusions\" -amd"
+    echo "Command: $mavenBinary $MVND_OPTS ${MAVEN_EXTRA_ARGS:-} install -pl \"$build_pl_with_exclusions\" -amd"
     echo ""
-    $mavenBinary -l "$log" $MVND_OPTS install -pl "$build_pl_with_exclusions" -amd || ret=$?
+    $mavenBinary -l "$log" $MVND_OPTS ${MAVEN_EXTRA_ARGS:-} install -pl "$build_pl_with_exclusions" -amd || ret=$?
   else
-    echo "Command: $mavenBinary $MVND_OPTS install -pl \"$build_pl\""
+    echo "Command: $mavenBinary $MVND_OPTS ${MAVEN_EXTRA_ARGS:-} install -pl \"$build_pl\""
     echo ""
-    $mavenBinary -l "$log" $MVND_OPTS install -pl "$build_pl" || ret=$?
+    $mavenBinary -l "$log" $MVND_OPTS ${MAVEN_EXTRA_ARGS:-} install -pl "$build_pl" || ret=$?
   fi
   echo ""
   echo "Maven build completed with exit code: $ret"

--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -102,7 +102,8 @@ jobs:
         shell: bash
         env:
           EXTRA_MODULES: ${{ inputs.extra_modules }}
-        run: ./mvnw -l build.log install -B -DskipTests -Dquickly -pl "$EXTRA_MODULES" -am
+          MAVEN_EXTRA_ARGS: ${{ matrix.maven_extra_args || '' }}
+        run: ./mvnw -l build.log install -B -DskipTests -Dquickly $MAVEN_EXTRA_ARGS -pl "$EXTRA_MODULES" -am
       - name: archive logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
@@ -121,6 +122,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-mvnd-install: 'true'
           extra-modules: ${{ inputs.extra_modules || '' }}
+          maven-extra-args: ${{ matrix.maven_extra_args || '' }}
       - name: archive incremental test logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()


### PR DESCRIPTION
relax the enforcer on the GH CI, so that we can keep testing with JDK17

---

The JDK 21+ enforcer rule added in #22608 correctly skips enforcement for JDK 17 in the full build (`regen.sh` uses `MAVEN_EXTRA_ARGS`), but the incremental test step and the quick dependency build step did not receive `-Denforcer.phase=none`, causing all JDK 17 CI jobs to fail.

**Changes:**
- Add `maven-extra-args` input to the `incremental-build` action
- Pass `MAVEN_EXTRA_ARGS` to all Maven/mvnd invocations in `incremental-build.sh` (main build commands and Scalpel validation)
- Pass `MAVEN_EXTRA_ARGS` to the quick dependency build step
- Pass `matrix.maven_extra_args` from the workflow to both steps