### PR TITLE
Add SMB delete access denied tests for UNIX security style + improve error message + docs

### DIFF
--- a/components/camel-smb/src/main/docs/smb-component.adoc
+++ b/components/camel-smb/src/main/docs/smb-component.adoc
@@ -95,4 +95,33 @@ To maintain backward compatibility, a new Camel Header `CamelSmbUncPath` has bee
 ====
 
 
+== Permissions
+
+The Camel SMB component requires the authenticated user to have appropriate permissions on the SMB share.
+The exact permissions depend on the operations being performed:
+
+* **Reading files**: requires `Read Data` permission on the file.
+* **Writing files**: requires `Write Data` permission on the file and `Create Files` on the parent directory.
+* **Deleting files** (e.g., when using `delete=true` on a consumer): requires `Delete` permission on the file.
+
+=== STATUS_ACCESS_DENIED (0xc0000022) when deleting files
+
+If you receive a `STATUS_ACCESS_DENIED` error when the consumer attempts to delete a file after processing,
+the most common causes are:
+
+1. **The authenticated user lacks the DELETE permission** on the file or the parent directory.
+Ensure the SMB user has been granted the `Delete` and `Delete Child` permissions.
+
+2. **The server's volume uses UNIX security style instead of NTFS**.
+Some storage systems (such as NetApp ONTAP, TrueNAS, or other unified NAS platforms) support multiple
+volume security styles. When a volume uses UNIX security style, the server ignores NTFS ACLs and evaluates
+only UNIX file ownership and mode bits (`chmod`/`chown`). In this case, even if the Windows "Effective Access"
+UI shows full permissions, the delete operation can still be denied because the NTFS ACLs shown are not the
+actual access control mechanism.
+
+To resolve this, either:
+
+* Change the volume security style to NTFS so that NTFS ACLs are evaluated, or
+* Ensure the UNIX file ownership and mode bits grant the SMB user delete access on the files and their parent directory.
+
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
@@ -181,6 +181,17 @@ public class SmbOperations implements SmbFileOperations {
                     SMB2ShareAccess.ALL,
                     SMB2CreateDisposition.FILE_OPEN, null)) {
                 f.deleteOnClose();
+            } catch (SMBApiException e) {
+                if (e.getStatusCode() == 0xc0000022L) {
+                    throw new GenericFileOperationFailedException(
+                            "Access denied when trying to delete file: " + name
+                                                                  + ". Ensure the authenticated user has DELETE permission on the file"
+                                                                  + " and that the server's volume security style allows SMB-based access control."
+                                                                  + " If the volume uses UNIX security style, NTFS ACLs are ignored"
+                                                                  + " and only file ownership and UNIX mode bits (chmod/chown) are evaluated.",
+                            e);
+                }
+                throw e;
             }
         }
         return true;

--- a/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbDeleteAccessDeniedIT.java
+++ b/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbDeleteAccessDeniedIT.java
@@ -30,6 +30,7 @@ import com.hierynomus.smbj.session.Session;
 import com.hierynomus.smbj.share.DiskShare;
 import com.hierynomus.smbj.share.File;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.file.GenericFileOperationFailedException;
 import org.apache.camel.test.infra.smb.services.SmbService;
 import org.apache.camel.test.infra.smb.services.SmbServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
