### PR TITLE
CAMEL-23387: camel-telemetry - Add span decorators for AWS EC2, ECS and EKS

### DIFF
--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsEc2SpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsEc2SpanDecorator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsEc2SpanDecorator extends AbstractSpanDecorator {
+
+    static final String EC2_OPERATION = "operation";
+    static final String EC2_IMAGE_ID = "imageId";
+    static final String EC2_INSTANCE_TYPE = "instanceType";
+    static final String EC2_SUBNET_ID = "subnetId";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.ec2.AWS2EC2Constants}
+     */
+    static final String OPERATION = "CamelAwsEC2Operation";
+    static final String IMAGE_ID = "CamelAwsEC2ImageId";
+    static final String INSTANCE_TYPE = "CamelAwsEC2InstanceType";
+    static final String SUBNET_ID = "CamelAwsEC2SubnetId";
+
+    @Override
+    public String getComponent() {
+        return "aws2-ec2";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.ec2.AWS2EC2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(EC2_OPERATION, operation);
+        }
+
+        String imageId = exchange.getIn().getHeader(IMAGE_ID, String.class);
+        if (imageId != null) {
+            span.setTag(EC2_IMAGE_ID, imageId);
+        }
+
+        String instanceType = exchange.getIn().getHeader(INSTANCE_TYPE, String.class);
+        if (instanceType != null) {
+            span.setTag(EC2_INSTANCE_TYPE, instanceType);
+        }
+
+        String subnetId = exchange.getIn().getHeader(SUBNET_ID, String.class);
+        if (subnetId != null) {
+            span.setTag(EC2_SUBNET_ID, subnetId);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsEcsSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsEcsSpanDecorator.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsEcsSpanDecorator extends AbstractSpanDecorator {
+
+    static final String ECS_OPERATION = "operation";
+    static final String ECS_CLUSTER_NAME = "clusterName";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.ecs.ECS2Constants}
+     */
+    static final String OPERATION = "CamelAwsECSOperation";
+    static final String CLUSTER_NAME = "CamelAwsECSClusterName";
+
+    @Override
+    public String getComponent() {
+        return "aws2-ecs";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.ecs.ECS2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(ECS_OPERATION, operation);
+        }
+
+        String clusterName = exchange.getIn().getHeader(CLUSTER_NAME, String.class);
+        if (clusterName != null) {
+            span.setTag(ECS_CLUSTER_NAME, clusterName);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsEksSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsEksSpanDecorator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsEksSpanDecorator extends AbstractSpanDecorator {
+
+    static final String EKS_OPERATION = "operation";
+    static final String EKS_CLUSTER_NAME = "clusterName";
+    static final String EKS_ROLE_ARN = "roleArn";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.eks.EKS2Constants}
+     */
+    static final String OPERATION = "CamelAwsEKSOperation";
+    static final String CLUSTER_NAME = "CamelAwsEKSClusterName";
+    static final String ROLE_ARN = "CamelAwsEKSRoleARN";
+
+    @Override
+    public String getComponent() {
+        return "aws2-eks";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.eks.EKS2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(EKS_OPERATION, operation);
+        }
+
+        String clusterName = exchange.getIn().getHeader(CLUSTER_NAME, String.class);
+        if (clusterName != null) {
+            span.setTag(EKS_CLUSTER_NAME, clusterName);
+        }
+
+        String roleArn = exchange.getIn().getHeader(ROLE_ARN, String.class);
+        if (roleArn != null) {
+            span.setTag(EKS_ROLE_ARN, roleArn);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsEksSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsEksSpanDecorator.java
@@ -24,14 +24,12 @@ public class AwsEksSpanDecorator extends AbstractSpanDecorator {
 
     static final String EKS_OPERATION = "operation";
     static final String EKS_CLUSTER_NAME = "clusterName";
-    static final String EKS_ROLE_ARN = "roleArn";
 
     /**
      * Constants copied from {@link org.apache.camel.component.aws2.eks.EKS2Constants}
      */
     static final String OPERATION = "CamelAwsEKSOperation";
     static final String CLUSTER_NAME = "CamelAwsEKSClusterName";
-    static final String ROLE_ARN = "CamelAwsEKSRoleARN";
 
     @Override
     public String getComponent() {
@@ -55,11 +53,6 @@ public class AwsEksSpanDecorator extends AbstractSpanDecorator {
         String clusterName = exchange.getIn().getHeader(CLUSTER_NAME, String.class);
         if (clusterName != null) {
             span.setTag(EKS_CLUSTER_NAME, clusterName);
-        }
-
-        String roleArn = exchange.getIn().getHeader(ROLE_ARN, String.class);
-        if (roleArn != null) {
-            span.setTag(EKS_ROLE_ARN, roleArn);
         }
     }
 

--- a/components/camel-telemetry/src/main/resources/META-INF/services/org.apache.camel.telemetry.SpanDecorator
+++ b/components/camel-telemetry/src/main/resources/META-INF/services/org.apache.camel.telemetry.SpanDecorator
@@ -26,6 +26,9 @@ org.apache.camel.telemetry.decorators.AwsConfigSpanDecorator
 org.apache.camel.telemetry.decorators.AwsCwSpanDecorator
 org.apache.camel.telemetry.decorators.AwsDdbSpanDecorator
 org.apache.camel.telemetry.decorators.AwsDdbStreamSpanDecorator
+org.apache.camel.telemetry.decorators.AwsEc2SpanDecorator
+org.apache.camel.telemetry.decorators.AwsEcsSpanDecorator
+org.apache.camel.telemetry.decorators.AwsEksSpanDecorator
 org.apache.camel.telemetry.decorators.AwsEventbridgeSpanDecorator
 org.apache.camel.telemetry.decorators.AwsIamSpanDecorator
 org.apache.camel.telemetry.decorators.AwsKinesisFirehoseSpanDecorator

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsEc2SpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsEc2SpanDecoratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsEc2SpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "createAndRunInstances";
+        String imageId = "ami-0abcdef1234567890";
+        String instanceType = "t2.micro";
+        String subnetId = "subnet-0abcd1234efgh5678";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-ec2:default");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsEc2SpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsEc2SpanDecorator.IMAGE_ID, String.class)).thenReturn(imageId);
+        Mockito.when(message.getHeader(AwsEc2SpanDecorator.INSTANCE_TYPE, String.class)).thenReturn(instanceType);
+        Mockito.when(message.getHeader(AwsEc2SpanDecorator.SUBNET_ID, String.class)).thenReturn(subnetId);
+
+        AbstractSpanDecorator decorator = new AwsEc2SpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsEc2SpanDecorator.EC2_OPERATION));
+        assertEquals(imageId, span.tags().get(AwsEc2SpanDecorator.EC2_IMAGE_ID));
+        assertEquals(instanceType, span.tags().get(AwsEc2SpanDecorator.EC2_INSTANCE_TYPE));
+        assertEquals(subnetId, span.tags().get(AwsEc2SpanDecorator.EC2_SUBNET_ID));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsEcsSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsEcsSpanDecoratorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsEcsSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "createCluster";
+        String clusterName = "production";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-ecs:default");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsEcsSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsEcsSpanDecorator.CLUSTER_NAME, String.class)).thenReturn(clusterName);
+
+        AbstractSpanDecorator decorator = new AwsEcsSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsEcsSpanDecorator.ECS_OPERATION));
+        assertEquals(clusterName, span.tags().get(AwsEcsSpanDecorator.ECS_CLUSTER_NAME));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsEksSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsEksSpanDecoratorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsEksSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "createCluster";
+        String clusterName = "prod-eks";
+        String roleArn = "arn:aws:iam::123456789012:role/EksClusterRole";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-eks:default");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsEksSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsEksSpanDecorator.CLUSTER_NAME, String.class)).thenReturn(clusterName);
+        Mockito.when(message.getHeader(AwsEksSpanDecorator.ROLE_ARN, String.class)).thenReturn(roleArn);
+
+        AbstractSpanDecorator decorator = new AwsEksSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsEksSpanDecorator.EKS_OPERATION));
+        assertEquals(clusterName, span.tags().get(AwsEksSpanDecorator.EKS_CLUSTER_NAME));
+        assertEquals(roleArn, span.tags().get(AwsEksSpanDecorator.EKS_ROLE_ARN));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsEksSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsEksSpanDecoratorTest.java
@@ -31,7 +31,6 @@ public class AwsEksSpanDecoratorTest {
     public void testPre() {
         String operation = "createCluster";
         String clusterName = "prod-eks";
-        String roleArn = "arn:aws:iam::123456789012:role/EksClusterRole";
 
         Endpoint endpoint = Mockito.mock(Endpoint.class);
         Exchange exchange = Mockito.mock(Exchange.class);
@@ -42,7 +41,6 @@ public class AwsEksSpanDecoratorTest {
         Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
         Mockito.when(message.getHeader(AwsEksSpanDecorator.OPERATION, String.class)).thenReturn(operation);
         Mockito.when(message.getHeader(AwsEksSpanDecorator.CLUSTER_NAME, String.class)).thenReturn(clusterName);
-        Mockito.when(message.getHeader(AwsEksSpanDecorator.ROLE_ARN, String.class)).thenReturn(roleArn);
 
         AbstractSpanDecorator decorator = new AwsEksSpanDecorator();
 
@@ -52,7 +50,6 @@ public class AwsEksSpanDecoratorTest {
 
         assertEquals(operation, span.tags().get(AwsEksSpanDecorator.EKS_OPERATION));
         assertEquals(clusterName, span.tags().get(AwsEksSpanDecorator.EKS_CLUSTER_NAME));
-        assertEquals(roleArn, span.tags().get(AwsEksSpanDecorator.EKS_ROLE_ARN));
     }
 
 }


### PR DESCRIPTION
## Summary

Fifth batch of AWS span decorators for `camel-telemetry`. Continues the work from #23038, #23040, #23045 and #23077 by covering the **Compute** group: virtual machines (EC2), container service (ECS), and managed Kubernetes (EKS).

JIRA: [CAMEL-23387](https://issues.apache.org/jira/browse/CAMEL-23387) — _the JIRA stays open; only the AI/ML batch (Polly, Rekognition, Textract, Transcribe, Translate, Comprehend, S3 Vectors) remains for AWS coverage._

### Note on X-Ray scope reduction

The original "Compute & Tracing" follow-up listed in #23045 and #23077 also mentioned `aws-xray`. That module no longer exists — `camel-aws-xray` was the **deprecated AWS X-Ray tracer integration** (its own `SegmentDecorator` system parallel to OpenTracing) and was removed in commit ba9f8c5340a ("Remove deprecated Amazon X-Ray component"). It is not a producer-style component and there is nothing to add a `SpanDecorator` for. This batch therefore covers EC2, ECS and EKS only.

## Changes

New `SpanDecorator` implementations under `org.apache.camel.telemetry.decorators`:

- **`AwsEc2SpanDecorator`** (`aws2-ec2`) — Elastic Compute Cloud. Tags: `operation`, `imageId`, `instanceType`, `subnetId`. Bulk request collections (instance IDs, security groups, tags, placement objects), key pair name, and EBS/monitoring/kernel flags are not surfaced.
- **`AwsEcsSpanDecorator`** (`aws2-ecs`) — Elastic Container Service. Tags: `operation`, `clusterName`. The component's input header surface is small (the cluster ARN is response-shaped only and is not visible in `beforeTracingEvent`).
- **`AwsEksSpanDecorator`** (`aws2-eks`) — Elastic Kubernetes Service. Tags: `operation`, `clusterName`. The VPC config object and free-form description are not surfaced.

All three decorators extend `AbstractSpanDecorator` (these are producer-only management APIs) and are registered alphabetically in `META-INF/services/org.apache.camel.telemetry.SpanDecorator`. Unit tests cover header-to-tag extraction for each decorator.

Header constants are mirrored from each component's `*Constants` interface (with a Javadoc reference back to the source), matching the convention used by previous batches and `AzureServiceBusSpanDecorator`. This avoids creating hard dependencies from `camel-telemetry` to the AWS component modules.

### Tag selection rationale

Same two rules applied across batches 3, 4 and now 5:

1. **Never emit values that may contain secrets or large payloads** — VPC config objects (EKS), placement objects, security-group/instance-ID/tag collections (EC2), free-form descriptions (EKS).
2. **Prefer the request _target_ over the response payload** — `clusterName`, `imageId`, `subnetId`, `instanceType`. Response ARNs (cluster ARNs in ECS/EKS, instance IDs from EC2 launch responses) are not tagged because they are response-shaped and not available in `beforeTracingEvent`.

### Review-driven adjustments (commit 8525094)

After review feedback from @davsclaus, one field was dropped from the initial draft:

- `AwsEksSpanDecorator` no longer emits `roleArn`. Even though the EKS cluster role ARN is a request input rather than a response value, surfacing IAM principal ARNs to observability backends is an unnecessary identity disclosure. This brings EKS in line with the same minimization principle that drove the IAM `userName`, KMS `keyId` and CloudTrail `username` drops in batches 3 and 4.

## Test plan

- [x] `mvn test` in `components/camel-telemetry` passes (124 tests, including 37 AWS decorator tests covering 29 components total)
- [x] Module-specific build (`mvn -DskipTests install`) succeeds
- [x] No code style or formatter changes required

## Coverage so far on CAMEL-23387

| Batch | PR | Components |
|---|---|---|
| 1 | #23038 (merged) | SQS, SNS, Kinesis, S3 |
| 2 | #23040 (merged) | DDB, DDB Streams, Lambda, EventBridge, SES, MQ, Kinesis Firehose, Bedrock |
| 3 | #23045 (merged) | Athena, CloudWatch, KMS, MSK, Step Functions, Timestream, Redshift Data, CloudTrail |
| 4 | #23077 (merged) | STS, IAM, Secrets Manager, Parameter Store, Security Hub, Config |
| 5 | this PR | EC2, ECS, EKS |

## Follow-ups still pending

- **AI/ML components**: Polly, Rekognition, Textract, Transcribe, Translate, Comprehend, S3 Vectors — to be added in a final AWS PR.
- **Google Cloud decorators** (mentioned in CAMEL-23387's description) — separate scope discussion / separate JIRA.

---

_Claude Code on behalf of Andrea Cosentino_