### PR TITLE
CAMEL-22539: Fix and re-enable 48 flaky tests across multiple modules

### DIFF
--- a/components/camel-aws/camel-aws-parameter-store/src/test/java/org/apache/camel/component/aws/parameterstore/integration/ParameterStoreDeleteParameterProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-parameter-store/src/test/java/org/apache/camel/component/aws/parameterstore/integration/ParameterStoreDeleteParameterProducerLocalstackIT.java
@@ -24,7 +24,6 @@ import org.apache.camel.component.aws.parameterstore.ParameterStoreConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.DeleteParameterResponse;
 import software.amazon.awssdk.services.ssm.model.ParameterType;
@@ -32,7 +31,6 @@ import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class ParameterStoreDeleteParameterProducerLocalstackIT extends AwsParameterStoreBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-parameter-store/src/test/java/org/apache/camel/component/aws/parameterstore/integration/ParameterStoreDescribeParametersProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-parameter-store/src/test/java/org/apache/camel/component/aws/parameterstore/integration/ParameterStoreDescribeParametersProducerLocalstackIT.java
@@ -24,7 +24,6 @@ import org.apache.camel.component.aws.parameterstore.ParameterStoreConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.DescribeParametersResponse;
 import software.amazon.awssdk.services.ssm.model.ParameterType;
@@ -32,7 +31,6 @@ import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class ParameterStoreDescribeParametersProducerLocalstackIT extends AwsParameterStoreBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-parameter-store/src/test/java/org/apache/camel/component/aws/parameterstore/integration/ParameterStoreGetParameterProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-parameter-store/src/test/java/org/apache/camel/component/aws/parameterstore/integration/ParameterStoreGetParameterProducerLocalstackIT.java
@@ -24,7 +24,6 @@ import org.apache.camel.component.aws.parameterstore.ParameterStoreConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.ParameterType;
 import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
@@ -32,7 +31,6 @@ import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class ParameterStoreGetParameterProducerLocalstackIT extends AwsParameterStoreBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-parameter-store/src/test/java/org/apache/camel/component/aws/parameterstore/integration/ParameterStoreGetParametersByPathProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-parameter-store/src/test/java/org/apache/camel/component/aws/parameterstore/integration/ParameterStoreGetParametersByPathProducerLocalstackIT.java
@@ -24,7 +24,6 @@ import org.apache.camel.component.aws.parameterstore.ParameterStoreConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.GetParametersByPathResponse;
 import software.amazon.awssdk.services.ssm.model.ParameterType;
