### PR TITLE
CAMEL-23431: Migrate thrift tests from AvailablePortFinder to port-0 binding

### DIFF
--- a/components/camel-thrift/src/main/java/org/apache/camel/component/thrift/ThriftConsumer.java
+++ b/components/camel-thrift/src/main/java/org/apache/camel/component/thrift/ThriftConsumer.java
@@ -85,6 +85,16 @@ public class ThriftConsumer extends DefaultConsumer {
         }
     }
 
+    public int getLocalPort() {
+        if (asyncServerTransport != null) {
+            return asyncServerTransport.getPort();
+        }
+        if (syncServerTransport != null) {
+            return syncServerTransport.getServerSocket().getLocalPort();
+        }
+        return -1;
+    }
+
     @Override
     protected void doStop() throws Exception {
         if (server != null) {

--- a/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftConsumerAsyncTest.java
+++ b/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftConsumerAsyncTest.java
@@ -29,7 +29,6 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.thrift.generated.Calculator;
 import org.apache.camel.component.thrift.generated.Operation;
 import org.apache.camel.component.thrift.generated.Work;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.thrift.async.AsyncMethodCallback;
 import org.apache.thrift.async.TAsyncClientManager;
@@ -40,7 +39,6 @@ import org.apache.thrift.transport.TTransportException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,8 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ThriftConsumerAsyncTest extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(ThriftConsumerAsyncTest.class);
-    @RegisterExtension
-    AvailablePortFinder.Port thriftTestPort = AvailablePortFinder.find();
+
     private static final int THRIFT_TEST_NUM1 = 12;
     private static final int THRIFT_TEST_NUM2 = 13;
     private Calculator.AsyncClient thriftClient;
@@ -63,11 +60,16 @@ public class ThriftConsumerAsyncTest extends CamelTestSupport {
     private int allTypesResult;
     private Work echoResult;
 
+    private int getActualPort() {
+        return ((ThriftConsumer) context.getRoutes().get(0).getConsumer()).getLocalPort();
+    }
+
     @BeforeEach
     public void startThriftClient() throws IOException, TTransportException {
         if (transport == null) {
-            LOG.info("Connecting to the Thrift server on port: {}", thriftTestPort.getPort());
-            transport = new TNonblockingSocket("localhost", thriftTestPort.getPort());
+            int thriftTestPort = getActualPort();
+            LOG.info("Connecting to the Thrift server on port: {}", thriftTestPort);
+            transport = new TNonblockingSocket("localhost", thriftTestPort);
             thriftClient = (new Calculator.AsyncClient.Factory(new TAsyncClientManager(), new TBinaryProtocol.Factory()))
                     .getAsyncClient(transport);
         }
@@ -243,8 +245,7 @@ public class ThriftConsumerAsyncTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("thrift://localhost:" + thriftTestPort.getPort()
-                     + "/org.apache.camel.component.thrift.generated.Calculator")
+                from("thrift://localhost:0/org.apache.camel.component.thrift.generated.Calculator")
                         .to("mock:thrift-service").choice()
                         .when(header(ThriftConstants.THRIFT_METHOD_NAME_HEADER).isEqualTo("calculate"))
                         .setBody(simple(Integer.valueOf(THRIFT_TEST_NUM1 * THRIFT_TEST_NUM2).toString()))

--- a/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftConsumerConcurrentTest.java
+++ b/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftConsumerConcurrentTest.java
@@ -27,7 +27,6 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.thrift.generated.Calculator;
 import org.apache.camel.component.thrift.generated.Operation;
 import org.apache.camel.component.thrift.generated.Work;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.thrift.TException;
 import org.apache.thrift.async.AsyncMethodCallback;
@@ -41,7 +40,6 @@ import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.layered.TFramedTransport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,15 +49,15 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 public class ThriftConsumerConcurrentTest extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(ThriftConsumerConcurrentTest.class);
 
-    @RegisterExtension
-    AvailablePortFinder.Port thriftSyncPort = AvailablePortFinder.find();
-    @RegisterExtension
-    AvailablePortFinder.Port thriftAsyncPort = AvailablePortFinder.find();
     private static final int THRIFT_TEST_NUM1 = 12;
     private static final int CONCURRENT_THREAD_COUNT = 30;
     private static final int ROUNDS_PER_THREAD_COUNT = 10;
 
     private static AtomicInteger idCounter = new AtomicInteger();
+
+    private int getPortForRoute(int index) {
+        return ((ThriftConsumer) context.getRoutes().get(index).getConsumer()).getLocalPort();
+    }
 
     public static Integer createId() {
         return idCounter.getAndIncrement();
@@ -75,7 +73,7 @@ public class ThriftConsumerConcurrentTest extends CamelTestSupport {
 
             @Override
             public void run() throws TTransportException {
-                TTransport transport = new TSocket("localhost", thriftSyncPort.getPort());
+                TTransport transport = new TSocket("localhost", getPortForRoute(0));
                 transport.open();
                 TProtocol protocol = new TBinaryProtocol(new TFramedTransport(transport));
                 Calculator.Client client = (new Calculator.Client.Factory()).getClient(protocol);
@@ -108,7 +106,7 @@ public class ThriftConsumerConcurrentTest extends CamelTestSupport {
             public void run() throws TTransportException, IOException, InterruptedException {
                 final CountDownLatch latch = new CountDownLatch(1);
 
-                TNonblockingTransport transport = new TNonblockingSocket("localhost", thriftAsyncPort.getPort());
+                TNonblockingTransport transport = new TNonblockingSocket("localhost", getPortForRoute(1));
                 Calculator.AsyncClient client
                         = (new Calculator.AsyncClient.Factory(new TAsyncClientManager(), new TBinaryProtocol.Factory()))
                                 .getAsyncClient(transport);
@@ -165,12 +163,10 @@ public class ThriftConsumerConcurrentTest extends CamelTestSupport {
             @Override
             public void configure() {
 
-                from("thrift://localhost:" + thriftSyncPort.getPort()
-                     + "/org.apache.camel.component.thrift.generated.Calculator?synchronous=true")
+                from("thrift://localhost:0/org.apache.camel.component.thrift.generated.Calculator?synchronous=true")
                         .setBody(simple("${body[1]}")).bean(new CalculatorMessageBuilder(), "multiply");
 
-                from("thrift://localhost:" + thriftAsyncPort.getPort()
-                     + "/org.apache.camel.component.thrift.generated.Calculator")
+                from("thrift://localhost:0/org.apache.camel.component.thrift.generated.Calculator")
                         .setBody(simple("${body[1]}")).bean(new CalculatorMessageBuilder(), "multiply");
             }
         };

--- a/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftConsumerSecurityTest.java
+++ b/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftConsumerSecurityTest.java
@@ -25,7 +25,6 @@ import org.apache.camel.spi.Registry;
 import org.apache.camel.support.jsse.KeyManagersParameters;
 import org.apache.camel.support.jsse.KeyStoreParameters;
 import org.apache.camel.support.jsse.SSLContextParameters;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -35,7 +34,6 @@ import org.apache.thrift.transport.TTransportException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,8 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ThriftConsumerSecurityTest extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(ThriftConsumerSecurityTest.class);
-    @RegisterExtension
-    AvailablePortFinder.Port thriftTestPort = AvailablePortFinder.find();
+
     private static final int THRIFT_TEST_NUM1 = 12;
     private static final int THRIFT_TEST_NUM2 = 13;
     private static final String TRUST_STORE_RESOURCE = "file:src/test/resources/certs/truststore.jks";
@@ -59,15 +56,20 @@ public class ThriftConsumerSecurityTest extends CamelTestSupport {
     private TProtocol protocol;
     private TTransport transport;
 
+    private int getActualPort() {
+        return ((ThriftConsumer) context.getRoutes().get(0).getConsumer()).getLocalPort();
+    }
+
     @BeforeEach
     public void startThriftSecureClient() throws TTransportException {
         if (transport == null) {
-            LOG.info("Connecting to the secured Thrift server on port: {}", thriftTestPort.getPort());
+            int thriftTestPort = getActualPort();
+            LOG.info("Connecting to the secured Thrift server on port: {}", thriftTestPort);
 
             TSSLTransportFactory.TSSLTransportParameters sslParams = new TSSLTransportFactory.TSSLTransportParameters();
 
             sslParams.setTrustStore(TRUST_STORE_RESOURCE, SECURITY_STORE_PASSWORD);
-            transport = TSSLTransportFactory.getClientSocket("localhost", thriftTestPort.getPort(), THRIFT_CLIENT_TIMEOUT,
+            transport = TSSLTransportFactory.getClientSocket("localhost", thriftTestPort, THRIFT_CLIENT_TIMEOUT,
                     sslParams);
 
             protocol = new TBinaryProtocol(transport);
@@ -140,8 +142,7 @@ public class ThriftConsumerSecurityTest extends CamelTestSupport {
             @Override
             public void configure() {
 
-                from("thrift://localhost:" + thriftTestPort.getPort()
-                     + "/org.apache.camel.component.thrift.generated.Calculator?negotiationType=SSL&sslParameters=#sslParams&synchronous=true")
+                from("thrift://localhost:0/org.apache.camel.component.thrift.generated.Calculator?negotiationType=SSL&sslParameters=#sslParams&synchronous=true")
                         .to("mock:thrift-secure-service").choice()
                         .when(header(ThriftConstants.THRIFT_METHOD_NAME_HEADER).isEqualTo("calculate"))
                         .setBody(simple(Integer.valueOf(THRIFT_TEST_NUM1 * THRIFT_TEST_NUM2).toString()))

--- a/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftConsumerSyncTest.java
+++ b/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftConsumerSyncTest.java
@@ -21,7 +21,6 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.thrift.generated.Calculator;
 import org.apache.camel.component.thrift.generated.Operation;
 import org.apache.camel.component.thrift.generated.Work;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -32,7 +31,6 @@ import org.apache.thrift.transport.layered.TFramedTransport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,8 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ThriftConsumerSyncTest extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(ThriftConsumerSyncTest.class);
-    @RegisterExtension
-    AvailablePortFinder.Port thriftTestPort = AvailablePortFinder.find();
+
     private static final int THRIFT_TEST_NUM1 = 12;
     private static final int THRIFT_TEST_NUM2 = 13;
     private Calculator.Client thriftClient;
@@ -51,11 +48,16 @@ public class ThriftConsumerSyncTest extends CamelTestSupport {
     private TProtocol protocol;
     private TTransport transport;
 
+    private int getActualPort() {
+        return ((ThriftConsumer) context.getRoutes().get(0).getConsumer()).getLocalPort();
+    }
+
     @BeforeEach
     public void startThriftClient() throws TTransportException {
         if (transport == null) {
-            LOG.info("Connecting to the Thrift server on port: {}", thriftTestPort.getPort());
-            transport = new TSocket("localhost", thriftTestPort.getPort());
+            int thriftTestPort = getActualPort();
+            LOG.info("Connecting to the Thrift server on port: {}", thriftTestPort);
+            transport = new TSocket("localhost", thriftTestPort);
             transport.open();
             protocol = new TBinaryProtocol(new TFramedTransport(transport));
             thriftClient = (new Calculator.Client.Factory()).getClient(protocol);
@@ -106,8 +108,7 @@ public class ThriftConsumerSyncTest extends CamelTestSupport {
             @Override
             public void configure() {
 
-                from("thrift://localhost:" + thriftTestPort.getPort()
-                     + "/org.apache.camel.component.thrift.generated.Calculator?synchronous=true")
+                from("thrift://localhost:0/org.apache.camel.component.thrift.generated.Calculator?synchronous=true")
                         .to("mock:thrift-service").choice()
                         .when(header(ThriftConstants.THRIFT_METHOD_NAME_HEADER).isEqualTo("calculate"))
                         .setBody(simple(Integer.valueOf(THRIFT_TEST_NUM1 * THRIFT_TEST_NUM2).toString()))

--- a/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftConsumerZlibCompressionTest.java
+++ b/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftConsumerZlibCompressionTest.java
@@ -21,7 +21,6 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.thrift.generated.Calculator;
 import org.apache.camel.component.thrift.generated.Operation;
 import org.apache.camel.component.thrift.generated.Work;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.thrift.TConfiguration;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -33,7 +32,6 @@ import org.apache.thrift.transport.TZlibTransport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,8 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ThriftConsumerZlibCompressionTest extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(ThriftConsumerZlibCompressionTest.class);
-    @RegisterExtension
-    AvailablePortFinder.Port thriftTestPort = AvailablePortFinder.find();
+
     private static final int THRIFT_TEST_NUM1 = 12;
     private static final int THRIFT_TEST_NUM2 = 13;
     private static final int THRIFT_CLIENT_TIMEOUT = 2000;
@@ -54,12 +51,17 @@ public class ThriftConsumerZlibCompressionTest extends CamelTestSupport {
     private TProtocol protocol;
     private TTransport transport;
 
+    private int getActualPort() {
+        return ((ThriftConsumer) context.getRoutes().get(0).getConsumer()).getLocalPort();
+    }
+
     @BeforeEach
     public void startThriftZlibClient() throws TTransportException {
         if (transport == null) {
-            LOG.info("Connecting to the Thrift server with zlib compression on port: {}", thriftTestPort.getPort());
+            int thriftTestPort = getActualPort();
+            LOG.info("Connecting to the Thrift server with zlib compression on port: {}", thriftTestPort);
 
-            transport = new TSocket(new TConfiguration(), "localhost", thriftTestPort.getPort(), THRIFT_CLIENT_TIMEOUT);
+            transport = new TSocket(new TConfiguration(), "localhost", thriftTestPort, THRIFT_CLIENT_TIMEOUT);
             protocol = new TBinaryProtocol(new TZlibTransport(transport));
             thriftClient = new Calculator.Client(protocol);
             transport.open();
@@ -115,8 +117,7 @@ public class ThriftConsumerZlibCompressionTest extends CamelTestSupport {
             @Override
             public void configure() {
 
-                from("thrift://localhost:" + thriftTestPort.getPort()
-                     + "/org.apache.camel.component.thrift.generated.Calculator?compressionType=ZLIB&synchronous=true")
+                from("thrift://localhost:0/org.apache.camel.component.thrift.generated.Calculator?compressionType=ZLIB&synchronous=true")
                         .to("mock:thrift-secure-service").choice()
                         .when(header(ThriftConstants.THRIFT_METHOD_NAME_HEADER).isEqualTo("calculate"))
                         .setBody(simple(Integer.valueOf(THRIFT_TEST_NUM1 * THRIFT_TEST_NUM2).toString()))

--- a/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftProducerBaseTest.java
+++ b/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftProducerBaseTest.java
@@ -18,19 +18,16 @@ package org.apache.camel.component.thrift;
 
 import org.apache.camel.component.thrift.generated.Calculator;
 import org.apache.camel.component.thrift.impl.CalculatorSyncServerImpl;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.thrift.server.THsHaServer;
 import org.apache.thrift.server.THsHaServer.Args;
 import org.apache.thrift.server.TServer;
 import org.apache.thrift.transport.TNonblockingServerSocket;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class ThriftProducerBaseTest extends CamelTestSupport {
-    @RegisterExtension
-    AvailablePortFinder.Port thriftTestPort = AvailablePortFinder.find();
+    protected int thriftTestPort;
     protected static final int THRIFT_TEST_NUM1 = 12;
     protected static final int THRIFT_TEST_NUM2 = 13;
     @SuppressWarnings({ "rawtypes" })
@@ -42,13 +39,14 @@ public abstract class ThriftProducerBaseTest extends CamelTestSupport {
 
     @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    protected void setupResources() throws Exception {
+    public void doPreSetup() throws Exception {
         processor = new Calculator.Processor(new CalculatorSyncServerImpl());
-        serverTransport = new TNonblockingServerSocket(thriftTestPort.getPort());
+        serverTransport = new TNonblockingServerSocket(0);
+        thriftTestPort = serverTransport.getPort();
         server = new THsHaServer(new Args(serverTransport).processor(processor));
         Runnable simple = new Runnable() {
             public void run() {
-                LOG.info("Thrift server started on port: {}", thriftTestPort.getPort());
+                LOG.info("Thrift server started on port: {}", thriftTestPort);
                 server.serve();
             }
         };

--- a/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftProducerSecurityTest.java
+++ b/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftProducerSecurityTest.java
@@ -34,14 +34,12 @@ import org.apache.camel.spi.Registry;
 import org.apache.camel.support.jsse.KeyStoreParameters;
 import org.apache.camel.support.jsse.SSLContextParameters;
 import org.apache.camel.support.jsse.TrustManagersParameters;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.thrift.server.TServer;
 import org.apache.thrift.server.TThreadPoolServer;
 import org.apache.thrift.transport.TSSLTransportFactory;
 import org.apache.thrift.transport.TServerSocket;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,8 +57,7 @@ public class ThriftProducerSecurityTest extends CamelTestSupport {
     @SuppressWarnings({ "rawtypes" })
     private Calculator.Processor processor;
 
-    @RegisterExtension
-    AvailablePortFinder.Port thriftTestPort = AvailablePortFinder.find();
+    private int thriftTestPort;
     private static final int THRIFT_TEST_NUM1 = 12;
     private static final int THRIFT_TEST_NUM2 = 13;
 
@@ -71,21 +68,22 @@ public class ThriftProducerSecurityTest extends CamelTestSupport {
 
     @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    protected void setupResources() throws Exception {
+    public void doPreSetup() throws Exception {
         processor = new Calculator.Processor(new CalculatorSyncServerImpl());
 
         TSSLTransportFactory.TSSLTransportParameters sslParams = new TSSLTransportFactory.TSSLTransportParameters();
 
         sslParams.setKeyStore(KEY_STORE_SOURCE, SECURITY_STORE_PASSWORD);
-        serverTransport = TSSLTransportFactory.getServerSocket(thriftTestPort.getPort(), THRIFT_CLIENT_TIMEOUT,
+        serverTransport = TSSLTransportFactory.getServerSocket(0, THRIFT_CLIENT_TIMEOUT,
                 InetAddress.getByName("localhost"), sslParams);
+        thriftTestPort = serverTransport.getServerSocket().getLocalPort();
         TThreadPoolServer.Args args = new TThreadPoolServer.Args(serverTransport);
         args.processor(processor);
         server = new TThreadPoolServer(args);
 
         Runnable simple = new Runnable() {
             public void run() {
-                LOG.info("Thrift secured server started on port: {}", thriftTestPort.getPort());
+                LOG.info("Thrift secured server started on port: {}", thriftTestPort);
                 server.serve();
             }
         };
@@ -201,23 +199,23 @@ public class ThriftProducerSecurityTest extends CamelTestSupport {
             @Override
             public void configure() {
                 from("direct:thrift-secured-calculate")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?"
                             + "method=calculate&negotiationType=SSL&sslParameters=#sslParams&synchronous=true");
                 from("direct:thrift-secured-add")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?"
                             + "method=add&negotiationType=SSL&sslParameters=#sslParams&synchronous=true");
                 from("direct:thrift-secured-ping")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?"
                             + "method=ping&negotiationType=SSL&sslParameters=#sslParams&synchronous=true");
                 from("direct:thrift-secured-zip")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?"
                             + "method=zip&negotiationType=SSL&sslParameters=#sslParams&synchronous=true");
                 from("direct:thrift-secured-alltypes")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?"
                             + "method=alltypes&negotiationType=SSL&sslParameters=#sslParams&synchronous=true");
             }

--- a/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftProducerSyncTest.java
+++ b/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftProducerSyncTest.java
@@ -158,22 +158,22 @@ public class ThriftProducerSyncTest extends ThriftProducerBaseTest {
             @Override
             public void configure() {
                 from("direct:thrift-calculate")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?method=calculate&synchronous=true");
                 from("direct:thrift-add")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?method=add&synchronous=true");
                 from("direct:thrift-ping")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?method=ping&synchronous=true");
                 from("direct:thrift-zip")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?method=zip&synchronous=true");
                 from("direct:thrift-alltypes")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?method=alltypes&synchronous=true");
                 from("direct:thrift-echo")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?method=echo&synchronous=true");
             }
         };

--- a/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftProducerZlibCompressionTest.java
+++ b/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/ThriftProducerZlibCompressionTest.java
@@ -26,7 +26,6 @@ import org.apache.camel.component.thrift.generated.Calculator;
 import org.apache.camel.component.thrift.generated.Operation;
 import org.apache.camel.component.thrift.generated.Work;
 import org.apache.camel.component.thrift.impl.CalculatorSyncServerImpl;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TServer;
@@ -34,7 +33,6 @@ import org.apache.thrift.server.TThreadPoolServer;
 import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TZlibTransport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,19 +49,19 @@ public class ThriftProducerZlibCompressionTest extends CamelTestSupport {
     @SuppressWarnings({ "rawtypes" })
     private Calculator.Processor processor;
 
-    @RegisterExtension
-    AvailablePortFinder.Port thriftTestPort = AvailablePortFinder.find();
+    private int thriftTestPort;
     private static final int THRIFT_TEST_NUM1 = 12;
     private static final int THRIFT_TEST_NUM2 = 13;
     private static final int THRIFT_CLIENT_TIMEOUT = 2000;
 
     @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    protected void setupResources() throws Exception {
+    public void doPreSetup() throws Exception {
         processor = new Calculator.Processor(new CalculatorSyncServerImpl());
 
         serverTransport = new TServerSocket(
-                new InetSocketAddress(InetAddress.getByName("localhost"), thriftTestPort.getPort()), THRIFT_CLIENT_TIMEOUT);
+                new InetSocketAddress(InetAddress.getByName("localhost"), 0), THRIFT_CLIENT_TIMEOUT);
+        thriftTestPort = serverTransport.getServerSocket().getLocalPort();
         TThreadPoolServer.Args args = new TThreadPoolServer.Args(serverTransport);
         args.processor(processor);
         args.protocolFactory(new TBinaryProtocol.Factory());
@@ -72,7 +70,7 @@ public class ThriftProducerZlibCompressionTest extends CamelTestSupport {
 
         Runnable simple = new Runnable() {
             public void run() {
-                LOG.info("Thrift server with zlib compression started on port: {}", thriftTestPort.getPort());
+                LOG.info("Thrift server with zlib compression started on port: {}", thriftTestPort);
                 server.serve();
             }
         };
@@ -120,10 +118,10 @@ public class ThriftProducerZlibCompressionTest extends CamelTestSupport {
             @Override
             public void configure() {
                 from("direct:thrift-zlib-calculate")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?method=calculate&compressionType=ZLIB&synchronous=true");
                 from("direct:thrift-zlib-ping")
-                        .to("thrift://localhost:" + thriftTestPort.getPort()
+                        .to("thrift://localhost:" + thriftTestPort
                             + "/org.apache.camel.component.thrift.generated.Calculator?method=ping&compressionType=ZLIB&synchronous=true");
             }
         };

--- a/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/local/ThriftThreadPoolServerTest.java
+++ b/components/camel-thrift/src/test/java/org/apache/camel/component/thrift/local/ThriftThreadPoolServerTest.java
@@ -22,7 +22,6 @@ import org.apache.camel.component.thrift.ThriftProducerSecurityTest;
 import org.apache.camel.component.thrift.generated.Calculator;
 import org.apache.camel.component.thrift.impl.CalculatorSyncServerImpl;
 import org.apache.camel.component.thrift.server.ThriftThreadPoolServer;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -34,7 +33,6 @@ import org.apache.thrift.transport.TTransport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,8 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ThriftThreadPoolServerTest extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(ThriftProducerSecurityTest.class);
 
-    @RegisterExtension
-    AvailablePortFinder.Port thriftTestPort = AvailablePortFinder.find();
+    private int thriftTestPort;
     private static final int THRIFT_TEST_NUM1 = 12;
     private static final int THRIFT_TEST_NUM2 = 13;
 
@@ -71,8 +68,9 @@ public class ThriftThreadPoolServerTest extends CamelTestSupport {
         TSSLTransportFactory.TSSLTransportParameters sslParams = new TSSLTransportFactory.TSSLTransportParameters();
 
         sslParams.setKeyStore(KEY_STORE_PATH, SECURITY_STORE_PASSWORD);
-        serverTransport = TSSLTransportFactory.getServerSocket(thriftTestPort.getPort(), THRIFT_CLIENT_TIMEOUT,
+        serverTransport = TSSLTransportFactory.getServerSocket(0, THRIFT_CLIENT_TIMEOUT,
                 InetAddress.getByName("localhost"), sslParams);
+        thriftTestPort = serverTransport.getServerSocket().getLocalPort();
         ThriftThreadPoolServer.Args args = new ThriftThreadPoolServer.Args(serverTransport);
 
         args.processor(processor);
@@ -82,7 +80,7 @@ public class ThriftThreadPoolServerTest extends CamelTestSupport {
 
         server = new ThriftThreadPoolServer(args);
         server.serve();
-        LOG.info("Thrift secured server started on port: {}", thriftTestPort.getPort());
+        LOG.info("Thrift secured server started on port: {}", thriftTestPort);
     }
 
     @AfterEach
@@ -98,7 +96,7 @@ public class ThriftThreadPoolServerTest extends CamelTestSupport {
     public void clientConnectionTest() throws TException {
         TSSLTransportFactory.TSSLTransportParameters sslParams = new TSSLTransportFactory.TSSLTransportParameters();
         sslParams.setTrustStore(TRUST_STORE_PATH, SECURITY_STORE_PASSWORD);
-        clientTransport = TSSLTransportFactory.getClientSocket("localhost", thriftTestPort.getPort(), 1000, sslParams);
+        clientTransport = TSSLTransportFactory.getClientSocket("localhost", thriftTestPort, 1000, sslParams);
 
         protocol = new TBinaryProtocol(clientTransport);
         Calculator.Client client = new Calculator.Client(protocol);


### PR DESCRIPTION
[CAMEL-23431](https://issues.apache.org/jira/browse/CAMEL-23431)

## Summary

Third PR for CAMEL-23431. Migrates all `camel-thrift` tests (10 test files) from `AvailablePortFinder` to port-0 binding, completely eliminating `AvailablePortFinder` from the thrift module.

**Production code:**
- Add `getLocalPort()` to `ThriftConsumer` to expose the OS-assigned port after server start

**Producer tests (create own server):**
- `ThriftProducerBaseTest`: Move server creation to `doPreSetup()`, bind `TNonblockingServerSocket` to port 0
- `ThriftProducerSecurityTest`: Same pattern with `TSSLTransportFactory`
- `ThriftProducerZlibCompressionTest`: Same pattern with `TServerSocket`
- `ThriftThreadPoolServerTest`: Bind to port 0 in `@BeforeEach`

**Consumer tests (Camel component creates server):**
- All 5 consumer tests use port 0 in `from()` URI, then read back actual port from `ThriftConsumer.getLocalPort()` for client connections
- `ThriftConsumerConcurrentTest`: 2 ports (sync + async) both use port 0

## Test plan
- [x] `mvn test` in `camel-thrift` — 39 tests pass
- [ ] CI green