@@ -42,15 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests that STATUS_ACCESS_DENIED (0xc0000022) is thrown when attempting to delete a file on a share where the
- * authenticated user lacks delete permissions. This reproduces the scenario reported by customers using NetApp ONTAP
- * SMB shares where read/write is allowed but delete is denied.
- *
- * Two shares simulate the ONTAP behavior:
- * <ul>
- * <li>{@code data-no-delete} - sticky bit on directory, root-owned files (POSIX-level denial)</li>
- * <li>{@code data-unix-security} - {@code nt acl support = no} simulates ONTAP UNIX security style where NTFS ACLs are
- * ignored and only POSIX permissions are evaluated</li>
- * </ul>
+ * authenticated user lacks delete permissions.
  */
 public class SmbDeleteAccessDeniedIT extends CamelTestSupport {
 
@@ -70,12 +63,13 @@ public class SmbDeleteAccessDeniedIT extends CamelTestSupport {
         try {
             operations.connect(config, null);
 
-            SMBApiException thrown = assertThrows(SMBApiException.class,
+            GenericFileOperationFailedException thrown = assertThrows(GenericFileOperationFailedException.class,
                     () -> operations.deleteFile("1.txt"));
 
-            assertEquals(0xc0000022L, thrown.getStatusCode(),
-                    "Expected STATUS_ACCESS_DENIED (0xc0000022) but got: "
-                                                              + String.format("0x%08x", thrown.getStatusCode()));
+            assertTrue(thrown.getMessage().contains("Access denied"),
+                    "Expected access denied message but got: " + thrown.getMessage());
+            assertTrue(thrown.getCause() instanceof SMBApiException);
+            assertEquals(0xc0000022L, ((SMBApiException) thrown.getCause()).getStatusCode());
         } finally {
             operations.disconnect();
         }
@@ -89,12 +83,15 @@ public class SmbDeleteAccessDeniedIT extends CamelTestSupport {
         try {
             operations.connect(config, null);
 
-            SMBApiException thrown = assertThrows(SMBApiException.class,
+            GenericFileOperationFailedException thrown = assertThrows(GenericFileOperationFailedException.class,
                     () -> operations.deleteFile("1.txt"));
 
-            assertEquals(0xc0000022L, thrown.getStatusCode(),
-                    "Expected STATUS_ACCESS_DENIED (0xc0000022) but got: "
-                                                              + String.format("0x%08x", thrown.getStatusCode()));
+            assertTrue(thrown.getMessage().contains("Access denied"),
+                    "Expected access denied message but got: " + thrown.getMessage());
+            assertTrue(thrown.getMessage().contains("volume security style"),
+                    "Error message should mention volume security style");
+            assertTrue(thrown.getCause() instanceof SMBApiException);
+            assertEquals(0xc0000022L, ((SMBApiException) thrown.getCause()).getStatusCode());
         } finally {
             operations.disconnect();
         }

--- a/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbDeleteAccessDeniedIT.java
+++ b/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbDeleteAccessDeniedIT.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.smb;
+
+import java.net.URI;
+import java.util.EnumSet;
+
+import com.hierynomus.msdtyp.AccessMask;
+import com.hierynomus.mssmb2.SMB2CreateDisposition;
+import com.hierynomus.mssmb2.SMB2ShareAccess;
+import com.hierynomus.mssmb2.SMBApiException;
+import com.hierynomus.smbj.SMBClient;
+import com.hierynomus.smbj.auth.AuthenticationContext;
+import com.hierynomus.smbj.connection.Connection;
+import com.hierynomus.smbj.session.Session;
+import com.hierynomus.smbj.share.DiskShare;
+import com.hierynomus.smbj.share.File;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.infra.smb.services.SmbService;
+import org.apache.camel.test.infra.smb.services.SmbServiceFactory;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that STATUS_ACCESS_DENIED (0xc0000022) is thrown when attempting to delete a file on a share where the
+ * authenticated user lacks delete permissions. This reproduces the scenario reported by customers using NetApp ONTAP
+ * SMB shares where read/write is allowed but delete is denied.
+ *
+ * Two shares simulate the ONTAP behavior:
+ * <ul>
+ * <li>{@code data-no-delete} - sticky bit on directory, root-owned files (POSIX-level denial)</li>
+ * <li>{@code data-unix-security} - {@code nt acl support = no} simulates ONTAP UNIX security style where NTFS ACLs are
+ * ignored and only POSIX permissions are evaluated</li>
+ * </ul>
+ */
+public class SmbDeleteAccessDeniedIT extends CamelTestSupport {
+
+    private static final String NO_DELETE_SHARE = "data-no-delete";
+    private static final String UNIX_SECURITY_SHARE = "data-unix-security";
+    private static final String FIXED_DELETE_SHARE = "data-fixed-delete";
+    private static final String UNIX_OWNED_SHARE = "data-unix-owned";
+
+    @RegisterExtension
+    public static SmbService service = SmbServiceFactory.createSingletonService();
+
+    @Test
+    public void testDeleteAccessDeniedViaSmbOperations() throws Exception {
+        SmbConfiguration config = createConfig(NO_DELETE_SHARE);
+        SmbOperations operations = new SmbOperations(config);
+
+        try {
+            operations.connect(config, null);
+
+            SMBApiException thrown = assertThrows(SMBApiException.class,
+                    () -> operations.deleteFile("1.txt"));
+
+            assertEquals(0xc0000022L, thrown.getStatusCode(),
+                    "Expected STATUS_ACCESS_DENIED (0xc0000022) but got: "
+                                                              + String.format("0x%08x", thrown.getStatusCode()));
+        } finally {
+            operations.disconnect();
+        }
+    }
+
+    @Test
+    public void testDeleteAccessDeniedOnUnixSecurityStyleViaSmbOperations() throws Exception {
+        SmbConfiguration config = createConfig(UNIX_SECURITY_SHARE);
+        SmbOperations operations = new SmbOperations(config);
+
+        try {
+            operations.connect(config, null);
+
+            SMBApiException thrown = assertThrows(SMBApiException.class,
+                    () -> operations.deleteFile("1.txt"));
+
+            assertEquals(0xc0000022L, thrown.getStatusCode(),
+                    "Expected STATUS_ACCESS_DENIED (0xc0000022) but got: "
+                                                              + String.format("0x%08x", thrown.getStatusCode()));
+        } finally {
+            operations.disconnect();
+        }
+    }
+
+    @Test
+    public void testReadStillWorksOnNoDeleteShare() throws Exception {
+        int port = Integer.parseInt(service.address().split(":")[1]);
+
+        try (SMBClient smbClient = new SMBClient();
+             Connection connection = smbClient.connect("localhost", port)) {
+
+            AuthenticationContext ac
+                    = new AuthenticationContext(service.userName(), service.password().toCharArray(), null);
+            Session session = connection.authenticate(ac);
+
+            try (DiskShare share = (DiskShare) session.connectShare(NO_DELETE_SHARE)) {
+                try (File f = share.openFile("1.txt", EnumSet.of(AccessMask.GENERIC_READ), null,
+                        SMB2ShareAccess.ALL,
+                        SMB2CreateDisposition.FILE_OPEN, null)) {
+                    byte[] content = f.getInputStream().readAllBytes();
+                    assertTrue(content.length > 0, "Should be able to read file content");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testDeleteSucceedsOnUnixStyleWhenUserOwnsFiles() throws Exception {
+        SmbConfiguration config = createConfig(UNIX_OWNED_SHARE);
+        SmbOperations operations = new SmbOperations(config);
+
+        try {
+            operations.connect(config, null);
+
+            assertTrue(operations.existsFile("1.txt"), "File 1.txt should exist before delete");
+            assertTrue(operations.deleteFile("1.txt"),
+                    "Delete should succeed on UNIX security style when user owns the file, regardless of ACLs");
+        } finally {
+            operations.disconnect();
+        }
+    }
+
+    @Test
+    public void testDeleteSucceedsWhenUserOwnsFiles() throws Exception {
+        SmbConfiguration config = createConfig(FIXED_DELETE_SHARE);
+        SmbOperations operations = new SmbOperations(config);
+
+        try {
+            operations.connect(config, null);
+
+            assertTrue(operations.existsFile("1.txt"), "File 1.txt should exist before delete");
+            assertTrue(operations.deleteFile("1.txt"), "Delete should succeed when user owns the file");
+        } finally {
+            operations.disconnect();
+        }
+    }
+
+    private SmbConfiguration createConfig(String shareName) {
+        String host = service.hostname();
+        int port = service.port();
+        URI uri = URI.create(String.format("smb://%s:%d/%s", host, port, shareName));
+        SmbConfiguration config = new SmbConfiguration(uri);
+        config.setUsername(service.userName());
+        config.setPassword(service.password());
+        return config;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+            }
+        };
+    }
+}

--- a/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/Dockerfile
+++ b/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/Dockerfile
@@ -19,7 +19,7 @@ FROM mirror.gcr.io/fedora:43 as samba
 LABEL maintainer="orpiske@apache.org"
 ENV SAMBA_ROOT /opt/camel/samba
 EXPOSE 139 445
-RUN dnf install -y samba && mkdir -p /data/rw /data/ro
+RUN dnf install -y samba && mkdir -p /data/rw /data/ro /data/no-delete /data/unix-security /data/fixed-delete /data/unix-owned
 ADD smb.conf /etc/samba/smb.conf
 ADD start.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/start.sh

--- a/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/smb.conf
+++ b/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/smb.conf
@@ -59,3 +59,29 @@
     path = /data/ro
     read only = yes
     browsable = yes
+
+[data-no-delete]
+    comment = Read-write share where delete is denied for non-owners (sticky bit)
+    path = /data/no-delete
+    read only = no
+    browsable = yes
+
+[data-unix-security]
+    comment = Simulates ONTAP UNIX security style - POSIX perms only, NTFS ACLs ignored
+    path = /data/unix-security
+    read only = no
+    browsable = yes
+    nt acl support = no
+
+[data-fixed-delete]
+    comment = Same as no-delete but files owned by the SMB user (the fix)
+    path = /data/fixed-delete
+    read only = no
+    browsable = yes
+
+[data-unix-owned]
+    comment = UNIX security style (no NTFS ACLs) but files owned by SMB user
+    path = /data/unix-owned
+    read only = no
+    browsable = yes
+    nt acl support = no

--- a/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/smb.conf
+++ b/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/smb.conf
@@ -67,7 +67,7 @@
     browsable = yes
 
 [data-unix-security]
-    comment = Simulates ONTAP UNIX security style - POSIX perms only, NTFS ACLs ignored
+    comment = Simulates UNIX security style - POSIX perms only, NTFS ACLs ignored
     path = /data/unix-security
     read only = no
     browsable = yes

--- a/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/start.sh
+++ b/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/start.sh
@@ -26,10 +26,34 @@ for file in $(seq 1 100) ; do
 	echo ${RANDOM} > /data/ro/${file}.txt ;
 done
 
+echo "Creating no-delete files (root-owned, sticky bit on directory)"
+for file in $(seq 1 10) ; do
+	echo ${RANDOM} > /data/no-delete/${file}.txt ;
+done
+chmod 1777 /data/no-delete
+
+echo "Creating unix-security files (simulates ONTAP UNIX security style)"
+for file in $(seq 1 10) ; do
+	echo ${RANDOM} > /data/unix-security/${file}.txt ;
+done
+chmod 1777 /data/unix-security
+
+echo "Creating fixed-delete files (same as no-delete but with correct ownership)"
+for file in $(seq 1 10) ; do
+	echo ${RANDOM} > /data/fixed-delete/${file}.txt ;
+done
+
+echo "Creating unix-owned files (UNIX security style + correct ownership)"
+for file in $(seq 1 10) ; do
+	echo ${RANDOM} > /data/unix-owned/${file}.txt ;
+done
+
 useradd camel
 printf "camelTester123\ncamelTester123\n" | smbpasswd -s -a camel
 
 chown -Rv camel /data/rw
+chown -Rv camel /data/fixed-delete
+chown -Rv camel /data/unix-owned
 
 nmbd -D
 smbd -D -s /etc/samba/smb.conf

--- a/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/start.sh
+++ b/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/start.sh
@@ -32,7 +32,7 @@ for file in $(seq 1 10) ; do
 done
 chmod 1777 /data/no-delete
 
-echo "Creating unix-security files (simulates ONTAP UNIX security style)"
+echo "Creating unix-security files (simulates UNIX security style)"
 for file in $(seq 1 10) ; do
 	echo ${RANDOM} > /data/unix-security/${file}.txt ;
 done


### PR DESCRIPTION
Add test infrastructure and integration tests that reproduce STATUS_ACCESS_DENIED (0xc0000022) when deleting files on SMB shares with UNIX security style, simulating the UNIX FS scenario where NTFS ACLs are ignored and only POSIX permissions are evaluated.

New Samba test shares:
- data-no-delete: sticky bit, root-owned files (POSIX denial)
- data-unix-security: nt acl support disabled
- data-unix-owned: UNIX style but user-owned files (proves fix)
- data-fixed-delete: NTFS style with user-owned files (control)