### PR TITLE
CAMEL-23388: camel-jbang-mcp - Add tool for generating visual route diagram

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteDiagramAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteDiagramAction.java
@@ -84,6 +84,35 @@ public class CamelRouteDiagramAction extends ActionBaseCommand {
         super(main);
     }
 
+    /**
+     * Renders the routes contained in the given source file as a PNG diagram saved to {@code outputFile}. Convenience
+     * entry point for programmatic invocation (e.g. from MCP tools) that always targets a non-running source file and
+     * skips the running-PID lookup.
+     *
+     * @param  sourceFile         path to the route source file (YAML, XML, Java, ...)
+     * @param  outputFile         path to the PNG file to write
+     * @param  theme              color theme spec (e.g. "dark", "light", "transparent" or custom)
+     * @param  filter             optional route filter (route id or filename pattern)
+     * @param  width              image width in pixels (0 = auto)
+     * @param  ignoreLoadingError whether to ignore route loading and compilation errors
+     * @return                    exit code; 0 on success, non-zero otherwise
+     * @throws Exception          if the source cannot be read or the diagram cannot be rendered
+     */
+    public Integer renderSourceToFile(
+            String sourceFile, String outputFile, String theme, String filter,
+            int width, boolean ignoreLoadingError)
+            throws Exception {
+        this.name = sourceFile;
+        this.output = outputFile;
+        if (theme != null && !theme.isBlank()) {
+            this.theme = theme;
+        }
+        this.filter = filter;
+        this.width = width;
+        this.ignoreLoadingError = ignoreLoadingError;
+        return doCall();
+    }
+
     @Override
     public Integer doCall() throws Exception {
         System.setProperty("java.awt.headless", "true");

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/RouteDiagramTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/RouteDiagramTools.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.mcp;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolCallException;
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.action.CamelRouteDiagramAction;
+import org.apache.camel.dsl.jbang.core.common.Printer;
+
+/**
+ * MCP Tool for generating a visual PNG diagram of Camel routes from a source file (non-running integration). Wraps the
+ * {@code camel route-diagram} jbang command.
+ */
+@ApplicationScoped
+public class RouteDiagramTools {
+
+    @Tool(annotations = @Tool.Annotations(readOnlyHint = false, destructiveHint = false, openWorldHint = false),
+          description = "Generate a visual PNG diagram of Camel routes from a route source file (YAML, XML, Java, ...). "
+                        + "The source file is parsed without running it. The resulting PNG is written to disk and the "
+                        + "absolute path is returned so it can be displayed or shared. Useful to visualize a route "
+                        + "structure for review, documentation, or troubleshooting.")
+    public RouteDiagramResult camel_render_route_diagram(
+            @ToolArg(description = "Absolute or relative path to the Camel route source file (YAML, XML, Java, ...)") String sourceFile,
+            @ToolArg(description = "Optional output PNG file path. If not specified, a temporary file is created.") String outputFile,
+            @ToolArg(description = "Color theme: 'dark' (default), 'light', 'transparent', or a custom spec like "
+                                   + "'bg=#1e1e1e:from=#2e7d32:to=#1565c0'") String theme,
+            @ToolArg(description = "Optional filter to limit the diagram to routes whose route id or source filename "
+                                   + "matches the given pattern (supports wildcards)") String filter,
+            @ToolArg(description = "Image width in pixels; 0 (or unset) = auto") Integer width,
+            @ToolArg(description = "Whether to ignore route loading and compilation errors (use with care)") Boolean ignoreLoadingError) {
+
+        if (sourceFile == null || sourceFile.isBlank()) {
+            throw new ToolCallException("'sourceFile' parameter is required", null);
+        }
+
+        File source = new File(sourceFile);
+        if (!source.isFile()) {
+            throw new ToolCallException("Source file does not exist: " + sourceFile, null);
+        }
+
+        String resolvedOutput;
+        try {
+            if (outputFile == null || outputFile.isBlank()) {
+                Path tmp = Files.createTempFile("camel-route-diagram-", ".png");
+                resolvedOutput = tmp.toAbsolutePath().toString();
+            } else {
+                resolvedOutput = new File(outputFile).getAbsolutePath();
+            }
+        } catch (Exception e) {
+            throw new ToolCallException(
+                    "Failed to resolve output file (" + e.getClass().getName() + "): " + e.getMessage(), null);
+        }
+
+        // headless rendering — required when running inside the MCP server
+        System.setProperty("java.awt.headless", "true");
+
+        CamelJBangMain main = new CamelJBangMain()
+                .withPrinter(new Printer.QuietPrinter(new Printer.SystemOutPrinter()));
+        CamelRouteDiagramAction action = new CamelRouteDiagramAction(main);
+
+        try {
+            int exit = action.renderSourceToFile(
+                    sourceFile, resolvedOutput, theme, filter,
+                    width != null ? width : 0,
+                    ignoreLoadingError != null && ignoreLoadingError);
+
+            File out = new File(resolvedOutput);
+            boolean success = exit == 0 && out.isFile() && out.length() > 0;
+            long size = out.exists() ? out.length() : 0L;
+
+            String message = success
+                    ? "Diagram saved to: " + resolvedOutput
+                    : "Failed to render diagram (exit code " + exit + ")";
+
+            return new RouteDiagramResult(success, resolvedOutput, size, message);
+        } catch (Throwable e) {
+            throw new ToolCallException(
+                    "Failed to render route diagram (" + e.getClass().getName() + "): " + e.getMessage(), null);
+        }
+    }
+
+    public record RouteDiagramResult(boolean success, String outputFile, long sizeBytes, String message) {
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/RouteDiagramToolsTest.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/RouteDiagramToolsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.mcp;
+
+import io.quarkiverse.mcp.server.ToolCallException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RouteDiagramToolsTest {
+
+    @Test
+    void missingSourceFileThrows() {
+        RouteDiagramTools tools = new RouteDiagramTools();
+
+        assertThatThrownBy(() -> tools.camel_render_route_diagram(null, null, null, null, null, null))
+                .isInstanceOf(ToolCallException.class)
+                .hasMessageContaining("sourceFile");
+    }
+
+    @Test
+    void blankSourceFileThrows() {
+        RouteDiagramTools tools = new RouteDiagramTools();
+
+        assertThatThrownBy(() -> tools.camel_render_route_diagram("   ", null, null, null, null, null))
+                .isInstanceOf(ToolCallException.class)
+                .hasMessageContaining("sourceFile");
+    }
+
+    @Test
+    void nonExistingSourceFileThrows() {
+        RouteDiagramTools tools = new RouteDiagramTools();
+
+        assertThatThrownBy(() -> tools.camel_render_route_diagram(
+                "/no/such/file.yaml", null, null, null, null, null))
+                .isInstanceOf(ToolCallException.class)
+                .hasMessageContaining("does not exist");
+    }
+}


### PR DESCRIPTION
# Description

This PR adds a new MCP tool `camel_render_route_diagram` to `camel-jbang-mcp` as described in [CAMEL-23388](https://issues.apache.org/jira/browse/CAMEL-23388).

The tool wraps the existing `camel route-diagram` jbang command so an MCP client can generate a visual PNG diagram from a route source file (YAML, XML, Java, ...) without requiring a running Camel integration. This is now possible because [CAMEL-23386](https://issues.apache.org/jira/browse/CAMEL-23386) (`route-structure` source-file support) is already merged in 4.21.0 and provides the underlying machinery.

# Changes

- **`CamelRouteDiagramAction.renderSourceToFile(...)`** — new public convenience entry point on the existing action that takes the source file, target PNG path, theme, filter, width, and `ignoreLoadingError`, then delegates to `doCall()`. This avoids exposing the package-private picocli fields and gives non-CLI callers (MCP, tests, embedding) a stable API.
- **`RouteDiagramTools`** — new `@ApplicationScoped` MCP tool class with one `@Tool` method `camel_render_route_diagram`. It validates the source file, resolves a default temp PNG output path when none is given, sets `java.awt.headless=true`, suppresses CLI chatter via `Printer.QuietPrinter`, invokes the action, and returns a result record with `success`, `outputFile`, `sizeBytes`, and a human-readable `message`.
- **`RouteDiagramToolsTest`** — unit tests covering the validation paths (missing / blank / non-existent source file). The full rendering flow is already exercised by `CamelRouteDiagramActionTest` in `camel-jbang-core`.

# Tool signature

```
camel_render_route_diagram(
  sourceFile: String,            // required, path to the route source file
  outputFile: String?,           // optional; defaults to a temp PNG file
  theme: String?,                // optional; default \"dark\"
  filter: String?,               // optional route id / filename pattern
  width: Integer?,               // optional; 0 = auto
  ignoreLoadingError: Boolean?   // optional; default false
) -> { success, outputFile, sizeBytes, message }
```

# Testing

- `RouteDiagramToolsTest` — 3 tests, all passing.
- `CamelRouteDiagramActionTest` — 31 existing tests still pass after adding the new public method.
- Full root build (`mvn clean install -DskipTests -Dquickly`) succeeds.

# Notes

- `readOnlyHint = false` on the tool annotation because it produces a PNG file artifact on disk.
- Output suppression: the tool wraps the action with `Printer.QuietPrinter` so the CLI's stdout chatter (\"Diagram saved to: ...\", etc.) does not pollute MCP transport. The structured result carries the same information.
- The implementation honours the same theme / filter / width semantics as the CLI and falls back to a temp file when no `outputFile` is supplied, so MCP clients can show or share the path without managing destinations themselves.

---

_Submitted by Claude Opus 4.7 on behalf of [Andrea Cosentino](https://github.com/oscerd)._