### PR TITLE
chore: migrate camel-jooq from commons-dbcp to commons-dbcp2

### DIFF
--- a/components/camel-jooq/pom.xml
+++ b/components/camel-jooq/pom.xml
@@ -54,9 +54,10 @@
             <version>${jakarta-annotation-api-version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
-            <version>${commons-dbcp-version}</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <version>${commons-dbcp2-version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- test dependencies -->

--- a/components/camel-jooq/src/main/docs/jooq-component.adoc
+++ b/components/camel-jooq/src/main/docs/jooq-component.adoc
@@ -87,7 +87,7 @@ When using jooq as a producer you can use any of the following `JooqOperation` o
     <context:property-placeholder location="classpath:config.properties"
                                   xmlns:context="http://www.springframework.org/schema/context"/>
 
-    <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
+    <bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
         <property name="url" value="${db.url}"/>
         <property name="driverClassName" value="${db.driver}"/>
         <property name="username" value="${db.username}"/>

--- a/components/camel-jooq/src/test/resources/config.properties
+++ b/components/camel-jooq/src/test/resources/config.properties
@@ -17,7 +17,7 @@
 #Database Configuration
 db.driver=org.hsqldb.jdbcDriver
 db.url=jdbc:hsqldb:file:target/db;shutdown=true
-db.pool.maxActive=50
+db.pool.maxTotal=50
 db.pool.maxIdle=20
 db.username=sa
 db.password=

--- a/components/camel-jooq/src/test/resources/jooq-spring.xml
+++ b/components/camel-jooq/src/test/resources/jooq-spring.xml
@@ -26,12 +26,12 @@
     <context:property-placeholder location="classpath:config.properties"
                                   xmlns:context="http://www.springframework.org/schema/context"/>
 
-    <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
+    <bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
         <property name="url" value="${db.url}"/>
         <property name="driverClassName" value="${db.driver}"/>
         <property name="username" value="${db.username}"/>
         <property name="password" value="${db.password}"/>
-        <property name="maxActive" value="${db.pool.maxActive}" />
+        <property name="maxTotal" value="${db.pool.maxTotal}" />
         <property name="maxIdle" value="${db.pool.maxIdle}" />
     </bean>
     

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -115,7 +115,6 @@
         <commons-collections4-version>4.5.0</commons-collections4-version>
         <commons-compress-version>1.28.0</commons-compress-version>
         <commons-csv-version>1.14.1</commons-csv-version>
-        <commons-dbcp-version>1.4</commons-dbcp-version>
         <commons-dbcp2-version>2.14.0</commons-dbcp2-version>
         <commons-exec-version>1.6.0</commons-exec-version>
         <commons-io-version>2.22.0</commons-io-version>


### PR DESCRIPTION
Replace unmaintained commons-dbcp 1.4 with modern commons-dbcp2 2.14.0 for test configuration. Changes include:

- Update Maven dependency to org.apache.commons:commons-dbcp2:2.14.0 with test scope
- Change package name from org.apache.commons.dbcp to org.apache.commons.dbcp2 in Spring configuration
- Rename maxActive property to maxTotal
- Update documentation example to reflect new package name
- Remove unused commons-dbcp-version property from parent POM

This aligns camel-jooq with other components (camel-jpa, camel-quarkus, camel-spring-batch) that already use commons-dbcp2 and removes the unmaintained commons-dbcp library.

Made with help from AI tools.