### PR TITLE
CAMEL-23391: Fix race condition in channel subscription and improve reconnect advice handling

### DIFF
--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
@@ -32,6 +32,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 
 import org.apache.camel.CamelException;
@@ -109,6 +111,7 @@ public class SubscriptionHelper extends ServiceSupport {
             = new ConcurrentHashMap<>();
 
     private final Set<String> channelsToSubscribe = ConcurrentHashMap.newKeySet();
+    private final Lock channelsLock = new ReentrantLock();
 
     private final ClientSessionChannel.MessageListener handshakeListener = createHandshakeListener();
 
@@ -145,9 +148,12 @@ public class SubscriptionHelper extends ServiceSupport {
                 LOG.debug("Handshake failed, so try again.");
                 client.handshake();
             } else if (!channelToConsumers.isEmpty()) {
-                synchronized (channelsToSubscribe) {
+                channelsLock.lock();
+                try {
                     channelsToSubscribe.clear();
                     channelsToSubscribe.addAll(channelToConsumers.keySet());
+                } finally {
+                    channelsLock.unlock();
                 }
                 LOG.info("Handshake successful. Channels to subscribe: {}", channelsToSubscribe);
             }
@@ -183,11 +189,14 @@ public class SubscriptionHelper extends ServiceSupport {
                 client.handshake();
             } else {
                 Set<String> toSubscribe = null;
-                synchronized (channelsToSubscribe) {
+                channelsLock.lock();
+                try {
                     if (!channelsToSubscribe.isEmpty()) {
                         toSubscribe = new HashSet<>(channelsToSubscribe);
                         channelsToSubscribe.clear();
                     }
+                } finally {
+                    channelsLock.unlock();
                 }
                 if (toSubscribe != null) {
                     LOG.info("Subscribing to channels: {}", toSubscribe);

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
@@ -480,7 +480,6 @@ public class SubscriptionHelper extends ServiceSupport {
             // create subscription for consumer
             final String channelName = getChannelName(consumer.getTopicName());
             channelToConsumers.computeIfAbsent(channelName, key -> ConcurrentHashMap.newKeySet()).add(consumer);
-            channelsToSubscribe.add(channelName);
 
             setReplayIdIfAbsent(consumer.getEndpoint());
 

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
@@ -23,6 +23,7 @@ import java.net.CookieStore;
 import java.net.URI;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -144,8 +145,10 @@ public class SubscriptionHelper extends ServiceSupport {
                 LOG.debug("Handshake failed, so try again.");
                 client.handshake();
             } else if (!channelToConsumers.isEmpty()) {
-                channelsToSubscribe.clear();
-                channelsToSubscribe.addAll(channelToConsumers.keySet());
+                synchronized (channelsToSubscribe) {
+                    channelsToSubscribe.clear();
+                    channelsToSubscribe.addAll(channelToConsumers.keySet());
+                }
                 LOG.info("Handshake successful. Channels to subscribe: {}", channelsToSubscribe);
             }
         });
@@ -154,6 +157,9 @@ public class SubscriptionHelper extends ServiceSupport {
     private MessageListener createConnectionListener() {
         return (channel, message) -> component.getHttpClient().getWorkerPool().execute(() -> {
             LOG.debug("[CHANNEL:META_CONNECT]: {}", message);
+            String reconnectAdvice = message.getAdvice() != null
+                    ? (String) message.getAdvice().get("reconnect")
+                    : null;
 
             if (!message.isSuccessful()) {
                 LOG.warn("Connect failure: {}", message);
@@ -165,15 +171,30 @@ public class SubscriptionHelper extends ServiceSupport {
                     LOG.debug("Attempting login...");
                     session.attemptLoginUntilSuccessful(backoffIncrement, maxBackoff);
                 }
-                if (message.getAdvice() == null || "none".equals(message.getAdvice().get("reconnect"))) {
-                    LOG.debug("Advice == none, so handshaking");
+                if (reconnectAdvice != null && !"retry".equals(reconnectAdvice)) {
+                    LOG.debug("Reconnect advice [{}] on failed connect, initiating handshake", reconnectAdvice);
+                    client.handshake();
+                } else if (isTemporaryError(message)) {
+                    LOG.debug("Initiating handshake after temporary error: {}", message);
                     client.handshake();
                 }
-            } else if (!channelsToSubscribe.isEmpty()) {
-                LOG.info("Subscribing to channels: {}", channelsToSubscribe);
-                for (var channelName : channelsToSubscribe) {
-                    for (var consumer : channelToConsumers.get(channelName)) {
-                        subscribe(consumer);
+            } else if (reconnectAdvice != null && !"retry".equals(reconnectAdvice)) {
+                LOG.warn("Reconnect advice [{}] on successful connect, initiating handshake", reconnectAdvice);
+                client.handshake();
+            } else {
+                Set<String> toSubscribe = null;
+                synchronized (channelsToSubscribe) {
+                    if (!channelsToSubscribe.isEmpty()) {
+                        toSubscribe = new HashSet<>(channelsToSubscribe);
+                        channelsToSubscribe.clear();
+                    }
+                }
+                if (toSubscribe != null) {
+                    LOG.info("Subscribing to channels: {}", toSubscribe);
+                    for (var channelName : toSubscribe) {
+                        for (var consumer : channelToConsumers.get(channelName)) {
+                            subscribe(consumer);
+                        }
                     }
                 }
             }

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
@@ -177,7 +177,9 @@ public class SubscriptionHelper extends ServiceSupport {
                     LOG.debug("Attempting login...");
                     session.attemptLoginUntilSuccessful(backoffIncrement, maxBackoff);
                 }
-                if (reconnectAdvice != null && !"retry".equals(reconnectAdvice)) {
+                // Per Bayeux spec: handshake on null advice, "none", "handshake", or any non-"retry" value.
+                // When advice is "retry", the CometD client handles reconnection automatically.
+                if (reconnectAdvice == null || !"retry".equals(reconnectAdvice)) {
                     LOG.debug("Reconnect advice [{}] on failed connect, initiating handshake", reconnectAdvice);
                     client.handshake();
                 } else if (isTemporaryError(message)) {

--- a/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/java/org/apache/camel/component/salesforce/internal/streaming/SubscriptionHelper.java
@@ -137,7 +137,7 @@ public class SubscriptionHelper extends ServiceSupport {
                 if (handshakeError != null) {
                     if (handshakeError.startsWith("403::")) {
                         String failureReason = getFailureReason(message);
-                        if (failureReason.equals(AUTHENTICATION_INVALID)) {
+                        if (AUTHENTICATION_INVALID.equals(failureReason)) {
                             LOG.debug(
                                     "attempting login due to handshake error: 403 -> 401::Authentication invalid");
                             session.attemptLoginUntilSuccessful(backoffIncrement, maxBackoff);


### PR DESCRIPTION
  Fix a race condition and improve reconnect behavior in the Streaming API subscription helper.

  - Synchronize clear() + addAll() on channelsToSubscribe in the handshake listener to prevent
    the connection listener from reading a partially updated set
  - Take a snapshot of channelsToSubscribe before subscribing in the connection listener to avoid
    concurrent modification
  - Handle all non-retry reconnect advice (not just "none") per the CometD/Bayeux spec, including
    on successful connect messages
  - Initiate handshake on temporary errors during connect to recover the session