### PR TITLE
CAMEL-23387: camel-telemetry - Add span decorators for DDB, Lambda, EventBridge, SES, MQ, Firehose and Bedrock

### DIFF
--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsBedrockSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsBedrockSpanDecorator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsBedrockSpanDecorator extends AbstractSpanDecorator {
+
+    static final String BEDROCK_OPERATION = "operation";
+    static final String BEDROCK_MODEL_CONTENT_TYPE = "modelContentType";
+    static final String BEDROCK_STOP_REASON = "stopReason";
+    static final String BEDROCK_TOKEN_COUNT = "tokenCount";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.bedrock.runtime.BedrockConstants}
+     */
+    static final String OPERATION = "CamelAwsBedrockOperation";
+    static final String MODEL_CONTENT_TYPE = "CamelAwsBedrockContentType";
+    static final String CONVERSE_STOP_REASON = "CamelAwsBedrockConverseStopReason";
+    static final String STREAMING_TOKEN_COUNT = "CamelAwsBedrockTokenCount";
+
+    @Override
+    public String getComponent() {
+        return "aws-bedrock";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.bedrock.runtime.BedrockComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(BEDROCK_OPERATION, operation);
+        }
+
+        String modelContentType = exchange.getIn().getHeader(MODEL_CONTENT_TYPE, String.class);
+        if (modelContentType != null) {
+            span.setTag(BEDROCK_MODEL_CONTENT_TYPE, modelContentType);
+        }
+
+        String stopReason = exchange.getIn().getHeader(CONVERSE_STOP_REASON, String.class);
+        if (stopReason != null) {
+            span.setTag(BEDROCK_STOP_REASON, stopReason);
+        }
+
+        Integer tokenCount = exchange.getIn().getHeader(STREAMING_TOKEN_COUNT, Integer.class);
+        if (tokenCount != null) {
+            span.setTag(BEDROCK_TOKEN_COUNT, tokenCount.toString());
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsDdbSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsDdbSpanDecorator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+import org.apache.camel.telemetry.TagConstants;
+
+public class AwsDdbSpanDecorator extends AbstractSpanDecorator {
+
+    static final String DDB_TABLE_NAME = "tableName";
+    static final String DDB_OPERATION = "operation";
+    static final String DDB_INDEX_NAME = "indexName";
+    static final String DDB_CONSUMED_CAPACITY = "consumedCapacity";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.ddb.Ddb2Constants}
+     */
+    static final String TABLE_NAME = "CamelAwsDdbTableName";
+    static final String OPERATION = "CamelAwsDdbOperation";
+    static final String INDEX_NAME = "CamelAwsDdbIndexName";
+    static final String CONSUMED_CAPACITY = "CamelAwsDdbConsumedCapacity";
+
+    @Override
+    public String getComponent() {
+        return "aws2-ddb";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.ddb.Ddb2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        span.setTag(TagConstants.DB_SYSTEM, "dynamodb");
+
+        String tableName = exchange.getIn().getHeader(TABLE_NAME, String.class);
+        if (tableName != null) {
+            span.setTag(DDB_TABLE_NAME, tableName);
+            span.setTag(TagConstants.DB_NAME, tableName);
+        }
+
+        Object operation = exchange.getIn().getHeader(OPERATION);
+        if (operation != null) {
+            span.setTag(DDB_OPERATION, operation.toString());
+        }
+
+        String indexName = exchange.getIn().getHeader(INDEX_NAME, String.class);
+        if (indexName != null) {
+            span.setTag(DDB_INDEX_NAME, indexName);
+        }
+
+        Double consumedCapacity = exchange.getIn().getHeader(CONSUMED_CAPACITY, Double.class);
+        if (consumedCapacity != null) {
+            span.setTag(DDB_CONSUMED_CAPACITY, consumedCapacity.toString());
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsDdbStreamSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsDdbStreamSpanDecorator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsDdbStreamSpanDecorator extends AbstractMessagingSpanDecorator {
+
+    static final String DDB_STREAM_EVENT_SOURCE = "eventSource";
+    static final String DDB_STREAM_EVENT_NAME = "eventName";
+    static final String DDB_STREAM_SIZE_BYTES = "sizeBytes";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.ddbstream.Ddb2StreamConstants}
+     */
+    static final String EVENT_SOURCE = "CamelAwsDdbStreamEventSource";
+    static final String EVENT_ID = "CamelAwsDdbStreamEventId";
+    static final String EVENT_NAME = "CamelAwsDdbStreamEventName";
+    static final String SEQUENCE_NUMBER = "CamelAwsDdbStreamSequenceNumber";
+    static final String SIZE_BYTES = "CamelAwsDdbStreamSizeBytes";
+
+    @Override
+    public String getComponent() {
+        return "aws2-ddbstream";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.ddbstream.Ddb2StreamComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String eventSource = exchange.getIn().getHeader(EVENT_SOURCE, String.class);
+        if (eventSource != null) {
+            span.setTag(DDB_STREAM_EVENT_SOURCE, eventSource);
+        }
+
+        String eventName = exchange.getIn().getHeader(EVENT_NAME, String.class);
+        if (eventName != null) {
+            span.setTag(DDB_STREAM_EVENT_NAME, eventName);
+        }
+
+        Long sizeBytes = exchange.getIn().getHeader(SIZE_BYTES, Long.class);
+        if (sizeBytes != null) {
+            span.setTag(DDB_STREAM_SIZE_BYTES, sizeBytes.toString());
+        }
+    }
+
+    @Override
+    protected String getMessageId(Exchange exchange) {
+        String eventId = exchange.getIn().getHeader(EVENT_ID, String.class);
+        if (eventId != null) {
+            return eventId;
+        }
+        return exchange.getIn().getHeader(SEQUENCE_NUMBER, String.class);
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsEventbridgeSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsEventbridgeSpanDecorator.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsEventbridgeSpanDecorator extends AbstractMessagingSpanDecorator {
+
+    static final String EVENTBRIDGE_OPERATION = "operation";
+    static final String EVENTBRIDGE_RULE_NAME = "ruleName";
+    static final String EVENTBRIDGE_EVENT_SOURCE = "eventSource";
+    static final String EVENTBRIDGE_EVENT_DETAIL_TYPE = "eventDetailType";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.eventbridge.EventbridgeConstants}
+     */
+    static final String OPERATION = "CamelAwsEventbridgeOperation";
+    static final String RULE_NAME = "CamelAwsEventbridgeRuleName";
+    static final String EVENT_SOURCE = "CamelAwsEventbridgeSource";
+    static final String EVENT_DETAIL_TYPE = "CamelAwsEventbridgeDetailType";
+    static final String MESSAGE_ID = "CamelAwsEventbridgeMessageId";
+
+    @Override
+    public String getComponent() {
+        return "aws2-eventbridge";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.eventbridge.EventbridgeComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(EVENTBRIDGE_OPERATION, operation);
+        }
+
+        String ruleName = exchange.getIn().getHeader(RULE_NAME, String.class);
+        if (ruleName != null) {
+            span.setTag(EVENTBRIDGE_RULE_NAME, ruleName);
+        }
+
+        String eventSource = exchange.getIn().getHeader(EVENT_SOURCE, String.class);
+        if (eventSource != null) {
+            span.setTag(EVENTBRIDGE_EVENT_SOURCE, eventSource);
+        }
+
+        String eventDetailType = exchange.getIn().getHeader(EVENT_DETAIL_TYPE, String.class);
+        if (eventDetailType != null) {
+            span.setTag(EVENTBRIDGE_EVENT_DETAIL_TYPE, eventDetailType);
+        }
+    }
+
+    @Override
+    protected String getMessageId(Exchange exchange) {
+        return exchange.getIn().getHeader(MESSAGE_ID, String.class);
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsKinesisFirehoseSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsKinesisFirehoseSpanDecorator.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsKinesisFirehoseSpanDecorator extends AbstractMessagingSpanDecorator {
+
+    static final String FIREHOSE_OPERATION = "operation";
+    static final String FIREHOSE_STREAM_NAME = "deliveryStreamName";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.firehose.KinesisFirehose2Constants}
+     */
+    static final String RECORD_ID = "CamelAwsKinesisFirehoseRecordId";
+    static final String OPERATION = "CamelAwsKinesisFirehoseOperation";
+    static final String STREAM_NAME = "CamelAwsKinesisFirehoseDeliveryStreamName";
+
+    @Override
+    public String getComponent() {
+        return "aws2-kinesis-firehose";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.firehose.KinesisFirehose2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(FIREHOSE_OPERATION, operation);
+        }
+
+        String streamName = exchange.getIn().getHeader(STREAM_NAME, String.class);
+        if (streamName != null) {
+            span.setTag(FIREHOSE_STREAM_NAME, streamName);
+        }
+    }
+
+    @Override
+    protected String getMessageId(Exchange exchange) {
+        return exchange.getIn().getHeader(RECORD_ID, String.class);
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsLambdaSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsLambdaSpanDecorator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsLambdaSpanDecorator extends AbstractSpanDecorator {
+
+    static final String LAMBDA_OPERATION = "operation";
+    static final String LAMBDA_FUNCTION_ARN = "functionArn";
+    static final String LAMBDA_STATUS_CODE = "statusCode";
+    static final String LAMBDA_FUNCTION_ERROR = "functionError";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.lambda.Lambda2Constants}
+     */
+    static final String OPERATION = "CamelAwsLambdaOperation";
+    static final String FUNCTION_ARN = "CamelAwsLambdaFunctionArn";
+    static final String STATUS_CODE = "CamelAwsLambdaStatusCode";
+    static final String FUNCTION_ERROR = "CamelAwsLambdaFunctionError";
+
+    @Override
+    public String getComponent() {
+        return "aws2-lambda";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.lambda.Lambda2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(LAMBDA_OPERATION, operation);
+        }
+
+        String functionArn = exchange.getIn().getHeader(FUNCTION_ARN, String.class);
+        if (functionArn != null) {
+            span.setTag(LAMBDA_FUNCTION_ARN, functionArn);
+        }
+
+        Integer statusCode = exchange.getIn().getHeader(STATUS_CODE, Integer.class);
+        if (statusCode != null) {
+            span.setTag(LAMBDA_STATUS_CODE, statusCode.toString());
+        }
+
+        String functionError = exchange.getIn().getHeader(FUNCTION_ERROR, String.class);
+        if (functionError != null) {
+            span.setTag(LAMBDA_FUNCTION_ERROR, functionError);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsMqSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsMqSpanDecorator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsMqSpanDecorator extends AbstractSpanDecorator {
+
+    static final String MQ_OPERATION = "operation";
+    static final String MQ_BROKER_NAME = "brokerName";
+    static final String MQ_BROKER_ID = "brokerId";
+    static final String MQ_BROKER_ARN = "brokerArn";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.mq.MQ2Constants}
+     */
+    static final String OPERATION = "CamelAwsMQOperation";
+    static final String BROKER_NAME = "CamelAwsMQBrokerName";
+    static final String BROKER_ID = "CamelAwsMQBrokerID";
+    static final String BROKER_ARN = "CamelAwsMQBrokerArn";
+
+    @Override
+    public String getComponent() {
+        return "aws2-mq";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.mq.MQ2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(MQ_OPERATION, operation);
+        }
+
+        String brokerName = exchange.getIn().getHeader(BROKER_NAME, String.class);
+        if (brokerName != null) {
+            span.setTag(MQ_BROKER_NAME, brokerName);
+        }
+
+        String brokerId = exchange.getIn().getHeader(BROKER_ID, String.class);
+        if (brokerId != null) {
+            span.setTag(MQ_BROKER_ID, brokerId);
+        }
+
+        String brokerArn = exchange.getIn().getHeader(BROKER_ARN, String.class);
+        if (brokerArn != null) {
+            span.setTag(MQ_BROKER_ARN, brokerArn);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsSesSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsSesSpanDecorator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsSesSpanDecorator extends AbstractSpanDecorator {
+
+    static final String SES_FROM = "from";
+    static final String SES_SUBJECT = "subject";
+    static final String SES_TO = "to";
+    static final String SES_MESSAGE_ID = "messageId";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.ses.Ses2Constants}
+     */
+    static final String FROM = "CamelAwsSesFrom";
+    static final String SUBJECT = "CamelAwsSesSubject";
+    static final String TO = "CamelAwsSesTo";
+    static final String MESSAGE_ID = "CamelAwsSesMessageId";
+
+    @Override
+    public String getComponent() {
+        return "aws2-ses";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.ses.Ses2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String from = exchange.getIn().getHeader(FROM, String.class);
+        if (from != null) {
+            span.setTag(SES_FROM, from);
+        }
+
+        String subject = exchange.getIn().getHeader(SUBJECT, String.class);
+        if (subject != null) {
+            span.setTag(SES_SUBJECT, subject);
+        }
+
+        String to = exchange.getIn().getHeader(TO, String.class);
+        if (to != null) {
+            span.setTag(SES_TO, to);
+        }
+
+        String messageId = exchange.getIn().getHeader(MESSAGE_ID, String.class);
+        if (messageId != null) {
+            span.setTag(SES_MESSAGE_ID, messageId);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/resources/META-INF/services/org.apache.camel.telemetry.SpanDecorator
+++ b/components/camel-telemetry/src/main/resources/META-INF/services/org.apache.camel.telemetry.SpanDecorator
@@ -19,6 +19,14 @@ org.apache.camel.telemetry.decorators.ActiveMQ6SpanDecorator
 org.apache.camel.telemetry.decorators.ActiveMQSpanDecorator
 org.apache.camel.telemetry.decorators.AhcSpanDecorator
 org.apache.camel.telemetry.decorators.AmqpSpanDecorator
+org.apache.camel.telemetry.decorators.AwsBedrockSpanDecorator
+org.apache.camel.telemetry.decorators.AwsDdbSpanDecorator
+org.apache.camel.telemetry.decorators.AwsDdbStreamSpanDecorator
+org.apache.camel.telemetry.decorators.AwsEventbridgeSpanDecorator
+org.apache.camel.telemetry.decorators.AwsKinesisFirehoseSpanDecorator
+org.apache.camel.telemetry.decorators.AwsLambdaSpanDecorator
+org.apache.camel.telemetry.decorators.AwsMqSpanDecorator
+org.apache.camel.telemetry.decorators.AwsSesSpanDecorator
 org.apache.camel.telemetry.decorators.AzureServiceBusSpanDecorator
 org.apache.camel.telemetry.decorators.CometdSpanDecorator
 org.apache.camel.telemetry.decorators.CometdsSpanDecorator

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsBedrockSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsBedrockSpanDecoratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsBedrockSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "invokeModel";
+        String modelContentType = "application/json";
+        String stopReason = "end_turn";
+        Integer tokenCount = 128;
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws-bedrock:claude");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsBedrockSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsBedrockSpanDecorator.MODEL_CONTENT_TYPE, String.class)).thenReturn(modelContentType);
+        Mockito.when(message.getHeader(AwsBedrockSpanDecorator.CONVERSE_STOP_REASON, String.class)).thenReturn(stopReason);
+        Mockito.when(message.getHeader(AwsBedrockSpanDecorator.STREAMING_TOKEN_COUNT, Integer.class)).thenReturn(tokenCount);
+
+        AbstractSpanDecorator decorator = new AwsBedrockSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsBedrockSpanDecorator.BEDROCK_OPERATION));
+        assertEquals(modelContentType, span.tags().get(AwsBedrockSpanDecorator.BEDROCK_MODEL_CONTENT_TYPE));
+        assertEquals(stopReason, span.tags().get(AwsBedrockSpanDecorator.BEDROCK_STOP_REASON));
+        assertEquals(tokenCount.toString(), span.tags().get(AwsBedrockSpanDecorator.BEDROCK_TOKEN_COUNT));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsDdbSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsDdbSpanDecoratorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.TagConstants;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsDdbSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String tableName = "myTable";
+        String operation = "PutItem";
+        String indexName = "myIndex";
+        Double consumedCapacity = 5.0;
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-ddb:myTable");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsDdbSpanDecorator.TABLE_NAME, String.class)).thenReturn(tableName);
+        Mockito.when(message.getHeader(AwsDdbSpanDecorator.OPERATION)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsDdbSpanDecorator.INDEX_NAME, String.class)).thenReturn(indexName);
+        Mockito.when(message.getHeader(AwsDdbSpanDecorator.CONSUMED_CAPACITY, Double.class)).thenReturn(consumedCapacity);
+
+        AbstractSpanDecorator decorator = new AwsDdbSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals("dynamodb", span.tags().get(TagConstants.DB_SYSTEM));
+        assertEquals(tableName, span.tags().get(AwsDdbSpanDecorator.DDB_TABLE_NAME));
+        assertEquals(tableName, span.tags().get(TagConstants.DB_NAME));
+        assertEquals(operation, span.tags().get(AwsDdbSpanDecorator.DDB_OPERATION));
+        assertEquals(indexName, span.tags().get(AwsDdbSpanDecorator.DDB_INDEX_NAME));
+        assertEquals(consumedCapacity.toString(), span.tags().get(AwsDdbSpanDecorator.DDB_CONSUMED_CAPACITY));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsDdbStreamSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsDdbStreamSpanDecoratorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsDdbStreamSpanDecoratorTest {
+
+    @Test
+    public void testGetMessageIdEventId() {
+        String eventId = "event-1";
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsDdbStreamSpanDecorator.EVENT_ID, String.class)).thenReturn(eventId);
+
+        AbstractMessagingSpanDecorator decorator = new AwsDdbStreamSpanDecorator();
+
+        assertEquals(eventId, decorator.getMessageId(exchange));
+    }
+
+    @Test
+    public void testGetMessageIdSequenceNumberFallback() {
+        String sequenceNumber = "1234567890";
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsDdbStreamSpanDecorator.EVENT_ID, String.class)).thenReturn(null);
+        Mockito.when(message.getHeader(AwsDdbStreamSpanDecorator.SEQUENCE_NUMBER, String.class)).thenReturn(sequenceNumber);
+
+        AbstractMessagingSpanDecorator decorator = new AwsDdbStreamSpanDecorator();
+
+        assertEquals(sequenceNumber, decorator.getMessageId(exchange));
+    }
+
+    @Test
+    public void testPre() {
+        String eventSource = "aws:dynamodb";
+        String eventName = "INSERT";
+        Long sizeBytes = 256L;
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-ddbstream:myTable");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsDdbStreamSpanDecorator.EVENT_SOURCE, String.class)).thenReturn(eventSource);
+        Mockito.when(message.getHeader(AwsDdbStreamSpanDecorator.EVENT_NAME, String.class)).thenReturn(eventName);
+        Mockito.when(message.getHeader(AwsDdbStreamSpanDecorator.SIZE_BYTES, Long.class)).thenReturn(sizeBytes);
+
+        AbstractMessagingSpanDecorator decorator = new AwsDdbStreamSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(eventSource, span.tags().get(AwsDdbStreamSpanDecorator.DDB_STREAM_EVENT_SOURCE));
+        assertEquals(eventName, span.tags().get(AwsDdbStreamSpanDecorator.DDB_STREAM_EVENT_NAME));
+        assertEquals(sizeBytes.toString(), span.tags().get(AwsDdbStreamSpanDecorator.DDB_STREAM_SIZE_BYTES));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsEventbridgeSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsEventbridgeSpanDecoratorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsEventbridgeSpanDecoratorTest {
+
+    @Test
+    public void testGetMessageId() {
+        String messageId = "abcd";
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsEventbridgeSpanDecorator.MESSAGE_ID, String.class)).thenReturn(messageId);
+
+        AbstractMessagingSpanDecorator decorator = new AwsEventbridgeSpanDecorator();
+
+        assertEquals(messageId, decorator.getMessageId(exchange));
+    }
+
+    @Test
+    public void testPre() {
+        String operation = "putRule";
+        String ruleName = "myRule";
+        String eventSource = "my.source";
+        String eventDetailType = "MyEventType";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-eventbridge:default");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsEventbridgeSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsEventbridgeSpanDecorator.RULE_NAME, String.class)).thenReturn(ruleName);
+        Mockito.when(message.getHeader(AwsEventbridgeSpanDecorator.EVENT_SOURCE, String.class)).thenReturn(eventSource);
+        Mockito.when(message.getHeader(AwsEventbridgeSpanDecorator.EVENT_DETAIL_TYPE, String.class))
+                .thenReturn(eventDetailType);
+
+        AbstractMessagingSpanDecorator decorator = new AwsEventbridgeSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsEventbridgeSpanDecorator.EVENTBRIDGE_OPERATION));
+        assertEquals(ruleName, span.tags().get(AwsEventbridgeSpanDecorator.EVENTBRIDGE_RULE_NAME));
+        assertEquals(eventSource, span.tags().get(AwsEventbridgeSpanDecorator.EVENTBRIDGE_EVENT_SOURCE));
+        assertEquals(eventDetailType, span.tags().get(AwsEventbridgeSpanDecorator.EVENTBRIDGE_EVENT_DETAIL_TYPE));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsKinesisFirehoseSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsKinesisFirehoseSpanDecoratorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsKinesisFirehoseSpanDecoratorTest {
+
+    @Test
+    public void testGetMessageId() {
+        String recordId = "record-1";
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsKinesisFirehoseSpanDecorator.RECORD_ID, String.class)).thenReturn(recordId);
+
+        AbstractMessagingSpanDecorator decorator = new AwsKinesisFirehoseSpanDecorator();
+
+        assertEquals(recordId, decorator.getMessageId(exchange));
+    }
+
+    @Test
+    public void testPre() {
+        String operation = "putRecord";
+        String streamName = "myStream";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-kinesis-firehose:myStream");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(message.getHeader(AwsKinesisFirehoseSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsKinesisFirehoseSpanDecorator.STREAM_NAME, String.class)).thenReturn(streamName);
+
+        AbstractMessagingSpanDecorator decorator = new AwsKinesisFirehoseSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsKinesisFirehoseSpanDecorator.FIREHOSE_OPERATION));
+        assertEquals(streamName, span.tags().get(AwsKinesisFirehoseSpanDecorator.FIREHOSE_STREAM_NAME));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsLambdaSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsLambdaSpanDecoratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsLambdaSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "invokeFunction";
+        String functionArn = "arn:aws:lambda:us-east-1:123456789012:function:my-function";
+        Integer statusCode = 200;
+        String functionError = "Unhandled";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-lambda:myFunction");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsLambdaSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsLambdaSpanDecorator.FUNCTION_ARN, String.class)).thenReturn(functionArn);
+        Mockito.when(message.getHeader(AwsLambdaSpanDecorator.STATUS_CODE, Integer.class)).thenReturn(statusCode);
+        Mockito.when(message.getHeader(AwsLambdaSpanDecorator.FUNCTION_ERROR, String.class)).thenReturn(functionError);
+
+        AbstractSpanDecorator decorator = new AwsLambdaSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsLambdaSpanDecorator.LAMBDA_OPERATION));
+        assertEquals(functionArn, span.tags().get(AwsLambdaSpanDecorator.LAMBDA_FUNCTION_ARN));
+        assertEquals(statusCode.toString(), span.tags().get(AwsLambdaSpanDecorator.LAMBDA_STATUS_CODE));
+        assertEquals(functionError, span.tags().get(AwsLambdaSpanDecorator.LAMBDA_FUNCTION_ERROR));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsMqSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsMqSpanDecoratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsMqSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "createBroker";
+        String brokerName = "myBroker";
+        String brokerId = "b-1234";
+        String brokerArn = "arn:aws:mq:us-east-1:123456789012:broker:myBroker:b-1234";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-mq:default");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsMqSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsMqSpanDecorator.BROKER_NAME, String.class)).thenReturn(brokerName);
+        Mockito.when(message.getHeader(AwsMqSpanDecorator.BROKER_ID, String.class)).thenReturn(brokerId);
+        Mockito.when(message.getHeader(AwsMqSpanDecorator.BROKER_ARN, String.class)).thenReturn(brokerArn);
+
+        AbstractSpanDecorator decorator = new AwsMqSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsMqSpanDecorator.MQ_OPERATION));
+        assertEquals(brokerName, span.tags().get(AwsMqSpanDecorator.MQ_BROKER_NAME));
+        assertEquals(brokerId, span.tags().get(AwsMqSpanDecorator.MQ_BROKER_ID));
+        assertEquals(brokerArn, span.tags().get(AwsMqSpanDecorator.MQ_BROKER_ARN));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsSesSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsSesSpanDecoratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsSesSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String from = "sender@example.com";
+        String subject = "Hello";
+        String to = "recipient@example.com";
+        String messageId = "msg-1234";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-ses:from@example.com");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsSesSpanDecorator.FROM, String.class)).thenReturn(from);
+        Mockito.when(message.getHeader(AwsSesSpanDecorator.SUBJECT, String.class)).thenReturn(subject);
+        Mockito.when(message.getHeader(AwsSesSpanDecorator.TO, String.class)).thenReturn(to);
+        Mockito.when(message.getHeader(AwsSesSpanDecorator.MESSAGE_ID, String.class)).thenReturn(messageId);
+
+        AbstractSpanDecorator decorator = new AwsSesSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(from, span.tags().get(AwsSesSpanDecorator.SES_FROM));
+        assertEquals(subject, span.tags().get(AwsSesSpanDecorator.SES_SUBJECT));
+        assertEquals(to, span.tags().get(AwsSesSpanDecorator.SES_TO));
+        assertEquals(messageId, span.tags().get(AwsSesSpanDecorator.SES_MESSAGE_ID));
+    }
+
+}


