### PR TITLE
CAMEL-22525: Fix flaky AS2 tests by eliminating port allocation race condition

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2AsyncMDNServerConnection.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2AsyncMDNServerConnection.java
@@ -72,6 +72,10 @@ public class AS2AsyncMDNServerConnection {
         listenerThread.start();
     }
 
+    public int getLocalPort() {
+        return listenerThread != null ? listenerThread.serverSocket.getLocalPort() : -1;
+    }
+
     public void close() {
         if (listenerThread != null) {
             lock.lock();

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2ServerConnection.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2ServerConnection.java
@@ -639,6 +639,10 @@ public class AS2ServerConnection {
         consumerConfigurations.put(path, config);
     }
 
+    public int getLocalPort() {
+        return serversocket != null ? serversocket.getLocalPort() : -1;
+    }
+
     public void close() {
         if (acceptorThread != null) {
             lock.lock();

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2AsyncMDNServerConnectionTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2AsyncMDNServerConnectionTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.component.as2.api;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpException;
@@ -28,19 +27,18 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class AS2AsyncMDNServerConnectionTest {
 
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
     private AS2AsyncMDNServerConnection connection;
+    private int port;
 
     @BeforeEach
     void setUp() throws Exception {
-        connection = new AS2AsyncMDNServerConnection(port.getPort(), null);
+        connection = new AS2AsyncMDNServerConnection(0, null);
+        port = connection.getLocalPort();
     }
 
     @AfterEach
@@ -69,7 +67,7 @@ class AS2AsyncMDNServerConnectionTest {
         // Send a request with a Host header that doesn't match the server's hostname
         // This previously caused HTTP 421 due to RequestValidateHost
         HttpURLConnection conn
-                = (HttpURLConnection) new URL("http://localhost:" + port.getPort() + "/test-mdn").openConnection();
+                = (HttpURLConnection) new URL("http://localhost:" + port + "/test-mdn").openConnection();
         conn.setRequestMethod("POST");
         conn.setRequestProperty("Host", "different-host.example.com");
         conn.setDoOutput(true);

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTest.java
@@ -85,9 +85,11 @@ public class AS2MessageTest extends AS2MessageTestBase {
         setupKeysAndCertificates();
 
         testServer = new AS2ServerConnection(
-                AS2_VERSION, "MyServer-HTTP/1.1", SERVER_FQDN, TARGET_PORT.getPort(), AS2SignatureAlgorithm.SHA256WITHRSA,
+                AS2_VERSION, "MyServer-HTTP/1.1", SERVER_FQDN, 0, AS2SignatureAlgorithm.SHA256WITHRSA,
                 certList.toArray(new Certificate[0]), signingKP.getPrivate(), decryptingKP.getPrivate(), MDN_MESSAGE_TEMPLATE,
                 VALIDATE_SIGNING_CERTIFICATE_CHAIN, null, null, null, null);
+        TARGET_PORT = testServer.getLocalPort();
+        RECIPIENT_DELIVERY_ADDRESS = "http://localhost:" + TARGET_PORT + "/handle-receipts";
         testServer.listen("*", new HttpRequestHandler() {
             @Override
             public void handle(ClassicHttpRequest request, ClassicHttpResponse response, HttpContext context)

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTest.java
@@ -88,8 +88,8 @@ public class AS2MessageTest extends AS2MessageTestBase {
                 AS2_VERSION, "MyServer-HTTP/1.1", SERVER_FQDN, 0, AS2SignatureAlgorithm.SHA256WITHRSA,
                 certList.toArray(new Certificate[0]), signingKP.getPrivate(), decryptingKP.getPrivate(), MDN_MESSAGE_TEMPLATE,
                 VALIDATE_SIGNING_CERTIFICATE_CHAIN, null, null, null, null);
-        TARGET_PORT = testServer.getLocalPort();
-        RECIPIENT_DELIVERY_ADDRESS = "http://localhost:" + TARGET_PORT + "/handle-receipts";
+        targetPort = testServer.getLocalPort();
+        recipientDeliveryAddress = "http://localhost:" + targetPort + "/handle-receipts";
         testServer.listen("*", new HttpRequestHandler() {
             @Override
             public void handle(ClassicHttpRequest request, ClassicHttpResponse response, HttpContext context)
@@ -137,7 +137,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -206,7 +206,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -264,7 +264,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT,
+        assertEquals(TARGET_HOST + ":" + targetPort,
                 request.getFirstHeader(AS2Header.TARGET_HOST).getValue(), "Unexpected target host value");
         assertEquals(USER_AGENT,
                 request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
@@ -377,7 +377,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
                 null, "Got ya message!", null);
 
         // Send MDN
-        HttpCoreContext httpContext = mdnManager.send(mdn, mdn.getMainMessageContentType(), RECIPIENT_DELIVERY_ADDRESS);
+        HttpCoreContext httpContext = mdnManager.send(mdn, mdn.getMainMessageContentType(), recipientDeliveryAddress);
         HttpRequest mndRequest = httpContext.getRequest();
         Arrays.stream(request.getHeaders(AS2Header.CONTENT_DISPOSITION)).forEach(h -> LOG.debug("{}", h));
         DispositionNotificationMultipartReportEntity reportEntity
@@ -442,7 +442,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -516,7 +516,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -670,7 +670,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -737,7 +737,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTestBase.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTestBase.java
@@ -84,13 +84,13 @@ public class AS2MessageTestBase {
 
     protected static final String METHOD = "POST";
     protected static final String TARGET_HOST = "localhost";
-    protected static int TARGET_PORT;
+    protected static int targetPort;
     protected static final Duration HTTP_SOCKET_TIMEOUT = Duration.ofSeconds(5);
     protected static final Duration HTTP_CONNECTION_TIMEOUT = Duration.ofSeconds(5);
     protected static final Integer HTTP_CONNECTION_POOL_SIZE = 5;
     protected static final Duration HTTP_CONNECTION_POOL_TTL = Duration.ofMinutes(15);
     protected static final Certificate[] VALIDATE_SIGNING_CERTIFICATE_CHAIN = null;
-    protected static String RECIPIENT_DELIVERY_ADDRESS;
+    protected static String recipientDeliveryAddress;
     protected static final String AS2_VERSION = "1.1";
     protected static final String USER_AGENT = "Camel AS2 Endpoint";
     protected static final String REQUEST_URI = "/";
@@ -171,7 +171,7 @@ public class AS2MessageTestBase {
         aSettings.setSenderData(AS2_NAME, FROM, "openas2a_alias");
 
         // Fixed receiver
-        aSettings.setReceiverData(AS2_NAME, "openas2b_alias", "http://" + TARGET_HOST + ":" + TARGET_PORT + "/");
+        aSettings.setReceiverData(AS2_NAME, "openas2b_alias", "http://" + TARGET_HOST + ":" + targetPort + "/");
         aSettings.setReceiverCertificate(issueCert);
 
         // AS2 stuff
@@ -217,7 +217,7 @@ public class AS2MessageTestBase {
         aSettings.setSenderData(AS2_NAME, FROM, "openas2a_alias");
 
         // Fixed receiver
-        aSettings.setReceiverData(AS2_NAME, "openas2b_alias", "http://" + TARGET_HOST + ":" + TARGET_PORT + "/");
+        aSettings.setReceiverData(AS2_NAME, "openas2b_alias", "http://" + TARGET_HOST + ":" + targetPort + "/");
         aSettings.setReceiverCertificate(issueCert);
 
         // AS2 stuff
@@ -252,7 +252,7 @@ public class AS2MessageTestBase {
     protected AS2ClientManager createDefaultClientManager() throws IOException {
         AS2ClientConnection clientConnection = new AS2ClientConnection(
                 AS2_VERSION, USER_AGENT, CLIENT_FQDN,
-                TARGET_HOST, TARGET_PORT, HTTP_SOCKET_TIMEOUT, HTTP_CONNECTION_TIMEOUT, HTTP_CONNECTION_POOL_SIZE,
+                TARGET_HOST, targetPort, HTTP_SOCKET_TIMEOUT, HTTP_CONNECTION_TIMEOUT, HTTP_CONNECTION_POOL_SIZE,
                 HTTP_CONNECTION_POOL_TTL, null, null);
         return new AS2ClientManager(clientConnection);
     }

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTestBase.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTestBase.java
@@ -43,12 +43,10 @@ import com.helger.as2lib.crypto.ECryptoAlgorithmSign;
 import com.helger.mail.cte.EContentTransferEncoding;
 import com.helger.security.keystore.EKeyStoreType;
 import org.apache.camel.component.as2.api.entity.ApplicationEntity;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.hc.core5.http.protocol.HttpDateGenerator;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -86,14 +84,13 @@ public class AS2MessageTestBase {
 
     protected static final String METHOD = "POST";
     protected static final String TARGET_HOST = "localhost";
-    @RegisterExtension
-    protected static AvailablePortFinder.Port TARGET_PORT = AvailablePortFinder.find();
+    protected static int TARGET_PORT;
     protected static final Duration HTTP_SOCKET_TIMEOUT = Duration.ofSeconds(5);
     protected static final Duration HTTP_CONNECTION_TIMEOUT = Duration.ofSeconds(5);
     protected static final Integer HTTP_CONNECTION_POOL_SIZE = 5;
     protected static final Duration HTTP_CONNECTION_POOL_TTL = Duration.ofMinutes(15);
     protected static final Certificate[] VALIDATE_SIGNING_CERTIFICATE_CHAIN = null;
-    protected static final String RECIPIENT_DELIVERY_ADDRESS = "http://localhost:" + TARGET_PORT.getPort() + "/handle-receipts";
+    protected static String RECIPIENT_DELIVERY_ADDRESS;
     protected static final String AS2_VERSION = "1.1";
     protected static final String USER_AGENT = "Camel AS2 Endpoint";
     protected static final String REQUEST_URI = "/";
@@ -174,7 +171,7 @@ public class AS2MessageTestBase {
         aSettings.setSenderData(AS2_NAME, FROM, "openas2a_alias");
 
         // Fixed receiver
-        aSettings.setReceiverData(AS2_NAME, "openas2b_alias", "http://" + TARGET_HOST + ":" + TARGET_PORT.getPort() + "/");
+        aSettings.setReceiverData(AS2_NAME, "openas2b_alias", "http://" + TARGET_HOST + ":" + TARGET_PORT + "/");
         aSettings.setReceiverCertificate(issueCert);
 
         // AS2 stuff
@@ -220,7 +217,7 @@ public class AS2MessageTestBase {
         aSettings.setSenderData(AS2_NAME, FROM, "openas2a_alias");
 
         // Fixed receiver
-        aSettings.setReceiverData(AS2_NAME, "openas2b_alias", "http://" + TARGET_HOST + ":" + TARGET_PORT.getPort() + "/");
+        aSettings.setReceiverData(AS2_NAME, "openas2b_alias", "http://" + TARGET_HOST + ":" + TARGET_PORT + "/");
         aSettings.setReceiverCertificate(issueCert);
 
         // AS2 stuff
@@ -255,7 +252,7 @@ public class AS2MessageTestBase {
     protected AS2ClientManager createDefaultClientManager() throws IOException {
         AS2ClientConnection clientConnection = new AS2ClientConnection(
                 AS2_VERSION, USER_AGENT, CLIENT_FQDN,
-                TARGET_HOST, TARGET_PORT.getPort(), HTTP_SOCKET_TIMEOUT, HTTP_CONNECTION_TIMEOUT, HTTP_CONNECTION_POOL_SIZE,
+                TARGET_HOST, TARGET_PORT, HTTP_SOCKET_TIMEOUT, HTTP_CONNECTION_TIMEOUT, HTTP_CONNECTION_POOL_SIZE,
                 HTTP_CONNECTION_POOL_TTL, null, null);
         return new AS2ClientManager(clientConnection);
     }

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2UnencryptedMessageTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2UnencryptedMessageTest.java
@@ -63,8 +63,8 @@ public class AS2UnencryptedMessageTest extends AS2MessageTestBase {
                 AS2_VERSION, "MyServer-HTTP/1.1", SERVER_FQDN, 0, AS2SignatureAlgorithm.SHA256WITHRSA,
                 certList.toArray(new Certificate[0]), signingKP.getPrivate(), null, MDN_MESSAGE_TEMPLATE,
                 null, null, null, null, null);
-        TARGET_PORT = testServer.getLocalPort();
-        RECIPIENT_DELIVERY_ADDRESS = "http://localhost:" + TARGET_PORT + "/handle-receipts";
+        targetPort = testServer.getLocalPort();
+        recipientDeliveryAddress = "http://localhost:" + targetPort + "/handle-receipts";
         testServer.listen("*", new HttpRequestHandler() {
             @Override
             public void handle(ClassicHttpRequest request, ClassicHttpResponse response, HttpContext context)
@@ -104,7 +104,7 @@ public class AS2UnencryptedMessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -146,7 +146,7 @@ public class AS2UnencryptedMessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2UnencryptedMessageTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2UnencryptedMessageTest.java
@@ -60,9 +60,11 @@ public class AS2UnencryptedMessageTest extends AS2MessageTestBase {
         setupKeysAndCertificates();
 
         testServer = new AS2ServerConnection(
-                AS2_VERSION, "MyServer-HTTP/1.1", SERVER_FQDN, TARGET_PORT.getPort(), AS2SignatureAlgorithm.SHA256WITHRSA,
+                AS2_VERSION, "MyServer-HTTP/1.1", SERVER_FQDN, 0, AS2SignatureAlgorithm.SHA256WITHRSA,
                 certList.toArray(new Certificate[0]), signingKP.getPrivate(), null, MDN_MESSAGE_TEMPLATE,
                 null, null, null, null, null);
+        TARGET_PORT = testServer.getLocalPort();
+        RECIPIENT_DELIVERY_ADDRESS = "http://localhost:" + TARGET_PORT + "/handle-receipts";
         testServer.listen("*", new HttpRequestHandler() {
             @Override
             public void handle(ClassicHttpRequest request, ClassicHttpResponse response, HttpContext context)

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2AsyncMdnBasicAuthHeaderTest.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2AsyncMdnBasicAuthHeaderTest.java
@@ -53,8 +53,6 @@ public class AS2AsyncMdnBasicAuthHeaderTest extends AbstractAS2ITSupport {
     private static final String MDN_PASSWORD = "rider";
     private static final String MDN_ACCESS_TOKEN = "MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3";
     @RegisterExtension
-    AvailablePortFinder.Port targetPort = AvailablePortFinder.find();
-    @RegisterExtension
     AvailablePortFinder.Port receiptServerPort = AvailablePortFinder.find();
     @RegisterExtension
     AvailablePortFinder.Port jettyPort = AvailablePortFinder.find();
@@ -88,6 +86,7 @@ public class AS2AsyncMdnBasicAuthHeaderTest extends AbstractAS2ITSupport {
             """;
 
     private AS2ServerConnection serverConnection;
+    private int targetPort;
 
     @Override
     public void setupResources() throws Exception {
@@ -186,18 +185,19 @@ public class AS2AsyncMdnBasicAuthHeaderTest extends AbstractAS2ITSupport {
 
     @Override
     protected void customizeConfiguration(AS2Configuration configuration) {
-        configuration.setTargetPortNumber(targetPort.getPort());
+        configuration.setTargetPortNumber(targetPort);
     }
 
     // AS2 server adds Authorization header to MDN returned asynchronously
     private void receiveTestMessages() throws IOException {
         serverConnection = new AS2ServerConnection(
                 "1.1", "AS2ClientManagerIntegrationTest Server",
-                "server.example.com", targetPort.getPort(), AS2SignatureAlgorithm.SHA256WITHRSA,
+                "server.example.com", 0, AS2SignatureAlgorithm.SHA256WITHRSA,
                 null, null, null,
                 "TBD", null, null,
                 // server authorization config
                 MDN_USER_NAME, MDN_PASSWORD, MDN_ACCESS_TOKEN);
+        targetPort = serverConnection.getLocalPort();
         serverConnection.listen("/", new AS2AsyncMDNServerManagerIT.RequestHandler());
     }
 }

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2AsyncMdnTokenAuthHeaderTest.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2AsyncMdnTokenAuthHeaderTest.java
@@ -43,8 +43,6 @@ public class AS2AsyncMdnTokenAuthHeaderTest extends AbstractAS2ITSupport {
 
     private static final String MDN_ACCESS_TOKEN = "MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3";
     @RegisterExtension
-    AvailablePortFinder.Port targetPort = AvailablePortFinder.find();
-    @RegisterExtension
     AvailablePortFinder.Port receiptServerPort = AvailablePortFinder.find();
     private static final String EDI_MESSAGE = """
             UNB+UNOA:1+005435656:1+006415160:1+060515:1434+00000000000778'
@@ -76,6 +74,7 @@ public class AS2AsyncMdnTokenAuthHeaderTest extends AbstractAS2ITSupport {
             """;
 
     private AS2ServerConnection serverConnection;
+    private int targetPort;
 
     @Override
     public void setupResources() throws Exception {
@@ -137,18 +136,19 @@ public class AS2AsyncMdnTokenAuthHeaderTest extends AbstractAS2ITSupport {
 
     @Override
     protected void customizeConfiguration(AS2Configuration configuration) {
-        configuration.setTargetPortNumber(targetPort.getPort());
+        configuration.setTargetPortNumber(targetPort);
     }
 
     // AS2 server adds Authorization header to MDN returned asynchronously
     private void receiveTestMessages() throws IOException {
         serverConnection = new AS2ServerConnection(
                 "1.1", "AS2ClientManagerIntegrationTest Server",
-                "server.example.com", targetPort.getPort(), AS2SignatureAlgorithm.SHA256WITHRSA,
+                "server.example.com", 0, AS2SignatureAlgorithm.SHA256WITHRSA,
                 null, null, null,
                 "TBD", null, null,
                 // server authorization config
                 null, null, MDN_ACCESS_TOKEN);
+        targetPort = serverConnection.getLocalPort();
         serverConnection.listen("/", new AS2AsyncMDNServerManagerIT.RequestHandler());
     }
 }

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2BasicAuthHeaderTest.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2BasicAuthHeaderTest.java
@@ -27,13 +27,11 @@ import org.apache.camel.component.as2.api.*;
 import org.apache.camel.component.as2.api.entity.ApplicationEntity;
 import org.apache.camel.component.as2.api.entity.DispositionNotificationMultipartReportEntity;
 import org.apache.camel.component.as2.api.entity.MimeEntity;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpRequest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -44,8 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 public class AS2BasicAuthHeaderTest extends AbstractAS2ITSupport {
 
-    @RegisterExtension
-    AvailablePortFinder.Port targetPort = AvailablePortFinder.find();
     // Basic Auth takes precedence when auth token also provided
     private static final String USER_NAME = "camel";
     private static final String PASSWORD = "rider";
@@ -80,6 +76,7 @@ public class AS2BasicAuthHeaderTest extends AbstractAS2ITSupport {
             """;
 
     private AS2ServerConnection serverConnection;
+    private int targetPort;
     private AS2ClientManagerIT.RequestHandler requestHandler;
 
     @Override
@@ -193,15 +190,16 @@ public class AS2BasicAuthHeaderTest extends AbstractAS2ITSupport {
 
     @Override
     protected void customizeConfiguration(AS2Configuration configuration) {
-        configuration.setTargetPortNumber(targetPort.getPort());
+        configuration.setTargetPortNumber(targetPort);
     }
 
     private void receiveTestMessages() throws IOException {
         serverConnection = new AS2ServerConnection(
                 "1.1", "AS2ClientManagerIntegrationTest Server",
-                "server.example.com", targetPort.getPort(), AS2SignatureAlgorithm.SHA256WITHRSA,
+                "server.example.com", 0, AS2SignatureAlgorithm.SHA256WITHRSA,
                 null, null, null,
                 "TBD", null, null, null, null, null);
+        targetPort = serverConnection.getLocalPort();
         requestHandler = new AS2ClientManagerIT.RequestHandler();
         serverConnection.listen("/", requestHandler);
     }

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2TokenAuthHeaderTest.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2TokenAuthHeaderTest.java
@@ -25,10 +25,8 @@ import org.apache.camel.component.as2.api.AS2MediaType;
 import org.apache.camel.component.as2.api.AS2MessageStructure;
 import org.apache.camel.component.as2.api.AS2ServerConnection;
 import org.apache.camel.component.as2.api.AS2SignatureAlgorithm;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.hc.core5.http.HttpRequest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -38,8 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 public class AS2TokenAuthHeaderTest extends AbstractAS2ITSupport {
 
-    @RegisterExtension
-    AvailablePortFinder.Port targetPort = AvailablePortFinder.find();
     private static final String ACCESS_TOKEN = "MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3";
     private static final String EDI_MESSAGE = """
             UNB+UNOA:1+005435656:1+006415160:1+060515:1434+00000000000778'
@@ -71,6 +67,7 @@ public class AS2TokenAuthHeaderTest extends AbstractAS2ITSupport {
             """;
 
     private AS2ServerConnection serverConnection;
+    private int targetPort;
     private AS2ClientManagerIT.RequestHandler requestHandler;
 
     @Override
@@ -139,15 +136,16 @@ public class AS2TokenAuthHeaderTest extends AbstractAS2ITSupport {
 
     @Override
     protected void customizeConfiguration(AS2Configuration configuration) {
-        configuration.setTargetPortNumber(targetPort.getPort());
+        configuration.setTargetPortNumber(targetPort);
     }
 
     private void receiveTestMessages() throws IOException {
         serverConnection = new AS2ServerConnection(
                 "1.1", "AS2ClientManagerIntegrationTest Server",
-                "server.example.com", targetPort.getPort(), AS2SignatureAlgorithm.SHA256WITHRSA,
+                "server.example.com", 0, AS2SignatureAlgorithm.SHA256WITHRSA,
                 null, null, null,
                 "TBD", null, null, null, null, null);
+        targetPort = serverConnection.getLocalPort();
         requestHandler = new AS2ClientManagerIT.RequestHandler();
         serverConnection.listen("/", requestHandler);
     }


### PR DESCRIPTION
[CAMEL-22525](https://issues.apache.org/jira/browse/CAMEL-22525)

## Summary

- Add `getLocalPort()` to `AS2ServerConnection` and `AS2AsyncMDNServerConnection` to expose the actual bound port
- Eliminate the TOCTOU race condition in AS2 tests by binding to port 0 (OS assigns a free port atomically) instead of pre-allocating a port with `AvailablePortFinder` which probes then closes a socket, leaving a window for another process to steal the port
- Rename non-final static fields to camelCase (`TARGET_PORT` → `targetPort`, `RECIPIENT_DELIVERY_ADDRESS` → `recipientDeliveryAddress`)

## Root Cause

`AvailablePortFinder.find()` opens a `ServerSocket` on port 0, records the assigned port, then **closes** the socket. When `AS2ServerConnection` later tries to bind to that port, another process may have already claimed it — a classic TOCTOU (time-of-check-to-time-of-use) race condition. This was particularly flaky on s390x CI where multiple processes compete for ports.

The prior fix (SO_REUSEADDR in #22095) helped with TIME_WAIT state but didn't eliminate the fundamental race.

## Fix

Instead of pre-allocating a port number, tests now:
1. Create `AS2ServerConnection` with port **0** — the OS assigns a free port atomically during `bind()`
2. Read the actual port back via the new `getLocalPort()` method
3. Use that port to configure the client

This completely eliminates the race condition since port assignment and binding happen in a single atomic operation.

## Test plan

- [x] All 94 camel-as2-api tests pass
- [x] All 12 camel-as2-component tests pass (1 skipped: manual Mendelson test)
- [x] Code formatted with `mvn formatter:format impsort:sort`