### PR TITLE
chore: Remove unused cglib-nodep dependency from camel-cxf modules

### DIFF
--- a/components/camel-cxf/camel-cxf-rest/pom.xml
+++ b/components/camel-cxf/camel-cxf-rest/pom.xml
@@ -170,13 +170,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>${cglib-version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
             <version>${commons-net-version}</version>

--- a/components/camel-cxf/camel-cxf-spring-rest/pom.xml
+++ b/components/camel-cxf/camel-cxf-spring-rest/pom.xml
@@ -186,13 +186,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>${cglib-version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
             <version>${commons-net-version}</version>

--- a/components/camel-cxf/camel-cxf-spring-soap/pom.xml
+++ b/components/camel-cxf/camel-cxf-spring-soap/pom.xml
@@ -214,13 +214,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>${cglib-version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
             <version>${commons-net-version}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -100,7 +100,6 @@
         <camunda-client-java-version>8.9.3</camunda-client-java-version>
         <cassandra-driver-version>4.19.2</cassandra-driver-version>
         <jta-api-1.2-version>1.2</jta-api-1.2-version>
-        <cglib-version>3.3.0</cglib-version>
         <chicory-version>1.7.5</chicory-version>
         <chunk-templates-version>3.6.2</chunk-templates-version>
         <citrus-version>4.10.1</citrus-version>


### PR DESCRIPTION
The explicit `cglib:cglib-nodep:3.3.0` test dependency is no longer needed in `camel-cxf` modules. The dependency is from 2019 and seems no longer updated. Modern Mockito (5.x) uses ByteBuddy for bytecode generation instead of cglib.

This change removes:
- `cglib-nodep` test dependency from `camel-cxf-rest`
- `cglib-nodep` test dependency from `camel-cxf-spring-rest`
- `cglib-nodep` test dependency from `camel-cxf-spring-soap`
- `cglib-version` property from parent POM

All `camel-cxf` unit tests continue to pass with this dependency removed. 
The dependency is not used in any other Maven modules than in `camel-cxf`.

Made with help from AI tools.