### PR TITLE
[DO NOT MERGE] Test: build without Java changes (no markers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ backlog
 .claude
 .omc
 .oss-ai-helper-rules
+.rewrite-enabled

--- a/README.md
+++ b/README.md
@@ -106,3 +106,4 @@ The Camel riders!
 
 The terms for software licensing are detailed in the `LICENSE.txt` file,  
 located in the working directory.
+

--- a/etc/scripts/regen.sh
+++ b/etc/scripts/regen.sh
@@ -25,6 +25,24 @@ cd `dirname "$0"`/../..
 git clean -fdx
 rm -Rf **/src/generated/
 
+# Enable OpenRewrite only for modules with changed Java files.
+# Maven's file-activated profile (<exists>.rewrite-enabled</exists>) checks
+# per-module, so OpenRewrite runs only where needed — no -Prewrite flag required.
+# We only need --deepen=1 (depth 1 -> 2) since we compare adjacent commits:
+# for PRs, HEAD~1 is the base branch tip (first parent of the merge commit);
+# for main builds, HEAD~1 is the previous squash-merged commit.
+if ! git rev-parse HEAD~1 >/dev/null 2>&1; then
+  git fetch --deepen=1 --quiet 2>/dev/null || true
+fi
+
+if git rev-parse HEAD~1 >/dev/null 2>&1; then
+  git diff HEAD~1 HEAD --name-only -- '*.java' ':!*/src/generated/*' \
+    | sed 's|/src/.*||' | sort -u \
+    | while read module; do
+        [ -d "$module" ] && touch "$module/.rewrite-enabled"
+      done
+fi
+
 # Regenerate everything
 if ./mvnw --batch-mode -Pregen -DskipTests ${MAVEN_EXTRA_ARGS} install >> build.log 2>&1; then
   echo "✅ mvn -Pregen succeeded."

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4183,6 +4183,11 @@
 
         <profile>
             <id>rewrite</id>
+            <activation>
+                <file>
+                    <exists>.rewrite-enabled</exists>
+                </file>
+            </activation>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,7 @@
                                     ${maven.multiModuleProjectDirectory}/buildingtools/src/main/resources/header.txt
                                 </header>
                                 <excludes>
+                                    <exclude>**/.rewrite-enabled</exclude>
                                     <exclude>release.properties</exclude>
                                     <exclude>**/pom.xml.tag</exclude>
                                     <exclude>**/pom.xml.releaseBackup</exclude>


### PR DESCRIPTION
Test PR — non-Java change only (README). No `.rewrite-enabled` markers should be created, OpenRewrite should not run in any module.

Companion to the "with Java change" test PR. **DO NOT MERGE** — close after comparing build times.