### PR TITLE
CAMEL-23434: camel-diagram - Adjust padding proportionally to nodeWidth

### DIFF
--- a/components/camel-diagram/src/main/java/org/apache/camel/diagram/RouteDiagramLayoutEngine.java
+++ b/components/camel-diagram/src/main/java/org/apache/camel/diagram/RouteDiagramLayoutEngine.java
@@ -31,15 +31,14 @@ import java.util.Set;
 public class RouteDiagramLayoutEngine {
 
     public static final int SCALE = 2;
-    private static final int H_GAP = 30 * SCALE;
     public static final int V_GAP = 40 * SCALE;
     public static final int PADDING = 30 * SCALE;
     public static final int SCOPE_BOX_PAD = 14 * SCALE;
     private static final int LABEL_OFFSET = 24 * SCALE;
-    private static final int NODE_TEXT_PADDING = 16 * SCALE;
     private static final int MAX_WRAP_LINES = 3;
     public static final int DEFAULT_FONT_SIZE = 12;
     public static final int DEFAULT_BOX_WIDTH = 180;
+    private static final int MIN_BOX_WIDTH = 80;
     private static final int DEFAULT_NODE_HEIGHT = 32;
 
     public enum NodeLabelMode {
@@ -49,6 +48,8 @@ public class RouteDiagramLayoutEngine {
     }
 
     private final int nodeWidth;
+    private final int hGap;
+    private final int nodeTextPadding;
     private final int baseNodeHeight;
     private final FontMetrics fontMetrics;
     private final NodeLabelMode nodeLabelMode;
@@ -98,7 +99,10 @@ public class RouteDiagramLayoutEngine {
      * @param nodeLabelMode controls what text is displayed in node labels
      */
     public RouteDiagramLayoutEngine(int boxWidth, int fontSize, NodeLabelMode nodeLabelMode) {
-        this.nodeWidth = boxWidth * SCALE;
+        int clampedWidth = Math.max(boxWidth, MIN_BOX_WIDTH);
+        this.nodeWidth = clampedWidth * SCALE;
+        this.hGap = nodeWidth / 2;
+        this.nodeTextPadding = Math.max(nodeWidth * 16 / (DEFAULT_BOX_WIDTH * SCALE), 8 * SCALE);
         this.baseNodeHeight = Math.max(DEFAULT_NODE_HEIGHT, fontSize * DEFAULT_NODE_HEIGHT / DEFAULT_FONT_SIZE) * SCALE;
         this.nodeLabelMode = nodeLabelMode != null ? nodeLabelMode : NodeLabelMode.CODE;
         BufferedImage scratch = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
@@ -120,7 +124,7 @@ public class RouteDiagramLayoutEngine {
     }
 
     public int getNodeTextPadding() {
-        return NODE_TEXT_PADDING;
+        return nodeTextPadding;
     }
 
     public static class NodeInfo {
@@ -219,7 +223,7 @@ public class RouteDiagramLayoutEngine {
     }
 
     private List<String> wrapLabel(String label) {
-        int maxTextWidth = nodeWidth - NODE_TEXT_PADDING;
+        int maxTextWidth = nodeWidth - nodeTextPadding;
         if (fontMetrics.stringWidth(label) <= maxTextWidth) {
             return List.of(label);
         }
@@ -355,7 +359,7 @@ public class RouteDiagramLayoutEngine {
             int totalWidth = 0;
             for (int i = 0; i < node.children.size(); i++) {
                 if (i > 0) {
-                    totalWidth += H_GAP;
+                    totalWidth += hGap;
                 }
                 totalWidth += computeSubtreeWidth(node.children.get(i));
             }
@@ -430,7 +434,7 @@ public class RouteDiagramLayoutEngine {
                     adjustedY += SCOPE_BOX_PAD;
                 }
                 assignPositions(child, childX, adjustedY, child.subtreeWidth, lr);
-                childX += child.subtreeWidth + H_GAP;
+                childX += child.subtreeWidth + hGap;
             }
         } else {
             int curY = childY;

--- a/components/camel-diagram/src/test/java/org/apache/camel/diagram/RouteDiagramTest.java
+++ b/components/camel-diagram/src/test/java/org/apache/camel/diagram/RouteDiagramTest.java
@@ -761,6 +761,51 @@ class RouteDiagramTest {
         assertTrue(rejoined.contains("👨"), "ZWJ emoji must not be split");
     }
 
+    @Test
+    void testMinimumNodeWidthClamped() {
+        RouteDiagramLayoutEngine engine = new RouteDiagramLayoutEngine(50, 12);
+        assertEquals(80 * RouteDiagramLayoutEngine.SCALE, engine.getNodeWidth(),
+                "Node width below 80 should be clamped to 80");
+    }
+
+    @Test
+    void testBranchGapScalesWithNodeWidth() {
+        RouteInfo route = new RouteInfo();
+        route.routeId = "route1";
+        route.nodes.add(node("from", "timer:tick", 0));
+        route.nodes.add(node("choice", "choice()", 1));
+        route.nodes.add(node("when", "when(a)", 2));
+        route.nodes.add(node("to", "log:a", 3));
+        route.nodes.add(node("otherwise", "otherwise()", 2));
+        route.nodes.add(node("to", "log:b", 3));
+
+        RouteDiagramLayoutEngine defaultEngine = new RouteDiagramLayoutEngine();
+        LayoutRoute defaultLr = defaultEngine.layoutRoute(route, RouteDiagramLayoutEngine.PADDING);
+
+        RouteDiagramLayoutEngine wideEngine = new RouteDiagramLayoutEngine(300, 12);
+        LayoutRoute wideLr = wideEngine.layoutRoute(route, RouteDiagramLayoutEngine.PADDING);
+
+        LayoutNode defaultWhen = defaultLr.nodes.get(2);
+        LayoutNode defaultOtherwise = defaultLr.nodes.get(4);
+        int defaultGap = defaultOtherwise.x - (defaultWhen.x + defaultEngine.getNodeWidth());
+
+        LayoutNode wideWhen = wideLr.nodes.get(2);
+        LayoutNode wideOtherwise = wideLr.nodes.get(4);
+        int wideGap = wideOtherwise.x - (wideWhen.x + wideEngine.getNodeWidth());
+
+        assertTrue(wideGap > defaultGap,
+                "Branch gap should increase with wider nodes (default=" + defaultGap + ", wide=" + wideGap + ")");
+    }
+
+    @Test
+    void testNodeTextPaddingScalesWithNodeWidth() {
+        RouteDiagramLayoutEngine defaultEngine = new RouteDiagramLayoutEngine();
+        RouteDiagramLayoutEngine wideEngine = new RouteDiagramLayoutEngine(300, 12);
+
+        assertTrue(wideEngine.getNodeTextPadding() > defaultEngine.getNodeTextPadding(),
+                "Text padding should increase with wider nodes");
+    }
+
     private static NodeInfo node(String type, String code, int level) {
         return node(type, code, level, null);
     }


### PR DESCRIPTION
[CAMEL-23434](https://issues.apache.org/jira/browse/CAMEL-23434)

## Summary

- Made `H_GAP` (horizontal gap between branch nodes) scale proportionally to `nodeWidth` (50% of node width) instead of being a fixed 30px constant
- Made `NODE_TEXT_PADDING` (text padding inside nodes) scale proportionally to `nodeWidth` at the same ratio as the default (16/180)
- Added minimum `nodeWidth` clamp of 80px to prevent unreadable diagrams
- Both `H_GAP` and `NODE_TEXT_PADDING` changed from static constants to instance fields computed in the constructor

## Test plan

- [x] Added test for minimum nodeWidth clamping (50 → clamped to 80)
- [x] Added test verifying branch gap scales with wider nodes
- [x] Added test verifying text padding scales with wider nodes
- [x] All 53 existing + new tests pass