### PR TITLE
CAMEL-23387: camel-telemetry - Add span decorators for AWS Polly, Rekognition, Textract, Transcribe, Translate, Comprehend and S3 Vectors

### DIFF
--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsComprehendSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsComprehendSpanDecorator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsComprehendSpanDecorator extends AbstractSpanDecorator {
+
+    static final String COMPREHEND_OPERATION = "operation";
+    static final String COMPREHEND_LANGUAGE_CODE = "languageCode";
+    static final String COMPREHEND_ENDPOINT_ARN = "endpointArn";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.comprehend.Comprehend2Constants}
+     */
+    static final String OPERATION = "CamelAwsComprehendOperation";
+    static final String LANGUAGE_CODE = "CamelAwsComprehendLanguageCode";
+    static final String ENDPOINT_ARN = "CamelAwsComprehendEndpointArn";
+
+    @Override
+    public String getComponent() {
+        return "aws2-comprehend";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.comprehend.Comprehend2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(COMPREHEND_OPERATION, operation);
+        }
+
+        String languageCode = exchange.getIn().getHeader(LANGUAGE_CODE, String.class);
+        if (languageCode != null) {
+            span.setTag(COMPREHEND_LANGUAGE_CODE, languageCode);
+        }
+
+        String endpointArn = exchange.getIn().getHeader(ENDPOINT_ARN, String.class);
+        if (endpointArn != null) {
+            span.setTag(COMPREHEND_ENDPOINT_ARN, endpointArn);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsComprehendSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsComprehendSpanDecorator.java
@@ -24,14 +24,12 @@ public class AwsComprehendSpanDecorator extends AbstractSpanDecorator {
 
     static final String COMPREHEND_OPERATION = "operation";
     static final String COMPREHEND_LANGUAGE_CODE = "languageCode";
-    static final String COMPREHEND_ENDPOINT_ARN = "endpointArn";
 
     /**
      * Constants copied from {@link org.apache.camel.component.aws2.comprehend.Comprehend2Constants}
      */
     static final String OPERATION = "CamelAwsComprehendOperation";
     static final String LANGUAGE_CODE = "CamelAwsComprehendLanguageCode";
-    static final String ENDPOINT_ARN = "CamelAwsComprehendEndpointArn";
 
     @Override
     public String getComponent() {
@@ -55,11 +53,6 @@ public class AwsComprehendSpanDecorator extends AbstractSpanDecorator {
         String languageCode = exchange.getIn().getHeader(LANGUAGE_CODE, String.class);
         if (languageCode != null) {
             span.setTag(COMPREHEND_LANGUAGE_CODE, languageCode);
-        }
-
-        String endpointArn = exchange.getIn().getHeader(ENDPOINT_ARN, String.class);
-        if (endpointArn != null) {
-            span.setTag(COMPREHEND_ENDPOINT_ARN, endpointArn);
         }
     }
 

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsPollySpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsPollySpanDecorator.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsPollySpanDecorator extends AbstractSpanDecorator {
+
+    static final String POLLY_OPERATION = "operation";
+    static final String POLLY_VOICE_ID = "voiceId";
+    static final String POLLY_OUTPUT_FORMAT = "outputFormat";
+    static final String POLLY_ENGINE = "engine";
+    static final String POLLY_LANGUAGE_CODE = "languageCode";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.polly.Polly2Constants}
+     */
+    static final String OPERATION = "CamelAwsPollyOperation";
+    static final String VOICE_ID = "CamelAwsPollyVoiceId";
+    static final String OUTPUT_FORMAT = "CamelAwsPollyOutputFormat";
+    static final String ENGINE = "CamelAwsPollyEngine";
+    static final String LANGUAGE_CODE = "CamelAwsPollyLanguageCode";
+
+    @Override
+    public String getComponent() {
+        return "aws2-polly";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.polly.Polly2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(POLLY_OPERATION, operation);
+        }
+
+        String voiceId = exchange.getIn().getHeader(VOICE_ID, String.class);
+        if (voiceId != null) {
+            span.setTag(POLLY_VOICE_ID, voiceId);
+        }
+
+        String outputFormat = exchange.getIn().getHeader(OUTPUT_FORMAT, String.class);
+        if (outputFormat != null) {
+            span.setTag(POLLY_OUTPUT_FORMAT, outputFormat);
+        }
+
+        String engine = exchange.getIn().getHeader(ENGINE, String.class);
+        if (engine != null) {
+            span.setTag(POLLY_ENGINE, engine);
+        }
+
+        String languageCode = exchange.getIn().getHeader(LANGUAGE_CODE, String.class);
+        if (languageCode != null) {
+            span.setTag(POLLY_LANGUAGE_CODE, languageCode);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsRekognitionSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsRekognitionSpanDecorator.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsRekognitionSpanDecorator extends AbstractSpanDecorator {
+
+    static final String REKOGNITION_OPERATION = "operation";
+    static final String REKOGNITION_COLLECTION_ID = "collectionId";
+    static final String REKOGNITION_JOB_ID = "jobId";
+    static final String REKOGNITION_JOB_NAME = "jobName";
+    static final String REKOGNITION_FACE_ID = "faceId";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.rekognition.Rekognition2Constants}
+     */
+    static final String OPERATION = "CamelAwsRekognitionOperation";
+    static final String COLLECTION_ID = "CamelAwsRekognitionCollectionId";
+    static final String JOB_ID = "CamelAwsRekognitionJobId";
+    static final String JOB_NAME = "CamelAwsRekognitionJobName";
+    static final String FACE_ID = "CamelAwsRekognitionFaceId";
+
+    @Override
+    public String getComponent() {
+        return "aws2-rekognition";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.rekognition.Rekognition2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(REKOGNITION_OPERATION, operation);
+        }
+
+        String collectionId = exchange.getIn().getHeader(COLLECTION_ID, String.class);
+        if (collectionId != null) {
+            span.setTag(REKOGNITION_COLLECTION_ID, collectionId);
+        }
+
+        String jobId = exchange.getIn().getHeader(JOB_ID, String.class);
+        if (jobId != null) {
+            span.setTag(REKOGNITION_JOB_ID, jobId);
+        }
+
+        String jobName = exchange.getIn().getHeader(JOB_NAME, String.class);
+        if (jobName != null) {
+            span.setTag(REKOGNITION_JOB_NAME, jobName);
+        }
+
+        String faceId = exchange.getIn().getHeader(FACE_ID, String.class);
+        if (faceId != null) {
+            span.setTag(REKOGNITION_FACE_ID, faceId);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsS3VectorsSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsS3VectorsSpanDecorator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsS3VectorsSpanDecorator extends AbstractSpanDecorator {
+
+    static final String S3_VECTORS_OPERATION = "operation";
+    static final String S3_VECTORS_VECTOR_BUCKET_NAME = "vectorBucketName";
+    static final String S3_VECTORS_VECTOR_INDEX_NAME = "vectorIndexName";
+    static final String S3_VECTORS_VECTOR_ID = "vectorId";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.s3vectors.AWS2S3VectorsConstants}
+     */
+    static final String OPERATION = "CamelAwsS3VectorsOperation";
+    static final String VECTOR_BUCKET_NAME = "CamelAwsS3VectorsVectorBucketName";
+    static final String VECTOR_INDEX_NAME = "CamelAwsS3VectorsVectorIndexName";
+    static final String VECTOR_ID = "CamelAwsS3VectorsVectorId";
+
+    @Override
+    public String getComponent() {
+        return "aws2-s3-vectors";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.s3vectors.AWS2S3VectorsComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(S3_VECTORS_OPERATION, operation);
+        }
+
+        String vectorBucketName = exchange.getIn().getHeader(VECTOR_BUCKET_NAME, String.class);
+        if (vectorBucketName != null) {
+            span.setTag(S3_VECTORS_VECTOR_BUCKET_NAME, vectorBucketName);
+        }
+
+        String vectorIndexName = exchange.getIn().getHeader(VECTOR_INDEX_NAME, String.class);
+        if (vectorIndexName != null) {
+            span.setTag(S3_VECTORS_VECTOR_INDEX_NAME, vectorIndexName);
+        }
+
+        String vectorId = exchange.getIn().getHeader(VECTOR_ID, String.class);
+        if (vectorId != null) {
+            span.setTag(S3_VECTORS_VECTOR_ID, vectorId);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsTextractSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsTextractSpanDecorator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsTextractSpanDecorator extends AbstractSpanDecorator {
+
+    static final String TEXTRACT_OPERATION = "operation";
+    static final String TEXTRACT_S3_BUCKET = "s3Bucket";
+    static final String TEXTRACT_S3_OBJECT = "s3Object";
+    static final String TEXTRACT_JOB_ID = "jobId";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.textract.Textract2Constants}
+     */
+    static final String OPERATION = "CamelAwsTextractOperation";
+    static final String S3_BUCKET = "CamelAwsTextractS3Bucket";
+    static final String S3_OBJECT = "CamelAwsTextractS3Object";
+    static final String JOB_ID = "CamelAwsTextractJobId";
+
+    @Override
+    public String getComponent() {
+        return "aws2-textract";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.textract.Textract2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(TEXTRACT_OPERATION, operation);
+        }
+
+        String s3Bucket = exchange.getIn().getHeader(S3_BUCKET, String.class);
+        if (s3Bucket != null) {
+            span.setTag(TEXTRACT_S3_BUCKET, s3Bucket);
+        }
+
+        String s3Object = exchange.getIn().getHeader(S3_OBJECT, String.class);
+        if (s3Object != null) {
+            span.setTag(TEXTRACT_S3_OBJECT, s3Object);
+        }
+
+        String jobId = exchange.getIn().getHeader(JOB_ID, String.class);
+        if (jobId != null) {
+            span.setTag(TEXTRACT_JOB_ID, jobId);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsTranscribeSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsTranscribeSpanDecorator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsTranscribeSpanDecorator extends AbstractSpanDecorator {
+
+    static final String TRANSCRIBE_TRANSCRIPTION_JOB_NAME = "transcriptionJobName";
+    static final String TRANSCRIBE_LANGUAGE_CODE = "languageCode";
+    static final String TRANSCRIBE_MEDIA_FORMAT = "mediaFormat";
+    static final String TRANSCRIBE_MEDIA_URI = "mediaUri";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.transcribe.Transcribe2Constants}
+     */
+    static final String TRANSCRIPTION_JOB_NAME = "CamelAwsTranscribeTranscriptionJobName";
+    static final String LANGUAGE_CODE = "CamelAwsTranscribeLanguageCode";
+    static final String MEDIA_FORMAT = "CamelAwsTranscribeMediaFormat";
+    static final String MEDIA_URI = "CamelAwsTranscribeMediaUri";
+
+    @Override
+    public String getComponent() {
+        return "aws2-transcribe";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.transcribe.Transcribe2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String transcriptionJobName = exchange.getIn().getHeader(TRANSCRIPTION_JOB_NAME, String.class);
+        if (transcriptionJobName != null) {
+            span.setTag(TRANSCRIBE_TRANSCRIPTION_JOB_NAME, transcriptionJobName);
+        }
+
+        String languageCode = exchange.getIn().getHeader(LANGUAGE_CODE, String.class);
+        if (languageCode != null) {
+            span.setTag(TRANSCRIBE_LANGUAGE_CODE, languageCode);
+        }
+
+        String mediaFormat = exchange.getIn().getHeader(MEDIA_FORMAT, String.class);
+        if (mediaFormat != null) {
+            span.setTag(TRANSCRIBE_MEDIA_FORMAT, mediaFormat);
+        }
+
+        String mediaUri = exchange.getIn().getHeader(MEDIA_URI, String.class);
+        if (mediaUri != null) {
+            span.setTag(TRANSCRIBE_MEDIA_URI, mediaUri);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsTranslateSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AwsTranslateSpanDecorator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class AwsTranslateSpanDecorator extends AbstractSpanDecorator {
+
+    static final String TRANSLATE_OPERATION = "operation";
+    static final String TRANSLATE_SOURCE_LANGUAGE = "sourceLanguage";
+    static final String TRANSLATE_TARGET_LANGUAGE = "targetLanguage";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.aws2.translate.Translate2Constants}
+     */
+    static final String OPERATION = "CamelAwsTranslateOperation";
+    static final String SOURCE_LANGUAGE = "CamelAwsTranslateSourceLanguage";
+    static final String TARGET_LANGUAGE = "CamelAwsTranslateTargetLanguage";
+
+    @Override
+    public String getComponent() {
+        return "aws2-translate";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.aws2.translate.Translate2Component";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String operation = exchange.getIn().getHeader(OPERATION, String.class);
+        if (operation != null) {
+            span.setTag(TRANSLATE_OPERATION, operation);
+        }
+
+        String sourceLanguage = exchange.getIn().getHeader(SOURCE_LANGUAGE, String.class);
+        if (sourceLanguage != null) {
+            span.setTag(TRANSLATE_SOURCE_LANGUAGE, sourceLanguage);
+        }
+
+        String targetLanguage = exchange.getIn().getHeader(TARGET_LANGUAGE, String.class);
+        if (targetLanguage != null) {
+            span.setTag(TRANSLATE_TARGET_LANGUAGE, targetLanguage);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/resources/META-INF/services/org.apache.camel.telemetry.SpanDecorator
+++ b/components/camel-telemetry/src/main/resources/META-INF/services/org.apache.camel.telemetry.SpanDecorator
@@ -22,6 +22,7 @@ org.apache.camel.telemetry.decorators.AmqpSpanDecorator
 org.apache.camel.telemetry.decorators.AwsAthenaSpanDecorator
 org.apache.camel.telemetry.decorators.AwsBedrockSpanDecorator
 org.apache.camel.telemetry.decorators.AwsCloudtrailSpanDecorator
+org.apache.camel.telemetry.decorators.AwsComprehendSpanDecorator
 org.apache.camel.telemetry.decorators.AwsConfigSpanDecorator
 org.apache.camel.telemetry.decorators.AwsCwSpanDecorator
 org.apache.camel.telemetry.decorators.AwsDdbSpanDecorator
@@ -38,8 +39,11 @@ org.apache.camel.telemetry.decorators.AwsLambdaSpanDecorator
 org.apache.camel.telemetry.decorators.AwsMqSpanDecorator
 org.apache.camel.telemetry.decorators.AwsMskSpanDecorator
 org.apache.camel.telemetry.decorators.AwsParameterStoreSpanDecorator
+org.apache.camel.telemetry.decorators.AwsPollySpanDecorator
 org.apache.camel.telemetry.decorators.AwsRedshiftDataSpanDecorator
+org.apache.camel.telemetry.decorators.AwsRekognitionSpanDecorator
 org.apache.camel.telemetry.decorators.AwsS3SpanDecorator
+org.apache.camel.telemetry.decorators.AwsS3VectorsSpanDecorator
 org.apache.camel.telemetry.decorators.AwsSecretsManagerSpanDecorator
 org.apache.camel.telemetry.decorators.AwsSecurityHubSpanDecorator
 org.apache.camel.telemetry.decorators.AwsSesSpanDecorator
@@ -47,7 +51,10 @@ org.apache.camel.telemetry.decorators.AwsSnsSpanDecorator
 org.apache.camel.telemetry.decorators.AwsSqsSpanDecorator
 org.apache.camel.telemetry.decorators.AwsStepFunctionsSpanDecorator
 org.apache.camel.telemetry.decorators.AwsStsSpanDecorator
+org.apache.camel.telemetry.decorators.AwsTextractSpanDecorator
 org.apache.camel.telemetry.decorators.AwsTimestreamSpanDecorator
+org.apache.camel.telemetry.decorators.AwsTranscribeSpanDecorator
+org.apache.camel.telemetry.decorators.AwsTranslateSpanDecorator
 org.apache.camel.telemetry.decorators.AzureServiceBusSpanDecorator
 org.apache.camel.telemetry.decorators.CometdSpanDecorator
 org.apache.camel.telemetry.decorators.CometdsSpanDecorator

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsComprehendSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsComprehendSpanDecoratorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsComprehendSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "detectSentiment";
+        String languageCode = "en";
+        String endpointArn = "arn:aws:comprehend:us-east-1:123456789012:document-classifier-endpoint/MyEndpoint";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-comprehend:default");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsComprehendSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsComprehendSpanDecorator.LANGUAGE_CODE, String.class)).thenReturn(languageCode);
+        Mockito.when(message.getHeader(AwsComprehendSpanDecorator.ENDPOINT_ARN, String.class)).thenReturn(endpointArn);
+
+        AbstractSpanDecorator decorator = new AwsComprehendSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsComprehendSpanDecorator.COMPREHEND_OPERATION));
+        assertEquals(languageCode, span.tags().get(AwsComprehendSpanDecorator.COMPREHEND_LANGUAGE_CODE));
+        assertEquals(endpointArn, span.tags().get(AwsComprehendSpanDecorator.COMPREHEND_ENDPOINT_ARN));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsComprehendSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsComprehendSpanDecoratorTest.java
@@ -31,7 +31,6 @@ public class AwsComprehendSpanDecoratorTest {
     public void testPre() {
         String operation = "detectSentiment";
         String languageCode = "en";
-        String endpointArn = "arn:aws:comprehend:us-east-1:123456789012:document-classifier-endpoint/MyEndpoint";
 
         Endpoint endpoint = Mockito.mock(Endpoint.class);
         Exchange exchange = Mockito.mock(Exchange.class);
@@ -42,7 +41,6 @@ public class AwsComprehendSpanDecoratorTest {
         Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
         Mockito.when(message.getHeader(AwsComprehendSpanDecorator.OPERATION, String.class)).thenReturn(operation);
         Mockito.when(message.getHeader(AwsComprehendSpanDecorator.LANGUAGE_CODE, String.class)).thenReturn(languageCode);
-        Mockito.when(message.getHeader(AwsComprehendSpanDecorator.ENDPOINT_ARN, String.class)).thenReturn(endpointArn);
 
         AbstractSpanDecorator decorator = new AwsComprehendSpanDecorator();
 
@@ -52,7 +50,6 @@ public class AwsComprehendSpanDecoratorTest {
 
         assertEquals(operation, span.tags().get(AwsComprehendSpanDecorator.COMPREHEND_OPERATION));
         assertEquals(languageCode, span.tags().get(AwsComprehendSpanDecorator.COMPREHEND_LANGUAGE_CODE));
-        assertEquals(endpointArn, span.tags().get(AwsComprehendSpanDecorator.COMPREHEND_ENDPOINT_ARN));
     }
 
 }

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsPollySpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsPollySpanDecoratorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsPollySpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "synthesizeSpeech";
+        String voiceId = "Joanna";
+        String outputFormat = "mp3";
+        String engine = "neural";
+        String languageCode = "en-US";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-polly:default");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsPollySpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsPollySpanDecorator.VOICE_ID, String.class)).thenReturn(voiceId);
+        Mockito.when(message.getHeader(AwsPollySpanDecorator.OUTPUT_FORMAT, String.class)).thenReturn(outputFormat);
+        Mockito.when(message.getHeader(AwsPollySpanDecorator.ENGINE, String.class)).thenReturn(engine);
+        Mockito.when(message.getHeader(AwsPollySpanDecorator.LANGUAGE_CODE, String.class)).thenReturn(languageCode);
+
+        AbstractSpanDecorator decorator = new AwsPollySpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsPollySpanDecorator.POLLY_OPERATION));
+        assertEquals(voiceId, span.tags().get(AwsPollySpanDecorator.POLLY_VOICE_ID));
+        assertEquals(outputFormat, span.tags().get(AwsPollySpanDecorator.POLLY_OUTPUT_FORMAT));
+        assertEquals(engine, span.tags().get(AwsPollySpanDecorator.POLLY_ENGINE));
+        assertEquals(languageCode, span.tags().get(AwsPollySpanDecorator.POLLY_LANGUAGE_CODE));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsRekognitionSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsRekognitionSpanDecoratorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsRekognitionSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "indexFaces";
+        String collectionId = "MyCollection";
+        String jobId = "job-1234";
+        String jobName = "media-analysis-1";
+        String faceId = "face-abcd";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-rekognition:default");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsRekognitionSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsRekognitionSpanDecorator.COLLECTION_ID, String.class)).thenReturn(collectionId);
+        Mockito.when(message.getHeader(AwsRekognitionSpanDecorator.JOB_ID, String.class)).thenReturn(jobId);
+        Mockito.when(message.getHeader(AwsRekognitionSpanDecorator.JOB_NAME, String.class)).thenReturn(jobName);
+        Mockito.when(message.getHeader(AwsRekognitionSpanDecorator.FACE_ID, String.class)).thenReturn(faceId);
+
+        AbstractSpanDecorator decorator = new AwsRekognitionSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsRekognitionSpanDecorator.REKOGNITION_OPERATION));
+        assertEquals(collectionId, span.tags().get(AwsRekognitionSpanDecorator.REKOGNITION_COLLECTION_ID));
+        assertEquals(jobId, span.tags().get(AwsRekognitionSpanDecorator.REKOGNITION_JOB_ID));
+        assertEquals(jobName, span.tags().get(AwsRekognitionSpanDecorator.REKOGNITION_JOB_NAME));
+        assertEquals(faceId, span.tags().get(AwsRekognitionSpanDecorator.REKOGNITION_FACE_ID));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsS3VectorsSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsS3VectorsSpanDecoratorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsS3VectorsSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "queryVectors";
+        String vectorBucketName = "my-vectors";
+        String vectorIndexName = "embeddings-v1";
+        String vectorId = "doc-1234";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-s3-vectors:default");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsS3VectorsSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsS3VectorsSpanDecorator.VECTOR_BUCKET_NAME, String.class))
+                .thenReturn(vectorBucketName);
+        Mockito.when(message.getHeader(AwsS3VectorsSpanDecorator.VECTOR_INDEX_NAME, String.class))
+                .thenReturn(vectorIndexName);
+        Mockito.when(message.getHeader(AwsS3VectorsSpanDecorator.VECTOR_ID, String.class)).thenReturn(vectorId);
+
+        AbstractSpanDecorator decorator = new AwsS3VectorsSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsS3VectorsSpanDecorator.S3_VECTORS_OPERATION));
+        assertEquals(vectorBucketName, span.tags().get(AwsS3VectorsSpanDecorator.S3_VECTORS_VECTOR_BUCKET_NAME));
+        assertEquals(vectorIndexName, span.tags().get(AwsS3VectorsSpanDecorator.S3_VECTORS_VECTOR_INDEX_NAME));
+        assertEquals(vectorId, span.tags().get(AwsS3VectorsSpanDecorator.S3_VECTORS_VECTOR_ID));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsTextractSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsTextractSpanDecoratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsTextractSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "detectDocumentText";
+        String s3Bucket = "my-docs";
+        String s3Object = "invoices/2024-01.pdf";
+        String jobId = "job-5678";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-textract:default");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsTextractSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsTextractSpanDecorator.S3_BUCKET, String.class)).thenReturn(s3Bucket);
+        Mockito.when(message.getHeader(AwsTextractSpanDecorator.S3_OBJECT, String.class)).thenReturn(s3Object);
+        Mockito.when(message.getHeader(AwsTextractSpanDecorator.JOB_ID, String.class)).thenReturn(jobId);
+
+        AbstractSpanDecorator decorator = new AwsTextractSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsTextractSpanDecorator.TEXTRACT_OPERATION));
+        assertEquals(s3Bucket, span.tags().get(AwsTextractSpanDecorator.TEXTRACT_S3_BUCKET));
+        assertEquals(s3Object, span.tags().get(AwsTextractSpanDecorator.TEXTRACT_S3_OBJECT));
+        assertEquals(jobId, span.tags().get(AwsTextractSpanDecorator.TEXTRACT_JOB_ID));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsTranscribeSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsTranscribeSpanDecoratorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsTranscribeSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String transcriptionJobName = "meeting-2024-01-15";
+        String languageCode = "en-US";
+        String mediaFormat = "mp3";
+        String mediaUri = "s3://my-audio/meeting.mp3";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-transcribe:default");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsTranscribeSpanDecorator.TRANSCRIPTION_JOB_NAME, String.class))
+                .thenReturn(transcriptionJobName);
+        Mockito.when(message.getHeader(AwsTranscribeSpanDecorator.LANGUAGE_CODE, String.class)).thenReturn(languageCode);
+        Mockito.when(message.getHeader(AwsTranscribeSpanDecorator.MEDIA_FORMAT, String.class)).thenReturn(mediaFormat);
+        Mockito.when(message.getHeader(AwsTranscribeSpanDecorator.MEDIA_URI, String.class)).thenReturn(mediaUri);
+
+        AbstractSpanDecorator decorator = new AwsTranscribeSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(transcriptionJobName, span.tags().get(AwsTranscribeSpanDecorator.TRANSCRIBE_TRANSCRIPTION_JOB_NAME));
+        assertEquals(languageCode, span.tags().get(AwsTranscribeSpanDecorator.TRANSCRIBE_LANGUAGE_CODE));
+        assertEquals(mediaFormat, span.tags().get(AwsTranscribeSpanDecorator.TRANSCRIBE_MEDIA_FORMAT));
+        assertEquals(mediaUri, span.tags().get(AwsTranscribeSpanDecorator.TRANSCRIBE_MEDIA_URI));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsTranslateSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AwsTranslateSpanDecoratorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AwsTranslateSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "translateText";
+        String sourceLanguage = "en";
+        String targetLanguage = "it";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("aws2-translate:default");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(AwsTranslateSpanDecorator.OPERATION, String.class)).thenReturn(operation);
+        Mockito.when(message.getHeader(AwsTranslateSpanDecorator.SOURCE_LANGUAGE, String.class)).thenReturn(sourceLanguage);
+        Mockito.when(message.getHeader(AwsTranslateSpanDecorator.TARGET_LANGUAGE, String.class)).thenReturn(targetLanguage);
+
+        AbstractSpanDecorator decorator = new AwsTranslateSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(AwsTranslateSpanDecorator.TRANSLATE_OPERATION));
+        assertEquals(sourceLanguage, span.tags().get(AwsTranslateSpanDecorator.TRANSLATE_SOURCE_LANGUAGE));
+        assertEquals(targetLanguage, span.tags().get(AwsTranslateSpanDecorator.TRANSLATE_TARGET_LANGUAGE));
+    }
+
+}


