### PR TITLE
Revert "chore(deps): Bump httpclient-version from 5.5.2 to 5.6.1"

### DIFF
--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
@@ -528,14 +528,18 @@ public class HttpProducer extends DefaultProducer implements LineNumberAware {
             return null;
         }
 
-        final boolean skipGzipEncoding = exchange.getProperty(Exchange.SKIP_GZIP_ENCODING, Boolean.FALSE, Boolean.class);
-        if (!skipGzipEncoding) {
-            String contentEncoding = entity.getContentEncoding();
+        Header header = httpResponse.getFirstHeader(HttpConstants.CONTENT_ENCODING);
+        String contentEncoding = header != null ? header.getValue() : null;
+
+        final boolean gzipEncoding = exchange.getProperty(Exchange.SKIP_GZIP_ENCODING, Boolean.FALSE, Boolean.class);
+        if (!gzipEncoding) {
             is = GZIPHelper.uncompressGzip(contentEncoding, is);
         }
         // Honor the character encoding
-        String contentType = entity.getContentType();
-        if (contentType != null) {
+        String contentType = null;
+        header = httpResponse.getFirstHeader("content-type");
+        if (header != null) {
+            contentType = header.getValue();
             // find the charset and set it to the Exchange
             HttpHelper.setCharsetFromContentType(contentType, exchange);
         }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -257,7 +257,7 @@
         <hsqldb-version>2.7.4</hsqldb-version>
         <httpunit-version>1.7</httpunit-version>
         <httpcore-version>5.4.2</httpcore-version>
-        <httpclient-version>5.6.1</httpclient-version>
+        <httpclient-version>5.5.2</httpclient-version>
         <httpcore4-version>4.4.16</httpcore4-version>
         <httpclient4-version>4.5.14</httpclient4-version>
         <httpasyncclient-version>4.1.5</httpasyncclient-version>


### PR DESCRIPTION
Reverts apache/camel#22688

unfotunately, it is causing troubles with restassured and some of our tests, see https://issues.apache.org/jira/browse/CAMEL-23366
The work to upgrade rest assured to httpclient 5.6 is consequent as it is still based on version 4