### PR TITLE
CAMEL-23422: Remove DefaultLaunchScript from camel-repackager-maven-plugin

### DIFF
--- a/tooling/maven/camel-repackager-maven-plugin/src/main/java/org/apache/camel/maven/RepackageMojo.java
+++ b/tooling/maven/camel-repackager-maven-plugin/src/main/java/org/apache/camel/maven/RepackageMojo.java
@@ -29,8 +29,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.springframework.boot.loader.tools.DefaultLaunchScript;
-import org.springframework.boot.loader.tools.LaunchScript;
 import org.springframework.boot.loader.tools.Library;
 import org.springframework.boot.loader.tools.LibraryCallback;
 import org.springframework.boot.loader.tools.LibraryScope;
@@ -95,10 +93,8 @@ public class RepackageMojo extends AbstractMojo {
             repackager.setBackupSource(backupSource);
             repackager.setMainClass(mainClass);
 
-            LaunchScript launchScript = new DefaultLaunchScript(null, null);
-
             File targetFile = getTargetFile();
-            repackager.repackage(targetFile, this::getLibraries, launchScript);
+            repackager.repackage(targetFile, this::getLibraries);
 
             getLog().info("Successfully created self-executing JAR: " + targetFile);
 


### PR DESCRIPTION
## Summary

- Remove `DefaultLaunchScript` from `camel-repackager-maven-plugin`, backporting the fix already on `main` (commit 5ab912dcd05e)
- The launch script prepends a 9KB `#!/bin/bash` header to the repackaged JAR, which breaks `JarInputStream`/`ZipInputStream` — they read sequentially from byte 0 and cannot find the ZIP `PK` signature
- This causes `FatJarPackageScanResourceResolver` to discover 0 entries, making **all** camel-main fatjar exports non-functional (no routes, no classes, no beans are loaded)

## Root Cause

The `camel-repackager-maven-plugin` was introduced in CAMEL-23169 (4.18.1) with a `DefaultLaunchScript` that prepends a bash header so the JAR can be executed directly as `./myjar.jar`. However, Camel Main's `FatJarPackageScanResourceResolver` and `FatJarPackageScanClassResolver` use `JarInputStream` to scan the JAR at startup. `JarInputStream` requires the PK signature at byte 0, so it returns 0 entries from a JAR with a prepended script.