### PR TITLE
CAMEL-23429: Fix flaky TimerRouteAutoConfigIT in camel-opentelemetry-metrics

### DIFF
--- a/components/camel-opentelemetry-metrics/src/test/java/org/apache/camel/opentelemetry/metrics/integration/TimerRouteAutoConfigIT.java
+++ b/components/camel-opentelemetry-metrics/src/test/java/org/apache/camel/opentelemetry/metrics/integration/TimerRouteAutoConfigIT.java
@@ -91,32 +91,31 @@ public class TimerRouteAutoConfigIT extends CamelTestSupport {
         mockEndpoint.expectedBodiesReceived(body);
         template.sendBody("direct:in1", body);
 
-        // capture logs from the LoggingMetricExporter
-        await().atMost(Duration.ofMillis(1000L)).until(handler::hasLogs);
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            List<LogRecord> logs = new ArrayList<>(handler.getLogs());
+            assertFalse(logs.isEmpty(), "No metrics were exported");
 
-        List<LogRecord> logs = new ArrayList<>(handler.getLogs());
-        assertFalse(logs.isEmpty(), "No metrics were exported");
-
-        long dataCount = logs.stream()
-                .map(LogRecord::getParameters)
-                .filter(Objects::nonNull)
-                .flatMap(Arrays::stream)
-                .filter(MetricData.class::isInstance)
-                .map(MetricData.class::cast)
-                .filter(md -> "A".equals(md.getName()))
-                .peek(md -> {
-                    PointData pd = md.getData()
-                            .getPoints()
-                            .stream()
-                            .findFirst()
-                            .orElseThrow();
-                    assertInstanceOf(HistogramPointData.class, pd, "Expected HistogramPointData");
-                    HistogramPointData hpd = (HistogramPointData) pd;
-                    assertEquals(1L, hpd.getCount());
-                    assertTrue(hpd.getMin() >= DELAY);
-                })
-                .count();
-        assertTrue(dataCount > 0, "No metric data found with name A");
+            long dataCount = logs.stream()
+                    .map(LogRecord::getParameters)
+                    .filter(Objects::nonNull)
+                    .flatMap(Arrays::stream)
+                    .filter(MetricData.class::isInstance)
+                    .map(MetricData.class::cast)
+                    .filter(md -> "A".equals(md.getName()))
+                    .peek(md -> {
+                        PointData pd = md.getData()
+                                .getPoints()
+                                .stream()
+                                .findFirst()
+                                .orElseThrow();
+                        assertInstanceOf(HistogramPointData.class, pd, "Expected HistogramPointData");
+                        HistogramPointData hpd = (HistogramPointData) pd;
+                        assertEquals(1L, hpd.getCount());
+                        assertTrue(hpd.getMin() >= DELAY);
+                    })
+                    .count();
+            assertTrue(dataCount > 0, "No metric data found with name A");
+        });
         MockEndpoint.assertIsSatisfied(context);
     }
 


### PR DESCRIPTION
[CAMEL-23429](https://issues.apache.org/jira/browse/CAMEL-23429)

The `TimerRouteAutoConfigIT.testOverrideMetricsName` test is flaky because it waits for **any** log record from the `LoggingMetricExporter`, then immediately asserts that metric "A" is present. However, the first export batch (at 300ms interval) may not include the "A" metric if the route hasn't finished processing yet.

**Fix:** Move the entire metric assertion inside `await().untilAsserted()` with a 5-second timeout, so the test keeps polling until metric "A" actually appears in the exported data rather than failing on the first export batch.

_Claude Code on behalf of Guillaume Nodet_