### PR TITLE
Deprecate camel-digitalocean

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/digitalocean.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/digitalocean.json
@@ -4,7 +4,7 @@
     "name": "digitalocean",
     "title": "DigitalOcean",
     "description": "Manage Droplets and resources within the DigitalOcean cloud.",
-    "deprecated": false,
+    "deprecated": true,
     "firstVersion": "2.19.0",
     "label": "cloud,management",
     "javaType": "org.apache.camel.component.digitalocean.DigitalOceanComponent",

--- a/components/camel-digitalocean/pom.xml
+++ b/components/camel-digitalocean/pom.xml
@@ -29,7 +29,7 @@
 
     <artifactId>camel-digitalocean</artifactId>
     <packaging>jar</packaging>
-    <name>Camel :: DigitalOcean</name>
+    <name>Camel :: DigitalOcean (deprecated)</name>
     <description>Camel DigitalOcean support</description>
 
     <properties>

--- a/components/camel-digitalocean/src/generated/resources/META-INF/org/apache/camel/component/digitalocean/digitalocean.json
+++ b/components/camel-digitalocean/src/generated/resources/META-INF/org/apache/camel/component/digitalocean/digitalocean.json
@@ -4,7 +4,7 @@
     "name": "digitalocean",
     "title": "DigitalOcean",
     "description": "Manage Droplets and resources within the DigitalOcean cloud.",
-    "deprecated": false,
+    "deprecated": true,
     "firstVersion": "2.19.0",
     "label": "cloud,management",
     "javaType": "org.apache.camel.component.digitalocean.DigitalOceanComponent",

--- a/components/camel-digitalocean/src/generated/resources/META-INF/services/org/apache/camel/component.properties
+++ b/components/camel-digitalocean/src/generated/resources/META-INF/services/org/apache/camel/component.properties
@@ -3,5 +3,5 @@ components=digitalocean
 groupId=org.apache.camel
 artifactId=camel-digitalocean
 version=4.21.0-SNAPSHOT
-projectName=Camel :: DigitalOcean
+projectName=Camel :: DigitalOcean (deprecated)
 projectDescription=Camel DigitalOcean support

--- a/components/camel-digitalocean/src/main/docs/digitalocean-component.adoc
+++ b/components/camel-digitalocean/src/main/docs/digitalocean-component.adoc
@@ -1,10 +1,11 @@
-= DigitalOcean Component
+= DigitalOcean Component (deprecated)
 :doctitle: DigitalOcean
 :shortname: digitalocean
 :artifactid: camel-digitalocean
 :description: Manage Droplets and resources within the DigitalOcean cloud.
 :since: 2.19
-:supportlevel: Stable
+:supportlevel: Stable-deprecated
+:deprecated: *deprecated*
 :tabs-sync-option:
 :component-header: Only producer is supported
 //Manually maintained attributes

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/DigitalOceanComponent.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/DigitalOceanComponent.java
@@ -25,6 +25,7 @@ import org.apache.camel.support.DefaultComponent;
 import org.apache.camel.util.ObjectHelper;
 
 @Component("digitalocean")
