### PR TITLE
CAMEL-23250: Fix security policy enforcement running on empty properties

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
@@ -673,13 +673,14 @@ public abstract class BaseMainSupport extends BaseService {
             }
         }
 
-        // log summary of configurations
+        // enforce security policies on all auto-configured properties
+        // (must run before logConfigurationSummary which clears the map)
+        enforceSecurityPolicies(camelContext, autoConfiguredProperties);
+
+        // log summary must be last as it removes entries from autoConfiguredProperties
         if (mainConfigurationProperties.isAutoConfigurationLogSummary() && !autoConfiguredProperties.isEmpty()) {
             logConfigurationSummary(camelContext, autoConfiguredProperties);
         }
-
-        // enforce security policies on all auto-configured properties
-        enforceSecurityPolicies(camelContext, autoConfiguredProperties);
 
         // we are now done with the main helper during bootstrap
         helper.bootstrapDone();

--- a/core/camel-main/src/test/java/org/apache/camel/main/MainSecurityPolicyTest.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/MainSecurityPolicyTest.java
@@ -511,4 +511,45 @@ public class MainSecurityPolicyTest {
                 .filter(v -> "secret".equals(v.category())).findFirst().orElseThrow();
         assertEquals("fail", secretViolation.policy());
     }
+
+    @Test
+    void testFileBasedInsecureDevFailPolicy() {
+        // Properties from files have a file-based location (not [camel-main]),
+        // which tests that enforcement works regardless of property source location
+        Main main = new Main();
+        main.setPropertyPlaceholderLocations("classpath:security-insecure-dev.properties");
+        main.addInitialProperty("camel.security.policy", "fail");
+
+        RuntimeCamelException ex = assertThrows(RuntimeCamelException.class, main::start);
+        assertTrue(ex.getMessage().contains("Security policy violations detected"));
+        assertTrue(ex.getMessage().contains("devConsoleEnabled"));
+    }
+
+    @Test
+    void testFileBasedInsecureSslFailPolicy() {
+        Main main = new Main();
+        main.setPropertyPlaceholderLocations("classpath:security-insecure-ssl.properties");
+        main.addInitialProperty("camel.security.policy", "fail");
+
+        RuntimeCamelException ex = assertThrows(RuntimeCamelException.class, main::start);
+        assertTrue(ex.getMessage().contains("Security policy violations detected"));
+        assertTrue(ex.getMessage().contains("trustAllCertificates"));
+    }
+
+    @Test
+    void testFileBasedInsecureDevWarnPolicy() throws Exception {
+        Main main = new Main();
+        main.setPropertyPlaceholderLocations("classpath:security-insecure-dev.properties");
+
+        main.start();
+        try {
+            SecurityPolicyResult result
+                    = main.getCamelContext().getCamelContextExtension().getContextPlugin(SecurityPolicyResult.class);
+            assertNotNull(result);
+            assertTrue(result.hasViolations());
+            assertEquals("insecure:dev", result.getViolations().get(0).category());
+        } finally {
+            main.stop();
+        }
+    }
 }

--- a/core/camel-main/src/test/resources/security-insecure-dev.properties
+++ b/core/camel-main/src/test/resources/security-insecure-dev.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+camel.main.devConsoleEnabled = true

--- a/core/camel-main/src/test/resources/security-insecure-ssl.properties
+++ b/core/camel-main/src/test/resources/security-insecure-ssl.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+camel.ssl.trustAllCertificates = true


### PR DESCRIPTION
## Summary

- Move `enforceSecurityPolicies()` before `logConfigurationSummary()` in `BaseMainSupport.autoconfigure()`
- `logConfigurationSummary()` delegates to `MainHelper.logConfigurationSummary()` which removes all entries from the `autoConfiguredProperties` map after logging them
- This caused `enforceSecurityPolicies()` to always receive an empty map and detect zero violations, making the entire security policy framework non-functional

## Test plan

- [x] Verified with Camel Quarkus integration tests (5 test cases covering warn, fail, allow, category override, and allowed-properties exclusion)
- [ ] Existing Camel tests should continue to pass

_Claude Code on behalf of Guillaume Nodet_