### PR TITLE
chore: replace inline FQCNs with imports in DependencyUpdate

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyUpdate.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyUpdate.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.dsl.jbang.core.commands;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -529,7 +531,7 @@ public class DependencyUpdate extends DependencyList {
             if (removed > 0) {
                 lines = content.split("\n");
                 Document updatedDom = XmlLineNumberParser.parseXml(
-                        new java.io.ByteArrayInputStream(content.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+                        new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
                 int insertLine = findLastCamelDependencyLine(updatedDom);
                 if (insertLine > 0) {
                     content = insertMavenDeps(lines, toAdd, insertLine);


### PR DESCRIPTION
## Summary
- Replace inline fully qualified class names (`java.io.ByteArrayInputStream`, `java.nio.charset.StandardCharsets`) with proper imports in `DependencyUpdate.java`

## Test plan
- [x] Verified the module compiles successfully

_Claude Code on behalf of Guillaume Nodet_