### PR TITLE
chore: suppress inherited testSamplingWithPropertyPlaceholder in Spring XML test

### DIFF
--- a/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringSamplingThrottlerTest.java
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/processor/SpringSamplingThrottlerTest.java
@@ -48,6 +48,11 @@ public class SpringSamplingThrottlerTest extends SamplingThrottlerTest {
     }
 
     @Override
+    public void testSamplingWithPropertyPlaceholder() throws Exception {
+        super.testSamplingWithPropertyPlaceholder();
+    }
+
+    @Override
     public void testSamplingUsingMessageFrequency() throws Exception {
         super.testSamplingUsingMessageFrequency();
     }


### PR DESCRIPTION
## Summary
- Add override of testSamplingWithPropertyPlaceholder() without @Test to suppress the inherited parent test
- The Spring XML context has no sample-placeholder route and the parent Java DSL test already covers the CAMEL-23279 fix
- Matches the existing pattern in this class where overrides intentionally drop @Test to control which inherited tests run
- Fixes CI failure on camel-4.18.x branch

## Test plan
- [x] Verify SpringSamplingThrottlerTest compiles and the inherited test no longer runs
- [x] No functional test coverage lost

_Claude Code on behalf of Croway_