### PR TITLE
Improve mdc.adoc

### DIFF
--- a/components/camel-mdc/src/main/docs/mdc.adoc
+++ b/components/camel-mdc/src/main/docs/mdc.adoc
@@ -70,6 +70,6 @@ The configuration properties for the MDC component are:
 |=======================================================================
 |Option |Default |Description
 |`camel.mdc.enabled`| false | Enable the MDC logging.
-|`camel.mdc.customHeaders` |  | Provide the exchange headers you would like to trace in MDC. Use `*` value as a wildcard to include more exchange headers at once, for example `CAMEL_HTTP_*` or only the `*` to include all available exchange headers.
-|`camel.mdc.customProperties` |  | Provide the exchange properties you would like to trace in MDC. Use `*` value as a wildcard to include more exchange properties at once, for example `property_*` or only the `*` to include all available exchange properties.
+|`camel.mdc.customExchangeHeaders` |  | Provide the exchange headers you would like to trace in MDC. Use `*` value as a wildcard to include more exchange headers at once, for example `CAMEL_HTTP_*` or only the `*` to include all available exchange headers.
+|`camel.mdc.customExchangeProperties` |  | Provide the exchange properties you would like to trace in MDC. Use `*` value as a wildcard to include more exchange properties at once, for example `property_*` or only the `*` to include all available exchange properties.
 |=======================================================================


### PR DESCRIPTION
I was trying to get this running in my Spring Boot application. I noticed that the documentation could be improved.

- update the usage; auto-configuration only works of the camel-mdc-starter is added
- otherwise service must be created and added
- camel.mdc properties names didn't match implementation
