### PR TITLE
CAMEL-23431: Migrate platform-http tests from AvailablePortFinder to port-0 binding

### DIFF
--- a/components/camel-openapi-validator/src/test/java/org/apache/camel/component/rest/openapi/validator/client/OpenApiValidatorIntegrationTest.java
+++ b/components/camel-openapi-validator/src/test/java/org/apache/camel/component/rest/openapi/validator/client/OpenApiValidatorIntegrationTest.java
@@ -21,9 +21,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.platform.http.vertx.VertxPlatformHttpServer;
 import org.apache.camel.component.platform.http.vertx.VertxPlatformHttpServerConfiguration;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
@@ -34,9 +32,6 @@ import static org.hamcrest.Matchers.containsString;
  * validator, providing full OpenAPI schema validation via the Atlassian Swagger Request Validator library.
  */
 public class OpenApiValidatorIntegrationTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
 
     @Test
     public void testValidRequestSucceeds() throws Exception {
@@ -54,7 +49,7 @@ public class OpenApiValidatorIntegrationTest {
             });
             context.start();
 
-            given().port(port.getPort())
+            given().port(server.getPort())
                     .contentType("application/json")
                     .body("{\"name\": \"tiger\", \"photoUrls\": [\"img.jpg\"]}")
                     .when()
@@ -82,7 +77,7 @@ public class OpenApiValidatorIntegrationTest {
             });
             context.start();
 
-            given().port(port.getPort())
+            given().port(server.getPort())
                     .contentType("application/json")
                     .when()
                     .put("/api/v3/pet")
@@ -110,7 +105,7 @@ public class OpenApiValidatorIntegrationTest {
             });
             context.start();
 
-            given().port(port.getPort())
+            given().port(server.getPort())
                     .contentType("application/json")
                     .body("{\"name\": \"tiger\"}")
                     .when()
@@ -139,7 +134,7 @@ public class OpenApiValidatorIntegrationTest {
             });
             context.start();
 
-            given().port(port.getPort())
+            given().port(server.getPort())
                     .when()
                     .get("/api/v3/pet/findByStatus")
                     .then()
@@ -166,7 +161,7 @@ public class OpenApiValidatorIntegrationTest {
             });
             context.start();
 
-            given().port(port.getPort())
+            given().port(server.getPort())
                     .when()
                     .get("/api/v3/pet/findByTags")
                     .then()
@@ -198,7 +193,7 @@ public class OpenApiValidatorIntegrationTest {
 
             // Body missing required "photoUrls" field, but the validation level for
             // schema.required is downgraded to INFO, so the request passes.
-            given().port(port.getPort())
+            given().port(server.getPort())
                     .contentType("application/json")
                     .body("{\"name\": \"tiger\"}")
                     .when()
@@ -210,11 +205,14 @@ public class OpenApiValidatorIntegrationTest {
         }
     }
 
+    private VertxPlatformHttpServer server;
+
     private CamelContext createCamelContext() throws Exception {
         VertxPlatformHttpServerConfiguration conf = new VertxPlatformHttpServerConfiguration();
-        conf.setBindPort(port.getPort());
+        conf.setBindPort(0);
+        server = new VertxPlatformHttpServer(conf);
         CamelContext context = new DefaultCamelContext();
-        context.addService(new VertxPlatformHttpServer(conf));
+        context.addService(server);
         return context;
     }
 }

