### PR TITLE
Update Jenkinsfile to use JDK 21 for JBang tests

### DIFF
--- a/Jenkinsfile.jbangtest
+++ b/Jenkinsfile.jbangtest
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 def AGENT_LABEL = env.AGENT_LABEL ?: 'ubuntu'
-def JDK_NAME = env.JDK_NAME ?: 'jdk_17_latest'
+def JDK_NAME = env.JDK_NAME ?: 'jdk_21_latest'
 
 def MAVEN_PARAMS = "-U -B -e -fae -V -Dnoassembly -Dmaven.compiler.fork=true "
 
@@ -59,8 +59,6 @@ pipeline {
             when {
                 anyOf {
                     branch 'main'
-                    branch 'camel-4.18.x'
-                    branch 'camel-4.14.x'
                 }
             }
             steps {


### PR DESCRIPTION
# Description

given that there is now an enforcer to compile with JDK 21 by default. I propose this first iteration to jhave green build back.

ideally, we should compile with JDK 21 and tests with JDK 17, 21 and 25.
A good intermediate step which shoudl be enough would be to create a matrix jobs whcih is compiling and testing with JDK 17, 21 and 25 with the JDk 17 one skipping the enforcer java rule.

Note that I also removed the branches from the triggeres as there are specific jobs for that

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

