### PR TITLE
ci: skip enforcer on JDK 17 CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,14 +142,14 @@ pipeline {
                                             // Enable virtual threads
                                             sh "./mvnw $MAVEN_PARAMS $MAVEN_TEST_PARAMS_UBUNTU -Darchetype.test.skip -Dmaven.test.failure.ignore=true -Dcheckstyle.skip=true install -Dcamel.threads.virtual.enabled=${params.VIRTUAL_THREAD}"
                                         } else if ("${JDK_NAME}" == "jdk_17_latest") {
-                                            // Enable coverage required later by Sonar check
-                                            sh "./mvnw $MAVEN_PARAMS $MAVEN_TEST_PARAMS -Darchetype.test.skip -Dmaven.test.failure.ignore=true -Dcheckstyle.skip=true install -Pcoverage"
+                                            // Enable coverage required later by Sonar check; skip enforcer since JDK 21+ is enforced for local builds only
+                                            sh "./mvnw $MAVEN_PARAMS $MAVEN_TEST_PARAMS -Darchetype.test.skip -Dmaven.test.failure.ignore=true -Dcheckstyle.skip=true -Denforcer.skip=true install -Pcoverage"
                                         } else {
                                             sh "./mvnw $MAVEN_PARAMS $MAVEN_TEST_PARAMS -Darchetype.test.skip -Dmaven.test.failure.ignore=true -Dcheckstyle.skip=true install"
                                         }
                                     } else {
                                         // Skip the test case execution of modules which are either not supported on ppc64le or vendor images are not available for ppc64le.
-                                        sh "./mvnw $MAVEN_PARAMS $MAVEN_TEST_PARAMS $MAVEN_TEST_PARAMS_ALT_ARCHS -Darchetype.test.skip -Dmaven.test.failure.ignore=true -Dcheckstyle.skip=true install -pl '!docs'"
+                                        sh "./mvnw $MAVEN_PARAMS $MAVEN_TEST_PARAMS $MAVEN_TEST_PARAMS_ALT_ARCHS -Darchetype.test.skip -Dmaven.test.failure.ignore=true -Dcheckstyle.skip=true -Denforcer.skip=true install -pl '!docs'"
                                         echo "Code quality review disabled for ${PLATFORM} with JDK ${JDK_NAME}"
                                     }
                                 }

--- a/Jenkinsfile.jbangtest
+++ b/Jenkinsfile.jbangtest
@@ -63,8 +63,8 @@ pipeline {
             }
             steps {
                 sh "./mvnw $MAVEN_PARAMS -Pdeploy,apache-snapshots -Dquickly clean install"
-                sh "./mvnw $MAVEN_PARAMS -f test-infra/camel-test-infra-cli/pom.xml -Pjbang-it-test"
-                sh "./mvnw $MAVEN_PARAMS -f dsl/camel-jbang/camel-jbang-it/pom.xml -Pjbang-it-test"
+                sh "./mvnw $MAVEN_PARAMS -Denforcer.skip=true -f test-infra/camel-test-infra-cli/pom.xml -Pjbang-it-test"
+                sh "./mvnw $MAVEN_PARAMS -Denforcer.skip=true -f dsl/camel-jbang/camel-jbang-it/pom.xml -Pjbang-it-test"
             }
             post {
                always {


### PR DESCRIPTION
## Summary
- Add `-Denforcer.skip=true` to JDK 17 build commands in `Jenkinsfile` (ubuntu-avx coverage build and alt architecture builds)
- Add `-Denforcer.skip=true` to jbang IT test commands in `Jenkinsfile.jbangtest`

The JDK 21+ enforcer remains active for local developer builds but is skipped on CI JDK 17 matrix builds to maintain test coverage across JDK versions.

## Context
Commit `7912666daeb` enforced JDK 21+ as the minimum build JDK for multi-release JAR support. This broke all JDK 17 CI builds since the `Jenkinsfile` matrix still includes `jdk_17_latest`. Rather than removing JDK 17 from CI (losing test coverage), we skip the enforcer for those builds.