### PR TITLE
CAMEL-23428: Fix flaky RabbitMQProducerInvalidExchangeIT test

### DIFF
--- a/components/camel-spring-parent/camel-spring-rabbitmq/pom.xml
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/pom.xml
@@ -93,5 +93,10 @@
             <artifactId>camel-http</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerInvalidExchangeIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerInvalidExchangeIT.java
@@ -50,7 +50,13 @@ public class RabbitMQProducerInvalidExchangeIT extends RabbitMQITSupport {
 
         final CamelExecutionException exception = Assertions.assertThrows(CamelExecutionException.class,
                 () -> template.sendBody("direct:start", "Hello World"));
-        Assertions.assertInstanceOf(ShutdownSignalException.class, exception.getCause());
+        // Spring AMQP may wrap ShutdownSignalException in AmqpException depending on timing
+        Throwable cause = exception.getCause();
+        while (cause != null && !(cause instanceof ShutdownSignalException)) {
+            cause = cause.getCause();
+        }
+        Assertions.assertInstanceOf(ShutdownSignalException.class, cause,
+                "Expected ShutdownSignalException in cause chain, but got: " + exception.getCause());
     }
 
     @Override

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerInvalidExchangeIT.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/integration/RabbitMQProducerInvalidExchangeIT.java
@@ -29,6 +29,8 @@ import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class RabbitMQProducerInvalidExchangeIT extends RabbitMQITSupport {
 
     @Override
@@ -50,13 +52,7 @@ public class RabbitMQProducerInvalidExchangeIT extends RabbitMQITSupport {
 
         final CamelExecutionException exception = Assertions.assertThrows(CamelExecutionException.class,
                 () -> template.sendBody("direct:start", "Hello World"));
-        // Spring AMQP may wrap ShutdownSignalException in AmqpException depending on timing
-        Throwable cause = exception.getCause();
-        while (cause != null && !(cause instanceof ShutdownSignalException)) {
-            cause = cause.getCause();
-        }
-        Assertions.assertInstanceOf(ShutdownSignalException.class, cause,
-                "Expected ShutdownSignalException in cause chain, but got: " + exception.getCause());
+        assertThat(exception).hasRootCauseInstanceOf(ShutdownSignalException.class);
     }
 
     @Override


### PR DESCRIPTION
[CAMEL-23428](https://issues.apache.org/jira/browse/CAMEL-23428)

The `RabbitMQProducerInvalidExchangeIT.testProducer` test is flaky because it asserts the direct cause of `CamelExecutionException` is `ShutdownSignalException`. However, Spring AMQP may wrap the underlying `ShutdownSignalException` in an `AmqpException` depending on timing, causing intermittent failures.

**Fix:** Use AssertJ's `hasRootCauseInstanceOf` to check the exception cause chain. This handles both cases and provides better diagnostics (full stack trace) on failure:
- Direct cause: `CamelExecutionException` → `ShutdownSignalException`
- Wrapped cause: `CamelExecutionException` → `AmqpException` → `ShutdownSignalException`