### PR TITLE
CAMEL-23370: Fix PackageScanJarResource getInputStream() for JAR subdirectories

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultPackageScanResourceResolverTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultPackageScanResourceResolverTest.java
@@ -17,11 +17,22 @@
 package org.apache.camel.impl.engine;
 
 import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spi.PackageScanResourceResolver;
+import org.apache.camel.spi.Resource;
 import org.apache.camel.support.PluginHelper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -47,5 +58,50 @@ public class DefaultPackageScanResourceResolverTest {
                 .anyMatch(r -> r.getLocation().contains("br" + File.separator + "camel-dummy.xml"));
         assertThat(resolver.findResources("file:src/test/resources/org/apache/camel/impl/engine/c?/*.xml"))
                 .isEmpty();
+    }
+
+    @Test
+    public void testJarResourcesScanWithSubdirectories(@TempDir Path tempDir) throws Exception {
+        Path jarPath = tempDir.resolve("test-routes.jar");
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarPath))) {
+            addJarDirectory(jos, "routes/");
+            addJarDirectory(jos, "routes/sub1/");
+            addJarDirectory(jos, "routes/sub2/");
+            addJarEntry(jos, "routes/sub1/a.txt", "content-a");
+            addJarEntry(jos, "routes/sub2/b.txt", "content-b");
+            addJarEntry(jos, "routes/c.txt", "content-c");
+        }
+
+        URLClassLoader jarClassLoader = new URLClassLoader(new URL[] { jarPath.toUri().toURL() });
+        try (DefaultCamelContext ctx = new DefaultCamelContext()) {
+            PackageScanResourceResolver resolver = PluginHelper.getPackageScanResourceResolver(ctx);
+            resolver.addClassLoader(jarClassLoader);
+
+            Collection<Resource> resources = resolver.findResources("classpath:routes/**/*.txt");
+
+            assertThat(resources).hasSize(3);
+
+            for (Resource resource : resources) {
+                try (InputStream is = resource.getInputStream()) {
+                    assertThat(is).isNotNull();
+                    String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                    assertThat(content).startsWith("content-");
+                }
+            }
+        } finally {
+            jarClassLoader.close();
+        }
+    }
+
+    private static void addJarDirectory(JarOutputStream jos, String name) throws Exception {
+        JarEntry entry = new JarEntry(name);
+        jos.putNextEntry(entry);
+        jos.closeEntry();
+    }
+
+    private static void addJarEntry(JarOutputStream jos, String name, String content) throws Exception {
+        jos.putNextEntry(new JarEntry(name));
+        jos.write(content.getBytes(StandardCharsets.UTF_8));
+        jos.closeEntry();
     }
 }

--- a/core/camel-support/src/main/java/org/apache/camel/support/scan/PackageScanJarResource.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/scan/PackageScanJarResource.java
@@ -22,20 +22,17 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLClassLoader;
+import java.net.URLConnection;
 
 import org.apache.camel.support.ResourceSupport;
-import org.apache.camel.util.StringHelper;
 
 public class PackageScanJarResource extends ResourceSupport {
 
     private final URL url;
-    private final URLClassLoader uc;
 
     public PackageScanJarResource(String scheme, URL url, String shortName) {
         super(scheme, url.getFile() + shortName);
         this.url = url;
-        this.uc = new URLClassLoader(new URL[] { url });
     }
 
     @Override
@@ -59,8 +56,14 @@ public class PackageScanJarResource extends ResourceSupport {
 
     @Override
     public InputStream getInputStream() throws IOException {
-        String loc = StringHelper.afterLast(getLocation(), "!");
-        return uc.getResourceAsStream(loc);
+        try {
+            URL jarUrl = URI.create("jar:" + getLocation()).toURL();
+            URLConnection con = jarUrl.openConnection();
+            con.setUseCaches(false);
+            return con.getInputStream();
+        } catch (Exception e) {
+            throw new IOException("Cannot open JAR resource: " + getLocation(), e);
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

- Replace `URLClassLoader.getResourceAsStream()` in `PackageScanJarResource.getInputStream()` with direct `jar:` URL resolution via `URLConnection`, fixing unreliable stream opening for resources in JAR subdirectories
- Remove the `URLClassLoader` field (`uc`) which was a resource leak (never closed) and whose behavior with leading-`/` paths is platform-dependent
- Add a test that creates a temporary JAR with resources in nested subdirectories, scans with `classpath:routes/**/*.txt`, and verifies all resources are found with readable content

## Test plan

- [x] `DefaultPackageScanResourceResolverTest.testJarResourcesScanWithSubdirectories` passes (new test)
- [x] `DefaultPackageScanResourceResolverTest.testFileResourcesScan` still passes (existing test)
- [ ] `CamelXmlWildcardRoutesIT` in camel-spring-boot should pass once this camel-core version is picked up (cross-repo verification)

_Claude Code on behalf of Federico Mariani_