### PR TITLE
Conditionally enable OpenRewrite per module via marker files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ backlog
 .claude
 .omc
 .oss-ai-helper-rules
+.rewrite-enabled

--- a/etc/scripts/regen.sh
+++ b/etc/scripts/regen.sh
@@ -25,6 +25,24 @@ cd `dirname "$0"`/../..
 git clean -fdx
 rm -Rf **/src/generated/
 
+# Enable OpenRewrite only for modules with changed Java files.
+# Maven's file-activated profile (<exists>.rewrite-enabled</exists>) checks
+# per-module, so OpenRewrite runs only where needed — no -Prewrite flag required.
+# We only need --deepen=1 (depth 1 -> 2) since we compare adjacent commits:
+# for PRs, HEAD~1 is the base branch tip (first parent of the merge commit);
+# for main builds, HEAD~1 is the previous squash-merged commit.
+if ! git rev-parse HEAD~1 >/dev/null 2>&1; then
+  git fetch --deepen=1 --quiet 2>/dev/null || true
+fi
+
+if git rev-parse HEAD~1 >/dev/null 2>&1; then
+  git diff HEAD~1 HEAD --name-only -- '*.java' ':!*/src/generated/*' \
+    | sed 's|/src/.*||' | sort -u \
+    | while read module; do
+        [ -d "$module" ] && touch "$module/.rewrite-enabled"
+      done
+fi
+
 # Regenerate everything
 if ./mvnw --batch-mode -Pregen -DskipTests ${MAVEN_EXTRA_ARGS} install >> build.log 2>&1; then
   echo "✅ mvn -Pregen succeeded."

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4183,6 +4183,11 @@
 
         <profile>
             <id>rewrite</id>
+            <activation>
+                <file>
+                    <exists>.rewrite-enabled</exists>
+                </file>
+            </activation>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,7 @@
                                     ${maven.multiModuleProjectDirectory}/buildingtools/src/main/resources/header.txt
                                 </header>
                                 <excludes>
+                                    <exclude>**/.rewrite-enabled</exclude>
                                     <exclude>release.properties</exclude>
                                     <exclude>**/pom.xml.tag</exclude>
                                     <exclude>**/pom.xml.releaseBackup</exclude>


### PR DESCRIPTION
Follow-up to #23041 which disabled OpenRewrite entirely because it quadrupled CI build times.

This re-enables OpenRewrite using Maven's file-activated profiles, scoped to only the modules that have changed Java files. Most builds skip OpenRewrite entirely, and when it does run, it only processes the affected modules.

## How it works

1. `regen.sh` detects which modules have modified `.java` files (via `git diff HEAD~1 HEAD --name-only`)
2. Creates a `.rewrite-enabled` marker file in each affected module
3. The `rewrite` profile in `parent/pom.xml` uses `<activation><file><exists>.rewrite-enabled</exists></file></activation>` — Maven evaluates this per-module, so OpenRewrite only runs where the marker exists
4. No `-Prewrite` flag needed — everything is automatic

This approach is **recipe-agnostic**: adding new OpenRewrite recipes to the profile requires no changes to the detection logic.

For shallow clones in CI, `--deepen=1` fetches just the parent commit. For PRs, `HEAD~1` is the base branch tip (first parent of the merge commit). For main builds, it's the previous squash-merged commit.

## Benchmark results (from earlier test PRs)

| PR | OpenRewrite | Build time (JDK 21) |
|---|---|---|
| #23068 (no FQCNs) | **skipped** | ~22 min |
| #23069 (with FQCNs) | **triggered** | ~30 min |

~8 minutes saved (~36% faster) on builds that don't introduce FQCNs.
With the per-module approach, even builds that trigger OpenRewrite will be faster since it only processes changed modules instead of all ~500.

## Test plan

- [x] Tested module detection locally against real commits
- [x] Correctly identifies affected modules (e.g. `components/camel-telemetry`)
- [x] No modules detected for non-Java changes (dep bumps)
- [x] Handles shallow clones (`--deepen=1`)
- [x] `.rewrite-enabled` added to `.gitignore`
- [ ] Verify CI passes with this change