### PR TITLE
CAMEL-23387: camel-telemetry - Add span decorators for AWS

### DIFF
--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsKinesisSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsKinesisSpanDecorator.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsKinesisSpanDecorator extends AbstractMessagingSpanDecorator {
+
+    static final String KINESIS_PARTITION_KEY = "partitionKey";
+    static final String KINESIS_SHARD_ID = "shardId";
+    static final String KINESIS_APPROX_ARRIVAL_TIME = "approximateArrivalTimestamp";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.kinesis.Kinesis2Constants}
+     */
+    static final String SEQUENCE_NUMBER = "CamelAwsKinesisSequenceNumber";
+    static final String APPROX_ARRIVAL_TIME = "CamelAwsKinesisApproximateArrivalTimestamp";
+    static final String PARTITION_KEY = "CamelAwsKinesisPartitionKey";
+    static final String SHARD_ID = "CamelAwsKinesisShardId";
+
+    @Override
+    public String getComponent() {
+        return "aws2-kinesis";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.kinesis.Kinesis2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String partitionKey = exchange.getIn().getHeader(PARTITION_KEY, String.class);
+        if (partitionKey != null) {
+            span.setTag(KINESIS_PARTITION_KEY, partitionKey);
+        }
+
+        String shardId = exchange.getIn().getHeader(SHARD_ID, String.class);
+        if (shardId != null) {
+            span.setTag(KINESIS_SHARD_ID, shardId);
+        }
+
+        String approxArrivalTimestamp = exchange.getIn().getHeader(APPROX_ARRIVAL_TIME, String.class);
+        if (approxArrivalTimestamp != null) {
+            span.setTag(KINESIS_APPROX_ARRIVAL_TIME, approxArrivalTimestamp);
+        }
+    }
+
+    @Override
+    protected String getMessageId(Exchange exchange) {
+        return exchange.getIn().getHeader(SEQUENCE_NUMBER, String.class);
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsS3SpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsS3SpanDecorator.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsS3SpanDecorator extends AbstractSpanDecorator {
+
+    static final String S3_BUCKET_NAME = "bucketName";
+    static final String S3_KEY = "key";
+    static final String S3_VERSION_ID = "versionId";
+    static final String S3_OPERATION = "operation";
+    static final String S3_STORAGE_CLASS = "storageClass";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.s3.AWS2S3Constants}
+     */
+    static final String BUCKET_NAME = "CamelAwsS3BucketName";
+    static final String KEY = "CamelAwsS3Key";
+    static final String VERSION_ID = "CamelAwsS3VersionId";
+    static final String OPERATION = "CamelAwsS3Operation";
+    static final String STORAGE_CLASS = "CamelAwsS3StorageClass";
+
+    @Override
+    public String getComponent() {
+        return "aws2-s3";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.s3.AWS2S3Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String bucketName = exchange.getIn().getHeader(BUCKET_NAME, String.class);
+        if (bucketName != null) {
+            span.setTag(S3_BUCKET_NAME, bucketName);
+        }
+
+        String key = exchange.getIn().getHeader(KEY, String.class);
+        if (key != null) {
+            span.setTag(S3_KEY, key);
+        }
+
+        String versionId = exchange.getIn().getHeader(VERSION_ID, String.class);
+        if (versionId != null) {
+            span.setTag(S3_VERSION_ID, versionId);
+        }
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(S3_OPERATION, operation);
+        }
+
+        String storageClass = exchange.getIn().getHeader(STORAGE_CLASS, String.class);
+        if (storageClass != null) {
+            span.setTag(S3_STORAGE_CLASS, storageClass);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsSnsSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsSnsSpanDecorator.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsSnsSpanDecorator extends AbstractMessagingSpanDecorator {
+
+    static final String SNS_SUBJECT = "subject";
+    static final String SNS_MESSAGE_STRUCTURE = "messageStructure";
+    static final String SNS_MESSAGE_GROUP_ID = "messageGroupId";
+    static final String SNS_SEQUENCE_NUMBER = "sequenceNumber";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.sns.Sns2Constants}
+     */
+    static final String MESSAGE_ID = "CamelAwsSnsMessageId";
+    static final String SUBJECT = "CamelAwsSnsSubject";
+    static final String MESSAGE_STRUCTURE = "CamelAwsSnsMessageStructure";
+    static final String MESSAGE_GROUP_ID = "CamelAwsSnsMessageGroupId";
+    static final String SEQUENCE_NUMBER = "CamelAwsSnsSequenceNumber";
+
+    @Override
+    public String getComponent() {
+        return "aws2-sns";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.sns.Sns2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String subject = exchange.getIn().getHeader(SUBJECT, String.class);
+        if (subject != null) {
+            span.setTag(SNS_SUBJECT, subject);
+        }
+
+        String messageStructure = exchange.getIn().getHeader(MESSAGE_STRUCTURE, String.class);
+        if (messageStructure != null) {
+            span.setTag(SNS_MESSAGE_STRUCTURE, messageStructure);
+        }
+
+        String messageGroupId = exchange.getIn().getHeader(MESSAGE_GROUP_ID, String.class);
+        if (messageGroupId != null) {
+            span.setTag(SNS_MESSAGE_GROUP_ID, messageGroupId);
+        }
+
+        String sequenceNumber = exchange.getIn().getHeader(SEQUENCE_NUMBER, String.class);
+        if (sequenceNumber != null) {
+            span.setTag(SNS_SEQUENCE_NUMBER, sequenceNumber);
+        }
+    }
+
+    @Override
+    protected String getMessageId(Exchange exchange) {
+        return exchange.getIn().getHeader(MESSAGE_ID, String.class);
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsSqsSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsSqsSpanDecorator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsSqsSpanDecorator extends AbstractMessagingSpanDecorator {
+
+    static final String SQS_MD5_OF_BODY = "md5OfBody";
+    static final String SQS_RECEIPT_HANDLE = "receiptHandle";
+    static final String SQS_DELAY_SECONDS = "delaySeconds";
+    static final String SQS_OPERATION = "operation";
+    static final String SQS_MESSAGE_GROUP_ID = "messageGroupId";
+    static final String SQS_SEQUENCE_NUMBER = "sequenceNumber";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.sqs.Sqs2Constants}
+     */
+    static final String MESSAGE_ID = "CamelAwsSqsMessageId";
+    static final String MD5_OF_BODY = "CamelAwsSqsMD5OfBody";
+    static final String RECEIPT_HANDLE = "CamelAwsSqsReceiptHandle";
+    static final String DELAY_HEADER = "CamelAwsSqsDelaySeconds";
+    static final String OPERATION = "CamelAwsSqsOperation";
+    static final String MESSAGE_GROUP_ID = "CamelAwsMessageGroupId";
+    static final String SEQUENCE_NUMBER = "CamelAwsSqsSequenceNumber";
+
+    @Override
+    public String getComponent() {
+        return "aws2-sqs";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.sqs.Sqs2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String md5OfBody = exchange.getIn().getHeader(MD5_OF_BODY, String.class);
+        if (md5OfBody != null) {
+            span.setTag(SQS_MD5_OF_BODY, md5OfBody);
+        }
+
+        String receiptHandle = exchange.getIn().getHeader(RECEIPT_HANDLE, String.class);
+        if (receiptHandle != null) {
+            span.setTag(SQS_RECEIPT_HANDLE, receiptHandle);
+        }
+
+        Integer delaySeconds = exchange.getIn().getHeader(DELAY_HEADER, Integer.class);
+        if (delaySeconds != null) {
+            span.setTag(SQS_DELAY_SECONDS, delaySeconds.toString());
+        }
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(SQS_OPERATION, operation);
+        }
+
+        String messageGroupId = exchange.getIn().getHeader(MESSAGE_GROUP_ID, String.class);
+        if (messageGroupId != null) {
+            span.setTag(SQS_MESSAGE_GROUP_ID, messageGroupId);
+        }
+
+        String sequenceNumber = exchange.getIn().getHeader(SEQUENCE_NUMBER, String.class);
+        if (sequenceNumber != null) {
+            span.setTag(SQS_SEQUENCE_NUMBER, sequenceNumber);
+        }
+    }
+
+    @Override
+    protected String getMessageId(Exchange exchange) {
+        return exchange.getIn().getHeader(MESSAGE_ID, String.class);
+    }
+
+}

--- a/components/camel-telemetry/src/main/resources/META-INF/services/org.apache.camel.telemetry.SpanDecorator
+++ b/components/camel-telemetry/src/main/resources/META-INF/services/org.apache.camel.telemetry.SpanDecorator
@@ -19,6 +19,10 @@ org.apache.camel.telemetry.decorators.ActiveMQ6SpanDecorator
 org.apache.camel.telemetry.decorators.ActiveMQSpanDecorator
 org.apache.camel.telemetry.decorators.AhcSpanDecorator
 org.apache.camel.telemetry.decorators.AmqpSpanDecorator
+org.apache.camel.telemetry.decorators.AwsKinesisSpanDecorator
+org.apache.camel.telemetry.decorators.AwsS3SpanDecorator
+org.apache.camel.telemetry.decorators.AwsSnsSpanDecorator
+org.apache.camel.telemetry.decorators.AwsSqsSpanDecorator
 org.apache.camel.telemetry.decorators.AzureServiceBusSpanDecorator
 org.apache.camel.telemetry.decorators.CometdSpanDecorator
 org.apache.camel.telemetry.decorators.CometdsSpanDecorator

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsKinesisSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsKinesisSpanDecoratorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsKinesisSpanDecoratorTest {
+
+    @Test
+    public void testGetMessageId() {
+        String sequenceNumber = "49545115243490985018280067714973144582180062593244200961";
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsKinesisSpanDecorator.SEQUENCE_NUMBER, String.class)).thenReturn(sequenceNumber);
+
+        AbstractMessagingSpanDecorator decorator = new AwsKinesisSpanDecorator();
+
+        assertEquals(sequenceNumber, decorator.getMessageId(exchange));
+    }
+
+    @Test
+    public void testPre() {
+        String partitionKey = "partition-1";
+        String shardId = "shardId-000000000000";
+        String approxArrivalTimestamp = "2026-04-30T12:00:00Z";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-kinesis:myStream");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsKinesisSpanDecorator.PARTITION_KEY, String.class)).thenReturn(partitionKey);
+        Mockito.when(message.getHeader(AwsKinesisSpanDecorator.SHARD_ID, String.class)).thenReturn(shardId);
+        Mockito.when(message.getHeader(AwsKinesisSpanDecorator.APPROX_ARRIVAL_TIME, String.class))
+                .thenReturn(approxArrivalTimestamp);
+
+        AbstractMessagingSpanDecorator decorator = new AwsKinesisSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(partitionKey, span.tags().get(AwsKinesisSpanDecorator.KINESIS_PARTITION_KEY));
+        assertEquals(shardId, span.tags().get(AwsKinesisSpanDecorator.KINESIS_SHARD_ID));
+        assertEquals(approxArrivalTimestamp, span.tags().get(AwsKinesisSpanDecorator.KINESIS_APPROX_ARRIVAL_TIME));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsS3SpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsS3SpanDecoratorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsS3SpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String bucketName = "my-bucket";
+        String key = "my/object/key.txt";
+        String versionId = "version-1234";
+        String operation = "putObject";
+        String storageClass = "STANDARD";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-s3:myBucket");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsS3SpanDecorator.BUCKET_NAME, String.class)).thenReturn(bucketName);
+        Mockito.when(message.getHeader(AwsS3SpanDecorator.KEY, String.class)).thenReturn(key);
+        Mockito.when(message.getHeader(AwsS3SpanDecorator.VERSION_ID, String.class)).thenReturn(versionId);
+        Mockito.when(message.getHeader(AwsS3SpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsS3SpanDecorator.STORAGE_CLASS, String.class)).thenReturn(storageClass);
+
+        AbstractSpanDecorator decorator = new AwsS3SpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(bucketName, span.tags().get(AwsS3SpanDecorator.S3_BUCKET_NAME));
+        assertEquals(key, span.tags().get(AwsS3SpanDecorator.S3_KEY));
+        assertEquals(versionId, span.tags().get(AwsS3SpanDecorator.S3_VERSION_ID));
+        assertEquals(operation, span.tags().get(AwsS3SpanDecorator.S3_OPERATION));
+        assertEquals(storageClass, span.tags().get(AwsS3SpanDecorator.S3_STORAGE_CLASS));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsSnsSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsSnsSpanDecoratorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsSnsSpanDecoratorTest {
+
+    @Test
+    public void testGetMessageId() {
+        String messageId = "abcd";
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsSnsSpanDecorator.MESSAGE_ID, String.class)).thenReturn(messageId);
+
+        AbstractMessagingSpanDecorator decorator = new AwsSnsSpanDecorator();
+
+        assertEquals(messageId, decorator.getMessageId(exchange));
+    }
+
+    @Test
+    public void testPre() {
+        String subject = "my-subject";
+        String messageStructure = "json";
+        String messageGroupId = "myGroup";
+        String sequenceNumber = "1234567890";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-sns:myTopic");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsSnsSpanDecorator.SUBJECT, String.class)).thenReturn(subject);
+        Mockito.when(message.getHeader(AwsSnsSpanDecorator.MESSAGE_STRUCTURE, String.class)).thenReturn(messageStructure);
+        Mockito.when(message.getHeader(AwsSnsSpanDecorator.MESSAGE_GROUP_ID, String.class)).thenReturn(messageGroupId);
+        Mockito.when(message.getHeader(AwsSnsSpanDecorator.SEQUENCE_NUMBER, String.class)).thenReturn(sequenceNumber);
+
+        AbstractMessagingSpanDecorator decorator = new AwsSnsSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(subject, span.tags().get(AwsSnsSpanDecorator.SNS_SUBJECT));
+        assertEquals(messageStructure, span.tags().get(AwsSnsSpanDecorator.SNS_MESSAGE_STRUCTURE));
+        assertEquals(messageGroupId, span.tags().get(AwsSnsSpanDecorator.SNS_MESSAGE_GROUP_ID));
+        assertEquals(sequenceNumber, span.tags().get(AwsSnsSpanDecorator.SNS_SEQUENCE_NUMBER));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsSqsSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsSqsSpanDecoratorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsSqsSpanDecoratorTest {
+
+    @Test
+    public void testGetMessageId() {
+        String messageId = "abcd";
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsSqsSpanDecorator.MESSAGE_ID, String.class)).thenReturn(messageId);
+
+        AbstractMessagingSpanDecorator decorator = new AwsSqsSpanDecorator();
+
+        assertEquals(messageId, decorator.getMessageId(exchange));
+    }
+
+    @Test
+    public void testPre() {
+        String md5OfBody = "098f6bcd4621d373cade4e832627b4f6";
+        String receiptHandle = "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3";
+        Integer delaySeconds = 30;
+        String operation = "sendMessage";
+        String messageGroupId = "myGroup";
+        String sequenceNumber = "1234567890";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-sqs:myQueue");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsSqsSpanDecorator.MD5_OF_BODY, String.class)).thenReturn(md5OfBody);
+        Mockito.when(message.getHeader(AwsSqsSpanDecorator.RECEIPT_HANDLE, String.class)).thenReturn(receiptHandle);
+        Mockito.when(message.getHeader(AwsSqsSpanDecorator.DELAY_HEADER, Integer.class)).thenReturn(delaySeconds);
+        Mockito.when(message.getHeader(AwsSqsSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsSqsSpanDecorator.MESSAGE_GROUP_ID, String.class)).thenReturn(messageGroupId);
+        Mockito.when(message.getHeader(AwsSqsSpanDecorator.SEQUENCE_NUMBER, String.class)).thenReturn(sequenceNumber);
+
+        AbstractMessagingSpanDecorator decorator = new AwsSqsSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(md5OfBody, span.tags().get(AwsSqsSpanDecorator.SQS_MD5_OF_BODY));
+        assertEquals(receiptHandle, span.tags().get(AwsSqsSpanDecorator.SQS_RECEIPT_HANDLE));
+        assertEquals(delaySeconds.toString(), span.tags().get(AwsSqsSpanDecorator.SQS_DELAY_SECONDS));
+        assertEquals(operation, span.tags().get(AwsSqsSpanDecorator.SQS_OPERATION));
+        assertEquals(messageGroupId, span.tags().get(AwsSqsSpanDecorator.SQS_MESSAGE_GROUP_ID));
+        assertEquals(sequenceNumber, span.tags().get(AwsSqsSpanDecorator.SQS_SEQUENCE_NUMBER));
+    }
+
+}


