### PR TITLE
chore(docs): sync 4.18 and 4.14 upgrade guides with backported entries

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -11,11 +11,65 @@ Note that manual migration is still required.
 See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 ====
 
-== Upgrading from 4.14.3 to 4.18.8
+== Upgrading from 4.14.3 to 4.14.8
 
 === camel-core
 
 The `org.apache.camel.support.DefaultHeaderFilterStrategy` changed default setting for lowercase from `false` to `true`.
+
+=== camel-jms
+
+JMS `ObjectMessage` support is now disabled by default. Java object serialization is a recurring source
+of security issues, and Camel JMS routes rarely use `ObjectMessage` in practice. The component will now
+refuse to create or read `jakarta.jms.ObjectMessage` instances unless the new `objectMessageEnabled`
+option is explicitly set to `true`.
+
+This affects the following endpoint/component options that rely on `ObjectMessage` internally:
+
+* `jmsMessageType=Object` (or sending a `Serializable` body that is auto-detected as `Object`)
+* `transferExchange=true`
+* `transferException=true`
+* receiving a JMS `ObjectMessage` produced by an external sender
+
+To restore the previous behavior, enable the option at the component or endpoint level:
+
+[source,properties]
+----
+camel.component.jms.objectMessageEnabled=true
+----
+
+Or, on a single endpoint:
+
+[source,text]
+----
+jms:queue:foo?objectMessageEnabled=true
+----
+
+=== camel-hazelcast
+
+Hazelcast instances created and managed by Camel (when no user-supplied
+`Config` or `HazelcastInstance` is provided) now apply a default
+`JavaSerializationFilterConfig` on the `SerializationConfig` of the
+`Config` built by Camel. The default whitelists the class name prefixes
+`java.`, `javax.`, `org.apache.camel.` and blacklists `java.net.`.
+
+This affects:
+
+* `camel-hazelcast` component endpoints when neither `hazelcastInstance`,
+`hazelcastConfigUri`, nor a referenced `Config` is supplied
+* `HazelcastAggregationRepository` and `HazelcastIdempotentRepository`
+when no `hazelcastInstance` is supplied
+* `HazelcastUtil#newInstance()` (no-arg)
+
+A user-supplied `JavaSerializationFilterConfig` (set on the
+`SerializationConfig` of a `Config` provided via `hazelcastConfigUri`, a
+referenced `Config` bean, or already wired into a pre-built
+`HazelcastInstance`) is respected and is not overwritten.
+
+Applications that store classes outside the default whitelist on a
+Hazelcast topic, queue, map, list, set, or in one of the repositories
+above must provide their own `Config` with a
+`JavaSerializationFilterConfig` configured for their class names.
 
 == Upgrading from 4.14.2 to 4.14.3
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -17,6 +17,60 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 
 The `org.apache.camel.support.DefaultHeaderFilterStrategy` changed default setting for lowercase from `false` to `true`.
 
+=== camel-jms
+
+JMS `ObjectMessage` support is now disabled by default. Java object serialization is a recurring source
+of security issues, and Camel JMS routes rarely use `ObjectMessage` in practice. The component will now
+refuse to create or read `jakarta.jms.ObjectMessage` instances unless the new `objectMessageEnabled`
+option is explicitly set to `true`.
+
+This affects the following endpoint/component options that rely on `ObjectMessage` internally:
+
+* `jmsMessageType=Object` (or sending a `Serializable` body that is auto-detected as `Object`)
+* `transferExchange=true`
+* `transferException=true`
+* receiving a JMS `ObjectMessage` produced by an external sender
+
+To restore the previous behavior, enable the option at the component or endpoint level:
+
+[source,properties]
+----
+camel.component.jms.objectMessageEnabled=true
+----
+
+Or, on a single endpoint:
+
+[source,text]
+----
+jms:queue:foo?objectMessageEnabled=true
+----
+
+=== camel-hazelcast
+
+Hazelcast instances created and managed by Camel (when no user-supplied
+`Config` or `HazelcastInstance` is provided) now apply a default
+`JavaSerializationFilterConfig` on the `SerializationConfig` of the
+`Config` built by Camel. The default whitelists the class name prefixes
+`java.`, `javax.`, `org.apache.camel.` and blacklists `java.net.`.
+
+This affects:
+
+* `camel-hazelcast` component endpoints when neither `hazelcastInstance`,
+`hazelcastConfigUri`, nor a referenced `Config` is supplied
+* `HazelcastAggregationRepository` and `HazelcastIdempotentRepository`
+when no `hazelcastInstance` is supplied
+* `HazelcastUtil#newInstance()` (no-arg)
+
+A user-supplied `JavaSerializationFilterConfig` (set on the
+`SerializationConfig` of a `Config` provided via `hazelcastConfigUri`, a
+referenced `Config` bean, or already wired into a pre-built
+`HazelcastInstance`) is respected and is not overwritten.
+
+Applications that store classes outside the default whitelist on a
+Hazelcast topic, queue, map, list, set, or in one of the repositories
+above must provide their own `Config` with a
+`JavaSerializationFilterConfig` configured for their class names.
+
 == Upgrading from 4.18.0 to 4.18.1
 
 === camel-bom


### PR DESCRIPTION
## Summary

The 4.18 and 4.14 upgrade guides on \`main\` had drifted out of sync with their counterparts on the maintenance branches. Backport PRs for CAMEL-23373 (camel-jms) and CAMEL-23414 (camel-hazelcast) updated only the maintenance branches; the entries never made it back to \`main\`'s copies.

This PR adds the missing entries so the canonical upgrade guides on \`main\` reflect what actually shipped (or is shipping) in 4.18.3 and 4.14.8.

## Changes

### \`camel-4x-upgrade-guide-4_18.adoc\` (under \"Upgrading from 4.18.1 to 4.18.3\")

- Add \`=== camel-jms\` (CAMEL-23373, on camel-4.18.x via #22866 / 844bbf8)
- Add \`=== camel-hazelcast\` (CAMEL-23414, on camel-4.18.x via #22946 / 5caf436)
- Existing \`=== camel-core\` (DefaultHeaderFilterStrategy lowercase) preserved
- Section title kept as-is (not aligned with the maintenance branch's \"4.18.2 to 4.18.3\")

### \`camel-4x-upgrade-guide-4_14.adoc\` (under section for 4.14.8)

- Fix typo: section title \`Upgrading from 4.14.3 to 4.18.8\` → \`Upgrading from 4.14.3 to 4.14.8\`
- Add \`=== camel-jms\` (CAMEL-23373, on camel-4.14.x via #22920 / 75d7991)
- Add \`=== camel-hazelcast\` (CAMEL-23414, on camel-4.14.x via #22955 / 974a11b)
- Existing \`=== camel-core\` preserved

## Not included

- \`camel-sjms / camel-sjms2\` (CAMEL-23409) is **intentionally omitted** for the 4.18.3 entry: PR #22968 (the 4.18.x backport) is still open. A follow-up will add it once that lands.
- Other doc divergences on the 4.14.5/4.14.6/etc sections are out of scope; this PR only catches up on the 4.18.3 and 4.14.8 sections.

## Test plan

Documentation-only change. No build verification needed beyond the AsciiDoc preview.

---

_Claude Code on behalf of Andrea Cosentino_