### PR TITLE
CAMEL-23426: Use JsonArray instead of ArrayList in dev console JSON responses

### DIFF
--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/BlockedConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/BlockedConsole.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.AsyncProcessorAwaitManager;
@@ -25,6 +23,7 @@ import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 
 @DevConsole(name = "blocked", displayName = "Blocked Exchanges", description = "Display blocked exchanges")
@@ -56,7 +55,7 @@ public class BlockedConsole extends AbstractDevConsole {
         AsyncProcessorAwaitManager am = PluginHelper.getAsyncProcessorAwaitManager(getCamelContext());
         root.put("blocked", am.size());
 
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
         for (AsyncProcessorAwaitManager.AwaitThread at : am.browse()) {
             JsonObject props = new JsonObject();
             props.put("exchangeId", at.getExchange().getExchangeId());

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/CircuitBreakerDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/CircuitBreakerDevConsole.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.Route;
@@ -26,6 +24,7 @@ import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.throttling.ThrottlingExceptionRoutePolicy;
 import org.apache.camel.util.TimeUtils;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 
 @DevConsole(name = "circuit-breaker", description = "Display circuit breaker information")
@@ -60,7 +59,7 @@ public class CircuitBreakerDevConsole extends AbstractDevConsole {
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
         JsonObject root = new JsonObject();
 
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
         for (Route route : getCamelContext().getRoutes()) {
             for (RoutePolicy rp : route.getRoutePolicyList()) {
                 if (rp instanceof ThrottlingExceptionRoutePolicy cb) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ConsoleHelper.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ConsoleHelper.java
@@ -28,6 +28,7 @@ import org.apache.camel.support.LoggerHelper;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 
@@ -36,7 +37,7 @@ public final class ConsoleHelper {
     private ConsoleHelper() {
     }
 
-    public static List<JsonObject> loadSourceAsJson(CamelContext camelContext, String location) {
+    public static JsonArray loadSourceAsJson(CamelContext camelContext, String location) {
         if (location == null) {
             return null;
         }
@@ -51,11 +52,11 @@ public final class ConsoleHelper {
             // ignore
         }
 
-        return Collections.EMPTY_LIST;
+        return new JsonArray();
     }
 
-    public static List<JsonObject> loadSourceAsJson(Reader reader, Integer lineNumber) {
-        List<JsonObject> code = new ArrayList<>();
+    public static JsonArray loadSourceAsJson(Reader reader, Integer lineNumber) {
+        JsonArray code = new JsonArray();
         try {
             LineNumberReader lnr = new LineNumberReader(reader);
             int i = 0;

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ConsumerDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ConsumerDevConsole.java
@@ -17,9 +17,7 @@
 package org.apache.camel.impl.console;
 
 import java.lang.management.ManagementFactory;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 
 import javax.management.MBeanServer;
@@ -32,6 +30,7 @@ import org.apache.camel.api.management.mbean.ManagedRouteMBean;
 import org.apache.camel.api.management.mbean.ManagedSchedulePollConsumerMBean;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 
 @DevConsole(name = "consumer", displayName = "Consumers", description = "Display information about Camel consumers")
@@ -132,7 +131,7 @@ public class ConsumerDevConsole extends AbstractDevConsole {
     @Override
     protected JsonObject doCallJson(Map<String, Object> options) {
         final JsonObject root = new JsonObject();
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
         root.put("consumers", list);
 
         ManagedCamelContext mcc = getCamelContext().getCamelContextExtension().getContextPlugin(ManagedCamelContext.class);

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/DebugDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/DebugDevConsole.java
@@ -256,7 +256,7 @@ public class DebugDevConsole extends AbstractDevConsole {
                         String rid = to.getString("routeId");
                         String loc = to.getString("location");
                         if (rid != null) {
-                            List<JsonObject> code = enrichSourceCode(rid, loc, limit);
+                            JsonArray code = enrichSourceCode(rid, loc, limit);
                             if (code != null && !code.isEmpty()) {
                                 to.put("code", code);
                             }
@@ -340,7 +340,7 @@ public class DebugDevConsole extends AbstractDevConsole {
         return arr;
     }
 
-    private List<JsonObject> enrichSourceCode(String routeId, String location, int lines) {
+    private JsonArray enrichSourceCode(String routeId, String location, int lines) {
         Route route = getCamelContext().getRoute(routeId);
         if (route == null) {
             return null;
@@ -350,7 +350,7 @@ public class DebugDevConsole extends AbstractDevConsole {
             return null;
         }
 
-        List<JsonObject> code = new ArrayList<>();
+        JsonArray code = new JsonArray();
 
         location = StringHelper.afterLast(location, ":");
         int line = 0;

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/EndpointDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/EndpointDevConsole.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +26,7 @@ import org.apache.camel.spi.EndpointRegistry;
 import org.apache.camel.spi.RuntimeEndpointRegistry;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 
 @DevConsole(name = "endpoint", displayName = "Endpoints", description = "Endpoint Registry information")
@@ -92,7 +92,7 @@ public class EndpointDevConsole extends AbstractDevConsole {
         root.put("dynamicSize", reg.dynamicSize());
         root.put("maximumCacheSize", reg.getMaximumCacheSize());
 
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
         root.put("endpoints", list);
         Collection<Endpoint> col = reg.getReadOnlyValues();
         for (Endpoint e : col) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ErrorRegistryConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ErrorRegistryConsole.java
@@ -16,9 +16,7 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.ErrorRegistry;
@@ -112,7 +110,7 @@ public class ErrorRegistryConsole extends AbstractDevConsole {
             entries = registry.browse(max);
         }
 
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
         for (ErrorRegistryEntry entry : entries) {
             JsonObject jo = new JsonObject();
             jo.put("exchangeId", entry.exchangeId());

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/InflightConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/InflightConsole.java
@@ -16,14 +16,13 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.InflightRepository;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 
 @DevConsole(name = "inflight", displayName = "Inflight Exchanges", description = "Display inflight exchanges")
@@ -78,7 +77,7 @@ public class InflightConsole extends AbstractDevConsole {
         root.put("inflight", repo.size());
         root.put("inflightBrowseEnabled", repo.isInflightBrowseEnabled());
         if (repo.isInflightBrowseEnabled()) {
-            final List<JsonObject> list = new ArrayList<>();
+            final JsonArray list = new JsonArray();
             for (InflightRepository.InflightExchange ie : repo.browse(filter, max, false)) {
                 JsonObject props = new JsonObject();
                 props.put("exchangeId", ie.getExchange().getExchangeId());

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/MessageHistoryDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/MessageHistoryDevConsole.java
@@ -17,9 +17,7 @@
 package org.apache.camel.impl.console;
 
 import java.io.LineNumberReader;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.Route;
@@ -79,7 +77,7 @@ public class MessageHistoryDevConsole extends AbstractDevConsole {
                     String rid = to.getString("routeId");
                     String loc = to.getString("location");
                     if (rid != null) {
-                        List<JsonObject> code = enrichSourceCode(rid, loc, limit);
+                        JsonArray code = enrichSourceCode(rid, loc, limit);
                         if (code != null && !code.isEmpty()) {
                             to.put("code", code);
                         }
@@ -95,7 +93,7 @@ public class MessageHistoryDevConsole extends AbstractDevConsole {
         return root;
     }
 
-    private List<JsonObject> enrichSourceCode(String routeId, String location, int lines) {
+    private JsonArray enrichSourceCode(String routeId, String location, int lines) {
         Route route = getCamelContext().getRoute(routeId);
         if (route == null) {
             return null;
@@ -105,7 +103,7 @@ public class MessageHistoryDevConsole extends AbstractDevConsole {
             return null;
         }
 
-        List<JsonObject> code = new ArrayList<>();
+        JsonArray code = new JsonArray();
 
         location = StringHelper.afterLast(location, ":");
         int line = 0;

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ProducerDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ProducerDevConsole.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -28,6 +26,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.api.management.mbean.ManagedProducerMBean;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 
 @DevConsole(name = "producer", displayName = "Producers", description = "Display information about Camel producers")
@@ -77,7 +76,7 @@ public class ProducerDevConsole extends AbstractDevConsole {
     @Override
     protected JsonObject doCallJson(Map<String, Object> options) {
         final JsonObject root = new JsonObject();
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
         root.put("producers", list);
 
         MBeanServer mbeanServer = getCamelContext().getManagementStrategy().getManagementAgent().getMBeanServer();

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RestDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RestDevConsole.java
@@ -16,14 +16,13 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.RestRegistry;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 
 @DevConsole(name = "rest", displayName = "Rest", description = "Rest DSL Registry information")
@@ -84,7 +83,7 @@ public class RestDevConsole extends AbstractDevConsole {
         JsonObject root = new JsonObject();
 
         if (rr != null) {
-            List<JsonObject> list = new ArrayList<>();
+            JsonArray list = new JsonArray();
             root.put("rests", list);
 
             for (RestRegistry.RestService rs : rr.listAllRestServices()) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteControllerConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteControllerConsole.java
@@ -16,10 +16,8 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -160,7 +158,7 @@ public class RouteControllerConsole extends AbstractDevConsole {
         boolean includeStacktrace = "true".equals(options.getOrDefault(STACKTRACE, "true"));
 
         JsonObject root = new JsonObject();
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
 
         RouteController rc = getCamelContext().getRouteController();
         if (rc instanceof SupervisingRouteController src) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDevConsole.java
@@ -218,7 +218,7 @@ public class RouteDevConsole extends AbstractDevConsole {
 
         final boolean processors = "true".equals(options.getOrDefault(PROCESSORS, "false"));
         final JsonObject root = new JsonObject();
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
         Function<ManagedRouteMBean, Object> task = mrb -> {
             JsonObject jo = new JsonObject();
             list.add(jo);

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDumpDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDumpDevConsole.java
@@ -19,7 +19,6 @@ package org.apache.camel.impl.console;
 import java.io.LineNumberReader;
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -37,6 +36,7 @@ import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 
@@ -111,7 +111,7 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
         final String uriAsParameters = (String) options.getOrDefault(URI_AS_PARAMETERS, "false");
 
         final JsonObject root = new JsonObject();
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
 
         Function<ManagedRouteMBean, Object> task = mrb -> {
             JsonObject jo = new JsonObject();
@@ -134,7 +134,7 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
                     dump = mrb.dumpRouteAsYaml(true, "true".equals(uriAsParameters), false, true);
                 }
                 if (dump != null) {
-                    List<JsonObject> code;
+                    JsonArray code;
                     if (format == null || "xml".equals(format)) {
                         code = xmlLoadSourceAsJson(new StringReader(dump));
                     } else {
@@ -193,8 +193,8 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
         return o1.getRouteId().compareTo(o2.getRouteId());
     }
 
-    private static List<JsonObject> xmlLoadSourceAsJson(Reader reader) {
-        List<JsonObject> code = new ArrayList<>();
+    private static JsonArray xmlLoadSourceAsJson(Reader reader) {
+        JsonArray code = new JsonArray();
         try {
             LineNumberReader lnr = new LineNumberReader(reader);
             String t;
@@ -226,8 +226,8 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
         return code.isEmpty() ? null : code;
     }
 
-    private static List<JsonObject> yamlLoadSourceAsJson(Reader reader) {
-        List<JsonObject> code = new ArrayList<>();
+    private static JsonArray yamlLoadSourceAsJson(Reader reader) {
+        JsonArray code = new JsonArray();
         try {
             LineNumberReader lnr = new LineNumberReader(reader);
             String t;
@@ -241,7 +241,7 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
                         String idx = StringHelper.after(t, "sourceLineNumber: ").trim();
                         if (!code.isEmpty()) {
                             // assign line number to previous code line
-                            JsonObject c = code.get(code.size() - 1);
+                            JsonObject c = (JsonObject) code.get(code.size() - 1);
                             try {
                                 c.put("line", Integer.parseInt(idx));
                             } catch (NumberFormatException e) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteGroupDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteGroupDevConsole.java
@@ -146,7 +146,7 @@ public class RouteGroupDevConsole extends AbstractDevConsole {
         }
 
         final JsonObject root = new JsonObject();
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
         Function<ManagedRouteGroupMBean, Object> task = mrg -> {
             JsonObject jo = new JsonObject();
             list.add(jo);

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteStructureDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteStructureDevConsole.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -34,6 +33,7 @@ import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StringHelper;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 
@@ -103,7 +103,7 @@ public class RouteStructureDevConsole extends AbstractDevConsole {
         final String brief = (String) options.getOrDefault(BRIEF, "false");
 
         final JsonObject root = new JsonObject();
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
 
         Function<ManagedRouteMBean, Object> task = mrb -> {
             JsonObject jo = new JsonObject();
@@ -122,7 +122,7 @@ public class RouteStructureDevConsole extends AbstractDevConsole {
                 ModelToStructureDumper dumper = PluginHelper.getModelToStructureDumper(getCamelContext());
                 List<ModelDumpLine> lines
                         = dumper.dumpStructure(getCamelContext(), mrb.getRouteId(), "true".equalsIgnoreCase(brief));
-                List<JsonObject> code = dumpAsJSon(lines);
+                JsonArray code = dumpAsJSon(lines);
                 jo.put("code", code);
             } catch (Exception e) {
                 // ignore
@@ -173,8 +173,8 @@ public class RouteStructureDevConsole extends AbstractDevConsole {
         return o1.getRouteId().compareTo(o2.getRouteId());
     }
 
-    private static List<JsonObject> dumpAsJSon(List<ModelDumpLine> lines) {
-        List<JsonObject> code = new ArrayList<>();
+    private static JsonArray dumpAsJSon(List<ModelDumpLine> lines) {
+        JsonArray code = new JsonArray();
         int counter = 0;
         for (var line : lines) {
             counter++;

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ServiceDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ServiceDevConsole.java
@@ -16,14 +16,13 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.EndpointServiceRegistry;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.URISupport;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 
 @DevConsole(name = "service", displayName = "Services", description = "Services used for network communication with clients")
@@ -62,7 +61,7 @@ public class ServiceDevConsole extends AbstractDevConsole {
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
         JsonObject root = new JsonObject();
 
-        List<JsonObject> list = new ArrayList<>();
+        JsonArray list = new JsonArray();
         root.put("services", list);
 
         EndpointServiceRegistry esr = getCamelContext().getCamelContextExtension().getEndpointServiceRegistry();

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/SourceDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/SourceDevConsole.java
@@ -17,7 +17,6 @@
 package org.apache.camel.impl.console;
 
 import java.io.LineNumberReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,6 +34,7 @@ import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 
 @DevConsole(name = "source", description = "Dump route source code")
@@ -104,7 +104,7 @@ public class SourceDevConsole extends AbstractDevConsole {
     @Override
     protected JsonObject doCallJson(Map<String, Object> options) {
         final JsonObject root = new JsonObject();
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
 
         Function<ManagedRouteMBean, Object> task = mrb -> {
             JsonObject jo = new JsonObject();
@@ -117,7 +117,7 @@ public class SourceDevConsole extends AbstractDevConsole {
             }
 
             String loc = mrb.getSourceLocation();
-            List<JsonObject> code = ConsoleHelper.loadSourceAsJson(getCamelContext(), loc);
+            JsonArray code = ConsoleHelper.loadSourceAsJson(getCamelContext(), loc);
             if (code != null) {
                 jo.put("code", code);
             }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/TopDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/TopDevConsole.java
@@ -39,6 +39,7 @@ import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.TimeUtils;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 
@@ -167,7 +168,7 @@ public class TopDevConsole extends AbstractDevConsole {
         final int max = limit == null ? Integer.MAX_VALUE : Integer.parseInt(limit);
 
         final JsonObject root = new JsonObject();
-        final List<JsonObject> list = new ArrayList<>();
+        final JsonArray list = new JsonArray();
 
         ManagedCamelContext mcc = getCamelContext().getCamelContextExtension().getContextPlugin(ManagedCamelContext.class);
         if (mcc != null) {
@@ -197,7 +198,7 @@ public class TopDevConsole extends AbstractDevConsole {
                     jo.put("routeId", mpb.getRouteId());
                     jo.put("processorId", mpb.getProcessorId());
                     String loc = mpb.getSourceLocation();
-                    List<JsonObject> code = new ArrayList<>();
+                    JsonArray code = new JsonArray();
                     if (loc != null && mpb.getSourceLineNumber() != null) {
                         int line = mpb.getSourceLineNumber();
                         try {

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/ConsoleHelperTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/ConsoleHelperTest.java
@@ -18,8 +18,8 @@ package org.apache.camel.impl.console;
 
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.List;
 
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -55,21 +55,21 @@ public class ConsoleHelperTest {
         String source = "line one\nline two\nline three";
         StringReader reader = new StringReader(source);
 
-        List<JsonObject> result = ConsoleHelper.loadSourceAsJson(reader, 2);
+        JsonArray result = ConsoleHelper.loadSourceAsJson(reader, 2);
         Assertions.assertNotNull(result);
         Assertions.assertEquals(3, result.size());
 
-        JsonObject line1 = result.get(0);
+        JsonObject line1 = (JsonObject) result.get(0);
         Assertions.assertEquals(1, line1.getInteger("line"));
         Assertions.assertEquals("line one", line1.getString("code"));
         Assertions.assertNull(line1.get("match"));
 
-        JsonObject line2 = result.get(1);
+        JsonObject line2 = (JsonObject) result.get(1);
         Assertions.assertEquals(2, line2.getInteger("line"));
         Assertions.assertEquals("line two", line2.getString("code"));
         Assertions.assertTrue(line2.getBoolean("match"));
 
-        JsonObject line3 = result.get(2);
+        JsonObject line3 = (JsonObject) result.get(2);
         Assertions.assertEquals(3, line3.getInteger("line"));
         Assertions.assertEquals("line three", line3.getString("code"));
         Assertions.assertNull(line3.get("match"));
@@ -80,12 +80,13 @@ public class ConsoleHelperTest {
         String source = "line one\nline two";
         StringReader reader = new StringReader(source);
 
-        List<JsonObject> result = ConsoleHelper.loadSourceAsJson(reader, null);
+        JsonArray result = ConsoleHelper.loadSourceAsJson(reader, null);
         Assertions.assertNotNull(result);
         Assertions.assertEquals(2, result.size());
 
         // No match should be set when lineNumber is null
-        for (JsonObject jo : result) {
+        for (Object obj : result) {
+            JsonObject jo = (JsonObject) obj;
             Assertions.assertNull(jo.get("match"));
         }
     }
@@ -94,14 +95,14 @@ public class ConsoleHelperTest {
     public void testLoadSourceAsJsonFromReaderEmpty() {
         StringReader reader = new StringReader("");
 
-        List<JsonObject> result = ConsoleHelper.loadSourceAsJson(reader, 1);
+        JsonArray result = ConsoleHelper.loadSourceAsJson(reader, 1);
         Assertions.assertNull(result);
     }
 
     @Test
     public void testLoadSourceAsJsonNullReader() {
         Reader nullReader = null;
-        List<JsonObject> result = ConsoleHelper.loadSourceAsJson(nullReader, 1);
+        JsonArray result = ConsoleHelper.loadSourceAsJson(nullReader, 1);
         Assertions.assertNull(result);
     }
 }

--- a/dsl/camel-jbang/camel-jbang-console/src/main/java/org/apache/camel/jbang/console/SourceDirDevConsole.java
+++ b/dsl/camel-jbang/camel-jbang-console/src/main/java/org/apache/camel/jbang/console/SourceDirDevConsole.java
@@ -154,7 +154,7 @@ public class SourceDirDevConsole extends AbstractDevConsole {
                                 jo.put("lastModified", Files.getLastModifiedTime(f).toMillis());
                                 if ("true".equals(source)) {
                                     try (Reader fileReader = Files.newBufferedReader(f, StandardCharsets.UTF_8)) {
-                                        List<JsonObject> code = ConsoleHelper.loadSourceAsJson(fileReader, null);
+                                        JsonArray code = ConsoleHelper.loadSourceAsJson(fileReader, null);
                                         if (code != null) {
                                             jo.put("code", code);
                                         }


### PR DESCRIPTION
[CAMEL-23426](https://issues.apache.org/jira/browse/CAMEL-23426)

## Summary

- Consistently use `JsonArray` instead of `ArrayList` for JSON array values in dev console responses
- Fixes `ClassCastException` when consumers (such as `DiagramDevConsole` in #22958) cast the collection to `JsonArray`
- Updated 19 console classes and 1 test class in `core/camel-console`
- Also fixes helper methods (`ConsoleHelper.loadSourceAsJson`, `RouteDumpDevConsole.xmlLoadSourceAsJson`/`yamlLoadSourceAsJson`, `RouteStructureDevConsole.dumpAsJSon`, etc.) to return `JsonArray` instead of `List<JsonObject>`

## Test plan

- [x] All 121 existing `camel-console` tests pass
- [x] Code formatted with `mvn formatter:format impsort:sort`