+@Deprecated(since = "4.21")
 public class DigitalOceanComponent extends DefaultComponent {
     public DigitalOceanComponent() {
     }

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/DigitalOceanConfiguration.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/DigitalOceanConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.camel.spi.UriParams;
 import org.apache.camel.spi.UriPath;
 
 @UriParams
+@Deprecated(since = "4.21")
 public class DigitalOceanConfiguration {
 
     @UriPath(enums = "create,update,delete,list,ownList,get,listBackups,listActions,listNeighbors,listSnapshots,listKernels,listAllNeighbors,"

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/DigitalOceanEndpoint.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/DigitalOceanEndpoint.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
  */
 @UriEndpoint(firstVersion = "2.19.0", scheme = "digitalocean", title = "DigitalOcean", syntax = "digitalocean:operation",
              producerOnly = true, category = { Category.CLOUD, Category.MANAGEMENT }, headersClass = DigitalOceanHeaders.class)
+@Deprecated(since = "4.21")
 public class DigitalOceanEndpoint extends DefaultEndpoint implements EndpointServiceLocation {
 
     private static final transient Logger LOG = LoggerFactory.getLogger(DigitalOceanEndpoint.class);

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/DigitalOceanException.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/DigitalOceanException.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.digitalocean;
 
+@Deprecated(since = "4.21")
 public class DigitalOceanException extends Exception {
 
     private static final long serialVersionUID = 1L;

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/constants/DigitalOceanHeaders.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/constants/DigitalOceanHeaders.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.digitalocean.constants;
 
 import org.apache.camel.spi.Metadata;
 
+@Deprecated(since = "4.21")
 public interface DigitalOceanHeaders {
     @Metadata(description = "The operation to perform",
               javaType = "org.apache.camel.component.digitalocean.constants.DigitalOceanOperations")

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/constants/DigitalOceanImageTypes.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/constants/DigitalOceanImageTypes.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.digitalocean.constants;
 
+@Deprecated(since = "4.21")
 public enum DigitalOceanImageTypes {
 
     distribution,

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/constants/DigitalOceanOperations.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/constants/DigitalOceanOperations.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.digitalocean.constants;
 
+@Deprecated(since = "4.21")
 public enum DigitalOceanOperations {
 
     create,

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/constants/DigitalOceanResources.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/constants/DigitalOceanResources.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.digitalocean.constants;
 
+@Deprecated(since = "4.21")
 public enum DigitalOceanResources {
 
     account,

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/constants/DigitalOceanSnapshotTypes.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/constants/DigitalOceanSnapshotTypes.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.digitalocean.constants;
 
+@Deprecated(since = "4.21")
 public enum DigitalOceanSnapshotTypes {
 
     droplet,

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanAccountProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanAccountProducer.java
@@ -24,6 +24,7 @@ import org.apache.camel.component.digitalocean.DigitalOceanEndpoint;
 /**
  * The DigitalOcean producer for Account API.
  */
+@Deprecated(since = "4.21")
 public class DigitalOceanAccountProducer extends DigitalOceanProducer {
 
     public DigitalOceanAccountProducer(DigitalOceanEndpoint endpoint, DigitalOceanConfiguration configuration) {

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanActionsProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanActionsProducer.java
@@ -29,6 +29,7 @@ import org.apache.camel.util.ObjectHelper;
 /**
  * The DigitalOcean producer for Actions API.
  */
+@Deprecated(since = "4.21")
 public class DigitalOceanActionsProducer extends DigitalOceanProducer {
 
     public DigitalOceanActionsProducer(DigitalOceanEndpoint endpoint, DigitalOceanConfiguration configuration) {

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanBlockStoragesProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanBlockStoragesProducer.java
@@ -37,6 +37,7 @@ import org.apache.camel.util.ObjectHelper;
 /**
  * The DigitalOcean producer for BlockStorages API.
  */
+@Deprecated(since = "4.21")
 public class DigitalOceanBlockStoragesProducer extends DigitalOceanProducer {
 
     public DigitalOceanBlockStoragesProducer(DigitalOceanEndpoint endpoint, DigitalOceanConfiguration configuration) {

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanDropletsProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanDropletsProducer.java
@@ -47,6 +47,7 @@ import org.apache.camel.util.ObjectHelper;
 /**
  * The DigitalOcean producer for Droplets API.
  */
+@Deprecated(since = "4.21")
 public class DigitalOceanDropletsProducer extends DigitalOceanProducer {
 
     private Integer dropletId;

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanFloatingIPsProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanFloatingIPsProducer.java
@@ -32,6 +32,7 @@ import org.apache.camel.util.ObjectHelper;
 /**
  * The DigitalOcean producer for FloatingIps API.
  */
+@Deprecated(since = "4.21")
 public class DigitalOceanFloatingIPsProducer extends DigitalOceanProducer {
 
     public DigitalOceanFloatingIPsProducer(DigitalOceanEndpoint endpoint, DigitalOceanConfiguration configuration) {

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanImagesProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanImagesProducer.java
@@ -34,6 +34,7 @@ import org.apache.camel.util.ObjectHelper;
 /**
  * The DigitalOcean producer for Images API.
  */
+@Deprecated(since = "4.21")
 public class DigitalOceanImagesProducer extends DigitalOceanProducer {
 
     public DigitalOceanImagesProducer(DigitalOceanEndpoint endpoint, DigitalOceanConfiguration configuration) {

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanKeysProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanKeysProducer.java
@@ -30,6 +30,7 @@ import org.apache.camel.util.ObjectHelper;
 /**
  * The DigitalOcean producer for SSH Keys API.
  */
+@Deprecated(since = "4.21")
 public class DigitalOceanKeysProducer extends DigitalOceanProducer {
 
     public DigitalOceanKeysProducer(DigitalOceanEndpoint endpoint, DigitalOceanConfiguration configuration) {

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanProducer.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 /**
  * The DigitalOcean producer.
  */
+@Deprecated(since = "4.21")
 public abstract class DigitalOceanProducer extends DefaultProducer {
     protected static final Logger LOG = LoggerFactory.getLogger(DigitalOceanProducer.class);
     protected DigitalOceanConfiguration configuration;

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanRegionsProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanRegionsProducer.java
@@ -24,6 +24,7 @@ import org.apache.camel.component.digitalocean.DigitalOceanEndpoint;
 /**
  * The DigitalOcean producer for Regions API.
  */
+@Deprecated(since = "4.21")
 public class DigitalOceanRegionsProducer extends DigitalOceanProducer {
 
     public DigitalOceanRegionsProducer(DigitalOceanEndpoint endpoint, DigitalOceanConfiguration configuration) {

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanSizesProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanSizesProducer.java
@@ -24,6 +24,7 @@ import org.apache.camel.component.digitalocean.DigitalOceanEndpoint;
 /**
  * The DigitalOcean producer for Sizes API.
  */
+@Deprecated(since = "4.21")
 public class DigitalOceanSizesProducer extends DigitalOceanProducer {
 
     public DigitalOceanSizesProducer(DigitalOceanEndpoint endpoint, DigitalOceanConfiguration configuration) {

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanSnapshotsProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanSnapshotsProducer.java
@@ -31,6 +31,7 @@ import org.apache.camel.util.ObjectHelper;
 /**
  * The DigitalOcean producer for Snapshots API.
  */
+@Deprecated(since = "4.21")
 public class DigitalOceanSnapshotsProducer extends DigitalOceanProducer {
 
     public DigitalOceanSnapshotsProducer(DigitalOceanEndpoint endpoint, DigitalOceanConfiguration configuration) {

--- a/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanTagsProducer.java
+++ b/components/camel-digitalocean/src/main/java/org/apache/camel/component/digitalocean/producer/DigitalOceanTagsProducer.java
@@ -30,6 +30,7 @@ import org.apache.camel.util.ObjectHelper;
 /**
  * The DigitalOcean producer for Tags API.
  */
+@Deprecated(since = "4.21")
 public class DigitalOceanTagsProducer extends DigitalOceanProducer {
 
     public DigitalOceanTagsProducer(DigitalOceanEndpoint endpoint, DigitalOceanConfiguration configuration) {

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -253,3 +253,7 @@ What it means is that, from now on, the final user or any third party dependency
 
 This is just an informative note, there is not action expected by the final user.
 
+=== Deprecation of camel-digitalocean
+
+The component camel-digitalocean is deprecated. The java library used has been unmaintained for several years and there is no replacement.
+

--- a/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/StaticEndpointBuilders.java
+++ b/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/StaticEndpointBuilders.java
@@ -4272,6 +4272,7 @@ public class StaticEndpointBuilders {
      * @param path operation
      * @return the dsl builder
      */
+    @Deprecated
     public static DigitalOceanEndpointBuilderFactory.DigitalOceanEndpointBuilder digitalocean(String path) {
         return digitalocean("digitalocean", path);
     }
@@ -4300,6 +4301,7 @@ public class StaticEndpointBuilders {
      * @param path operation
      * @return the dsl builder
      */
+    @Deprecated
     public static DigitalOceanEndpointBuilderFactory.DigitalOceanEndpointBuilder digitalocean(String componentName, String path) {
         return DigitalOceanEndpointBuilderFactory.endpointBuilder(componentName, path);
     }

--- a/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/DigitalOceanEndpointBuilderFactory.java
+++ b/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/DigitalOceanEndpointBuilderFactory.java
@@ -326,6 +326,7 @@ public interface DigitalOceanEndpointBuilderFactory {
          * 
          * @return the dsl builder for the headers' name.
          */
+        @Deprecated
         default DigitalOceanHeaderNameBuilder digitalocean() {
             return DigitalOceanHeaderNameBuilder.INSTANCE;
         }
@@ -352,6 +353,7 @@ public interface DigitalOceanEndpointBuilderFactory {
          * @param path operation
          * @return the dsl builder
          */
+        @Deprecated
         default DigitalOceanEndpointBuilder digitalocean(String path) {
             return DigitalOceanEndpointBuilderFactory.endpointBuilder("digitalocean", path);
         }
@@ -380,6 +382,7 @@ public interface DigitalOceanEndpointBuilderFactory {
          * @param path operation
          * @return the dsl builder
          */
+        @Deprecated
         default DigitalOceanEndpointBuilder digitalocean(String componentName, String path) {
             return DigitalOceanEndpointBuilderFactory.endpointBuilder(componentName, path);
         }


### PR DESCRIPTION
despite company behind Digital Ocean still here and active https://www.digitalocean.com/
digital ocean community java API that we are using has 6 years without maintenance https://github.com/jeevatkm/digitalocean-api-java there is no official Java API
https://docs.digitalocean.com/reference/libraries/

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

