### PR TITLE
CAMEL-23216: Fix flaky mina sftp tests

### DIFF
--- a/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/SftpEmbeddedInfraService.java
+++ b/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/SftpEmbeddedInfraService.java
@@ -20,6 +20,7 @@ package org.apache.camel.test.infra.ftp.services.embedded;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -136,6 +137,23 @@ public class SftpEmbeddedInfraService extends AbstractService implements FtpInfr
         sshd.start();
 
         port = ((InetSocketAddress) sshd.getBoundAddresses().iterator().next()).getPort();
+
+        waitForServerReady();
+    }
+
+    private void waitForServerReady() throws IOException {
+        long deadline = System.nanoTime() + 30_000_000_000L; // 30 seconds
+        IOException lastException = null;
+        while (System.nanoTime() < deadline) {
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress("localhost", port), 1000);
+                return;
+            } catch (IOException e) {
+                lastException = e;
+                Thread.onSpinWait();
+            }
+        }
+        throw new IOException("SFTP server not ready after 30 seconds on port " + port, lastException);
     }
 
     protected PublickeyAuthenticator getPublickeyAuthenticator() {

--- a/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/SftpEmbeddedInfraService.java
+++ b/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/SftpEmbeddedInfraService.java
@@ -28,6 +28,7 @@ import java.security.KeyPair;
 import java.security.PublicKey;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 import org.apache.camel.spi.annotations.InfraService;
@@ -142,7 +143,7 @@ public class SftpEmbeddedInfraService extends AbstractService implements FtpInfr
     }
 
     private void waitForServerReady() throws IOException {
-        long deadline = System.nanoTime() + 30_000_000_000L; // 30 seconds
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
         IOException lastException = null;
         while (System.nanoTime() < deadline) {
             try (Socket socket = new Socket()) {


### PR DESCRIPTION
[CAMEL-23216](https://issues.apache.org/jira/browse/CAMEL-23216)

## Summary

Several mina-sftp integration tests were flaky due to the embedded SFTP server not being fully ready to accept connections when tests started. The server restarts per test (`beforeEach`/`afterEach`), and without a readiness check, tests could attempt SSH connections before the server was listening.

## Changes

- **Add server readiness probe** in `SftpEmbeddedInfraService.setUpServer()` — after starting the embedded SSHD server, verify it accepts TCP connections before returning. Throws `IOException` if the server is not ready within 5 seconds, failing fast with a clear error message instead of proceeding to confusing timeout errors.

## Test plan

- [x] All 26 previously-flaky tests pass (MinaSftpAdvancedFileOperationsIT + MinaSftpAuthenticationIT)
- [x] Full mina-sftp integration test suite passes (249 tests, 0 failures)