--- a/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServer.java
+++ b/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServer.java
@@ -131,7 +131,7 @@ public class MainHttpServer extends ServiceSupport implements CamelContextAware,
 
     @ManagedAttribute(description = "HTTP server port number")
     public int getPort() {
-        return configuration.getBindPort();
+        return server != null ? server.getPort() : configuration.getBindPort();
     }
 
     public void setPort(int port) {

--- a/components/camel-platform-http-main/src/test/java/org/apache/camel/component/platform/http/main/MainHttpServerRouteTest.java
+++ b/components/camel-platform-http-main/src/test/java/org/apache/camel/component/platform/http/main/MainHttpServerRouteTest.java
@@ -24,20 +24,16 @@ import java.net.http.HttpResponse;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MainHttpServerRouteTest {
 
-    @RegisterExtension
-    static AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     private static CamelContext camelContext;
+    private static MainHttpServer httpServer;
 
     @BeforeAll
     static void setUp() throws Exception {
@@ -53,8 +49,8 @@ class MainHttpServerRouteTest {
 
         // MainHttpServer needs to get registered/started explicitly
         // https://issues.apache.org/jira/browse/CAMEL-21741
-        MainHttpServer httpServer = new MainHttpServer();
-        httpServer.setPort(port.getPort());
+        httpServer = new MainHttpServer();
+        httpServer.setPort(0);
 
         camelContext.addService(httpServer);
         camelContext.start();
@@ -71,7 +67,7 @@ class MainHttpServerRouteTest {
     public void routeStatusOk() throws Exception {
 
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("http://localhost:" + port.getPort() + "/hello"))
+                .uri(URI.create("http://localhost:" + httpServer.getPort() + "/hello"))
                 .build();
 
         HttpResponse<String> response = HttpClient.newBuilder().build()

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/PlatformHttpRestOpenApiConsumerRestDslBindingTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/PlatformHttpRestOpenApiConsumerRestDslBindingTest.java
@@ -20,21 +20,15 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.platform.http.vertx.model.Pet;
 import org.apache.camel.model.rest.RestBindingMode;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 public class PlatformHttpRestOpenApiConsumerRestDslBindingTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     public void testRestOpenApiOutType() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -56,7 +50,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslBindingTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -72,7 +66,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslBindingTest {
 
     @Test
     public void testRestOpenApiInType() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -92,7 +86,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslBindingTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/PlatformHttpRestOpenApiConsumerRestDslRouteMetricsTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/PlatformHttpRestOpenApiConsumerRestDslRouteMetricsTest.java
@@ -20,10 +20,8 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.api.management.ManagedCamelContext;
 import org.apache.camel.api.management.mbean.ManagedRouteMBean;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -31,13 +29,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class PlatformHttpRestOpenApiConsumerRestDslRouteMetricsTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     public void testRouteMetrics() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -59,7 +53,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslRouteMetricsTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             ManagedRouteMBean mr
                     = context.getCamelContextExtension().getContextPlugin(ManagedCamelContext.class).getManagedRoute("myRest");

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/PlatformHttpRestOpenApiConsumerRestDslTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/PlatformHttpRestOpenApiConsumerRestDslTest.java
@@ -20,10 +20,8 @@ import java.io.FileInputStream;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.util.IOHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -32,13 +30,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PlatformHttpRestOpenApiConsumerRestDslTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     public void testRestOpenApi() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -54,7 +48,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -70,7 +64,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
 
     @Test
     public void testRestOpenApiDevMode() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
         // run in developer mode
         context.getCamelContextExtension().setProfile("dev");
 
@@ -85,7 +79,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -100,7 +94,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
 
     @Test
     public void testRestOpenApiMock() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -113,7 +107,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -136,7 +130,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
 
     @Test
     public void testRestOpenApiMissingOperation() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             assertThrows(Exception.class, () -> {
@@ -150,7 +144,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
                     }
                 });
 
-                context.start();
+                VertxPlatformHttpEngineTest.startCamelContext(context);
             }, "OpenAPI specification has 18 unmapped operations to corresponding routes");
         } finally {
             context.stop();
@@ -159,7 +153,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
 
     @Test
     public void testRestOpenApiNotFound() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -172,7 +166,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -186,7 +180,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
 
     @Test
     public void testRestOpenApiNotAllowed() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -199,7 +193,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -213,7 +207,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
 
     @Test
     public void testRestOpenApiValidate() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -226,7 +220,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when().contentType("application/json")
@@ -240,7 +234,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
 
     @Test
     public void testRestOpenApiMockData() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -250,7 +244,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -270,7 +264,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
 
     @Test
     public void testRestOpenApiContextPath() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -286,7 +280,7 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/PlatformHttpRestOpenApiConsumerTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/PlatformHttpRestOpenApiConsumerTest.java
@@ -19,9 +19,7 @@ package org.apache.camel.component.platform.http.vertx;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -29,13 +27,9 @@ import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PlatformHttpRestOpenApiConsumerTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     public void testRestOpenApi() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -49,7 +43,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             MockEndpoint mock = context.getEndpoint("mock:result", MockEndpoint.class);
             mock.expectedMessageCount(1);
@@ -70,7 +64,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
 
     @Test
     public void testRestOpenApiDevMode() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
         // run in developer mode
         context.getCamelContextExtension().setProfile("dev");
 
@@ -86,7 +80,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -101,7 +95,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
 
     @Test
     public void testRestOpenApiMock() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -115,7 +109,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -138,7 +132,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
 
     @Test
     public void testRestOpenApiMissingOperation() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             assertThrows(Exception.class, () -> {
@@ -153,7 +147,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
                     }
                 });
 
-                context.start();
+                VertxPlatformHttpEngineTest.startCamelContext(context);
             }, "OpenAPI specification has 18 unmapped operations to corresponding routes");
         } finally {
             context.stop();
@@ -162,7 +156,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
 
     @Test
     public void testRestOpenApiNotFound() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -176,7 +170,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -190,7 +184,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
 
     @Test
     public void testRestOpenApiNotAllowed() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -204,7 +198,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -218,7 +212,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
 
     @Test
     public void testRestOpenApiValidate() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -232,7 +226,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -247,7 +241,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
 
     @Test
     public void testRestOpenApiMockData() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -258,7 +252,7 @@ public class PlatformHttpRestOpenApiConsumerTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxClientResponseCodeValidationTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxClientResponseCodeValidationTest.java
@@ -20,21 +20,15 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.RestBindingMode;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 public class VertxClientResponseCodeValidationTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     public void testInvalidResponseCode() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -62,7 +56,7 @@ public class VertxClientResponseCodeValidationTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxInvalidJSonClientRequestValidationTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxInvalidJSonClientRequestValidationTest.java
@@ -19,21 +19,15 @@ package org.apache.camel.component.platform.http.vertx;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.RestBindingMode;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 public class VertxInvalidJSonClientRequestValidationTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     public void testInvalidJSon() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -52,7 +46,7 @@ public class VertxInvalidJSonClientRequestValidationTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxInvalidJSonClientResponseValidationTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxInvalidJSonClientResponseValidationTest.java
@@ -19,21 +19,15 @@ package org.apache.camel.component.platform.http.vertx;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.RestBindingMode;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 public class VertxInvalidJSonClientResponseValidationTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     public void testInvalidJSon() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -52,7 +46,7 @@ public class VertxInvalidJSonClientResponseValidationTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformEventNotifierTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformEventNotifierTest.java
@@ -24,24 +24,18 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spi.CamelEvent;
 import org.apache.camel.support.EventNotifierSupport;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 public class VertxPlatformEventNotifierTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     private final List<String> events = new ArrayList<>();
 
     @Test
     void testEventNotifierOk() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
         context.getManagementStrategy().addEventNotifier(new MyEventListener());
         events.clear();
 
@@ -54,7 +48,7 @@ public class VertxPlatformEventNotifierTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .body("Hello World")
@@ -73,7 +67,7 @@ public class VertxPlatformEventNotifierTest {
 
     @Test
     void testEventNotifierError() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
         context.getManagementStrategy().addEventNotifier(new MyEventListener());
         events.clear();
 
@@ -86,7 +80,7 @@ public class VertxPlatformEventNotifierTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .body("Hello World")

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpBasicTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpBasicTest.java
@@ -18,21 +18,16 @@ package org.apache.camel.component.platform.http.vertx;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 public class VertxPlatformHttpBasicTest {
 
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     void testBasicOk() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -46,7 +41,7 @@ public class VertxPlatformHttpBasicTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .body("Hello World")
@@ -61,7 +56,7 @@ public class VertxPlatformHttpBasicTest {
 
     @Test
     void testBasicError() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -72,7 +67,7 @@ public class VertxPlatformHttpBasicTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .body("Hello World")

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpEngineTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpEngineTest.java
@@ -1352,6 +1352,10 @@ public class VertxPlatformHttpEngineTest {
         return createCamelContext(port.getPort(), customizer);
     }
 
+    static CamelContext createCamelContext() throws Exception {
+        return createCamelContext(0, null);
+    }
+
     static CamelContext createCamelContext(int port) throws Exception {
         return createCamelContext(port, null);
     }
@@ -1360,7 +1364,9 @@ public class VertxPlatformHttpEngineTest {
         VertxPlatformHttpServerConfiguration conf = new VertxPlatformHttpServerConfiguration();
         conf.setBindPort(port);
 
-        RestAssured.port = port;
+        if (port != 0) {
+            RestAssured.port = port;
+        }
 
         if (customizer != null) {
             customizer.customize(conf);
@@ -1369,6 +1375,14 @@ public class VertxPlatformHttpEngineTest {
         CamelContext context = new DefaultCamelContext();
         context.addService(new VertxPlatformHttpServer(conf));
         return context;
+    }
+
+    static void startCamelContext(CamelContext context) throws Exception {
+        context.start();
+        VertxPlatformHttpServer server = context.hasService(VertxPlatformHttpServer.class);
+        if (server != null) {
+            RestAssured.port = server.getPort();
+        }
     }
 
     interface ServerConfigurationCustomizer {

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpEngineWithTypeConverterTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpEngineWithTypeConverterTest.java
@@ -28,21 +28,15 @@ import org.apache.camel.Exchange;
 import org.apache.camel.TypeConversionException;
 import org.apache.camel.TypeConverter;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 public class VertxPlatformHttpEngineWithTypeConverterTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     public void testByteBufferConversion() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         TypeConverter tc = mockByteBufferTypeConverter();
         context.getTypeConverterRegistry().addTypeConverter(ByteBuffer.class, Map.class, tc);
@@ -57,7 +51,7 @@ public class VertxPlatformHttpEngineWithTypeConverterTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()
@@ -72,7 +66,7 @@ public class VertxPlatformHttpEngineWithTypeConverterTest {
 
     @Test
     public void testInputStreamConversion() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         TypeConverter tc = mockInputStreamTypeConverter();
         context.getTypeConverterRegistry().addTypeConverter(InputStream.class, Map.class, tc);
@@ -87,7 +81,7 @@ public class VertxPlatformHttpEngineWithTypeConverterTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpFileResponseTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpFileResponseTest.java
@@ -20,21 +20,15 @@ import java.io.File;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 public class VertxPlatformHttpFileResponseTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     void testFileResponse() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
         final File file = new File("src/test/resources/dummy.txt");
 
         try {
@@ -46,7 +40,7 @@ public class VertxPlatformHttpFileResponseTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             String requestBody = "Give me a file";
             given()
@@ -62,7 +56,7 @@ public class VertxPlatformHttpFileResponseTest {
 
     @Test
     void testFileEndpointResponse() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -73,7 +67,7 @@ public class VertxPlatformHttpFileResponseTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             String requestBody = "Give me a file";
             given()

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpJacksonTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpJacksonTest.java
@@ -19,21 +19,15 @@ package org.apache.camel.component.platform.http.vertx;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jackson.JacksonConstants;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 public class VertxPlatformHttpJacksonTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     public void testJackson() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             // turn on jackson type converter
@@ -48,7 +42,7 @@ public class VertxPlatformHttpJacksonTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .when()

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpLargeMessageStreamingTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpLargeMessageStreamingTest.java
@@ -26,24 +26,18 @@ import java.util.Random;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.util.IOHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @EnabledIfSystemProperty(named = "performance-tests", matches = ".*")
 public class VertxPlatformHttpLargeMessageStreamingTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     void testStreamingWithLargeRequestAndResponseBody() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
         context.getStreamCachingStrategy().setSpoolEnabled(true);
 
         Path input = createLargeFile();
@@ -58,7 +52,7 @@ public class VertxPlatformHttpLargeMessageStreamingTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             InputStream response = given()
                     .body(new FileInputStream(input.toFile()))

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpStreamingTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpStreamingTest.java
@@ -28,10 +28,8 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.util.IOHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.emptyOrNullString;
@@ -39,13 +37,9 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class VertxPlatformHttpStreamingTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     void testStreamingWithStringRequestAndResponseBody() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -56,7 +50,7 @@ public class VertxPlatformHttpStreamingTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             String requestBody = "Vert.x Platform HTTP";
             given()
@@ -72,7 +66,7 @@ public class VertxPlatformHttpStreamingTest {
 
     @Test
     void testStreamingWithFileRequestAndResponseBody() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
         String content = "Hello World";
         Path testFile = Files.createTempFile("platform-http-testing", "txt");
         Files.writeString(testFile, content);
@@ -86,7 +80,7 @@ public class VertxPlatformHttpStreamingTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .body(testFile.toFile())
@@ -102,7 +96,7 @@ public class VertxPlatformHttpStreamingTest {
 
     @Test
     void testPopulateOnlyHeadersWithFormUrlEncodedBody() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
         try {
             context.addRoutes(new RouteBuilder() {
                 @Override
@@ -112,7 +106,7 @@ public class VertxPlatformHttpStreamingTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .contentType(ContentType.URLENC)
@@ -129,7 +123,7 @@ public class VertxPlatformHttpStreamingTest {
 
     @Test
     void testStreamingWithFormUrlEncodedBody() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
         try {
             context.addRoutes(new RouteBuilder() {
                 @Override
@@ -139,7 +133,7 @@ public class VertxPlatformHttpStreamingTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .contentType(ContentType.URLENC)
@@ -159,7 +153,7 @@ public class VertxPlatformHttpStreamingTest {
         Path testFile = Files.createTempFile("platform-http-testing", "txt");
         Files.writeString(testFile, content);
 
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort(), configuration -> {
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(0, configuration -> {
             VertxPlatformHttpServerConfiguration.BodyHandler bodyHandler
                     = new VertxPlatformHttpServerConfiguration.BodyHandler();
             // turn on file uploads
@@ -177,7 +171,7 @@ public class VertxPlatformHttpStreamingTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .multiPart(testFile.toFile())
@@ -192,7 +186,7 @@ public class VertxPlatformHttpStreamingTest {
 
     @Test
     void testStreamingWithSpecificEncoding() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
         Path input = Files.createTempFile("platform-http-input", "dat");
         Path output = Files.createTempFile("platform-http-output", "dat");
 
@@ -208,7 +202,7 @@ public class VertxPlatformHttpStreamingTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             InputStream response = given()
                     .body(new FileInputStream(input.toFile()))
@@ -231,7 +225,7 @@ public class VertxPlatformHttpStreamingTest {
 
     @Test
     void testStreamingWithClosedInputStreamResponse() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
         try {
             context.addRoutes(new RouteBuilder() {
                 @Override
@@ -252,7 +246,7 @@ public class VertxPlatformHttpStreamingTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .get("/streaming")
@@ -265,7 +259,7 @@ public class VertxPlatformHttpStreamingTest {
 
     @Test
     void testStreamingWithUnconvertableResponseType() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
         try {
             context.addRoutes(new RouteBuilder() {
                 @Override
@@ -281,7 +275,7 @@ public class VertxPlatformHttpStreamingTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .get("/streaming")

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformServerRequestValidationTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformServerRequestValidationTest.java
@@ -19,21 +19,15 @@ package org.apache.camel.component.platform.http.vertx;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.platform.http.PlatformHttpComponent;
-import org.apache.camel.test.AvailablePortFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 public class VertxPlatformServerRequestValidationTest {
-
-    @RegisterExtension
-    AvailablePortFinder.Port port = AvailablePortFinder.find();
-
     @Test
     void testServerRequestFalse() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -55,7 +49,7 @@ public class VertxPlatformServerRequestValidationTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .body("<hello>World</hello>")
@@ -80,7 +74,7 @@ public class VertxPlatformServerRequestValidationTest {
 
     @Test
     void testServerRequestTrue() throws Exception {
-        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext(port.getPort());
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
             context.addRoutes(new RouteBuilder() {
@@ -102,7 +96,7 @@ public class VertxPlatformServerRequestValidationTest {
                 }
             });
 
-            context.start();
+            VertxPlatformHttpEngineTest.startCamelContext(context);
 
             given()
                     .body("<hello>World</hello>")


### PR DESCRIPTION
[CAMEL-23431](https://issues.apache.org/jira/browse/CAMEL-23431)

## Summary

- Migrate 18 test files in `camel-platform-http-vertx`, `camel-platform-http-main`, and `camel-openapi-validator` from `AvailablePortFinder` to true port-0 binding
- Fix `MainHttpServer.getPort()` to return actual bound port after start (aligning with `VertxPlatformHttpServer.getPort()` which already returns `server.actualPort()`)
- Add `createCamelContext()` (no-arg) and `startCamelContext(context)` helpers in `VertxPlatformHttpEngineTest` for port-0 tests

## Approach

True port-0 binding: pass 0 to the server, let the OS assign an ephemeral port, then read the actual port back after start. This eliminates TOCTOU race conditions where a reserved port could be taken by another process between reservation and binding.

Only tests where the port is NOT baked into route URIs at definition time are converted. Tests where port appears in `from()/to()/toF()` route URIs are left unchanged.

## Test plan

- [x] `mvn test -pl components/camel-openapi-validator` — 6/6 pass
- [x] `mvn test -pl components/camel-platform-http-main` — 10/10 pass
- [x] `mvn test -pl components/camel-platform-http-vertx` — 114/114 pass