### PR TITLE
CAMEL-23451: skip non-module files in incremental build instead of aborting

### DIFF
--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -512,10 +512,8 @@ main() {
       local projectRoot
       projectRoot=$(findProjectRoot "${project}")
       if [[ ${projectRoot} = "." ]]; then
-        echo "The root project is affected, skipping targeted module testing"
-        echo "<!-- ci-tested-modules -->" > "incremental-test-comment.md"
-        echo ":information_source: CI did not run targeted module tests (root project files changed)." >> "incremental-test-comment.md"
-        exit 0
+        echo "  Skipping non-module file: ${project} (no parent pom.xml found)"
+        continue
       elif [[ ${projectRoot} != "${lastProjectRoot}" ]]; then
         totalAffected=$((totalAffected + 1))
         pl="$pl,${projectRoot}"


### PR DESCRIPTION
[CAMEL-23451](https://issues.apache.org/jira/browse/CAMEL-23451)

Regression from #22247: when the CI rationalization removed the `buildAll` mode, the
`projectRoot == "."` case was changed from "build everything" to `exit 0` (skip all tests).
This means files in directories without a `pom.xml` (e.g. `proposals/*.adoc`, `README.md`)
cause `findProjectRoot` to return `"."`, and the script aborts all test execution — even
when the PR also contains real code changes.

For example, [PR #23002](https://github.com/apache/camel/pull/23002) ran no tests because
it modified `proposals/tracing.adoc`.

**Fix:** Skip non-module files with `continue` instead of aborting. Root-level POM changes
are already handled separately by the grep and Scalpel dependency analysis in Step 2.

## Test plan
- [ ] PR that touches only `proposals/*.adoc` → no modules tested (correct, doc-only)
- [ ] PR that touches `proposals/*.adoc` + component code → component tests run (was broken, now fixed)
- [ ] PR that touches only component code → unchanged behavior