### PR TITLE
CAMEL-23412: Add getChildren() to NamedNode for uniform model tree traversal

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/NamedNode.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NamedNode.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Represents a node in the {@link org.apache.camel.model routes} which is identified by an id.
  */
@@ -69,28 +72,32 @@ public interface NamedNode extends LineNumberAware {
      * Processor Level in the route tree
      */
     default int getLevel() {
-        NamedNode node = this;
         int level = 0;
+        NamedNode node = this;
         while (node != null && node.getParent() != null) {
-            boolean shallow = "when".equals(node.getShortName()) || "otherwise".equals(node.getShortName());
             node = node.getParent();
-            if (!shallow) {
-                level++;
-            }
+            level++;
         }
         return level;
     }
 
     default String getParentId() {
         NamedNode node = this;
-        while (node != null && node.getParent() != null) {
-            boolean shallow = "when".equals(node.getShortName()) || "otherwise".equals(node.getShortName());
-            node = node.getParent();
-            if (!shallow) {
-                return node.getId();
-            }
+        if (node.getParent() != null) {
+            return node.getParent().getId();
         }
         return null;
+    }
+
+    /**
+     * Returns the direct children of this node in the route model tree.
+     *
+     * This provides a uniform API for tree walkers to traverse the full model structure without needing to special-case
+     * EIPs like Choice (whose when/otherwise children are not {@link org.apache.camel.model.ProcessorDefinition}s and
+     * therefore invisible to {@code getOutputs()}).
+     */
+    default List<NamedNode> getChildren() {
+        return Collections.emptyList();
     }
 
     /**

--- a/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultModelToStructureDumper.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultModelToStructureDumper.java
@@ -24,7 +24,6 @@ import org.apache.camel.NamedNode;
 import org.apache.camel.model.EndpointRequiredDefinition;
 import org.apache.camel.model.Model;
 import org.apache.camel.model.OptionalIdentifiedDefinition;
-import org.apache.camel.model.ProcessorDefinitionHelper;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.spi.ModelDumpLine;
 import org.apache.camel.spi.ModelToStructureDumper;
@@ -54,44 +53,30 @@ public class DefaultModelToStructureDumper implements ModelToStructureDumper {
         }
         answer.add(new ModelDumpLine(loc, "from", routeId, 1, "from[" + uri + "]", def.getDescription()));
 
-        var outputs = ProcessorDefinitionHelper.filterTypeInOutputs(def.getOutputs(), OptionalIdentifiedDefinition.class);
-        for (var output : outputs) {
-            loc = scheme + ":" + output.getLocation();
-            if (output.getLineNumber() > 0) {
-                loc += ":" + output.getLineNumber();
-            }
-            String kind = output.getShortName();
-            String id = output.getId();
-            int level = getLevel(output) + 1;
-            boolean choice = "choice".equals(output.getShortName());
-            String code = choice || brief ? output.getShortName() : output.getLabel();
-            // even in brief mode we want to see the uri for EIPs
-            if (brief && output instanceof EndpointRequiredDefinition erd) {
-                uri = StringHelper.before(erd.getEndpointUri(), "?", erd.getEndpointUri());
-                code = output.getShortName() + "[" + uri + "]";
-            }
-            String desc = output.getDescription();
-            answer.add(new ModelDumpLine(loc, kind, id, level, code, desc));
-        }
+        dumpChildren(def, scheme, brief, 2, answer);
 
         return answer;
     }
 
-    private static int getLevel(NamedNode node) {
-        int level = 0;
-        while (node != null && node.getParent() != null) {
-            // special for choice
-            boolean choice = "choice".equals(node.getParent().getShortName());
-            if (choice) {
-                level++;
+    private static void dumpChildren(NamedNode parent, String scheme, boolean brief, int level, List<ModelDumpLine> answer) {
+        for (NamedNode child : parent.getChildren()) {
+            if (child instanceof OptionalIdentifiedDefinition<?> output) {
+                String loc = scheme + ":" + output.getLocation();
+                if (output.getLineNumber() > 0) {
+                    loc += ":" + output.getLineNumber();
+                }
+                String kind = output.getShortName();
+                String id = output.getId();
+                boolean choice = "choice".equals(kind);
+                String code = choice || brief ? output.getShortName() : output.getLabel();
+                if (brief && output instanceof EndpointRequiredDefinition erd) {
+                    String uri = StringHelper.before(erd.getEndpointUri(), "?", erd.getEndpointUri());
+                    code = output.getShortName() + "[" + uri + "]";
+                }
+                answer.add(new ModelDumpLine(loc, kind, id, level, code, output.getDescription()));
             }
-            boolean shallow = "when".equals(node.getShortName()) || "otherwise".equals(node.getShortName());
-            if (!shallow) {
-                level++;
-            }
-            node = node.getParent();
+            dumpChildren(child, scheme, brief, level + 1, answer);
         }
-        return level;
     }
 
 }

--- a/core/camel-core-model/src/main/java/org/apache/camel/builder/AdviceWithTasks.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/builder/AdviceWithTasks.java
@@ -23,8 +23,8 @@ import java.util.List;
 
 import org.apache.camel.Endpoint;
 import org.apache.camel.LineNumberAware;
+import org.apache.camel.NamedNode;
 import org.apache.camel.model.AdviceWithDefinition;
-import org.apache.camel.model.ChoiceDefinition;
 import org.apache.camel.model.EndpointRequiredDefinition;
 import org.apache.camel.model.EnrichDefinition;
 import org.apache.camel.model.FromDefinition;
@@ -32,6 +32,7 @@ import org.apache.camel.model.InterceptDefinition;
 import org.apache.camel.model.InterceptSendToEndpointDefinition;
 import org.apache.camel.model.OnCompletionDefinition;
 import org.apache.camel.model.OnExceptionDefinition;
+import org.apache.camel.model.OutputNode;
 import org.apache.camel.model.PipelineDefinition;
 import org.apache.camel.model.PollEnrichDefinition;
 import org.apache.camel.model.ProcessorDefinition;
@@ -39,7 +40,6 @@ import org.apache.camel.model.ProcessorDefinitionHelper;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.ToDynamicDefinition;
 import org.apache.camel.model.TransactedDefinition;
-import org.apache.camel.model.WhenDefinition;
 import org.apache.camel.support.PatternHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -475,17 +475,13 @@ public final class AdviceWithTasks {
         if (parent == null) {
             return null;
         }
-        // for CBR then use the outputs from the node itself
-        // so we work on the right branch in the CBR (when/otherwise)
-        if (parent instanceof ChoiceDefinition choice) {
-            // look in which branch the node is from
-            for (WhenDefinition when : choice.getWhenClauses()) {
-                if (when.getOutputs().contains(node)) {
-                    return when.getOutputs();
+        // check if the node is inside a structural child (e.g., when/otherwise in a choice)
+        // so we work on the right branch
+        for (NamedNode child : parent.getChildren()) {
+            if (child instanceof OutputNode outputNode && !(child instanceof ProcessorDefinition)) {
+                if (outputNode.getOutputs().contains(node)) {
+                    return outputNode.getOutputs();
                 }
-            }
-            if (choice.getOtherwise() != null) {
-                return choice.getOtherwise().getOutputs();
             }
         }
         List<ProcessorDefinition<?>> outputs = parent.getOutputs();

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ChoiceDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ChoiceDefinition.java
@@ -253,6 +253,16 @@ public class ChoiceDefinition extends NoOutputDefinition<ChoiceDefinition> {
     }
 
     @Override
+    public List<NamedNode> getChildren() {
+        var answer = new ArrayList<NamedNode>();
+        answer.addAll(whenClauses);
+        if (otherwise != null) {
+            answer.add(otherwise);
+        }
+        return answer;
+    }
+
+    @Override
     public List<ProcessorDefinition<?>> getOutputs() {
         var answer = new ArrayList<ProcessorDefinition<?>>();
         for (WhenDefinition when : whenClauses) {

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/OtherwiseDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/OtherwiseDefinition.java
@@ -26,6 +26,7 @@ import jakarta.xml.bind.annotation.XmlElementRef;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 
+import org.apache.camel.NamedNode;
 import org.apache.camel.spi.Metadata;
 
 /**
@@ -58,6 +59,11 @@ public class OtherwiseDefinition extends OptionalIdentifiedDefinition<OtherwiseD
     @Override
     public OtherwiseDefinition copyDefinition() {
         return new OtherwiseDefinition(this);
+    }
+
+    @Override
+    public List<NamedNode> getChildren() {
+        return new ArrayList<>(outputs);
     }
 
     public List<ProcessorDefinition<?>> getOutputs() {

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ProcessorDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ProcessorDefinition.java
@@ -41,6 +41,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.Expression;
 import org.apache.camel.LoggingLevel;
+import org.apache.camel.NamedNode;
 import org.apache.camel.Predicate;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.DataFormatClause;
@@ -130,6 +131,11 @@ public abstract class ProcessorDefinition<Type extends ProcessorDefinition<Type>
 
     // else to use an optional attribute in JAXB2
     public abstract List<ProcessorDefinition<?>> getOutputs();
+
+    @Override
+    public List<NamedNode> getChildren() {
+        return new ArrayList<>(getOutputs());
+    }
 
     /**
      * Whether this definition can only be added as top-level directly on the route itself (such as

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ProcessorDefinitionHelper.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ProcessorDefinitionHelper.java
@@ -208,16 +208,33 @@ public final class ProcessorDefinitionHelper {
             }
         }
 
-        // traverse outputs and recursive children as well
-        List<ProcessorDefinition<?>> children = node.getOutputs();
-        if (children != null && !children.isEmpty()) {
-            for (ProcessorDefinition<?> child : children) {
-                // traverse children also
-                gatherAllNodeIds(child, set, onlyCustomId, includeAbstract);
+        // traverse children (including non-ProcessorDefinition nodes like WhenDefinition, OtherwiseDefinition)
+        for (NamedNode child : node.getChildren()) {
+            if (child instanceof ProcessorDefinition<?> pd) {
+                gatherAllNodeIds(pd, set, onlyCustomId, includeAbstract);
+            } else {
+                gatherAllNodeIdsFromNode(child, set, onlyCustomId);
             }
         }
 
         return set;
+    }
+
+    private static void gatherAllNodeIdsFromNode(NamedNode node, List<String> set, boolean onlyCustomId) {
+        if (node instanceof OptionalIdentifiedDefinition<?> oid) {
+            if (oid.getId() != null) {
+                if (!onlyCustomId || oid.hasCustomIdAssigned()) {
+                    set.add(oid.getId());
+                }
+            }
+        }
+        for (NamedNode child : node.getChildren()) {
+            if (child instanceof ProcessorDefinition<?> pd) {
+                gatherAllNodeIds(pd, set, onlyCustomId, false);
+            } else {
+                gatherAllNodeIdsFromNode(child, set, onlyCustomId);
+            }
+        }
     }
 
     /**
@@ -239,12 +256,27 @@ public final class ProcessorDefinitionHelper {
             }
         }
 
-        // traverse outputs and recursive children as well
-        List<ProcessorDefinition<?>> children = node.getOutputs();
-        if (children != null && !children.isEmpty()) {
-            for (ProcessorDefinition<?> child : children) {
-                // traverse children also
-                resetAllAutoAssignedNodeIds(child);
+        // traverse children (including non-ProcessorDefinition nodes like WhenDefinition, OtherwiseDefinition)
+        for (NamedNode child : node.getChildren()) {
+            if (child instanceof ProcessorDefinition<?> pd) {
+                resetAllAutoAssignedNodeIds(pd);
+            } else {
+                resetAllAutoAssignedNodeIdsFromNode(child);
+            }
+        }
+    }
+
+    private static void resetAllAutoAssignedNodeIdsFromNode(NamedNode node) {
+        if (node instanceof OptionalIdentifiedDefinition<?> oid) {
+            if (oid.getId() != null && !oid.hasCustomIdAssigned()) {
+                oid.setId(null);
+            }
+        }
+        for (NamedNode child : node.getChildren()) {
+            if (child instanceof ProcessorDefinition<?> pd) {
+                resetAllAutoAssignedNodeIds(pd);
+            } else {
+                resetAllAutoAssignedNodeIdsFromNode(child);
             }
         }
     }
@@ -264,13 +296,12 @@ public final class ProcessorDefinitionHelper {
         }
 
         // start from level 1
-        doFindType(outputs, type, found, 1, maxDeep);
+        doFindTypeInNodes(outputs, type, found, 1, maxDeep);
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    private static <
-            T> void doFindType(List<ProcessorDefinition<?>> outputs, Class<T> type, List<T> found, int current, int maxDeep) {
-        if (outputs == null || outputs.isEmpty()) {
+    private static <T> void doFindTypeInNodes(
+            List<? extends NamedNode> nodes, Class<T> type, List<T> found, int current, int maxDeep) {
+        if (nodes == null || nodes.isEmpty()) {
             return;
         }
 
@@ -279,104 +310,14 @@ public final class ProcessorDefinitionHelper {
             return;
         }
 
-        for (ProcessorDefinition out : outputs) {
-
-            // send is much common
-            if (out instanceof SendDefinition send) {
-                List<ProcessorDefinition<?>> children = send.getOutputs();
-                doFindType(children, type, found, ++current, maxDeep);
+        for (NamedNode node : nodes) {
+            if (type.isInstance(node)) {
+                found.add(type.cast(node));
             }
-
-            // special for choice
-            if (out instanceof ChoiceDefinition choice) {
-                // ensure to add ourself if we match also
-                if (type.isInstance(choice)) {
-                    found.add((T) choice);
-                }
-
-                // only look at when/otherwise if current < maxDeep (or max deep
-                // is disabled)
-                if (maxDeep < 0 || current < maxDeep) {
-                    for (WhenDefinition when : choice.getWhenClauses()) {
-                        if (type.isInstance(when)) {
-                            found.add((T) when);
-                        }
-                        List<ProcessorDefinition<?>> children = when.getOutputs();
-                        doFindType(children, type, found, ++current, maxDeep);
-                    }
-
-                    // otherwise is optional
-                    if (choice.getOtherwise() != null) {
-                        OtherwiseDefinition other = choice.getOtherwise();
-                        if (type.isInstance(other)) {
-                            found.add((T) other);
-                        }
-                        List<ProcessorDefinition<?>> children = choice.getOtherwise().getOutputs();
-                        doFindType(children, type, found, ++current, maxDeep);
-                    }
-                }
-
-                // do not check children as we already did that
-                continue;
-            }
-
-            // special for try ... catch ... finally
-            if (out instanceof TryDefinition doTry) {
-                // ensure to add ourself if we match also
-                if (type.isInstance(doTry)) {
-                    found.add((T) doTry);
-                }
-
-                // only look at children if current < maxDeep (or max deep is
-                // disabled)
-                if (maxDeep < 0 || current < maxDeep) {
-                    List<ProcessorDefinition<?>> doTryOut = doTry.getOutputsWithoutCatches();
-                    doFindType(doTryOut, type, found, ++current, maxDeep);
-
-                    List<CatchDefinition> doTryCatch = doTry.getCatchClauses();
-                    for (CatchDefinition doCatch : doTryCatch) {
-                        // ensure to add ourself if we match also
-                        if (type.isInstance(doCatch)) {
-                            found.add((T) doCatch);
-                        }
-                        doFindType(doCatch.getOutputs(), type, found, ++current, maxDeep);
-                    }
-
-                    if (doTry.getFinallyClause() != null) {
-                        // ensure to add ourself if we match also
-                        FinallyDefinition doFinally = doTry.getFinallyClause();
-                        if (type.isInstance(doFinally)) {
-                            found.add((T) doFinally);
-                        }
-                        doFindType(doFinally.getOutputs(), type, found, ++current, maxDeep);
-                    }
-                }
-
-                // do not check children as we already did that
-                continue;
-            }
-
-            // special for some types which has special outputs
-            if (out instanceof OutputDefinition outDef) {
-                // ensure to add ourself if we match also
-                if (type.isInstance(outDef)) {
-                    found.add((T) outDef);
-                }
-
-                List<ProcessorDefinition<?>> outDefOut = outDef.getOutputs();
-                doFindType(outDefOut, type, found, ++current, maxDeep);
-
-                // do not check children as we already did that
-                continue;
-            }
-
-            if (type.isInstance(out)) {
-                found.add((T) out);
-            }
-
-            // try children as well
-            List<ProcessorDefinition<?>> children = out.getOutputs();
-            doFindType(children, type, found, ++current, maxDeep);
+            // structural nodes (non-ProcessorDefinition children like WhenDefinition, OtherwiseDefinition)
+            // are transparent for depth counting — they don't consume a maxDeep level
+            int childLevel = node instanceof ProcessorDefinition ? current + 1 : current;
+            doFindTypeInNodes(node.getChildren(), type, found, childLevel, maxDeep);
         }
     }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/RouteDefinitionHelper.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/RouteDefinitionHelper.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ErrorHandlerFactory;
 import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.NamedNode;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.model.rest.RestDefinition;
 import org.apache.camel.model.rest.VerbDefinition;
@@ -783,10 +784,16 @@ public final class RouteDefinitionHelper {
             }
         }
 
-        List<ProcessorDefinition<?>> children = processor.getOutputs();
-        if (children != null && !children.isEmpty()) {
-            for (ProcessorDefinition child : children) {
-                forceAssignIds(context, child);
+        for (NamedNode child : ((NamedNode) processor).getChildren()) {
+            if (child instanceof ProcessorDefinition<?> pd) {
+                forceAssignIds(context, pd);
+            } else if (child instanceof OptionalIdentifiedDefinition<?> oid) {
+                oid.idOrCreate(context.getCamelContextExtension().getContextPlugin(NodeIdFactory.class));
+                for (NamedNode grandchild : child.getChildren()) {
+                    if (grandchild instanceof ProcessorDefinition<?> gpd) {
+                        forceAssignIds(context, gpd);
+                    }
+                }
             }
         }
     }

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/WhenDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/WhenDefinition.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
@@ -23,6 +26,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 
 import org.apache.camel.Expression;
+import org.apache.camel.NamedNode;
 import org.apache.camel.Predicate;
 import org.apache.camel.model.language.ExpressionDefinition;
 import org.apache.camel.spi.AsPredicate;
@@ -64,6 +68,11 @@ public class WhenDefinition extends BasicOutputExpressionNode
 
     public WhenDefinition(ExpressionDefinition expression) {
         super(expression);
+    }
+
+    @Override
+    public List<NamedNode> getChildren() {
+        return new ArrayList<>(getOutputs());
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/impl/CustomIdFactoryTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/CustomIdFactoryTest.java
@@ -88,7 +88,8 @@ public class CustomIdFactoryTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // this should take the when path (first to)
-        assertEquals("#choice3##to4#", ids);
+        // when4 and otherwise6 are now assigned IDs too (via getChildren traversal)
+        assertEquals("#choice3##to5#", ids);
     }
 
     /**
@@ -103,7 +104,8 @@ public class CustomIdFactoryTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // this should take the otherwise path
-        assertEquals("#choice3##log5##to6#", ids);
+        // when4 and otherwise6 are now assigned IDs too (via getChildren traversal)
+        assertEquals("#choice3##log7##to8#", ids);
     }
 
     private static class MyDebuggerCheckingId implements InterceptStrategy {

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -24,6 +24,18 @@ However, using Java serialization is discouraged and highly recommend to use oth
 
 Removed `org.apache.camel.spi.ReifierStrategy` which is no longer in use by Camel and can safely be removed.
 
+A new `getChildren()` default method has been added to `org.apache.camel.NamedNode`. It returns `List<NamedNode>` and
+provides a uniform API for traversing the route model tree, including structural nodes like `WhenDefinition` and
+`OtherwiseDefinition` that are not `ProcessorDefinition` subclasses and therefore invisible to `getOutputs()`.
+Code that walks the model tree recursively should prefer `getChildren()` over `getOutputs()` to avoid needing
+special-case handling for Choice EIP.
+
+The `NamedNode.getLevel()` and `getParentId()` methods no longer treat `when` and `otherwise` nodes as "shallow".
+Previously these nodes were flattened to the same level as their parent `choice`, which was inconsistent with how
+`doCatch` and `doFinally` work inside `doTry`. Now `when` and `otherwise` contribute their own level, consistent
+with the tree structure exposed by `getChildren()`. This affects level values reported via JMX (`ManagedProcessor.getLevel()`)
+and dev consoles for nodes inside Choice EIP branches.
+
 === camel-yaml-dsl
 
 A new canonical JSON Schema variant (`camelYamlDsl-canonical.json`) has been added alongside the existing classic


### PR DESCRIPTION
[CAMEL-23412](https://issues.apache.org/jira/browse/CAMEL-23412)

## Summary

Adds a `getChildren()` default method on `NamedNode` that returns `List<NamedNode>`, providing a uniform API for model tree traversal that includes non-`ProcessorDefinition` children like `WhenDefinition` and `OtherwiseDefinition`. This eliminates most ChoiceDefinition special cases from tree walkers and makes the model tree self-consistent.

## Problem

`ChoiceDefinition`'s when/otherwise children are invisible to generic tree walkers because `getOutputs()` returns `List<ProcessorDefinition<?>>` and neither `WhenDefinition` nor `OtherwiseDefinition` extends `ProcessorDefinition`. This forces every tree walker to special-case `ChoiceDefinition` — and several don't, creating gaps:

- `gatherAllNodeIds()` missed when/otherwise node IDs
- `resetAllAutoAssignedNodeIds()` skipped when/otherwise nodes
- `forceAssignIds()` skipped when/otherwise nodes
- `NamedNode.getLevel()` / `getParentId()` treated when/otherwise as "shallow" (inconsistent with try/catch)

## Relation to CAMEL-23402

[CAMEL-23402](https://issues.apache.org/jira/browse/CAMEL-23402) fixed a specific symptom (structure dumper missing `OtherwiseDefinition`) by adding it to `doFindType()`'s special case. This PR addresses the root cause: the lack of a uniform tree traversal API. With `getChildren()`, the special cases in `doFindType()` are no longer needed, and future tree walkers get correct behavior by default.

## Changes

### New API
- **`NamedNode.getChildren()`**: new default method returning `List<NamedNode>` (empty by default)
- **`ProcessorDefinition`**: overrides to delegate to `getOutputs()`
- **`ChoiceDefinition`**: overrides to return when/otherwise nodes as direct children
- **`WhenDefinition` / `OtherwiseDefinition`**: override to return their body processors

### Simplified tree walkers
- **`ProcessorDefinitionHelper.doFindType()`**: replaced ~110 lines of special-case code (ChoiceDefinition, TryDefinition, OutputDefinition, SendDefinition) with ~15 lines of generic `getChildren()` traversal. Non-ProcessorDefinition structural nodes are transparent for `maxDeep` depth counting to preserve backward compatibility.
- **`ProcessorDefinitionHelper.gatherAllNodeIds()` / `resetAllAutoAssignedNodeIds()`**: now traverse when/otherwise nodes via `getChildren()`
- **`RouteDefinitionHelper.forceAssignIds()`**: now assigns IDs to when/otherwise nodes
- **`DefaultModelToStructureDumper`**: simplified from `filterTypeInOutputs` + `getLevel()` with choice/when/otherwise special cases to a recursive `getChildren()` walk where levels are implicit in the recursion depth
- **`AdviceWithTasks`**: replaced `instanceof ChoiceDefinition` with generic `getChildren()` + `OutputNode` pattern to find the correct branch

### Level consistency
- **`NamedNode.getLevel()` / `getParentId()`**: removed "shallow" when/otherwise handling. Previously when/otherwise were flattened to the same level as their parent choice (choice=1, when=1, to-in-when=2), which was inconsistent with try/catch where doCatch properly increments the level (doTry=1, doCatch=2, to-in-catch=3). Now when/otherwise contribute their own level, consistent with the tree structure.

### Structure dump before/after

**Before (when/otherwise flattened):**
```
  0: [route] route[dotry-choice]
    1: [from] from[timer://tryChoiceInside?repeatCount=1]
      2: [setHeader] setHeader[type]
      2: [doTry] doTry
        3: [choice] choice[when[{header(type) == A}]otherwise]
          4: [log] log[Type A]
          4: [log] log[Other type]
          4: [throwException] throwException[java.lang.Exception]
        3: [doCatch] doCatch[ [class java.lang.Exception]]
          4: [log] log[Err: ${exception.message}]
      2: [log] log[Do other processing...]
```

**After (when/otherwise as proper tree nodes):**
```
  0: [route] route[dotry-choice]
    1: [from] from[timer://tryChoiceInside?repeatCount=1]
      2: [setHeader] setHeader[type]
      2: [doTry] doTry
        3: [choice] choice
          4: [when] when[{header(type) == A}]
            5: [log] log[Type A]
          4: [otherwise] otherwise
            5: [log] log[Other type]
            5: [throwException] throwException[java.lang.Exception]
        3: [doCatch] doCatch[ [class java.lang.Exception]]
          4: [log] log[Err: ${exception.message}]
      2: [log] log[Do other processing...]
```

### Other
- **`CustomIdFactoryTest`**: updated expected IDs (when/otherwise nodes now get IDs assigned by `forceAssignIds`)
- **Upgrade guide**: documented new API and level change

_Claude Code on behalf of Guillaume Nodet_