### PR TITLE
CAMEL-23461: docs - sync 4.18 upgrade-guide entry to main for camel-aws-bedrock

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -73,6 +73,16 @@ sjms:queue:foo?objectMessageEnabled=true
 sjms2:queue:foo?objectMessageEnabled=true
 ----
 
+=== camel-aws-bedrock
+
+The `applyGuardrail` producer operation now reads the guardrail identifier from a new dedicated header
+`CamelAwsBedrockGuardrailIdentifier` (constant `BedrockConstants.GUARDRAIL_IDENTIFIER`, typed `String`)
+instead of `CamelAwsBedrockGuardrailConfig`. The `CamelAwsBedrockGuardrailConfig` header is typed
+`GuardrailConfiguration` and is reserved for the `converse` and `converseStream` operations; the
+previous code path silently produced `null` whenever a route mixed `converse` and `applyGuardrail`
+calls. If you were not setting the guardrail identifier via header, the endpoint-level
+`guardrailIdentifier` option continues to work without changes.
+
 === camel-hazelcast
 
 Hazelcast instances created and managed by Camel (when no user-supplied


### PR DESCRIPTION
## Doc-sync follow-up for #23161

Adds the `camel-aws-bedrock` upgrade-guide entry to `main`'s
`docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc` to match the entry that
shipped on the `camel-4.18.x` branch via the backport PR #23161 (merged as `e22edbb5`).

### Why

Per the [project's backport upgrade-guide policy](https://github.com/apache/camel/blob/main/CLAUDE.md):

> The `docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_XX.adoc` files for ALL versions
> live on `main` and act as the canonical history across all releases. When a PR is backported to a
> maintenance branch and adds an upgrade-guide note for that release line, the corresponding entry
> must ALSO be added to the matching `camel-4x-upgrade-guide-4_XX.adoc` file on `main` — either as
> part of the backport workflow or in a follow-up doc-sync PR.

Without this sync, `main`'s 4.18 upgrade guide drifts out of sync with what is actually shipping on
the `camel-4.18.x` maintenance branch.

### Original work

- Original fix on `main`: #23151 — `CAMEL-23461: camel-aws-bedrock - applyGuardrail reads guardrail identifier from wrong header`
- Backport to `camel-4.18.x`: #23161 (merged)
- JIRA: https://issues.apache.org/jira/browse/CAMEL-23461

### Change

Docs-only: a single `=== camel-aws-bedrock` section is inserted into the "Upgrading from 4.18.1 to
4.18.3" block, placed before `=== camel-hazelcast` to match the ordering on the `camel-4.18.x`
branch. The wording is identical to the entry shipped on `camel-4.18.x`. No code changes.

---
_Claude Code on behalf of Andrea Cosentino._