### PR TITLE
CAMEL-23220: Replace Thread.sleep() with Awaitility in camel-atom tests

### DIFF
--- a/components/camel-atom/src/test/java/org/apache/camel/component/atom/AtomGoodBlogDefaultIdempotencyTest.java
+++ b/components/camel-atom/src/test/java/org/apache/camel/component/atom/AtomGoodBlogDefaultIdempotencyTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.atom;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.*;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -24,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -84,13 +88,10 @@ public class AtomGoodBlogDefaultIdempotencyTest {
 
         // Get the mock endpoint
         MockEndpoint mock = context.getEndpoint("mock:result", MockEndpoint.class);
-        Thread.sleep(5000);
 
-        // There should be at least two good blog entries from the feed
-        mock.expectedMessageCount(7);
-
-        // Assert
-        mock.assertIsSatisfied();
+        // Wait for the polling consumer to read all 7 entries from the feed
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals(7, mock.getReceivedCounter()));
 
         // stop Camel after use
         context.stop();

--- a/components/camel-atom/src/test/java/org/apache/camel/component/atom/AtomGoodBlogsRepositoryItempotencyCustomRepositoryTest.java
+++ b/components/camel-atom/src/test/java/org/apache/camel/component/atom/AtomGoodBlogsRepositoryItempotencyCustomRepositoryTest.java
@@ -101,11 +101,8 @@ public class AtomGoodBlogsRepositoryItempotencyCustomRepositoryTest {
         // There should be at only three good blog entries, not already in customRepository
         mock.expectedMessageCount(3);
 
-        // Make sure that the component has time for several reads
-        Thread.sleep(3000);
-
         // Assert
-        mock.assertIsSatisfied(3000);
+        mock.assertIsSatisfied(10000);
 
         // stop Camel after use
         context.stop();

--- a/components/camel-atom/src/test/java/org/apache/camel/component/atom/AtomGoodBlogsRepositoryItempotencyTest.java
+++ b/components/camel-atom/src/test/java/org/apache/camel/component/atom/AtomGoodBlogsRepositoryItempotencyTest.java
@@ -94,11 +94,8 @@ public class AtomGoodBlogsRepositoryItempotencyTest {
         // There should be at least two good blog entries from the feed
         mock.expectedMessageCount(7);
 
-        // Make sure that the component has time for several reads
-        Thread.sleep(3000);
-
         // Assert
-        mock.assertIsSatisfied(3000);
+        mock.assertIsSatisfied(10000);
 
         // stop Camel after use
         context.stop();


### PR DESCRIPTION
[CAMEL-23220](https://issues.apache.org/jira/browse/CAMEL-23220)

Replace `Thread.sleep()` calls with proper asynchronous assertions in three camel-atom idempotency test files, per project coding standards.

## Changes

- **AtomGoodBlogDefaultIdempotencyTest**: Replaced `Thread.sleep(5000)` + `expectedMessageCount` + `assertIsSatisfied` with Awaitility `await().atMost(10, SECONDS).untilAsserted(...)`
- **AtomGoodBlogsRepositoryItempotencyTest**: Removed redundant `Thread.sleep(3000)` before `assertIsSatisfied`; increased `assertIsSatisfied` timeout to 10s (it polls internally)
- **AtomGoodBlogsRepositoryItempotencyCustomRepositoryTest**: Same fix as above

## Test plan

- [x] `mvn test -B -pl components/camel-atom` — all 33 tests pass
- [x] `mvn formatter:format impsort:sort -B -pl components/camel-atom` — no formatting changes needed