### PR TITLE
CAMEL-23279: add missing sample-placeholder route to Spring XML test …

### DIFF
--- a/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/processor/samplingThrottler.xml
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/processor/samplingThrottler.xml
@@ -41,6 +41,11 @@
             <sample messageFrequency="5"/>
             <to uri="mock:result"/>
         </route>
+        <route>
+            <from uri="direct:sample-placeholder"/>
+            <sample samplePeriod="{{sample.period}}"/>
+            <to uri="mock:result"/>
+        </route>
         <!-- END SNIPPET: e1 -->
 
     </camelContext>


### PR DESCRIPTION
…config

Address CI failures https://ci-builds.apache.org/job/Camel/job/Camel%20Core%20(Build%20and%20test)/job/camel-4.18.x/