### PR TITLE
CAMEL-23498: Cleanup remaining SLF4J 1.x artifacts after upgrade to 2.0.x

### DIFF
--- a/components/camel-ai/camel-milvus/pom.xml
+++ b/components/camel-ai/camel-milvus/pom.xml
@@ -101,7 +101,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-slf4j-impl</artifactId>
+                    <artifactId>log4j-slf4j2-impl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/components/camel-camunda/pom.xml
+++ b/components/camel-camunda/pom.xml
@@ -65,7 +65,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2-version}</version>
             <scope>test</scope>
         </dependency>

--- a/components/camel-datasonnet/pom.xml
+++ b/components/camel-datasonnet/pom.xml
@@ -81,7 +81,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2-version}</version>
             <scope>test</scope>
         </dependency>

--- a/components/camel-flowable/pom.xml
+++ b/components/camel-flowable/pom.xml
@@ -62,7 +62,7 @@
     	</dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2-version}</version>
             <scope>test</scope>
         </dependency>

--- a/components/camel-kudu/pom.xml
+++ b/components/camel-kudu/pom.xml
@@ -120,7 +120,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-slf4j-impl</artifactId>
+                    <artifactId>log4j-slf4j2-impl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/components/camel-optaplanner/pom.xml
+++ b/components/camel-optaplanner/pom.xml
@@ -71,7 +71,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2-version}</version>
             <scope>test</scope>
         </dependency>

--- a/components/camel-parquet-avro/pom.xml
+++ b/components/camel-parquet-avro/pom.xml
@@ -82,7 +82,7 @@
         <!-- logging -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2-version}</version>
             <scope>test</scope>
         </dependency>

--- a/components/camel-pulsar/pom.xml
+++ b/components/camel-pulsar/pom.xml
@@ -87,7 +87,7 @@
 
     	<dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2-version}</version>
             <scope>test</scope>
     	</dependency>

--- a/components/camel-solr/pom.xml
+++ b/components/camel-solr/pom.xml
@@ -85,7 +85,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2-version}</version>
             <scope>test</scope>
         </dependency>

--- a/components/camel-swift/pom.xml
+++ b/components/camel-swift/pom.xml
@@ -80,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2-version}</version>
             <scope>test</scope>
         </dependency>

--- a/components/camel-zeebe/pom.xml
+++ b/components/camel-zeebe/pom.xml
@@ -76,7 +76,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2-version}</version>
             <scope>test</scope>
         </dependency>

--- a/dsl/camel-jbang/camel-launcher/pom.xml
+++ b/dsl/camel-jbang/camel-launcher/pom.xml
@@ -53,7 +53,7 @@
         <httpclient-version>4.5.14</httpclient-version>
         <httpcore-version>4.4.16</httpcore-version>
         <commons-codec-version>1.22.0</commons-codec-version>
-        <jcl-over-slf4j-version>1.7.36</jcl-over-slf4j-version>
+        <jcl-over-slf4j-version>${slf4j-version}</jcl-over-slf4j-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

- Replace `log4j-slf4j-impl` (SLF4J 1.x Log4j2 binding) with `log4j-slf4j2-impl` (SLF4J 2.x) in 9 component test dependencies and 2 exclusions
- Fix hardcoded `jcl-over-slf4j` version 1.7.36 in `camel-launcher` to use `${slf4j-version}`

These are remnants missed during the SLF4J 1.7.x → 2.0.x upgrade (CAMEL-18932).

### Modules updated (test dependency `log4j-slf4j-impl` → `log4j-slf4j2-impl`)
- camel-zeebe, camel-parquet-avro, camel-flowable, camel-optaplanner, camel-solr, camel-datasonnet, camel-swift, camel-camunda, camel-pulsar

### Exclusions updated (stale artifact name)
- camel-milvus, camel-kudu

### Version fix
- `dsl/camel-jbang/camel-launcher/pom.xml`: `jcl-over-slf4j-version` changed from `1.7.36` to `${slf4j-version}`

## Test plan

- [x] Full reactor build passes (`mvn clean install -DskipTests`)
- [ ] CI build passes

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)