### PR TITLE
Fix copy-paste error in camel-dhis2 Dhis2ResourceTables (found by OpenScanHub SAST)

### DIFF
--- a/components/camel-dhis2/camel-dhis2-api/src/main/java/org/apache/camel/component/dhis2/api/Dhis2ResourceTables.java
+++ b/components/camel-dhis2/camel-dhis2-api/src/main/java/org/apache/camel/component/dhis2/api/Dhis2ResourceTables.java
@@ -35,7 +35,7 @@ public class Dhis2ResourceTables {
         if (skipEvents != null) {
             postOperation.withParameter("skipEvents", String.valueOf(skipEvents));
         }
-        if (skipEvents != null) {
+        if (skipAggregate != null) {
             postOperation.withParameter("skipAggregate", String.valueOf(skipAggregate));
         }
         if (lastYears != null) {


### PR DESCRIPTION
## What

Fix a copy-paste error in `Dhis2ResourceTables.analytics()` where `skipEvents != null` was used instead of `skipAggregate != null` when deciding whether to set the `skipAggregate` query parameter.

## Why

The `skipAggregate` parameter is only sent to the DHIS2 API when `skipEvents` is non-null, regardless of whether `skipAggregate` was actually set. This means:
- If `skipEvents` is null but `skipAggregate` is set, the `skipAggregate` parameter is silently dropped
- If `skipEvents` is non-null but `skipAggregate` is null, the parameter is sent with a null value

## Fix

Change the condition on line 38 from `skipEvents != null` to `skipAggregate != null`.

Found via static analysis (Coverity `COPY_PASTE_ERROR` checker).