### PR TITLE
ci: fix JBang IT tests on main

### DIFF
--- a/Jenkinsfile.jbangtest
+++ b/Jenkinsfile.jbangtest
@@ -62,7 +62,7 @@ pipeline {
                 }
             }
             steps {
-                sh "./mvnw $MAVEN_PARAMS -Pdeploy,apache-snapshots -Dquickly clean"
+                sh "./mvnw $MAVEN_PARAMS -Pdeploy,apache-snapshots -Dquickly clean install"
                 sh "./mvnw $MAVEN_PARAMS -f test-infra/camel-test-infra-cli/pom.xml -Pjbang-it-test"
                 sh "./mvnw $MAVEN_PARAMS -f dsl/camel-jbang/camel-jbang-it/pom.xml -Pjbang-it-test"
             }

--- a/test-infra/camel-test-infra-cli/src/main/resources/org/apache/camel/test/infra/cli/services/Dockerfile
+++ b/test-infra/camel-test-infra-cli/src/main/resources/org/apache/camel/test/infra/cli/services/Dockerfile
@@ -84,7 +84,7 @@ EXPOSE 22
 USER jbang
 
 RUN echo "Updating jbang" \
-    && jbang version --update
+    && jbang version --update || true
 
 RUN echo "Clearing JBang cache" \
     && jbang cache clear


### PR DESCRIPTION
## Summary

- Add missing `install` goal to the Maven build step in `Jenkinsfile.jbangtest` — without it, SNAPSHOT artifacts are never placed in the local Maven repository, causing the subsequent IT test steps to fail with unresolved dependencies on ephemeral EC2 agents
- Make `jbang version --update` non-fatal in the Dockerfile (`|| true`) — when jbang is already at the latest version, the update command returns exit code 1 which aborts the Docker image build

## Root Cause

The pipeline runs `./mvnw ... -Dquickly clean` but never `install`. On agents with a warm `.m2` cache (e.g. from a previous Snapshot Deploy), the IT tests can resolve `4.21.0-SNAPSHOT` artifacts. On fresh ephemeral agents, they fail immediately with:
```
Could not find artifact org.apache.camel:camel-test-infra-common:jar:4.21.0-SNAPSHOT
```

Build history confirms: 6 out of 7 recent builds failed in ~3 minutes (dependency resolution). The single success (build 445) landed on an agent with cached SNAPSHOTs.

The same `install` fix was already applied to `camel-4.18.x` in commit dff1285a9ca.

## Test plan

- [ ] Verify the next JBang IT Tests build on `main` passes the dependency resolution stage
- [ ] Verify Docker image builds succeed (no `jbang version --update` exit code 1)