### PR TITLE
chore(camel-jetty): Re-enable RestApi override tests on CI

### DIFF
--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestApiOverrideBasePathJettyTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestApiOverrideBasePathJettyTest.java
@@ -20,18 +20,11 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jetty.BaseJettyTest;
 import org.apache.camel.model.rest.RestParamType;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI due to use of JMX")
 public class RestApiOverrideBasePathJettyTest extends BaseJettyTest {
-
-    @Override
-    protected boolean useJmx() {
-        return true;
-    }
 
     @Test
     public void testApi() {

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestApiOverrideHostJettyTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestApiOverrideHostJettyTest.java
@@ -20,18 +20,11 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jetty.BaseJettyTest;
 import org.apache.camel.model.rest.RestParamType;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI due to use of JMX")
 public class RestApiOverrideHostJettyTest extends BaseJettyTest {
-
-    @Override
-    protected boolean useJmx() {
-        return true;
-    }
 
     @Test
     public void testApi() {


### PR DESCRIPTION
These two tests were disabled on CI with `@DisabledIfSystemProperty(named = "ci.env.name")` and the reason "Flaky on Github CI due to use of JMX":

- `RestApiOverrideHostJettyTest`
- `RestApiOverrideBasePathJettyTest`

Both tests override `useJmx()` to return `true`, but they don't actually test JMX functionality — they test REST API documentation generation. The `useJmx()` override was present since the tests were created in 2015 (CAMEL-8545), likely copy-pasted from related tests. In 2018, Claus disabled them on CI with `@Ignore("Does not run well on CI due test uses JMX mbeans")` (e8dd127b1e2e), which was later converted to `@DisabledIfSystemProperty` during the JUnit 5 migration.

Since then, Jetty has been upgraded from 9 to 12 and JMX handling has changed significantly. The tests pass without JMX and are stable (30/30 runs with `-Dci.env.name=github.com`).

This PR removes the `useJmx()` override and the `@DisabledIfSystemProperty` annotation so the tests run in CI again.