### PR TITLE
chore: protect LTS release branches against force push and deletion

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,8 +30,9 @@ github:
     - CAMEL
 
   protected_branches:
-    # protect main against force push
     main: {}
+    camel-4.14.x: {}
+    camel-4.18.x: {}
   
 notifications:
   pullrequests: commits@camel.apache.org

--- a/docs/user-manual/modules/ROOT/pages/release-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/release-guide.adoc
@@ -152,6 +152,33 @@ http://maven.apache.org/guides/mini/guide-encryption.html[password encryption re
 </settings>
 ----
 
+[[ReleaseGuide-CreatingNewLTSBranch]]
+== Creating a New LTS Branch
+
+When creating a new LTS release branch (e.g., `camel-4.22.x`), the following additional steps are required beyond the normal branch creation:
+
+. Add branch protection in `.asf.yaml` (on the `main` branch):
++
+The `.asf.yaml` file in the `main` branch controls GitHub branch protection for the entire repository.
+Add the new branch to the `protected_branches` section to prevent force pushes and accidental branch deletion:
++
+[source,yaml]
+----
+github:
+  protected_branches:
+    main: {}
+    camel-4.14.x: {}
+    camel-4.18.x: {}
+    camel-4.22.x: {}   # <-- add new LTS branch here
+----
++
+NOTE: `.asf.yaml` does not support wildcard patterns — each branch must be listed explicitly.
+Only the `.asf.yaml` on the default branch (`main`) is used for repository-level settings like branch protection.
+
+. Remove branch protection for EOL branches:
++
+When an LTS branch reaches end of life, remove it from the `protected_branches` section in `.asf.yaml`.
+
 [[ReleaseGuide-CreatingTheRelease-Camel]]
 == Creating the Release
 


### PR DESCRIPTION
## Summary

- Add `camel-4.14.x` and `camel-4.18.x` to `protected_branches` in `.asf.yaml` to prevent force pushes and accidental branch deletion
- Document the branch protection step in `release-guide.adoc` so future LTS branches are protected at creation time