### PR DESCRIPTION
## Summary

**Final AWS batch** of span decorators for `camel-telemetry`. Closes out AWS coverage for [CAMEL-23387](https://issues.apache.org/jira/browse/CAMEL-23387) by adding decorators for the **AI/ML** group: text-to-speech (Polly), image AI (Rekognition), OCR (Textract), speech-to-text (Transcribe), translation (Translate), NLP (Comprehend) and vector search (S3 Vectors).

After this PR, all 36 AWS components in `components/camel-aws/` that have a Camel scheme will have a corresponding `SpanDecorator`. The only remaining follow-up on CAMEL-23387 is the Google Cloud decorators mentioned in the original ticket, which is in scope for a separate JIRA.

## Changes

New `SpanDecorator` implementations under `org.apache.camel.telemetry.decorators`:

- **`AwsPollySpanDecorator`** (`aws2-polly`) — Text-to-speech. Tags: `operation`, `voiceId`, `outputFormat`, `engine`, `languageCode`. Lexicon content (PLS XML), the synthesized audio's S3 destination (bucket/key), the SNS topic ARN for notifications, and the `requestCharacters` response counter are not surfaced.
- **`AwsRekognitionSpanDecorator`** (`aws2-rekognition`) — Image/video AI. Tags: `operation`, `collectionId`, `jobId`, `jobName`, `faceId`. Image data (binary), kms key id, large config objects (operations/output/human-loop config) and bulk facial-attribute / feature collections are not surfaced.
- **`AwsTextractSpanDecorator`** (`aws2-textract`) — Document OCR. Tags: `operation`, `s3Bucket`, `s3Object`, `jobId`. The S3 object version, pagination tokens and feature-type collection are not surfaced.
- **`AwsTranscribeSpanDecorator`** (`aws2-transcribe`) — Speech-to-text. Tags: `transcriptionJobName`, `languageCode`, `mediaFormat`, `mediaUri`. The `Transcribe2Constants` interface does not define an `OPERATION` header — operations are configured via the URI — so no `operation` tag is emitted (the span name from the URI already conveys the action). Vocabulary phrase lists, tag maps and the resource ARN are not surfaced.
- **`AwsTranslateSpanDecorator`** (`aws2-translate`) — Translation. Tags: `operation`, `sourceLanguage`, `targetLanguage`. Custom-terminology name collections are not surfaced.
- **`AwsComprehendSpanDecorator`** (`aws2-comprehend`) — NLP. Tags: `operation`, `languageCode`. Detection results (detected language, sentiment, scores) live on the OUT message and are not visible in `beforeTracingEvent`, so they are not surfaced.
- **`AwsS3VectorsSpanDecorator`** (`aws2-s3-vectors`) — Vector search. Tags: `operation`, `vectorBucketName`, `vectorIndexName`, `vectorId`. Vector embedding data and query vectors (floats), metadata maps, similarity thresholds, distance metrics and response payloads (similarity scores, result counts, index status, bucket ARN) are not surfaced.

All seven decorators extend `AbstractSpanDecorator` (these are producer-only or producer+polling-consumer components without messaging-style ordering semantics) and are registered alphabetically in `META-INF/services/org.apache.camel.telemetry.SpanDecorator`. Unit tests cover header-to-tag extraction for each decorator.

Header constants are mirrored from each component's `*Constants` interface (with a Javadoc reference back to the source), matching the convention used by previous batches and `AzureServiceBusSpanDecorator`. This avoids creating hard dependencies from `camel-telemetry` to the AWS component modules.

### Tag selection rationale

Same two rules applied across batches 3 through 6:

1. **Never emit values that may contain secrets, large payloads or PII** — image bytes, audio bytes, vector embeddings, lexicon content, vocabulary phrases, encrypted vector metadata.
2. **Prefer the request _target_ over the response payload** — `voiceId`, `s3Bucket/s3Object`, `transcriptionJobName`, `vectorIndexName`, `collectionId` etc. Response data (detected sentiment in Comprehend, similarity scores in S3 Vectors, request character counts in Polly) is response-shaped and not visible in `beforeTracingEvent`.

In addition to the two rules above, this batch follows the IAM-principal-minimization principle established in earlier review fixes (KMS `keyId`, CloudTrail `username`, IAM `userName`, EKS `roleArn`): no `userId` from Rekognition collections, no `kmsKeyId` from Rekognition, no `resourceArn` from Transcribe.

### Review-driven adjustments (commit 7e9fdfb)

After review feedback from @davsclaus, one field was dropped from the initial draft:

- `AwsComprehendSpanDecorator` no longer emits `endpointArn`. The Comprehend custom-classifier endpoint ARN embeds the AWS account ID (e.g. `arn:aws:comprehend:us-east-1:123456789012:document-classifier-endpoint/MyEndpoint`), and surfacing account identifiers to observability backends is the same kind of identity disclosure that drove the IAM `userName`, KMS `keyId`, CloudTrail `username` and EKS `roleArn` drops in earlier batches.

## Test plan

- [x] `mvn test` in `components/camel-telemetry` passes (133 tests, including 44 AWS decorator tests covering 36 components total — all AWS coverage on CAMEL-23387)
- [x] Module-specific build (`mvn -DskipTests install`) succeeds
- [x] No code style or formatter changes required

## Coverage on CAMEL-23387 (AWS — complete after this PR)

| Batch | PR | Components |
|---|---|---|
| 1 | #23038 (merged) | SQS, SNS, Kinesis, S3 |
| 2 | #23040 (merged) | DDB, DDB Streams, Lambda, EventBridge, SES, MQ, Kinesis Firehose, Bedrock |
| 3 | #23045 (merged) | Athena, CloudWatch, KMS, MSK, Step Functions, Timestream, Redshift Data, CloudTrail |
| 4 | #23077 (merged) | STS, IAM, Secrets Manager, Parameter Store, Security Hub, Config |
| 5 | #23081 (merged) | EC2, ECS, EKS |
| 6 | this PR | Polly, Rekognition, Textract, Transcribe, Translate, Comprehend, S3 Vectors |

## Follow-ups still pending

- **Google Cloud decorators** mentioned in CAMEL-23387's description — separate scope, separate JIRA. Not in scope for this PR.
- **Note on `aws-xray`**: the original "Compute & Tracing" follow-up listed in earlier PRs mentioned `camel-aws-xray`, but that module was **deprecated and removed** in commit ba9f8c5340a — it was a tracer integration with its own `SegmentDecorator` system, not a producer-style component, and there is nothing to add a `SpanDecorator` for.

After this PR merges the AWS portion of CAMEL-23387 is fully complete and the JIRA can be closed pending the Google Cloud follow-up decision.

---

_Claude Code on behalf of Andrea Cosentino_