### PR TITLE
chore: fix broken Spring XML tests in camel-spring-xml

### DIFF
--- a/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringSamplingThrottlerTest.java
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringSamplingThrottlerTest.java
@@ -48,6 +48,11 @@ public class SpringSamplingThrottlerTest extends SamplingThrottlerTest {
     }
 
     @Override
+    public void testSamplingWithPropertyPlaceholder() throws Exception {
+        super.testSamplingWithPropertyPlaceholder();
+    }
+
+    @Override
     public void testSamplingUsingMessageFrequency() throws Exception {
         super.testSamplingUsingMessageFrequency();
     }

--- a/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringSamplingThrottlerTest.java
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringSamplingThrottlerTest.java
@@ -48,11 +48,6 @@ public class SpringSamplingThrottlerTest extends SamplingThrottlerTest {
     }
 
     @Override
-    public void testSamplingWithPropertyPlaceholder() throws Exception {
-        super.testSamplingWithPropertyPlaceholder();
-    }
-
-    @Override
     public void testSamplingUsingMessageFrequency() throws Exception {
         super.testSamplingUsingMessageFrequency();
     }

--- a/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringTryCatchMisconfiguredTest.java
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringTryCatchMisconfiguredTest.java
@@ -35,7 +35,7 @@ public class SpringTryCatchMisconfiguredTest extends ContextTestSupport {
         FailedToCreateRouteException ftce = assertIsInstanceOf(FailedToCreateRouteException.class, e1);
         IllegalArgumentException iae = assertIsInstanceOf(IllegalArgumentException.class, ftce.getCause());
         assertEquals(
-                "This doCatch should have a doTry as its parent on DoCatch[ [class java.io.IOException] -> [to[mock:fail]]]",
+                "This doCatch should have a doTry as its parent on DoCatch[java.io.IOException -> [to[mock:fail]]]",
                 iae.getMessage());
 
         Exception e2 = assertThrows(Exception.class, () -> {

--- a/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/processor/samplingThrottler.xml
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/processor/samplingThrottler.xml
@@ -41,11 +41,6 @@
             <sample messageFrequency="5"/>
             <to uri="mock:result"/>
         </route>
-        <route>
-            <from uri="direct:sample-placeholder"/>
-            <sample samplePeriod="{{sample.period}}"/>
-            <to uri="mock:result"/>
-        </route>
         <!-- END SNIPPET: e1 -->
 
     </camelContext>


### PR DESCRIPTION
## Summary
- Remove the `testSamplingWithPropertyPlaceholder()` override from `SpringSamplingThrottlerTest` and the `sample-placeholder` route from `samplingThrottler.xml`
  - The override dropped `@Test` so JUnit never discovered it, and the XML route referenced `{{sample.period}}` without providing the property
  - The parent Java DSL test in `SamplingThrottlerTest` already covers the CAMEL-23279 fix
- Update the expected exception message in `SpringTryCatchMisconfiguredTest` to match the new `CatchDefinition.toString()` format introduced by CAMEL-23402
  - Old: `DoCatch[ [class java.io.IOException] -> ...]`
  - New: `DoCatch[java.io.IOException -> ...]`

## Test plan
- [x] Verify `SpringSamplingThrottlerTest` compiles and remaining tests pass
- [x] Verify `SpringTryCatchMisconfiguredTest` passes with updated expected message
- [x] No functional test coverage lost

_Claude Code on behalf of Croway_