### PR TITLE
CAMEL-23431: Migrate lumberjack and SSH tests from AvailablePortFinder to port-0 binding

### DIFF
--- a/components/camel-lumberjack/src/main/java/org/apache/camel/component/lumberjack/LumberjackConsumer.java
+++ b/components/camel-lumberjack/src/main/java/org/apache/camel/component/lumberjack/LumberjackConsumer.java
@@ -59,6 +59,10 @@ public class LumberjackConsumer extends DefaultConsumer {
         super.doSuspend();
     }
 
+    public int getLocalPort() {
+        return lumberjackServer.getLocalPort();
+    }
+
     private ThreadFactory getThreadFactory() {
         String threadNamePattern = getEndpoint().getCamelContext().getExecutorServiceManager().getThreadNamePattern();
         return new CamelThreadFactory(threadNamePattern, "LumberjackNettyExecutor", true);

--- a/components/camel-lumberjack/src/main/java/org/apache/camel/component/lumberjack/io/LumberjackServer.java
+++ b/components/camel-lumberjack/src/main/java/org/apache/camel/component/lumberjack/io/LumberjackServer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.lumberjack.io;
 
+import java.net.InetSocketAddress;
 import java.util.concurrent.ThreadFactory;
 
 import javax.net.ssl.SSLContext;
@@ -88,6 +89,10 @@ public final class LumberjackServer {
         channel = serverBootstrap.bind(host, port).sync().channel();
 
         LOG.info("LUMBERJACK server is started (host={}, port={}).", host, port);
+    }
+
+    public int getLocalPort() {
+        return channel != null ? ((InetSocketAddress) channel.localAddress()).getPort() : -1;
     }
 
     /**

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackComponentGlobalSSLTest.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackComponentGlobalSSLTest.java
@@ -27,18 +27,14 @@ import org.apache.camel.support.jsse.KeyManagersParameters;
 import org.apache.camel.support.jsse.KeyStoreParameters;
 import org.apache.camel.support.jsse.SSLContextParameters;
 import org.apache.camel.support.jsse.TrustManagersParameters;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Isolated
 public class LumberjackComponentGlobalSSLTest extends CamelTestSupport {
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -53,11 +49,13 @@ public class LumberjackComponentGlobalSSLTest extends CamelTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-
-                // Lumberjack configured with SSL
-                from("lumberjack:0.0.0.0:" + port.getPort()).to("mock:output");
+                from("lumberjack:0.0.0.0:0").routeId("lumberjack").to("mock:output");
             }
         };
+    }
+
+    private int getActualPort() {
+        return ((LumberjackConsumer) context.getRoute("lumberjack").getConsumer()).getLocalPort();
     }
 
     @Test
@@ -72,7 +70,7 @@ public class LumberjackComponentGlobalSSLTest extends CamelTestSupport {
 
         // When sending messages
         List<Integer> responses
-                = LumberjackUtil.sendMessages(port.getPort(), createClientSSLContextParameters(context), windows);
+                = LumberjackUtil.sendMessages(getActualPort(), createClientSSLContextParameters(context), windows);
 
         // Then we should have the messages we're expecting
         mock.assertIsSatisfied();

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackComponentSSLTest.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackComponentSSLTest.java
@@ -27,18 +27,14 @@ import org.apache.camel.support.jsse.KeyManagersParameters;
 import org.apache.camel.support.jsse.KeyStoreParameters;
 import org.apache.camel.support.jsse.SSLContextParameters;
 import org.apache.camel.support.jsse.TrustManagersParameters;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Isolated
 public class LumberjackComponentSSLTest extends CamelTestSupport {
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
 
     @Override
     protected RouteBuilder createRouteBuilder() {
@@ -47,10 +43,13 @@ public class LumberjackComponentSSLTest extends CamelTestSupport {
 
         return new RouteBuilder() {
             public void configure() {
-                // Lumberjack configured with SSL
-                from("lumberjack:0.0.0.0:" + port.getPort() + "?sslContextParameters=#ssl").to("mock:output");
+                from("lumberjack:0.0.0.0:0?sslContextParameters=#ssl").routeId("lumberjack").to("mock:output");
             }
         };
+    }
+
+    private int getActualPort() {
+        return ((LumberjackConsumer) context.getRoute("lumberjack").getConsumer()).getLocalPort();
     }
 
     @Test
@@ -62,7 +61,7 @@ public class LumberjackComponentSSLTest extends CamelTestSupport {
         List<Integer> windows = Arrays.asList(15, 10, 15, 10, 10);
 
         // When sending messages
-        List<Integer> responses = LumberjackUtil.sendMessages(port.getPort(), createClientSSLContextParameters(), windows);
+        List<Integer> responses = LumberjackUtil.sendMessages(getActualPort(), createClientSSLContextParameters(), windows);
 
         // Then we should have the messages we're expecting
         mock.assertIsSatisfied();

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackComponentTest.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackComponentTest.java
@@ -22,12 +22,10 @@ import java.util.Map;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,17 +35,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
               disabledReason = "This test does not run reliably multiple platforms (see CAMEL-21438)")
 @Isolated
 public class LumberjackComponentTest extends CamelTestSupport {
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
 
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                // Lumberjack configured with a specific port
-                from("lumberjack:0.0.0.0:" + port.getPort()).to("mock:output");
+                from("lumberjack:0.0.0.0:0").routeId("lumberjack").to("mock:output");
             }
         };
+    }
+
+    private int getActualPort() {
+        return ((LumberjackConsumer) context.getRoute("lumberjack").getConsumer()).getLocalPort();
     }
 
     @Test
@@ -60,7 +59,7 @@ public class LumberjackComponentTest extends CamelTestSupport {
         List<Integer> windows = Arrays.asList(15, 10, 15, 10, 10);
 
         // When sending messages
-        List<Integer> responses = LumberjackUtil.sendMessages(port.getPort(), null, windows);
+        List<Integer> responses = LumberjackUtil.sendMessages(getActualPort(), null, windows);
 
         // Then we should have the messages we're expecting
         mock.assertIsSatisfied();

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackDisconnectionTest.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackDisconnectionTest.java
@@ -25,12 +25,10 @@ import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.apache.camel.test.junit6.TestSupport.assertCollectionSize;
@@ -40,17 +38,18 @@ import static org.apache.camel.test.junit6.TestSupport.assertCollectionSize;
               disabledReason = "This test does not run reliably on multiple platforms (see CAMEL-21438)")
 @Isolated
 public class LumberjackDisconnectionTest extends CamelTestSupport {
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
 
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                // Lumberjack configured with something that throws an exception
-                from("lumberjack:0.0.0.0:" + port.getPort()).process(new ErrorProcessor()).to("mock:output");
+                from("lumberjack:0.0.0.0:0").routeId("lumberjack").process(new ErrorProcessor()).to("mock:output");
             }
         };
+    }
+
+    private int getActualPort() {
+        return ((LumberjackConsumer) context.getRoute("lumberjack").getConsumer()).getLocalPort();
     }
 
     @Test
@@ -64,7 +63,7 @@ public class LumberjackDisconnectionTest extends CamelTestSupport {
         List<Integer> windows = Arrays.asList(15, 10);
 
         // When sending messages
-        List<Integer> responses = LumberjackUtil.sendMessages(port.getPort(), null, windows, false);
+        List<Integer> responses = LumberjackUtil.sendMessages(getActualPort(), null, windows, false);
 
         // Then we should have the messages we're expecting
         mock.assertIsSatisfied();

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackMultiThreadIT.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackMultiThreadIT.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,8 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Isolated
 public class LumberjackMultiThreadIT extends CamelTestSupport {
 
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
     private static final int CONCURRENCY_LEVEL = Math.min(Runtime.getRuntime().availableProcessors(), 4);
     private CountDownLatch latch = new CountDownLatch(CONCURRENCY_LEVEL);
     private volatile boolean interrupted;
@@ -58,10 +54,13 @@ public class LumberjackMultiThreadIT extends CamelTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                // Lumberjack configured with a specific port
-                from("lumberjack:0.0.0.0:" + port.getPort()).to("mock:output");
+                from("lumberjack:0.0.0.0:0").routeId("lumberjack").to("mock:output");
             }
         };
+    }
+
+    private int getActualPort() {
+        return ((LumberjackConsumer) context.getRoute("lumberjack").getConsumer()).getLocalPort();
     }
 
     @BeforeEach
@@ -106,7 +105,7 @@ public class LumberjackMultiThreadIT extends CamelTestSupport {
         @Override
         public void run() {
             try {
-                this.responses = LumberjackUtil.sendMessages(port.getPort(), null, Arrays.asList(15, 10));
+                this.responses = LumberjackUtil.sendMessages(getActualPort(), null, Arrays.asList(15, 10));
                 latch.countDown();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/components/camel-ssh/src/test/java/org/apache/camel/component/ssh/SshAlgorithmParametersTest.java
+++ b/components/camel-ssh/src/test/java/org/apache/camel/component/ssh/SshAlgorithmParametersTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.camel.spi.Registry;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.sshd.client.ClientBuilder;
@@ -39,15 +38,13 @@ import org.apache.sshd.common.signature.BuiltinSignatures;
 import org.apache.sshd.common.signature.Signature;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SshAlgorithmParametersTest extends CamelTestSupport {
 
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
+    private final int port = 0;
 
     private String getSshEndpointURI() {
-        return "ssh://smx:smx@localhost:" + port.getPort() + "?timeout=3000" +
+        return "ssh://smx:smx@localhost:" + port + "?timeout=3000" +
                "&ciphers=aes192-ctr" +
                "&macs=hmac-sha1-etm@openssh.com,hmac-sha2-256,hmac-sha1" +
                "&kex=ecdh-sha2-nistp521" +
@@ -56,7 +53,7 @@ public class SshAlgorithmParametersTest extends CamelTestSupport {
     }
 
     private String getCustomClientSshEndpointURI() {
-        return "ssh://smx:smx@localhost:" + port.getPort() + "?timeout=3000&clientBuilder=#myClient";
+        return "ssh://smx:smx@localhost:" + port + "?timeout=3000&clientBuilder=#myClient";
     }
 
     @Override

--- a/components/camel-ssh/src/test/java/org/apache/camel/component/ssh/SshComponentTestSupport.java
+++ b/components/camel-ssh/src/test/java/org/apache/camel/component/ssh/SshComponentTestSupport.java
@@ -19,29 +19,24 @@ package org.apache.camel.component.ssh;
 import java.io.IOException;
 import java.nio.file.Paths;
 
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.sshd.common.keyprovider.FileKeyPairProvider;
 import org.apache.sshd.server.SshServer;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SshComponentTestSupport extends CamelTestSupport {
-    @RegisterExtension
-    AvailablePortFinder.Port portHolder = AvailablePortFinder.find();
     protected SshServer sshd;
     protected int port;
 
     @Override
     public void doPreSetup() throws Exception {
-        port = portHolder.getPort();
-
         sshd = SshServer.setUpDefaultServer();
-        sshd.setPort(port);
+        sshd.setPort(0);
         sshd.setKeyPairProvider(new FileKeyPairProvider(Paths.get(getHostKey())));
         sshd.setCommandFactory(new TestEchoCommandFactory());
         sshd.setPasswordAuthenticator((username, password, session) -> true);
         sshd.setPublickeyAuthenticator((username, key, session) -> true);
         sshd.start();
+        port = sshd.getPort();
     }
 
     protected String getHostKey() {

--- a/components/camel-ssh/src/test/java/org/apache/camel/component/ssh/SshIdleTimeoutTest.java
+++ b/components/camel-ssh/src/test/java/org/apache/camel/component/ssh/SshIdleTimeoutTest.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.common.keyprovider.FileKeyPairProvider;
@@ -32,13 +31,17 @@ import org.apache.sshd.server.SshServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SshIdleTimeoutTest extends SshComponentTestSupport {
 
-    @RegisterExtension
-    AvailablePortFinder.Port delayedPort = AvailablePortFinder.find();
+    private int delayedPort;
     private SshServer delayedSshd;
+
+    @Override
+    public void doPreSetup() throws Exception {
+        super.doPreSetup();
+        startDelayedServer();
+    }
 
     @AfterEach
     public void stopDelayedServer() throws Exception {
@@ -103,18 +106,21 @@ public class SshIdleTimeoutTest extends SshComponentTestSupport {
     }
 
     private void startDelayedServer() throws Exception {
+        if (delayedSshd != null) {
+            return;
+        }
         delayedSshd = SshServer.setUpDefaultServer();
-        delayedSshd.setPort(delayedPort.getPort());
+        delayedSshd.setPort(0);
         delayedSshd.setKeyPairProvider(new FileKeyPairProvider(Paths.get("src/test/resources/hostkey.pem")));
         delayedSshd.setCommandFactory(new DelayedEchoCommandFactory(1000));
         delayedSshd.setPasswordAuthenticator((username, password, session) -> true);
         delayedSshd.setPublickeyAuthenticator((username, key, session) -> true);
         delayedSshd.start();
+        delayedPort = delayedSshd.getPort();
     }
 
     @Test
     public void testIdleTimeoutExpiresBeforeCommandCompletes() throws Exception {
-        startDelayedServer();
         // Send the command using a producer with idleTimeout=500ms.
         // The client's idle timeout fires during the 3s command delay,
         // closing the session before the command completes.
@@ -130,7 +136,6 @@ public class SshIdleTimeoutTest extends SshComponentTestSupport {
 
     @Test
     public void testIdleTimeoutLongerThanCommandDelay() throws Exception {
-        startDelayedServer();
         // Send the command using a producer with idleTimeout=5000ms.
         // The command delay (3s) completes before the idle timeout fires.
         Exchange exchange = template.send(
@@ -152,9 +157,9 @@ public class SshIdleTimeoutTest extends SshComponentTestSupport {
                         .to("mock:result");
 
                 from("direct:sshWithShortIdleTimeout")
-                        .to("ssh://smx:smx@localhost:" + delayedPort.getPort() + "?timeout=5000&idleTimeout=500");
+                        .to("ssh://smx:smx@localhost:" + delayedPort + "?timeout=5000&idleTimeout=500");
                 from("direct:sshWithLongIdleTimeout")
-                        .to("ssh://smx:smx@localhost:" + delayedPort.getPort() + "?timeout=5000&idleTimeout=5000");
+                        .to("ssh://smx:smx@localhost:" + delayedPort + "?timeout=5000&idleTimeout=5000");
             }
         };
     }


### PR DESCRIPTION
[CAMEL-23431](https://issues.apache.org/jira/browse/CAMEL-23431)

## Summary

Second PR for CAMEL-23431. Migrates `camel-lumberjack` (5 test files) and `camel-ssh` (3 test files) from `AvailablePortFinder` to port-0 `ServerSocket` binding, eliminating the TOCTOU race condition.

**Lumberjack changes:**
- Add `getLocalPort()` to `LumberjackServer` (reads actual port from Netty channel) and `LumberjackConsumer`
- All 5 tests now use `from("lumberjack:0.0.0.0:0")` and read back the actual port from the consumer for client connections

**SSH changes:**
- `SshComponentTestSupport`: Start `SshServer` with port 0, read back via `sshd.getPort()` — all 7+ subclasses automatically work
- `SshIdleTimeoutTest`: Start delayed server in `doPreSetup()` with port 0
- `SshAlgorithmParametersTest`: Use dummy port 0 (no connection is made, only algorithm inspection)

## Test plan
- [x] `mvn test` in `camel-lumberjack` — 5 tests pass
- [x] `mvn test` in `camel-ssh` — 39 tests pass
- [ ] CI green