### PR TITLE
camel-jbang: Ensure target directory exists before writing application.properties

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -1072,6 +1072,7 @@ public abstract class ExportBaseCommand extends CamelCommand {
         }
 
         // write all the properties
+        Files.createDirectories(targetDir);
         Path appPropsPath = targetDir.resolve("application.properties");
         Files.writeString(appPropsPath, content.toString(), StandardCharsets.UTF_8);
     }


### PR DESCRIPTION
When running `camel run` in Spring Boot mode, the internal export step calls `copySettingsAndProfile()` to write `application.properties` to the build work directory. However, the target directory (`src/main/resources` inside `.camel-jbang/work`) may not exist at the time of the write, causing a `NoSuchFileException`.

This adds a defensive `Files.createDirectories()` call before writing the file.

```
java.nio.file.NoSuchFileException: .camel-jbang/work/src/main/resources/application.properties
    at ExportBaseCommand.copySettingsAndProfile(ExportBaseCommand.java:882)
    at ExportSpringBoot.export(ExportSpringBoot.java:119)
    at Run.runSpringBoot(Run.java:1319)
    at Run.run(Run.java:516)
    at Run.doCall(Run.java:399)
```