### PR DESCRIPTION
## Summary

Second batch of AWS span decorators for `camel-telemetry`. Continues the work from #23038 (SQS/SNS/Kinesis/S3) by covering serverless, NoSQL, event-bus, email, message-broker management, streaming-delivery and GenAI components.

JIRA: [CAMEL-23387](https://issues.apache.org/jira/browse/CAMEL-23387) — _the JIRA stays open; further AWS components will land in subsequent PRs._

> **Note:** This PR is logically a follow-up to #23038. Both PRs touch the SPI service file `META-INF/services/org.apache.camel.telemetry.SpanDecorator`, so whichever merges first, the other will need a one-line rebase. The decorator class files themselves are disjoint between the two PRs.

## Changes

New `SpanDecorator` implementations under `org.apache.camel.telemetry.decorators`:

- **`AwsDdbSpanDecorator`** (`aws2-ddb`) — DynamoDB. Sets `db.system=dynamodb`, `db.name=<table>`, plus `tableName`, `operation`, `indexName`, `consumedCapacity`.
- **`AwsDdbStreamSpanDecorator`** (`aws2-ddbstream`) — DynamoDB Streams. Messaging-style decorator. Tags: `eventSource`, `eventName`, `sizeBytes`. Message id falls back from `EVENT_ID` to `SEQUENCE_NUMBER`.
- **`AwsLambdaSpanDecorator`** (`aws2-lambda`) — Lambda. Tags: `operation`, `functionArn`, `statusCode`, `functionError`.
- **`AwsEventbridgeSpanDecorator`** (`aws2-eventbridge`) — EventBridge. Messaging-style decorator. Tags: `operation`, `ruleName`, `eventSource`, `eventDetailType`. Message id from EventBridge consumer header.
- **`AwsSesSpanDecorator`** (`aws2-ses`) — Simple Email Service. Tags: `from`, `subject`, `to`, `messageId`.
- **`AwsMqSpanDecorator`** (`aws2-mq`) — Managed Message Broker (admin operations). Tags: `operation`, `brokerName`, `brokerId`, `brokerArn`.
- **`AwsKinesisFirehoseSpanDecorator`** (`aws2-kinesis-firehose`) — Firehose. Messaging-style decorator. Tags: `operation`, `deliveryStreamName`. Message id from `RECORD_ID`.
- **`AwsBedrockSpanDecorator`** (`aws-bedrock`) — Bedrock Runtime (GenAI). Tags: `operation`, `modelContentType`, `stopReason` (Converse API), `tokenCount`.

All eight decorators are registered alphabetically in `META-INF/services/org.apache.camel.telemetry.SpanDecorator`. Unit tests cover header-to-tag extraction for each decorator; the messaging decorators also test message-id extraction (DDB Streams covers both the `EVENT_ID` happy path and the `SEQUENCE_NUMBER` fallback).

The choice of base class follows the natural component shape:
- **`AbstractMessagingSpanDecorator`** for streaming/event-bus components (DDB Streams, EventBridge, Firehose) — sets PRODUCER/CONSUMER span kinds and `messaging.destination.name`.
- **`AbstractSpanDecorator`** for everything else (DDB, Lambda, SES, MQ, Bedrock).

Header constants are mirrored from each component's `*Constants` interface (with a Javadoc reference back to the source), matching the convention already used by `AzureServiceBusSpanDecorator` and #23038. This avoids creating hard dependencies from `camel-telemetry` to the AWS component modules.

## Test plan

- [x] `mvn test` in `components/camel-telemetry` passes (99 tests, including 12 new tests across the 8 new decorators)
- [x] Module-specific build (`mvn -DskipTests install`) succeeds
- [x] No code style or formatter changes required

## Follow-ups still pending

- Remaining AWS components: MSK, KMS, STS, IAM, Step Functions, Timestream, Athena, CloudWatch, EC2/ECS/EKS, Polly, Rekognition, Textract, Transcribe, Translate, Comprehend, Redshift, S3 Vectors, CloudTrail, Config, Parameter Store, Secrets Manager, Security Hub, X-Ray, Bedrock Agent / Bedrock Agent Runtime — to be added in subsequent PRs against the same JIRA.
- Google Cloud decorators (mentioned in CAMEL-23387's description) — separate scope discussion / separate JIRA.

---

_Claude Code on behalf of Andrea Cosentino_