### PR TITLE
jbang-it: adds missing commands compared to documentation

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelGetITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelGetITCase.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.it;
+
+import java.io.IOException;
+
+import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+@DisabledOnOs(WINDOWS)
+public class CamelGetITCase extends JBangTestSupport {
+
+    @Test
+    public void testGetContext() throws IOException {
+        copyResourceInDataFolder(TestResources.ROUTE2);
+        executeBackground(String.format("run %s/route2.yaml", mountPoint()));
+        checkLogContains("Hello Camel from custom integration");
+        checkCommandOutputs("get context", "Running");
+    }
+
+    @Test
+    public void testGetRoute() throws IOException {
+        copyResourceInDataFolder(TestResources.DIR_ROUTE);
+        copyResourceInDataFolder(TestResources.ROUTE2);
+        executeBackground(String.format("run --source-dir=%s", mountPoint()));
+        checkLogContains("Hello world!");
+        checkCommandOutputs("get route", "route1");
+        checkCommandOutputs("get route", "route2");
+    }
+
+    @Test
+    public void testGetGroup() throws IOException {
+        copyResourceInDataFolder(TestResources.GROUP_ROUTE);
+        executeBackground(String.format("run %s/GroupRoute.java", mountPoint()));
+        checkLogContains("Group A message");
+        checkCommandOutputs("get group", "groupA");
+        checkCommandOutputs("get group", "groupB");
+    }
+
+    @Test
+    public void testGetMetric() throws IOException {
+        copyResourceInDataFolder(TestResources.SERVER_ROUTE);
+        executeBackground(String.format("run %s/server.yaml --metrics", mountPoint()));
+        checkLogContains("Started route1");
+        checkCommandOutputs("get metric", "camel.routes");
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelLogITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelLogITCase.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.it;
+
+import java.io.IOException;
+
+import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+@DisabledOnOs(WINDOWS)
+public class CamelLogITCase extends JBangTestSupport {
+
+    @Test
+    public void testLogCommand() throws IOException {
+        copyResourceInDataFolder(TestResources.ROUTE2);
+        executeBackground(String.format("run %s/route2.yaml", mountPoint()));
+        checkLogContains("Hello Camel from custom integration");
+        checkCommandOutputs("log --follow=false --tail=5", "Hello Camel from custom integration");
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelTopITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelTopITCase.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.it;
+
+import java.io.IOException;
+
+import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+@DisabledOnOs(WINDOWS)
+public class CamelTopITCase extends JBangTestSupport {
+
+    @Test
+    public void testTop() throws IOException {
+        copyResourceInDataFolder(TestResources.ROUTE2);
+        executeBackground(String.format("run %s/route2.yaml", mountPoint()));
+        checkLogContains("Hello Camel from custom integration");
+        checkCommandOutputs("top", "Running");
+    }
+
+    @Test
+    public void testTopRoute() throws IOException {
+        copyResourceInDataFolder(TestResources.ROUTE2);
+        executeBackground(String.format("run %s/route2.yaml", mountPoint()));
+        checkLogContains("Hello Camel from custom integration");
+        checkCommandOutputs("top route", "route1");
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelTraceITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelTraceITCase.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.it;
+
+import java.io.IOException;
+
+import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+@DisabledOnOs(WINDOWS)
+public class CamelTraceITCase extends JBangTestSupport {
+
+    @Test
+    public void testTrace() throws IOException {
+        copyResourceInDataFolder(TestResources.ROUTE2);
+        executeBackground(String.format("run %s/route2.yaml", mountPoint()));
+        checkLogContains("Hello Camel from custom integration");
+        checkCommandOutputs("trace --follow=false --tail=5", "route2");
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdGroupITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdGroupITCase.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.it;
+
+import java.io.IOException;
+
+import org.apache.camel.dsl.jbang.it.support.InVersion;
+import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+@DisabledOnOs(WINDOWS)
+public class CmdGroupITCase extends JBangTestSupport {
+
+    @Test
+    @InVersion(from = "4.14.00")
+    public void testStopGroup() throws IOException {
+        copyResourceInDataFolder(TestResources.GROUP_ROUTE);
+        executeBackground(String.format("run %s/GroupRoute.java", mountPoint()));
+        checkLogContains("Group A message");
+        checkLogContains("Group B message");
+        execute("cmd stop-group --id=groupA");
+        checkCommandOutputsPattern("get route",
+                "(?s)routeA\\s+.*?Stopped.*?routeB\\s+.*?Started",
+                30);
+    }
+
+    @Test
+    @InVersion(from = "4.14.00")
+    public void testStartGroup() throws IOException {
+        copyResourceInDataFolder(TestResources.GROUP_ROUTE);
+        executeBackground(String.format("run %s/GroupRoute.java", mountPoint()));
+        checkLogContains("Group A message");
+        execute("cmd stop-group --id=groupA");
+        checkCommandOutputsPattern("get route",
+                "(?s)routeA\\s+.*?Stopped",
+                30);
+        execute("cmd start-group --id=groupA");
+        checkCommandOutputsPattern("get route",
+                "(?s)routeA\\s+.*?Started.*?routeB\\s+.*?Started",
+                30);
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdReceiveITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdReceiveITCase.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.it;
+
+import java.io.IOException;
+
+import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.infra.mosquitto.services.MosquittoLocalContainerService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.GenericContainer;
+
+@Tag("container-only")
+public class CmdReceiveITCase extends JBangTestSupport {
+
+    @RegisterExtension
+    static AvailablePortFinder.Port mqttPort = AvailablePortFinder.find();
+    private static MosquittoLocalContainerService service;
+
+    @BeforeAll
+    public static void init() {
+        service = new MosquittoLocalContainerService(mqttPort.getPort());
+        service.initialize();
+    }
+
+    @AfterAll
+    public static void end() {
+        service.shutdown();
+    }
+
+    @Test
+    public void testCmdSendAndReceive() throws IOException {
+        copyResourceInDataFolder(TestResources.MQQT_CONSUMER);
+        final String ipAddr = getIpAddr(service.getContainer());
+        final String process = executeBackground(String.format("run --property=brokerUrl=%s %s/%s",
+                "tcp://" + ipAddr + ":1883",
+                mountPoint(), TestResources.MQQT_CONSUMER.getName()));
+        checkLogContains("Started route1 (kamelet:mqtt5-source)");
+        final String payloadFile = "payload.json";
+        newFileInDataFolder(payloadFile, "{\"value\": 42}");
+        checkCommandOutputs(String.format("cmd send --body=file:%s/%s %s", mountPoint(), payloadFile, process),
+                "Sent (success)");
+        checkLogContains("The temperature is 42");
+    }
+
+    private String getIpAddr(final GenericContainer container) {
+        return container.getCurrentContainerInfo().getNetworkSettings().getNetworks().entrySet()
+                .stream().filter(entry -> "127.0.0.1" != entry.getValue().getIpAddress())
+                .map(entry -> entry.getValue().getIpAddress()).findFirst()
+                .orElseThrow(() -> new IllegalStateException("no ip address found"));
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -111,7 +111,8 @@ public abstract class JBangTestSupport {
         FORMATS_MAPPING_DATA("data.csv", "/jbang/it/data-mapping/data-formats/data.csv"),
         STUB_ROUTE("StubRoute.java", "/jbang/it/StubRoute.java"),
         HISTORY_ROUTE("HistoryRoute.java", "/jbang/it/HistoryRoute.java"),
-        USER_SOURCE_KAMELET("user-source.kamelet.yaml", "/jbang/it/user-source.kamelet.yaml");
+        USER_SOURCE_KAMELET("user-source.kamelet.yaml", "/jbang/it/user-source.kamelet.yaml"),
+        GROUP_ROUTE("GroupRoute.java", "/jbang/it/GroupRoute.java");
 
         private String name;
         private String resPath;

--- a/dsl/camel-jbang/camel-jbang-it/src/test/resources/jbang/it/GroupRoute.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/resources/jbang/it/GroupRoute.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.camel.builder.RouteBuilder;
+
+public class GroupRoute extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from("timer:a?period=1000").routeGroup("groupA").routeId("routeA")
+                .setBody().constant("Group A message")
+                .log("${body}");
+
+        from("timer:b?period=1000").routeGroup("groupB").routeId("routeB")
+                .setBody().constant("Group B message")
+                .log("${body}");
+    }
+}


### PR DESCRIPTION
Adds jbang tests for uncovered commands

- camel log                                                                                                                                                                                                    
- camel get context 
- camel get route                                                                                                                                                                                                   
- camel get group                                                                                                                                                                                                       
- camel get metric 
- camel top                                                                                                                                                                                                         
- camel top route                                                                                                                                                                                                
- camel trace                                                                                                                                                                                                        
- camel cmd send                                                                                                                                                                                               
- camel cmd stop-group                                                                                                                                                                                          
- camel cmd start-group