### PR TITLE
CAMEL-23431: Migrate camel-grpc and camel-mllp tests from AvailablePortFinder to port-0 binding

### DIFF
--- a/components/camel-grpc/pom.xml
+++ b/components/camel-grpc/pom.xml
@@ -251,6 +251,14 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Djava.util.logging.config.file=${project.build.testOutputDirectory}/logging.properties</argLine>
+                </configuration>
+            </plugin>
+
             <!-- Force the version of guava to camel-package-maven-plugin to prevent build failure due to the
              usage of an old/incompatible version of guava -->
             <plugin>

--- a/components/camel-grpc/pom.xml
+++ b/components/camel-grpc/pom.xml
@@ -255,7 +255,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Djava.util.logging.config.file=${project.build.testOutputDirectory}/logging.properties</argLine>
+                    <systemPropertyVariables>
+                        <java.util.logging.config.file>${project.build.testOutputDirectory}/logging.properties</java.util.logging.config.file>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
 

--- a/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcComponent.java
+++ b/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcComponent.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.component.grpc;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Map;
@@ -28,23 +26,26 @@ import io.grpc.ServerInterceptor;
 import org.apache.camel.Endpoint;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component("grpc")
 public class GrpcComponent extends DefaultComponent {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GrpcComponent.class);
 
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
         GrpcConfiguration config = new GrpcConfiguration();
         config = parseConfiguration(config, uri);
 