### PR DESCRIPTION
## Summary

Adds span decorators for the foundational AWS messaging/streaming/storage components in `camel-telemetry`, following the pattern of the existing `AzureServiceBusSpanDecorator`. This resumes the AWS coverage that previously lived in the deprecated `camel-tracing` module (it was lost when the v1 `camel-aws-*` components were removed) and updates it to the current `aws2-*` component schemes.

JIRA: [CAMEL-23387](https://issues.apache.org/jira/browse/CAMEL-23387)

> **Scope note:** CAMEL-23387 covers AWS span decorators broadly, and Camel ships ~30 AWS components. To keep this PR reviewable, it tackles only the four most foundational ones (the messaging/streaming/storage core). The JIRA will remain open after this merges, and additional decorators (DynamoDB, Lambda, EventBridge, SES, MQ, Bedrock, KMS, Step Functions, Timestream, …) will land in subsequent PRs against the same ticket.

## Changes

New `SpanDecorator` implementations under `org.apache.camel.telemetry.decorators`:

- **`AwsSqsSpanDecorator`** (`aws2-sqs`) — extracts message id, MD5-of-body, receipt handle, delay seconds, operation, message group id (FIFO) and sequence number (FIFO).
- **`AwsSnsSpanDecorator`** (`aws2-sns`) — extracts message id, subject, message structure, message group id (FIFO) and sequence number (FIFO).
- **`AwsKinesisSpanDecorator`** (`aws2-kinesis`) — extracts sequence number (as message id), partition key, shard id and approximate arrival timestamp.
- **`AwsS3SpanDecorator`** (`aws2-s3`) — extracts bucket name, key, version id, operation and storage class.

All four decorators are registered in `META-INF/services/org.apache.camel.telemetry.SpanDecorator`. Unit tests cover header-to-tag extraction for each decorator.

The messaging decorators (`Sqs`, `Sns`, `Kinesis`) extend `AbstractMessagingSpanDecorator`, while the storage decorator (`S3`) extends `AbstractSpanDecorator`. Header constants are mirrored from the corresponding component's `*Constants` interface (with a Javadoc reference back to the source), matching the convention already used by `AzureServiceBusSpanDecorator`. This avoids creating a hard dependency from `camel-telemetry` to the AWS component modules.

## Test plan

- [x] `mvn test` in `components/camel-telemetry` passes (94 tests, including 7 new tests across the 4 new decorators)
- [x] Module-specific build (`mvn -DskipTests install`) succeeds
- [x] Direct dependents (`camel-telemetry-dev`, `camel-micrometer-observability`, `camel-opentelemetry2`) still build cleanly
- [x] No code style or formatter changes required

## Follow-ups

- Remaining AWS components (DDB, Lambda, EventBridge, MQ, MSK, SES, Bedrock, KMS, STS, IAM, Step Functions, Timestream, Athena, CloudWatch, EC2/ECS/EKS, Polly/Rekognition/Textract/Transcribe/Translate, Comprehend, Redshift, S3 Vectors, Firehose, CloudTrail, Config, Parameter Store, Secrets Manager, Security Hub, X-Ray) — to be added in follow-up PRs against the same JIRA.
- Google Cloud decorators (mentioned in CAMEL-23387's description as "as well in fact") — separate scope discussion, can spin off into its own JIRA when prioritised.

---

_Claude Code on behalf of Andrea Cosentino_