### PR TITLE
Fix copy-paste error in camel-milo MiloClientConfiguration (found by OpenScanHub SAST)

### DIFF
--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientConfiguration.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientConfiguration.java
@@ -461,7 +461,7 @@ public class MiloClientConfiguration implements Cloneable {
         }
 
         if (configuration.getMaxResponseMessageSize() != null) {
-            builder.setMaxResponseMessageSize(UInteger.valueOf(configuration.getMaxPendingPublishRequests()));
+            builder.setMaxResponseMessageSize(UInteger.valueOf(configuration.getMaxResponseMessageSize()));
         }
 
         if (configuration.getKeyStoreUrl() != null) {


### PR DESCRIPTION
## What

Fix a copy-paste error in `MiloClientConfiguration` where `getMaxPendingPublishRequests()` was called instead of `getMaxResponseMessageSize()` when configuring the OPC UA client's max response message size.

## Why

The OPC UA client's `maxResponseMessageSize` is set to the value of `maxPendingPublishRequests` instead of `maxResponseMessageSize`. This applies the wrong value to the message size limit — for example, if `maxPendingPublishRequests` is 10, the max response size would be set to 10 bytes instead of the intended limit.

## Fix

Change `configuration.getMaxPendingPublishRequests()` to `configuration.getMaxResponseMessageSize()` on line 464.

Found via static analysis (Coverity `COPY_PASTE_ERROR` checker).