### PR TITLE
CAMEL-23132: Update camel-aws2-s3 to use ListObjectsV2 API

### DIFF
--- a/components/camel-aws/camel-aws2-s3/src/main/docs/aws2-s3-component.adoc
+++ b/components/camel-aws/camel-aws2-s3/src/main/docs/aws2-s3-component.adoc
@@ -1219,7 +1219,7 @@ In AWS S3 there are multiple operations you can submit, as an example for List b
 [source,java]
 ------------------------------------------------------------------------------------------------------
 from("direct:aws2-s3")
-     .setBody(ListObjectsRequest.builder().bucket(bucketName).build())
+.setBody(ListObjectsV2Request.builder().bucket(bucketName).build())
      .to("aws2-s3://test?amazonS3Client=#amazonS3Client&operation=listObjects&pojoRequest=true")
 ------------------------------------------------------------------------------------------------------
 

--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Consumer.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Consumer.java
@@ -52,8 +52,8 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest.Builder;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
-import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.utils.IoUtils;
@@ -130,7 +130,7 @@ public class AWS2S3Consumer extends ScheduledBatchPollingConsumer {
         } else {
             LOG.trace("Queueing objects in bucket [{}]...", bucketName);
 
-            ListObjectsRequest.Builder listObjectsRequest = ListObjectsRequest.builder();
+            ListObjectsV2Request.Builder listObjectsRequest = ListObjectsV2Request.builder();
             listObjectsRequest.bucket(bucketName);
             if (ObjectHelper.isNotEmpty(getConfiguration().getPrefix())) {
                 listObjectsRequest.prefix(getConfiguration().getPrefix());
@@ -146,13 +146,13 @@ public class AWS2S3Consumer extends ScheduledBatchPollingConsumer {
             // continue from where we left last time
             if (marker != null) {
                 LOG.trace("Resuming from marker: {}", marker);
-                listObjectsRequest.marker(marker);
+                listObjectsRequest.continuationToken(marker);
             }
 
-            ListObjectsResponse listObjects = getAmazonS3Client().listObjects(listObjectsRequest.build());
+            ListObjectsV2Response listObjects = getAmazonS3Client().listObjectsV2(listObjectsRequest.build());
 
             if (Boolean.TRUE.equals(listObjects.isTruncated())) {
-                String next = listObjects.nextMarker();
+                String next = listObjects.nextContinuationToken();
                 if (next == null && listObjects.hasContents() && ObjectHelper.isEmpty(listObjects.prefix())) {
                     // fallback to use last key from the returned list of objects
                     int size = listObjects.contents().size();
@@ -162,7 +162,7 @@ public class AWS2S3Consumer extends ScheduledBatchPollingConsumer {
                     }
                 }
                 marker = next;
-                LOG.trace("Returned list is truncated, so setting next marker: {}", marker);
+                LOG.trace("Returned list is truncated, so setting next continuation token: {}", marker);
             } else {
                 // no more data so clear marker
                 marker = null;

--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
@@ -690,8 +690,8 @@ public class AWS2S3Producer extends DefaultProducer {
 
         if (getConfiguration().isPojoRequest()) {
             Object payload = exchange.getIn().getMandatoryBody();
-            if (payload instanceof ListObjectsRequest req) {
-                ListObjectsResponse objectList = s3Client.listObjects(req);
+            if (payload instanceof ListObjectsV2Request req) {
+                ListObjectsV2Response objectList = s3Client.listObjectsV2(req);
                 Message message = getMessageForResponse(exchange);
                 message.setBody(objectList.contents());
                 populateHttpResponseCode(objectList, message);
@@ -702,13 +702,13 @@ public class AWS2S3Producer extends DefaultProducer {
             final String prefix
                     = exchange.getIn().getHeader(AWS2S3Constants.PREFIX, getConfiguration().getPrefix(), String.class);
 
-            final ListObjectsRequest listObjectsRequest = ListObjectsRequest
+            final ListObjectsV2Request listObjectsRequest = ListObjectsV2Request
                     .builder()
                     .bucket(bucketName)
                     .delimiter(delimiter)
                     .prefix(prefix)
                     .build();
-            ListObjectsResponse objectList = s3Client.listObjects(listObjectsRequest);
+            ListObjectsV2Response objectList = s3Client.listObjectsV2(listObjectsRequest);
 
             Message message = getMessageForResponse(exchange);
             message.setBody(objectList.contents());

--- a/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/AWS2S3ProducerHttpResponseCodeTest.java
+++ b/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/AWS2S3ProducerHttpResponseCodeTest.java
@@ -34,8 +34,8 @@ import software.amazon.awssdk.services.s3.model.DeleteBucketResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
-import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
-import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -126,8 +126,8 @@ public class AWS2S3ProducerHttpResponseCodeTest {
     @Test
     public void listObjectsShouldSetHttpResponseCode() throws Exception {
         when(configuration.getOperation()).thenReturn(AWS2S3Operations.listObjects);
-        when(s3Client.listObjects(any(ListObjectsRequest.class)))
-                .thenReturn((ListObjectsResponse) ListObjectsResponse.builder()
+        when(s3Client.listObjectsV2(any(ListObjectsV2Request.class)))
+                .thenReturn((ListObjectsV2Response) ListObjectsV2Response.builder()
                         .sdkHttpResponse(httpStatus(200))
                         .build());
 


### PR DESCRIPTION
**_Bob Shell on behalf of oscerd_**

This PR updates the camel-aws2-s3 component to use the ListObjectsV2 API instead of the deprecated ListObjects API.

**Changes:**
- Updated AWS2S3Producer to use ListObjectsV2Request/Response
- Updated AWS2S3Consumer to use ListObjectsV2Request/Response and continuationToken instead of marker
- Updated test mocks to use V2 APIs
- Updated documentation example

**API Changes:**
- ListObjectsRequest → ListObjectsV2Request
- ListObjectsResponse → ListObjectsV2Response
- marker() → continuationToken()
- nextMarker() → nextContinuationToken()
- listObjects() → listObjectsV2()

Fixes: https://issues.apache.org/jira/browse/CAMEL-23132