### PR TITLE
Deprecate Paho component and disable related flaky test on CI

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/paho.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/paho.json
@@ -4,7 +4,7 @@
     "name": "paho",
     "title": "Paho",
     "description": "Communicate with MQTT message brokers using Eclipse Paho MQTT Client.",
-    "deprecated": false,
+    "deprecated": true,
     "firstVersion": "2.16.0",
     "label": "messaging,iot",
     "javaType": "org.apache.camel.component.paho.PahoComponent",

--- a/components/camel-paho/pom.xml
+++ b/components/camel-paho/pom.xml
@@ -29,7 +29,7 @@
 
     <artifactId>camel-paho</artifactId>
     <packaging>jar</packaging>
-    <name>Camel :: Paho</name>
+    <name>Camel :: Paho (deprecated)</name>
     <description>Camel Eclipse Paho support</description>
 
     <properties>

--- a/components/camel-paho/src/generated/resources/META-INF/org/apache/camel/component/paho/paho.json
+++ b/components/camel-paho/src/generated/resources/META-INF/org/apache/camel/component/paho/paho.json
@@ -4,7 +4,7 @@
     "name": "paho",
     "title": "Paho",
     "description": "Communicate with MQTT message brokers using Eclipse Paho MQTT Client.",
-    "deprecated": false,
+    "deprecated": true,
     "firstVersion": "2.16.0",
     "label": "messaging,iot",
     "javaType": "org.apache.camel.component.paho.PahoComponent",

--- a/components/camel-paho/src/generated/resources/META-INF/services/org/apache/camel/component.properties
+++ b/components/camel-paho/src/generated/resources/META-INF/services/org/apache/camel/component.properties
@@ -3,5 +3,5 @@ components=paho
 groupId=org.apache.camel
 artifactId=camel-paho
 version=4.21.0-SNAPSHOT
-projectName=Camel :: Paho
+projectName=Camel :: Paho (deprecated)
 projectDescription=Camel Eclipse Paho support

--- a/components/camel-paho/src/main/docs/paho-component.adoc
+++ b/components/camel-paho/src/main/docs/paho-component.adoc
@@ -1,10 +1,11 @@
-= Paho Component
+= Paho Component (deprecated)
 :doctitle: Paho
 :shortname: paho
 :artifactid: camel-paho
 :description: Communicate with MQTT message brokers using Eclipse Paho MQTT Client.
 :since: 2.16
-:supportlevel: Stable
+:supportlevel: Stable-deprecated
+:deprecated: *deprecated*
 :tabs-sync-option:
 :component-header: Both producer and consumer are supported
 //Manually maintained attributes

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoComponent.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoComponent.java
@@ -29,6 +29,7 @@ import org.eclipse.paho.client.mqttv3.MqttClient;
  * Component to integrate with the Eclipse Paho MQTT library.
  */
 @Component("paho")
