### PR TITLE
Add missing Javadoc to camel-api enums, events, SPI interfaces, and packages

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/BeanScope.java
+++ b/core/camel-api/src/main/java/org/apache/camel/BeanScope.java
@@ -18,11 +18,15 @@ package org.apache.camel;
 
 import jakarta.xml.bind.annotation.XmlEnum;
 
+/** Defines the scope for bean lookups in the {@link org.apache.camel.spi.Registry}. */
 @XmlEnum
 public enum BeanScope {
 
+    /** Reuses a single bean instance for all invocations (default). */
     Singleton,
+    /** Creates a new bean instance per exchange. */
     Request,
+    /** Creates a new bean instance per invocation. */
     Prototype
 
 }

--- a/core/camel-api/src/main/java/org/apache/camel/ExchangePattern.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExchangePattern.java
@@ -25,7 +25,9 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlType
 @XmlEnum
 public enum ExchangePattern {
+    /** Fire-and-forget: the caller sends a message and does not expect a reply. */
     InOnly,
+    /** Request-reply: the caller sends a message and expects a response. */
     InOut;
 
     /**

--- a/core/camel-api/src/main/java/org/apache/camel/LoggingLevel.java
+++ b/core/camel-api/src/main/java/org/apache/camel/LoggingLevel.java
@@ -24,11 +24,17 @@ import jakarta.xml.bind.annotation.XmlEnum;
 @XmlEnum
 public enum LoggingLevel {
 
+    /** Most detailed logging level. */
     TRACE,
+    /** Detailed information useful during development. */
     DEBUG,
+    /** Informational messages. */
     INFO,
+    /** Warning messages. */
     WARN,
+    /** Error messages. */
     ERROR,
+    /** Disables logging entirely. */
     OFF;
 
     /**

--- a/core/camel-api/src/main/java/org/apache/camel/ManagementMBeansLevel.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ManagementMBeansLevel.java
@@ -24,8 +24,11 @@ import jakarta.xml.bind.annotation.XmlEnum;
 @XmlEnum
 public enum ManagementMBeansLevel {
 
+    /** Only register the CamelContext MBean. */
     ContextOnly,
+    /** Register MBeans for the CamelContext and routes. */
     RoutesOnly,
+    /** Register MBeans for the CamelContext, routes, and processors. */
     Default;
 
     public boolean isRoutes() {

--- a/core/camel-api/src/main/java/org/apache/camel/ManagementStatisticsLevel.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ManagementStatisticsLevel.java
@@ -24,9 +24,13 @@ import jakarta.xml.bind.annotation.XmlEnum;
 @XmlEnum
 public enum ManagementStatisticsLevel {
 
+    /** Extended statistics including additional performance metrics. */
     Extended,
+    /** Default statistics for context, routes, and processors. */
     Default,
+    /** Statistics for the context and routes only (no processors). */
     RoutesOnly,
+    /** No statistics collected. */
     Off;
 
     public boolean isDefaultOrExtended() {

--- a/core/camel-api/src/main/java/org/apache/camel/Route.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Route.java
@@ -398,26 +398,26 @@ public interface Route extends RuntimeConfiguration {
      */
     List<RoutePolicy> getRoutePolicyList();
 
-    // called at completion time
+    /** Sets the error handler factory for this route. */
     void setErrorHandlerFactory(ErrorHandlerFactory errorHandlerFactory);
 
-    // called at runtime
+    /** Gets the error handler factory for this route. */
     ErrorHandlerFactory getErrorHandlerFactory();
 
-    // called at runtime
+    /** Gets the on completion processors. */
     Collection<Processor> getOnCompletions();
 
-    // called at completion time
+    /** Sets an on completion processor. */
     void setOnCompletion(String onCompletionId, Processor processor);
 
-    // called at runtime
+    /** Gets the on exception processors. */
     Collection<Processor> getOnExceptions();
 
-    // called at runtime
+    /** Gets the on exception processor for the given id. */
     @Nullable
     Processor getOnException(String onExceptionId);
 
-    // called at completion time
+    /** Sets an on exception processor. */
     void setOnException(String onExceptionId, Processor processor);
 
     /**

--- a/core/camel-api/src/main/java/org/apache/camel/ServiceStatus.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ServiceStatus.java
@@ -22,13 +22,21 @@ import java.io.Serializable;
  * Represents the status of a {@link Service} instance
  */
 public enum ServiceStatus implements Serializable {
+    /** The service is being initialized. */
     Initializing,
+    /** The service has been initialized but not yet started. */
     Initialized,
+    /** The service is starting. */
     Starting,
+    /** The service is started and ready. */
     Started,
+    /** The service is stopping. */
     Stopping,
+    /** The service has been stopped. */
     Stopped,
+    /** The service is suspending. */
     Suspending,
+    /** The service has been suspended. */
     Suspended;
 
     public boolean isStartable() {

--- a/core/camel-api/src/main/java/org/apache/camel/StartupSummaryLevel.java
+++ b/core/camel-api/src/main/java/org/apache/camel/StartupSummaryLevel.java
@@ -24,10 +24,15 @@ import jakarta.xml.bind.annotation.XmlEnum;
 @XmlEnum
 public enum StartupSummaryLevel {
 
+    /** Most detailed startup summary with all routes and their endpoints. */
     Verbose,
+    /** Default startup summary with route overview. */
     Default,
+    /** Brief startup summary with route count. */
     Brief,
+    /** Single-line startup summary. */
     Oneline,
+    /** No startup summary logged. */
     Off
 
 }

--- a/core/camel-api/src/main/java/org/apache/camel/TypeConverterExists.java
+++ b/core/camel-api/src/main/java/org/apache/camel/TypeConverterExists.java
@@ -24,8 +24,11 @@ import jakarta.xml.bind.annotation.XmlEnum;
 @XmlEnum
 public enum TypeConverterExists {
 
+    /** Replace the existing type converter. */
     Override,
+    /** Keep the existing type converter and discard the new one. */
     Ignore,
+    /** Throw an exception to signal a duplicate type converter. */
     Fail
 
 }

--- a/core/camel-api/src/main/java/org/apache/camel/WaitForTaskToComplete.java
+++ b/core/camel-api/src/main/java/org/apache/camel/WaitForTaskToComplete.java
@@ -29,7 +29,10 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlEnum
 public enum WaitForTaskToComplete {
 
+    /** Never wait for the async task to complete. */
     Never,
+    /** Wait only if the exchange pattern expects a reply (InOut). */
     IfReplyExpected,
+    /** Always wait for the async task to complete. */
     Always
 }

--- a/core/camel-api/src/main/java/org/apache/camel/catalog/package-info.java
+++ b/core/camel-api/src/main/java/org/apache/camel/catalog/package-info.java
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Runtime catalog API for validating endpoint URIs, configuration properties, and language expressions.
+ */
 @NullMarked
 package org.apache.camel.catalog;
 

--- a/core/camel-api/src/main/java/org/apache/camel/cluster/CamelClusterService.java
+++ b/core/camel-api/src/main/java/org/apache/camel/cluster/CamelClusterService.java
@@ -26,6 +26,10 @@ import org.apache.camel.Ordered;
 import org.apache.camel.Service;
 import org.apache.camel.spi.IdAware;
 
+/**
+ * Represents a cluster service providing distributed operations such as leader election and view-based namespace
+ * partitioning. Implementations are backed by distributed coordination systems (e.g., ZooKeeper, Consul, Kubernetes).
+ */
 public interface CamelClusterService extends Service, CamelContextAware, IdAware, Ordered {
 
     @Override

--- a/core/camel-api/src/main/java/org/apache/camel/cluster/package-info.java
+++ b/core/camel-api/src/main/java/org/apache/camel/cluster/package-info.java
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Cluster API for leader election, namespace-based partitioning, and cluster membership management.
+ */
 @NullMarked
 package org.apache.camel.cluster;
 

--- a/core/camel-api/src/main/java/org/apache/camel/console/package-info.java
+++ b/core/camel-api/src/main/java/org/apache/camel/console/package-info.java
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Developer console API for exposing runtime operational information in text and JSON formats.
+ */
 @NullMarked
 package org.apache.camel.console;
 

--- a/core/camel-api/src/main/java/org/apache/camel/health/package-info.java
+++ b/core/camel-api/src/main/java/org/apache/camel/health/package-info.java
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Health check API for readiness and liveness monitoring of the CamelContext, routes, and components.
+ */
 @NullMarked
 package org.apache.camel.health;
 

--- a/core/camel-api/src/main/java/org/apache/camel/resume/cache/package-info.java
+++ b/core/camel-api/src/main/java/org/apache/camel/resume/cache/package-info.java
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Cache abstraction for storing resume offset state.
+ */
 @NullMarked
 package org.apache.camel.resume.cache;
 

--- a/core/camel-api/src/main/java/org/apache/camel/resume/package-info.java
+++ b/core/camel-api/src/main/java/org/apache/camel/resume/package-info.java
@@ -14,6 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Resume strategy API for offset-based message consumption, allowing consumers to resume processing from a previously
+ * saved position.
+ */
 @NullMarked
 package org.apache.camel.resume;
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/CamelEvent.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/CamelEvent.java
@@ -24,7 +24,9 @@ import org.apache.camel.Route;
 import org.jspecify.annotations.Nullable;
 
 /**
- * This interface is implemented by all events.
+ * Base interface for all Camel events used by the {@link EventNotifier} for notifications about
+ * {@link org.apache.camel.Exchange}, {@link org.apache.camel.Route}, {@link org.apache.camel.CamelContext}, and
+ * {@link org.apache.camel.Service} lifecycle changes.
  */
 public interface CamelEvent {
 
@@ -76,8 +78,10 @@ public interface CamelEvent {
         Custom
     }
 
+    /** Returns the type of this event. */
     Type getType();
 
+    /** Returns the source of this event (typically the CamelContext, Exchange, Route, or Service). */
     Object getSource();
 
     /**
@@ -98,8 +102,10 @@ public interface CamelEvent {
 
     }
 
+    /** Event related to {@link CamelContext} lifecycle changes. */
     interface CamelContextEvent extends CamelEvent {
 
+        /** Returns the CamelContext. */
         CamelContext getContext();
 
         @Override
@@ -109,6 +115,7 @@ public interface CamelEvent {
 
     }
 
+    /** Fired when the CamelContext is initializing. */
     interface CamelContextInitializingEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -116,6 +123,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext has been initialized. */
     interface CamelContextInitializedEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -123,6 +131,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext has been resumed. */
     interface CamelContextResumedEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -130,6 +139,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext failed to resume. */
     interface CamelContextResumeFailureEvent extends CamelContextEvent, FailureEvent {
         @Override
         default Type getType() {
@@ -137,6 +147,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext is resuming. */
     interface CamelContextResumingEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -144,6 +155,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext has been fully started. */
     interface CamelContextStartedEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -151,6 +163,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext is starting. */
     interface CamelContextStartingEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -158,6 +171,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext failed to start. */
     interface CamelContextStartupFailureEvent extends CamelContextEvent, FailureEvent {
         @Override
         default Type getType() {
@@ -165,6 +179,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext failed to stop cleanly. */
     interface CamelContextStopFailureEvent extends CamelContextEvent, FailureEvent {
         @Override
         default Type getType() {
@@ -172,6 +187,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext has been stopped. */
     interface CamelContextStoppedEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -179,6 +195,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext is stopping. */
     interface CamelContextStoppingEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -186,6 +203,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext has been suspended. */
     interface CamelContextSuspendedEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -193,6 +211,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext is suspending. */
     interface CamelContextSuspendingEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -200,6 +219,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when routes are starting. */
     interface CamelContextRoutesStartingEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -207,6 +227,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when routes have been started. */
     interface CamelContextRoutesStartedEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -214,6 +235,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when routes are stopping. */
     interface CamelContextRoutesStoppingEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -221,6 +243,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when routes have been stopped. */
     interface CamelContextRoutesStoppedEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -228,6 +251,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext is reloading. */
     interface CamelContextReloadingEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -235,6 +259,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext has been reloaded. */
     interface CamelContextReloadedEvent extends CamelContextEvent {
         @Override
         default Type getType() {
@@ -242,6 +267,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when the CamelContext failed to reload. */
     interface CamelContextReloadFailureEvent extends CamelContextEvent, FailureEvent {
         @Override
         default Type getType() {
@@ -249,8 +275,10 @@ public interface CamelEvent {
         }
     }
 
+    /** Event related to {@link Exchange} processing. */
     interface ExchangeEvent extends CamelEvent {
 
+        /** Returns the exchange. */
         Exchange getExchange();
 
         @Override
@@ -259,6 +287,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when an exchange has been completed successfully. */
     interface ExchangeCompletedEvent extends ExchangeEvent {
         @Override
         default Type getType() {
@@ -266,6 +295,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when a new exchange has been created. */
     interface ExchangeCreatedEvent extends ExchangeEvent {
         @Override
         default Type getType() {
@@ -273,6 +303,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when an exchange has failed. */
     interface ExchangeFailedEvent extends ExchangeEvent, FailureEvent {
         @Override
         default Type getType() {
@@ -280,17 +311,22 @@ public interface CamelEvent {
         }
     }
 
+    /** Event providing details about how a failure was handled during exchange processing. */
     interface ExchangeFailureEvent extends ExchangeEvent {
 
+        /** Returns the processor that handled the failure. */
         Processor getFailureHandler();
 
+        /** Whether the failure was handled by a dead letter channel. */
         boolean isDeadLetterChannel();
 
+        /** Returns the dead letter channel endpoint URI, or null if not applicable. */
         @Nullable
         String getDeadLetterUri();
 
     }
 
+    /** Fired after a failure has been handled by an error handler. */
     interface ExchangeFailureHandledEvent extends ExchangeFailureEvent {
         @Override
         default Type getType() {
@@ -298,6 +334,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when a failure is about to be handled by an error handler. */
     interface ExchangeFailureHandlingEvent extends ExchangeFailureEvent {
         @Override
         default Type getType() {
@@ -305,8 +342,10 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when an exchange is about to be redelivered. */
     interface ExchangeRedeliveryEvent extends ExchangeEvent {
 
+        /** Returns the redelivery attempt number (starts from 1). */
         int getAttempt();
 
         @Override
@@ -315,8 +354,10 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when an exchange is about to be sent to an endpoint. */
     interface ExchangeSendingEvent extends ExchangeEvent {
 
+        /** Returns the destination endpoint. */
         Endpoint getEndpoint();
 
         @Override
@@ -325,10 +366,13 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when an exchange has been sent to an endpoint. */
     interface ExchangeSentEvent extends ExchangeEvent {
 
+        /** Returns the destination endpoint. */
         Endpoint getEndpoint();
 
+        /** Returns the time taken in milliseconds. */
         long getTimeTaken();
 
         @Override
@@ -337,10 +381,13 @@ public interface CamelEvent {
         }
     }
 
+    /** Event related to a Step EIP processing. */
     interface StepEvent extends ExchangeEvent {
+        /** Returns the Step EIP id. */
         String getStepId();
     }
 
+    /** Fired when a Step EIP has started processing an exchange. */
     interface StepStartedEvent extends StepEvent {
         @Override
         default Type getType() {
@@ -348,6 +395,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when a Step EIP has completed processing an exchange. */
     interface StepCompletedEvent extends StepEvent {
         @Override
         default Type getType() {
@@ -355,6 +403,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when a Step EIP has failed processing an exchange. */
     interface StepFailedEvent extends StepEvent, FailureEvent {
         @Override
         default Type getType() {
@@ -362,8 +411,10 @@ public interface CamelEvent {
         }
     }
 
+    /** Event related to {@link Route} lifecycle changes. */
     interface RouteEvent extends CamelEvent {
 
+        /** Returns the route. */
         Route getRoute();
 
         @Override
@@ -372,6 +423,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when a route has been added. */
     interface RouteAddedEvent extends RouteEvent {
         @Override
         default Type getType() {
@@ -379,6 +431,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when a route has been removed. */
     interface RouteRemovedEvent extends RouteEvent {
         @Override
         default Type getType() {
@@ -403,6 +456,7 @@ public interface CamelEvent {
         int getTotal();
     }
 
+    /** Fired when a route is starting. */
     interface RouteStartingEvent extends RouteEvent {
         @Override
         default Type getType() {
@@ -410,6 +464,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when a route has been started. */
     interface RouteStartedEvent extends RouteEvent {
         @Override
         default Type getType() {
@@ -417,6 +472,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when a route is stopping. */
     interface RouteStoppingEvent extends RouteEvent {
         @Override
         default Type getType() {
@@ -424,6 +480,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when a route has been stopped. */
     interface RouteStoppedEvent extends RouteEvent {
         @Override
         default Type getType() {
@@ -463,8 +520,10 @@ public interface CamelEvent {
         }
     }
 
+    /** Event related to {@link org.apache.camel.Service} lifecycle changes. */
     interface ServiceEvent extends CamelEvent {
 
+        /** Returns the service. */
         Object getService();
 
         @Override
@@ -473,6 +532,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when a service failed to start. */
     interface ServiceStartupFailureEvent extends ServiceEvent, FailureEvent {
         @Override
         default Type getType() {
@@ -480,6 +540,7 @@ public interface CamelEvent {
         }
     }
 
+    /** Fired when a service failed to stop. */
     interface ServiceStopFailureEvent extends ServiceEvent, FailureEvent {
         @Override
         default Type getType() {

--- a/core/camel-api/src/main/java/org/apache/camel/spi/EventNotifier.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/EventNotifier.java
@@ -17,9 +17,10 @@
 package org.apache.camel.spi;
 
 /**
- * Notifier to send {@link java.util.EventObject events}.
+ * Notifier to send {@link CamelEvent} notifications.
  *
- * @see org.apache.camel.spi.EventFactory
+ * @see CamelEvent
+ * @see EventFactory
  */
 public interface EventNotifier {
 
@@ -48,57 +49,83 @@ public interface EventNotifier {
      */
     boolean isDisabled();
 
+    /** Whether to ignore CamelContext initialization events. */
     boolean isIgnoreCamelContextInitEvents();
 
+    /** Set whether to ignore CamelContext initialization events. */
     void setIgnoreCamelContextInitEvents(boolean ignoreCamelContextInitEvents);
 
+    /** Whether to ignore CamelContext lifecycle events (start, stop, suspend, resume). */
     boolean isIgnoreCamelContextEvents();
 
+    /** Set whether to ignore CamelContext lifecycle events (start, stop, suspend, resume). */
     void setIgnoreCamelContextEvents(boolean ignoreCamelContextEvents);
 
+    /** Whether to ignore route lifecycle events (added, removed, started, stopped). */
     boolean isIgnoreRouteEvents();
 
+    /** Set whether to ignore route lifecycle events (added, removed, started, stopped). */
     void setIgnoreRouteEvents(boolean ignoreRouteEvents);
 
+    /** Whether to ignore service lifecycle events (start failure, stop failure). */
     boolean isIgnoreServiceEvents();
 
+    /** Set whether to ignore service lifecycle events (start failure, stop failure). */
     void setIgnoreServiceEvents(boolean ignoreServiceEvents);
 
+    /** Whether to ignore all exchange events. */
     boolean isIgnoreExchangeEvents();
 
+    /** Set whether to ignore all exchange events. */
     void setIgnoreExchangeEvents(boolean ignoreExchangeEvents);
 
+    /** Whether to ignore exchange created events. */
     boolean isIgnoreExchangeCreatedEvent();
 
+    /** Set whether to ignore exchange created events. */
     void setIgnoreExchangeCreatedEvent(boolean ignoreExchangeCreatedEvent);
 
+    /** Whether to ignore exchange completed events. */
     boolean isIgnoreExchangeCompletedEvent();
 
+    /** Set whether to ignore exchange completed events. */
     void setIgnoreExchangeCompletedEvent(boolean ignoreExchangeCompletedEvent);
 
+    /** Whether to ignore exchange failed events. */
     boolean isIgnoreExchangeFailedEvents();
 
+    /** Set whether to ignore exchange failed events. */
     void setIgnoreExchangeFailedEvents(boolean ignoreExchangeFailureEvents);
 
+    /** Whether to ignore exchange redelivery events. */
     boolean isIgnoreExchangeRedeliveryEvents();
 
+    /** Set whether to ignore exchange redelivery events. */
     void setIgnoreExchangeRedeliveryEvents(boolean ignoreExchangeRedeliveryEvents);
 
+    /** Whether to ignore exchange sent events (after sending to an endpoint). */
     boolean isIgnoreExchangeSentEvents();
 
+    /** Set whether to ignore exchange sent events (after sending to an endpoint). */
     void setIgnoreExchangeSentEvents(boolean ignoreExchangeSentEvents);
 
+    /** Whether to ignore exchange sending events (before sending to an endpoint). */
     boolean isIgnoreExchangeSendingEvents();
 
+    /** Set whether to ignore exchange sending events (before sending to an endpoint). */
     void setIgnoreExchangeSendingEvents(boolean ignoreExchangeSendingEvents);
 
+    /** Whether to ignore step events. */
     boolean isIgnoreStepEvents();
 
+    /** Set whether to ignore step events. */
     void setIgnoreStepEvents(boolean ignoreStepEvents);
 
+    /** @deprecated Set whether to ignore exchange async processing started events. */
     @Deprecated(since = "4.19.0")
     void setIgnoreExchangeAsyncProcessingStartedEvents(boolean ignoreExchangeAsyncProcessingStartedEvents);
 
+    /** @deprecated Whether to ignore exchange async processing started events. */
     @Deprecated(since = "4.19.0")
     boolean isIgnoreExchangeAsyncProcessingStartedEvents();
 }

--- a/core/camel-api/src/main/java/org/apache/camel/support/jsse/package-info.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/jsse/package-info.java
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Configuration classes for Java Secure Socket Extension (JSSE) SSL/TLS setup.
+ */
 @NullMarked
 package org.apache.camel.support.jsse;
 

--- a/core/camel-api/src/main/java/org/apache/camel/support/service/package-info.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/service/package-info.java
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Base classes for implementing the Camel service lifecycle (build, init, start, stop, suspend, resume).
+ */
 @NullMarked
 package org.apache.camel.support.service;
 

--- a/core/camel-api/src/main/java/org/apache/camel/vault/package-info.java
+++ b/core/camel-api/src/main/java/org/apache/camel/vault/package-info.java
@@ -14,6 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Configuration classes for accessing external secret vaults such as AWS Secrets Manager, GCP Secret Manager, Azure Key
+ * Vault, and HashiCorp Vault.
+ */
 @NullMarked
 package org.apache.camel.vault;
 


### PR DESCRIPTION
## Summary

Add missing Javadoc documentation across the camel-api module:

- Add Javadoc to ~40 `CamelEvent` nested event interfaces describing when each event fires
- Fix `EventNotifier` class doc (`EventObject` -> `CamelEvent`) and document all 26 ignore/set methods
- Document enum constants across 9 enums (`ExchangePattern`, `ServiceStatus`, `BeanScope`, `LoggingLevel`, `ManagementStatisticsLevel`, `ManagementMBeansLevel`, `WaitForTaskToComplete`, `TypeConverterExists`, `StartupSummaryLevel`)
- Add class-level Javadoc to `BeanScope` and `CamelClusterService`
- Add descriptive Javadoc to 9 `package-info.java` files (catalog, health, vault, console, resume, cluster, support/service, support/jsse)
- Convert `Route.java` inline comments to proper Javadoc blocks (7 methods)

All changes are Javadoc-only — no functional code modified.

## Test plan

- [x] `mvn install -pl core/camel-api -DskipTests` passes
- [x] Formatter applied (`mvn formatter:format impsort:sort`)
- [x] No generated file changes needed (verified spurious `ExchangeConstantProvider` diff reverted)