### PR TITLE
chore: fix FQCN in AggregateProcessorTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateProcessorTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateProcessorTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.processor.aggregator;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.camel.AggregationStrategy;
@@ -237,7 +238,7 @@ public class AggregateProcessorTest extends ContextTestSupport {
         ap.process(e2);
         ap.process(e3);
 
-        await().atMost(5, java.util.concurrent.TimeUnit.SECONDS)
+        await().atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertEquals(1, mock.getReceivedCounter()));
 
         ap.process(e4);
@@ -285,7 +286,7 @@ public class AggregateProcessorTest extends ContextTestSupport {
         ap.process(e2);
         ap.process(e3);
 
-        await().atMost(5, java.util.concurrent.TimeUnit.SECONDS)
+        await().atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertEquals(1, mock.getReceivedCounter()));
 
         ap.process(e4);


### PR DESCRIPTION
## Summary

- Fix fully-qualified `java.util.concurrent.TimeUnit.SECONDS` usage in `AggregateProcessorTest` — add proper import and use simple class name instead.
- This was introduced in commit 9e5c829e7a25 (CAMEL-22539) and causes CI failure in the "Fail if there are uncommitted changes" step because the OpenRewrite FQCN-shortening plugin rewrites it during the build.

## Test plan

- [x] `mvn compile test-compile -pl core/camel-core` passes
- [ ] CI "uncommitted changes" check passes