### PR TITLE
CAMEL-23472: camel-jbang-mcp - Deduplicate @ToolArg descriptions

### DIFF
--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/CatalogTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/CatalogTools.java
@@ -52,15 +52,9 @@ public class CatalogTools {
             @ToolArg(description = "Filter components by name (case-insensitive substring match)") String filter,
             @ToolArg(description = "Filter by category label (e.g., cloud, messaging, database, file)") String label,
             @ToolArg(description = "Maximum number of results to return (default: 50)") Integer limit,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Version to query. For Main or Spring Boot: the Camel version (e.g., 4.17.0). "
-                                   + "For quarkus: the Quarkus Platform version (e.g., 3.31.3) as returned by "
-                                   + "camel_version_list quarkusVersion field. "
-                                   + "If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion. For quarkus runtime, all three coordinates "
-                                   + "are used for BOM resolution. For main and spring-boot, the version is extracted "
-                                   + "and used as the catalog version.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.VERSION_QUERY) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         int maxResults = limit != null ? limit : 50;
 
@@ -98,15 +92,9 @@ public class CatalogTools {
                         "endpoint parameters, and usage examples.")
     public ComponentDetailResult camel_catalog_component_doc(
             @ToolArg(description = "Component name (e.g., kafka, http, file, timer)") String component,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Version to query. For Main or Spring Boot: the Camel version (e.g., 4.17.0). "
-                                   + "For quarkus: the Quarkus Platform version (e.g., 3.31.3) as returned by "
-                                   + "camel_version_list quarkusVersion field. "
-                                   + "If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion. For quarkus runtime, all three coordinates "
-                                   + "are used for BOM resolution. For main and spring-boot, the version is extracted "
-                                   + "and used as the catalog version.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.VERSION_QUERY) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         if (component == null || component.isBlank()) {
             throw new ToolCallException("Component name is required", null);
@@ -162,10 +150,9 @@ public class CatalogTools {
     public DataFormatListResult camel_catalog_dataformats(
             @ToolArg(description = "Filter by name") String filter,
             @ToolArg(description = "Maximum results (default: 50)") Integer limit,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Camel version to use (e.g., 4.17.0). If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         int maxResults = limit != null ? limit : 50;
 
@@ -195,10 +182,9 @@ public class CatalogTools {
                         "(e.g., simple, jsonpath, xpath, groovy, jq).")
     public LanguageListResult camel_catalog_languages(
             @ToolArg(description = "Filter by name") String filter,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Camel version to use (e.g., 4.17.0). If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         try {
             CamelCatalog cat = catalogService.loadCatalog(runtime, camelVersion, platformBom);
@@ -225,10 +211,9 @@ public class CatalogTools {
                         + "Maven coordinates, and configuration parameters.")
     public DataFormatDetailResult camel_catalog_dataformat_doc(
             @ToolArg(description = "Data format name (e.g., json-jackson, avro, csv, protobuf, jaxb)") String dataformat,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Camel version to use (e.g., 4.17.0). If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         if (dataformat == null || dataformat.isBlank()) {
             throw new ToolCallException("Data format name is required", null);
@@ -260,10 +245,9 @@ public class CatalogTools {
                         + "Maven coordinates, and configuration parameters.")
     public LanguageDetailResult camel_catalog_language_doc(
             @ToolArg(description = "Language name (e.g., simple, jsonpath, xpath, jq, groovy)") String language,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Camel version to use (e.g., 4.17.0). If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         if (language == null || language.isBlank()) {
             throw new ToolCallException("Language name is required", null);
@@ -295,10 +279,9 @@ public class CatalogTools {
     public EipListResult camel_catalog_eips(
             @ToolArg(description = "Filter by name") String filter,
             @ToolArg(description = "Filter by category (e.g., routing, transformation, error handling)") String label,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Camel version to use (e.g., 4.17.0). If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         try {
             CamelCatalog cat = catalogService.loadCatalog(runtime, camelVersion, platformBom);
@@ -325,10 +308,9 @@ public class CatalogTools {
           description = "Get detailed documentation for a Camel EIP (Enterprise Integration Pattern).")
     public EipDetailResult camel_catalog_eip_doc(
             @ToolArg(description = "EIP name (e.g., split, aggregate, choice, filter)") String eip,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Camel version to use (e.g., 4.17.0). If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         if (eip == null || eip.isBlank()) {
             throw new ToolCallException("EIP name is required", null);

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/ComponentPropertiesTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/ComponentPropertiesTools.java
@@ -52,12 +52,9 @@ public class ComponentPropertiesTools {
                         "component-level defaults via the same prefix in application.properties.")
     public ComponentPropertiesResult camel_component_properties(
             @ToolArg(description = "Component name / scheme (e.g., kafka, http, file, timer)") String component,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Version to query. For Main or Spring Boot: the Camel version (e.g., 4.17.0). "
-                                   + "For quarkus: the Quarkus Platform version. "
-                                   + "If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.VERSION_QUERY) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         if (component == null || component.isBlank()) {
             throw new ToolCallException("Component name is required", null);

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/ConfigurationValidateTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/ConfigurationValidateTools.java
@@ -56,10 +56,9 @@ public class ConfigurationValidateTools {
     public ConfigurationValidateResult camel_configuration_validate(
             @ToolArg(description = "Configuration property lines to validate. Can be a single line "
                                    + "(e.g. \"camel.main.streamCaching=true\") or multiple lines separated by newlines.") String properties,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Camel version to query. If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         if (properties == null || properties.isBlank()) {
             throw new ToolCallException("properties argument is required", null);

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/DependencyCheckTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/DependencyCheckTools.java
@@ -60,10 +60,9 @@ public class DependencyCheckTools {
                                    + "Sensitive content is automatically detected and masked.") String pomContent,
             @ToolArg(description = "Route definitions (YAML, XML, or Java DSL) to check for missing component dependencies. "
                                    + "Multiple routes can be provided concatenated.") String routes,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Camel version to use (e.g., 4.17.0). If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom,
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom,
             @ToolArg(description = "If true (default), automatically sanitize POM content by masking credentials") Boolean sanitizePom) {
 
         if (pomContent == null || pomContent.isBlank()) {

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/DiagnoseTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/DiagnoseTools.java
@@ -78,10 +78,9 @@ public class DiagnoseTools {
                         + "ResolveEndpointFailedException, FailedToCreateRouteException, and more.")
     public DiagnoseResult camel_error_diagnose(
             @ToolArg(description = "The Camel stack trace or error message to diagnose") String error,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Camel version to use (e.g., 4.17.0). If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         if (error == null || error.isBlank()) {
             throw new ToolCallException("Error message or stack trace is required", null);

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/ExplainTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/ExplainTools.java
@@ -52,10 +52,9 @@ public class ExplainTools {
     public RouteContextResult camel_route_context(
             @ToolArg(description = "The Camel route content (YAML, XML, or Java DSL)") String route,
             @ToolArg(description = "Route format: yaml, xml, or java (default: yaml)") String format,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Camel version to use (e.g., 4.17.0). If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         if (route == null || route.isBlank()) {
             throw new ToolCallException("Route content is required", null);

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/HardenTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/HardenTools.java
@@ -54,10 +54,9 @@ public class HardenTools {
     public HardenContextResult camel_route_harden_context(
             @ToolArg(description = "The Camel route content (YAML, XML, or Java DSL)") String route,
             @ToolArg(description = "Route format: yaml, xml, or java (default: yaml)") String format,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Camel version to use (e.g., 4.17.0). If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         if (route == null || route.isBlank()) {
             throw new ToolCallException("Route content is required", null);

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/MigrationTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/MigrationTools.java
@@ -112,7 +112,7 @@ public class MigrationTools {
             @ToolArg(description = "Comma-separated list of Camel component artifactIds") String camelComponents,
             @ToolArg(description = "Current Camel version (e.g., 3.20.0)") String currentVersion,
             @ToolArg(description = "Target Camel version (e.g., 4.18.0)") String targetVersion,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus") String runtime,
+            @ToolArg(description = ToolArgDocs.RUNTIME_REQUIRED) String runtime,
             @ToolArg(description = "Current Java version (e.g., 11, 17, 21)") String javaVersion) {
 
         if (camelComponents == null || camelComponents.isBlank()) {
@@ -210,7 +210,7 @@ public class MigrationTools {
                         + "BEFORE running the OpenRewrite recipes. If the project does not compile, fix the build "
                         + "errors first. OpenRewrite requires a compilable project to parse and transform the code.")
     public MigrationRecipesResult camel_migration_recipes(
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus") String runtime,
+            @ToolArg(description = ToolArgDocs.RUNTIME_REQUIRED) String runtime,
             @ToolArg(description = "Current Camel version (e.g., 4.4.0)") String currentVersion,
             @ToolArg(description = "Target Camel version (e.g., 4.18.0)") String targetVersion,
             @ToolArg(description = "Current Java version (e.g., 11, 17)") String javaVersion,

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/TestScaffoldTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/TestScaffoldTools.java
@@ -82,10 +82,8 @@ public class TestScaffoldTools {
             @ToolArg(description = "The Camel route definition (YAML or XML)") String route,
             @ToolArg(description = "Route format: yaml or xml (default: yaml)") String format,
             @ToolArg(description = "Target runtime: main or spring-boot (default: main)") String runtime,
-            @ToolArg(description = "Camel version to use for catalog lookups (e.g., 4.17.0). "
-                                   + "If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion for catalog lookups.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         if (route == null || route.isBlank()) {
             throw new ToolCallException("Route content is required", null);

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/ToolArgDocs.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/ToolArgDocs.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.mcp;
+
+/**
+ * Shared description literals for {@code @ToolArg} annotations on MCP tools. Centralized to keep the MCP tool schema
+ * payload (sent to clients on every session start) small.
+ */
+final class ToolArgDocs {
+
+    /** Runtime selector with default. */
+    static final String RUNTIME = "Runtime: main | spring-boot | quarkus (default: main)";
+
+    /** Runtime selector without default. */
+    static final String RUNTIME_REQUIRED = "Runtime: main | spring-boot | quarkus";
+
+    /** Camel version for catalog lookups. */
+    static final String CAMEL_VERSION = "Camel version (e.g., 4.17.0); defaults to catalog version.";
+
+    /** Multi-runtime version selector; for quarkus use the Quarkus Platform version. */
+    static final String VERSION_QUERY = "Version: main/spring-boot uses Camel version (e.g., 4.17.0); "
+                                        + "quarkus uses Quarkus Platform version (e.g., 3.31.3) "
+                                        + "from camel_version_list quarkusVersion. Defaults to catalog version.";
+
+    /** Platform BOM override. */
+    static final String PLATFORM_BOM = "Platform BOM GAV (groupId:artifactId:version); overrides camelVersion.";
+
+    private ToolArgDocs() {
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/TransformTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/TransformTools.java
@@ -65,10 +65,9 @@ public class TransformTools {
     public ValidationResult camel_validate_route(
             @ToolArg(description = "Camel endpoint URI to validate (e.g., 'kafka:myTopic?brokers=localhost:9092')") String uri,
             @ToolArg(description = "YAML route definition to validate") String route,
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
-            @ToolArg(description = "Camel version to use (e.g., 4.17.0). If not specified, uses the default catalog version.") String camelVersion,
-            @ToolArg(description = "Platform BOM coordinates in GAV format (groupId:artifactId:version). "
-                                   + "When provided, overrides camelVersion.") String platformBom) {
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
+            @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
+            @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
         if (uri == null && route == null) {
             throw new ToolCallException("Either 'uri' or 'route' is required", null);

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/VersionTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/VersionTools.java
@@ -45,7 +45,7 @@ public class VersionTools {
           description = "List available Camel versions for a specific runtime (main, spring-boot, quarkus). " +
                         "Returns version information including release date, JDK requirements, and LTS status.")
     public VersionListResult camel_version_list(
-            @ToolArg(description = "Runtime type: main, spring-boot, or quarkus (default: main)") String runtime,
+            @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
             @ToolArg(description = "Only show LTS (Long Term Support) releases (default: false)") Boolean lts,
             @ToolArg(description = "Minimum Camel version to include (e.g., 4.0)") String fromVersion,
             @ToolArg(description = "Maximum number of versions to return (default: 10)") Integer limit) {


### PR DESCRIPTION
## Summary

[CAMEL-23472](https://issues.apache.org/jira/browse/CAMEL-23472) — part of the ongoing effort to reduce token consumption of the `camel-jbang-mcp` MCP server.

Several `@ToolArg` descriptions were duplicated verbatim across the 31 MCP tools whose schemas are sent to the client on every session start. The largest duplicate clusters were:

- `Runtime type: main, spring-boot, or quarkus (default: main)` — 18 copies
- `Platform BOM coordinates in GAV format ...` (multi-line) — 16 copies
- `Camel version to use ...` — 12+ copies (with two minor variants)
- `Version to query ...` (multi-line, runtime-aware) — 3 copies

## Changes

- Introduces `ToolArgDocs` with five shared constants: `RUNTIME`, `RUNTIME_REQUIRED`, `CAMEL_VERSION`, `VERSION_QUERY`, `PLATFORM_BOM`.
- Trims each description to the minimum useful payload (e.g. `Runtime: main | spring-boot | quarkus (default: main)`).
- Replaces 50 duplicated `@ToolArg` descriptions across 11 tool classes (CatalogTools, ComponentPropertiesTools, ConfigurationValidateTools, DependencyCheckTools, DiagnoseTools, ExplainTools, HardenTools, MigrationTools, TestScaffoldTools, TransformTools, VersionTools).

No two `@ToolArg` annotations in the module now share the same multi-line description literal.

## Test plan

- [x] `mvn install` from `dsl/camel-jbang/camel-jbang-mcp` — 224 tests pass.
- [x] All `@ToolArg` references in the module verified to resolve against `ToolArgDocs` constants.
- [x] No public API changes.

----

_Claude Code on behalf of Andrea Cosentino_