### PR TITLE
ci: fix JBang IT tests on 4.18.x

### DIFF
--- a/test-infra/camel-test-infra-cli/src/test/resources/org/apache/camel/test/infra/cli/services/Dockerfile
+++ b/test-infra/camel-test-infra-cli/src/test/resources/org/apache/camel/test/infra/cli/services/Dockerfile
@@ -84,7 +84,7 @@ EXPOSE 22
 USER jbang
 
 RUN echo "Updating jbang" \
-    && jbang version --update
+    && jbang version --update || true
 
 RUN echo "Clearing JBang cache" \
     && jbang cache clear

--- a/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/services/TestServiceUtil.java
+++ b/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/services/TestServiceUtil.java
@@ -70,14 +70,18 @@ public final class TestServiceUtil {
      */
     public static void logAndRethrow(TestService service, ExtensionContext extensionContext, Exception exception)
             throws Exception {
-        final Object testInstance = extensionContext.getTestInstance().orElse(null);
+        if (extensionContext != null) {
+            final Object testInstance = extensionContext.getTestInstance().orElse(null);
 
-        if (testInstance != null) {
-            LOG.error("Failed to initialize service {} for test {} on ({})", service.getClass().getSimpleName(),
-                    extensionContext.getDisplayName(), testInstance.getClass().getName());
+            if (testInstance != null) {
+                LOG.error("Failed to initialize service {} for test {} on ({})", service.getClass().getSimpleName(),
+                        extensionContext.getDisplayName(), testInstance.getClass().getName());
+            } else {
+                LOG.error("Failed to initialize service {} for test {}", service.getClass().getSimpleName(),
+                        extensionContext.getDisplayName());
+            }
         } else {
-            LOG.error("Failed to initialize service {} for test {}", service.getClass().getSimpleName(),
-                    extensionContext.getDisplayName());
+            LOG.error("Failed to initialize service {}", service.getClass().getSimpleName());
         }
 
         throw exception;


### PR DESCRIPTION
## Summary

- Make `jbang version --update` non-fatal in the Dockerfile (`|| true`) — when jbang is already at the latest version, the update command returns exit code 1 which aborts the Docker image build
- Backport null-guard for `ExtensionContext` in `TestServiceUtil.logAndRethrow` from main — prevents NPE from masking the real Docker build error

## Root Cause

**Primary**: The Dockerfile runs `jbang version --update` which returns exit code 1 when jbang is already up to date (or the update check fails). This aborts the Docker image build, and every test container fails:
```
The command '/bin/sh -c echo "Updating jbang" && jbang version --update' returned a non-zero code: 1
```

**Secondary**: When the Docker build fails, `CliLocalContainerService.initialize()` throws. The call chain goes through `AbstractTestSupport.execute()` which calls `beforeAll(null)`, so when `TestServiceUtil.logAndRethrow` tries to call `extensionContext.getTestInstance()` on the null context, it throws an NPE that masks the real Docker build error:
```
java.lang.NullPointerException: Cannot invoke "org.junit.jupiter.api.extension.ExtensionContext.getTestInstance()" because "extensionContext" is null
```

Build 20 shows all 6 tests in `CliConfigITCase` failing with this NPE (each retried 3 times = 18 error entries).

The null-guard already exists on `main` (commit 82a05e072b4) but was never backported to 4.18.x.

## Test plan

- [ ] Verify Docker image builds succeed (no `jbang version --update` exit code 1)
- [ ] Verify that if Docker build does fail for other reasons, the real error is logged instead of NPE