### PR TITLE
Remove Woodstox 4 usage and replace by Woodstox version 7

### DIFF
--- a/core/camel-core-engine/pom.xml
+++ b/core/camel-core-engine/pom.xml
@@ -309,16 +309,10 @@
             <dependencies>
                 <!-- xmltokenizer using woodstox -->
                 <dependency>
-                    <groupId>org.codehaus.woodstox</groupId>
-                    <artifactId>woodstox-core-asl</artifactId>
-                    <version>${woodstox-version}</version>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
+                    <version>${woodstox-core-version}</version>
                     <scope>test</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>javax.xml.stream</groupId>
-                            <artifactId>stax-api</artifactId>
-                        </exclusion>
-                    </exclusions>
                 </dependency>
             </dependencies>
         </profile>

--- a/core/camel-core/pom.xml
+++ b/core/camel-core/pom.xml
@@ -165,16 +165,10 @@
         <!-- testing -->
         <!-- woodstox is needed by the StaxConverter test-->
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
-            <version>${woodstox-version}</version>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>${woodstox-core-version}</version>
             <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.xml.stream</groupId>
-                        <artifactId>stax-api</artifactId>
-                    </exclusion>
-                </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/core/camel-management-api/pom.xml
+++ b/core/camel-management-api/pom.xml
@@ -55,16 +55,10 @@
 
         <!-- xmltokenizer using woodstox -->
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
-            <version>${woodstox-version}</version>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>${woodstox-core-version}</version>
             <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.xml.stream</groupId>
-                        <artifactId>stax-api</artifactId>
-                    </exclusion>
-                </exclusions>
         </dependency>
     </dependencies>
 
@@ -248,16 +242,10 @@
             <dependencies>
                 <!-- xmltokenizer using woodstox -->
                 <dependency>
-                    <groupId>org.codehaus.woodstox</groupId>
-                    <artifactId>woodstox-core-asl</artifactId>
-                    <version>${woodstox-version}</version>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
+                    <version>${woodstox-core-version}</version>
                     <scope>test</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>javax.xml.stream</groupId>
-                            <artifactId>stax-api</artifactId>
-                        </exclusion>
-                    </exclusions>
                 </dependency>
             </dependencies>
         </profile>

--- a/core/camel-management/pom.xml
+++ b/core/camel-management/pom.xml
@@ -307,9 +307,9 @@
             <dependencies>
                 <!-- xmltokenizer using woodstox -->
                 <dependency>
-                    <groupId>org.codehaus.woodstox</groupId>
-                    <artifactId>woodstox-core-asl</artifactId>
-                    <version>${woodstox-version}</version>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
+                    <version>${woodstox-core-version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/core/camel-xml-jaxp-util/pom.xml
+++ b/core/camel-xml-jaxp-util/pom.xml
@@ -39,16 +39,10 @@
     <dependencies>
         <!-- testing -->
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
-            <version>${woodstox-version}</version>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>${woodstox-core-version}</version>
             <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.xml.stream</groupId>
-                        <artifactId>stax-api</artifactId>
-                    </exclusion>
-                </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/core/camel-xml-jaxp/pom.xml
+++ b/core/camel-xml-jaxp/pom.xml
@@ -59,16 +59,10 @@
 
         <!-- testing -->
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
-            <version>${woodstox-version}</version>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>${woodstox-core-version}</version>
             <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.xml.stream</groupId>
-                        <artifactId>stax-api</artifactId>
-                    </exclusion>
-                </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
* Woodstox 7 was already used in other places
* no more need to exclude the stax-api (which in fact is now stax2-api)

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

