### PR TITLE
CAMEL-23385: Fix watch mode exit and terminal resource leak

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/ActionWatchCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/ActionWatchCommand.java
@@ -41,7 +41,6 @@ abstract class ActionWatchCommand extends ActionBaseCommand {
     @Override
     public Integer doCall() throws Exception {
         int exit;
-        final AtomicBoolean running = new AtomicBoolean(true);
         if (watch) {
             Thread t = new Thread(() -> {
                 waitUserTask = waitForUserEnter();

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteDiagramAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteDiagramAction.java
@@ -129,7 +129,13 @@ public class CamelRouteDiagramAction extends ActionWatchCommand {
             lineReader = LineReaderBuilder.builder().terminal(terminal).build();
         }
 
-        return super.doCall();
+        try {
+            return super.doCall();
+        } finally {
+            if (terminal != null) {
+                terminal.close();
+            }
+        }
     }
 
     @Override
@@ -248,6 +254,7 @@ public class CamelRouteDiagramAction extends ActionWatchCommand {
                     // ignore
                 }
             }
+            running.set(false);
         };
     }
 


### PR DESCRIPTION
[CAMEL-23385](https://issues.apache.org/jira/browse/CAMEL-23385)

Follow-up to #23121 — fixes three bugs introduced in the watch mode implementation:

1. **Shadowed `running` variable prevents watch exit**: `ActionWatchCommand.doCall()` declared a local `AtomicBoolean running` that shadowed the field. The `waitForUserEnter()` method set the *field* to false, but the loop checked the *local* — so pressing Enter could never exit the watch loop.

2. **`CamelRouteDiagramAction.waitForUserEnter()` never signals stop**: The override read a line from `lineReader` but never called `running.set(false)`, so even without the shadowing bug, the loop would continue after the user pressed Enter.

3. **Terminal resource leak**: The terminal opened in `doCall()` was stored as a field but never closed. Wrapped in try/finally to ensure cleanup.