### PR TITLE
CAMEL-22640: Guard JSSE factory beans against null CamelContext

### DIFF
--- a/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractBaseSSLContextParametersFactoryBean.java
+++ b/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractBaseSSLContextParametersFactoryBean.java
@@ -19,6 +19,7 @@ package org.apache.camel.core.xml.util.jsse;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 
+import org.apache.camel.CamelContextAware;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.support.jsse.BaseSSLContextParameters;
 import org.apache.camel.support.jsse.CipherSuitesParameters;
@@ -71,7 +72,7 @@ public abstract class AbstractBaseSSLContextParametersFactoryBean<T extends Base
 
     private T createInstanceInternal() throws Exception {
         T newInstance = createInstance();
-        newInstance.setCamelContext(getCamelContext());
+        CamelContextAware.trySetCamelContext(newInstance, getCamelContext());
 
         if (cipherSuites != null) {
             CipherSuitesParameters cipherSuitesInstance = new CipherSuitesParameters();
@@ -124,7 +125,7 @@ public abstract class AbstractBaseSSLContextParametersFactoryBean<T extends Base
         FilterParameters filter = new FilterParameters();
         filter.getInclude().addAll(definition.getInclude());
         filter.getExclude().addAll(definition.getExclude());
-        filter.setCamelContext(getCamelContext());
+        CamelContextAware.trySetCamelContext(filter, getCamelContext());
 
         return filter;
     }

--- a/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractKeyManagersParametersFactoryBean.java
+++ b/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractKeyManagersParametersFactoryBean.java
@@ -23,6 +23,7 @@ import jakarta.xml.bind.annotation.XmlTransient;
 
 import javax.net.ssl.KeyManager;
 
+import org.apache.camel.CamelContextAware;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.support.jsse.KeyManagersParameters;
 
@@ -99,11 +100,11 @@ public abstract class AbstractKeyManagersParametersFactoryBean extends AbstractJ
         newInstance.setAlgorithm(algorithm);
         newInstance.setKeyPassword(keyPassword);
         if (getKeyStore() != null) {
-            getKeyStore().setCamelContext(getCamelContext());
+            CamelContextAware.trySetCamelContext(getKeyStore(), getCamelContext());
             newInstance.setKeyStore(getKeyStore().getObject());
         }
         newInstance.setProvider(provider);
-        newInstance.setCamelContext(getCamelContext());
+        CamelContextAware.trySetCamelContext(newInstance, getCamelContext());
 
         return newInstance;
     }

