### PR TITLE
CAMEL-21438: Re-enable disabled flaky FTPS and netty-http tests

### DIFF
--- a/components/camel-csimple-joor/src/test/java/org/apache/camel/language/csimple/joor/OriginalSimpleTest.java
+++ b/components/camel-csimple-joor/src/test/java/org/apache/camel/language/csimple/joor/OriginalSimpleTest.java
@@ -404,7 +404,7 @@ public class OriginalSimpleTest extends LanguageTestSupport {
         assertExpression("${body[0][code]}", 4321);
     }
 
-    @Disabled("Investigation pending - see CAMEL-19681")
+    @Disabled("csimple does not support null-safe OGNL, nested functions, or complex escaping")
     @Test
     public void testOGNLBodyEmptyList() {
         Map<String, List<String>> map = new HashMap<>();
@@ -1325,7 +1325,7 @@ public class OriginalSimpleTest extends LanguageTestSupport {
         assertTrue(cause2.getMessage().startsWith("Index 3 out of bounds for length 2"));
     }
 
-    @Disabled("Investigation pending - see CAMEL-19681")
+    @Disabled("csimple does not support null-safe OGNL, nested functions, or complex escaping")
     @Test
     public void testBodyOGNLOrderListOutOfBoundsWithNullSafe() {
         List<OrderLine> lines = new ArrayList<>();
@@ -1338,7 +1338,7 @@ public class OriginalSimpleTest extends LanguageTestSupport {
         assertExpression("${bodyAs(Order)?.getLines[3].getId}", null);
     }
 
-    @Disabled("Investigation pending - see CAMEL-19681")
+    @Disabled("csimple does not support null-safe OGNL, nested functions, or complex escaping")
     @Test
     public void testBodyOGNLOrderListOutOfBoundsWithNullSafeShorthand() {
         List<OrderLine> lines = new ArrayList<>();
@@ -1351,7 +1351,7 @@ public class OriginalSimpleTest extends LanguageTestSupport {
         assertExpression("${bodyAs(Order)?.lines[3].id}", null);
     }
 
-    @Disabled("Investigation pending - see CAMEL-19681")
+    @Disabled("csimple does not support null-safe OGNL, nested functions, or complex escaping")
     @Test
     public void testBodyOGNLOrderListNoMethodNameWithNullSafe() {
         List<OrderLine> lines = new ArrayList<>();
@@ -1367,7 +1367,7 @@ public class OriginalSimpleTest extends LanguageTestSupport {
         assertEquals("getRating", cause.getMethodName());
     }
 
-    @Disabled("Investigation pending - see CAMEL-19681")
+    @Disabled("csimple does not support null-safe OGNL, nested functions, or complex escaping")
     @Test
     public void testBodyOGNLOrderListNoMethodNameWithNullSafeShorthand() {
         List<OrderLine> lines = new ArrayList<>();
@@ -1383,7 +1383,7 @@ public class OriginalSimpleTest extends LanguageTestSupport {
         assertEquals("rating", cause.getMethodName());
     }
 
-    @Disabled("Investigation pending - see CAMEL-19681")
+    @Disabled("csimple does not support null-safe OGNL, nested functions, or complex escaping")
     @Test
     public void testBodyOGNLNullSafeToAvoidNPE() {
         Animal tiger = new Animal("Tony the Tiger", 13);
@@ -1409,7 +1409,7 @@ public class OriginalSimpleTest extends LanguageTestSupport {
                 e.getMessage());
     }
 
-    @Disabled("Investigation pending - see CAMEL-19681")
+    @Disabled("csimple does not support null-safe OGNL, nested functions, or complex escaping")
     @Test
     public void testBodyOGNLNullSafeToAvoidNPEShorthand() {
         Animal tiger = new Animal("Tony the Tiger", 13);
@@ -1528,7 +1528,7 @@ public class OriginalSimpleTest extends LanguageTestSupport {
         assertExpression("${bodyAs(String).replace(\"$\", \"-\")}", "foo-bar-baz");
     }
 
-    @Disabled("Investigation pending - see CAMEL-19681")
+    @Disabled("csimple does not support null-safe OGNL, nested functions, or complex escaping")
     @Test
     public void testBodyOgnlReplaceEscapedBackslashChar() {
         exchange.getIn().setBody("foo\\bar\\baz");
@@ -1547,7 +1547,7 @@ public class OriginalSimpleTest extends LanguageTestSupport {
         assertExpression("${bodyAs(String).replaceFirst(\"http:\",\" \")}", " camel.apache.org");
     }
 
-    @Disabled("Investigation pending - see CAMEL-19681")
+    @Disabled("csimple does not support null-safe OGNL, nested functions, or complex escaping")
     @Test
     public void testBodyOgnlReplaceSingleQuoteInDouble() {
         exchange.getIn().setBody("Hello O\"Conner");
@@ -1940,7 +1940,7 @@ public class OriginalSimpleTest extends LanguageTestSupport {
         assertExpression("Hi ${bodyOneLine} Again", "Hi HelloGreatWorld Again");
     }
 
-    @Disabled("Investigation pending - see CAMEL-19681")
+    @Disabled("csimple does not support null-safe OGNL, nested functions, or complex escaping")
     @Test
     public void testListIndexByNestedFunction() {
         List<String> alist = new ArrayList<>();
@@ -1957,7 +1957,7 @@ public class OriginalSimpleTest extends LanguageTestSupport {
         assertExpression(exp, "99");
     }
 
-    @Disabled("Investigation pending - see CAMEL-19681")
+    @Disabled("csimple does not support null-safe OGNL, nested functions, or complex escaping")
     @Test
     public void testNestedFunction() {
         exchange.getMessage().setBody("Tony");

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsExplicitSSLWithClientAuthIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsExplicitSSLWithClientAuthIT.java
@@ -18,22 +18,22 @@ package org.apache.camel.component.file.remote.integration;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 /**
  * Test the ftps component over SSL (explicit) with client authentication
  */
+@EnabledIf(value = "org.apache.camel.test.infra.ftp.services.embedded.FtpsUtil#hasRequiredAlgorithms")
 public class FileToFtpsExplicitSSLWithClientAuthIT extends FtpsServerExplicitSSLWithClientAuthTestSupport {
 
     protected String getFtpUrl() {
         return "ftps://admin@localhost:{{ftp.server.port}}"
                + "/tmp2/camel?password=admin&initialDelay=2000&disableSecureDataChannelDefaults=true"
-               + "&securityProtocol=SSLv3&implicit=false&ftpClient.keyStore.file=./src/test/resources/server.jks&ftpClient.keyStore.type=JKS"
+               + "&securityProtocol=TLSv1.2&implicit=false&ftpClient.keyStore.file=./src/test/resources/server.jks&ftpClient.keyStore.type=JKS"
                + "&ftpClient.keyStore.algorithm=SunX509&ftpClient.keyStore.password=password&ftpClient.keyStore.keyPassword=password&delete=true";
     }
 
-    @Disabled("CAMEL-16784:Disable testFromFileToFtp tests")
     @Test
     public void testFromFileToFtp() throws Exception {
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsExplicitSSLWithoutClientAuthAndGlobalSSLContextParametersIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsExplicitSSLWithoutClientAuthAndGlobalSSLContextParametersIT.java
@@ -36,7 +36,7 @@ public class FileToFtpsExplicitSSLWithoutClientAuthAndGlobalSSLContextParameters
         tmp.setKeyStore(ksp);
 
         SSLContextParameters sslContextParameters = new SSLContextParameters();
-        sslContextParameters.setSecureSocketProtocol("SSLv3");
+        sslContextParameters.setSecureSocketProtocol("TLSv1.2");
         sslContextParameters.setTrustManagers(tmp);
         context.setSSLContextParameters(sslContextParameters);
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsExplicitSSLWithoutClientAuthAndSSLContextParametersIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsExplicitSSLWithoutClientAuthAndSSLContextParametersIT.java
@@ -34,7 +34,7 @@ public class FileToFtpsExplicitSSLWithoutClientAuthAndSSLContextParametersIT
         tmp.setKeyStore(ksp);
 
         SSLContextParameters sslContextParameters = new SSLContextParameters();
-        sslContextParameters.setSecureSocketProtocol("SSLv3");
+        sslContextParameters.setSecureSocketProtocol("TLSv1.2");
         sslContextParameters.setTrustManagers(tmp);
 
         return sslContextParameters;

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsExplicitSSLWithoutClientAuthIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsExplicitSSLWithoutClientAuthIT.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.file.remote.integration;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
@@ -31,10 +30,9 @@ public class FileToFtpsExplicitSSLWithoutClientAuthIT extends FtpsServerExplicit
     protected String getFtpUrl() {
         return "ftps://admin@localhost:{{ftp.server.port}}"
                + "/tmp2/camel?password=admin&initialDelay=2000&disableSecureDataChannelDefaults=true&delete=true"
-               + "&securityProtocol=SSLv3&implicit=false";
+               + "&securityProtocol=TLSv1.2&implicit=false";
     }
 
-    @Disabled("CAMEL-16784:Disable testFromFileToFtp tests")
     @Test
     public void testFromFileToFtp() throws Exception {
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsExplicitTLSWithClientAuthIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsExplicitTLSWithClientAuthIT.java
@@ -35,7 +35,7 @@ public class FileToFtpsExplicitTLSWithClientAuthIT extends FtpsServerExplicitTLS
                + "&ftpClient.keyStore.algorithm=SunX509&ftpClient.keyStore.password=password&ftpClient.keyStore.keyPassword=password&delete=true";
     }
 
-    @Disabled("CAMEL-16784:Disable testFromFileToFtp tests")
+    @Disabled("Embedded Apache FtpServer does not support TLS 1.3")
     @Test
     public void testFromFileToFtp() throws Exception {
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsExplicitTLSWithoutClientAuthIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsExplicitTLSWithoutClientAuthIT.java
@@ -34,7 +34,7 @@ public class FileToFtpsExplicitTLSWithoutClientAuthIT extends FtpsServerExplicit
                + "&securityProtocol=TLSv1.3&implicit=false&delete=true";
     }
 
-    @Disabled("CAMEL-16784:Disable testFromFileToFtp tests")
+    @Disabled("Embedded Apache FtpServer does not support TLS 1.3")
     @Test
     public void testFromFileToFtp() throws Exception {
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsImplicitSSLWithClientAuthAndSSLContextParametersIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsImplicitSSLWithClientAuthAndSSLContextParametersIT.java
@@ -37,7 +37,7 @@ public class FileToFtpsImplicitSSLWithClientAuthAndSSLContextParametersIT extend
         tmp.setKeyStore(ksp);
 
         SSLContextParameters sslContextParameters = new SSLContextParameters();
-        sslContextParameters.setSecureSocketProtocol("SSLv3");
+        sslContextParameters.setSecureSocketProtocol("TLSv1.2");
         sslContextParameters.setKeyManagers(kmp);
         sslContextParameters.setTrustManagers(tmp);
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsImplicitSSLWithClientAuthIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsImplicitSSLWithClientAuthIT.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.file.remote.integration;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
@@ -31,11 +30,10 @@ public class FileToFtpsImplicitSSLWithClientAuthIT extends FtpsServerImplicitSSL
     protected String getFtpUrl() {
         return "ftps://admin@localhost:{{ftp.server.port}}"
                + "/tmp2/camel?password=admin&initialDelay=2000&disableSecureDataChannelDefaults=true"
-               + "&securityProtocol=SSLv3&implicit=true&ftpClient.keyStore.file=./src/test/resources/server.jks&ftpClient.keyStore.type=JKS"
+               + "&securityProtocol=TLSv1.2&implicit=true&ftpClient.keyStore.file=./src/test/resources/server.jks&ftpClient.keyStore.type=JKS"
                + "&ftpClient.keyStore.algorithm=SunX509&ftpClient.keyStore.password=password&ftpClient.keyStore.keyPassword=password&delete=true";
     }
 
-    @Disabled("CAMEL-16784:Disable testFromFileToFtp tests")
     @Test
     public void testFromFileToFtp() throws Exception {
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsImplicitSSLWithoutClientAuthAndSSLContextParametersIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsImplicitSSLWithoutClientAuthAndSSLContextParametersIT.java
@@ -33,7 +33,7 @@ public class FileToFtpsImplicitSSLWithoutClientAuthAndSSLContextParametersIT
         tmp.setKeyStore(ksp);
 
         SSLContextParameters sslContextParameters = new SSLContextParameters();
-        sslContextParameters.setSecureSocketProtocol("SSLv3");
+        sslContextParameters.setSecureSocketProtocol("TLSv1.2");
         sslContextParameters.setTrustManagers(tmp);
 
         return sslContextParameters;

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsImplicitSSLWithoutClientAuthIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsImplicitSSLWithoutClientAuthIT.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.file.remote.integration;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
@@ -31,10 +30,9 @@ public class FileToFtpsImplicitSSLWithoutClientAuthIT extends FtpsServerImplicit
     protected String getFtpUrl() {
         return "ftps://admin@localhost:{{ftp.server.port}}"
                + "/tmp2/camel?password=admin&initialDelay=2000&disableSecureDataChannelDefaults=true"
-               + "&securityProtocol=SSLv3&implicit=true&delete=true";
+               + "&securityProtocol=TLSv1.2&implicit=true&delete=true";
     }
 
-    @Disabled("CAMEL-16784:Disable testFromFileToFtp tests")
     @Test
     public void testFromFileToFtp() throws Exception {
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsImplicitTLSWithClientAuthIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsImplicitTLSWithClientAuthIT.java
@@ -35,7 +35,7 @@ public class FileToFtpsImplicitTLSWithClientAuthIT extends FtpsServerImplicitTLS
                + "&ftpClient.keyStore.algorithm=SunX509&ftpClient.keyStore.password=password&ftpClient.keyStore.keyPassword=password&delete=true";
     }
 
-    @Disabled("CAMEL-16784:Disable testFromFileToFtp tests")
+    @Disabled("Embedded Apache FtpServer does not support TLS 1.3")
     @Test
     public void testFromFileToFtp() throws Exception {
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsImplicitTLSWithoutClientAuthIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsImplicitTLSWithoutClientAuthIT.java
@@ -34,7 +34,7 @@ public class FileToFtpsImplicitTLSWithoutClientAuthIT extends FtpsServerImplicit
                + "&securityProtocol=TLSv1.3&implicit=true&delete=true";
     }
 
-    @Disabled("CAMEL-16784:Disable testFromFileToFtp tests")
+    @Disabled("Embedded Apache FtpServer does not support TLS 1.3")
     @Test
     public void testFromFileToFtp() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsWithCustomKeyAndTrustStorePropertiesIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsWithCustomKeyAndTrustStorePropertiesIT.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.file.remote.integration;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
@@ -31,13 +30,12 @@ public class FileToFtpsWithCustomKeyAndTrustStorePropertiesIT extends FtpsServer
     private String getFtpUrl() {
         return "ftps://admin@localhost:{{ftp.server.port}}"
                + "/tmp2/camel?password=admin&initialDelay=2000&disableSecureDataChannelDefaults=true"
-               + "&securityProtocol=SSLv3&implicit=false&ftpClient.keyStore.file=./src/test/resources/server.jks&ftpClient.keyStore.type=JKS"
+               + "&securityProtocol=TLSv1.2&implicit=false&ftpClient.keyStore.file=./src/test/resources/server.jks&ftpClient.keyStore.type=JKS"
                + "&ftpClient.keyStore.algorithm=SunX509&ftpClient.keyStore.password=password&ftpClient.keyStore.keyPassword=password"
                + "&ftpClient.trustStore.file=./src/test/resources/server.jks&ftpClient.trustStore.type=JKS"
                + "&ftpClient.trustStore.algorithm=SunX509&ftpClient.trustStore.password=password&delete=true";
     }
 
-    @Disabled
     @Test
     public void testFromFileToFtp() throws Exception {
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsWithCustomTrustStorePropertiesIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsWithCustomTrustStorePropertiesIT.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.file.remote.integration;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
@@ -31,11 +30,10 @@ public class FileToFtpsWithCustomTrustStorePropertiesIT extends FtpsServerExplic
     private String getFtpUrl() {
         return "ftps://admin@localhost:{{ftp.server.port}}"
                + "/tmp2/camel?password=admin&initialDelay=2000&disableSecureDataChannelDefaults=true"
-               + "&securityProtocol=SSLv3&implicit=false&ftpClient.trustStore.file=./src/test/resources/server.jks&ftpClient.trustStore.type=JKS"
+               + "&securityProtocol=TLSv1.2&implicit=false&ftpClient.trustStore.file=./src/test/resources/server.jks&ftpClient.trustStore.type=JKS"
                + "&ftpClient.trustStore.algorithm=SunX509&ftpClient.trustStore.password=password&delete=true";
     }
 
-    @Disabled("CAMEL-16784:Disable testFromFileToFtp tests")
     @Test
     public void testFromFileToFtp() throws Exception {
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsWithDefaultSettingsIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsWithDefaultSettingsIT.java
@@ -33,7 +33,7 @@ public class FileToFtpsWithDefaultSettingsIT extends FtpsServerExplicitTLSWithou
                + "/tmp2/camel?password=admin&initialDelay=2000&disableSecureDataChannelDefaults=true&delete=true";
     }
 
-    @Disabled("CAMEL-16784:Disable testFromFileToFtp tests")
+    @Disabled("Embedded Apache FtpServer does not support TLS 1.3")
     @Test
     public void testFromFileToFtp() throws Exception {
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsWithFtpClientConfigRefIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FileToFtpsWithFtpClientConfigRefIT.java
@@ -20,7 +20,6 @@ import org.apache.camel.BindToRegistry;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.commons.net.ftp.FTPSClient;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
@@ -31,10 +30,10 @@ import org.junit.jupiter.api.condition.EnabledIf;
 public class FileToFtpsWithFtpClientConfigRefIT extends FtpsServerExplicitSSLWithoutClientAuthTestSupport {
 
     @BindToRegistry("ftpsClient")
-    private final FTPSClient client = new FTPSClient("SSLv3");
+    private final FTPSClient client = new FTPSClient("TLSv1.2");
 
     @BindToRegistry("ftpsClientIn")
-    private final FTPSClient client1 = new FTPSClient("SSLv3");
+    private final FTPSClient client1 = new FTPSClient("TLSv1.2");
 
     private String getFtpUrl(boolean in) {
         return "ftps://admin@localhost:{{ftp.server.port}}/tmp2/camel?password=admin&initialDelay=2000&ftpClient=#ftpsClient"
@@ -42,7 +41,6 @@ public class FileToFtpsWithFtpClientConfigRefIT extends FtpsServerExplicitSSLWit
                + "&disableSecureDataChannelDefaults=true&delete=true";
     }
 
-    @Disabled("CAMEL-16784:Disable testFromFileToFtp tests")
     @Test
     public void testFromFileToFtp() throws Exception {
 

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpsServerTestSupport.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpsServerTestSupport.java
@@ -22,6 +22,6 @@ import org.apache.camel.component.file.remote.BaseServerTestSupport;
  * Abstract base class for unit testing using a secure FTP Server (over SSL/TLS)
  */
 public abstract class FtpsServerTestSupport extends BaseServerTestSupport {
-    protected static final String AUTH_VALUE_SSL = "SSLv3";
+    protected static final String AUTH_VALUE_SSL = "TLSv1.2";
     protected static final String AUTH_VALUE_TLS = "TLSv1.3";
 }

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/ProxyProtocolTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/ProxyProtocolTest.java
@@ -31,7 +31,6 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ResourceLeakDetector;
 import org.apache.camel.Exchange;
@@ -47,7 +46,6 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -56,9 +54,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled("TODO: https://issues.apache.org/jira/projects/CAMEL/issues/CAMEL-16718")
-// this test was working before due to a netty ref count exception was ignored (seems we attempt to write 2 times)
-// now this real caused exception is detected by Camel
 public class ProxyProtocolTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProxyProtocolTest.class);
@@ -272,12 +267,10 @@ public class ProxyProtocolTest {
 
     private static void uppercase(final Exchange exchange) {
         final Message message = exchange.getMessage();
-        final ByteBuf body = message.getBody(ByteBuf.class);
+        final String body = message.getBody(String.class);
 
-        if (body.capacity() != 0) {
-            // only if we received a payload we'll uppercase it
-            message.setBody(body.toString(StandardCharsets.US_ASCII).toUpperCase(Locale.US));
+        if (ObjectHelper.isNotEmpty(body)) {
+            message.setBody(body.toUpperCase(Locale.US));
         }
-        body.release();
     }
 }

--- a/components/camel-olingo4/camel-olingo4-api/src/test/java/org/apache/camel/component/olingo4/Olingo4AppAPITest.java
+++ b/components/camel-olingo4/camel-olingo4-api/src/test/java/org/apache/camel/component/olingo4/Olingo4AppAPITest.java
@@ -205,7 +205,7 @@ public class Olingo4AppAPITest {
     }
 
     @Test
-    @Disabled("CAMEL-22271 - failing since jackson upgrade from 2.19.1 to 2.19.2")
+    @Disabled("CAMEL-22271 - olingo4 is deprecated (Apache Attic), upstream bug OLINGO-1641 will not be fixed")
     public void testReadUnparsedEntitySet() throws Exception {
         final TestOlingo4ResponseHandler<InputStream> responseHandler = new TestOlingo4ResponseHandler<>();
 
@@ -244,7 +244,7 @@ public class Olingo4AppAPITest {
     }
 
     @Test
-    @Disabled("CAMEL-22271 - failing since jackson upgrade from 2.19.1 to 2.19.2")
+    @Disabled("CAMEL-22271 - olingo4 is deprecated (Apache Attic), upstream bug OLINGO-1641 will not be fixed")
     public void testReadUnparsedEntity() throws Exception {
         final TestOlingo4ResponseHandler<InputStream> responseHandler = new TestOlingo4ResponseHandler<>();
 

--- a/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/account/AccountProducerTest.java
+++ b/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/account/AccountProducerTest.java
@@ -31,7 +31,7 @@ import org.knowm.xchange.dto.account.Wallet;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@Disabled("See CAMEL-19751 before enabling")
+@Disabled("CAMEL-19751 - tests hit live Binance API during exchange init, WireMock does not cover futures endpoint")
 public class AccountProducerTest extends XChangeTestSupport {
 
     @Override

--- a/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/market/MarketDataProducerTest.java
+++ b/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/market/MarketDataProducerTest.java
@@ -26,7 +26,7 @@ import org.knowm.xchange.dto.marketdata.Ticker;
 import static org.apache.camel.component.xchange.XChangeConfiguration.HEADER_CURRENCY_PAIR;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@Disabled("See CAMEL-19751 before enabling")
+@Disabled("CAMEL-19751 - tests hit live Binance API during exchange init, WireMock does not cover futures endpoint")
 public class MarketDataProducerTest extends XChangeTestSupport {
 
     @Override

--- a/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/metadata/MetaDataProducerTest.java
+++ b/components/camel-xchange/src/test/java/org/apache/camel/component/xchange/metadata/MetaDataProducerTest.java
@@ -32,7 +32,7 @@ import static org.apache.camel.component.xchange.XChangeConfiguration.HEADER_CUR
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled("See CAMEL-19751 before enabling")
+@Disabled("CAMEL-19751 - tests hit live Binance API during exchange init, WireMock does not cover futures endpoint")
 public class MetaDataProducerTest extends XChangeTestSupport {
 
     @Override


### PR DESCRIPTION
[CAMEL-21438](https://issues.apache.org/jira/browse/CAMEL-21438)

## Summary

- **Re-enable 12 FTPS integration tests** (camel-ftp) disabled since 2021 (CAMEL-16784). Migrated from SSLv3 (disabled in JDK 17+) to TLSv1.2. Restores FTPS test coverage that was completely absent for 4+ years.
- **Re-enable 15 ProxyProtocolTest tests** (camel-netty-http, CAMEL-16718) by fixing the `uppercase()` processor to use String conversion instead of manual ByteBuf ref-count management, which caused a double-release.
- **Keep 5 TLS 1.3 FTPS tests disabled** with accurate annotation — embedded Apache FtpServer does not support TLS 1.3.
- **Update misleading `@Disabled` annotations** on 16 tests whose JIRAs are resolved but tests should remain disabled (csimple-joor code-gen limitations, olingo4 deprecated/Attic, xchange missing WireMock coverage).

## Details

### camel-ftp (17 files)
The FTPS tests were blanket-disabled in 2021 via CAMEL-16784, leaving **zero FTPS integration test coverage**. The root cause was SSLv3 being disabled in modern JDKs. This PR:
- Changes `AUTH_VALUE_SSL` from `"SSLv3"` to `"TLSv1.2"`
- Updates all test URLs, `FTPSClient` constructors, and `SSLContextParameters` accordingly
- Removes `@Disabled("CAMEL-16784")` from 7 parent test classes (+ 5 SSLContextParameters subclasses inherit the re-enabled test)
- Adds `@EnabledIf(FtpsUtil#hasRequiredAlgorithms)` guard to `FileToFtpsExplicitSSLWithClientAuthIT`

### camel-netty-http (1 file)
`ProxyProtocolTest` was disabled since CAMEL-16718 due to a ByteBuf double-release. The `uppercase()` processor manually called `body.release()` on a ByteBuf obtained via type conversion, but Camel also managed the lifecycle — causing a ref-count error. Fix: use `String` type conversion and let Camel handle ByteBuf lifecycle.

### Annotation updates (5 files)
Updated `@Disabled` reasons on 16 tests across csimple-joor, olingo4, and xchange to accurately reflect why they remain disabled (previously referenced resolved JIRAs with no explanation).

## Test plan

- [x] All 12 re-enabled FTPS tests pass locally
- [x] All 15 re-enabled ProxyProtocolTest tests pass locally
- [x] Both test suites verified stable over **100 consecutive iterations** (2700 total executions, 0 failures)
- [x] All modules compile cleanly
- [x] Code formatted with `mvn formatter:format impsort:sort`
- [x] CI green

_Claude Code on behalf of Guillaume Nodet_