### PR TITLE
CAMEL-23427: Fix flaky SpanPropagationUpstreamTest in camel-telemetry-dev

### DIFF
--- a/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/TelemetryDevTracerTestSupport.java
+++ b/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/TelemetryDevTracerTestSupport.java
@@ -31,7 +31,7 @@ import org.apache.camel.test.junit6.ExchangeTestSupport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public class TelemetryDevTracerTestSupport extends ExchangeTestSupport {
 
@@ -61,7 +61,7 @@ public class TelemetryDevTracerTestSupport extends ExchangeTestSupport {
      * This one is required to rollover the log traces database file and make sure each test has its own
      * set of fresh data.
      */
-    @AfterEach
+    @BeforeEach
     public synchronized void clearLogTraces() throws IOException {
         final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
         RollingFileAppender appender = (RollingFileAppender) ctx.getConfiguration().getAppenders().get("file2");


### PR DESCRIPTION
[CAMEL-23427](https://issues.apache.org/jira/browse/CAMEL-23427)

Change `clearLogTraces()` from `@AfterEach` to `@BeforeEach` to ensure the trace log file is rolled over **before** each test runs, not after.

**Root cause:** In JUnit 5, subclass `@AfterEach` methods run before superclass `@AfterEach`. This means `TelemetryDevTracerTestSupport.clearLogTraces()` (rollover) executes before `CamelTestSupport.tearDown()` (context stop). Any trace output emitted during context shutdown is written to the new clean log file and picked up by the next test as a stale trace, causing `assertEquals(1, traces.size())` to fail with 2.

**Fix:** Rolling over `@BeforeEach` guarantees a clean log file regardless of what the previous test's shutdown did.