### PR TITLE
chore: Remove unused and outdated test dependency com.jcraft:jzlib from camel-netty-http

### DIFF
--- a/components/camel-netty-http/pom.xml
+++ b/components/camel-netty-http/pom.xml
@@ -90,12 +90,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jcraft</groupId>
-            <artifactId>jzlib</artifactId>
-            <version>${jzlib-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit6</artifactId>
             <scope>test</scope>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -331,7 +331,6 @@
         <juniversalchardet-version>1.0.3</juniversalchardet-version>
         <jxmpp-version>1.1.0</jxmpp-version>
         <jython-version>2.7.4</jython-version>
-        <jzlib-version>1.1.3</jzlib-version>
         <kafka-version>4.2.0</kafka-version>
         <keycloak-client-version>26.0.8</keycloak-client-version>
         <kubernetes-client-version>7.6.1</kubernetes-client-version>


### PR DESCRIPTION
The com.jcraft:jzlib dependency was originally added in 2014 (CAMEL-7848) when HTTP compression support was added, as it was an optional dependency for Netty's HttpContentDecompressor.

In 2021, the test was refactored and switched to using standard Java GZIPInputStream instead of Netty's HttpContentDecompressor, making jzlib unnecessary.

Modern Netty (4.2.x) uses JDK's built-in compression support and doesn't require jzlib. The dependency is not used anywhere in the code and all unit tests pass without it.

Made with help from AI tools.