### PR TITLE
ci: pass maven-extra-args to incremental build for JDK 17 enforcer skip

### DIFF
--- a/.github/actions/incremental-build/action.yaml
+++ b/.github/actions/incremental-build/action.yaml
@@ -39,6 +39,10 @@ inputs:
     description: 'Suffix for artifacts stored'
     required: false
     default: ''
+  maven-extra-args:
+    description: 'Extra Maven arguments to pass to the build (e.g. -Denforcer.phase=none)'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -52,6 +56,7 @@ runs:
         MODE: ${{ inputs.mode }}
         PR_ID: ${{ inputs.pr-id }}
         GITHUB_REPO: ${{ inputs.github-repo }}
+        MAVEN_EXTRA_ARGS: ${{ inputs.maven-extra-args }}
       shell: bash
       run: ${{ github.action_path }}/incremental-build.sh ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd $MODE $PR_ID $GITHUB_REPO
     - name: archive logs

--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -16,6 +16,7 @@
 #
 
 echo "Using MVND_OPTS=$MVND_OPTS"
+echo "Using MAVEN_EXTRA_ARGS=${MAVEN_EXTRA_ARGS:-}"
 
 maxNumberOfBuildableProjects=100
 maxNumberOfTestableProjects=50
@@ -96,7 +97,7 @@ function main() {
     fi
     if [[ ${buildAll} = "true" ]] ; then
       echo "Building all projects"
-      $mavenBinary -l $log $MVND_OPTS -DskipTests install
+      $mavenBinary -l $log $MVND_OPTS ${MAVEN_EXTRA_ARGS:-} -DskipTests install
       ret=$?
     else
       local buildDependents
@@ -109,21 +110,21 @@ function main() {
         for w in $pl; do
           echo "$w"
         done
-        totalTestableProjects=$(./mvnw -q -amd exec:exec -Dexec.executable="pwd" -pl "$pl" | wc -l)
+        totalTestableProjects=$(./mvnw -q -amd ${MAVEN_EXTRA_ARGS:-} exec:exec -Dexec.executable="pwd" -pl "$pl" | wc -l)
       fi
       if [[ ${totalTestableProjects} -gt ${maxNumberOfTestableProjects} ]] ; then
         echo "Launching fast build command against the projects ${pl}, their dependencies and the projects that depend on them"
         for w in $pl; do
           echo "$w"
         done
-        $mavenBinary -l $log $MVND_OPTS -DskipTests install -pl "$pl" -amd -am
+        $mavenBinary -l $log $MVND_OPTS ${MAVEN_EXTRA_ARGS:-} -DskipTests install -pl "$pl" -amd -am
         ret=$?
       else
         echo "Launching fast build command against the projects ${pl} and their dependencies"
         for w in $pl; do
           echo "$w"
         done
-        $mavenBinary -l $log $MVND_OPTS -DskipTests install -pl "$pl" -am
+        $mavenBinary -l $log $MVND_OPTS ${MAVEN_EXTRA_ARGS:-} -DskipTests install -pl "$pl" -am
         ret=$?
       fi
     fi
@@ -144,7 +145,7 @@ function main() {
         echo "The test-dependents label has been detected thus the projects that depend on affected projects will be tested"
         totalTestableProjects=0
       else
-        totalTestableProjects=$(./mvnw -q -amd exec:exec -Dexec.executable="pwd" -pl "$pl" | wc -l)
+        totalTestableProjects=$(./mvnw -q -amd ${MAVEN_EXTRA_ARGS:-} exec:exec -Dexec.executable="pwd" -pl "$pl" | wc -l)
       fi
       if [[ ${totalTestableProjects} -gt ${maxNumberOfTestableProjects} ]] ; then
         echo "There are too many projects to test so only the affected projects are tested:"
@@ -152,7 +153,7 @@ function main() {
           echo "$w"
         done
         # This need to install, other commands like test are not enough, otherwise test-infra will fail due to jandex maven plugin
-        $mavenBinary -l $log $MVND_OPTS install -DskipITs -pl "$pl"
+        $mavenBinary -l $log $MVND_OPTS ${MAVEN_EXTRA_ARGS:-} install -DskipITs -pl "$pl"
         ret=$?
       else
         echo "Testing the affected projects and the projects that depend on them:"
@@ -160,7 +161,7 @@ function main() {
           echo "$w"
         done
         # This need to install, other commands like test are not enough, otherwise test-infra will fail due to jandex maven plugin
-        $mavenBinary -l $log $MVND_OPTS install -DskipITs -pl "$pl" -amd
+        $mavenBinary -l $log $MVND_OPTS ${MAVEN_EXTRA_ARGS:-} install -DskipITs -pl "$pl" -amd
         ret=$?
       fi
     fi

--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -85,6 +85,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-mvnd-install: 'true'
           artifact-upload-suffix: java-${{ matrix.java }}
+          maven-extra-args: ${{ matrix.maven_extra_args || '' }}
       - name: mvn test parent pom dependencies changed
         uses: ./.github/actions/detect-dependencies
         with:


### PR DESCRIPTION
## Summary
- Backport of b1059083635 from `main`: the incremental build action (used for `mvn test`) was missing `MAVEN_EXTRA_ARGS` support, so the enforcer plugin failed on JDK 17 builds with `JDK 21+ is required`.
- Added `maven-extra-args` input to the incremental build action and propagated it to all Maven invocations in the shell script.
- Passes `-Denforcer.phase=none` from the JDK 17 matrix entry through to the test step.

## Test plan
- [ ] Verify JDK 17 CI build no longer fails with enforcer error
- [ ] Verify JDK 21 CI build is unaffected (no extra args passed)