### PR TITLE
chore(docs): sync 4.18 and 4.14 upgrade guides with camel-sjms entry

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -45,6 +45,34 @@ Or, on a single endpoint:
 jms:queue:foo?objectMessageEnabled=true
 ----
 
+=== camel-sjms / camel-sjms2
+
+The same default applies to `camel-sjms` (and `camel-sjms2`, which inherits from it): JMS `ObjectMessage`
+support is now disabled by default and gated by a new `objectMessageEnabled` option (default `false`)
+on `SjmsComponent` / `SjmsEndpoint`.
+
+This affects the same endpoint/component options as `camel-jms`:
+
+* `jmsMessageType=Object` (or sending a `Serializable` body that is auto-detected as `Object`)
+* `transferException=true`
+* receiving a JMS `ObjectMessage` produced by an external sender
+
+To restore the previous behavior, enable the option at the component or endpoint level:
+
+[source,properties]
+----
+camel.component.sjms.objectMessageEnabled=true
+camel.component.sjms2.objectMessageEnabled=true
+----
+
+Or, on a single endpoint:
+
+[source,text]
+----
+sjms:queue:foo?objectMessageEnabled=true
+sjms2:queue:foo?objectMessageEnabled=true
+----
+
 === camel-hazelcast
 
 Hazelcast instances created and managed by Camel (when no user-supplied

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -45,6 +45,34 @@ Or, on a single endpoint:
 jms:queue:foo?objectMessageEnabled=true
 ----
 
+=== camel-sjms / camel-sjms2
+
+The same default applies to `camel-sjms` (and `camel-sjms2`, which inherits from it): JMS `ObjectMessage`
+support is now disabled by default and gated by a new `objectMessageEnabled` option (default `false`)
+on `SjmsComponent` / `SjmsEndpoint`.
+
+This affects the same endpoint/component options as `camel-jms`:
+
+* `jmsMessageType=Object` (or sending a `Serializable` body that is auto-detected as `Object`)
+* `transferException=true`
+* receiving a JMS `ObjectMessage` produced by an external sender
+
+To restore the previous behavior, enable the option at the component or endpoint level:
+
+[source,properties]
+----
+camel.component.sjms.objectMessageEnabled=true
+camel.component.sjms2.objectMessageEnabled=true
+----
+
+Or, on a single endpoint:
+
+[source,text]
+----
+sjms:queue:foo?objectMessageEnabled=true
+sjms2:queue:foo?objectMessageEnabled=true
+----
+
 === camel-hazelcast
 
 Hazelcast instances created and managed by Camel (when no user-supplied


### PR DESCRIPTION
## Summary

Follow-up to #22969. CAMEL-23409 (\`camel-sjms\` - Disable ObjectMessage by default) was backported to:
- \`camel-4.18.x\` via #22968 (merged)
- \`camel-4.14.x\` via #22970 (merged)

Both backports updated the upgrade guides on their respective maintenance branches, but the corresponding entry was deferred from #22969 because the backports were still open at that time. This PR closes the loop now that they have landed.

## Changes

Adds \`=== camel-sjms / camel-sjms2\` to:

- \`camel-4x-upgrade-guide-4_18.adoc\` under \"Upgrading from 4.18.1 to 4.18.3\"
- \`camel-4x-upgrade-guide-4_14.adoc\` under \"Upgrading from 4.14.3 to 4.14.8\"

Placed between the existing \`camel-jms\` and \`camel-hazelcast\` entries so the two JMS-related notes sit together.

## Why

Per the project's *Backport upgrade-guide policy* rule (codified in #22969 and the OSS helper rule pack at Open-Harness-Engineering/ai-agents-oss-helper#50), the per-version upgrade guides on \`main\` are the canonical history across all releases and must reflect what shipped on each maintenance branch.

## Test plan

Documentation-only change. No build verification needed.

---

_Claude Code on behalf of Andrea Cosentino_