### PR TITLE
CAMEL-23181: camel-jbang-mcp - Add camel_properties_translate tool

### DIFF
--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/PropertiesTranslateTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/PropertiesTranslateTools.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.mcp;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolCallException;
+
+/**
+ * MCP Tool for translating Camel configuration properties between Camel runtimes (camel-main / jbang standalone,
+ * camel-spring-boot, camel-quarkus).
+ *
+ * Most Camel properties are runtime-agnostic ({@code camel.main.*}, {@code camel.component.*}, etc.) and are returned
+ * unchanged. The properties that actually differ between runtimes are the embedded HTTP server and management endpoints
+ * ({@code camel.server.*} / {@code camel.management.*} are jbang-only) and the legacy {@code camel.springboot.*}
+ * configuration that was harmonized to {@code camel.main.*} in Camel 4.5 and removed in 4.13.
+ */
+@ApplicationScoped
+public class PropertiesTranslateTools {
+
+    enum Runtime {
+        MAIN("main"),
+        SPRING_BOOT("spring-boot"),
+        QUARKUS("quarkus");
+
+        private final String label;
+
+        Runtime(String label) {
+            this.label = label;
+        }
+
+        String label() {
+            return label;
+        }
+
+        static Runtime fromLabel(String value) {
+            if (value == null) {
+                return null;
+            }
+            String v = value.trim().toLowerCase(Locale.ENGLISH);
+            for (Runtime r : values()) {
+                if (r.label.equals(v)) {
+                    return r;
+                }
+            }
+            // accept a few common aliases
+            switch (v) {
+                case "camel-main":
+                case "jbang":
+                case "standalone":
+                    return MAIN;
+                case "camel-spring-boot":
+                case "springboot":
+                case "spring":
+                    return SPRING_BOOT;
+                case "camel-quarkus":
+                    return QUARKUS;
+                default:
+                    return null;
+            }
+        }
+    }
+
+    /**
+     * Canonical translation table. Each entry maps a "logical" property to the per-runtime physical key. A {@code null}
+     * value means the runtime has no direct equivalent (e.g. Spring Boot Actuator auto-enables management endpoints).
+     */
+    private static final Map<String, Map<Runtime, String>> CANONICAL = buildCanonical();
+
+    private static Map<String, Map<Runtime, String>> buildCanonical() {
+        Map<String, Map<Runtime, String>> m = new LinkedHashMap<>();
+        m.put("http.port", entry(
+                "camel.server.port",
+                "server.port",
+                "quarkus.http.port"));
+        m.put("http.host", entry(
+                "camel.server.host",
+                "server.address",
+                "quarkus.http.host"));
+        m.put("http.path", entry(
+                "camel.server.path",
+                "server.servlet.context-path",
+                "quarkus.http.root-path"));
+        m.put("management.port", entry(
+                "camel.management.port",
+                "management.server.port",
+                "quarkus.management.port"));
+        m.put("management.path", entry(
+                "camel.management.path",
+                "management.endpoints.web.base-path",
+                "quarkus.management.root-path"));
+        m.put("management.enabled", entry(
+                "camel.management.enabled",
+                null, // Spring Boot Actuator auto-enables when on classpath
+                "quarkus.management.enabled"));
+        return m;
+    }
+
+    private static Map<Runtime, String> entry(String main, String springBoot, String quarkus) {
+        // Use a HashMap (not Map.copyOf) because some runtimes legitimately have no equivalent
+        // for a given canonical key (e.g. Spring Boot has no direct counterpart for
+        // camel.management.enabled), and Map.copyOf rejects null values.
+        Map<Runtime, String> e = new LinkedHashMap<>();
+        e.put(Runtime.MAIN, main);
+        e.put(Runtime.SPRING_BOOT, springBoot);
+        e.put(Runtime.QUARKUS, quarkus);
+        return e;
+    }
+
+    /**
+     * Reverse index: per-runtime physical key -> canonical key. Built once at class load.
+     */
+    private static final Map<Runtime, Map<String, String>> KEY_TO_CANONICAL = buildKeyToCanonical();
+
+    private static Map<Runtime, Map<String, String>> buildKeyToCanonical() {
+        Map<Runtime, Map<String, String>> m = new LinkedHashMap<>();
+        for (Runtime r : Runtime.values()) {
+            Map<String, String> rev = new LinkedHashMap<>();
+            for (Map.Entry<String, Map<Runtime, String>> e : CANONICAL.entrySet()) {
+                String key = e.getValue().get(r);
+                if (key != null) {
+                    rev.put(key, e.getKey());
+                }
+            }
+            m.put(r, rev);
+        }
+        return m;
+    }
+
+    /**
+     * Camel property prefixes that are runtime-agnostic and must NOT be rewritten when changing runtime.
+     */
+    private static final Set<String> CAMEL_AGNOSTIC_PREFIXES = Set.of(
+            "camel.main.",
+            "camel.component.",
+            "camel.dataformat.",
+            "camel.language.",
+            "camel.transformer.",
+            "camel.beans.",
+            "camel.routes.",
+            "camel.routetemplate.",
+            "camel.routeconfiguration.",
+            "camel.routecontroller.",
+            "camel.startupcondition.",
+            "camel.health.",
+            "camel.cluster.",
+            "camel.lra.",
+            "camel.metrics.",
+            "camel.opentelemetry.",
+            "camel.opentelemetry2.",
+            "camel.tracing.",
+            "camel.threadpool.",
+            "camel.resilience4j.",
+            "camel.faulttolerance.",
+            "camel.kamelet.",
+            "camel.rest.",
+            "camel.ssl.",
+            "camel.vault.",
+            "camel.devconsole.",
+            "camel.debug.");
+
+    /**
+     * Tool to translate Camel configuration property lines between Camel runtimes.
+     */
+    @Tool(annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false, openWorldHint = false),
+          description = "Translate Camel configuration property lines (e.g. lines from application.properties) between "
+                        +
+                        "Camel runtimes: camel-main (jbang/standalone), camel-spring-boot, and camel-quarkus. "
+                        +
+                        "Most camel.* properties are runtime-agnostic and are returned unchanged. The keys that "
+                        +
+                        "actually differ are the embedded HTTP server and management endpoint configuration "
+                        +
+                        "(camel.server.* / camel.management.* are jbang-only; camel-spring-boot uses server.* / "
+                        +
+                        "management.* via Spring Boot; camel-quarkus uses quarkus.http.* / quarkus.management.*). "
+                        +
+                        "Legacy camel.springboot.* keys are rewritten to camel.main.* (deprecated in 4.5, removed in "
+                        +
+                        "4.13). Properties without a known translation are passed through with status=unknown so the "
+                        +
+                        "caller can review them — the tool never guesses.")
+    public PropertiesTranslateResult camel_properties_translate(
+            @ToolArg(description = "Configuration property lines to translate. Can be a single line or multiple lines "
+                                   + "separated by newlines.") String properties,
+            @ToolArg(description = "Source Camel runtime: main, spring-boot, or quarkus.") String fromRuntime,
+            @ToolArg(description = "Target Camel runtime: main, spring-boot, or quarkus.") String toRuntime) {
+
+        if (properties == null || properties.isBlank()) {
+            throw new ToolCallException("properties argument is required", null);
+        }
+
+        Runtime from = Runtime.fromLabel(fromRuntime);
+        if (from == null) {
+            throw new ToolCallException(
+                    "fromRuntime argument is required and must be one of: main, spring-boot, quarkus", null);
+        }
+        Runtime to = Runtime.fromLabel(toRuntime);
+        if (to == null) {
+            throw new ToolCallException(
+                    "toRuntime argument is required and must be one of: main, spring-boot, quarkus", null);
+        }
+
+        List<TranslatedLine> results = new ArrayList<>();
+        int translated = 0;
+        int unchanged = 0;
+        int unknown = 0;
+        int comments = 0;
+
+        String[] lines = properties.split("\\r?\\n");
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            int lineNumber = i + 1;
+            String trimmed = line == null ? "" : line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#") || trimmed.startsWith("!")) {
+                results.add(new TranslatedLine(lineNumber, line, line, "comment", null));
+                comments++;
+                continue;
+            }
+
+            TranslatedLine result = translateLine(lineNumber, line, from, to);
+            results.add(result);
+            switch (result.status()) {
+                case "translated" -> translated++;
+                case "unchanged" -> unchanged++;
+                case "unknown" -> unknown++;
+                default -> {
+                    // unreachable for non-comment lines
+                }
+            }
+        }
+
+        TranslateSummary summary = new TranslateSummary(results.size(), translated, unchanged, unknown, comments);
+        return new PropertiesTranslateResult(from.label(), to.label(), summary, results);
+    }
+
+    private TranslatedLine translateLine(int lineNumber, String line, Runtime from, Runtime to) {
+        int eq = line.indexOf('=');
+        if (eq < 0) {
+            return new TranslatedLine(
+                    lineNumber, line, line, "unknown",
+                    "Line is not in key=value form; passed through unchanged");
+        }
+        String rawKey = line.substring(0, eq);
+        String value = line.substring(eq + 1);
+        String key = rawKey.trim();
+
+        // 1. Legacy cleanup: camel.springboot.* is deprecated and removed since 4.13.
+        // Rewrite to camel.main.* regardless of source/target runtime.
+        if (key.startsWith("camel.springboot.")) {
+            String newKey = "camel.main." + key.substring("camel.springboot.".length());
+            String translatedLine = newKey + "=" + value;
+            return new TranslatedLine(
+                    lineNumber, line, translatedLine, "translated",
+                    "Legacy camel.springboot.* prefix rewritten to camel.main.* (deprecated since Camel 4.5, removed in 4.13)");
+        }
+
+        // 2. Known per-runtime physical keys -> look up the canonical, then re-emit for the target.
+        String canonical = KEY_TO_CANONICAL.get(from).get(key);
+        if (canonical != null) {
+            if (from == to) {
+                return new TranslatedLine(lineNumber, line, line, "unchanged", null);
+            }
+            String targetKey = CANONICAL.get(canonical).get(to);
+            if (targetKey == null) {
+                return new TranslatedLine(
+                        lineNumber, line, line, "unknown",
+                        "No equivalent in " + to.label() + " for canonical '" + canonical
+                                                           + "' (e.g. Spring Boot Actuator auto-enables management endpoints when on the classpath)");
+            }
+            String translatedLine = targetKey + "=" + value;
+            return new TranslatedLine(lineNumber, line, translatedLine, "translated", null);
+        }
+
+        // 3. Camel-agnostic prefixes are identical across runtimes.
+        for (String prefix : CAMEL_AGNOSTIC_PREFIXES) {
+            if (key.startsWith(prefix)) {
+                return new TranslatedLine(lineNumber, line, line, "unchanged", null);
+            }
+        }
+
+        // 4. Anything else (server.*, quarkus.datasource.*, spring.jpa.*, logging.*, etc.) is out of scope —
+        // we never guess. Pass through unchanged with a note.
+        return new TranslatedLine(
+                lineNumber, line, line, "unknown",
+                "No translation rule for this key; passed through unchanged");
+    }
+
+    // Result record classes for Jackson serialization
+
+    public record PropertiesTranslateResult(String fromRuntime, String toRuntime, TranslateSummary summary,
+            List<TranslatedLine> properties) {
+    }
+
+    public record TranslateSummary(int total, int translated, int unchanged, int unknown, int comments) {
+    }
+
+    public record TranslatedLine(int lineNumber, String original, String translated, String status, String note) {
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/PropertiesTranslateToolsTest.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/PropertiesTranslateToolsTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.mcp;
+
+import io.quarkiverse.mcp.server.ToolCallException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PropertiesTranslateToolsTest {
+
+    private final PropertiesTranslateTools tools = new PropertiesTranslateTools();
+
+    @Test
+    void translatesMainToSpringBoot() {
+        PropertiesTranslateTools.PropertiesTranslateResult result = tools.camel_properties_translate(
+                "camel.server.port=8080\ncamel.management.port=8081", "main", "spring-boot");
+
+        assertThat(result.fromRuntime()).isEqualTo("main");
+        assertThat(result.toRuntime()).isEqualTo("spring-boot");
+        assertThat(result.summary().total()).isEqualTo(2);
+        assertThat(result.summary().translated()).isEqualTo(2);
+        assertThat(result.properties().get(0).translated()).isEqualTo("server.port=8080");
+        assertThat(result.properties().get(0).status()).isEqualTo("translated");
+        assertThat(result.properties().get(1).translated()).isEqualTo("management.server.port=8081");
+        assertThat(result.properties().get(1).status()).isEqualTo("translated");
+    }
+
+    @Test
+    void translatesMainToQuarkus() {
+        PropertiesTranslateTools.PropertiesTranslateResult result = tools.camel_properties_translate(
+                "camel.server.port=8080\ncamel.server.host=0.0.0.0\ncamel.server.path=/api\n"
+                                                                                                     + "camel.management.port=9000\ncamel.management.path=/q\ncamel.management.enabled=true",
+                "main", "quarkus");
+
+        assertThat(result.summary().translated()).isEqualTo(6);
+        assertThat(result.properties().get(0).translated()).isEqualTo("quarkus.http.port=8080");
+        assertThat(result.properties().get(1).translated()).isEqualTo("quarkus.http.host=0.0.0.0");
+        assertThat(result.properties().get(2).translated()).isEqualTo("quarkus.http.root-path=/api");
+        assertThat(result.properties().get(3).translated()).isEqualTo("quarkus.management.port=9000");
+        assertThat(result.properties().get(4).translated()).isEqualTo("quarkus.management.root-path=/q");
+        assertThat(result.properties().get(5).translated()).isEqualTo("quarkus.management.enabled=true");
+    }
+
+    @Test
+    void translatesSpringBootToQuarkus() {
+        PropertiesTranslateTools.PropertiesTranslateResult result = tools.camel_properties_translate(
+                "server.port=8080\nserver.address=0.0.0.0\nmanagement.server.port=9000",
+                "spring-boot", "quarkus");
+
+        assertThat(result.summary().translated()).isEqualTo(3);
+        assertThat(result.properties().get(0).translated()).isEqualTo("quarkus.http.port=8080");
+        assertThat(result.properties().get(1).translated()).isEqualTo("quarkus.http.host=0.0.0.0");
+        assertThat(result.properties().get(2).translated()).isEqualTo("quarkus.management.port=9000");
+    }
+
+    @Test
+    void translatesQuarkusToMain() {
+        PropertiesTranslateTools.PropertiesTranslateResult result = tools.camel_properties_translate(
+                "quarkus.http.port=8080\nquarkus.management.root-path=/admin",
+                "quarkus", "main");
+
+        assertThat(result.properties().get(0).translated()).isEqualTo("camel.server.port=8080");
+        assertThat(result.properties().get(1).translated()).isEqualTo("camel.management.path=/admin");
+    }
+
+    @Test
+    void agnosticCamelPropertiesPassThroughUnchanged() {
+        String input = "camel.main.streamCachingEnabled=true\n"
+                       + "camel.component.kafka.brokers=localhost:9092\n"
+                       + "camel.dataformat.json-jackson.prettyPrint=true\n"
+                       + "camel.health.enabled=true\n"
+                       + "camel.routecontroller.enabled=true";
+
+        PropertiesTranslateTools.PropertiesTranslateResult result = tools.camel_properties_translate(
+                input, "spring-boot", "quarkus");
+
+        assertThat(result.summary().total()).isEqualTo(5);
+        assertThat(result.summary().unchanged()).isEqualTo(5);
+        assertThat(result.summary().translated()).isZero();
+        assertThat(result.properties()).allSatisfy(p -> {
+            assertThat(p.status()).isEqualTo("unchanged");
+            assertThat(p.translated()).isEqualTo(p.original());
+        });
+    }
+
+    @Test
+    void legacySpringbootPrefixIsRewrittenToMain() {
+        PropertiesTranslateTools.PropertiesTranslateResult result = tools.camel_properties_translate(
+                "camel.springboot.name=Foo\ncamel.springboot.streamCachingEnabled=true",
+                "spring-boot", "spring-boot");
+
+        assertThat(result.summary().translated()).isEqualTo(2);
+        assertThat(result.properties().get(0).translated()).isEqualTo("camel.main.name=Foo");
+        assertThat(result.properties().get(0).note()).contains("4.13");
+        assertThat(result.properties().get(1).translated()).isEqualTo("camel.main.streamCachingEnabled=true");
+    }
+
+    @Test
+    void legacySpringbootPrefixIsRewrittenEvenWhenTargetIsQuarkus() {
+        PropertiesTranslateTools.PropertiesTranslateResult result = tools.camel_properties_translate(
+                "camel.springboot.name=Foo", "spring-boot", "quarkus");
+
+        assertThat(result.properties().get(0).translated()).isEqualTo("camel.main.name=Foo");
+        assertThat(result.properties().get(0).status()).isEqualTo("translated");
+    }
+
+    @Test
+    void managementEnabledHasNoSpringBootEquivalent() {
+        PropertiesTranslateTools.PropertiesTranslateResult result = tools.camel_properties_translate(
+                "camel.management.enabled=true", "main", "spring-boot");
+
+        assertThat(result.properties().get(0).status()).isEqualTo("unknown");
+        assertThat(result.properties().get(0).note())
+                .contains("Spring Boot Actuator");
+    }
+
+    @Test
+    void unknownKeysArePassedThroughWithNote() {
+        PropertiesTranslateTools.PropertiesTranslateResult result = tools.camel_properties_translate(
+                "spring.jpa.hibernate.ddl-auto=update\nlogging.level.root=INFO",
+                "spring-boot", "quarkus");
+
+        assertThat(result.summary().unknown()).isEqualTo(2);
+        assertThat(result.properties()).allSatisfy(p -> {
+            assertThat(p.status()).isEqualTo("unknown");
+            assertThat(p.translated()).isEqualTo(p.original());
+            assertThat(p.note()).contains("No translation rule");
+        });
+    }
+
+    @Test
+    void sameRuntimeReturnsKnownKeysUnchanged() {
+        PropertiesTranslateTools.PropertiesTranslateResult result = tools.camel_properties_translate(
+                "camel.server.port=8080\ncamel.main.streamCachingEnabled=true",
+                "main", "main");
+
+        assertThat(result.summary().unchanged()).isEqualTo(2);
+        assertThat(result.summary().translated()).isZero();
+        assertThat(result.properties().get(0).translated()).isEqualTo("camel.server.port=8080");
+        assertThat(result.properties().get(1).translated()).isEqualTo("camel.main.streamCachingEnabled=true");
+    }
+
+    @Test
+    void commentsAndBlankLinesArePreserved() {
+        String input = """
+                # this is a comment
+                ! shell comment
+
+                camel.server.port=8080
+                """;
+
+        PropertiesTranslateTools.PropertiesTranslateResult result = tools.camel_properties_translate(
+                input, "main", "quarkus");
+
+        assertThat(result.summary().comments()).isEqualTo(3);
+        assertThat(result.summary().translated()).isEqualTo(1);
+        assertThat(result.properties().get(0).status()).isEqualTo("comment");
+        assertThat(result.properties().get(1).status()).isEqualTo("comment");
+        assertThat(result.properties().get(2).status()).isEqualTo("comment");
+        assertThat(result.properties().get(3).status()).isEqualTo("translated");
+        assertThat(result.properties().get(3).translated()).isEqualTo("quarkus.http.port=8080");
+    }
+
+    @Test
+    void preservesPropertyValuesContainingEqualsSign() {
+        // Values can legally contain '=' (e.g. JDBC URLs); only the first '=' is the delimiter.
+        PropertiesTranslateTools.PropertiesTranslateResult result = tools.camel_properties_translate(
+                "camel.main.name=foo=bar=baz", "main", "quarkus");
+
+        assertThat(result.properties().get(0).status()).isEqualTo("unchanged");
+        assertThat(result.properties().get(0).translated()).isEqualTo("camel.main.name=foo=bar=baz");
+    }
+
+    @Test
+    void blankPropertiesArgumentThrows() {
+        assertThatThrownBy(() -> tools.camel_properties_translate("   ", "main", "quarkus"))
+                .isInstanceOf(ToolCallException.class)
+                .hasMessageContaining("properties");
+    }
+
+    @Test
+    void invalidFromRuntimeThrows() {
+        assertThatThrownBy(() -> tools.camel_properties_translate("camel.main.x=1", "bogus", "quarkus"))
+                .isInstanceOf(ToolCallException.class)
+                .hasMessageContaining("fromRuntime");
+    }
+
+    @Test
+    void invalidToRuntimeThrows() {
+        assertThatThrownBy(() -> tools.camel_properties_translate("camel.main.x=1", "main", "bogus"))
+                .isInstanceOf(ToolCallException.class)
+                .hasMessageContaining("toRuntime");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `camel_properties_translate` MCP tool that translates Camel
`application.properties` entries between the three Camel runtimes
(CAMEL-23181):

- **camel-main** (jbang / standalone)
- **camel-spring-boot**
- **camel-quarkus**

Most `camel.*` properties are runtime-agnostic (`camel.main.*`,
`camel.component.*`, `camel.dataformat.*`, `camel.health.*`,
`camel.routecontroller.*`, `camel.cluster.*`, `camel.kamelet.*`,
`camel.lra.*`, `camel.metrics.*`, `camel.opentelemetry.*`, etc.) and are
returned with `status=unchanged`. The keys that actually differ across
runtimes are the embedded HTTP server and management endpoint
configuration:

| canonical | camel-main | camel-spring-boot | camel-quarkus |
|---|---|---|---|
| HTTP port | `camel.server.port` | `server.port` | `quarkus.http.port` |
| HTTP host | `camel.server.host` | `server.address` | `quarkus.http.host` |
| HTTP path | `camel.server.path` | `server.servlet.context-path` | `quarkus.http.root-path` |
| management port | `camel.management.port` | `management.server.port` | `quarkus.management.port` |
| management path | `camel.management.path` | `management.endpoints.web.base-path` | `quarkus.management.root-path` |
| management enabled | `camel.management.enabled` | _(Actuator auto-enables)_ | `quarkus.management.enabled` |

The tool also rewrites the legacy `camel.springboot.*` prefix to
`camel.main.*` (deprecated in Camel 4.5 per
[`camel-4x-upgrade-guide-4_5.adoc`](https://github.com/apache/camel/blob/main/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_5.adoc),
removed in 4.13 per
[`camel-4x-upgrade-guide-4_13.adoc`](https://github.com/apache/camel/blob/main/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_13.adoc)).

Properties without a known translation rule (`spring.jpa.*`,
`logging.*`, `quarkus.datasource.*`, etc.) are **passed through with
`status=unknown` and a note, never guessed**. The issue specifically
called out that AI agents currently break configurations by guessing,
so the bar for any rule the tool ships is high.

Comments (`#`, `!`) and blank lines are preserved with `status=comment`
so round-tripping a properties file is non-destructive.

## Tool signature

```java
camel_properties_translate(
    properties: String,            // single line or multi-line
    fromRuntime: String,           // main | spring-boot | quarkus
    toRuntime: String              // main | spring-boot | quarkus
) -> {
    fromRuntime, toRuntime,
    summary { total, translated, unchanged, unknown, comments },
    properties: [
        { lineNumber, original, translated, status, note }
    ]
}
```

`status` is one of `translated` / `unchanged` / `unknown` / `comment`.

A few common runtime-name aliases are accepted (`camel-main`, `jbang`,
`standalone` -> main; `camel-spring-boot`, `springboot`, `spring` ->
spring-boot; `camel-quarkus` -> quarkus).

## Changes

- `PropertiesTranslateTools` — new `@ApplicationScoped` MCP tool. Holds
  a static `CANONICAL` table mapping each logical key
  (`http.port`, `http.host`, `http.path`, `management.port`,
  `management.path`, `management.enabled`) to its physical name in each
  runtime, plus a reverse lookup index, plus a set of recognised
  runtime-agnostic Camel prefixes. No catalog access is needed since
  these are framework-host properties not modeled in the camel-catalog.
- `PropertiesTranslateToolsTest` — 15 unit tests covering each
  runtime-pair direction (main↔SB, main↔Q, SB↔Q), agnostic-prefix
  passthrough, legacy springboot rewrite, no-equivalent handling
  (Actuator), unknown keys, comments and blank-line preservation, and
  argument validation (blank input, invalid runtime).

No public APIs were modified. No changes to other modules.

## Test plan

- [x] `mvn test` in `dsl/camel-jbang/camel-jbang-mcp` (221 tests
      passing, 15 new)
- [x] `mvn -DskipTests install` in the module passes (formatter clean)

## Issue context

cc @oscerd as operator and @lburgazzoli — the issue was filed by
@DeMa1980 (Luigi De Masi) with guidance from @davsclaus on which
properties are actually runtime-specific. The PR scope follows that
guidance precisely: it does not attempt to translate pure framework
properties (Spring's `logging.*`, Quarkus' `quarkus.datasource.*`,
etc.) which are out of Camel's concern.

_Claude Code on behalf of Andrea Cosentino_