### PR TITLE
chore: add .omc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ mvnd.zip*
 .mvn/.develocity/develocity-workspace-id
 backlog
 .claude
+.omc


### PR DESCRIPTION
Add `.omc` directory (oh-my-claudecode state files) to `.gitignore`, similar to the existing `.claude` entry.