@@ -33,7 +32,6 @@ import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class ParameterStoreGetParametersByPathProducerLocalstackIT extends AwsParameterStoreBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-parameter-store/src/test/java/org/apache/camel/component/aws/parameterstore/integration/ParameterStorePropertiesSourceTestLocalstackIT.java
+++ b/components/camel-aws/camel-aws-parameter-store/src/test/java/org/apache/camel/component/aws/parameterstore/integration/ParameterStorePropertiesSourceTestLocalstackIT.java
@@ -20,11 +20,9 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.ssm.model.ParameterType;
 import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class ParameterStorePropertiesSourceTestLocalstackIT extends AwsParameterStoreBaseTest {
 
     @BeforeAll

--- a/components/camel-aws/camel-aws-parameter-store/src/test/java/org/apache/camel/component/aws/parameterstore/integration/ParameterStorePutParameterProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-parameter-store/src/test/java/org/apache/camel/component/aws/parameterstore/integration/ParameterStorePutParameterProducerLocalstackIT.java
@@ -23,13 +23,11 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.parameterstore.ParameterStoreConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.ssm.model.PutParameterResponse;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class ParameterStorePutParameterProducerLocalstackIT extends AwsParameterStoreBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerCreateSecretProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerCreateSecretProducerLocalstackIT.java
@@ -23,12 +23,10 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.secretsmanager.SecretsManagerConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SecretsManagerCreateSecretProducerLocalstackIT extends AwsSecretsManagerBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerDescribeSecretProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerDescribeSecretProducerLocalstackIT.java
@@ -23,7 +23,6 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.secretsmanager.SecretsManagerConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse;
 import software.amazon.awssdk.services.secretsmanager.model.DescribeSecretResponse;
 
@@ -31,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SecretsManagerDescribeSecretProducerLocalstackIT extends AwsSecretsManagerBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerProducerListSecretsLocalstackIT.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerProducerListSecretsLocalstackIT.java
@@ -23,7 +23,6 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.secretsmanager.SecretsManagerConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse;
 import software.amazon.awssdk.services.secretsmanager.model.ListSecretsResponse;
 
@@ -31,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SecretsManagerProducerListSecretsLocalstackIT extends AwsSecretsManagerBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerPutSecretValueProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerPutSecretValueProducerLocalstackIT.java
@@ -24,13 +24,11 @@ import org.apache.camel.component.aws.secretsmanager.SecretsManagerConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse;
 import software.amazon.awssdk.services.secretsmanager.model.PutSecretValueResponse;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SecretsManagerPutSecretValueProducerLocalstackIT extends AwsSecretsManagerBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerRotateSecretProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerRotateSecretProducerLocalstackIT.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse;
 import software.amazon.awssdk.services.secretsmanager.model.RotateSecretResponse;
 
@@ -36,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SecretsManagerRotateSecretProducerLocalstackIT extends AwsSecretsManagerBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerUpdateSecretProducerLocalstackIT.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/integration/SecretsManagerUpdateSecretProducerLocalstackIT.java
@@ -24,7 +24,6 @@ import org.apache.camel.component.aws.secretsmanager.SecretsManagerConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse;
 import software.amazon.awssdk.services.secretsmanager.model.UpdateSecretResponse;
 
@@ -32,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SecretsManagerUpdateSecretProducerLocalstackIT extends AwsSecretsManagerBaseTest {
 
     @EndpointInject("mock:result")

--- a/components/camel-aws/camel-aws2-kinesis/src/test/java/org/apache/camel/component/aws2/kinesis/Kinesis2ConsumerHealthCustomClientIT.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/test/java/org/apache/camel/component/aws2/kinesis/Kinesis2ConsumerHealthCustomClientIT.java
@@ -36,12 +36,10 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.awaitility.Awaitility.await;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class Kinesis2ConsumerHealthCustomClientIT extends CamelTestSupport {

--- a/components/camel-aws/camel-aws2-kms/src/test/java/org/apache/camel/component/aws2/kms/localstack/KmsCreateKeyIT.java
+++ b/components/camel-aws/camel-aws2-kms/src/test/java/org/apache/camel/component/aws2/kms/localstack/KmsCreateKeyIT.java
@@ -24,13 +24,11 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.kms.KMS2Constants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.kms.model.CreateKeyResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class KmsCreateKeyIT extends Aws2KmsBase {
 
     @EndpointInject

--- a/components/camel-aws/camel-aws2-kms/src/test/java/org/apache/camel/component/aws2/kms/localstack/KmsDisableKeyIT.java
+++ b/components/camel-aws/camel-aws2-kms/src/test/java/org/apache/camel/component/aws2/kms/localstack/KmsDisableKeyIT.java
@@ -24,14 +24,12 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.kms.KMS2Constants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.kms.model.CreateKeyResponse;
 import software.amazon.awssdk.services.kms.model.ListKeysResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class KmsDisableKeyIT extends Aws2KmsBase {
 
     @EndpointInject

--- a/components/camel-aws/camel-aws2-kms/src/test/java/org/apache/camel/component/aws2/kms/localstack/KmsListKeysIT.java
+++ b/components/camel-aws/camel-aws2-kms/src/test/java/org/apache/camel/component/aws2/kms/localstack/KmsListKeysIT.java
@@ -24,13 +24,11 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.kms.KMS2Constants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.kms.model.ListKeysResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class KmsListKeysIT extends Aws2KmsBase {
 
     @EndpointInject

--- a/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaAliasesIT.java
+++ b/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaAliasesIT.java
@@ -24,7 +24,6 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.lambda.Lambda2Constants;
 import org.apache.camel.component.aws2.lambda.Lambda2Operations;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.lambda.model.CreateAliasResponse;
 import software.amazon.awssdk.services.lambda.model.CreateFunctionResponse;
 import software.amazon.awssdk.services.lambda.model.GetAliasResponse;
@@ -33,7 +32,6 @@ import software.amazon.awssdk.services.lambda.model.ListAliasesResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class LambdaAliasesIT extends Aws2LambdaBase {
 
     @Test

--- a/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaDeleteFunctionIT.java
+++ b/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaDeleteFunctionIT.java
@@ -28,12 +28,10 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.lambda.Lambda2Constants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.lambda.model.DeleteFunctionResponse;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class LambdaDeleteFunctionIT extends Aws2LambdaBase {
 
     @EndpointInject

--- a/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaListFunctionsIT.java
+++ b/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/integration/LambdaListFunctionsIT.java
@@ -28,13 +28,11 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.lambda.Lambda2Constants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import software.amazon.awssdk.services.lambda.model.ListFunctionsResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class LambdaListFunctionsIT extends Aws2LambdaBase {
 
     @EndpointInject

--- a/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsTopicProducerBatchIT.java
+++ b/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsTopicProducerBatchIT.java
@@ -26,14 +26,12 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.infra.common.SharedNameGenerator;
 import org.apache.camel.test.infra.common.TestEntityNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.services.sns.model.PublishBatchRequestEntry;
 import software.amazon.awssdk.services.sns.model.PublishBatchResponse;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SnsTopicProducerBatchIT extends Aws2SNSBase {
 
     @RegisterExtension

--- a/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsTopicProducerIT.java
+++ b/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsTopicProducerIT.java
@@ -24,12 +24,10 @@ import org.apache.camel.component.aws2.sns.Sns2Constants;
 import org.apache.camel.test.infra.common.SharedNameGenerator;
 import org.apache.camel.test.infra.common.TestEntityNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SnsTopicProducerIT extends Aws2SNSBase {
 
     @RegisterExtension

--- a/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsTopicProducerSubjectTruncationIT.java
+++ b/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/integration/SnsTopicProducerSubjectTruncationIT.java
@@ -25,7 +25,6 @@ import org.apache.camel.test.infra.common.SharedNameGenerator;
 import org.apache.camel.test.infra.common.TestEntityNameGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -34,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * Integration test for CAMEL-22429: Verify that subjects longer than 100 characters are properly truncated when sending
  * to AWS SNS, preventing InvalidParameterException.
  */
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SnsTopicProducerSubjectTruncationIT extends Aws2SNSBase {
 
     @RegisterExtension

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.grpc;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -31,7 +32,6 @@ import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +40,6 @@ import static org.apache.camel.test.junit6.TestSupport.assertListSize;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class GrpcProducerStreamingTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProducerStreamingTest.class);
@@ -100,7 +99,7 @@ public class GrpcProducerStreamingTest extends CamelTestSupport {
         replies.expectedMessageCount(messageGroupCount);
         replies.assertIsSatisfied();
 
-        Thread.sleep(2000);
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertListSize(pingPongServer.getLastStreamRequests(), 1));
 
         for (int i = messageGroupCount + 1; i <= 2 * messageGroupCount; i++) {
             template.sendBody("direct:grpc-stream-async-async-route",

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpNoConnectionTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpNoConnectionTest.java
@@ -24,14 +24,12 @@ import org.apache.hc.core5.http.impl.bootstrap.HttpServer;
 import org.apache.hc.core5.http.impl.bootstrap.ServerBootstrap;
 import org.apache.hc.core5.util.TimeValue;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.apache.camel.http.common.HttpMethods.GET;
 import static org.apache.camel.test.junit6.TestSupport.assertIsInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class HttpNoConnectionTest extends BaseHttpTest {
 
     private HttpServer localServer;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsComponentIbmMQTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsComponentIbmMQTest.java
@@ -26,12 +26,10 @@ import org.apache.camel.test.infra.ibmmq.services.IbmMQService;
 import org.apache.camel.test.infra.ibmmq.services.IbmMQServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class JmsComponentIbmMQTest extends CamelTestSupport {
 
     @RegisterExtension

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsMultipleConsumersQueueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsMultipleConsumersQueueTest.java
@@ -27,10 +27,8 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class JmsMultipleConsumersQueueTest extends AbstractJMSTest {
 
     @Order(2)
@@ -90,8 +88,8 @@ public class JmsMultipleConsumersQueueTest extends AbstractJMSTest {
     }
 
     private void waitForConnections() {
-        Awaitility.await().until(() -> context.getRoute("route-1").getUptimeMillis() > 100);
-        Awaitility.await().until(() -> context.getRoute("route-2").getUptimeMillis() > 100);
-        Awaitility.await().until(() -> context.getRoute("route-3").getUptimeMillis() > 100);
+        Awaitility.await().until(() -> context.getRoute("route-1").getUptimeMillis() > 500);
+        Awaitility.await().until(() -> context.getRoute("route-2").getUptimeMillis() > 500);
+        Awaitility.await().until(() -> context.getRoute("route-3").getUptimeMillis() > 500);
     }
 }

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsMultipleConsumersTopicTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsMultipleConsumersTopicTest.java
@@ -27,10 +27,8 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class JmsMultipleConsumersTopicTest extends AbstractJMSTest {
 
     @Order(2)
@@ -91,8 +89,8 @@ public class JmsMultipleConsumersTopicTest extends AbstractJMSTest {
     }
 
     private void waitForConnections() {
-        Awaitility.await().until(() -> context.getRoute("route-1").getUptimeMillis() > 100);
-        Awaitility.await().until(() -> context.getRoute("route-2").getUptimeMillis() > 100);
-        Awaitility.await().until(() -> context.getRoute("route-3").getUptimeMillis() > 100);
+        Awaitility.await().until(() -> context.getRoute("route-1").getUptimeMillis() > 500);
+        Awaitility.await().until(() -> context.getRoute("route-2").getUptimeMillis() > 500);
+        Awaitility.await().until(() -> context.getRoute("route-3").getUptimeMillis() > 500);
     }
 }

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/ManagedJmsEndpointTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/ManagedJmsEndpointTest.java
@@ -27,13 +27,11 @@ import org.apache.camel.support.ShortUuidGenerator;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tags({ @Tag("not-parallel") })
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class ManagedJmsEndpointTest extends AbstractPersistentJMSTest {
 
     private final String uuid = new ShortUuidGenerator().generateUuid();

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/consumers/TwoConsumerOnSameQueueIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/consumers/TwoConsumerOnSameQueueIT.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
@@ -69,7 +68,6 @@ public class TwoConsumerOnSameQueueIT extends CamelTestSupport {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
     public void testStopAndStartOneRoute() throws Exception {
         sendTwoMessagesWhichShouldReceivedOnBothEndpointsAndAssert();
 
@@ -97,7 +95,6 @@ public class TwoConsumerOnSameQueueIT extends CamelTestSupport {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
     public void testRemoveOneRoute() throws Exception {
         sendTwoMessagesWhichShouldReceivedOnBothEndpointsAndAssert();
 

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsReplyToIbmMQTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsReplyToIbmMQTest.java
@@ -25,13 +25,11 @@ import org.apache.camel.test.infra.ibmmq.services.IbmMQService;
 import org.apache.camel.test.infra.ibmmq.services.IbmMQServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class JmsReplyToIbmMQTest extends CamelTestSupport {
 
     @RegisterExtension

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/temp/TemporaryQueueRouteTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/temp/TemporaryQueueRouteTest.java
@@ -27,10 +27,8 @@ import org.apache.camel.test.infra.core.TransientCamelContextExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class TemporaryQueueRouteTest extends AbstractJMSTest {
     @Order(2)
     @RegisterExtension

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerAuthInvalidIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaConsumerAuthInvalidIT.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperties;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -64,7 +63,6 @@ import static org.junit.jupiter.api.Assertions.fail;
                                  disabledReason = "Requires Kafka container"),
         @EnabledIfSystemProperty(named = "kafka.instance.type", matches = "kafka", disabledReason = "Requires Kafka container")
 })
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class KafkaConsumerAuthInvalidIT {
     public static final String TOPIC = "test-auth-invalid-it";
@@ -153,10 +151,10 @@ public class KafkaConsumerAuthInvalidIT {
         MockEndpoint dlq = contextExtension.getMockEndpoint("mock:dlq");
 
         dlq.expectedMessageCount(1);
-        dlq.assertIsSatisfied(3000);
+        dlq.assertIsSatisfied(10000);
 
         to.expectedMessageCount(0);
-        to.assertIsSatisfied(3000);
+        to.assertIsSatisfied(10000);
 
         final Map<String, ConsumerGroupDescription> allGroups
                 = assertDoesNotThrow(() -> KafkaAdminUtil.getConsumerGroupInfo("KafkaConsumerAuthInvalidIT",

--- a/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpTcpClientProducerConnectionErrorTest.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpTcpClientProducerConnectionErrorTest.java
@@ -32,13 +32,11 @@ import org.apache.camel.test.junit.rule.mllp.MllpServerResource;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.camel.test.mllp.Hl7TestMessageGenerator;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 public class MllpTcpClientProducerConnectionErrorTest extends CamelTestSupport {
 
     @RegisterExtension
@@ -130,15 +128,15 @@ public class MllpTcpClientProducerConnectionErrorTest extends CamelTestSupport {
 
         // Need to send one message to get the connection established
         source.sendBody(Hl7TestMessageGenerator.generateMessage());
-        assertTrue(oneDone.matches(5, TimeUnit.SECONDS), "Should have completed an exchange");
+        assertTrue(oneDone.matches(10, TimeUnit.SECONDS), "Should have completed an exchange");
 
         mllpServer.closeClientConnections();
 
         source.sendBody(Hl7TestMessageGenerator.generateMessage());
 
-        assertTrue(twoDone.matches(5, TimeUnit.SECONDS), "Should have completed two exchanges");
+        assertTrue(twoDone.matches(10, TimeUnit.SECONDS), "Should have completed two exchanges");
 
-        MockEndpoint.assertIsSatisfied(context, 5, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, 10, TimeUnit.SECONDS);
     }
 
     /**
@@ -159,14 +157,14 @@ public class MllpTcpClientProducerConnectionErrorTest extends CamelTestSupport {
 
         // Need to send one message to get the connection established
         source.sendBody(Hl7TestMessageGenerator.generateMessage());
-        assertTrue(oneDone.matches(5, TimeUnit.SECONDS), "Should have completed an exchange");
+        assertTrue(oneDone.matches(10, TimeUnit.SECONDS), "Should have completed an exchange");
 
         mllpServer.resetClientConnections();
 
         source.sendBody(Hl7TestMessageGenerator.generateMessage());
-        assertTrue(twoDone.matches(5, TimeUnit.SECONDS), "Should have completed two exchanges");
+        assertTrue(twoDone.matches(10, TimeUnit.SECONDS), "Should have completed two exchanges");
 
-        MockEndpoint.assertIsSatisfied(context, 5, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, 10, TimeUnit.SECONDS);
     }
 
     @Test()
@@ -183,9 +181,9 @@ public class MllpTcpClientProducerConnectionErrorTest extends CamelTestSupport {
 
         source.sendBody(Hl7TestMessageGenerator.generateMessage());
 
-        assertTrue(done.matches(5, TimeUnit.SECONDS), "Should have completed an exchange");
+        assertTrue(done.matches(10, TimeUnit.SECONDS), "Should have completed an exchange");
 
-        MockEndpoint.assertIsSatisfied(context, 5, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, 10, TimeUnit.SECONDS);
     }
 
     @Test()
@@ -202,9 +200,9 @@ public class MllpTcpClientProducerConnectionErrorTest extends CamelTestSupport {
 
         source.sendBody(Hl7TestMessageGenerator.generateMessage());
 
-        assertTrue(done.matches(5, TimeUnit.SECONDS), "Should have completed an exchange");
+        assertTrue(done.matches(10, TimeUnit.SECONDS), "Should have completed an exchange");
 
-        MockEndpoint.assertIsSatisfied(context, 5, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, 10, TimeUnit.SECONDS);
     }
 
     @Test()
@@ -222,9 +220,9 @@ public class MllpTcpClientProducerConnectionErrorTest extends CamelTestSupport {
 
         source.sendBody(Hl7TestMessageGenerator.generateMessage());
 
-        assertTrue(done.matches(5, TimeUnit.SECONDS), "Should have completed an exchange");
+        assertTrue(done.matches(10, TimeUnit.SECONDS), "Should have completed an exchange");
 
-        MockEndpoint.assertIsSatisfied(context, 5, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, 10, TimeUnit.SECONDS);
 
         // Depending on the timing, either a write or a receive exception will be thrown
         assertEquals(1, writeEx.getExchanges().size() + acknowledgementEx.getExchanges().size(),
@@ -247,9 +245,9 @@ public class MllpTcpClientProducerConnectionErrorTest extends CamelTestSupport {
 
         source.sendBody(Hl7TestMessageGenerator.generateMessage());
 
-        assertTrue(done.matches(5, TimeUnit.SECONDS), "Should have completed an exchange");
+        assertTrue(done.matches(10, TimeUnit.SECONDS), "Should have completed an exchange");
 
-        MockEndpoint.assertIsSatisfied(context, 5, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, 10, TimeUnit.SECONDS);
 
         // Depending on the timing, either a write or a receive exception will be thrown
         assertEquals(1, writeEx.getExchanges().size() + acknowledgementEx.getExchanges().size(),
@@ -274,9 +272,9 @@ public class MllpTcpClientProducerConnectionErrorTest extends CamelTestSupport {
 
         source.sendBody(Hl7TestMessageGenerator.generateMessage());
 
-        assertTrue(done.matches(5, TimeUnit.SECONDS), "Should have completed an exchange");
+        assertTrue(done.matches(10, TimeUnit.SECONDS), "Should have completed an exchange");
 
-        MockEndpoint.assertIsSatisfied(context, 5, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, 10, TimeUnit.SECONDS);
     }
 
 }

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerIT.java
@@ -21,9 +21,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.nats.NatsConstants;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class NatsConsumerIT extends NatsITSupport {
 
     @EndpointInject("mock:result")
@@ -36,6 +34,7 @@ public class NatsConsumerIT extends NatsITSupport {
 
         template.sendBody("direct:send", "Hello World");
 
+        mockResultEndpoint.setAssertPeriod(5000);
         mockResultEndpoint.assertIsSatisfied();
     }
 

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerMaxMessagesIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerMaxMessagesIT.java
@@ -20,9 +20,7 @@ import org.apache.camel.EndpointInject;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class NatsConsumerMaxMessagesIT extends NatsITSupport {
 
     @EndpointInject("mock:result")
@@ -43,6 +41,7 @@ public class NatsConsumerMaxMessagesIT extends NatsITSupport {
         template.sendBody("direct:send", "test9");
         template.sendBody("direct:send", "test10");
 
+        mockResultEndpoint.setAssertPeriod(5000);
         mockResultEndpoint.assertIsSatisfied();
     }
 

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerReplyToIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerReplyToIT.java
@@ -21,9 +21,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.nats.NatsConstants;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class NatsConsumerReplyToIT extends NatsITSupport {
 
     @EndpointInject("mock:result")
@@ -41,7 +39,9 @@ public class NatsConsumerReplyToIT extends NatsITSupport {
 
         template.sendBody("direct:send", "World");
 
+        mockResultEndpoint.setAssertPeriod(5000);
         mockResultEndpoint.assertIsSatisfied();
+        mockReplyEndpoint.setAssertPeriod(5000);
         mockReplyEndpoint.assertIsSatisfied();
     }
 

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsProducerReplyToIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsProducerReplyToIT.java
@@ -19,11 +19,9 @@ package org.apache.camel.component.nats.integration;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class NatsProducerReplyToIT extends NatsITSupport {
 
     protected String startUri = "direct:start";
@@ -42,6 +40,7 @@ public class NatsProducerReplyToIT extends NatsITSupport {
         String out = template.requestBody(startUri, body1, String.class);
         String out2 = template.requestBody(startUri, body2, String.class);
 
+        resultEndpoint.setAssertPeriod(5000);
         resultEndpoint.assertIsSatisfied();
 
         assertEquals("Bye Camel", out);

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsProducerReplyToTimeoutIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsProducerReplyToTimeoutIT.java
@@ -20,13 +20,11 @@ import org.apache.camel.CamelExecutionException;
 import org.apache.camel.ExchangeTimedOutException;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.apache.camel.test.junit6.TestSupport.assertIsInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class NatsProducerReplyToTimeoutIT extends NatsITSupport {
 
     protected String startUri = "direct:start";

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerAckPolicyNoneIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerAckPolicyNoneIT.java
@@ -26,10 +26,8 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.nats.NatsConstants;
 import org.apache.camel.component.nats.integration.NatsITSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.parallel.Isolated;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 @Isolated
 public class NatsJetstreamConsumerAckPolicyNoneIT extends NatsITSupport {
 
@@ -56,6 +54,8 @@ public class NatsJetstreamConsumerAckPolicyNoneIT extends NatsITSupport {
         template.sendBody("direct:send", "Hello World 2");
         template.sendBody("direct:send", "Hello World 3");
 
+        mockResultEndpoint.setAssertPeriod(5000);
+        mockInputEndpoint.setAssertPeriod(5000);
         MockEndpoint.assertIsSatisfied(context);
     }
 

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerIT.java
@@ -22,10 +22,8 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.nats.NatsConstants;
 import org.apache.camel.component.nats.integration.NatsITSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.parallel.Isolated;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 @Isolated
 public class NatsJetstreamConsumerIT extends NatsITSupport {
 
@@ -39,6 +37,7 @@ public class NatsJetstreamConsumerIT extends NatsITSupport {
 
         template.sendBody("direct:send", "Hello World");
 
+        mockResultEndpoint.setAssertPeriod(5000);
         MockEndpoint.assertIsSatisfied(context);
     }
 

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerMaxDeliverIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerMaxDeliverIT.java
@@ -26,10 +26,8 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.nats.NatsConstants;
 import org.apache.camel.component.nats.integration.NatsITSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.parallel.Isolated;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 @Isolated
 public class NatsJetstreamConsumerMaxDeliverIT extends NatsITSupport {
 

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerRedeliveryIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerRedeliveryIT.java
@@ -26,10 +26,8 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.nats.NatsConstants;
 import org.apache.camel.component.nats.integration.NatsITSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.parallel.Isolated;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 @Isolated
 public class NatsJetstreamConsumerRedeliveryIT extends NatsITSupport {
 
@@ -54,6 +52,8 @@ public class NatsJetstreamConsumerRedeliveryIT extends NatsITSupport {
 
         template.sendBody("direct:send", "Hello World");
 
+        mockResultEndpoint.setAssertPeriod(5000);
+        mockInputEndpoint.setAssertPeriod(5000);
         MockEndpoint.assertIsSatisfied(context);
     }
 

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/SjmsToDTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/SjmsToDTest.java
@@ -20,9 +20,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.sjms.support.JmsTestSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class SjmsToDTest extends JmsTestSupport {
 
     @Test

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsConsumerRouteTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsConsumerRouteTest.java
@@ -43,7 +43,6 @@ import org.apache.camel.component.undertow.UndertowConstants.EventType;
 import org.apache.camel.converter.IOConverter;
 import org.apache.camel.test.infra.common.http.WebsocketTestClient;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -163,7 +162,6 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
         testClient2.close();
     }
 
-    @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
     @Test
     public void echo() throws Exception {
         WebsocketTestClient wsclient1 = new WebsocketTestClient("ws://localhost:" + getPort() + "/app3", 2);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateProcessorTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateProcessorTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.processor.aggregator;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.camel.AggregationStrategy;
@@ -237,7 +238,7 @@ public class AggregateProcessorTest extends ContextTestSupport {
         ap.process(e2);
         ap.process(e3);
 
-        await().atMost(5, java.util.concurrent.TimeUnit.SECONDS)
+        await().atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertEquals(1, mock.getReceivedCounter()));
 
         ap.process(e4);
@@ -285,7 +286,7 @@ public class AggregateProcessorTest extends ContextTestSupport {
         ap.process(e2);
         ap.process(e3);
 
-        await().atMost(5, java.util.concurrent.TimeUnit.SECONDS)
+        await().atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertEquals(1, mock.getReceivedCounter()));
 
         ap.process(e4);

--- a/core/camel-management/src/test/java/org/apache/camel/management/AbstractManagedThrottlerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/AbstractManagedThrottlerTest.java
@@ -24,8 +24,8 @@ import javax.management.ObjectName;
 
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledOnOs(OS.AIX)
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public abstract class AbstractManagedThrottlerTest extends ManagementTestSupport {
 
     protected Long runTestManageThrottler() throws Exception {
@@ -76,8 +75,8 @@ public abstract class AbstractManagedThrottlerTest extends ManagementTestSupport
 
         Long total = (Long) mbeanServer.getAttribute(routeName, "TotalProcessingTime");
 
-        // 10 * delay (100) + tolerance (200)
-        assertTrue(total < 1200, "Should take at most 1.2 sec: was " + total);
+        // 10 * delay (100) + tolerance (1500 for slow CI)
+        assertTrue(total < 2500, "Should take at most 2.5 sec: was " + total);
 
         // change the throttler using JMX
         mbeanServer.setAttribute(throttlerName, new Attribute("MaximumRequests", (long) 2));
@@ -120,7 +119,7 @@ public abstract class AbstractManagedThrottlerTest extends ManagementTestSupport
             template.sendBody("seda:throttleCountAsync", "Message " + i);
         }
 
-        assertTrue(notifier.matches(2, TimeUnit.SECONDS));
+        assertTrue(notifier.matches(5, TimeUnit.SECONDS));
         assertMockEndpointsSatisfied();
 
         Long completed = (Long) mbeanServer.getAttribute(routeName, "ExchangesCompleted");
@@ -147,15 +146,15 @@ public abstract class AbstractManagedThrottlerTest extends ManagementTestSupport
             template.sendBody("seda:throttleCountAsyncException", "Message " + i);
         }
 
-        assertTrue(notifier.matches(2, TimeUnit.SECONDS));
+        assertTrue(notifier.matches(5, TimeUnit.SECONDS));
         assertMockEndpointsSatisfied();
 
-        // give a sec for exception handling to finish..
-        Thread.sleep(500);
-
-        // since all exchanges ended w/ exception, they are not completed
-        Long completed = (Long) mbeanServer.getAttribute(routeName, "ExchangesCompleted");
-        assertEquals(0, completed.longValue());
+        // wait for exception handling to finish
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    Long c = (Long) mbeanServer.getAttribute(routeName, "ExchangesCompleted");
+                    assertEquals(0, c.longValue());
+                });
     }
 
     @Test

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedAConcurrentThrottlerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedAConcurrentThrottlerTest.java
@@ -26,22 +26,20 @@ import java.util.concurrent.TimeUnit;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.ThrottlingMode;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledOnOs(OS.AIX)
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class ManagedAConcurrentThrottlerTest extends AbstractManagedThrottlerTest {
 
     @Test
     public void testManageThrottler() throws Exception {
         final Long total = super.runTestManageThrottler();
 
-        // 10 * delay (100) + tolerance (200)
-        assertTrue(total < 1200, "Should take at most 1.2 sec: was " + total);
+        // 10 * delay (100) + tolerance (1500 for slow CI)
+        assertTrue(total < 2500, "Should take at most 2.5 sec: was " + total);
     }
 
     @DisabledOnOs(OS.WINDOWS)

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedAThrottlerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedAThrottlerTest.java
@@ -25,14 +25,12 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledOnOs(OS.AIX)
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on GitHub Actions")
 public class ManagedAThrottlerTest extends AbstractManagedThrottlerTest {
 
     @Test

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedAggregateControllerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedAggregateControllerTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.management;
 
+import java.util.concurrent.TimeUnit;
+
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
@@ -66,7 +68,7 @@ public class ManagedAggregateControllerTest extends ManagementTestSupport {
         getMockEndpoint("mock:aggregated").expectedBodiesReceivedInAnyOrder("test1test3", "test2test4");
         getMockEndpoint("mock:aggregated").expectedPropertyReceived(Exchange.AGGREGATED_COMPLETED_BY, "force");
 
-        Awaitility.await().atMost(5, java.util.concurrent.TimeUnit.SECONDS)
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
                     Integer p = (Integer) mbeanServer.invoke(on, "aggregationRepositoryGroups", null, null);
                     assertEquals(2, p.intValue());
@@ -125,7 +127,7 @@ public class ManagedAggregateControllerTest extends ManagementTestSupport {
         getMockEndpoint("mock:aggregated").expectedBodiesReceivedInAnyOrder("test1test3");
         getMockEndpoint("mock:aggregated").expectedPropertyReceived(Exchange.AGGREGATED_COMPLETED_BY, "force");
 
-        Awaitility.await().atMost(5, java.util.concurrent.TimeUnit.SECONDS)
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
                     Integer p = (Integer) mbeanServer.invoke(on, "aggregationRepositoryGroups", null, null);
                     assertEquals(2, p.intValue());

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedAggregateControllerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedAggregateControllerTest.java
@@ -104,7 +104,7 @@ public class ManagedAggregateControllerTest extends ManagementTestSupport {
         Integer inflight = (Integer) mbeanServer.getAttribute(on, "InProgressCompleteExchanges");
         assertEquals(0, inflight.intValue());
 
-        pending = (Integer) mbeanServer.invoke(on, "aggregationRepositoryGroups", null, null);
+        Integer pending = (Integer) mbeanServer.invoke(on, "aggregationRepositoryGroups", null, null);
         assertEquals(0, pending.intValue());
     }
 
@@ -164,8 +164,8 @@ public class ManagedAggregateControllerTest extends ManagementTestSupport {
         Integer inflight = (Integer) mbeanServer.getAttribute(on, "InProgressCompleteExchanges");
         assertEquals(0, inflight.intValue());
 
-        pending = (Integer) mbeanServer.invoke(on, "aggregationRepositoryGroups", null, null);
-        assertEquals(1, pending.intValue());
+        Integer pending2 = (Integer) mbeanServer.invoke(on, "aggregationRepositoryGroups", null, null);
+        assertEquals(1, pending2.intValue());
 
         // we can also use the client mbean
         ManagedAggregateProcessorMBean client = context.getCamelContextExtension().getContextPlugin(ManagedCamelContext.class)

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedAggregateControllerTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedAggregateControllerTest.java
@@ -27,10 +27,10 @@ import org.apache.camel.api.management.mbean.ManagedAggregateProcessorMBean;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.processor.aggregate.AggregateController;
 import org.apache.camel.processor.aggregate.DefaultAggregateController;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
@@ -38,7 +38,6 @@ import static org.apache.camel.management.DefaultManagementObjectNameStrategy.TY
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Flaky on Github CI")
 @DisabledOnOs(OS.AIX)
 public class ManagedAggregateControllerTest extends ManagementTestSupport {
 
@@ -67,8 +66,11 @@ public class ManagedAggregateControllerTest extends ManagementTestSupport {
         getMockEndpoint("mock:aggregated").expectedBodiesReceivedInAnyOrder("test1test3", "test2test4");
         getMockEndpoint("mock:aggregated").expectedPropertyReceived(Exchange.AGGREGATED_COMPLETED_BY, "force");
 
-        Integer pending = (Integer) mbeanServer.invoke(on, "aggregationRepositoryGroups", null, null);
-        assertEquals(2, pending.intValue());
+        Awaitility.await().atMost(5, java.util.concurrent.TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    Integer p = (Integer) mbeanServer.invoke(on, "aggregationRepositoryGroups", null, null);
+                    assertEquals(2, p.intValue());
+                });
 
         Integer groups = (Integer) mbeanServer.invoke(on, "forceCompletionOfAllGroups", null, null);
         assertEquals(2, groups.intValue());
@@ -123,8 +125,11 @@ public class ManagedAggregateControllerTest extends ManagementTestSupport {
         getMockEndpoint("mock:aggregated").expectedBodiesReceivedInAnyOrder("test1test3");
         getMockEndpoint("mock:aggregated").expectedPropertyReceived(Exchange.AGGREGATED_COMPLETED_BY, "force");
 
-        Integer pending = (Integer) mbeanServer.invoke(on, "aggregationRepositoryGroups", null, null);
-        assertEquals(2, pending.intValue());
+        Awaitility.await().atMost(5, java.util.concurrent.TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    Integer p = (Integer) mbeanServer.invoke(on, "aggregationRepositoryGroups", null, null);
+                    assertEquals(2, p.intValue());
+                });
 
         Integer groups = (Integer) mbeanServer.invoke(on, "forceCompletionOfGroup", new Object[] { "1" },
                 new String[] { "java.lang.String" });

--- a/test-infra/camel-test-infra-aws-v2/src/main/java/org/apache/camel/test/infra/aws2/services/AWSContainer.java
+++ b/test-infra/camel-test-infra-aws-v2/src/main/java/org/apache/camel/test/infra/aws2/services/AWSContainer.java
@@ -19,6 +19,7 @@ package org.apache.camel.test.infra.aws2.services;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -84,7 +85,10 @@ public class AWSContainer extends GenericContainer<AWSContainer> {
     protected void setupContainer(boolean fixedPort) {
         ContainerEnvironmentUtil.configurePort(this, fixedPort, SERVICE_PORT);
 
-        waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
+        waitingFor(Wait.forHttp("/_localstack/health")
+                .forPort(SERVICE_PORT)
+                .forStatusCode(200)
+                .withStartupTimeout(Duration.ofSeconds(120)));
     }
 
     public AwsCredentialsProvider getCredentialsProvider() {


### PR DESCRIPTION
[CAMEL-22539](https://issues.apache.org/jira/browse/CAMEL-22539)

## Summary

Fix and re-enable 48 flaky tests across multiple modules that were disabled on CI via `@DisabledIfSystemProperty(named = "ci.env.name")`. This is a follow-up to PR #23020 which fixed 13 flaky tests in camel-core.

### camel-management (4 tests)
- `AbstractManagedThrottlerTest`: replace `Thread.sleep(500)` with Awaitility, increase timing tolerance (1200→2500ms), increase NotifyBuilder timeout (2→5s)
- `ManagedAConcurrentThrottlerTest`: increase timing tolerance
- `ManagedAThrottlerTest`: re-enable
- `ManagedAggregateControllerTest`: add Awaitility wait for pending aggregation groups to prevent race condition

### AWS Localstack infrastructure + 20 tests
- `AWSContainer`: replace unreliable `Wait.forLogMessage(".*Ready\\.\n", 1)` with `Wait.forHttp("/_localstack/health").forStatusCode(200)` — the log-based strategy returns before services are actually ready
- Re-enable all 20 disabled AWS integration tests (parameter-store, secrets-manager, kinesis, kms, lambda, sns)

### camel-jms (7 tests)
- `JmsMultipleConsumersQueueTest`/`TopicTest`: increase `waitForConnections` uptime check (100→500ms)
- Re-enable all 7 disabled JMS tests

### camel-nats (9 tests)
- Add explicit `setAssertPeriod(5000)` before mock assertions to accommodate async NATS message delivery
- Re-enable all 9 disabled NATS integration tests

### Remaining components (6 tests)
- `GrpcProducerStreamingTest`: replace `Thread.sleep(2000)` with Awaitility
- `KafkaConsumerAuthInvalidIT`: increase `assertIsSatisfied` timeout (3→10s)
- Re-enable: `HttpNoConnectionTest`, `MllpTcpClientProducerConnectionErrorTest`, `SjmsToDTest`, `UndertowWsConsumerRouteTest`

## Test plan

- [x] All non-container tests compile and pass locally
- [x] Formatter applied to all affected modules
- [ ] CI passes with all tests re-enabled