### PR TITLE
CAMEL-23477: camel-jbang-mcp - Stop re-embedding pomContent in migrateProject prompt

### DIFF
--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/PromptDefinitions.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/PromptDefinitions.java
@@ -101,7 +101,9 @@ public class PromptDefinitions {
                           + "get OpenRewrite recipes, search migration guides, "
                           + "and produce a migration summary.")
     public List<PromptMessage> migrateProject(
-            @PromptArg(name = "pomContent", description = "The project's pom.xml file content") String pomContent,
+            @PromptArg(name = "pomContent",
+                       description = "Optional: project's pom.xml content. If omitted, the LLM uses the pom.xml already in its conversation context.",
+                       required = false) String pomContent,
             @PromptArg(name = "targetVersion", description = "Target Camel version to migrate to (e.g., 4.18.0)",
                        required = false) String targetVersion) {
 
@@ -109,54 +111,35 @@ public class PromptDefinitions {
                 ? "Target version: " + targetVersion
                 : "Target version: latest stable (determine from camel_version_list)";
 
-        String instructions = """
-                You are migrating a Camel project to a newer version.
+        String pomNote = pomContent != null && !pomContent.isBlank()
+                ? "A pom.xml has been supplied as the `pomContent` argument to this prompt."
+                : "Use the project's pom.xml from your conversation context.";
 
-                ## %s
+        String instructions
+                = """
+                        You are migrating a Camel project to a newer version.
 
-                ## Project pom.xml
-                ```xml
-                %s
-                ```
+                        %s
+                        %s
 
-                ## Workflow
+                        ## Workflow
 
-                Follow these steps in order:
-
-                ### Step 1: Analyze the project
-                Call `camel_migration_analyze` with the pom.xml content above.
-                This detects the current runtime, Camel version, Java version, and component dependencies.
-
-                ### Step 2: Determine target version
-                If no target version was specified, call `camel_version_list` with the detected runtime \
-                to find the latest stable version. For LTS releases, filter with lts=true.
-
-                ### Step 3: Check compatibility
-                Based on the detected runtime from Step 1:
-                - For **wildfly** or **karaf** runtimes: call `camel_migration_wildfly_karaf` with the pom.xml \
-                content, target runtime, and target version.
-                - For **main**, **spring-boot**, or **quarkus** runtimes: call `camel_migration_compatibility` \
-                with the detected components, current version, target version, runtime, and Java version.
-
-                Review any blockers (e.g., Java version too old) and warnings.
-
-                ### Step 4: Get migration recipes
-                Call `camel_migration_recipes` with the runtime, current version, target version, \
-                Java version, and dryRun=true to get the OpenRewrite Maven commands.
-
-                ### Step 5: Search for breaking changes
-                For each component detected in Step 1, call `camel_migration_guide_search` \
-                with the component name to find relevant breaking changes and rename mappings.
-
-                ### Step 6: Produce migration summary
-                Present a structured summary:
-                - **Current state**: runtime, Camel version, Java version, component count
-                - **Target state**: target version, required Java version
-                - **Blockers**: issues that must be resolved before migration
-                - **Breaking changes**: component renames, API changes found in guides
-                - **Migration commands**: the OpenRewrite commands from Step 4
-                - **Manual steps**: any changes that OpenRewrite cannot automate
-                """.formatted(versionNote, pomContent);
+                        1. **Analyze**: call `camel_migration_analyze` with the pom.xml to detect runtime, \
+                        Camel version, Java version, and component dependencies.
+                        2. **Target version**: if not specified, call `camel_version_list` with the detected runtime \
+                        (use `lts=true` for LTS releases).
+                        3. **Compatibility** (based on detected runtime):
+                           - **wildfly** or **karaf**: call `camel_migration_wildfly_karaf` with the pom, target runtime, and target version.
+                           - **main**, **spring-boot**, or **quarkus**: call `camel_migration_compatibility` \
+                        with components, current/target version, runtime, and Java version.
+                        4. **Recipes**: call `camel_migration_recipes` with runtime, versions, Java version, and `dryRun=true` \
+                        to get the OpenRewrite Maven commands.
+                        5. **Breaking changes**: for each detected component, call `camel_migration_guide_search` \
+                        to find renames and API changes.
+                        6. **Summary**: report current state, target state, blockers, breaking changes, \
+                        migration commands, and manual steps that OpenRewrite cannot automate.
+                        """
+                        .formatted(versionNote, pomNote);
 
         return List.of(PromptMessage.withUserRole(instructions));
     }

--- a/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/PromptDefinitionsTest.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/PromptDefinitionsTest.java
@@ -90,12 +90,40 @@ class PromptDefinitionsTest {
     }
 
     @Test
-    void migrateProjectContainsPomContent() {
-        String pom = "<project><version>3.20.0</version></project>";
-        List<PromptMessage> result = prompts.migrateProject(pom, null);
+    void migrateProjectDoesNotInlinePomContent() {
+        // The prompt must not embed the full pom content; size should not scale with pomContent length.
+        String smallPom = "<project/>";
+        String largePom = "<project>" + "<dependency/>".repeat(1000) + "</project>";
+
+        int smallSize = extractText(prompts.migrateProject(smallPom, "4.18.0")).length();
+        int largeSize = extractText(prompts.migrateProject(largePom, "4.18.0")).length();
+
+        assertThat(largeSize).isEqualTo(smallSize);
+        assertThat(extractText(prompts.migrateProject(largePom, "4.18.0"))).doesNotContain(largePom);
+    }
+
+    @Test
+    void migrateProjectAcknowledgesSuppliedPom() {
+        List<PromptMessage> result = prompts.migrateProject("<project/>", "4.18.0");
 
         String text = extractText(result);
-        assertThat(text).contains(pom);
+        assertThat(text).contains("supplied as the `pomContent` argument");
+    }
+
+    @Test
+    void migrateProjectFallsBackToContextWhenPomOmitted() {
+        List<PromptMessage> result = prompts.migrateProject(null, "4.18.0");
+
+        String text = extractText(result);
+        assertThat(text).contains("conversation context");
+    }
+
+    @Test
+    void migrateProjectBlankPomFallsBackToContext() {
+        List<PromptMessage> result = prompts.migrateProject("  ", "4.18.0");
+
+        String text = extractText(result);
+        assertThat(text).contains("conversation context");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Stops re-embedding the full `pomContent` argument inside the `migrate_project` prompt
instructions. Previously, `PromptDefinitions.migrateProject` inlined the entire pom.xml
inside a multi-paragraph workflow block, so the prompt size grew linearly with pom size —
duplicating content the client typically already has in conversation context. Verbose
"Step 1 … Step 6" descriptions are also compressed into a tight numbered list.

JIRA: [CAMEL-23477](https://issues.apache.org/jira/browse/CAMEL-23477)

## Changes

- `pomContent` is now `required = false` (backward compatible — old clients still send it).
- The prompt no longer interpolates the full pom content; instead it emits a one-line
  acknowledgement of whether a pom was supplied or should be read from conversation context.
- Workflow descriptions compressed from ~6 paragraphs of "Step N: …" into a 6-item numbered
  list, preserving every tool call and decision branch (`camel_migration_analyze`,
  `camel_version_list`, `camel_migration_wildfly_karaf`, `camel_migration_compatibility`,
  `camel_migration_recipes`, `camel_migration_guide_search`).

## Test plan

- [x] Updated `PromptDefinitionsTest`:
  - Replaced `migrateProjectContainsPomContent` (which asserted the pom was inlined).
  - Added `migrateProjectDoesNotInlinePomContent` — supplies a 1000×`<dependency/>` pom and
    asserts the resulting prompt size matches the size produced by a small pom, and that the
    large pom text is not present in the output.
  - Added `migrateProjectAcknowledgesSuppliedPom`, `migrateProjectFallsBackToContextWhenPomOmitted`,
    and `migrateProjectBlankPomFallsBackToContext`.
- [x] `mvn verify` in `dsl/camel-jbang/camel-jbang-mcp` — passes.
- [x] Full reactor build (`mvn clean install -DskipTests`) — passes; no regen artifacts.

## Acceptance

> Prompt size does not scale with `pomContent` length.

Verified by `migrateProjectDoesNotInlinePomContent`.

---
_Claude Code on behalf of Andrea Cosentino_
