### PR TITLE
CAMEL-23495: Replace Thread.sleep() with Awaitility in camel-core and camel-management tests

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/scheduler/SchedulerMulticastParallelGreedyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/scheduler/SchedulerMulticastParallelGreedyTest.java
@@ -28,9 +28,7 @@ public class SchedulerMulticastParallelGreedyTest extends ContextTestSupport {
     public void testGreedy() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:parentComplete");
         mock.expectedMessageCount(1);
-
-        // give it time to see if too many messages are sent if greedy kicks-in
-        Thread.sleep(50);
+        mock.setAssertPeriod(200);
 
         assertMockEndpointsSatisfied();
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaConsumerSuspendResumeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaConsumerSuspendResumeTest.java
@@ -59,11 +59,14 @@ public class SedaConsumerSuspendResumeTest extends ContextTestSupport {
         // mode where
         // it would poll and route (there is a little slack (up till 1 sec)
         // before suspension is empowered)
-        // wait for queues to empty and consumer to complete its poll cycle
-        await().pollDelay(1, TimeUnit.SECONDS)
-                .atMost(5, TimeUnit.SECONDS)
+        // wait for queues to empty
+        await().atMost(5, TimeUnit.SECONDS)
                 .until(() -> context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty()
                         && context.getEndpoint("seda:bar", SedaEndpoint.class).getQueue().isEmpty());
+        // give consumer thread time to idle after queues empty
+        await().pollDelay(1, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals("Suspended", consumer.getStatus().name()));
 
         template.sendBody("seda:foo", "B");
         // wait a little to ensure seda consumer thread would have tried to poll

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaConsumerSuspendResumeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaConsumerSuspendResumeTest.java
@@ -59,15 +59,11 @@ public class SedaConsumerSuspendResumeTest extends ContextTestSupport {
         // mode where
         // it would poll and route (there is a little slack (up till 1 sec)
         // before suspension is empowered)
-        await().atMost(1, TimeUnit.SECONDS)
+        // wait for queues to empty and consumer to complete its poll cycle
+        await().pollDelay(1, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
                 .until(() -> context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty()
                         && context.getEndpoint("seda:bar", SedaEndpoint.class).getQueue().isEmpty());
-
-        // even though we wait for the queues to empty, there is a race condition where the consumer
-        // may still process messages while it's being suspended due to asynchronous message handling.
-        // as a result, we need to wait a bit longer to ensure that the seda consumer is suspended before
-        // sending the next message.
-        Thread.sleep(1000L);
 
         template.sendBody("seda:foo", "B");
         // wait a little to ensure seda consumer thread would have tried to poll

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextSuspendResumeRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextSuspendResumeRouteTest.java
@@ -49,9 +49,12 @@ public class DefaultCamelContextSuspendResumeRouteTest extends ContextTestSuppor
 
         context.suspend();
 
-        // wait for the seda consumer to complete its current poll cycle and become idle
+        // wait for the context to be fully suspended
         Awaitility.await().atMost(5, TimeUnit.SECONDS)
-                .pollDelay(1, TimeUnit.SECONDS)
+                .until(() -> context.isSuspended());
+        // give seda consumer thread time to complete its current poll cycle
+        Awaitility.await().pollDelay(1, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> Assertions.assertDoesNotThrow(() -> template.sendBody("seda:foo", "B")));
 
         mock.assertIsSatisfied(1000);

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextSuspendResumeRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextSuspendResumeRouteTest.java
@@ -49,15 +49,9 @@ public class DefaultCamelContextSuspendResumeRouteTest extends ContextTestSuppor
 
         context.suspend();
 
-        // even though we wait for the route to suspend, there is a race condition where the consumer
-        // may still process messages while it's being suspended due to asynchronous message handling.
-        // as a result, we need to wait a bit longer to ensure that the seda consumer is suspended before
-        // sending the next message.
-        Thread.sleep(1000L);
-
-        // need to give seda consumer thread time to idle
-        Awaitility.await().atMost(200, TimeUnit.MILLISECONDS)
-                .pollDelay(100, TimeUnit.MILLISECONDS)
+        // wait for the seda consumer to complete its current poll cycle and become idle
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .pollDelay(1, TimeUnit.SECONDS)
                 .untilAsserted(() -> Assertions.assertDoesNotThrow(() -> template.sendBody("seda:foo", "B")));
 
         mock.assertIsSatisfied(1000);

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultExecutorServiceManagerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultExecutorServiceManagerTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -540,12 +541,14 @@ public class DefaultExecutorServiceManagerTest extends ContextTestSupport {
     @Test
     public void testLongShutdownOfThreadPool() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch started = new CountDownLatch(1);
         ExecutorService pool = context.getExecutorServiceManager().newSingleThreadExecutor(this, "Cool");
 
         pool.execute(new Runnable() {
             @Override
             public void run() {
                 log.info("Starting thread");
+                started.countDown();
 
                 // this should take a long time to shutdown
                 try {
@@ -558,8 +561,8 @@ public class DefaultExecutorServiceManagerTest extends ContextTestSupport {
             }
         });
 
-        // sleep a bit before shutting down
-        Thread.sleep(3000);
+        // wait for the task to start before shutting down
+        await().atMost(5, TimeUnit.SECONDS).until(() -> started.getCount() == 0);
 
         context.getExecutorServiceManager().shutdown(pool);
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/RouteSedaSuspendResumeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/RouteSedaSuspendResumeTest.java
@@ -53,9 +53,9 @@ public class RouteSedaSuspendResumeTest extends ContextTestSupport {
             assertEquals("Suspended", statefulService.getStatus().name());
         }
 
-        Thread.sleep(1000L);
-        // need to give seda consumer thread time to idle
-        await().atMost(1, TimeUnit.SECONDS)
+        // need to give seda consumer thread time to idle after suspension
+        await().pollDelay(1, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
                 .until(() -> context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty());
 
         template.sendBody("seda:foo", "B");

--- a/core/camel-core/src/test/java/org/apache/camel/impl/TwoRouteSuspendResumeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/TwoRouteSuspendResumeTest.java
@@ -49,10 +49,13 @@ public class TwoRouteSuspendResumeTest extends ContextTestSupport {
 
         context.getRouteController().suspendRoute("foo");
 
-        // need to give seda consumer thread time to idle after suspension
+        // wait for seda queue to empty
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty());
+        // give consumer thread time to idle after queue empties
         await().pollDelay(1, TimeUnit.SECONDS)
                 .atMost(5, TimeUnit.SECONDS)
-                .until(() -> context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty());
+                .untilAsserted(() -> assertEquals("Suspended", context.getRouteController().getRouteStatus("foo").name()));
 
         template.sendBody("seda:foo", "B");
         template.sendBody("direct:bar", "C");

--- a/core/camel-core/src/test/java/org/apache/camel/impl/TwoRouteSuspendResumeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/TwoRouteSuspendResumeTest.java
@@ -49,16 +49,10 @@ public class TwoRouteSuspendResumeTest extends ContextTestSupport {
 
         context.getRouteController().suspendRoute("foo");
 
-        // need to give seda consumer thread time to idle
-        await().atMost(1, TimeUnit.SECONDS).until(() -> {
-            return context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty();
-        });
-
-        // even though we wait for the queues to empty, there is a race condition where the consumer
-        // may still process messages while it's being suspended due to asynchronous message handling.
-        // as a result, we need to wait a bit longer to ensure that the seda consumer is suspended before
-        // sending the next message.
-        Thread.sleep(1000L);
+        // need to give seda consumer thread time to idle after suspension
+        await().pollDelay(1, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .until(() -> context.getEndpoint("seda:foo", SedaEndpoint.class).getQueue().isEmpty());
 
         template.sendBody("seda:foo", "B");
         template.sendBody("direct:bar", "C");

--- a/core/camel-core/src/test/java/org/apache/camel/issues/ThreadsRejectedExecutionWithDeadLetterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/ThreadsRejectedExecutionWithDeadLetterTest.java
@@ -26,6 +26,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
+
 public class ThreadsRejectedExecutionWithDeadLetterTest extends ContextTestSupport {
 
     @Override
@@ -62,7 +64,9 @@ public class ThreadsRejectedExecutionWithDeadLetterTest extends ContextTestSuppo
         template.sendBody("seda:start", "Hi World"); // will be queued
         template.sendBody("seda:start", "Bye World"); // will be rejected
 
-        Thread.sleep(100);
+        // wait for the rejected message to arrive at dead letter
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> getMockEndpoint("mock:failed").getReceivedCounter() >= 1);
 
         latch.countDown();
         latch.countDown();

--- a/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingDeadLetterChannelTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingDeadLetterChannelTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.processor;
 
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -25,6 +26,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class NotAllowRedeliveryWhileStoppingDeadLetterChannelTest extends ContextTestSupport {
@@ -40,7 +42,10 @@ public class NotAllowRedeliveryWhileStoppingDeadLetterChannelTest extends Contex
 
         assertMockEndpointsSatisfied();
 
-        Thread.sleep(500);
+        // wait for the error handler to start the redelivery cycle
+        await().pollDelay(200, TimeUnit.MILLISECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .until(() -> context.getInflightRepository().size() > 0);
 
         context.getRouteController().stopRoute("foo");
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingDeadLetterChannelTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingDeadLetterChannelTest.java
@@ -43,9 +43,9 @@ public class NotAllowRedeliveryWhileStoppingDeadLetterChannelTest extends Contex
         assertMockEndpointsSatisfied();
 
         // wait for the error handler to start the redelivery cycle
-        await().pollDelay(200, TimeUnit.MILLISECONDS)
-                .atMost(5, TimeUnit.SECONDS)
-                .until(() -> context.getInflightRepository().size() > 0);
+        await().pollDelay(500, TimeUnit.MILLISECONDS)
+                .atMost(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertTrue(context.getInflightRepository().size() > 0));
 
         context.getRouteController().stopRoute("foo");
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingTest.java
@@ -16,12 +16,15 @@
  */
 package org.apache.camel.processor;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NotAllowRedeliveryWhileStoppingTest extends ContextTestSupport {
@@ -37,7 +40,10 @@ public class NotAllowRedeliveryWhileStoppingTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        Thread.sleep(500);
+        // wait for the error handler to start the redelivery cycle
+        await().pollDelay(200, TimeUnit.MILLISECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .until(() -> context.getInflightRepository().size() > 0);
 
         context.stop();
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingTest.java
@@ -41,9 +41,9 @@ public class NotAllowRedeliveryWhileStoppingTest extends ContextTestSupport {
         assertMockEndpointsSatisfied();
 
         // wait for the error handler to start the redelivery cycle
-        await().pollDelay(200, TimeUnit.MILLISECONDS)
-                .atMost(5, TimeUnit.SECONDS)
-                .until(() -> context.getInflightRepository().size() > 0);
+        await().pollDelay(500, TimeUnit.MILLISECONDS)
+                .atMost(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertTrue(context.getInflightRepository().size() > 0));
 
         context.stop();
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/RedeliveryDeadLetterErrorHandlerNoRedeliveryOnShutdownTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/RedeliveryDeadLetterErrorHandlerNoRedeliveryOnShutdownTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.processor;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.ContextTestSupport;
@@ -27,6 +28,7 @@ import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Isolated
@@ -46,8 +48,8 @@ public class RedeliveryDeadLetterErrorHandlerNoRedeliveryOnShutdownTest extends 
 
         // should not take long to stop the route
         StopWatch watch = new StopWatch();
-        // sleep 0.5 seconds to do some redeliveries before we stop
-        Thread.sleep(500);
+        // wait for enough redeliveries before we stop
+        await().atMost(5, TimeUnit.SECONDS).until(() -> counter.get() >= 20);
         log.info("==== stopping route foo ====");
         context.getRouteController().stopRoute("foo");
         long taken = watch.taken();

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ResequenceStreamRejectOldExchangesTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ResequenceStreamRejectOldExchangesTest.java
@@ -16,12 +16,16 @@
  */
 package org.apache.camel.processor;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.processor.resequencer.MessageRejectedException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+
+import static org.awaitility.Awaitility.await;
 
 @DisabledOnOs(value = { OS.LINUX },
               architectures = { "s390x" },
@@ -76,7 +80,9 @@ public class ResequenceStreamRejectOldExchangesTest extends ContextTestSupport {
         template.sendBodyAndHeader("direct:start", "D", "seqno", 4);
         template.sendBodyAndHeader("direct:start", "A", "seqno", 1);
 
-        Thread.sleep(100);
+        // wait for at least one message to be delivered before sending the rest
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> getMockEndpoint("mock:result").getReceivedCounter() >= 1);
 
         template.sendBodyAndHeader("direct:start", "B", "seqno", 2);
         template.sendBodyAndHeader("direct:start", "C", "seqno", 3);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateClosedCorrelationKeyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateClosedCorrelationKeyTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.processor.aggregator;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
@@ -23,6 +25,7 @@ import org.apache.camel.processor.BodyInAggregatingStrategy;
 import org.apache.camel.processor.aggregate.ClosedCorrelationKeyException;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -79,7 +82,9 @@ public class AggregateClosedCorrelationKeyTest extends ContextTestSupport {
         template.sendBodyAndHeader("direct:start", "D", "id", 2);
         template.sendBodyAndHeader("direct:start", "E", "id", 3);
         template.sendBodyAndHeader("direct:start", "F", "id", 3);
-        Thread.sleep(200);
+        // wait for all 3 aggregated results to arrive (keys become closed)
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> getMockEndpoint("mock:result").getReceivedCounter() >= 3);
         // 2 of them should now be closed
         int closed = 0;
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateDiscardOnTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateDiscardOnTimeoutTest.java
@@ -36,9 +36,8 @@ public class AggregateDiscardOnTimeoutTest extends ContextTestSupport {
         template.sendBodyAndHeader("direct:start", "A", "id", 123);
         template.sendBodyAndHeader("direct:start", "B", "id", 123);
 
-        // wait 0.25 seconds
-        Thread.sleep(250);
-
+        // verify no aggregated message arrives (discarded on timeout)
+        mock.setAssertPeriod(500);
         mock.assertIsSatisfied();
 
         // now send 3 which does not timeout

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeBatchSizeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateGroupedExchangeBatchSizeTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.processor.aggregator;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -25,6 +26,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.processor.aggregate.GroupedExchangeAggregationStrategy;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -58,8 +60,10 @@ public class AggregateGroupedExchangeBatchSizeTest extends ContextTestSupport {
         assertEquals("100", grouped.get(0).getIn().getBody(String.class));
         assertEquals("150", grouped.get(1).getIn().getBody(String.class));
 
-        // wait a bit for the remainder to come in
-        Thread.sleep(1000);
+        // wait for the remainder to come in via completion timeout
+        await().atMost(5, TimeUnit.SECONDS)
+                .pollDelay(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertTrue(result.getReceivedCounter() >= 1));
 
         if (result.getReceivedCounter() == 2) {
 

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedInflightStatisticsTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedInflightStatisticsTest.java
@@ -70,7 +70,11 @@ public class ManagedInflightStatisticsTest extends ManagementTestSupport {
 
         // start some exchanges.
         template.asyncSendBody("direct:start", latch1);
-        Thread.sleep(250);
+        // wait for first exchange to be inflight before sending the second
+        await().atMost(5, TimeUnit.SECONDS).until(() -> {
+            Long num = (Long) mbeanServer.getAttribute(on, "ExchangesInflight");
+            return num != null && num == 1;
+        });
         template.asyncSendBody("direct:start", latch2);
 
         await().atMost(2, TimeUnit.SECONDS).until(() -> {
@@ -91,8 +95,11 @@ public class ManagedInflightStatisticsTest extends ManagementTestSupport {
         // complete first exchange
         latch1.countDown();
 
-        // Lets wait for the first exchange to complete.
-        Thread.sleep(200);
+        // wait for the first exchange to complete (inflight drops to 1)
+        await().atMost(5, TimeUnit.SECONDS).until(() -> {
+            Long num = (Long) mbeanServer.getAttribute(on, "ExchangesInflight");
+            return num != null && num == 1;
+        });
         Long ts2 = (Long) mbeanServer.getAttribute(on, "OldestInflightDuration");
         assertNotNull(ts2);
         String id2 = (String) mbeanServer.getAttribute(on, "OldestInflightExchangeId");

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedInflightStatisticsTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedInflightStatisticsTest.java
@@ -95,10 +95,13 @@ public class ManagedInflightStatisticsTest extends ManagementTestSupport {
         // complete first exchange
         latch1.countDown();
 
-        // wait for the first exchange to complete (inflight drops to 1)
-        await().atMost(5, TimeUnit.SECONDS).until(() -> {
-            Long num = (Long) mbeanServer.getAttribute(on, "ExchangesInflight");
-            return num != null && num == 1;
+        // wait for the first exchange to complete and the oldest to change
+        final Long tsSnapshot = ts;
+        final String idSnapshot = id;
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(Long.valueOf(1), (Long) mbeanServer.getAttribute(on, "ExchangesInflight"));
+            assertNotEquals(idSnapshot, (String) mbeanServer.getAttribute(on, "OldestInflightExchangeId"));
+            assertNotEquals(tsSnapshot, (Long) mbeanServer.getAttribute(on, "OldestInflightDuration"));
         });
         Long ts2 = (Long) mbeanServer.getAttribute(on, "OldestInflightDuration");
         assertNotNull(ts2);
@@ -106,11 +109,6 @@ public class ManagedInflightStatisticsTest extends ManagementTestSupport {
         assertNotNull(id2);
 
         log.info("Oldest Exchange id: {}, duration: {}", id2, ts2);
-
-        // Lets verify the oldest changed.
-        assertNotEquals(id, id2);
-        // The duration values could be different
-        assertNotEquals(ts, ts2);
 
         latch2.countDown();
 


### PR DESCRIPTION
[CAMEL-23495](https://issues.apache.org/jira/browse/CAMEL-23495)

Replace `Thread.sleep()` synchronization calls with Awaitility in 15 test files across camel-core and camel-management to reduce flakiness under CI load.

## Changes by category

### Suspend/resume tests (4 files)
- `RouteSedaSuspendResumeTest`, `DefaultCamelContextSuspendResumeRouteTest`, `TwoRouteSuspendResumeTest`, `SedaConsumerSuspendResumeTest`
- Replaced `Thread.sleep(1000L)` + existing `await()` with a single `await().pollDelay(1s).atMost(5s)` to give SEDA consumer thread time to idle after route suspension

### Management tests (2 files)
- `ManagedInflightStatisticsTest` — replaced `Thread.sleep(250)` and `Thread.sleep(200)` with `await().until()` checking JMX inflight exchange count
- `DefaultExecutorServiceManagerTest` — replaced `Thread.sleep(3000)` with a `started` CountDownLatch + `await()` to detect when the pool task begins

### Async/scheduler tests (2 files)
- `SchedulerMulticastParallelGreedyTest` — replaced `Thread.sleep(50)` with `MockEndpoint.setAssertPeriod(200)` to verify no extra messages arrive
- `ThreadsRejectedExecutionWithDeadLetterTest` — replaced `Thread.sleep(100)` with `await().until()` checking the rejected message arrived at dead letter

### Aggregation tests (3 files)
- `AggregateGroupedExchangeBatchSizeTest` — replaced `Thread.sleep(1000)` with `await()` for the second batch via completion timeout
- `AggregateDiscardOnTimeoutTest` — replaced `Thread.sleep(250)` with `MockEndpoint.setAssertPeriod(500)`
- `AggregateClosedCorrelationKeyTest` — replaced `Thread.sleep(200)` with `await().until()` checking all aggregated results arrived

### Redelivery/shutdown tests (3 files)
- `NotAllowRedeliveryWhileStoppingTest`, `NotAllowRedeliveryWhileStoppingDeadLetterChannelTest` — replaced `Thread.sleep(500)` with `await()` checking inflight repository
- `RedeliveryDeadLetterErrorHandlerNoRedeliveryOnShutdownTest` — replaced `Thread.sleep(500)` with `await().until(() -> counter.get() >= 20)`

### Resequencer test (1 file)
- `ResequenceStreamRejectOldExchangesTest` — replaced `Thread.sleep(100)` with `await().until()` checking first message delivered before sending the rest

## Out of scope
The following `Thread.sleep()` uses were intentionally left unchanged:
- Sleeps inside `Processor.process()` or `Runnable.run()` simulating slow I/O
- Timing-specific tests (completion intervals, rate calculations, timeout ordering)
- Pacing sleeps between message sends where the delay is the test's intent

_Claude Code on behalf of Guillaume Nodet_