### PR TITLE
CAMEL-23431: Migrate AS2 tests from AvailablePortFinder to port-0 binding

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2AsyncMDNServerConnection.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2AsyncMDNServerConnection.java
@@ -72,6 +72,10 @@ public class AS2AsyncMDNServerConnection {
         listenerThread.start();
     }
 
+    public int getLocalPort() {
+        return listenerThread != null ? listenerThread.serverSocket.getLocalPort() : -1;
+    }
+
     public void close() {
         if (listenerThread != null) {
             lock.lock();

--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2ServerConnection.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2ServerConnection.java
@@ -639,6 +639,10 @@ public class AS2ServerConnection {
         consumerConfigurations.put(path, config);
     }
 
+    public int getLocalPort() {
+        return serversocket != null ? serversocket.getLocalPort() : -1;
+    }
+
     public void close() {
         if (acceptorThread != null) {
             lock.lock();

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2AsyncMDNServerConnectionTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2AsyncMDNServerConnectionTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.component.as2.api;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpException;
@@ -28,19 +27,18 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class AS2AsyncMDNServerConnectionTest {
 
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
     private AS2AsyncMDNServerConnection connection;
+    private int port;
 
     @BeforeEach
     void setUp() throws Exception {
-        connection = new AS2AsyncMDNServerConnection(port.getPort(), null);
+        connection = new AS2AsyncMDNServerConnection(0, null);
+        port = connection.getLocalPort();
     }
 
     @AfterEach
@@ -69,7 +67,7 @@ class AS2AsyncMDNServerConnectionTest {
         // Send a request with a Host header that doesn't match the server's hostname
         // This previously caused HTTP 421 due to RequestValidateHost
         HttpURLConnection conn
-                = (HttpURLConnection) new URL("http://localhost:" + port.getPort() + "/test-mdn").openConnection();
+                = (HttpURLConnection) new URL("http://localhost:" + port + "/test-mdn").openConnection();
         conn.setRequestMethod("POST");
         conn.setRequestProperty("Host", "different-host.example.com");
         conn.setDoOutput(true);

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTest.java
@@ -85,9 +85,11 @@ public class AS2MessageTest extends AS2MessageTestBase {
         setupKeysAndCertificates();
 
         testServer = new AS2ServerConnection(
-                AS2_VERSION, "MyServer-HTTP/1.1", SERVER_FQDN, TARGET_PORT.getPort(), AS2SignatureAlgorithm.SHA256WITHRSA,
+                AS2_VERSION, "MyServer-HTTP/1.1", SERVER_FQDN, 0, AS2SignatureAlgorithm.SHA256WITHRSA,
                 certList.toArray(new Certificate[0]), signingKP.getPrivate(), decryptingKP.getPrivate(), MDN_MESSAGE_TEMPLATE,
                 VALIDATE_SIGNING_CERTIFICATE_CHAIN, null, null, null, null);
+        targetPort = testServer.getLocalPort();
+        recipientDeliveryAddress = "http://localhost:" + targetPort + "/handle-receipts";
         testServer.listen("*", new HttpRequestHandler() {
             @Override
             public void handle(ClassicHttpRequest request, ClassicHttpResponse response, HttpContext context)
@@ -135,7 +137,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -204,7 +206,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -262,7 +264,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT,
+        assertEquals(TARGET_HOST + ":" + targetPort,
                 request.getFirstHeader(AS2Header.TARGET_HOST).getValue(), "Unexpected target host value");
         assertEquals(USER_AGENT,
                 request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
@@ -375,7 +377,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
                 null, "Got ya message!", null);
 
         // Send MDN
-        HttpCoreContext httpContext = mdnManager.send(mdn, mdn.getMainMessageContentType(), RECIPIENT_DELIVERY_ADDRESS);
+        HttpCoreContext httpContext = mdnManager.send(mdn, mdn.getMainMessageContentType(), recipientDeliveryAddress);
         HttpRequest mndRequest = httpContext.getRequest();
         Arrays.stream(request.getHeaders(AS2Header.CONTENT_DISPOSITION)).forEach(h -> LOG.debug("{}", h));
         DispositionNotificationMultipartReportEntity reportEntity
@@ -440,7 +442,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -514,7 +516,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -668,7 +670,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -735,7 +737,7 @@ public class AS2MessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTestBase.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTestBase.java
@@ -43,12 +43,10 @@ import com.helger.as2lib.crypto.ECryptoAlgorithmSign;
 import com.helger.mail.cte.EContentTransferEncoding;
 import com.helger.security.keystore.EKeyStoreType;
 import org.apache.camel.component.as2.api.entity.ApplicationEntity;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.hc.core5.http.protocol.HttpDateGenerator;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -86,14 +84,13 @@ public class AS2MessageTestBase {
 
     protected static final String METHOD = "POST";
     protected static final String TARGET_HOST = "localhost";
-    @RegisterExtension
-    protected static AvailablePortFinder.Port TARGET_PORT = AvailablePortFinder.find();
+    protected static int targetPort;
     protected static final Duration HTTP_SOCKET_TIMEOUT = Duration.ofSeconds(5);
     protected static final Duration HTTP_CONNECTION_TIMEOUT = Duration.ofSeconds(5);
     protected static final Integer HTTP_CONNECTION_POOL_SIZE = 5;
     protected static final Duration HTTP_CONNECTION_POOL_TTL = Duration.ofMinutes(15);
     protected static final Certificate[] VALIDATE_SIGNING_CERTIFICATE_CHAIN = null;
-    protected static final String RECIPIENT_DELIVERY_ADDRESS = "http://localhost:" + TARGET_PORT.getPort() + "/handle-receipts";
+    protected static String recipientDeliveryAddress;
     protected static final String AS2_VERSION = "1.1";
     protected static final String USER_AGENT = "Camel AS2 Endpoint";
     protected static final String REQUEST_URI = "/";
@@ -174,7 +171,7 @@ public class AS2MessageTestBase {
         aSettings.setSenderData(AS2_NAME, FROM, "openas2a_alias");
 
         // Fixed receiver
-        aSettings.setReceiverData(AS2_NAME, "openas2b_alias", "http://" + TARGET_HOST + ":" + TARGET_PORT.getPort() + "/");
+        aSettings.setReceiverData(AS2_NAME, "openas2b_alias", "http://" + TARGET_HOST + ":" + targetPort + "/");
         aSettings.setReceiverCertificate(issueCert);
 
         // AS2 stuff
@@ -220,7 +217,7 @@ public class AS2MessageTestBase {
         aSettings.setSenderData(AS2_NAME, FROM, "openas2a_alias");
 
         // Fixed receiver
-        aSettings.setReceiverData(AS2_NAME, "openas2b_alias", "http://" + TARGET_HOST + ":" + TARGET_PORT.getPort() + "/");
+        aSettings.setReceiverData(AS2_NAME, "openas2b_alias", "http://" + TARGET_HOST + ":" + targetPort + "/");
         aSettings.setReceiverCertificate(issueCert);
 
         // AS2 stuff
@@ -255,7 +252,7 @@ public class AS2MessageTestBase {
     protected AS2ClientManager createDefaultClientManager() throws IOException {
         AS2ClientConnection clientConnection = new AS2ClientConnection(
                 AS2_VERSION, USER_AGENT, CLIENT_FQDN,
-                TARGET_HOST, TARGET_PORT.getPort(), HTTP_SOCKET_TIMEOUT, HTTP_CONNECTION_TIMEOUT, HTTP_CONNECTION_POOL_SIZE,
+                TARGET_HOST, targetPort, HTTP_SOCKET_TIMEOUT, HTTP_CONNECTION_TIMEOUT, HTTP_CONNECTION_POOL_SIZE,
                 HTTP_CONNECTION_POOL_TTL, null, null);
         return new AS2ClientManager(clientConnection);
     }

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2UnencryptedMessageTest.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2UnencryptedMessageTest.java
@@ -60,9 +60,11 @@ public class AS2UnencryptedMessageTest extends AS2MessageTestBase {
         setupKeysAndCertificates();
 
         testServer = new AS2ServerConnection(
-                AS2_VERSION, "MyServer-HTTP/1.1", SERVER_FQDN, TARGET_PORT.getPort(), AS2SignatureAlgorithm.SHA256WITHRSA,
+                AS2_VERSION, "MyServer-HTTP/1.1", SERVER_FQDN, 0, AS2SignatureAlgorithm.SHA256WITHRSA,
                 certList.toArray(new Certificate[0]), signingKP.getPrivate(), null, MDN_MESSAGE_TEMPLATE,
                 null, null, null, null, null);
+        targetPort = testServer.getLocalPort();
+        recipientDeliveryAddress = "http://localhost:" + targetPort + "/handle-receipts";
         testServer.listen("*", new HttpRequestHandler() {
             @Override
             public void handle(ClassicHttpRequest request, ClassicHttpResponse response, HttpContext context)
@@ -102,7 +104,7 @@ public class AS2UnencryptedMessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -144,7 +146,7 @@ public class AS2UnencryptedMessageTest extends AS2MessageTestBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + TARGET_PORT, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ServerManagerEncryptedIT.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ServerManagerEncryptedIT.java
@@ -60,7 +60,7 @@ public class AS2ServerManagerEncryptedIT extends AS2ServerManagerITBase {
     public void receiveEnvelopedMessageTest() throws Exception {
         AS2ClientConnection clientConnection
                 = new AS2ClientConnection(
-                        AS2_VERSION, USER_AGENT, CLIENT_FQDN, TARGET_HOST, targetPort.getPort(), HTTP_SOCKET_TIMEOUT,
+                        AS2_VERSION, USER_AGENT, CLIENT_FQDN, TARGET_HOST, targetPort, HTTP_SOCKET_TIMEOUT,
                         HTTP_CONNECTION_TIMEOUT, HTTP_CONNECTION_POOL_SIZE, HTTP_CONNECTION_POOL_TTL, clientSslContext,
                         null);
         AS2ClientManager clientManager = new AS2ClientManager(clientConnection);
@@ -96,7 +96,7 @@ public class AS2ServerManagerEncryptedIT extends AS2ServerManagerITBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + targetPort.getPort(), request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -133,7 +133,7 @@ public class AS2ServerManagerEncryptedIT extends AS2ServerManagerITBase {
     public void receiveEnvelopedCompressedAndSignedMessageTest() throws Exception {
         AS2ClientConnection clientConnection
                 = new AS2ClientConnection(
-                        AS2_VERSION, USER_AGENT, CLIENT_FQDN, TARGET_HOST, targetPort.getPort(), HTTP_SOCKET_TIMEOUT,
+                        AS2_VERSION, USER_AGENT, CLIENT_FQDN, TARGET_HOST, targetPort, HTTP_SOCKET_TIMEOUT,
                         HTTP_CONNECTION_TIMEOUT, HTTP_CONNECTION_POOL_SIZE, HTTP_CONNECTION_POOL_TTL, clientSslContext,
                         null);
         AS2ClientManager clientManager = new AS2ClientManager(clientConnection);

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ServerManagerIT.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ServerManagerIT.java
@@ -127,7 +127,7 @@ public class AS2ServerManagerIT extends AS2ServerManagerITBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + targetPort.getPort(), request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -204,7 +204,7 @@ public class AS2ServerManagerIT extends AS2ServerManagerITBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + targetPort.getPort(), request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -242,7 +242,7 @@ public class AS2ServerManagerIT extends AS2ServerManagerITBase {
     private AS2ClientConnection getAs2ClientConnection() throws IOException {
         AS2ClientConnection clientConnection
                 = new AS2ClientConnection(
-                        AS2_VERSION, USER_AGENT, CLIENT_FQDN, TARGET_HOST, targetPort.getPort(), HTTP_SOCKET_TIMEOUT,
+                        AS2_VERSION, USER_AGENT, CLIENT_FQDN, TARGET_HOST, targetPort, HTTP_SOCKET_TIMEOUT,
                         HTTP_CONNECTION_TIMEOUT, HTTP_CONNECTION_POOL_SIZE, HTTP_CONNECTION_POOL_TTL, clientSslContext,
                         null);
         return clientConnection;
@@ -303,7 +303,7 @@ public class AS2ServerManagerIT extends AS2ServerManagerITBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + targetPort.getPort(), request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -382,7 +382,7 @@ public class AS2ServerManagerIT extends AS2ServerManagerITBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + targetPort.getPort(), request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");
@@ -473,7 +473,7 @@ public class AS2ServerManagerIT extends AS2ServerManagerITBase {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + targetPort.getPort(), request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ServerManagerITBase.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ServerManagerITBase.java
@@ -53,7 +53,6 @@ import org.apache.camel.support.jsse.KeyStoreParameters;
 import org.apache.camel.support.jsse.SSLContextParameters;
 import org.apache.camel.support.jsse.SSLContextServerParameters;
 import org.apache.camel.support.jsse.TrustManagersParameters;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpVersion;
@@ -68,7 +67,6 @@ import org.bouncycastle.cert.jcajce.JcaCertStore;
 import org.bouncycastle.cms.jcajce.ZlibExpanderProvider;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -84,8 +82,7 @@ public class AS2ServerManagerITBase extends AbstractAS2ITSupport {
 
     protected static final String METHOD = "POST";
     protected static final String TARGET_HOST = "localhost";
-    @RegisterExtension
-    protected AvailablePortFinder.Port targetPort = AvailablePortFinder.find();
+    protected int targetPort;
     protected static final Duration HTTP_SOCKET_TIMEOUT = Duration.ofSeconds(5);
     protected static final Duration HTTP_CONNECTION_TIMEOUT = Duration.ofSeconds(5);
     protected static final Integer HTTP_CONNECTION_POOL_SIZE = 5;
@@ -144,7 +141,18 @@ public class AS2ServerManagerITBase extends AbstractAS2ITSupport {
 
     @Override
     protected void customizeConfiguration(AS2Configuration configuration) {
-        configuration.setServerPortNumber(targetPort.getPort());
+        configuration.setServerPortNumber(0);
+    }
+
+    @Override
+    protected void doPostSetup() throws Exception {
+        super.doPostSetup();
+        for (var e : context.getEndpoints()) {
+            if (e instanceof AS2Endpoint as2e && as2e.getAS2ServerConnection() != null) {
+                targetPort = as2e.getAS2ServerConnection().getLocalPort();
+                break;
+            }
+        }
     }
 
     @Override
@@ -291,7 +299,7 @@ public class AS2ServerManagerITBase extends AbstractAS2ITSupport {
         assertEquals(AS2_NAME, request.getFirstHeader(AS2Header.AS2_TO).getValue(), "Unexpected AS2 to value");
         assertTrue(request.getFirstHeader(AS2Header.MESSAGE_ID).getValue().endsWith(CLIENT_FQDN + ">"),
                 "Unexpected message id value");
-        assertEquals(TARGET_HOST + ":" + targetPort.getPort(), request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
+        assertEquals(TARGET_HOST + ":" + targetPort, request.getFirstHeader(AS2Header.TARGET_HOST).getValue(),
                 "Unexpected target host value");
         assertEquals(USER_AGENT, request.getFirstHeader(AS2Header.USER_AGENT).getValue(), "Unexpected user agent value");
         assertNotNull(request.getFirstHeader(AS2Header.DATE), "Date value missing");

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ServerSecTestBase.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2ServerSecTestBase.java
@@ -39,7 +39,6 @@ import org.apache.camel.component.as2.api.entity.AS2DispositionType;
 import org.apache.camel.component.as2.api.entity.AS2MessageDispositionNotificationEntity;
 import org.apache.camel.component.as2.api.entity.DispositionNotificationMultipartReportEntity;
 import org.apache.camel.component.as2.api.util.MicUtils;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpEntity;
@@ -49,7 +48,6 @@ import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.protocol.HttpCoreContext;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -59,8 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class AS2ServerSecTestBase extends AbstractAS2ITSupport {
 
     protected static final String TARGET_HOST = "localhost";
-    @RegisterExtension
-    protected AvailablePortFinder.Port targetPort = AvailablePortFinder.find();
+    protected int targetPort;
     protected static final Duration HTTP_SOCKET_TIMEOUT = Duration.ofSeconds(5);
     protected static final Duration HTTP_CONNECTION_TIMEOUT = Duration.ofSeconds(5);
     protected static final Integer HTTP_CONNECTION_POOL_SIZE = 5;
@@ -114,7 +111,18 @@ public class AS2ServerSecTestBase extends AbstractAS2ITSupport {
 
     @Override
     protected void customizeConfiguration(AS2Configuration configuration) {
-        configuration.setServerPortNumber(targetPort.getPort());
+        configuration.setServerPortNumber(0);
+    }
+
+    @Override
+    protected void doPostSetup() throws Exception {
+        super.doPostSetup();
+        for (var e : context.getEndpoints()) {
+            if (e instanceof AS2Endpoint as2e && as2e.getAS2ServerConnection() != null) {
+                targetPort = as2e.getAS2ServerConnection().getLocalPort();
+                break;
+            }
+        }
     }
 
     @Override
@@ -233,7 +241,7 @@ public class AS2ServerSecTestBase extends AbstractAS2ITSupport {
     protected AS2ClientManager clientConnection() throws IOException {
         AS2ClientConnection clientConnection
                 = new AS2ClientConnection(
-                        AS2_VERSION, USER_AGENT, CLIENT_FQDN, TARGET_HOST, targetPort.getPort(), HTTP_SOCKET_TIMEOUT,
+                        AS2_VERSION, USER_AGENT, CLIENT_FQDN, TARGET_HOST, targetPort, HTTP_SOCKET_TIMEOUT,
                         HTTP_CONNECTION_TIMEOUT, HTTP_CONNECTION_POOL_SIZE, HTTP_CONNECTION_POOL_TTL, null,
                         null);
         return new AS2ClientManager(clientConnection);


### PR DESCRIPTION
[CAMEL-23431](https://issues.apache.org/jira/browse/CAMEL-23431)

## Summary

Migrate AS2 test infrastructure from `AvailablePortFinder` to direct port-0 `ServerSocket` binding to eliminate the TOCTOU (time-of-check-to-time-of-use) race condition that causes flaky `BindException` failures in CI.

**Production code changes:**
- Add `getLocalPort()` to `AS2ServerConnection` and `AS2AsyncMDNServerConnection` to expose the OS-assigned port after binding

**Test changes (10 files):**
- `AS2MessageTestBase`, `AS2MessageTest`, `AS2UnencryptedMessageTest`: API tests now create servers with port 0 and read back the actual port
- `AS2AsyncMDNServerConnectionTest`: Uses port 0 directly
- `AS2ServerManagerITBase`, `AS2ServerManagerIT`, `AS2ServerManagerEncryptedIT`: Component tests use port 0 in configuration, read back actual port via `doPostSetup()`
- `AS2ServerSecTestBase`: Same pattern for security test base class

**Not migrated yet (follow-up):**
- 8 component tests that create their own "partner" servers require lifecycle restructuring (the port must be known before the Camel context starts). These still use `AvailablePortFinder.find()` with `@RegisterExtension`.

## Test plan
- [x] `mvn test` in `camel-as2-api` — 94 tests pass
- [x] `mvn test` in `camel-as2-component` — 12 tests pass
- [ ] CI green