-        boolean dynamicPort = config.getPort() == 0;
-        if (dynamicPort) {
-            int port = allocatePort();
-            config.setPort(port);
-            uri = uri.replace("//" + config.getHost() + ":0/", "//" + config.getHost() + ":" + port + "/");
+        if (config.getPort() == 0 && !uri.contains("hash=")) {
+            LOG.warn("gRPC endpoint configured with port=0 (dynamic port). "
+                     + "If multiple routes use the same URI, add a unique 'hash' query parameter "
+                     + "to each route to avoid endpoint collisions, e.g. grpc://localhost:0/service?hash=1");
         }
 
-        Endpoint endpoint = new GrpcEndpoint(uri, this, config, dynamicPort);
+        Endpoint endpoint = new GrpcEndpoint(uri, this, config);
         setProperties(endpoint, parameters);
         if (config.isAutoDiscoverClientInterceptors()) {
             checkAndSetRegistryClientInterceptors(config);
@@ -69,12 +70,6 @@ public class GrpcComponent extends DefaultComponent {
         Set<ClientInterceptor> clientInterceptors = getCamelContext().getRegistry().findByType(ClientInterceptor.class);
         if (!clientInterceptors.isEmpty()) {
             configuration.setClientInterceptors(new ArrayList<>(clientInterceptors));
-        }
-    }
-
-    private static int allocatePort() throws IOException {
-        try (ServerSocket ss = new ServerSocket(0)) {
-            return ss.getLocalPort();
         }
     }
 

--- a/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcComponent.java
+++ b/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcComponent.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.grpc;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Map;
@@ -35,7 +37,14 @@ public class GrpcComponent extends DefaultComponent {
         GrpcConfiguration config = new GrpcConfiguration();
         config = parseConfiguration(config, uri);
 
-        Endpoint endpoint = new GrpcEndpoint(uri, this, config);
+        boolean dynamicPort = config.getPort() == 0;
+        if (dynamicPort) {
+            int port = allocatePort();
+            config.setPort(port);
+            uri = uri.replace("//" + config.getHost() + ":0/", "//" + config.getHost() + ":" + port + "/");
+        }
+
+        Endpoint endpoint = new GrpcEndpoint(uri, this, config, dynamicPort);
         setProperties(endpoint, parameters);
         if (config.isAutoDiscoverClientInterceptors()) {
             checkAndSetRegistryClientInterceptors(config);
@@ -60,6 +69,12 @@ public class GrpcComponent extends DefaultComponent {
         Set<ClientInterceptor> clientInterceptors = getCamelContext().getRegistry().findByType(ClientInterceptor.class);
         if (!clientInterceptors.isEmpty()) {
             configuration.setClientInterceptors(new ArrayList<>(clientInterceptors));
+        }
+    }
+
+    private static int allocatePort() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            return ss.getLocalPort();
         }
     }
 

--- a/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcConsumer.java
+++ b/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcConsumer.java
@@ -68,6 +68,14 @@ public class GrpcConsumer extends DefaultConsumer {
         return configuration;
     }
 
+    /**
+     * Returns the actual local port the gRPC server is listening on. Useful when the server was started with port 0
+     * (OS-assigned port).
+     */
+    public int getLocalPort() {
+        return server != null ? server.getPort() : -1;
+    }
+
     @Override
     protected void doStart() throws Exception {
         super.doStart();
@@ -94,7 +102,7 @@ public class GrpcConsumer extends DefaultConsumer {
         BindableService bindableService = getBindableServiceFactory().createBindableService(this);
         ServerInterceptor headerInterceptor = new GrpcHeaderInterceptor();
 
-        if (ObjectHelper.isNotEmpty(configuration.getHost()) && configuration.getPort() > 0) {
+        if (ObjectHelper.isNotEmpty(configuration.getHost()) && configuration.getPort() >= 0) {
             LOG.debug("Building gRPC server on {}:{}", configuration.getHost(), configuration.getPort());
             serverBuilder
                     = NettyServerBuilder.forAddress(new InetSocketAddress(configuration.getHost(), configuration.getPort()));

--- a/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcEndpoint.java
+++ b/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcEndpoint.java
@@ -39,19 +39,12 @@ public class GrpcEndpoint extends DefaultEndpoint {
     @UriParam
     protected final GrpcConfiguration configuration;
 
-    private final boolean dynamicPort;
     private String serviceName;
     private String servicePackage;
 
-    public GrpcEndpoint(String uri, GrpcComponent component, GrpcConfiguration config, boolean dynamicPort) {
+    public GrpcEndpoint(String uri, GrpcComponent component, GrpcConfiguration config) {
         super(uri, component);
         this.configuration = config;
-        this.dynamicPort = dynamicPort;
-    }
-
-    @Override
-    public boolean isSingleton() {
-        return !dynamicPort;
     }
 
     public GrpcConfiguration getConfiguration() {

--- a/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcEndpoint.java
+++ b/components/camel-grpc/src/main/java/org/apache/camel/component/grpc/GrpcEndpoint.java
@@ -39,12 +39,19 @@ public class GrpcEndpoint extends DefaultEndpoint {
     @UriParam
     protected final GrpcConfiguration configuration;
 
+    private final boolean dynamicPort;
     private String serviceName;
     private String servicePackage;
 
-    public GrpcEndpoint(String uri, GrpcComponent component, GrpcConfiguration config) {
+    public GrpcEndpoint(String uri, GrpcComponent component, GrpcConfiguration config, boolean dynamicPort) {
         super(uri, component);
         this.configuration = config;
+        this.dynamicPort = dynamicPort;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return !dynamicPort;
     }
 
     public GrpcConfiguration getConfiguration() {

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerAggregationTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerAggregationTest.java
@@ -25,12 +25,10 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,10 +40,6 @@ public class GrpcConsumerAggregationTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerAggregationTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcSyncRequestTestPort = AvailablePortFinder.find();
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcAsyncRequestTestPort = AvailablePortFinder.find();
     private static final int GRPC_TEST_PING_ID = 1;
     private static final String GRPC_TEST_PING_VALUE = "PING";
     private static final String GRPC_TEST_PONG_VALUE = "PONG";
@@ -58,10 +52,12 @@ public class GrpcConsumerAggregationTest extends CamelTestSupport {
 
     @BeforeEach
     public void startGrpcChannels() {
-        syncRequestChannel
-                = ManagedChannelBuilder.forAddress("localhost", grpcSyncRequestTestPort.getPort()).usePlaintext().build();
-        asyncRequestChannel
-                = ManagedChannelBuilder.forAddress("localhost", grpcAsyncRequestTestPort.getPort()).usePlaintext().build();
+        syncRequestChannel = ManagedChannelBuilder
+                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-sync").getConsumer()).getLocalPort())
+                .usePlaintext().build();
+        asyncRequestChannel = ManagedChannelBuilder
+                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-async").getConsumer()).getLocalPort())
+                .usePlaintext().build();
         blockingStub = PingPongGrpc.newBlockingStub(syncRequestChannel);
         nonBlockingStub = PingPongGrpc.newStub(syncRequestChannel);
         asyncNonBlockingStub = PingPongGrpc.newStub(asyncRequestChannel);
@@ -186,12 +182,12 @@ public class GrpcConsumerAggregationTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("grpc://localhost:" + grpcSyncRequestTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                        .routeId("grpc-sync")
                         .bean(new GrpcMessageBuilder(), "buildPongResponse");
 
-                from("grpc://localhost:" + grpcAsyncRequestTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                        .routeId("grpc-async")
                         .bean(new GrpcMessageBuilder(), "buildAsyncPongResponse");
             }
         };

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerAggregationTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerAggregationTest.java
@@ -25,7 +25,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GrpcConsumerAggregationTest extends CamelTestSupport {
+public class GrpcConsumerAggregationTest extends GrpcTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerAggregationTest.class);
 
@@ -49,10 +48,6 @@ public class GrpcConsumerAggregationTest extends CamelTestSupport {
     private PingPongGrpc.PingPongBlockingStub blockingStub;
     private PingPongGrpc.PingPongStub nonBlockingStub;
     private PingPongGrpc.PingPongStub asyncNonBlockingStub;
-
-    private int getRoutePort(String routeId) {
-        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
-    }
 
     @BeforeEach
     public void startGrpcChannels() {

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerAggregationTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerAggregationTest.java
@@ -186,11 +186,11 @@ public class GrpcConsumerAggregationTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION&hash=1")
                         .routeId("grpc-sync")
                         .bean(new GrpcMessageBuilder(), "buildPongResponse");
 
-                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION&hash=2")
                         .routeId("grpc-async")
                         .bean(new GrpcMessageBuilder(), "buildAsyncPongResponse");
             }

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerAggregationTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerAggregationTest.java
@@ -50,13 +50,17 @@ public class GrpcConsumerAggregationTest extends CamelTestSupport {
     private PingPongGrpc.PingPongStub nonBlockingStub;
     private PingPongGrpc.PingPongStub asyncNonBlockingStub;
 
+    private int getRoutePort(String routeId) {
+        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
+    }
+
     @BeforeEach
     public void startGrpcChannels() {
         syncRequestChannel = ManagedChannelBuilder
-                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-sync").getConsumer()).getLocalPort())
+                .forAddress("localhost", getRoutePort("grpc-sync"))
                 .usePlaintext().build();
         asyncRequestChannel = ManagedChannelBuilder
-                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-async").getConsumer()).getLocalPort())
+                .forAddress("localhost", getRoutePort("grpc-async"))
                 .usePlaintext().build();
         blockingStub = PingPongGrpc.newBlockingStub(syncRequestChannel);
         nonBlockingStub = PingPongGrpc.newStub(syncRequestChannel);

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerConcurrentTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerConcurrentTest.java
@@ -29,10 +29,8 @@ import io.grpc.stub.StreamObserver;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,10 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class GrpcConsumerConcurrentTest extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerConcurrentTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcAsyncRequestTestPort = AvailablePortFinder.find();
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcHeadersTestPort = AvailablePortFinder.find();
     private static final int CONCURRENT_THREAD_COUNT = 30;
     private static final int ROUNDS_PER_THREAD_COUNT = 10;
     private static final String GRPC_TEST_PING_VALUE = "PING";
@@ -64,13 +58,14 @@ public class GrpcConsumerConcurrentTest extends CamelTestSupport {
 
     @Test
     public void testAsyncWithConcurrentThreads() {
+        int asyncPort = ((GrpcConsumer) context.getRoute("grpc-async").getConsumer()).getLocalPort();
         RunnableAssert ra = new RunnableAssert("foo") {
 
             @Override
             public void run() {
                 final CountDownLatch latch = new CountDownLatch(1);
                 ManagedChannel asyncRequestChannel
-                        = NettyChannelBuilder.forAddress("localhost", grpcAsyncRequestTestPort.getPort()).usePlaintext()
+                        = NettyChannelBuilder.forAddress("localhost", asyncPort).usePlaintext()
                                 .build();
                 PingPongGrpc.PingPongStub asyncNonBlockingStub = PingPongGrpc.newStub(asyncRequestChannel);
 
@@ -105,13 +100,14 @@ public class GrpcConsumerConcurrentTest extends CamelTestSupport {
 
     @Test
     public void testHeadersWithConcurrentThreads() {
+        int headersPort = ((GrpcConsumer) context.getRoute("grpc-headers").getConsumer()).getLocalPort();
         RunnableAssert ra = new RunnableAssert("foo") {
 
             @Override
             public void run() {
                 int instanceId = createId();
                 final CountDownLatch latch = new CountDownLatch(1);
-                ManagedChannel asyncRequestChannel = NettyChannelBuilder.forAddress("localhost", grpcHeadersTestPort.getPort())
+                ManagedChannel asyncRequestChannel = NettyChannelBuilder.forAddress("localhost", headersPort)
                         .userAgent(GRPC_USER_AGENT_PREFIX + instanceId)
                         .usePlaintext().build();
                 PingPongGrpc.PingPongStub asyncNonBlockingStub = PingPongGrpc.newStub(asyncRequestChannel);
@@ -149,12 +145,12 @@ public class GrpcConsumerConcurrentTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("grpc://localhost:" + grpcAsyncRequestTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                        .routeId("grpc-async")
                         .bean(new GrpcMessageBuilder(), "buildAsyncPongResponse");
 
-                from("grpc://localhost:" + grpcHeadersTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                        .routeId("grpc-headers")
                         .process(new HeaderExchangeProcessor());
             }
         };

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerConcurrentTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerConcurrentTest.java
@@ -29,7 +29,6 @@ import io.grpc.stub.StreamObserver;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GrpcConsumerConcurrentTest extends CamelTestSupport {
+public class GrpcConsumerConcurrentTest extends GrpcTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerConcurrentTest.class);
 
     private static final int CONCURRENT_THREAD_COUNT = 30;
@@ -54,10 +53,6 @@ public class GrpcConsumerConcurrentTest extends CamelTestSupport {
 
     public static Integer getId() {
         return idCounter.get();
-    }
-
-    private int getRoutePort(String routeId) {
-        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
     }
 
     @Test

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerConcurrentTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerConcurrentTest.java
@@ -56,9 +56,13 @@ public class GrpcConsumerConcurrentTest extends CamelTestSupport {
         return idCounter.get();
     }
 
+    private int getRoutePort(String routeId) {
+        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
+    }
+
     @Test
     public void testAsyncWithConcurrentThreads() {
-        int asyncPort = ((GrpcConsumer) context.getRoute("grpc-async").getConsumer()).getLocalPort();
+        int asyncPort = getRoutePort("grpc-async");
         RunnableAssert ra = new RunnableAssert("foo") {
 
             @Override
@@ -100,7 +104,7 @@ public class GrpcConsumerConcurrentTest extends CamelTestSupport {
 
     @Test
     public void testHeadersWithConcurrentThreads() {
-        int headersPort = ((GrpcConsumer) context.getRoute("grpc-headers").getConsumer()).getLocalPort();
+        int headersPort = getRoutePort("grpc-headers");
         RunnableAssert ra = new RunnableAssert("foo") {
 
             @Override

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerConcurrentTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerConcurrentTest.java
@@ -149,11 +149,11 @@ public class GrpcConsumerConcurrentTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION&hash=1")
                         .routeId("grpc-async")
                         .bean(new GrpcMessageBuilder(), "buildAsyncPongResponse");
 
-                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION&hash=2")
                         .routeId("grpc-headers")
                         .process(new HeaderExchangeProcessor());
             }

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerConfigurationTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerConfigurationTest.java
@@ -39,13 +39,6 @@ class GrpcConsumerConfigurationTest extends CamelTestSupport {
     }
 
     @Test
-    void invalidPort() {
-        FailedToCreateConsumerException exception = assertThrows(FailedToCreateConsumerException.class,
-                () -> consumer.receive("grpc:localhost:0/org.apache.camel.component.grpc.PingPong"));
-        assertInstanceOf(IllegalArgumentException.class, exception.getCause());
-    }
-
-    @Test
     void invalidMaxRstFramesPerWindowWithValidMaxRstPeriodSeconds() {
         FailedToCreateConsumerException exception = assertThrows(FailedToCreateConsumerException.class,
                 () -> consumer.receive(

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerExceptionTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerExceptionTest.java
@@ -25,12 +25,10 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.CamelException;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,8 +41,6 @@ public class GrpcConsumerExceptionTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerExceptionTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcSyncRequestTestPort = AvailablePortFinder.find();
     private static final int GRPC_TEST_PING_ID = 1;
     private static final String GRPC_TEST_PING_VALUE = "PING";
 
@@ -54,8 +50,8 @@ public class GrpcConsumerExceptionTest extends CamelTestSupport {
 
     @BeforeEach
     public void startGrpcChannels() {
-        syncRequestChannel
-                = ManagedChannelBuilder.forAddress("localhost", grpcSyncRequestTestPort.getPort()).usePlaintext().build();
+        int port = ((GrpcConsumer) context.getRoute("grpc-exception").getConsumer()).getLocalPort();
+        syncRequestChannel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build();
         blockingStub = PingPongGrpc.newBlockingStub(syncRequestChannel);
         nonBlockingStub = PingPongGrpc.newStub(syncRequestChannel);
     }
@@ -96,8 +92,8 @@ public class GrpcConsumerExceptionTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("grpc://localhost:" + grpcSyncRequestTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?synchronous=true")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true")
+                        .routeId("grpc-exception")
                         .throwException(CamelException.class, "GRPC Camel exception message");
 
             }

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerExceptionTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerExceptionTest.java
@@ -25,7 +25,6 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.CamelException;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GrpcConsumerExceptionTest extends CamelTestSupport {
+public class GrpcConsumerExceptionTest extends GrpcTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerExceptionTest.class);
 
@@ -47,10 +46,6 @@ public class GrpcConsumerExceptionTest extends CamelTestSupport {
     private ManagedChannel syncRequestChannel;
     private PingPongGrpc.PingPongBlockingStub blockingStub;
     private PingPongGrpc.PingPongStub nonBlockingStub;
-
-    private int getRoutePort(String routeId) {
-        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
-    }
 
     @BeforeEach
     public void startGrpcChannels() {

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerExceptionTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerExceptionTest.java
@@ -48,9 +48,13 @@ public class GrpcConsumerExceptionTest extends CamelTestSupport {
     private PingPongGrpc.PingPongBlockingStub blockingStub;
     private PingPongGrpc.PingPongStub nonBlockingStub;
 
+    private int getRoutePort(String routeId) {
+        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
+    }
+
     @BeforeEach
     public void startGrpcChannels() {
-        int port = ((GrpcConsumer) context.getRoute("grpc-exception").getConsumer()).getLocalPort();
+        int port = getRoutePort("grpc-exception");
         syncRequestChannel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build();
         blockingStub = PingPongGrpc.newBlockingStub(syncRequestChannel);
         nonBlockingStub = PingPongGrpc.newStub(syncRequestChannel);

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerPropagationTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerPropagationTest.java
@@ -24,12 +24,10 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,10 +39,6 @@ public class GrpcConsumerPropagationTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerPropagationTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcAsyncNextRequestTestPort = AvailablePortFinder.find();
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcAsyncCompletedRequestTestPort = AvailablePortFinder.find();
     private static final int GRPC_TEST_PING_ID = 1;
     private static final String GRPC_TEST_PING_VALUE = "PING";
     private static final String GRPC_TEST_PONG_VALUE = "PONG";
@@ -56,11 +50,12 @@ public class GrpcConsumerPropagationTest extends CamelTestSupport {
 
     @BeforeEach
     public void startGrpcChannels() {
-        asyncOnNextChannel
-                = ManagedChannelBuilder.forAddress("localhost", grpcAsyncNextRequestTestPort.getPort()).usePlaintext().build();
-        asyncOnCompletedChannel
-                = ManagedChannelBuilder.forAddress("localhost", grpcAsyncCompletedRequestTestPort.getPort()).usePlaintext()
-                        .build();
+        asyncOnNextChannel = ManagedChannelBuilder
+                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-on-next").getConsumer()).getLocalPort())
+                .usePlaintext().build();
+        asyncOnCompletedChannel = ManagedChannelBuilder
+                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-on-completed").getConsumer()).getLocalPort())
+                .usePlaintext().build();
         asyncOnNextStub = PingPongGrpc.newStub(asyncOnNextChannel);
         asyncOnCompletedStub = PingPongGrpc.newStub(asyncOnCompletedChannel);
     }
@@ -126,13 +121,13 @@ public class GrpcConsumerPropagationTest extends CamelTestSupport {
             @Override
             public void configure() {
 
-                from("grpc://localhost:" + grpcAsyncNextRequestTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION")
+                        .routeId("grpc-on-next")
                         .to("mock:async-on-next-propagation")
                         .bean(new GrpcMessageBuilder(), "buildAsyncPongResponse");
 
-                from("grpc://localhost:" + grpcAsyncCompletedRequestTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION&forwardOnCompleted=true")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION&forwardOnCompleted=true")
+                        .routeId("grpc-on-completed")
                         .to("mock:async-on-completed-propagation");
             }
         };

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerPropagationTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerPropagationTest.java
@@ -48,13 +48,17 @@ public class GrpcConsumerPropagationTest extends CamelTestSupport {
     private PingPongGrpc.PingPongStub asyncOnNextStub;
     private PingPongGrpc.PingPongStub asyncOnCompletedStub;
 
+    private int getRoutePort(String routeId) {
+        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
+    }
+
     @BeforeEach
     public void startGrpcChannels() {
         asyncOnNextChannel = ManagedChannelBuilder
-                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-on-next").getConsumer()).getLocalPort())
+                .forAddress("localhost", getRoutePort("grpc-on-next"))
                 .usePlaintext().build();
         asyncOnCompletedChannel = ManagedChannelBuilder
-                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-on-completed").getConsumer()).getLocalPort())
+                .forAddress("localhost", getRoutePort("grpc-on-completed"))
                 .usePlaintext().build();
         asyncOnNextStub = PingPongGrpc.newStub(asyncOnNextChannel);
         asyncOnCompletedStub = PingPongGrpc.newStub(asyncOnCompletedChannel);

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerPropagationTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerPropagationTest.java
@@ -24,7 +24,6 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GrpcConsumerPropagationTest extends CamelTestSupport {
+public class GrpcConsumerPropagationTest extends GrpcTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerPropagationTest.class);
 
@@ -47,10 +46,6 @@ public class GrpcConsumerPropagationTest extends CamelTestSupport {
     private ManagedChannel asyncOnCompletedChannel;
     private PingPongGrpc.PingPongStub asyncOnNextStub;
     private PingPongGrpc.PingPongStub asyncOnCompletedStub;
-
-    private int getRoutePort(String routeId) {
-        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
-    }
 
     @BeforeEach
     public void startGrpcChannels() {

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerSecurityTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerSecurityTest.java
@@ -34,13 +34,11 @@ import org.apache.camel.component.grpc.auth.jwt.JwtAlgorithm;
 import org.apache.camel.component.grpc.auth.jwt.JwtCallCredentials;
 import org.apache.camel.component.grpc.auth.jwt.JwtHelper;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,12 +50,6 @@ public class GrpcConsumerSecurityTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerSecurityTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcTlsTestPort = AvailablePortFinder.find();
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcJwtCorrectTestPort = AvailablePortFinder.find();
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcJwtIncorrectTestPort = AvailablePortFinder.find();
     private static final int GRPC_TEST_PING_ID = 1;
     private static final String GRPC_TEST_PING_VALUE = "PING";
     private static final String GRPC_TEST_PONG_VALUE = "PONG";
@@ -85,14 +77,16 @@ public class GrpcConsumerSecurityTest extends CamelTestSupport {
 
         Assumptions.assumeTrue(sslContext instanceof OpenSslClientContext || sslContext instanceof JdkSslContext);
 
-        tlsChannel = NettyChannelBuilder.forAddress("localhost", grpcTlsTestPort.getPort())
+        int tlsPort = ((GrpcConsumer) context.getRoute("grpc-tls").getConsumer()).getLocalPort();
+        int jwtCorrectPort = ((GrpcConsumer) context.getRoute("grpc-jwt-correct").getConsumer()).getLocalPort();
+        int jwtIncorrectPort = ((GrpcConsumer) context.getRoute("grpc-jwt-incorrect").getConsumer()).getLocalPort();
+
+        tlsChannel = NettyChannelBuilder.forAddress("localhost", tlsPort)
                 .sslContext(sslContext)
                 .build();
 
-        jwtCorrectChannel
-                = NettyChannelBuilder.forAddress("localhost", grpcJwtCorrectTestPort.getPort()).usePlaintext().build();
-        jwtIncorrectChannel
-                = NettyChannelBuilder.forAddress("localhost", grpcJwtIncorrectTestPort.getPort()).usePlaintext().build();
+        jwtCorrectChannel = NettyChannelBuilder.forAddress("localhost", jwtCorrectPort).usePlaintext().build();
+        jwtIncorrectChannel = NettyChannelBuilder.forAddress("localhost", jwtIncorrectPort).usePlaintext().build();
 
         tlsAsyncStub = PingPongGrpc.newStub(tlsChannel);
         jwtCorrectAsyncStub
@@ -193,22 +187,25 @@ public class GrpcConsumerSecurityTest extends CamelTestSupport {
             @Override
             public void configure() {
 
-                from("grpc://localhost:" + grpcTlsTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION&"
+                from("grpc://localhost:0" +
+                     "/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION&"
                      + "negotiationType=TLS&keyCertChainResource=file:src/test/resources/certs/server.pem&"
                      + "keyResource=file:src/test/resources/certs/server.key&trustCertCollectionResource=file:src/test/resources/certs/ca.pem")
+                        .routeId("grpc-tls")
                         .to("mock:tls-enable")
                         .bean(new GrpcMessageBuilder(), "buildAsyncPongResponse");
 
-                from("grpc://localhost:" + grpcJwtCorrectTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION&"
+                from("grpc://localhost:0" +
+                     "/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION&"
                      + "authenticationType=JWT&jwtSecret=" + GRPC_JWT_CORRECT_SECRET)
+                        .routeId("grpc-jwt-correct")
                         .to("mock:jwt-correct-secret")
                         .bean(new GrpcMessageBuilder(), "buildAsyncPongResponse");
 
-                from("grpc://localhost:" + grpcJwtIncorrectTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION&"
+                from("grpc://localhost:0" +
+                     "/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION&"
                      + "authenticationType=JWT&jwtSecret=" + GRPC_JWT_CORRECT_SECRET)
+                        .routeId("grpc-jwt-incorrect")
                         .to("mock:jwt-incorrect-secret")
                         .bean(new GrpcMessageBuilder(), "buildAsyncPongResponse");
             }

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerSecurityTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerSecurityTest.java
@@ -194,21 +194,21 @@ public class GrpcConsumerSecurityTest extends CamelTestSupport {
                 from("grpc://localhost:0" +
                      "/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION&"
                      + "negotiationType=TLS&keyCertChainResource=file:src/test/resources/certs/server.pem&"
-                     + "keyResource=file:src/test/resources/certs/server.key&trustCertCollectionResource=file:src/test/resources/certs/ca.pem")
+                     + "keyResource=file:src/test/resources/certs/server.key&trustCertCollectionResource=file:src/test/resources/certs/ca.pem&hash=1")
                         .routeId("grpc-tls")
                         .to("mock:tls-enable")
                         .bean(new GrpcMessageBuilder(), "buildAsyncPongResponse");
 
                 from("grpc://localhost:0" +
                      "/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION&"
-                     + "authenticationType=JWT&jwtSecret=" + GRPC_JWT_CORRECT_SECRET)
+                     + "authenticationType=JWT&jwtSecret=" + GRPC_JWT_CORRECT_SECRET + "&hash=2")
                         .routeId("grpc-jwt-correct")
                         .to("mock:jwt-correct-secret")
                         .bean(new GrpcMessageBuilder(), "buildAsyncPongResponse");
 
                 from("grpc://localhost:0" +
                      "/org.apache.camel.component.grpc.PingPong?consumerStrategy=PROPAGATION&"
-                     + "authenticationType=JWT&jwtSecret=" + GRPC_JWT_CORRECT_SECRET)
+                     + "authenticationType=JWT&jwtSecret=" + GRPC_JWT_CORRECT_SECRET + "&hash=3")
                         .routeId("grpc-jwt-incorrect")
                         .to("mock:jwt-incorrect-secret")
                         .bean(new GrpcMessageBuilder(), "buildAsyncPongResponse");

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerSecurityTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerSecurityTest.java
@@ -65,6 +65,10 @@ public class GrpcConsumerSecurityTest extends CamelTestSupport {
     private PingPongGrpc.PingPongStub jwtCorrectAsyncStub;
     private PingPongGrpc.PingPongStub jwtIncorrectAsyncStub;
 
+    private int getRoutePort(String routeId) {
+        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
+    }
+
     @BeforeEach
     public void startGrpcChannels() throws SSLException {
         String correctJwtToken = JwtHelper.createJwtToken(JwtAlgorithm.HMAC256, GRPC_JWT_CORRECT_SECRET, null, null);
@@ -77,9 +81,9 @@ public class GrpcConsumerSecurityTest extends CamelTestSupport {
 
         Assumptions.assumeTrue(sslContext instanceof OpenSslClientContext || sslContext instanceof JdkSslContext);
 
-        int tlsPort = ((GrpcConsumer) context.getRoute("grpc-tls").getConsumer()).getLocalPort();
-        int jwtCorrectPort = ((GrpcConsumer) context.getRoute("grpc-jwt-correct").getConsumer()).getLocalPort();
-        int jwtIncorrectPort = ((GrpcConsumer) context.getRoute("grpc-jwt-incorrect").getConsumer()).getLocalPort();
+        int tlsPort = getRoutePort("grpc-tls");
+        int jwtCorrectPort = getRoutePort("grpc-jwt-correct");
+        int jwtIncorrectPort = getRoutePort("grpc-jwt-incorrect");
 
         tlsChannel = NettyChannelBuilder.forAddress("localhost", tlsPort)
                 .sslContext(sslContext)

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerSecurityTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerSecurityTest.java
@@ -34,7 +34,6 @@ import org.apache.camel.component.grpc.auth.jwt.JwtAlgorithm;
 import org.apache.camel.component.grpc.auth.jwt.JwtCallCredentials;
 import org.apache.camel.component.grpc.auth.jwt.JwtHelper;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GrpcConsumerSecurityTest extends CamelTestSupport {
+public class GrpcConsumerSecurityTest extends GrpcTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerSecurityTest.class);
 
@@ -64,10 +63,6 @@ public class GrpcConsumerSecurityTest extends CamelTestSupport {
     private PingPongGrpc.PingPongStub tlsAsyncStub;
     private PingPongGrpc.PingPongStub jwtCorrectAsyncStub;
     private PingPongGrpc.PingPongStub jwtIncorrectAsyncStub;
-
-    private int getRoutePort(String routeId) {
-        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
-    }
 
     @BeforeEach
     public void startGrpcChannels() throws SSLException {

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerServerInterceptorTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerServerInterceptorTest.java
@@ -20,14 +20,11 @@ import java.util.List;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.Server;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,15 +40,10 @@ public class GrpcConsumerServerInterceptorTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerServerInterceptorTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcRequestInterceptTestPort = AvailablePortFinder.find();
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcRequestNoInterceptTestPort = AvailablePortFinder.find();
     private static final int GRPC_TEST_PING_ID = 1;
     private static final String GRPC_TEST_PING_VALUE = "PING";
     private static final String GRPC_TEST_PONG_VALUE = "PONG";
 
-    private static Server grpcServer;
     private final GrpcMockServerInterceptor mockServerInterceptor = mock(GrpcMockServerInterceptor.class);
     private final GrpcMockServerInterceptor mockServerInterceptor2 = mock(GrpcMockServerInterceptor.class);
 
@@ -62,11 +54,12 @@ public class GrpcConsumerServerInterceptorTest extends CamelTestSupport {
 
     @BeforeEach
     public void startGrpcChannels() {
-        interceptRequestChannel
-                = ManagedChannelBuilder.forAddress("localhost", grpcRequestInterceptTestPort.getPort()).usePlaintext().build();
-        nointerceptRequestChannel
-                = ManagedChannelBuilder.forAddress("localhost", grpcRequestNoInterceptTestPort.getPort()).usePlaintext()
-                        .build();
+        interceptRequestChannel = ManagedChannelBuilder
+                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-intercept").getConsumer()).getLocalPort())
+                .usePlaintext().build();
+        nointerceptRequestChannel = ManagedChannelBuilder
+                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-no-intercept").getConsumer()).getLocalPort())
+                .usePlaintext().build();
         interceptBlockingStub = PingPongGrpc.newBlockingStub(interceptRequestChannel);
         nointerceptBlockingStub = PingPongGrpc.newBlockingStub(nointerceptRequestChannel);
     }
@@ -116,13 +109,12 @@ public class GrpcConsumerServerInterceptorTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("grpc://localhost:" + grpcRequestInterceptTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                        .routeId("grpc-intercept")
                         .bean(new GrpcMessageBuilder(), "buildPongResponse");
 
-                from("grpc://localhost:" + grpcRequestNoInterceptTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION"
-                     + "&autoDiscoverServerInterceptors=false")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION&autoDiscoverServerInterceptors=false")
+                        .routeId("grpc-no-intercept")
                         .bean(new GrpcMessageBuilder(), "buildPongResponse");
             }
         };

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerServerInterceptorTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerServerInterceptorTest.java
@@ -52,13 +52,17 @@ public class GrpcConsumerServerInterceptorTest extends CamelTestSupport {
     private PingPongGrpc.PingPongBlockingStub interceptBlockingStub;
     private PingPongGrpc.PingPongBlockingStub nointerceptBlockingStub;
 
+    private int getRoutePort(String routeId) {
+        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
+    }
+
     @BeforeEach
     public void startGrpcChannels() {
         interceptRequestChannel = ManagedChannelBuilder
-                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-intercept").getConsumer()).getLocalPort())
+                .forAddress("localhost", getRoutePort("grpc-intercept"))
                 .usePlaintext().build();
         nointerceptRequestChannel = ManagedChannelBuilder
-                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-no-intercept").getConsumer()).getLocalPort())
+                .forAddress("localhost", getRoutePort("grpc-no-intercept"))
                 .usePlaintext().build();
         interceptBlockingStub = PingPongGrpc.newBlockingStub(interceptRequestChannel);
         nointerceptBlockingStub = PingPongGrpc.newBlockingStub(nointerceptRequestChannel);

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerServerInterceptorTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcConsumerServerInterceptorTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,7 +35,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class GrpcConsumerServerInterceptorTest extends CamelTestSupport {
+public class GrpcConsumerServerInterceptorTest extends GrpcTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerServerInterceptorTest.class);
 
@@ -51,10 +50,6 @@ public class GrpcConsumerServerInterceptorTest extends CamelTestSupport {
     private ManagedChannel nointerceptRequestChannel;
     private PingPongGrpc.PingPongBlockingStub interceptBlockingStub;
     private PingPongGrpc.PingPongBlockingStub nointerceptBlockingStub;
-
-    private int getRoutePort(String routeId) {
-        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
-    }
 
     @BeforeEach
     public void startGrpcChannels() {

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerClientInterceptorTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerClientInterceptorTest.java
@@ -20,12 +20,10 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,8 +39,6 @@ public class GrpcProducerClientInterceptorTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProducerClientInterceptorTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcTestPort = AvailablePortFinder.find();
     private static final int GRPC_TEST_PING_ID = 1;
     private static final String GRPC_TEST_PING_VALUE = "PING";
     private static final String GRPC_TEST_PONG_VALUE = "PONG";
@@ -53,10 +49,8 @@ public class GrpcProducerClientInterceptorTest extends CamelTestSupport {
 
     @BeforeAll
     public static void startGrpcServer() throws Exception {
-        grpcServer
-                = ServerBuilder.forPort(grpcTestPort.getPort()).addService(new GrpcProducerClientInterceptorTest.PingPongImpl())
-                        .build().start();
-        LOG.info("gRPC server started on port {}", grpcTestPort.getPort());
+        grpcServer = ServerBuilder.forPort(0).addService(new GrpcProducerClientInterceptorTest.PingPongImpl()).build().start();
+        LOG.info("gRPC server started on port {}", grpcServer.getPort());
     }
 
     @AfterAll
@@ -83,7 +77,7 @@ public class GrpcProducerClientInterceptorTest extends CamelTestSupport {
     @Test
     public void testNoAutoDiscover() throws Exception {
         GrpcComponent component = context.getComponent("grpc", GrpcComponent.class);
-        GrpcEndpoint endpoint = (GrpcEndpoint) component.createEndpoint("grpc://localhost:" + grpcTestPort.getPort()
+        GrpcEndpoint endpoint = (GrpcEndpoint) component.createEndpoint("grpc://localhost:" + grpcServer.getPort()
                                                                         + "/org.apache.camel.component.grpc"
                                                                         + ".PingPong?method=pingSyncSync&autoDiscoverClientInterceptors=false");
 
@@ -101,7 +95,7 @@ public class GrpcProducerClientInterceptorTest extends CamelTestSupport {
             @Override
             public void configure() {
                 from("direct:grpc-interceptor")
-                        .to("grpc://localhost:" + grpcTestPort.getPort()
+                        .to("grpc://localhost:" + grpcServer.getPort()
                             + "/org.apache.camel.component.grpc"
                             + ".PingPong?method=pingSyncSync");
             }

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerSecurityTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerSecurityTest.java
@@ -30,13 +30,11 @@ import io.netty.handler.ssl.SslContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.grpc.auth.jwt.JwtAlgorithm;
 import org.apache.camel.component.grpc.auth.jwt.JwtServerInterceptor;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,10 +46,6 @@ public class GrpcProducerSecurityTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProducerSecurityTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcTlsTestPort = AvailablePortFinder.find();
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcJwtTestPort = AvailablePortFinder.find();
     private static final int GRPC_TEST_PING_ID = 1;
     private static final int GRPC_TEST_PONG_ID01 = 1;
     private static final int GRPC_TEST_PONG_ID02 = 2;
@@ -74,18 +68,18 @@ public class GrpcProducerSecurityTest extends CamelTestSupport {
 
         Assumptions.assumeTrue(sslContext instanceof OpenSslClientContext || sslContext instanceof JdkSslContext);
 
-        grpcServerWithTLS = NettyServerBuilder.forPort(grpcTlsTestPort.getPort())
+        grpcServerWithTLS = NettyServerBuilder.forPort(0)
                 .sslContext(sslContext)
                 .addService(new PingPongImpl()).build().start();
 
-        grpcServerWithJWT = NettyServerBuilder.forPort(grpcJwtTestPort.getPort())
+        grpcServerWithJWT = NettyServerBuilder.forPort(0)
                 .addService(new PingPongImpl())
                 .intercept(new JwtServerInterceptor(JwtAlgorithm.HMAC256, GRPC_JWT_CORRECT_SECRET, null, null))
                 .build()
                 .start();
 
-        LOG.info("gRPC server with TLS started on port {}", grpcTlsTestPort.getPort());
-        LOG.info("gRPC server with the JWT auth started on port {}", grpcJwtTestPort.getPort());
+        LOG.info("gRPC server with TLS started on port {}", grpcServerWithTLS.getPort());
+        LOG.info("gRPC server with the JWT auth started on port {}", grpcServerWithJWT.getPort());
     }
 
     @AfterAll
@@ -153,18 +147,18 @@ public class GrpcProducerSecurityTest extends CamelTestSupport {
             @Override
             public void configure() {
                 from("direct:grpc-tls")
-                        .to("grpc://localhost:" + grpcTlsTestPort.getPort()
+                        .to("grpc://localhost:" + grpcServerWithTLS.getPort()
                             + "/org.apache.camel.component.grpc.PingPong?method=pingSyncSync&synchronous=true&"
                             + "negotiationType=TLS&keyCertChainResource=file:src/test/resources/certs/client.pem&"
                             + "keyResource=file:src/test/resources/certs/client.key&trustCertCollectionResource=file:src/test/resources/certs/ca.pem");
 
                 from("direct:grpc-correct-jwt")
-                        .to("grpc://localhost:" + grpcJwtTestPort.getPort()
+                        .to("grpc://localhost:" + grpcServerWithJWT.getPort()
                             + "/org.apache.camel.component.grpc.PingPong?method=pingSyncSync&synchronous=true&"
                             + "authenticationType=JWT&jwtSecret=" + GRPC_JWT_CORRECT_SECRET);
 
                 from("direct:grpc-incorrect-jwt")
-                        .to("grpc://localhost:" + grpcJwtTestPort.getPort()
+                        .to("grpc://localhost:" + grpcServerWithJWT.getPort()
                             + "/org.apache.camel.component.grpc.PingPong?method=pingSyncSync&synchronous=true&"
                             + "authenticationType=JWT&jwtSecret=" + GRPC_JWT_INCORRECT_SECRET);
             }

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
@@ -27,12 +27,10 @@ import io.grpc.stub.StreamObserver;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,17 +42,14 @@ public class GrpcProducerStreamingTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProducerStreamingTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcTestPort = AvailablePortFinder.find();
-
     private static Server grpcServer;
     private static PingPongImpl pingPongServer;
 
     @BeforeEach
     public void startGrpcServer() throws Exception {
         pingPongServer = new PingPongImpl();
-        grpcServer = ServerBuilder.forPort(grpcTestPort.getPort()).addService(pingPongServer).build().start();
-        LOG.info("gRPC server started on port {}", grpcTestPort.getPort());
+        grpcServer = ServerBuilder.forPort(0).addService(pingPongServer).build().start();
+        LOG.info("gRPC server started on port {}", grpcServer.getPort());
     }
 
     @AfterEach
@@ -124,7 +119,7 @@ public class GrpcProducerStreamingTest extends CamelTestSupport {
             @Override
             public void configure() {
                 from("direct:grpc-stream-async-async-route")
-                        .to("grpc://localhost:" + grpcTestPort.getPort()
+                        .to("grpc://localhost:" + grpcServer.getPort()
                             + "/org.apache.camel.component.grpc.PingPong?producerStrategy=STREAMING&streamRepliesTo=direct:grpc-replies&method=pingAsyncAsync");
 
                 from("direct:grpc-replies")

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerStreamingTest.java
@@ -28,8 +28,6 @@ import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,18 +40,18 @@ public class GrpcProducerStreamingTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProducerStreamingTest.class);
 
-    private static Server grpcServer;
-    private static PingPongImpl pingPongServer;
+    private Server grpcServer;
+    private PingPongImpl pingPongServer;
 
-    @BeforeEach
-    public void startGrpcServer() throws Exception {
+    @Override
+    protected void setupResources() throws Exception {
         pingPongServer = new PingPongImpl();
         grpcServer = ServerBuilder.forPort(0).addService(pingPongServer).build().start();
         LOG.info("gRPC server started on port {}", grpcServer.getPort());
     }
 
-    @AfterEach
-    public void stopGrpcServer() {
+    @Override
+    protected void cleanupResources() {
         if (grpcServer != null) {
             grpcServer.shutdown();
             LOG.info("gRPC server stopped");

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerSyncTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProducerSyncTest.java
@@ -22,13 +22,11 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,8 +38,6 @@ public class GrpcProducerSyncTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProducerSyncTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcTestPort = AvailablePortFinder.find();
     private static final int GRPC_TEST_PING_ID = 1;
     private static final int GRPC_TEST_PONG_ID01 = 1;
     private static final int GRPC_TEST_PONG_ID02 = 2;
@@ -53,8 +49,8 @@ public class GrpcProducerSyncTest extends CamelTestSupport {
 
     @BeforeAll
     public static void startGrpcServer() throws Exception {
-        grpcServer = ServerBuilder.forPort(grpcTestPort.getPort()).addService(new PingPongImpl()).build().start();
-        LOG.info("gRPC server started on port {}", grpcTestPort.getPort());
+        grpcServer = ServerBuilder.forPort(0).addService(new PingPongImpl()).build().start();
+        LOG.info("gRPC server started on port {}", grpcServer.getPort());
     }
 
     @AfterAll
@@ -120,13 +116,13 @@ public class GrpcProducerSyncTest extends CamelTestSupport {
             @Override
             public void configure() {
                 from("direct:grpc-sync-sync")
-                        .to("grpc://localhost:" + grpcTestPort.getPort()
+                        .to("grpc://localhost:" + grpcServer.getPort()
                             + "/org.apache.camel.component.grpc.PingPong?method=pingSyncSync&synchronous=true");
                 from("direct:grpc-sync-proto-method-name")
-                        .to("grpc://localhost:" + grpcTestPort.getPort()
+                        .to("grpc://localhost:" + grpcServer.getPort()
                             + "/org.apache.camel.component.grpc.PingPong?method=PingSyncSync&synchronous=true");
                 from("direct:grpc-sync-async")
-                        .to("grpc://localhost:" + grpcTestPort.getPort()
+                        .to("grpc://localhost:" + grpcServer.getPort()
                             + "/org.apache.camel.component.grpc.PingPong?method=pingSyncAsync&synchronous=true");
             }
         };

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProxyAsyncAsyncTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProxyAsyncAsyncTest.java
@@ -29,10 +29,8 @@ import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,11 +40,6 @@ public class GrpcProxyAsyncAsyncTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProxyAsyncAsyncTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcStubPort = AvailablePortFinder.find();
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcRoutePort = AvailablePortFinder.find();
-
     private static Server grpcServer;
     private ManagedChannel channel;
     private PingPongGrpc.PingPongStub stub;
@@ -54,8 +47,8 @@ public class GrpcProxyAsyncAsyncTest extends CamelTestSupport {
 
     @BeforeAll
     public static void beforeAll() throws Exception {
-        grpcServer = ServerBuilder.forPort(grpcStubPort.getPort()).addService(new PingPongImpl()).build().start();
-        LOG.info("gRPC server started on port {}", grpcStubPort.getPort());
+        grpcServer = ServerBuilder.forPort(0).addService(new PingPongImpl()).build().start();
+        LOG.info("gRPC server started on port {}", grpcServer.getPort());
     }
 
     @AfterAll
@@ -68,8 +61,12 @@ public class GrpcProxyAsyncAsyncTest extends CamelTestSupport {
 
     @BeforeEach
     public void beforeEach() {
-        channel = ManagedChannelBuilder.forAddress("localhost", grpcRoutePort.getPort()).usePlaintext().build();
+        channel = ManagedChannelBuilder.forAddress("localhost", getRoutePort()).usePlaintext().build();
         stub = PingPongGrpc.newStub(channel);
+    }
+
+    private int getRoutePort() {
+        return ((GrpcConsumer) context.getRoute("grpc-consumer").getConsumer()).getLocalPort();
     }
 
     @AfterEach
@@ -120,13 +117,13 @@ public class GrpcProxyAsyncAsyncTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 onException(Exception.class).process(e -> routeHasException.set(true));
-                from("grpc://localhost:" + grpcRoutePort.getPort() +
+                from("grpc://localhost:0" +
                      "/org.apache.camel.component.grpc.PingPong" +
                      "?routeControlledStreamObserver=true" +
                      "&consumerStrategy=DELEGATION" +
                      "&forwardOnError=true" +
-                     "&forwardOnCompleted=true")
-                        .toD("grpc://localhost:" + grpcStubPort.getPort() +
+                     "&forwardOnCompleted=true").routeId("grpc-consumer")
+                        .toD("grpc://localhost:" + grpcServer.getPort() +
                              "/org.apache.camel.component.grpc.PingPong" +
                              "?method=${header.CamelGrpcMethodName}" +
                              "&producerStrategy=STREAMING" +

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProxyAsyncAsyncTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProxyAsyncAsyncTest.java
@@ -29,14 +29,13 @@ import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class GrpcProxyAsyncAsyncTest extends CamelTestSupport {
+public class GrpcProxyAsyncAsyncTest extends GrpcTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProxyAsyncAsyncTest.class);
 
@@ -61,12 +60,8 @@ public class GrpcProxyAsyncAsyncTest extends CamelTestSupport {
 
     @BeforeEach
     public void beforeEach() {
-        channel = ManagedChannelBuilder.forAddress("localhost", getRoutePort()).usePlaintext().build();
+        channel = ManagedChannelBuilder.forAddress("localhost", getRoutePort("grpc-consumer")).usePlaintext().build();
         stub = PingPongGrpc.newStub(channel);
-    }
-
-    private int getRoutePort() {
-        return ((GrpcConsumer) context.getRoute("grpc-consumer").getConsumer()).getLocalPort();
     }
 
     @AfterEach

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProxyAsyncSyncTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProxyAsyncSyncTest.java
@@ -29,10 +29,8 @@ import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,11 +40,6 @@ public class GrpcProxyAsyncSyncTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProxyAsyncSyncTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcStubPort = AvailablePortFinder.find();
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcRoutePort = AvailablePortFinder.find();
-
     private static Server grpcServer;
     private ManagedChannel channel;
     private PingPongGrpc.PingPongStub stub;
@@ -54,8 +47,8 @@ public class GrpcProxyAsyncSyncTest extends CamelTestSupport {
 
     @BeforeAll
     public static void beforeAll() throws Exception {
-        grpcServer = ServerBuilder.forPort(grpcStubPort.getPort()).addService(new PingPongImpl()).build().start();
-        LOG.info("gRPC server started on port {}", grpcStubPort.getPort());
+        grpcServer = ServerBuilder.forPort(0).addService(new PingPongImpl()).build().start();
+        LOG.info("gRPC server started on port {}", grpcServer.getPort());
     }
 
     @AfterAll
@@ -68,8 +61,12 @@ public class GrpcProxyAsyncSyncTest extends CamelTestSupport {
 
     @BeforeEach
     public void beforeEach() {
-        channel = ManagedChannelBuilder.forAddress("localhost", grpcRoutePort.getPort()).usePlaintext().build();
+        channel = ManagedChannelBuilder.forAddress("localhost", getRoutePort()).usePlaintext().build();
         stub = PingPongGrpc.newStub(channel);
+    }
+
+    private int getRoutePort() {
+        return ((GrpcConsumer) context.getRoute("grpc-consumer").getConsumer()).getLocalPort();
     }
 
     @AfterEach
@@ -118,13 +115,13 @@ public class GrpcProxyAsyncSyncTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 onException(Exception.class).process(e -> routeHasException.set(true));
-                from("grpc://localhost:" + grpcRoutePort.getPort() +
+                from("grpc://localhost:0" +
                      "/org.apache.camel.component.grpc.PingPong" +
                      "?routeControlledStreamObserver=true" +
                      "&consumerStrategy=DELEGATION" +
                      "&forwardOnError=true" +
-                     "&forwardOnCompleted=true")
-                        .toD("grpc://localhost:" + grpcStubPort.getPort() +
+                     "&forwardOnCompleted=true").routeId("grpc-consumer")
+                        .toD("grpc://localhost:" + grpcServer.getPort() +
                              "/org.apache.camel.component.grpc.PingPong" +
                              "?method=${header.CamelGrpcMethodName}" +
                              "&producerStrategy=STREAMING" +

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProxyAsyncSyncTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProxyAsyncSyncTest.java
@@ -29,14 +29,13 @@ import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class GrpcProxyAsyncSyncTest extends CamelTestSupport {
+public class GrpcProxyAsyncSyncTest extends GrpcTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProxyAsyncSyncTest.class);
 
@@ -61,12 +60,8 @@ public class GrpcProxyAsyncSyncTest extends CamelTestSupport {
 
     @BeforeEach
     public void beforeEach() {
-        channel = ManagedChannelBuilder.forAddress("localhost", getRoutePort()).usePlaintext().build();
+        channel = ManagedChannelBuilder.forAddress("localhost", getRoutePort("grpc-consumer")).usePlaintext().build();
         stub = PingPongGrpc.newStub(channel);
-    }
-
-    private int getRoutePort() {
-        return ((GrpcConsumer) context.getRoute("grpc-consumer").getConsumer()).getLocalPort();
     }
 
     @AfterEach

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProxySyncAsyncTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProxySyncAsyncTest.java
@@ -29,10 +29,8 @@ import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,11 +40,6 @@ public class GrpcProxySyncAsyncTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProxySyncAsyncTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcStubPort = AvailablePortFinder.find();
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcRoutePort = AvailablePortFinder.find();
-
     private static Server grpcServer;
     private ManagedChannel channel;
     private PingPongGrpc.PingPongStub stub;
@@ -54,8 +47,8 @@ public class GrpcProxySyncAsyncTest extends CamelTestSupport {
 
     @BeforeAll
     public static void beforeAll() throws Exception {
-        grpcServer = ServerBuilder.forPort(grpcStubPort.getPort()).addService(new PingPongImpl()).build().start();
-        LOG.info("gRPC server started on port {}", grpcStubPort.getPort());
+        grpcServer = ServerBuilder.forPort(0).addService(new PingPongImpl()).build().start();
+        LOG.info("gRPC server started on port {}", grpcServer.getPort());
     }
 
     @AfterAll
@@ -68,8 +61,12 @@ public class GrpcProxySyncAsyncTest extends CamelTestSupport {
 
     @BeforeEach
     public void beforeEach() {
-        channel = ManagedChannelBuilder.forAddress("localhost", grpcRoutePort.getPort()).usePlaintext().build();
+        channel = ManagedChannelBuilder.forAddress("localhost", getRoutePort()).usePlaintext().build();
         stub = PingPongGrpc.newStub(channel);
+    }
+
+    private int getRoutePort() {
+        return ((GrpcConsumer) context.getRoute("grpc-consumer").getConsumer()).getLocalPort();
     }
 
     @AfterEach
@@ -116,10 +113,10 @@ public class GrpcProxySyncAsyncTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 onException(Exception.class).process(e -> routeHasException.set(true));
-                from("grpc://localhost:" + grpcRoutePort.getPort() +
+                from("grpc://localhost:0" +
                      "/org.apache.camel.component.grpc.PingPong" +
-                     "?routeControlledStreamObserver=true")
-                        .toD("grpc://localhost:" + grpcStubPort.getPort() +
+                     "?routeControlledStreamObserver=true").routeId("grpc-consumer")
+                        .toD("grpc://localhost:" + grpcServer.getPort() +
                              "/org.apache.camel.component.grpc.PingPong" +
                              "?method=${header.CamelGrpcMethodName}" +
                              "&streamRepliesTo=direct:next" +

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProxySyncAsyncTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcProxySyncAsyncTest.java
@@ -29,14 +29,13 @@ import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class GrpcProxySyncAsyncTest extends CamelTestSupport {
+public class GrpcProxySyncAsyncTest extends GrpcTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcProxySyncAsyncTest.class);
 
@@ -61,12 +60,8 @@ public class GrpcProxySyncAsyncTest extends CamelTestSupport {
 
     @BeforeEach
     public void beforeEach() {
-        channel = ManagedChannelBuilder.forAddress("localhost", getRoutePort()).usePlaintext().build();
+        channel = ManagedChannelBuilder.forAddress("localhost", getRoutePort("grpc-consumer")).usePlaintext().build();
         stub = PingPongGrpc.newStub(channel);
-    }
-
-    private int getRoutePort() {
-        return ((GrpcConsumer) context.getRoute("grpc-consumer").getConsumer()).getLocalPort();
     }
 
     @AfterEach

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcTestSupport.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/GrpcTestSupport.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.grpc;
+
+import org.apache.camel.test.junit6.CamelTestSupport;
+
+public abstract class GrpcTestSupport extends CamelTestSupport {
+
+    protected int getRoutePort(String routeId) {
+        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
+    }
+}

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/RouteControlledStreamObserverTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/RouteControlledStreamObserverTest.java
@@ -29,12 +29,10 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,10 +42,6 @@ public class RouteControlledStreamObserverTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerAggregationTest.class);
 
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcSyncRequestTestPort = AvailablePortFinder.find();
-    @RegisterExtension
-    static AvailablePortFinder.Port grpcAsyncRequestTestPort = AvailablePortFinder.find();
     private static final int GRPC_TEST_PING_ID = 1;
     private static final String GRPC_TEST_PING_VALUE = "PING";
     private static final String GRPC_TEST_PONG_VALUE = "PONG";
@@ -60,10 +54,12 @@ public class RouteControlledStreamObserverTest extends CamelTestSupport {
 
     @BeforeEach
     public void startGrpcChannels() {
-        syncRequestChannel
-                = ManagedChannelBuilder.forAddress("localhost", grpcSyncRequestTestPort.getPort()).usePlaintext().build();
-        asyncRequestChannel
-                = ManagedChannelBuilder.forAddress("localhost", grpcAsyncRequestTestPort.getPort()).usePlaintext().build();
+        syncRequestChannel = ManagedChannelBuilder
+                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-sync").getConsumer()).getLocalPort())
+                .usePlaintext().build();
+        asyncRequestChannel = ManagedChannelBuilder
+                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-async").getConsumer()).getLocalPort())
+                .usePlaintext().build();
         blockingStub = PingPongGrpc.newBlockingStub(syncRequestChannel);
         nonBlockingStub = PingPongGrpc.newStub(syncRequestChannel);
         asyncNonBlockingStub = PingPongGrpc.newStub(asyncRequestChannel);
@@ -189,9 +185,8 @@ public class RouteControlledStreamObserverTest extends CamelTestSupport {
         camelContext.addRoutes(new RouteBuilder() {
             @Override
             public void configure() {
-                from("grpc://localhost:" + grpcSyncRequestTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION" +
-                     "&routeControlledStreamObserver=true").to("log:foo");
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION&routeControlledStreamObserver=true")
+                        .to("log:foo");
             }
         });
         assertThrows(IllegalArgumentException.class, camelContext::start);
@@ -216,12 +211,12 @@ public class RouteControlledStreamObserverTest extends CamelTestSupport {
 
             @Override
             public void configure() {
-                from("grpc://localhost:" + grpcSyncRequestTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=PROPAGATION&routeControlledStreamObserver=true")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=PROPAGATION&routeControlledStreamObserver=true")
+                        .routeId("grpc-sync")
                         .process(this::process);
 
-                from("grpc://localhost:" + grpcAsyncRequestTestPort.getPort()
-                     + "/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                from("grpc://localhost:0/org.apache.camel.component.grpc.PingPong?synchronous=true&consumerStrategy=AGGREGATION")
+                        .routeId("grpc-async")
                         .bean(new GrpcMessageBuilder(), "buildAsyncPongResponse");
             }
         };

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/RouteControlledStreamObserverTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/RouteControlledStreamObserverTest.java
@@ -29,7 +29,6 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class RouteControlledStreamObserverTest extends CamelTestSupport {
+public class RouteControlledStreamObserverTest extends GrpcTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsumerAggregationTest.class);
 
@@ -51,10 +50,6 @@ public class RouteControlledStreamObserverTest extends CamelTestSupport {
     private PingPongGrpc.PingPongBlockingStub blockingStub;
     private PingPongGrpc.PingPongStub nonBlockingStub;
     private PingPongGrpc.PingPongStub asyncNonBlockingStub;
-
-    private int getRoutePort(String routeId) {
-        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
-    }
 
     @BeforeEach
     public void startGrpcChannels() {

--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/RouteControlledStreamObserverTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/RouteControlledStreamObserverTest.java
@@ -52,13 +52,17 @@ public class RouteControlledStreamObserverTest extends CamelTestSupport {
     private PingPongGrpc.PingPongStub nonBlockingStub;
     private PingPongGrpc.PingPongStub asyncNonBlockingStub;
 
+    private int getRoutePort(String routeId) {
+        return ((GrpcConsumer) context.getRoute(routeId).getConsumer()).getLocalPort();
+    }
+
     @BeforeEach
     public void startGrpcChannels() {
         syncRequestChannel = ManagedChannelBuilder
-                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-sync").getConsumer()).getLocalPort())
+                .forAddress("localhost", getRoutePort("grpc-sync"))
                 .usePlaintext().build();
         asyncRequestChannel = ManagedChannelBuilder
-                .forAddress("localhost", ((GrpcConsumer) context.getRoute("grpc-async").getConsumer()).getLocalPort())
+                .forAddress("localhost", getRoutePort("grpc-async"))
                 .usePlaintext().build();
         blockingStub = PingPongGrpc.newBlockingStub(syncRequestChannel);
         nonBlockingStub = PingPongGrpc.newStub(syncRequestChannel);

--- a/components/camel-grpc/src/test/resources/log4j2.properties
+++ b/components/camel-grpc/src/test/resources/log4j2.properties
@@ -26,3 +26,8 @@ appender.stdout.layout.type = PatternLayout
 appender.stdout.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %m%n
 rootLogger.level = INFO
 rootLogger.appenderRef.file.ref = file
+
+logger.grpc.name = io.grpc
+logger.grpc.level = WARN
+logger.netty.name = io.netty
+logger.netty.level = WARN

--- a/components/camel-grpc/src/test/resources/logging.properties
+++ b/components/camel-grpc/src/test/resources/logging.properties
@@ -1,0 +1,22 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+## Suppress gRPC/Netty JUL logging to prevent excessive console output
+## that can fill CI runner disk space.
+.level = SEVERE
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = SEVERE

--- a/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/MllpTcpServerConsumer.java
+++ b/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/MllpTcpServerConsumer.java
@@ -241,10 +241,7 @@ public class MllpTcpServerConsumer extends DefaultConsumer {
      * configured with port 0 to let the OS assign a port atomically.
      */
     public int getLocalPort() {
-        if (acceptThread != null && acceptThread.serverSocket != null && acceptThread.serverSocket.isBound()) {
-            return acceptThread.serverSocket.getLocalPort();
-        }
-        return -1;
+        return acceptThread != null ? acceptThread.getLocalPort() : -1;
     }
 
     public void startConsumer(Socket clientSocket, MllpSocketBuffer mllpBuffer) {

--- a/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/MllpTcpServerConsumer.java
+++ b/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/MllpTcpServerConsumer.java
@@ -236,6 +236,17 @@ public class MllpTcpServerConsumer extends DefaultConsumer {
         acceptThread.start();
     }
 
+    /**
+     * Returns the local port the server socket is bound to, or -1 if not yet bound. Useful when the consumer is
+     * configured with port 0 to let the OS assign a port atomically.
+     */
+    public int getLocalPort() {
+        if (acceptThread != null && acceptThread.serverSocket != null && acceptThread.serverSocket.isBound()) {
+            return acceptThread.serverSocket.getLocalPort();
+        }
+        return -1;
+    }
+
     public void startConsumer(Socket clientSocket, MllpSocketBuffer mllpBuffer) {
         TcpSocketConsumerRunnable client = new TcpSocketConsumerRunnable(
                 this, clientSocket, mllpBuffer, hl7Util, logPhi);

--- a/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/internal/TcpServerAcceptThread.java
+++ b/components/camel-mllp/src/main/java/org/apache/camel/component/mllp/internal/TcpServerAcceptThread.java
@@ -45,6 +45,10 @@ public class TcpServerAcceptThread extends Thread {
         this.serverSocket = serverSocket;
     }
 
+    public int getLocalPort() {
+        return serverSocket != null && serverSocket.isBound() ? serverSocket.getLocalPort() : -1;
+    }
+
     /**
      * Derive a thread name from the class name, the component URI and the connection information.
      * <p/>

--- a/components/camel-mllp/src/test/java/org/apache/camel/MllpTcpServerConsumerLenientBindTest.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/MllpTcpServerConsumerLenientBindTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit.rule.mllp.MllpClientResource;
 import org.apache.camel.test.junit.rule.mllp.MllpJUnitResourceTimeoutException;
 import org.apache.camel.test.junit6.CamelTestSupport;
@@ -41,9 +40,6 @@ public class MllpTcpServerConsumerLenientBindTest extends CamelTestSupport {
     static final int READ_TIMEOUT = 500;
 
     @RegisterExtension
-    AvailablePortFinder.Port mllpClientPort = AvailablePortFinder.find();
-
-    @RegisterExtension
     public MllpClientResource mllpClient = new MllpClientResource();
 
     @EndpointInject("mock://result")
@@ -54,9 +50,10 @@ public class MllpTcpServerConsumerLenientBindTest extends CamelTestSupport {
     @Override
     protected void doPreSetup() throws Exception {
         mllpClient.setMllpHost("localhost");
-        mllpClient.setMllpPort(mllpClientPort.getPort());
 
-        portBlocker = new ServerSocket(mllpClient.getMllpPort());
+        // Bind to port 0 to get an OS-assigned port atomically, then close and reuse that port
+        portBlocker = new ServerSocket(0);
+        mllpClient.setMllpPort(portBlocker.getLocalPort());
 
         assertTrue(portBlocker.isBound());
     }

--- a/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/LogPhiTest.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/LogPhiTest.java
@@ -25,7 +25,6 @@ import org.apache.camel.Exchange;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.ServiceStatus;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit.rule.mllp.MllpServerResource;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.camel.test.mllp.Hl7TestMessageGenerator;
@@ -42,9 +41,6 @@ public class LogPhiTest extends CamelTestSupport {
     static final int SERVER_ACKNOWLEDGEMENT_DELAY = 10000;
 
     @RegisterExtension
-    AvailablePortFinder.Port mllpServerPort = AvailablePortFinder.find();
-
-    @RegisterExtension
     public MllpServerResource mllpServer = new MllpServerResource();
 
     @EndpointInject("direct:startNoLogPhi")
@@ -59,7 +55,7 @@ public class LogPhiTest extends CamelTestSupport {
     @Override
     protected void doPreSetup() throws Exception {
         mllpServer.setListenHost("localhost");
-        mllpServer.setListenPort(mllpServerPort.getPort());
+        mllpServer.setListenPort(0);
         mllpServer.setDelayDuringAcknowledgement(SERVER_ACKNOWLEDGEMENT_DELAY);
         mllpServer.startup();
         assertTrue(mllpServer.isActive());

--- a/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpIdleTimeoutStrategyTest.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpIdleTimeoutStrategyTest.java
@@ -29,7 +29,6 @@ import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mllp.internal.MllpSocketBuffer;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit.rule.mllp.MllpServerResource;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.camel.test.mllp.Hl7TestMessageGenerator;
@@ -50,10 +49,7 @@ public class MllpIdleTimeoutStrategyTest extends CamelTestSupport {
     static final int IDLE_TIMEOUT = 500;
 
     @RegisterExtension
-    AvailablePortFinder.Port mllpServerPort = AvailablePortFinder.find();
-
-    @RegisterExtension
-    public MllpServerResource mllpServer = new MllpServerResource("localhost", mllpServerPort.getPort());
+    public MllpServerResource mllpServer = new MllpServerResource("localhost", 0);
 
     @EndpointInject("direct://sourcedefault")
     ProducerTemplate defaultStrategySource;

--- a/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpTcpClientProducerConnectionErrorTest.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpTcpClientProducerConnectionErrorTest.java
@@ -27,7 +27,6 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit.rule.mllp.MllpServerResource;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.apache.camel.test.mllp.Hl7TestMessageGenerator;
@@ -40,10 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class MllpTcpClientProducerConnectionErrorTest extends CamelTestSupport {
 
     @RegisterExtension
-    AvailablePortFinder.Port mllpServerPort = AvailablePortFinder.find();
-
-    @RegisterExtension
-    public MllpServerResource mllpServer = new MllpServerResource("localhost", mllpServerPort.getPort());
+    public MllpServerResource mllpServer = new MllpServerResource("localhost", 0);
 
     @EndpointInject("direct://source")
     ProducerTemplate source;

--- a/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpTcpClientProducerIdleConnectionTimeoutTest.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/MllpTcpClientProducerIdleConnectionTimeoutTest.java
@@ -26,7 +26,6 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit.rule.mllp.MllpJUnitResourceException;
 import org.apache.camel.test.junit.rule.mllp.MllpServerResource;
 import org.apache.camel.test.junit6.CamelTestSupport;
@@ -50,10 +49,7 @@ public class MllpTcpClientProducerIdleConnectionTimeoutTest extends CamelTestSup
     Logger log = LoggerFactory.getLogger(MllpTcpClientProducerIdleConnectionTimeoutTest.class);
 
     @RegisterExtension
-    AvailablePortFinder.Port mllpServerPort = AvailablePortFinder.find();
-
-    @RegisterExtension
-    MllpServerResource mllpServer = new MllpServerResource("localhost", mllpServerPort.getPort());
+    MllpServerResource mllpServer = new MllpServerResource("localhost", 0);
 
     @EndpointInject("direct://source")
     ProducerTemplate source;

--- a/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/TcpServerConsumerAcknowledgementTestSupport.java
+++ b/components/camel-mllp/src/test/java/org/apache/camel/component/mllp/TcpServerConsumerAcknowledgementTestSupport.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.mllp;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.Consumer;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.LoggingLevel;
@@ -26,7 +27,6 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit.rule.mllp.MllpClientResource;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -40,9 +40,6 @@ public abstract class TcpServerConsumerAcknowledgementTestSupport extends CamelT
 
     static final String EXPECTED_ACKNOWLEDGEMENT = "MSH|^~\\&|^org^sys||APP_A|FAC_A|||ACK^A04^ACK|||2.6" + '\r'
                                                    + "MSA|AA|" + '\r';
-
-    @RegisterExtension
-    AvailablePortFinder.Port mllpClientPort = AvailablePortFinder.find();
 
     @RegisterExtension
     public MllpClientResource mllpClient = new MllpClientResource();
@@ -64,6 +61,9 @@ public abstract class TcpServerConsumerAcknowledgementTestSupport extends CamelT
 
     @Override
     protected void doPostSetup() throws Exception {
+        Consumer consumer = context.getRoute("mllp-test-receiver-route").getConsumer();
+        mllpClient.setMllpPort(((MllpTcpServerConsumer) consumer).getLocalPort());
+
         result.expectedMessageCount(0);
         complete.expectedMessageCount(0);
         failure.expectedMessageCount(0);
@@ -85,7 +85,6 @@ public abstract class TcpServerConsumerAcknowledgementTestSupport extends CamelT
     @Override
     protected RouteBuilder createRouteBuilder() {
         mllpClient.setMllpHost("localhost");
-        mllpClient.setMllpPort(mllpClientPort.getPort());
 
         return new RouteBuilder() {
             int connectTimeout = 500;
@@ -114,7 +113,7 @@ public abstract class TcpServerConsumerAcknowledgementTestSupport extends CamelT
                         .to("mock://on-failure-only");
 
                 fromF("mllp://%s:%d?bridgeErrorHandler=%b&autoAck=%b&exchangePattern=%s&connectTimeout=%d&receiveTimeout=%d",
-                        mllpClient.getMllpHost(), mllpClient.getMllpPort(), isBridgeErrorHandler(), isAutoAck(),
+                        mllpClient.getMllpHost(), 0, isBridgeErrorHandler(), isAutoAck(),
                         exchangePattern(), connectTimeout, responseTimeout)
                         .routeId(routeId)
                         .to(result);


### PR DESCRIPTION
[CAMEL-23431](https://issues.apache.org/jira/browse/CAMEL-23431)

## Summary

Migrate `camel-grpc` and `camel-mllp` tests from `AvailablePortFinder` to port-0 dynamic binding, eliminating TOCTOU race conditions.

### camel-grpc
- Use `ServerBuilder.forPort(0)` to let the OS assign ports dynamically
- Extract `GrpcTestSupport` base class with `getRoutePort(String routeId)` helper to retrieve dynamically assigned ports after route startup
- Use Camel's built-in `hash` query parameter to differentiate port-0 endpoints that share the same URI
- Add `LOG.warn` in `GrpcComponent` when port=0 is used without a `hash` parameter
- Suppress gRPC/Netty JUL logging in tests via `logging.properties` + Surefire `systemPropertyVariables`
- Fix `GrpcProducerStreamingTest` lifecycle: use `setupResources()`/`cleanupResources()` instead of `@BeforeEach`/`@AfterEach`
- Remove `invalidPort()` test (port 0 is now valid for dynamic allocation)

### camel-mllp
- Bind to port 0 and retrieve assigned port via `getLocalPort()`

## Test plan

- [x] All 46 `camel-grpc` tests pass locally
- [ ] CI passes on PR