### PR TITLE
camel-diagram: Fix route source name stripping line numbers

### DIFF
--- a/components/camel-diagram/src/main/java/org/apache/camel/diagram/RouteDiagramHelper.java
+++ b/components/camel-diagram/src/main/java/org/apache/camel/diagram/RouteDiagramHelper.java
@@ -86,10 +86,15 @@ public final class RouteDiagramHelper {
         if (source == null || source.isBlank()) {
             return null;
         }
-        // strip scheme prefix (e.g. "file:")
-        int colon = source.lastIndexOf(':');
-        if (colon >= 0 && colon < source.length() - 1) {
-            source = source.substring(colon + 1);
+        // strip URI scheme prefix (e.g. "file:", "classpath:") — only if the part
+        // before the first colon is all letters (a valid scheme). This avoids
+        // stripping line numbers from sources like "cheese.java:9".
+        int colon = source.indexOf(':');
+        if (colon > 0) {
+            String scheme = source.substring(0, colon);
+            if (scheme.chars().allMatch(Character::isLetter)) {
+                source = source.substring(colon + 1);
+            }
         }
         // return just the filename part
         int slash = Math.max(source.lastIndexOf('/'), source.lastIndexOf('\\'));

--- a/components/camel-diagram/src/test/java/org/apache/camel/diagram/RouteDiagramTest.java
+++ b/components/camel-diagram/src/test/java/org/apache/camel/diagram/RouteDiagramTest.java
@@ -806,6 +806,46 @@ class RouteDiagramTest {
                 "Text padding should increase with wider nodes");
     }
 
+    @Test
+    void testExtractSourceNameWithScheme() {
+        assertEquals("my-route.yaml", RouteDiagramHelper.extractSourceName("file:/path/to/my-route.yaml"));
+    }
+
+    @Test
+    void testExtractSourceNameClasspath() {
+        assertEquals("my-route.yaml", RouteDiagramHelper.extractSourceName("classpath:my-route.yaml"));
+    }
+
+    @Test
+    void testExtractSourceNameWithLineNumber() {
+        assertEquals("cheese.java:9", RouteDiagramHelper.extractSourceName("cheese.java:9"));
+    }
+
+    @Test
+    void testExtractSourceNameSchemeAndLineNumber() {
+        assertEquals("cheese.java:9", RouteDiagramHelper.extractSourceName("file:/path/to/cheese.java:9"));
+    }
+
+    @Test
+    void testExtractSourceNamePlainFilename() {
+        assertEquals("my-route.yaml", RouteDiagramHelper.extractSourceName("my-route.yaml"));
+    }
+
+    @Test
+    void testExtractSourceNameWindowsPath() {
+        assertEquals("route.yaml", RouteDiagramHelper.extractSourceName("C:\\Users\\test\\route.yaml"));
+    }
+
+    @Test
+    void testExtractSourceNameNull() {
+        assertNull(RouteDiagramHelper.extractSourceName(null));
+    }
+
+    @Test
+    void testExtractSourceNameBlank() {
+        assertNull(RouteDiagramHelper.extractSourceName(""));
+    }
+
     private static NodeInfo node(String type, String code, int level) {
         return node(type, code, level, null);
     }


### PR DESCRIPTION
Fix route source display in diagram that was stripping line numbers from source names like `cheese.java:9`, showing just `9` instead.

## Problem

`extractSourceName()` used `lastIndexOf(':')` to strip URI scheme prefixes (e.g. `file:`), but this also stripped line number suffixes from sources like `cheese.java:9`, leaving just `9`.

## Fix

Changed to use `indexOf(':')` (first colon) with a check that the part before the colon consists only of letters (a valid URI scheme like `file`, `classpath`, `ref`). This correctly handles:
- `file:/path/to/my-route.yaml` → `my-route.yaml`
- `classpath:my-route.yaml` → `my-route.yaml`
- `cheese.java:9` → `cheese.java:9` (preserved)
- `file:/path/to/cheese.java:9` → `cheese.java:9` (preserved)

## Test plan

- [x] Added unit tests for all source name extraction scenarios
- [x] All 58 tests pass in camel-diagram module