### PR TITLE
Revert "chore(camel-test-infra-infinispan): upgrade infinispan.container to 16.2"

### DIFF
--- a/test-infra/camel-test-infra-infinispan/src/main/resources/org/apache/camel/test/infra/infinispan/services/container.properties
+++ b/test-infra/camel-test-infra-infinispan/src/main/resources/org/apache/camel/test/infra/infinispan/services/container.properties
@@ -14,6 +14,6 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-infinispan.container=quay.io/infinispan/server:16.2
+infinispan.container=quay.io/infinispan/server:16.1
 infinispan.container.ppc64le=icr.io/ppc64le-oss/infinispan-server-ppc64le:16.0.1
 infinispan.container.version.exclude=dev,alpha,beta,rc


### PR DESCRIPTION
Reverts apache/camel#22316

Infinispan upgrade to 16.2 is causing the tests to be very very flaky. Like 4 out 5 times failing.

see https://issues.apache.org/jira/browse/CAMEL-23410

I reproduced locally the failure several times with 16.2, and it always passed with 16.1

note that it is currently causing the CI to go on timeout on all builds, there si always at least one combination on which there is the problem and for which it goes on timEout.