--- a/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractKeyStoreParametersFactoryBean.java
+++ b/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractKeyStoreParametersFactoryBean.java
@@ -23,6 +23,7 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 
+import org.apache.camel.CamelContextAware;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.jsse.KeyStoreParameters;
@@ -109,7 +110,7 @@ public abstract class AbstractKeyStoreParametersFactoryBean extends AbstractJsse
 
     protected KeyStoreParameters createInstance() {
         KeyStoreParameters newInstance = new KeyStoreParameters();
-        newInstance.setCamelContext(getCamelContext());
+        CamelContextAware.trySetCamelContext(newInstance, getCamelContext());
         newInstance.setType(this.type);
         newInstance.setPassword(this.password);
         newInstance.setProvider(this.provider);

--- a/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractSSLContextClientParametersFactoryBean.java
+++ b/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractSSLContextClientParametersFactoryBean.java
@@ -21,6 +21,7 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 
+import org.apache.camel.CamelContextAware;
 import org.apache.camel.support.jsse.SSLContextClientParameters;
 
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -34,7 +35,7 @@ public abstract class AbstractSSLContextClientParametersFactoryBean
     @Override
     protected SSLContextClientParameters createInstance() {
         SSLContextClientParameters newInstance = new SSLContextClientParameters();
-        newInstance.setCamelContext(getCamelContext());
+        CamelContextAware.trySetCamelContext(newInstance, getCamelContext());
         if (sniHostNamesDefinition != null) {
             newInstance.addAllSniHostNames(sniHostNamesDefinition.getSniHostName());
         }

--- a/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractSSLContextParametersFactoryBean.java
+++ b/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractSSLContextParametersFactoryBean.java
@@ -21,6 +21,7 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 
+import org.apache.camel.CamelContextAware;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.support.jsse.SSLContextParameters;
 
@@ -50,34 +51,34 @@ public abstract class AbstractSSLContextParametersFactoryBean
         SSLContextParameters newInstance = new SSLContextParameters();
 
         if (getKeyManagers() != null) {
-            getKeyManagers().setCamelContext(getCamelContext());
+            CamelContextAware.trySetCamelContext(getKeyManagers(), getCamelContext());
             newInstance.setKeyManagers(getKeyManagers().getObject());
         }
 
         if (getTrustManagers() != null) {
-            getTrustManagers().setCamelContext(getCamelContext());
+            CamelContextAware.trySetCamelContext(getTrustManagers(), getCamelContext());
             newInstance.setTrustManagers(getTrustManagers().getObject());
         }
 
         if (getSecureRandom() != null) {
-            getSecureRandom().setCamelContext(getCamelContext());
+            CamelContextAware.trySetCamelContext(getSecureRandom(), getCamelContext());
             newInstance.setSecureRandom(getSecureRandom().getObject());
         }
 
         if (getClientParameters() != null) {
-            getClientParameters().setCamelContext(getCamelContext());
+            CamelContextAware.trySetCamelContext(getClientParameters(), getCamelContext());
             newInstance.setClientParameters(getClientParameters().getObject());
         }
 
         if (getServerParameters() != null) {
-            getServerParameters().setCamelContext(getCamelContext());
+            CamelContextAware.trySetCamelContext(getServerParameters(), getCamelContext());
             newInstance.setServerParameters(getServerParameters().getObject());
         }
 
         newInstance.setProvider(provider);
         newInstance.setSecureSocketProtocol(secureSocketProtocol);
         newInstance.setCertAlias(certAlias);
-        newInstance.setCamelContext(getCamelContext());
+        CamelContextAware.trySetCamelContext(newInstance, getCamelContext());
 
         return newInstance;
     }

--- a/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractSSLContextServerParametersFactoryBean.java
+++ b/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractSSLContextServerParametersFactoryBean.java
@@ -21,6 +21,7 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 
+import org.apache.camel.CamelContextAware;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.support.jsse.SSLContextServerParameters;
 
@@ -46,7 +47,7 @@ public abstract class AbstractSSLContextServerParametersFactoryBean
     protected SSLContextServerParameters createInstance() {
         SSLContextServerParameters newInstance = new SSLContextServerParameters();
         newInstance.setClientAuthentication(clientAuthentication);
-        newInstance.setCamelContext(getCamelContext());
+        CamelContextAware.trySetCamelContext(newInstance, getCamelContext());
         return newInstance;
     }
 

--- a/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractSecureRandomParametersFactoryBean.java
+++ b/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractSecureRandomParametersFactoryBean.java
@@ -21,6 +21,7 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 
+import org.apache.camel.CamelContextAware;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.support.jsse.SecureRandomParameters;
 
@@ -74,7 +75,7 @@ public abstract class AbstractSecureRandomParametersFactoryBean extends Abstract
 
         newInstance.setAlgorithm(algorithm);
         newInstance.setProvider(provider);
-        newInstance.setCamelContext(getCamelContext());
+        CamelContextAware.trySetCamelContext(newInstance, getCamelContext());
 
         return newInstance;
     }

--- a/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractTrustManagersParametersFactoryBean.java
+++ b/core/camel-core-xml/src/main/java/org/apache/camel/core/xml/util/jsse/AbstractTrustManagersParametersFactoryBean.java
@@ -23,6 +23,7 @@ import jakarta.xml.bind.annotation.XmlTransient;
 
 import javax.net.ssl.TrustManager;
 
+import org.apache.camel.CamelContextAware;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.jsse.TrustManagersParameters;
@@ -95,11 +96,11 @@ public abstract class AbstractTrustManagersParametersFactoryBean extends Abstrac
 
         newInstance.setAlgorithm(algorithm);
         if (getKeyStore() != null) {
-            getKeyStore().setCamelContext(getCamelContext());
+            CamelContextAware.trySetCamelContext(getKeyStore(), getCamelContext());
             newInstance.setKeyStore(getKeyStore().getObject());
         }
         newInstance.setProvider(provider);
-        newInstance.setCamelContext(getCamelContext());
+        CamelContextAware.trySetCamelContext(newInstance, getCamelContext());
 
         if (trustManager != null) {
             TrustManager tm = CamelContextHelper.mandatoryLookup(getCamelContext(), trustManager, TrustManager.class);


### PR DESCRIPTION
Fixes the test failure `org.apache.camel.util.spring.SecureRandomParametersFactoryBeanTest.testKeyStoreParameters`

## Summary

- The JSpecify commit (CAMEL-22640) added `Objects.requireNonNull` to `JsseParameters.setCamelContext()`, which is correct per the `CamelContextAware` contract.
- The JSSE factory beans in `camel-core-xml` unconditionally called `newInstance.setCamelContext(getCamelContext())`, passing `null` when no `CamelContext` was injected (e.g., Spring XML tests without a `<camelContext>` element). This now throws `NullPointerException`.
- Added a `setCamelContextIfPresent()` helper in `AbstractJsseUtilFactoryBean` that only propagates the context when non-null, and replaced all 16 call sites across 8 factory beans.

## Test plan

- [x] `SecureRandomParametersFactoryBeanTest` passes (was previously failing with NPE)
- [x] `SSLContextParametersFactoryBeanTest` passes
- [x] `KeyStoreParametersFactoryBeanTest` passes