### PR TITLE
CAMEL-23495: Replace Thread.sleep() with Awaitility and fix ~30 flaky tests

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeFilesAndDeleteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeFilesAndDeleteTest.java
@@ -56,7 +56,7 @@ public class FileConsumeFilesAndDeleteTest extends ContextTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from(fileUri("?initialDelay=0&delay=10&fileName=" + TEST_FILE_NAME_1 + "&delete=true"))
+                from(fileUri("?initialDelay=0&delay=2000&fileName=" + TEST_FILE_NAME_1 + "&delete=true"))
                         .convertBodyTo(String.class).to("mock:result");
             }
         };

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest.java
@@ -56,7 +56,7 @@ public class MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest extends Con
             @Override
             public void configure() {
                 from(fileUri(
-                        "d1?fileName=d1.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=10"))
+                        "d1?fileName=d1.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=2000"))
                         .to("mock:result");
             }
         });
@@ -78,7 +78,7 @@ public class MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest extends Con
             @Override
             public void configure() {
                 from(fileUri(
-                        "d1?include=.*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=10&recursive=true&minDepth=2&maxDepth=2"))
+                        "d1?include=.*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=2000&recursive=true&minDepth=2&maxDepth=2"))
                         .to("mock:result");
             }
         });
@@ -104,7 +104,7 @@ public class MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest extends Con
             @Override
             public void configure() {
                 from(fileUri(
-                        "d1?include=.*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=10&recursive=true&minDepth=2&maxDepth=4"))
+                        "d1?include=.*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=2000&recursive=true&minDepth=2&maxDepth=4"))
                         .to("mock:result");
             }
         });
@@ -129,7 +129,7 @@ public class MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest extends Con
             @Override
             public void configure() {
                 from(fileUri(
-                        "d1?antInclude=**/*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=10&recursive=true&minDepth=2&maxDepth=4"))
+                        "d1?antInclude=**/*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=2000&recursive=true&minDepth=2&maxDepth=4"))
                         .to("mock:result");
             }
         });
@@ -154,7 +154,7 @@ public class MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest extends Con
             @Override
             public void configure() {
                 from(fileUri(
-                        "d1?include=.*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=10&recursive=true"))
+                        "d1?include=.*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=2000&recursive=true"))
                         .to("mock:result");
             }
         });

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest.java
@@ -56,7 +56,7 @@ public class MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest extends Con
             @Override
             public void configure() {
                 from(fileUri(
-                        "d1?fileName=d1.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=2000"))
+                        "d1?fileName=d1.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=1000&delay=2000"))
                         .to("mock:result");
             }
         });
@@ -78,7 +78,7 @@ public class MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest extends Con
             @Override
             public void configure() {
                 from(fileUri(
-                        "d1?include=.*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=2000&recursive=true&minDepth=2&maxDepth=2"))
+                        "d1?include=.*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=1000&delay=2000&recursive=true&minDepth=2&maxDepth=2"))
                         .to("mock:result");
             }
         });
@@ -104,7 +104,7 @@ public class MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest extends Con
             @Override
             public void configure() {
                 from(fileUri(
-                        "d1?include=.*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=2000&recursive=true&minDepth=2&maxDepth=4"))
+                        "d1?include=.*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=1000&delay=2000&recursive=true&minDepth=2&maxDepth=4"))
                         .to("mock:result");
             }
         });
@@ -129,7 +129,7 @@ public class MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest extends Con
             @Override
             public void configure() {
                 from(fileUri(
-                        "d1?antInclude=**/*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=2000&recursive=true&minDepth=2&maxDepth=4"))
+                        "d1?antInclude=**/*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=1000&delay=2000&recursive=true&minDepth=2&maxDepth=4"))
                         .to("mock:result");
             }
         });
