### PR TITLE
CAMEL-23179: camel-jbang-mcp - Add camel_configuration_validate tool for validating Camel configuration properties

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/catalog/PropertiesValidationResult.java
+++ b/core/camel-api/src/main/java/org/apache/camel/catalog/PropertiesValidationResult.java
@@ -257,6 +257,10 @@ abstract class PropertiesValidationResult implements Serializable {
         return invalidEnumChoices;
     }
 
+    public Map<String, String[]> getInvalidEnumSuggestions() {
+        return invalidEnumSuggestions;
+    }
+
     public List<String> getEnumChoices(String optionName) {
         if (invalidEnumChoices != null) {
             String[] enums = invalidEnumChoices.get(optionName);

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/ConfigurationValidateTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/ConfigurationValidateTools.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.mcp;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolCallException;
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.catalog.ConfigurationPropertiesValidationResult;
+
+/**
+ * MCP Tool for validating Camel configuration properties (e.g. {@code application.properties} for camel-main, Spring
+ * Boot or Quarkus). Wraps {@link CamelCatalog#validateConfigurationProperty(String)} so that misspelled option names,
+ * invalid values and suggested corrections can be surfaced to LLMs.
+ */
+@ApplicationScoped
+public class ConfigurationValidateTools {
+
+    @Inject
+    CatalogService catalogService;
+
+    /**
+     * Tool to validate one or more Camel configuration property lines.
+     */
+    @Tool(annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false, openWorldHint = false),
+          description = "Validate one or more Camel configuration property lines (e.g. lines from application.properties). "
+                        +
+                        "Detects misspelled option names, invalid values (boolean/integer/number/duration/enum) and "
+                        +
+                        "returns suggestions when available. The input can be a single line or a multi-line string with "
+                        +
+                        "one property per line; blank lines and comments (starting with # or !) are skipped.")
+    public ConfigurationValidateResult camel_configuration_validate(
+            @ToolArg(description = "Configuration property lines to validate. Can be a single line "
+                                   + "(e.g. \"camel.main.streamCaching=true\") or multiple lines separated by newlines.") String properties,
+            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
+            @ToolArg(description = "Camel version to query. If not specified, uses the default catalog version.") String camelVersion,
+            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
+                                   + "When provided, overrides camelVersion.") String platformBom) {
+
+        if (properties == null || properties.isBlank()) {
+            throw new ToolCallException("properties argument is required", null);
+        }
+
+        try {
+            CamelCatalog catalog = catalogService.loadCatalog(runtime, camelVersion, platformBom);
+
+            List<PropertyValidationInfo> results = new ArrayList<>();
+            int totalErrors = 0;
+            int totalWarnings = 0;
+            int validCount = 0;
+
+            String[] lines = properties.split("\\r?\\n");
+            for (int i = 0; i < lines.length; i++) {
+                String line = lines[i];
+                String trimmed = line == null ? "" : line.trim();
+                if (trimmed.isEmpty() || trimmed.startsWith("#") || trimmed.startsWith("!")) {
+                    continue;
+                }
+
+                ConfigurationPropertiesValidationResult result = catalog.validateConfigurationProperty(line);
+                PropertyValidationInfo info = toPropertyValidationInfo(i + 1, line, result);
+                results.add(info);
+                totalErrors += info.errors();
+                totalWarnings += info.warnings();
+                if (info.valid()) {
+                    validCount++;
+                }
+            }
+
+            ConfigurationValidateSummary summary
+                    = new ConfigurationValidateSummary(results.size(), validCount, totalErrors, totalWarnings);
+
+            return new ConfigurationValidateResult(catalog.getCatalogVersion(), summary, results);
+        } catch (ToolCallException e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new ToolCallException(
+                    "Failed to validate configuration properties (" + e.getClass().getName() + "): " + e.getMessage(),
+                    null);
+        }
+    }
+
+    private PropertyValidationInfo toPropertyValidationInfo(
+            int lineNumber, String text, ConfigurationPropertiesValidationResult result) {
+        boolean valid = result.isSuccess();
+        boolean accepted = result.isAccepted();
+        int errors = result.getNumberOfErrors();
+        int warnings = result.getNumberOfWarnings();
+
+        List<PropertyIssue> issues = collectIssues(result);
+        String summary = result.summaryErrorMessage(false, true, true);
+
+        return new PropertyValidationInfo(lineNumber, text, accepted, valid, errors, warnings, summary, issues);
+    }
+
+    private List<PropertyIssue> collectIssues(ConfigurationPropertiesValidationResult result) {
+        List<PropertyIssue> issues = new ArrayList<>();
+
+        if (result.getSyntaxError() != null) {
+            issues.add(new PropertyIssue(null, "syntax", result.getSyntaxError(), Collections.emptyList()));
+        }
+        if (result.getUnknownComponent() != null) {
+            issues.add(new PropertyIssue(
+                    result.getUnknownComponent(), "unknownComponent",
+                    "Unknown component: " + result.getUnknownComponent(),
+                    Collections.emptyList()));
+        }
+        if (result.getIncapable() != null) {
+            issues.add(new PropertyIssue(null, "incapable", result.getIncapable(), Collections.emptyList()));
+        }
+
+        if (result.getUnknown() != null) {
+            Map<String, String[]> unknownSuggestions = result.getUnknownSuggestions();
+            for (String name : result.getUnknown()) {
+                String[] suggestions = unknownSuggestions != null ? unknownSuggestions.get(name) : null;
+                issues.add(new PropertyIssue(name, "unknown", "Unknown option", asSuggestionList(suggestions)));
+            }
+        }
+        if (result.getRequired() != null) {
+            for (String name : result.getRequired()) {
+                issues.add(new PropertyIssue(name, "required", "Missing required option", Collections.emptyList()));
+            }
+        }
+        if (result.getDeprecated() != null) {
+            for (String name : result.getDeprecated()) {
+                issues.add(new PropertyIssue(name, "deprecated", "Deprecated option", Collections.emptyList()));
+            }
+        }
+
+        addInvalidValueIssues(issues, result.getInvalidEnum(), "invalidEnum", "Invalid enum value",
+                result.getInvalidEnumChoices(), result.getInvalidEnumSuggestions());
+        addInvalidValueIssues(issues, result.getInvalidReference(), "invalidReference", "Invalid reference value", null,
+                null);
+        addInvalidValueIssues(issues, result.getInvalidBoolean(), "invalidBoolean", "Invalid boolean value", null, null);
+        addInvalidValueIssues(issues, result.getInvalidInteger(), "invalidInteger", "Invalid integer value", null, null);
+        addInvalidValueIssues(issues, result.getInvalidNumber(), "invalidNumber", "Invalid number value", null, null);
+        addInvalidValueIssues(issues, result.getInvalidDuration(), "invalidDuration", "Invalid duration value", null,
+                null);
+        addInvalidValueIssues(issues, result.getInvalidMap(), "invalidMap", "Invalid map key/value", null, null);
+        addInvalidValueIssues(issues, result.getInvalidArray(), "invalidArray", "Invalid array index/value", null, null);
+
+        return issues;
+    }
+
+    private void addInvalidValueIssues(
+            List<PropertyIssue> issues, Map<String, String> values, String kind, String baseMessage,
+            Map<String, String[]> choicesMap, Map<String, String[]> suggestionsMap) {
+        if (values == null) {
+            return;
+        }
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            String name = entry.getKey();
+            String value = entry.getValue();
+            StringBuilder msg = new StringBuilder(baseMessage);
+            if (value != null && !value.isBlank()) {
+                msg.append(": ").append(value);
+            }
+            if (choicesMap != null) {
+                String[] choices = choicesMap.get(name);
+                if (choices != null && choices.length > 0) {
+                    msg.append(". Possible values: ").append(Arrays.asList(choices));
+                }
+            }
+            String[] suggestions = suggestionsMap != null ? suggestionsMap.get(name) : null;
+            issues.add(new PropertyIssue(name, kind, msg.toString(), asSuggestionList(suggestions)));
+        }
+    }
+
+    private static List<String> asSuggestionList(String[] suggestions) {
+        if (suggestions == null || suggestions.length == 0) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(Arrays.asList(suggestions));
+    }
+
+    // Result record classes for Jackson serialization
+
+    public record ConfigurationValidateResult(String camelVersion, ConfigurationValidateSummary summary,
+            List<PropertyValidationInfo> properties) {
+    }
+
+    public record ConfigurationValidateSummary(int total, int valid, int errors, int warnings) {
+    }
+
+    public record PropertyValidationInfo(int lineNumber, String text, boolean accepted, boolean valid, int errors,
+            int warnings, String summary, List<PropertyIssue> issues) {
+    }
+
+    public record PropertyIssue(String name, String kind, String message, List<String> suggestions) {
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/ConfigurationValidateToolsTest.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/ConfigurationValidateToolsTest.java
@@ -84,6 +84,47 @@ class ConfigurationValidateToolsTest {
     }
 
     @Test
+    void acceptsPlaceholderValuesAcrossTypes() {
+        ConfigurationValidateTools tools = createTools();
+
+        // Property placeholders ({{...}}) should be accepted as a value for any option type
+        // (boolean, integer, string, ...) since the actual value is resolved at runtime.
+        String input = "camel.main.streamCachingEnabled={{myCacheEnabled}}\n"
+                       + "camel.main.durationMaxSeconds={{myDurationSeconds}}\n"
+                       + "camel.main.uuidGenerator={{myUuidGenerator}}";
+
+        ConfigurationValidateTools.ConfigurationValidateResult result
+                = tools.camel_configuration_validate(input, null, null, null);
+
+        assertThat(result.summary().total()).isEqualTo(3);
+        assertThat(result.summary().valid()).isEqualTo(3);
+        assertThat(result.summary().errors()).isZero();
+        assertThat(result.properties())
+                .allSatisfy(info -> {
+                    assertThat(info.accepted()).isTrue();
+                    assertThat(info.valid()).isTrue();
+                    assertThat(info.errors()).isZero();
+                    assertThat(info.issues()).isEmpty();
+                });
+    }
+
+    @Test
+    void acceptsSpringStylePlaceholderValue() {
+        ConfigurationValidateTools tools = createTools();
+
+        // Spring/Quarkus style ${...} placeholders must also be accepted for typed options.
+        ConfigurationValidateTools.ConfigurationValidateResult result
+                = tools.camel_configuration_validate("camel.main.streamCachingEnabled=${my.cache.enabled}", null, null,
+                        null);
+
+        ConfigurationValidateTools.PropertyValidationInfo info = result.properties().get(0);
+        assertThat(info.accepted()).isTrue();
+        assertThat(info.valid()).isTrue();
+        assertThat(info.errors()).isZero();
+        assertThat(info.issues()).isEmpty();
+    }
+
+    @Test
     void skipsBlankLinesAndComments() {
         ConfigurationValidateTools tools = createTools();
 

--- a/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/ConfigurationValidateToolsTest.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/ConfigurationValidateToolsTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.mcp;
+
+import java.util.Optional;
+
+import io.quarkiverse.mcp.server.ToolCallException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConfigurationValidateToolsTest {
+
+    private ConfigurationValidateTools createTools() {
+        CatalogService catalogService = new CatalogService();
+        catalogService.catalogRepos = Optional.empty();
+
+        ConfigurationValidateTools tools = new ConfigurationValidateTools();
+        tools.catalogService = catalogService;
+        return tools;
+    }
+
+    @Test
+    void validatesValidMainProperty() {
+        ConfigurationValidateTools tools = createTools();
+
+        ConfigurationValidateTools.ConfigurationValidateResult result
+                = tools.camel_configuration_validate("camel.main.streamCachingEnabled=true", null, null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.camelVersion()).isNotNull();
+        assertThat(result.summary().total()).isEqualTo(1);
+        assertThat(result.summary().valid()).isEqualTo(1);
+        assertThat(result.summary().errors()).isZero();
+        assertThat(result.properties()).hasSize(1);
+
+        ConfigurationValidateTools.PropertyValidationInfo info = result.properties().get(0);
+        assertThat(info.lineNumber()).isEqualTo(1);
+        assertThat(info.accepted()).isTrue();
+        assertThat(info.valid()).isTrue();
+        assertThat(info.errors()).isZero();
+        assertThat(info.issues()).isEmpty();
+    }
+
+    @Test
+    void detectsUnknownOption() {
+        ConfigurationValidateTools tools = createTools();
+
+        ConfigurationValidateTools.ConfigurationValidateResult result
+                = tools.camel_configuration_validate("camel.main.streamCachngEnabled=true", null, null, null);
+
+        assertThat(result.summary().errors()).isPositive();
+        ConfigurationValidateTools.PropertyValidationInfo info = result.properties().get(0);
+        assertThat(info.valid()).isFalse();
+        assertThat(info.issues()).anyMatch(i -> "unknown".equals(i.kind()));
+    }
+
+    @Test
+    void detectsInvalidBoolean() {
+        ConfigurationValidateTools tools = createTools();
+
+        ConfigurationValidateTools.ConfigurationValidateResult result
+                = tools.camel_configuration_validate("camel.main.streamCachingEnabled=notabool", null, null, null);
+
+        ConfigurationValidateTools.PropertyValidationInfo info = result.properties().get(0);
+        assertThat(info.valid()).isFalse();
+        assertThat(info.issues()).anyMatch(i -> "invalidBoolean".equals(i.kind())
+                && i.message().contains("notabool"));
+    }
+
+    @Test
+    void skipsBlankLinesAndComments() {
+        ConfigurationValidateTools tools = createTools();
+
+        String input = """
+                # this is a comment
+                ! shell-style comment
+
+                camel.main.streamCachingEnabled=true
+                """;
+
+        ConfigurationValidateTools.ConfigurationValidateResult result
+                = tools.camel_configuration_validate(input, null, null, null);
+
+        assertThat(result.summary().total()).isEqualTo(1);
+        assertThat(result.properties()).hasSize(1);
+        assertThat(result.properties().get(0).lineNumber()).isEqualTo(4);
+    }
+
+    @Test
+    void multipleLinesAggregated() {
+        ConfigurationValidateTools tools = createTools();
+
+        String input = "camel.main.streamCachingEnabled=true\n"
+                       + "camel.main.streamCachngEnabled=true\n"
+                       + "camel.main.streamCachingEnabled=notabool";
+
+        ConfigurationValidateTools.ConfigurationValidateResult result
+                = tools.camel_configuration_validate(input, null, null, null);
+
+        assertThat(result.summary().total()).isEqualTo(3);
+        assertThat(result.summary().valid()).isEqualTo(1);
+        assertThat(result.summary().errors()).isGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    void nonCamelKeyMarkedNotAccepted() {
+        ConfigurationValidateTools tools = createTools();
+
+        ConfigurationValidateTools.ConfigurationValidateResult result
+                = tools.camel_configuration_validate("server.port=8080", null, null, null);
+
+        ConfigurationValidateTools.PropertyValidationInfo info = result.properties().get(0);
+        assertThat(info.accepted()).isFalse();
+    }
+
+    @Test
+    void blankInputThrows() {
+        ConfigurationValidateTools tools = createTools();
+
+        assertThatThrownBy(() -> tools.camel_configuration_validate("   ", null, null, null))
+                .isInstanceOf(ToolCallException.class)
+                .hasMessageContaining("required");
+    }
+
+    @Test
+    void nullInputThrows() {
+        ConfigurationValidateTools tools = createTools();
+
+        assertThatThrownBy(() -> tools.camel_configuration_validate(null, null, null, null))
+                .isInstanceOf(ToolCallException.class)
+                .hasMessageContaining("required");
+    }
+}


### PR DESCRIPTION
## Summary

Exposes `CamelCatalog.validateConfigurationProperty()` as an MCP tool so an
agent can validate one or more `application.properties` lines and receive
per-property errors, suggestions for misspelled options and human-readable
summaries (CAMEL-23179).

The tool accepts a single property line or a multi-line string, skips blank
lines and `#` / `!` comments, and reports each line with:

- `accepted` — whether the key is a Camel-prefixed key the catalog recognises
- `valid` — whether the line passed validation
- `errors` / `warnings` counts
- a structured list of `issues` tagged by kind (`unknown`, `required`,
  `deprecated`, `invalidEnum`, `invalidBoolean`, `invalidInteger`,
  `invalidNumber`, `invalidDuration`, `invalidReference`, `invalidMap`,
  `invalidArray`, `unknownComponent`, `incapable`, `syntax`), each carrying
  the option name, message and suggestions when available
- a human-readable `summary` from `summaryErrorMessage`

Property placeholder values (`{{...}}`, `${...}`, `$simple{...}`) are
accepted for any option type — the underlying
`AbstractCamelCatalog.doValidateConfigurationProperty()` skips type-based
validation when a placeholder is detected, since the actual value is
resolved at runtime.

## Changes

- `ConfigurationValidateTools` — new `@ApplicationScoped` tool class exposing
  `camel_configuration_validate`. Resolves a `CamelCatalog` via the existing
  `CatalogService` so the runtime / camelVersion / platformBom selectors
  match the rest of the MCP catalog tools.
- `PropertiesValidationResult` — new public `getInvalidEnumSuggestions()`
  getter (backwards-compatible additive change). The field already existed
  with a public adder; a getter was missing, which the new tool needs to
  surface enum suggestions without reflection.
- `ConfigurationValidateToolsTest` — 10 unit tests covering valid input,
  unknown options, invalid boolean, multi-line aggregation,
  comment/blank-line skipping, non-camel keys (`accepted=false`), missing
  input validation, and placeholder values across multiple types
  (boolean / integer / string) for both `{{...}}` and `${...}` forms.

## Test plan

- [x] `mvn test` in `dsl/camel-jbang/camel-jbang-mcp` (199 tests passing,
      10 new)
- [x] Full root build `mvn clean install -DskipTests -Dquickly` succeeds
- [x] `camel-api` rebuilt and installed before module build to pick up the
      new getter

## Review feedback addressed

- **@davsclaus**: confirmed and tested that property placeholders
  (`foo={{bar}}`, `foo=${bar}`) are accepted as values for any option type
  (boolean, integer, string, ...) — handled in
  `AbstractCamelCatalog.doValidateConfigurationProperty()` via the
  `optionPlaceholder` check, with new tests in `ConfigurationValidateToolsTest`.

_Claude Code on behalf of Andrea Cosentino_