+@Deprecated(since = "4.21")
 public class PahoComponent extends DefaultComponent {
 
     @Metadata

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoConfiguration.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoConfiguration.java
@@ -27,6 +27,7 @@ import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriParams;
 
 @UriParams
+@Deprecated(since = "4.21")
 public class PahoConfiguration implements Cloneable {
 
     @UriParam

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoConstants.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoConstants.java
@@ -21,6 +21,7 @@ import org.apache.camel.spi.Metadata;
 /**
  * Constants to use when working with Paho component.
  */
+@Deprecated(since = "4.21")
 public final class PahoConstants {
 
     /**

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoConsumer.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoConsumer.java
@@ -31,6 +31,7 @@ import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated(since = "4.21")
 public class PahoConsumer extends DefaultConsumer {
 
     private static final Logger LOG = LoggerFactory.getLogger(PahoConsumer.class);

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoEndpoint.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoEndpoint.java
@@ -41,6 +41,7 @@ import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
  */
 @UriEndpoint(firstVersion = "2.16.0", scheme = "paho", title = "Paho", category = { Category.MESSAGING, Category.IOT },
              syntax = "paho:topic", headersClass = PahoConstants.class)
+@Deprecated(since = "4.21")
 public class PahoEndpoint extends DefaultEndpoint implements EndpointServiceLocation {
 
     // Configuration members

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoMessage.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoMessage.java
@@ -20,6 +20,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.support.DefaultMessage;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 
+@Deprecated(since = "4.21")
 public class PahoMessage extends DefaultMessage {
 
     private transient MqttMessage mqttMessage;

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoPersistence.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoPersistence.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.paho;
 
+@Deprecated(since = "4.21")
 public enum PahoPersistence {
 
     FILE,

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoProducer.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoProducer.java
@@ -28,6 +28,7 @@ import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated(since = "4.21")
 public class PahoProducer extends DefaultAsyncProducer {
 
     private static final Logger LOG = LoggerFactory.getLogger(PahoProducer.class);

--- a/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoSendDynamicAware.java
+++ b/components/camel-paho/src/main/java/org/apache/camel/component/paho/PahoSendDynamicAware.java
@@ -31,6 +31,7 @@ import org.apache.camel.util.StringHelper;
  * endpoint and its producer to service dynamic requests.
  */
 @SendDynamic("paho")
+@Deprecated(since = "4.21")
 public class PahoSendDynamicAware extends ServiceSupport implements SendDynamicAware {
 
     private CamelContext camelContext;

--- a/components/camel-paho/src/test/java/org/apache/camel/component/paho/PahoManualAcksTest.java
+++ b/components/camel-paho/src/test/java/org/apache/camel/component/paho/PahoManualAcksTest.java
@@ -26,8 +26,11 @@ import org.apache.camel.test.infra.core.DefaultCamelContextExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
+                          disabledReason = "Started to be very flaky on CI and component is now deprecated")
 public class PahoManualAcksTest extends PahoTestSupport {
     @Order(2)
     @RegisterExtension

--- a/components/camel-paho/src/test/java/org/apache/camel/component/paho/PahoOverrideTopicTest.java
+++ b/components/camel-paho/src/test/java/org/apache/camel/component/paho/PahoOverrideTopicTest.java
@@ -25,8 +25,11 @@ import org.apache.camel.test.infra.core.DefaultCamelContextExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
+                          disabledReason = "Started to be very flaky on CI and component is now deprecated")
 public class PahoOverrideTopicTest extends PahoTestSupport {
 
     @Order(2)

--- a/components/camel-paho/src/test/java/org/apache/camel/component/paho/PahoToDSendDynamicTest.java
+++ b/components/camel-paho/src/test/java/org/apache/camel/component/paho/PahoToDSendDynamicTest.java
@@ -24,10 +24,13 @@ import org.apache.camel.test.infra.core.DefaultCamelContextExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
+                          disabledReason = "Started to be very flaky on CI and component is now deprecated")
 public class PahoToDSendDynamicTest extends PahoTestSupport {
 
     @Order(2)

--- a/components/camel-paho/src/test/java/org/apache/camel/component/paho/PahoToDTest.java
+++ b/components/camel-paho/src/test/java/org/apache/camel/component/paho/PahoToDTest.java
@@ -24,8 +24,11 @@ import org.apache.camel.test.infra.core.DefaultCamelContextExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
+                          disabledReason = "Started to be very flaky on CI and component is now deprecated")
 public class PahoToDTest extends PahoTestSupport {
 
     @Order(2)

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -18,7 +18,7 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 The library used for Camel Grok component has been migrated from no more maintained `io.krakens:java-grok` to its fork `io.github.whatap:java-grok`.
 It implies small differences listed https://github.com/whatap/java-grok#what-is-different-from-iokrakensjava-grok[here].
 
-=== camel-core
+=== camel-coreand camel-paho-mqtt5 are
 
 The `camel-api` module now has an optional dependency on `org.jspecify:jspecify` for null safety annotations
 (`@NullMarked`, `@Nullable`). The dependency is `<optional>true</optional>`, so it is not pulled transitively
@@ -508,3 +508,8 @@ The component camel-irc is deprecated. The library used had no stable release si
 === Deprecation of camel-iec-60870
 
 The component camel-iec-60870 is deprecated. The library used to implement it NeoScada is no more maintained since 2021. There are no alternatives in Java with compatible license.
+
+=== Deprecation of camel-paho
+
+The components camel-paho is deprecated. There were no new release since 2020 of the Java client, last non-regulatory commit was in 2022.
+

--- a/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/StaticEndpointBuilders.java
+++ b/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/StaticEndpointBuilders.java
@@ -13052,6 +13052,7 @@ public class StaticEndpointBuilders {
      * @param path topic
      * @return the dsl builder
      */
+    @Deprecated
     public static PahoEndpointBuilderFactory.PahoEndpointBuilder paho(String path) {
         return paho("paho", path);
     }
@@ -13073,6 +13074,7 @@ public class StaticEndpointBuilders {
      * @param path topic
      * @return the dsl builder
      */
+    @Deprecated
     public static PahoEndpointBuilderFactory.PahoEndpointBuilder paho(String componentName, String path) {
         return PahoEndpointBuilderFactory.endpointBuilder(componentName, path);
     }

--- a/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/PahoEndpointBuilderFactory.java
+++ b/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/PahoEndpointBuilderFactory.java
@@ -2975,6 +2975,7 @@ public interface PahoEndpointBuilderFactory {
          * 
          * @return the dsl builder for the headers' name.
          */
+        @Deprecated
         default PahoHeaderNameBuilder paho() {
             return PahoHeaderNameBuilder.INSTANCE;
         }
@@ -2994,6 +2995,7 @@ public interface PahoEndpointBuilderFactory {
          * @param path topic
          * @return the dsl builder
          */
+        @Deprecated
         default PahoEndpointBuilder paho(String path) {
             return PahoEndpointBuilderFactory.endpointBuilder("paho", path);
         }
@@ -3015,6 +3017,7 @@ public interface PahoEndpointBuilderFactory {
          * @param path topic
          * @return the dsl builder
          */
+        @Deprecated
         default PahoEndpointBuilder paho(String componentName, String path) {
             return PahoEndpointBuilderFactory.endpointBuilder(componentName, path);
         }


### PR DESCRIPTION
# Description

there were no new release since 2020 of the Java client, last non-regulatory commit was in 2022
Disbale the related flaky tests CAMEL-23484

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