@@ -154,7 +154,7 @@ public class MarkerFileExclusiveReadLockStrategyRecursiveCleanupTest extends Con
             @Override
             public void configure() {
                 from(fileUri(
-                        "d1?include=.*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=0&delay=2000&recursive=true"))
+                        "d1?include=.*.dat&readLock=markerFile&readLockDeleteOrphanLockFiles=true&initialDelay=1000&delay=2000&recursive=true"))
                         .to("mock:result");
             }
         });

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/MarkerFileExclusiveReadLockStrategyUnlockTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/MarkerFileExclusiveReadLockStrategyUnlockTest.java
@@ -58,8 +58,8 @@ public class MarkerFileExclusiveReadLockStrategyUnlockTest extends ContextTestSu
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(fileUri("input-a?fileName=file1.dat&readLock=markerFile&initialDelay=0&delay=10"))
-                        .pollEnrich(fileUri("input-b?fileName=file2.dat&readLock=markerFile&initialDelay=0&delay=10"))
+                from(fileUri("input-a?fileName=file1.dat&readLock=markerFile&initialDelay=0&delay=2000"))
+                        .pollEnrich(fileUri("input-b?fileName=file2.dat&readLock=markerFile&initialDelay=0&delay=2000"))
                         .to("mock:result");
             }
         };

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/strategy/MarkerFileExclusiveReadLockStrategyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/strategy/MarkerFileExclusiveReadLockStrategyTest.java
@@ -104,7 +104,7 @@ public class MarkerFileExclusiveReadLockStrategyTest extends ContextTestSupport 
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(fileUri("in?readLock=markerFile&initialDelay=0&delay=10")).onCompletion()
+                from(fileUri("in?readLock=markerFile&initialDelay=0&delay=2000")).onCompletion()
                         .process(new Processor() {
                             public void process(Exchange exchange) {
                                 numberOfFilesProcessed.addAndGet(1);

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/strategy/MarkerFileExclusiveReadLockStrategyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/strategy/MarkerFileExclusiveReadLockStrategyTest.java
@@ -104,7 +104,7 @@ public class MarkerFileExclusiveReadLockStrategyTest extends ContextTestSupport 
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from(fileUri("in?readLock=markerFile&initialDelay=0&delay=2000")).onCompletion()
+                from(fileUri("in?readLock=markerFile&initialDelay=1000&delay=2000")).onCompletion()
                         .process(new Processor() {
                             public void process(Exchange exchange) {
                                 numberOfFilesProcessed.addAndGet(1);

--- a/core/camel-core/src/test/java/org/apache/camel/component/scheduler/SchedulerMulticastParallelGreedyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/scheduler/SchedulerMulticastParallelGreedyTest.java
@@ -28,9 +28,7 @@ public class SchedulerMulticastParallelGreedyTest extends ContextTestSupport {
     public void testGreedy() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:parentComplete");
         mock.expectedMessageCount(1);
-
-        // give it time to see if too many messages are sent if greedy kicks-in
-        Thread.sleep(50);
+        mock.setAssertPeriod(200);
 
         assertMockEndpointsSatisfied();
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/FileSedaShutdownCompleteAllTasksTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/FileSedaShutdownCompleteAllTasksTest.java
@@ -33,7 +33,7 @@ public class FileSedaShutdownCompleteAllTasksTest extends ContextTestSupport {
 
     @Test
     public void testShutdownCompleteAllTasks() throws Exception {
-        String url = fileUri("?initialDelay=0&delay=10");
+        String url = fileUri("?initialDelay=0&delay=2000");
 
         // prepare 5 files to begin with
         template.sendBodyAndHeader(url, "A", Exchange.FILE_NAME, "a.txt");

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaBlockWhenFullTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaBlockWhenFullTest.java
@@ -91,7 +91,7 @@ public class SedaBlockWhenFullTest extends ContextTestSupport {
     @Test
     public void testAsyncSedaBlockingWhenFull() throws Exception {
         getMockEndpoint(MOCK_URI).setExpectedMessageCount(QUEUE_SIZE + 1);
-        getMockEndpoint(MOCK_URI).setResultWaitTime(DELAY_LONG * 10);
+        getMockEndpoint(MOCK_URI).setResultWaitTime(DELAY_LONG * 3);
 
         SedaEndpoint seda = context.getEndpoint(BLOCK_WHEN_FULL_URI, SedaEndpoint.class);
         assertEquals(QUEUE_SIZE, seda.getQueue().remainingCapacity());

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaBlockWhenFullTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaBlockWhenFullTest.java
@@ -91,14 +91,13 @@ public class SedaBlockWhenFullTest extends ContextTestSupport {
     @Test
     public void testAsyncSedaBlockingWhenFull() throws Exception {
         getMockEndpoint(MOCK_URI).setExpectedMessageCount(QUEUE_SIZE + 1);
-        getMockEndpoint(MOCK_URI).setResultWaitTime(DELAY_LONG * 3);
+        getMockEndpoint(MOCK_URI).setResultWaitTime(DELAY_LONG * 10);
 
         SedaEndpoint seda = context.getEndpoint(BLOCK_WHEN_FULL_URI, SedaEndpoint.class);
         assertEquals(QUEUE_SIZE, seda.getQueue().remainingCapacity());
 
         asyncSendTwoOverCapacity(BLOCK_WHEN_FULL_URI, QUEUE_SIZE + 4);
-        // wait a bit to allow the async processing to complete
-        assertMockEndpointsSatisfied(2, TimeUnit.SECONDS);
+        assertMockEndpointsSatisfied(5, TimeUnit.SECONDS);
     }
 
     /**

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaConsumerSuspendResumeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaConsumerSuspendResumeTest.java
@@ -59,11 +59,14 @@ public class SedaConsumerSuspendResumeTest extends ContextTestSupport {
         // mode where
         // it would poll and route (there is a little slack (up till 1 sec)
         // before suspension is empowered)
-        // wait for queues to empty and consumer to complete its poll cycle
-        await().pollDelay(1, TimeUnit.SECONDS)
-                .atMost(5, TimeUnit.SECONDS)
+        // wait for queues to empty
+        await().atMost(5, TimeUnit.SECONDS)
                 .until(() -> context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty()
                         && context.getEndpoint("seda:bar", SedaEndpoint.class).getQueue().isEmpty());
+        // give consumer thread time to idle after queues empty
+        await().pollDelay(1, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals("Suspended", consumer.getStatus().name()));
 
         template.sendBody("seda:foo", "B");
         // wait a little to ensure seda consumer thread would have tried to poll

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaConsumerSuspendResumeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaConsumerSuspendResumeTest.java
@@ -59,15 +59,11 @@ public class SedaConsumerSuspendResumeTest extends ContextTestSupport {
         // mode where
         // it would poll and route (there is a little slack (up till 1 sec)
         // before suspension is empowered)
-        await().atMost(1, TimeUnit.SECONDS)
+        // wait for queues to empty and consumer to complete its poll cycle
+        await().pollDelay(1, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
                 .until(() -> context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty()
                         && context.getEndpoint("seda:bar", SedaEndpoint.class).getQueue().isEmpty());
-
-        // even though we wait for the queues to empty, there is a race condition where the consumer
-        // may still process messages while it's being suspended due to asynchronous message handling.
-        // as a result, we need to wait a bit longer to ensure that the seda consumer is suspended before
-        // sending the next message.
-        Thread.sleep(1000L);
 
         template.sendBody("seda:foo", "B");
         // wait a little to ensure seda consumer thread would have tried to poll

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextSuspendResumeRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextSuspendResumeRouteTest.java
@@ -49,9 +49,12 @@ public class DefaultCamelContextSuspendResumeRouteTest extends ContextTestSuppor
 
         context.suspend();
 
-        // wait for the seda consumer to complete its current poll cycle and become idle
+        // wait for the context to be fully suspended
         Awaitility.await().atMost(5, TimeUnit.SECONDS)
-                .pollDelay(1, TimeUnit.SECONDS)
+                .until(() -> context.isSuspended());
+        // give seda consumer thread time to complete its current poll cycle
+        Awaitility.await().pollDelay(1, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> Assertions.assertDoesNotThrow(() -> template.sendBody("seda:foo", "B")));
 
         mock.assertIsSatisfied(1000);

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextSuspendResumeRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextSuspendResumeRouteTest.java
@@ -49,15 +49,9 @@ public class DefaultCamelContextSuspendResumeRouteTest extends ContextTestSuppor
 
         context.suspend();
 
-        // even though we wait for the route to suspend, there is a race condition where the consumer
-        // may still process messages while it's being suspended due to asynchronous message handling.
-        // as a result, we need to wait a bit longer to ensure that the seda consumer is suspended before
-        // sending the next message.
-        Thread.sleep(1000L);
-
-        // need to give seda consumer thread time to idle
-        Awaitility.await().atMost(200, TimeUnit.MILLISECONDS)
-                .pollDelay(100, TimeUnit.MILLISECONDS)
+        // wait for the seda consumer to complete its current poll cycle and become idle
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .pollDelay(1, TimeUnit.SECONDS)
                 .untilAsserted(() -> Assertions.assertDoesNotThrow(() -> template.sendBody("seda:foo", "B")));
 
         mock.assertIsSatisfied(1000);

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultExecutorServiceManagerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultExecutorServiceManagerTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -540,12 +541,14 @@ public class DefaultExecutorServiceManagerTest extends ContextTestSupport {
     @Test
     public void testLongShutdownOfThreadPool() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch started = new CountDownLatch(1);
         ExecutorService pool = context.getExecutorServiceManager().newSingleThreadExecutor(this, "Cool");
 
         pool.execute(new Runnable() {
             @Override
             public void run() {
                 log.info("Starting thread");
+                started.countDown();
 
                 // this should take a long time to shutdown
                 try {
@@ -558,8 +561,8 @@ public class DefaultExecutorServiceManagerTest extends ContextTestSupport {
             }
         });
 
-        // sleep a bit before shutting down
-        Thread.sleep(3000);
+        // wait for the task to start before shutting down
+        await().atMost(5, TimeUnit.SECONDS).until(() -> started.getCount() == 0);
 
         context.getExecutorServiceManager().shutdown(pool);
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/RouteSedaSuspendResumeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/RouteSedaSuspendResumeTest.java
@@ -53,9 +53,9 @@ public class RouteSedaSuspendResumeTest extends ContextTestSupport {
             assertEquals("Suspended", statefulService.getStatus().name());
         }
 
-        Thread.sleep(1000L);
-        // need to give seda consumer thread time to idle
-        await().atMost(1, TimeUnit.SECONDS)
+        // need to give seda consumer thread time to idle after suspension
+        await().pollDelay(1, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
                 .until(() -> context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty());
 
         template.sendBody("seda:foo", "B");

--- a/core/camel-core/src/test/java/org/apache/camel/impl/TwoRouteSuspendResumeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/TwoRouteSuspendResumeTest.java
@@ -49,10 +49,13 @@ public class TwoRouteSuspendResumeTest extends ContextTestSupport {
 
         context.getRouteController().suspendRoute("foo");
 
-        // need to give seda consumer thread time to idle after suspension
+        // wait for seda queue to empty
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty());
+        // give consumer thread time to idle after queue empties
         await().pollDelay(1, TimeUnit.SECONDS)
                 .atMost(5, TimeUnit.SECONDS)
-                .until(() -> context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty());
+                .untilAsserted(() -> assertEquals("Suspended", context.getRouteController().getRouteStatus("foo").name()));
 
         template.sendBody("seda:foo", "B");
         template.sendBody("direct:bar", "C");

--- a/core/camel-core/src/test/java/org/apache/camel/impl/TwoRouteSuspendResumeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/TwoRouteSuspendResumeTest.java
@@ -49,16 +49,10 @@ public class TwoRouteSuspendResumeTest extends ContextTestSupport {
 
         context.getRouteController().suspendRoute("foo");
 
-        // need to give seda consumer thread time to idle
-        await().atMost(1, TimeUnit.SECONDS).until(() -> {
-            return context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty();
-        });
-
-        // even though we wait for the queues to empty, there is a race condition where the consumer
-        // may still process messages while it's being suspended due to asynchronous message handling.
-        // as a result, we need to wait a bit longer to ensure that the seda consumer is suspended before
-        // sending the next message.
-        Thread.sleep(1000L);
+        // need to give seda consumer thread time to idle after suspension
+        await().pollDelay(1, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .until(() -> context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty());
 
         template.sendBody("seda:foo", "B");
         template.sendBody("direct:bar", "C");

--- a/core/camel-core/src/test/java/org/apache/camel/issues/ThreadsRejectedExecutionWithDeadLetterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/ThreadsRejectedExecutionWithDeadLetterTest.java
@@ -26,6 +26,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
+
 public class ThreadsRejectedExecutionWithDeadLetterTest extends ContextTestSupport {
 
     @Override
@@ -62,7 +64,9 @@ public class ThreadsRejectedExecutionWithDeadLetterTest extends ContextTestSuppo
         template.sendBody("seda:start", "Hi World"); // will be queued
         template.sendBody("seda:start", "Bye World"); // will be rejected
 
-        Thread.sleep(100);
+        // wait for the rejected message to arrive at dead letter
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> getMockEndpoint("mock:failed").getReceivedCounter() >= 1);
 
         latch.countDown();
         latch.countDown();

--- a/core/camel-core/src/test/java/org/apache/camel/processor/MulticastParallelStreamingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/MulticastParallelStreamingTest.java
@@ -78,7 +78,7 @@ public class MulticastParallelStreamingTest extends ContextTestSupport {
                         // use end to indicate end of multicast route
                         .end().to("mock:result");
 
-                from("direct:a").delay(2000).asyncDelayed().setBody(constant("A"));
+                from("direct:a").delay(2000).syncDelayed().setBody(constant("A"));
 
                 from("direct:b").setBody(constant("B"));
             }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/MulticastParallelStreamingTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/MulticastParallelStreamingTimeoutTest.java
@@ -33,6 +33,7 @@ public class MulticastParallelStreamingTimeoutTest extends ContextTestSupport {
         MockEndpoint mock = getMockEndpoint("mock:result");
         // A will timeout so we only get B and C (C is faster than B)
         mock.expectedBodiesReceived("CB");
+        mock.setResultWaitTime(20000);
 
         template.sendBody("direct:start", "Hello");
 
@@ -54,11 +55,11 @@ public class MulticastParallelStreamingTimeoutTest extends ContextTestSupport {
                         oldExchange.getIn().setBody(body + newExchange.getIn().getBody(String.class));
                         return oldExchange;
                     }
-                }).parallelProcessing().streaming().timeout(5000).to("direct:a", "direct:b", "direct:c")
+                }).parallelProcessing().streaming().timeout(10000).to("direct:a", "direct:b", "direct:c")
                         // use end to indicate end of multicast route
                         .end().to("mock:result");
 
-                from("direct:a").delay(10000).setBody(constant("A"));
+                from("direct:a").delay(20000).setBody(constant("A"));
 
                 from("direct:b").delay(500).setBody(constant("B"));
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/MulticastParallelTimeoutStreamCachingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/MulticastParallelTimeoutStreamCachingTest.java
@@ -67,7 +67,9 @@ public class MulticastParallelTimeoutStreamCachingTest extends ContextTestSuppor
     @Test
     public void testCreateOutputStreamCacheBeforeTimeoutButWriteToOutputStreamCacheAfterTimeout() throws Exception {
         getMockEndpoint("mock:exception").expectedMessageCount(1);
+        getMockEndpoint("mock:exception").setResultWaitTime(15000);
         getMockEndpoint("mock:y").expectedMessageCount(0);
+        getMockEndpoint("mock:y").setAssertPeriod(2000);
 
         template.sendBody("direct:b", "testMessage");
         assertMockEndpointsSatisfied();

--- a/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingDeadLetterChannelTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingDeadLetterChannelTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.processor;
 
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -25,6 +26,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class NotAllowRedeliveryWhileStoppingDeadLetterChannelTest extends ContextTestSupport {
@@ -40,7 +42,10 @@ public class NotAllowRedeliveryWhileStoppingDeadLetterChannelTest extends Contex
 
         assertMockEndpointsSatisfied();
 
-        Thread.sleep(500);
+        // wait for the error handler to start the redelivery cycle
+        await().pollDelay(200, TimeUnit.MILLISECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .until(() -> context.getInflightRepository().size() > 0);
 
         context.getRouteController().stopRoute("foo");
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingDeadLetterChannelTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingDeadLetterChannelTest.java
@@ -43,9 +43,9 @@ public class NotAllowRedeliveryWhileStoppingDeadLetterChannelTest extends Contex
         assertMockEndpointsSatisfied();
 
         // wait for the error handler to start the redelivery cycle
-        await().pollDelay(200, TimeUnit.MILLISECONDS)
-                .atMost(5, TimeUnit.SECONDS)
-                .until(() -> context.getInflightRepository().size() > 0);
+        await().pollDelay(500, TimeUnit.MILLISECONDS)
+                .atMost(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertTrue(context.getInflightRepository().size() > 0));
 
         context.getRouteController().stopRoute("foo");
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingTest.java
@@ -16,12 +16,15 @@
  */
 package org.apache.camel.processor;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NotAllowRedeliveryWhileStoppingTest extends ContextTestSupport {
@@ -37,7 +40,10 @@ public class NotAllowRedeliveryWhileStoppingTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        Thread.sleep(500);
+        // wait for the error handler to start the redelivery cycle
+        await().pollDelay(200, TimeUnit.MILLISECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .until(() -> context.getInflightRepository().size() > 0);
 
         context.stop();
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingTest.java
@@ -41,9 +41,9 @@ public class NotAllowRedeliveryWhileStoppingTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // wait for the error handler to start the redelivery cycle
-        await().pollDelay(200, TimeUnit.MILLISECONDS)
-                .atMost(5, TimeUnit.SECONDS)
-                .until(() -> context.getInflightRepository().size() > 0);
+        await().pollDelay(500, TimeUnit.MILLISECONDS)
+                .atMost(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertTrue(context.getInflightRepository().size() > 0));
 
         context.stop();
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/RecipientListParallelStreamingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/RecipientListParallelStreamingTest.java
@@ -49,8 +49,8 @@ public class RecipientListParallelStreamingTest extends ContextTestSupport {
 
                 from("direct:streaming").recipientList(header("foo")).parallelProcessing().streaming().to("mock:result");
 
-                from("direct:a").delay(100).transform(constant("a"));
-                from("direct:b").delay(500).transform(constant("b"));
+                from("direct:a").delay(100).syncDelayed().transform(constant("a"));
+                from("direct:b").delay(500).syncDelayed().transform(constant("b"));
                 from("direct:c").transform(constant("c"));
             }
         };

--- a/core/camel-core/src/test/java/org/apache/camel/processor/RedeliveryDeadLetterErrorHandlerNoRedeliveryOnShutdownTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/RedeliveryDeadLetterErrorHandlerNoRedeliveryOnShutdownTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.processor;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.ContextTestSupport;
@@ -27,6 +28,7 @@ import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Isolated
@@ -46,8 +48,8 @@ public class RedeliveryDeadLetterErrorHandlerNoRedeliveryOnShutdownTest extends 
 
         // should not take long to stop the route
         StopWatch watch = new StopWatch();
-        // sleep 0.5 seconds to do some redeliveries before we stop
-        Thread.sleep(500);
+        // wait for enough redeliveries before we stop
+        await().atMost(5, TimeUnit.SECONDS).until(() -> counter.get() >= 20);
         log.info("==== stopping route foo ====");
         context.getRouteController().stopRoute("foo");
         long taken = watch.taken();

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ResequenceStreamRejectOldExchangesTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ResequenceStreamRejectOldExchangesTest.java
@@ -16,12 +16,16 @@
  */
 package org.apache.camel.processor;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.processor.resequencer.MessageRejectedException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+
+import static org.awaitility.Awaitility.await;
 
 @DisabledOnOs(value = { OS.LINUX },
               architectures = { "s390x" },
@@ -76,7 +80,9 @@ public class ResequenceStreamRejectOldExchangesTest extends ContextTestSupport {
         template.sendBodyAndHeader("direct:start", "D", "seqno", 4);
         template.sendBodyAndHeader("direct:start", "A", "seqno", 1);
 
-        Thread.sleep(100);
+        // wait for at least one message to be delivered before sending the rest
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> getMockEndpoint("mock:result").getReceivedCounter() >= 1);
 
         template.sendBodyAndHeader("direct:start", "B", "seqno", 2);
         template.sendBodyAndHeader("direct:start", "C", "seqno", 3);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ShutdownCompleteCurrentTaskOnlyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ShutdownCompleteCurrentTaskOnlyTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
               disabledReason = "This test does not run reliably on s390x (see CAMEL-21438)")
 public class ShutdownCompleteCurrentTaskOnlyTest extends ContextTestSupport {
 
-    public static final String FILE_QUERY = "?initialDelay=0&delay=10&synchronous=true";
+    public static final String FILE_QUERY = "?initialDelay=0&delay=2000&synchronous=true";
 
     @Override
     @BeforeEach

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateClosedCorrelationKeyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateClosedCorrelationKeyTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.processor.aggregator;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
@@ -23,6 +25,7 @@ import org.apache.camel.processor.BodyInAggregatingStrategy;
 import org.apache.camel.processor.aggregate.ClosedCorrelationKeyException;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -79,7 +82,9 @@ public class AggregateClosedCorrelationKeyTest extends ContextTestSupport {
         template.sendBodyAndHeader("direct:start", "D", "id", 2);
         template.sendBodyAndHeader("direct:start", "E", "id", 3);
         template.sendBodyAndHeader("direct:start", "F", "id", 3);
-        Thread.sleep(200);
+        // wait for all 3 aggregated results to arrive (keys become closed)
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> getMockEndpoint("mock:result").getReceivedCounter() >= 3);
         // 2 of them should now be closed
         int closed = 0;
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompleteAllOnStopTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompleteAllOnStopTest.java
@@ -58,7 +58,7 @@ public class AggregateCompleteAllOnStopTest extends ContextTestSupport {
                         .to("mock:input")
                         .aggregate(header("id"), new BodyInAggregatingStrategy())
                         .aggregationRepository(new MemoryAggregationRepository())
-                        .completionSize(2).completionTimeout(100).completeAllOnStop().completionTimeoutCheckerInterval(10)
+                        .completionSize(2).completionTimeout(5000).completeAllOnStop().completionTimeoutCheckerInterval(10)
                         .to("mock:aggregated");
             }
         };

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompleteAllOnStopWithIntervalTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompleteAllOnStopWithIntervalTest.java
@@ -16,11 +16,15 @@
  */
 package org.apache.camel.processor.aggregator;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.processor.aggregate.GroupedBodyAggregationStrategy;
 import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
 
 /**
  * This test verifies that completeAllOnStop() properly completes aggregations on shutdown when using
@@ -53,7 +57,7 @@ public class AggregateCompleteAllOnStopWithIntervalTest extends ContextTestSuppo
         // With completeAllOnStop(), we expect the aggregation to be completed
         context.stop();
 
-        mock.assertIsSatisfied();
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(mock::assertIsSatisfied);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompleteAllOnStopWithIntervalTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompleteAllOnStopWithIntervalTest.java
@@ -35,7 +35,7 @@ public class AggregateCompleteAllOnStopWithIntervalTest extends ContextTestSuppo
     @Test
     public void testCompleteAllOnStopWithCompletionIntervalOnly() throws Exception {
         // Set shutdown timeout to 5x the completion interval (1 second)
-        context.getShutdownStrategy().setTimeout(5);
+        context.getShutdownStrategy().setTimeout(10);
 
         MockEndpoint mock = getMockEndpoint("mock:aggregated");
         // We expect the incomplete aggregation to be completed on shutdown
@@ -57,7 +57,7 @@ public class AggregateCompleteAllOnStopWithIntervalTest extends ContextTestSuppo
         // With completeAllOnStop(), we expect the aggregation to be completed
         context.stop();
 
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(mock::assertIsSatisfied);
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(mock::assertIsSatisfied);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompleteAllOnStopWithIntervalTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompleteAllOnStopWithIntervalTest.java
@@ -16,15 +16,11 @@
  */
 package org.apache.camel.processor.aggregator;
 
-import java.util.concurrent.TimeUnit;
-
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.processor.aggregate.GroupedBodyAggregationStrategy;
 import org.junit.jupiter.api.Test;
-
-import static org.awaitility.Awaitility.await;
 
 /**
  * This test verifies that completeAllOnStop() properly completes aggregations on shutdown when using
@@ -35,7 +31,7 @@ public class AggregateCompleteAllOnStopWithIntervalTest extends ContextTestSuppo
     @Test
     public void testCompleteAllOnStopWithCompletionIntervalOnly() throws Exception {
         // Set shutdown timeout to 5x the completion interval (1 second)
-        context.getShutdownStrategy().setTimeout(10);
+        context.getShutdownStrategy().setTimeout(5);
 
         MockEndpoint mock = getMockEndpoint("mock:aggregated");
         // We expect the incomplete aggregation to be completed on shutdown
@@ -57,7 +53,7 @@ public class AggregateCompleteAllOnStopWithIntervalTest extends ContextTestSuppo
         // With completeAllOnStop(), we expect the aggregation to be completed
         context.stop();
 
-        await().atMost(10, TimeUnit.SECONDS).untilAsserted(mock::assertIsSatisfied);
+        mock.assertIsSatisfied();
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateDiscardOnTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateDiscardOnTimeoutTest.java
@@ -36,9 +36,8 @@ public class AggregateDiscardOnTimeoutTest extends ContextTestSupport {
         template.sendBodyAndHeader("direct:start", "A", "id", 123);
         template.sendBodyAndHeader("direct:start", "B", "id", 123);
 
-        // wait 0.25 seconds
-        Thread.sleep(250);
-
+        // verify no aggregated message arrives (discarded on timeout)
+        mock.setAssertPeriod(500);
         mock.assertIsSatisfied();
 
         // now send 3 which does not timeout

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateForceCompletionOnStopParallelTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateForceCompletionOnStopParallelTest.java
@@ -16,13 +16,63 @@
  */
 package org.apache.camel.processor.aggregator;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.processor.BodyInAggregatingStrategy;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisabledOnOs(architectures = { "s390x" },
               disabledReason = "This test does not run reliably on s390x (see CAMEL-21438)")
 public class AggregateForceCompletionOnStopParallelTest extends AggregateForceCompletionOnStopTest {
+
+    @Override
+    @Test
+    public void testForceCompletionTrue() {
+        MyCompletionProcessor myCompletionProcessor
+                = context.getRegistry().lookupByNameAndType("myCompletionProcessor", MyCompletionProcessor.class);
+        myCompletionProcessor.reset();
+
+        context.getShutdownStrategy().setShutdownNowOnTimeout(true);
+        context.getShutdownStrategy().setTimeout(5);
+
+        template.sendBodyAndHeader("direct:forceCompletionTrue", "test1", "id", "1");
+        template.sendBodyAndHeader("direct:forceCompletionTrue", "test2", "id", "2");
+        template.sendBodyAndHeader("direct:forceCompletionTrue", "test3", "id", "1");
+        template.sendBodyAndHeader("direct:forceCompletionTrue", "test4", "id", "2");
+
+        assertEquals(0, myCompletionProcessor.getAggregationCount(), "aggregation should not have completed yet");
+        context.stop();
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals(2, myCompletionProcessor.getAggregationCount(),
+                        "aggregation should have completed"));
+    }
+
+    @Override
+    @Test
+    public void testStopRouteForceCompletionTrue() throws Exception {
+        MyCompletionProcessor myCompletionProcessor
+                = context.getRegistry().lookupByNameAndType("myCompletionProcessor", MyCompletionProcessor.class);
+        myCompletionProcessor.reset();
+
+        context.getShutdownStrategy().setShutdownNowOnTimeout(true);
+        context.getShutdownStrategy().setTimeout(5);
+
+        template.sendBodyAndHeader("direct:forceCompletionTrue", "test1", "id", "1");
+        template.sendBodyAndHeader("direct:forceCompletionTrue", "test2", "id", "2");
+        template.sendBodyAndHeader("direct:forceCompletionTrue", "test3", "id", "1");
+        template.sendBodyAndHeader("direct:forceCompletionTrue", "test4", "id", "2");
+
+        assertEquals(0, myCompletionProcessor.getAggregationCount(), "aggregation should not have completed yet");
+        context.getRouteController().stopRoute("foo");
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals(2, myCompletionProcessor.getAggregationCount(),
+                        "aggregation should have completed"));
+    }
 
     @Override
     protected RouteBuilder createRouteBuilder() {

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeBatchSizeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeBatchSizeTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.processor.aggregator;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -25,6 +26,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.processor.aggregate.GroupedExchangeAggregationStrategy;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -58,8 +60,10 @@ public class AggregateGroupedExchangeBatchSizeTest extends ContextTestSupport {
         assertEquals("100", grouped.get(0).getIn().getBody(String.class));
         assertEquals("150", grouped.get(1).getIn().getBody(String.class));
 
-        // wait a bit for the remainder to come in
-        Thread.sleep(1000);
+        // wait for the remainder to come in via completion timeout
+        await().atMost(5, TimeUnit.SECONDS)
+                .pollDelay(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertTrue(result.getReceivedCounter() >= 1));
 
         if (result.getReceivedCounter() == 2) {
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/async/AsyncEndpointRedeliveryErrorHandlerNonBlockedDelay2Test.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/async/AsyncEndpointRedeliveryErrorHandlerNonBlockedDelay2Test.java
@@ -23,6 +23,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,9 +38,16 @@ public class AsyncEndpointRedeliveryErrorHandlerNonBlockedDelay2Test extends Con
     private static String beforeThreadName;
     private static String afterThreadName;
 
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        attempt.reset();
+    }
+
     @Test
     public void testRedelivery() throws Exception {
-        MockEndpoint before = getMockEndpoint("mock:result");
+        MockEndpoint before = getMockEndpoint("mock:before");
         before.expectedBodiesReceived("World");
 
         MockEndpoint result = getMockEndpoint("mock:result");

--- a/core/camel-core/src/test/java/org/apache/camel/processor/onexception/ContextScopedOnExceptionLoadBalancerStopRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/onexception/ContextScopedOnExceptionLoadBalancerStopRouteTest.java
@@ -57,6 +57,7 @@ public class ContextScopedOnExceptionLoadBalancerStopRouteTest extends ContextTe
     @Test
     public void testErrorOk() throws Exception {
         getMockEndpoint("mock:error").expectedBodiesReceived("Kaboom");
+        getMockEndpoint("mock:error").setResultWaitTime(5000);
         getMockEndpoint("mock:start").expectedBodiesReceived("Kaboom", "World");
         getMockEndpoint("mock:result").expectedBodiesReceived("Bye World");
         getMockEndpoint("mock:exception").expectedBodiesReceived("Kaboom");

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedInflightStatisticsTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedInflightStatisticsTest.java
@@ -70,7 +70,11 @@ public class ManagedInflightStatisticsTest extends ManagementTestSupport {
 
         // start some exchanges.
         template.asyncSendBody("direct:start", latch1);
-        Thread.sleep(250);
+        // wait for first exchange to be inflight before sending the second
+        await().atMost(5, TimeUnit.SECONDS).until(() -> {
+            Long num = (Long) mbeanServer.getAttribute(on, "ExchangesInflight");
+            return num != null && num == 1;
+        });
         template.asyncSendBody("direct:start", latch2);
 
         await().atMost(2, TimeUnit.SECONDS).until(() -> {
@@ -91,8 +95,11 @@ public class ManagedInflightStatisticsTest extends ManagementTestSupport {
         // complete first exchange
         latch1.countDown();
 
-        // Lets wait for the first exchange to complete.
-        Thread.sleep(200);
+        // wait for the first exchange to complete (inflight drops to 1)
+        await().atMost(5, TimeUnit.SECONDS).until(() -> {
+            Long num = (Long) mbeanServer.getAttribute(on, "ExchangesInflight");
+            return num != null && num == 1;
+        });
         Long ts2 = (Long) mbeanServer.getAttribute(on, "OldestInflightDuration");
         assertNotNull(ts2);
         String id2 = (String) mbeanServer.getAttribute(on, "OldestInflightExchangeId");

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedInflightStatisticsTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedInflightStatisticsTest.java
@@ -95,10 +95,13 @@ public class ManagedInflightStatisticsTest extends ManagementTestSupport {
         // complete first exchange
         latch1.countDown();
 
-        // wait for the first exchange to complete (inflight drops to 1)
-        await().atMost(5, TimeUnit.SECONDS).until(() -> {
-            Long num = (Long) mbeanServer.getAttribute(on, "ExchangesInflight");
-            return num != null && num == 1;
+        // wait for the first exchange to complete and the oldest to change
+        final Long tsSnapshot = ts;
+        final String idSnapshot = id;
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(Long.valueOf(1), (Long) mbeanServer.getAttribute(on, "ExchangesInflight"));
+            assertNotEquals(idSnapshot, (String) mbeanServer.getAttribute(on, "OldestInflightExchangeId"));
+            assertNotEquals(tsSnapshot, (Long) mbeanServer.getAttribute(on, "OldestInflightDuration"));
         });
         Long ts2 = (Long) mbeanServer.getAttribute(on, "OldestInflightDuration");
         assertNotNull(ts2);
@@ -106,11 +109,6 @@ public class ManagedInflightStatisticsTest extends ManagementTestSupport {
         assertNotNull(id2);
 
         log.info("Oldest Exchange id: {}, duration: {}", id2, ts2);
-
-        // Lets verify the oldest changed.
-        assertNotEquals(id, id2);
-        // The duration values could be different
-        assertNotEquals(ts, ts2);
 
         latch2.countDown();
 


### PR DESCRIPTION
[CAMEL-23495](https://issues.apache.org/jira/browse/CAMEL-23495)

## Summary

Fix ~30 flaky tests across `camel-core` and `camel-management` by replacing `Thread.sleep()` with Awaitility, increasing tight timeouts, fixing race conditions, and fixing bugs. Changes span 32 test files.

## Root causes addressed

| Category | Tests | Fix |
|---|---|---|
| **Thread.sleep() for synchronization** | Suspend/resume tests, management tests, executor tests, redelivery tests (~15 files) | Replace with `await().atMost().until()` or `untilAsserted()` |
| **Tight timeouts under CI load** | Seda, multicast, file consumer, aggregator tests (~10 files) | Increase `resultWaitTime`, assertion timeouts, poll delays |
| **Race conditions** | `AggregateForceCompletionOnStopParallelTest` | Awaitility after async `context.stop()` / `stopRoute()` |
| **File consumer partial reads** | `MarkerFileExclusiveReadLockStrategy*` tests | Increase `initialDelay` from 0 to 1000ms to prevent reading during writes |
| **Bugs** | `AsyncEndpointRedeliveryErrorHandlerNonBlockedDelay2Test` | Reset static counter; fix `mock:result` → `mock:before` copy-paste bug |
| **Deterministic ordering** | `MulticastParallelStreamingTest`, `RecipientListParallelStreamingTest` | Use `syncDelayed()` instead of `asyncDelayed()` |

## Verification

All 30 modified test classes were run in a **100-iteration loop** to verify stability:

- **camel-core (29 tests):** **0 failures out of 100 iterations**
- **camel-management (1 test):** **0 failures out of 100 iterations**

Note: `AggregateCompleteAllOnStopWithIntervalTest` was reverted to its original state — it has a real bug where `completeAllOnStop()` with `completionInterval()` never completes aggregations during shutdown. Tracked as [CAMEL-23513](https://issues.apache.org/jira/browse/CAMEL-23513).

_Claude Code on behalf of Guillaume Nodet_