### PR TITLE
CAMEL-23401: Upgrade JSch to 2.28.2 (RSA certificate authentication fix)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -311,7 +311,7 @@
         <johnzon-version>2.0.2</johnzon-version>
         <jslt-version>0.1.14</jslt-version>
         <jsmpp-version>3.0.2</jsmpp-version>
-        <jsch-version>2.28.1</jsch-version>
+        <jsch-version>2.28.2</jsch-version>
         <javax-json-api-version>1.1.4</javax-json-api-version>
         <jsonschema-generator-version>4.38.0</jsonschema-generator-version>
         <jsonassert-version>1.5.3</jsonassert-version>


### PR DESCRIPTION
## Summary

- Upgrade JSch dependency from 2.28.1 to 2.28.2
- JSch 2.28.2 ([release notes](https://github.com/mwiede/jsch/releases/tag/jsch-2.28.2)) fixes [mwiede/jsch#1045](https://github.com/mwiede/jsch/issues/1045): RSA certificate authentication was ignoring the negotiated signature algorithm, causing authentication failures in certain SSH server configurations
- This bug affects Camel's SFTP and SCP components when using OpenSSH certificate-based authentication with RSA keys (added in CAMEL-23277)

## Test plan

- [x] `camel-jsch` module: 7 tests pass (SCP certificate auth tests)
- [x] `camel-ftp` module: 372 tests pass (FTP/FTPS/SFTP tests including key exchange and public key algorithm tests)

_Claude Code on behalf of Luigi De Masi_