### PR TITLE
CAMEL-23223 - improve assertion failure message to help investigation on

### DIFF
--- a/components/camel-opentelemetry-metrics/pom.xml
+++ b/components/camel-opentelemetry-metrics/pom.xml
@@ -84,6 +84,11 @@
             <artifactId>opentelemetry-exporter-logging</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/components/camel-opentelemetry-metrics/src/test/java/org/apache/camel/opentelemetry/metrics/integration/messagehistory/ManagedMessageHistoryAutoConfigIT.java
+++ b/components/camel-opentelemetry-metrics/src/test/java/org/apache/camel/opentelemetry/metrics/integration/messagehistory/ManagedMessageHistoryAutoConfigIT.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.opentelemetry.metrics.OpenTelemetryConstants.DEFAULT_CAMEL_MESSAGE_HISTORY_METER_NAME;
 import static org.apache.camel.opentelemetry.metrics.OpenTelemetryConstants.ROUTE_ID_ATTRIBUTE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -113,9 +114,9 @@ public class ManagedMessageHistoryAutoConfigIT extends CamelTestSupport {
 
                 assertPointDataForRouteId(metricData, "route1");
 
-                assertTrue(verifyMetricDataHasNodeId(metricData, "route1", "foo"));
-                assertTrue(verifyMetricDataHasNodeId(metricData, "route2", "bar"));
-                assertTrue(verifyMetricDataHasNodeId(metricData, "route2", "baz"));
+                assertMetricDataHasNodeId(metricData, "route1", "foo");
+                assertMetricDataHasNodeId(metricData, "route2", "bar");
+                assertMetricDataHasNodeId(metricData, "route2", "baz");
 
                 dataCount++;
             }
@@ -123,10 +124,12 @@ public class ManagedMessageHistoryAutoConfigIT extends CamelTestSupport {
         assertTrue(dataCount > 0, "No metric data found");
     }
 
-    private boolean verifyMetricDataHasNodeId(MetricData metricData, String routeId, String nodeId) {
-        return metricData.getData().getPoints().stream()
-                .filter(point -> routeId.equals(getRouteId(point)))
-                .anyMatch(point -> nodeId.equals(point.getAttributes().get(AttributeKey.stringKey("nodeId"))));
+    private void assertMetricDataHasNodeId(MetricData metricData, String routeId, String nodeId) {
+        assertThat(metricData.getData().getPoints())
+                .anyMatch(point -> {
+                    return routeId.equals(getRouteId(point))
+                            && nodeId.equals(point.getAttributes().get(AttributeKey.stringKey("nodeId")));
+                }, "No metric data found for node " + nodeId + "of route " + routeId + " ");
     }
 
     private void assertPointDataForRouteId(MetricData metricData, String routeId) {


### PR DESCRIPTION
flaky test ManagedMessageHistoryAutoConfigIT

instead of

```
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
```

there will now be a message like:
```
ManagedMessageHistoryAutoConfigIT.testMessageHistory:120->assertMetricDataHasNodeId:130
Expecting any elements of:
  [ImmutableHistogramPointData{getStartEpochNanos=1776755336333536296,
getEpochNanos=1776755336415229081,
getAttributes={camelContext="camel-1", kind="CamelMessageHistory",
nodeId="foo", routeId="route1"}, getSum=1.0, getCount=5, hasMin=true,
getMin=0.0, hasMax=true, getMax=1.0, getBoundaries=[0.0, 5.0, 10.0,
25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0,
7500.0, 10000.0], getCounts=[4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
0, 0], getExemplars=[]},
    ImmutableHistogramPointData{getStartEpochNanos=1776755336333480676,
getEpochNanos=1776755336415229081,
getAttributes={camelContext="camel-1", kind="CamelMessageHistory",
nodeId="bar", routeId="route2"}, getSum=1.0, getCount=5, hasMin=true,
getMin=0.0, hasMax=true, getMax=1.0, getBoundaries=[0.0, 5.0, 10.0,
25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0,
7500.0, 10000.0], getCounts=[4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
0, 0], getExemplars=[]},
    ImmutableHistogramPointData{getStartEpochNanos=1776755336334308001,
getEpochNanos=1776755336415229081,
getAttributes={camelContext="camel-1", kind="CamelMessageHistory",
nodeId="baz", routeId="route2"}, getSum=0.0, getCount=5, hasMin=true,
getMin=0.0, hasMax=true, getMax=0.0, getBoundaries=[0.0, 5.0, 10.0,
25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0,
7500.0, 10000.0], getCounts=[5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
0, 0], getExemplars=[]}]
to match 'No metric data found for node invalidToCheckErrorMessageof
route route2 ' predicate but none did.
```

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

