### PR TITLE
camel-openai: handle null finish_reason from OpenAI-compatible servers

### DIFF
--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIProducer.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openai.core.JsonField;
 import com.openai.core.JsonValue;
 import com.openai.core.http.StreamResponse;
 import com.openai.models.ResponseFormatJsonSchema;
@@ -378,7 +379,7 @@ public class OpenAIProducer extends DefaultAsyncProducer {
             exchange.setProperty(OpenAIConstants.RESPONSE, response);
         }
 
-        if (response.choices().get(0).finishReason().equals(ChatCompletion.Choice.FinishReason.TOOL_CALLS)) {
+        if (isToolCallsFinishReason(response.choices().get(0))) {
             exchange.getMessage().setBody(response.choices().get(0).message().toolCalls());
         } else {
             String content = response.choices().get(0).message().content().orElse("");
@@ -409,10 +410,10 @@ public class OpenAIProducer extends DefaultAsyncProducer {
             ChatCompletion response = getEndpoint().getClient().chat().completions().create(paramsBuilder.build());
             ChatCompletion.Choice choice = response.choices().get(0);
 
-            if (!choice.finishReason().equals(ChatCompletion.Choice.FinishReason.TOOL_CALLS)) {
+            if (!isToolCallsFinishReason(choice)) {
                 // Final LLM response
                 LOG.debug("Agentic loop completed after {} iterations, finish reason: {}", iteration,
-                        choice.finishReason());
+                        getFinishReasonString(choice));
                 String content = choice.message().content().orElse("");
                 exchange.getMessage().setBody(content);
                 setResponseHeaders(exchange.getMessage(), response);
@@ -566,13 +567,27 @@ public class OpenAIProducer extends DefaultAsyncProducer {
 
     }
 
+    private static boolean isToolCallsFinishReason(ChatCompletion.Choice choice) {
+        JsonField<ChatCompletion.Choice.FinishReason> field = choice._finishReason();
+        return field.asKnown()
+                .map(r -> r.equals(ChatCompletion.Choice.FinishReason.TOOL_CALLS))
+                .orElse(false);
+    }
+
+    private static String getFinishReasonString(ChatCompletion.Choice choice) {
+        JsonField<ChatCompletion.Choice.FinishReason> field = choice._finishReason();
+        return field.asKnown()
+                .map(ChatCompletion.Choice.FinishReason::toString)
+                .orElse("stop");
+    }
+
     private void setResponseHeaders(Message message, ChatCompletion response) {
         message.setHeader(OpenAIConstants.RESPONSE_ID, response.id());
         message.setHeader(OpenAIConstants.RESPONSE_MODEL, response.model());
 
         if (!response.choices().isEmpty()) {
             ChatCompletion.Choice choice = response.choices().get(0);
-            message.setHeader(OpenAIConstants.FINISH_REASON, choice.finishReason().toString());
+            message.setHeader(OpenAIConstants.FINISH_REASON, getFinishReasonString(choice));
         }
 
         if (response.usage().isPresent()) {


### PR DESCRIPTION
## Summary

- Handle `null` `finish_reason` in `OpenAIProducer` to avoid NPE when using OpenAI-compatible servers (e.g. mlx-lm) that don't always set this field
- Use the SDK's null-safe `_finishReason()` accessor (`JsonField`) instead of the throwing `finishReason()` (`getRequired`)
- Default to `"stop"` when `finish_reason` is null or missing

## Context

The OpenAI spec says `finish_reason` should always be set, but several popular local model servers (mlx-lm, some llama.cpp versions) return `null` when tools are defined in the request but the model responds without calling any. The openai-java SDK's `finishReason()` method calls `getRequired()` which throws on null, crashing the agentic loop.

## Test plan

- [x] Verified with mlx-lm serving Qwen3-35B with MCP tools configured
- [ ] Existing unit tests pass (`mvn verify` in camel-openai module)

_Claude Code on behalf of Federico Mariani_