### PR TITLE
CAMEL-23497: Fix NPE in ManagedTransformerRegistry.listTransformers()

### DIFF
--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedTransformerRegistry.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedTransformerRegistry.java
@@ -94,7 +94,9 @@ public class ManagedTransformerRegistry extends ManagedService implements Manage
 
                 CompositeData data = new CompositeDataSupport(
                         ct, new String[] { "name", "from", "to", "static", "dynamic", "description" },
-                        new Object[] { name, from.toString(), to.toString(), fromStatic, fromDynamic, desc });
+                        new Object[] {
+                                name, from != null ? from.toString() : "", to != null ? to.toString() : "",
+                                fromStatic, fromDynamic, desc });
                 answer.put(data);
             }
             return answer;

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedTransformerRegistryTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedTransformerRegistryTest.java
@@ -29,6 +29,7 @@ import org.apache.camel.Message;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spi.DataType;
 import org.apache.camel.spi.Transformer;
+import org.apache.camel.spi.TransformerKey;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -103,13 +104,51 @@ public class ManagedTransformerRegistryTest extends ManagementTestSupport {
                 assertEquals("xml:test", to);
             } else if (description.startsWith("MyTransformer")) {
                 assertEquals("custom", name);
-                assertEquals("camel:any", from);
-                assertEquals("camel:any", to);
+                assertEquals("", from);
+                assertEquals("", to);
             } else {
                 fail("Unexpected transformer:" + description);
             }
         }
         assertEquals(2, data.size());
+    }
+
+    @Test
+    public void testListTransformersWithNullFromTo() throws Exception {
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+        template.sendBody("direct:start", "Hello World");
+        assertMockEndpointsSatisfied();
+
+        // add a transformer with null from/to directly to the registry
+        Transformer nullTypesTransformer = new MyTransformer();
+        nullTypesTransformer.setName("null-types");
+        context.getTransformerRegistry().put(new TransformerKey("null-types"), nullTypesTransformer);
+
+        MBeanServer mbeanServer = getMBeanServer();
+        Set<ObjectName> set = mbeanServer.queryNames(new ObjectName("*:type=services,*"), null);
+        ObjectName on = null;
+        for (ObjectName name : set) {
+            if (name.getCanonicalName().contains("DefaultTransformerRegistry")) {
+                on = name;
+                break;
+            }
+        }
+        assertNotNull(on, "Should have found TransformerRegistry");
+
+        TabularData data = (TabularData) mbeanServer.invoke(on, "listTransformers", null, null);
+        assertEquals(3, data.size());
+
+        boolean found = false;
+        for (Object row : data.values()) {
+            CompositeData composite = (CompositeData) row;
+            String name = (String) composite.get("name");
+            if ("null-types".equals(name)) {
+                found = true;
+                assertEquals("", composite.get("from"));
+                assertEquals("", composite.get("to"));
+            }
+        }
+        assertTrue(found, "Should have found the null-types transformer");
     }
 
     @Override


### PR DESCRIPTION
[CAMEL-23497](https://issues.apache.org/jira/browse/CAMEL-23497)

Handle null `from`/`to` DataType in `ManagedTransformerRegistry.listTransformers()`. The `Transformer.getFrom()` and `getTo()` methods are `@Nullable` — when a transformer is registered by name only (without explicit from/to types), these can be null, causing an NPE when building the JMX CompositeData.

- Add null checks for `from`/`to` in `listTransformers()`, using empty string when null
- Fix incorrect test assertions that expected `"camel:any"` for a named transformer with null from/to
- Add dedicated test `testListTransformersWithNullFromTo` that registers a transformer with null from/to directly in the registry and verifies `listTransformers()` handles it correctly