### PR TITLE
chore: Replace commons-dbcp with HikariCP in camel-jooq

### DIFF
--- a/components/camel-jooq/pom.xml
+++ b/components/camel-jooq/pom.xml
@@ -54,9 +54,10 @@
             <version>${jakarta-annotation-api-version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
-            <version>${commons-dbcp-version}</version>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikaricp-version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- test dependencies -->

--- a/components/camel-jooq/src/main/docs/jooq-component.adoc
+++ b/components/camel-jooq/src/main/docs/jooq-component.adoc
@@ -87,8 +87,8 @@ When using jooq as a producer you can use any of the following `JooqOperation` o
     <context:property-placeholder location="classpath:config.properties"
                                   xmlns:context="http://www.springframework.org/schema/context"/>
 
-    <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
-        <property name="url" value="${db.url}"/>
+    <bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
+        <property name="jdbcUrl" value="${db.url}"/>
         <property name="driverClassName" value="${db.driver}"/>
         <property name="username" value="${db.username}"/>
         <property name="password" value="${db.password}"/>

--- a/components/camel-jooq/src/test/resources/config.properties
+++ b/components/camel-jooq/src/test/resources/config.properties
@@ -17,8 +17,8 @@
 #Database Configuration
 db.driver=org.hsqldb.jdbcDriver
 db.url=jdbc:hsqldb:file:target/db;shutdown=true
-db.pool.maxActive=50
-db.pool.maxIdle=20
+db.pool.maximumPoolSize=10
+db.pool.minimumIdle=2
 db.username=sa
 db.password=
 

--- a/components/camel-jooq/src/test/resources/jooq-spring.xml
+++ b/components/camel-jooq/src/test/resources/jooq-spring.xml
@@ -26,13 +26,18 @@
     <context:property-placeholder location="classpath:config.properties"
                                   xmlns:context="http://www.springframework.org/schema/context"/>
 
-    <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
-        <property name="url" value="${db.url}"/>
+    <bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
+        <property name="jdbcUrl" value="${db.url}"/>
         <property name="driverClassName" value="${db.driver}"/>
         <property name="username" value="${db.username}"/>
         <property name="password" value="${db.password}"/>
-        <property name="maxActive" value="${db.pool.maxActive}" />
-        <property name="maxIdle" value="${db.pool.maxIdle}" />
+        <property name="maximumPoolSize" value="${db.pool.maximumPoolSize}" />
+        <property name="minimumIdle" value="${db.pool.minimumIdle}" />
+        <!-- Test-optimized settings -->
+        <property name="connectionTimeout" value="10000" />
+        <property name="idleTimeout" value="300000" />
+        <property name="maxLifetime" value="600000" />
+        <property name="poolName" value="CamelJooqTestPool" />
     </bean>
     
     <bean id="bookStoreBean" class="org.apache.camel.component.jooq.beans.BookStoreRecordBean">

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -226,6 +226,7 @@
             the enterprise hazelcast product -->
         <hazelcast-version>5.4.0</hazelcast-version>
         <hdrhistrogram-version>2.2.2</hdrhistrogram-version>
+        <hikaricp-version>7.0.2</hikaricp-version>
         <hibernate-validator-version>9.1.0.Final</hibernate-validator-version>
         <hibernate-version>6.3.2.Final</hibernate-version>
         <hsqldb-version>2.7.4</hsqldb-version>


### PR DESCRIPTION
Replaced the unmaintained commons-dbcp:1.4 library with HikariCP 7.0.2 for JDBC connection pooling in camel-jooq test infrastructure.

Changes:
- Updated parent POM to include hikaricp-version property (7.0.2)
- Replaced commons-dbcp dependency with HikariCP (test scope)
- Updated Spring XML configuration to use HikariDataSource
- Updated connection pool properties (maximumPoolSize, minimumIdle)
- Updated documentation example to reflect HikariCP usage
- All tests pass successfully

Made with help from AI tools.