### PR TITLE
[4.14.x] Align with spring boot 3.5.14 dependencies

### DIFF
--- a/components/camel-fop/pom.xml
+++ b/components/camel-fop/pom.xml
@@ -81,6 +81,18 @@
             <version>${bouncycastle-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${bouncycastle-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk18on</artifactId>
+            <version>${bouncycastle-version}</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 </project>

--- a/components/camel-pdf/pom.xml
+++ b/components/camel-pdf/pom.xml
@@ -63,6 +63,16 @@
             <version>${bouncycastle-version}</version>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${bouncycastle-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk18on</artifactId>
+            <version>${bouncycastle-version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-junit5</artifactId>
             <scope>test</scope>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -146,7 +146,7 @@
         <dropbox-version>7.0.0</dropbox-version>
         <eddsa-version>0.3.0</eddsa-version>
         <egit-github-core-version>2.1.5</egit-github-core-version>
-        <ehcache3-version>3.10.8</ehcache3-version>
+        <ehcache3-version>3.10.9</ehcache3-version>
         <elasticsearch-java-client-version>9.1.2</elasticsearch-java-client-version>
         <elasticsearch-java-client-sniffer-version>9.1.2</elasticsearch-java-client-sniffer-version>
         <elytron-web>4.1.2.Final</elytron-web>
@@ -204,10 +204,10 @@
         <google-cloud-secretmanager-version>2.75.0</google-cloud-secretmanager-version>
         <google-cloud-storage-version>2.58.0</google-cloud-storage-version>
         <graaljs-version>24.2.2</graaljs-version>
-        <graphql-java-version>24.2</graphql-java-version>
+        <graphql-java-version>24.3</graphql-java-version>
         <greenmail-version>2.1.5</greenmail-version>
         <grizzly-websockets-version>2.4.4</grizzly-websockets-version>
-        <groovy-version>4.0.30</groovy-version>
+        <groovy-version>4.0.31</groovy-version>
         <grpc-version>1.75.0</grpc-version>
         <grpc-google-auth-library-version>1.39.1</grpc-google-auth-library-version>
         <grpc-java-jwt-version>4.5.0</grpc-java-jwt-version>
@@ -232,7 +232,7 @@
         <hsqldb-version>2.7.4</hsqldb-version>
         <httpunit-version>1.7</httpunit-version>
         <httpcore-version>5.3.6</httpcore-version>
-        <httpclient-version>5.4.4</httpclient-version>
+        <httpclient-version>5.5.2</httpclient-version>
         <httpcore4-version>4.4.16</httpcore4-version>
         <httpclient4-version>4.5.14</httpclient4-version>
         <httpasyncclient-version>4.1.5</httpasyncclient-version>
@@ -268,20 +268,20 @@
         <javassist-version>3.30.2-GA</javassist-version>
         <jakarta-el-api-version>6.0.1</jakarta-el-api-version>
         <jakarta-el-expressly-version>6.0.0</jakarta-el-expressly-version>
-        <jakarta-activation-version>2.1.3</jakarta-activation-version>
+        <jakarta-activation-version>2.1.4</jakarta-activation-version>
         <jakarta-annotation-api-version>3.0.0</jakarta-annotation-api-version>
         <jakarta-servlet-api-version>6.1.0</jakarta-servlet-api-version>
         <jakarta-enterprise-cdi-api-version>4.1.0</jakarta-enterprise-cdi-api-version>
         <jakarta-inject-version>2.0.1</jakarta-inject-version>
-        <jakarta-xml-bind-api-version>4.0.2</jakarta-xml-bind-api-version>
+        <jakarta-xml-bind-api-version>4.0.4</jakarta-xml-bind-api-version>
         <jakarta-xml-soap-api-version>3.0.2</jakarta-xml-soap-api-version>
-        <jakarta-xml-ws-api-version>4.0.2</jakarta-xml-ws-api-version>
+        <jakarta-xml-ws-api-version>4.0.3</jakarta-xml-ws-api-version>
         <glassfish-javax-json>1.1.4</glassfish-javax-json>
-        <glassfish-jaxb-runtime-version>4.0.5</glassfish-jaxb-runtime-version>
+        <glassfish-jaxb-runtime-version>4.0.6</glassfish-jaxb-runtime-version>
         <jaxb2-maven-plugin-version>3.3.0</jaxb2-maven-plugin-version>
         <jaxp-ri-version>1.4.5</jaxp-ri-version>
         <jboss-el-api_3.0_spec-version>2.0.0.Final</jboss-el-api_3.0_spec-version>
-        <jboss-logging-version>3.6.1.Final</jboss-logging-version>
+        <jboss-logging-version>3.6.3.Final</jboss-logging-version>
         <jboss-marshalling-version>1.4.10.Final</jboss-marshalling-version>
         <jboss-transaction-spi-version>7.6.1.Final</jboss-transaction-spi-version>
         <jboss-xnio-version>3.8.14.Final</jboss-xnio-version>
@@ -289,7 +289,7 @@
         <jcip-annotations-version>1.0-1</jcip-annotations-version>
         <jcr-version>2.0</jcr-version>
         <jedis-client-version>6.1.0</jedis-client-version>
-        <jetty-version>12.0.33</jetty-version>
+        <jetty-version>12.0.34</jetty-version>
         <jetty-for-solr-version>10.0.20</jetty-for-solr-version>
         <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
         <jetty-runner-groupId>org.eclipse.jetty</jetty-runner-groupId>
@@ -400,7 +400,7 @@
         <narayana-version>5.13.1.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
         <neo4j-version>5.28.10</neo4j-version>
-        <netty-version>4.1.131.Final</netty-version>
+        <netty-version>4.1.132.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.5.8</networknt-json-schema-validator-version>
         <nimbus-jose-jwt>10.4.2</nimbus-jose-jwt>
@@ -483,12 +483,12 @@
         <spock-version>2.3-groovy-4.0</spock-version>
         <spring-cloud-config-version>4.3.0</spring-cloud-config-version>
         <spring-batch-version>5.2.5</spring-batch-version>
-        <spring-data-redis-version>3.5.5</spring-data-redis-version>
-        <spring-ldap-version>3.3.6</spring-ldap-version>
+        <spring-data-redis-version>3.5.9</spring-data-redis-version>
+        <spring-ldap-version>3.3.7</spring-ldap-version>
         <spring-vault-core-version>3.2.0</spring-vault-core-version>
-        <spring-version>6.2.17</spring-version>
-        <spring-rabbitmq-version>3.2.6</spring-rabbitmq-version>
-        <spring-security-version>6.5.9</spring-security-version>
+        <spring-version>6.2.18</spring-version>
+        <spring-rabbitmq-version>3.2.10</spring-rabbitmq-version>
+        <spring-security-version>6.5.10</spring-security-version>
         <spring-ws-version>4.1.3</spring-ws-version>
         <sql-maven-plugin-version>3.0.0</sql-maven-plugin-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>
@@ -506,11 +506,11 @@
         <stringtemplate-version>4.3.4</stringtemplate-version>
         <tahu-version>1.0.14</tahu-version>
         <testcontainers-version>1.21.4</testcontainers-version>
-        <thymeleaf-version>3.1.3.RELEASE</thymeleaf-version>
+        <thymeleaf-version>3.1.5.RELEASE</thymeleaf-version>
         <tika-version>3.2.3</tika-version>
         <twilio-version>10.9.2</twilio-version>
         <twitter4j-version>4.1.2</twitter4j-version>
-        <undertow-version>2.3.23.Final</undertow-version>
+        <undertow-version>2.3.24.Final</undertow-version>
         <univocity-parsers-version>2.10.2</univocity-parsers-version>
         <validation-api-version>2.0.1.Final</validation-api-version>
         <vavr-version>0.10.7</vavr-version>


### PR DESCRIPTION
# Description

- https://github.com/apache/camel-spring-boot/pull/1772 aligns camel-spring-boot 4.14.x to 3.5.14.    This PR aligns dependencies in camel to the versions used in spring-boot 3.5.14.

- explicitly declare bouncycastle  bcpkix and bcutil test dependencies to prevent transitive resolution failures - I was seeing resolution failures on versions not being used by camel

# Target

- [x ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

