### PR TITLE
Improve Javadoc across camel-api: URLs, Exchange, SPI contracts, and exception constructors

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/AggregationStrategy.java
+++ b/core/camel-api/src/main/java/org/apache/camel/AggregationStrategy.java
@@ -44,13 +44,13 @@ import org.slf4j.LoggerFactory;
  * market data prices; where old values are of little use.
  * <p/>
  * If an implementation also implements {@link org.apache.camel.Service} then any
- * <a href="http://camel.apache.org/eip">EIP</a> that allowing configuring a {@link AggregationStrategy} will invoke the
- * {@link org.apache.camel.Service#start()} and {@link org.apache.camel.Service#stop()} to control the lifecycle aligned
- * with the EIP itself.
+ * <a href="https://camel.apache.org/eip">EIP</a> that allowing configuring a {@link AggregationStrategy} will invoke
+ * the {@link org.apache.camel.Service#start()} and {@link org.apache.camel.Service#stop()} to control the lifecycle
+ * aligned with the EIP itself.
  * <p/>
  * If an implementation also implements {@link org.apache.camel.CamelContextAware} then any
- * <a href="http://camel.apache.org/eip">EIP</a> that allowing configuring a {@link AggregationStrategy} will inject the
- * {@link org.apache.camel.CamelContext} prior to using the aggregation strategy.
+ * <a href="https://camel.apache.org/eip">EIP</a> that allowing configuring a {@link AggregationStrategy} will inject
+ * the {@link org.apache.camel.CamelContext} prior to using the aggregation strategy.
  */
 public interface AggregationStrategy {
 

--- a/core/camel-api/src/main/java/org/apache/camel/CamelContext.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelContext.java
@@ -1000,7 +1000,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
      * Creates a new {@link ProducerTemplate} which is <b>started</b> and therefore ready to use right away.
      * <p/>
      * See this FAQ before use:
-     * <a href="http://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html"> Why does Camel
+     * <a href="https://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html"> Why does Camel
      * use too many threads with ProducerTemplate?</a>
      * <p/>
      * <b>Important:</b> Make sure to call {@link org.apache.camel.ProducerTemplate#stop()} when you are done using the
@@ -1020,7 +1020,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
      * Creates a new {@link ProducerTemplate} which is <b>started</b> and therefore ready to use right away.
      * <p/>
      * See this FAQ before use:
-     * <a href="http://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html"> Why does Camel
+     * <a href="https://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html"> Why does Camel
      * use too many threads with ProducerTemplate?</a>
      * <p/>
      * <b>Important:</b> Make sure to call {@link ProducerTemplate#stop()} when you are done using the template, to
@@ -1036,7 +1036,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
      * Creates a new {@link FluentProducerTemplate} which is <b>started</b> and therefore ready to use right away.
      * <p/>
      * See this FAQ before use:
-     * <a href="http://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html"> Why does Camel
+     * <a href="https://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html"> Why does Camel
      * use too many threads with ProducerTemplate?</a>
      * <p/>
      * <b>Important:</b> Make sure to call {@link org.apache.camel.FluentProducerTemplate#stop()} when you are done
@@ -1056,7 +1056,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
      * Creates a new {@link FluentProducerTemplate} which is <b>started</b> and therefore ready to use right away.
      * <p/>
      * See this FAQ before use:
-     * <a href="http://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html"> Why does Camel
+     * <a href="https://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html"> Why does Camel
      * use too many threads with ProducerTemplate?</a>
      * <p/>
      * <b>Important:</b> Make sure to call {@link FluentProducerTemplate#stop()} when you are done using the template,
@@ -1072,7 +1072,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
      * Creates a new {@link ConsumerTemplate} which is <b>started</b> and therefore ready to use right away.
      * <p/>
      * See this FAQ before use:
-     * <a href="http://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html"> Why does Camel
+     * <a href="https://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html"> Why does Camel
      * use too many threads with ProducerTemplate?</a> as it also applies for ConsumerTemplate.
      * <p/>
      * <b>Important:</b> Make sure to call {@link ConsumerTemplate#stop()} when you are done using the template, to
@@ -1092,7 +1092,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
      * Creates a new {@link ConsumerTemplate} which is <b>started</b> and therefore ready to use right away.
      * <p/>
      * See this FAQ before use:
-     * <a href="http://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html"> Why does Camel
+     * <a href="https://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html"> Why does Camel
      * use too many threads with ProducerTemplate?</a> as it also applies for ConsumerTemplate.
      * <p/>
      * <b>Important:</b> Make sure to call {@link ConsumerTemplate#stop()} when you are done using the template, to
@@ -1177,7 +1177,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
      * <b>Important:</b> This has nothing to do with property placeholders, and is just a plain set of key/value pairs
      * which are used to configure global options on CamelContext, such as a maximum debug logging length etc. For
      * property placeholders use {@link #resolvePropertyPlaceholders(String)} method and see more details at the
-     * <a href="http://camel.apache.org/using-propertyplaceholder.html">property placeholder</a> documentation.
+     * <a href="https://camel.apache.org/using-propertyplaceholder.html">property placeholder</a> documentation.
      *
      * @param globalOptions global options that can be referenced in the camel context
      */
@@ -1189,7 +1189,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
      * <b>Important:</b> This has nothing to do with property placeholders, and is just a plain set of key/value pairs
      * which are used to configure global options on CamelContext, such as a maximum debug logging length etc. For
      * property placeholders use {@link #resolvePropertyPlaceholders(String)} method and see more details at the
-     * <a href="http://camel.apache.org/using-propertyplaceholder.html">property placeholder</a> documentation.
+     * <a href="https://camel.apache.org/using-propertyplaceholder.html">property placeholder</a> documentation.
      *
      * @return global options for this context
      */
@@ -1201,7 +1201,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
      * <b>Important:</b> This has nothing to do with property placeholders, and is just a plain set of key/value pairs
      * which are used to configure global options on CamelContext, such as a maximum debug logging length etc. For
      * property placeholders use {@link #resolvePropertyPlaceholders(String)} method and see more details at the
-     * <a href="http://camel.apache.org/using-propertyplaceholder.html">property placeholder</a> documentation.
+     * <a href="https://camel.apache.org/using-propertyplaceholder.html">property placeholder</a> documentation.
      *
      * @return the string value of the global option
      */

--- a/core/camel-api/src/main/java/org/apache/camel/CamelExchangeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelExchangeException.java
@@ -29,12 +29,21 @@ public class CamelExchangeException extends CamelException {
     // exchange is not guaranteed to be serializable so we set it as transient
     private final transient @Nullable Exchange exchange;
 
+    /**
+     * @param message  the detail message
+     * @param exchange the exchange that caused the error
+     */
     public CamelExchangeException(String message, @Nullable Exchange exchange) {
         super(CamelExchangeException.createExceptionMessage(
                 Objects.requireNonNull(message, "message"), exchange, null));
         this.exchange = exchange;
     }
 
+    /**
+     * @param message  the detail message
+     * @param exchange the exchange that caused the error
+     * @param cause    the cause of the failure
+     */
     public CamelExchangeException(String message, @Nullable Exchange exchange, Throwable cause) {
         super(CamelExchangeException.createExceptionMessage(
                 Objects.requireNonNull(message, "message"), exchange,

--- a/core/camel-api/src/main/java/org/apache/camel/CamelExecutionException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelExecutionException.java
@@ -27,10 +27,19 @@ import org.jspecify.annotations.Nullable;
  */
 public class CamelExecutionException extends RuntimeExchangeException {
 
+    /**
+     * @param message  the detail message
+     * @param exchange the exchange that caused the error
+     */
     public CamelExecutionException(String message, @Nullable Exchange exchange) {
         super(Objects.requireNonNull(message, "message"), exchange);
     }
 
+    /**
+     * @param message  the detail message
+     * @param exchange the exchange that caused the error
+     * @param cause    the cause of the failure
+     */
     public CamelExecutionException(String message, @Nullable Exchange exchange, Throwable cause) {
         super(Objects.requireNonNull(message, "message"), exchange,
               Objects.requireNonNull(cause, "cause"));

--- a/core/camel-api/src/main/java/org/apache/camel/Component.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Component.java
@@ -26,7 +26,7 @@ import org.apache.camel.spi.PropertyConfigurer;
 import org.jspecify.annotations.Nullable;
 
 /**
- * A <a href="http://camel.apache.org/component.html">component</a> is a factory of {@link Endpoint} objects.
+ * A <a href="https://camel.apache.org/component.html">component</a> is a factory of {@link Endpoint} objects.
  */
 public interface Component extends CamelContextAware, Service {
 

--- a/core/camel-api/src/main/java/org/apache/camel/Consume.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Consume.java
@@ -23,11 +23,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Subscribes a method to an {@link Endpoint} either via its <a href="http://camel.apache.org/uris.html">URI</a> or via
+ * Subscribes a method to an {@link Endpoint} either via its <a href="https://camel.apache.org/uris.html">URI</a> or via
  * the name of the endpoint reference which is then resolved in a registry such as the Spring Application Context.
  * <p/>
  * When a message {@link Exchange} is received from the {@link Endpoint} then the
- * <a href="http://camel.apache.org/bean-integration.html">Bean Integration</a> mechanism is used to map the incoming
+ * <a href="https://camel.apache.org/bean-integration.html">Bean Integration</a> mechanism is used to map the incoming
  * {@link Message} to the method parameters.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/camel-api/src/main/java/org/apache/camel/ConsumerTemplate.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ConsumerTemplate.java
@@ -22,8 +22,8 @@ import org.jspecify.annotations.Nullable;
  * Template for working with Camel and consuming {@link Message} instances in an {@link Exchange} from an
  * {@link Endpoint}. <br/>
  * <p/>
- * This template is an implementation of the <a href="http://camel.apache.org/polling-consumer.html">Polling Consumer
- * EIP</a>. This is <b>not</b> the <a href="http://camel.apache.org/event-driven-consumer.html">Event Driven Consumer
+ * This template is an implementation of the <a href="https://camel.apache.org/polling-consumer.html">Polling Consumer
+ * EIP</a>. This is <b>not</b> the <a href="https://camel.apache.org/event-driven-consumer.html">Event Driven Consumer
  * EIP</a>. <br/>
  * <p/>
  * The {@link ConsumerTemplate} is <b>thread safe</b>. <br/>
@@ -36,8 +36,8 @@ import org.jspecify.annotations.Nullable;
  * the template.
  * <p/>
  * <b>Important note on usage:</b> See this
- * <a href="http://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html">FAQ entry</a> before
- * using, it applies to this {@link ConsumerTemplate} as well.
+ * <a href="https://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html">FAQ entry</a>
+ * before using, it applies to this {@link ConsumerTemplate} as well.
  *
  * @see ProducerTemplate
  * @see FluentProducerTemplate

--- a/core/camel-api/src/main/java/org/apache/camel/Converter.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Converter.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 /**
  * An annotation used to mark classes and methods to indicate code capable of converting from a type to another type
- * which are then auto-discovered using the <a href="http://camel.apache.org/type-converter.html">Type Conversion
+ * which are then auto-discovered using the <a href="https://camel.apache.org/type-converter.html">Type Conversion
  * Support</a>
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/camel-api/src/main/java/org/apache/camel/DynamicRouter.java
+++ b/core/camel-api/src/main/java/org/apache/camel/DynamicRouter.java
@@ -23,11 +23,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that this method is to be used as a <a href="http://camel.apache.org/dynamic-router.html">Dynamic
+ * Indicates that this method is to be used as a <a href="https://camel.apache.org/dynamic-router.html">Dynamic
  * Router</a> routing the incoming message through a series of processing steps.
  *
  * When a message {@link Exchange} is received from an {@link Endpoint} then the
- * <a href="http://camel.apache.org/bean-integration.html">Bean Integration</a> mechanism is used to map the incoming
+ * <a href="https://camel.apache.org/bean-integration.html">Bean Integration</a> mechanism is used to map the incoming
  * {@link Message} to the method parameters.
  *
  * The return value of the method is then converted to either a {@link java.util.Collection} or array of objects where

--- a/core/camel-api/src/main/java/org/apache/camel/Endpoint.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Endpoint.java
@@ -22,8 +22,8 @@ import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.StringHelper;
 
 /**
- * An <a href="http://camel.apache.org/endpoint.html">endpoint</a> implements the
- * <a href="http://camel.apache.org/message-endpoint.html">Message Endpoint</a> pattern and represents an endpoint that
+ * An <a href="https://camel.apache.org/endpoint.html">endpoint</a> implements the
+ * <a href="https://camel.apache.org/message-endpoint.html">Message Endpoint</a> pattern and represents an endpoint that
  * can send and receive message exchanges
  *
  * @see Exchange
@@ -130,7 +130,7 @@ public interface Endpoint extends IsSingleton, Service, ComponentAware {
     AsyncProducer createAsyncProducer() throws Exception;
 
     /**
-     * Creates a new <a href="http://camel.apache.org/event-driven-consumer.html">Event Driven Consumer</a> which
+     * Creates a new <a href="https://camel.apache.org/event-driven-consumer.html">Event Driven Consumer</a> which
      * consumes messages from the endpoint using the given processor
      *
      * Important: Do not do any initialization in the constructor of the {@link Consumer}. Instead use
@@ -143,10 +143,10 @@ public interface Endpoint extends IsSingleton, Service, ComponentAware {
     Consumer createConsumer(Processor processor) throws Exception;
 
     /**
-     * Creates a new <a href="http://camel.apache.org/polling-consumer.html">Polling Consumer</a> so that the caller can
-     * poll message exchanges from the consumer using {@link PollingConsumer#receive()},
+     * Creates a new <a href="https://camel.apache.org/polling-consumer.html">Polling Consumer</a> so that the caller
+     * can poll message exchanges from the consumer using {@link PollingConsumer#receive()},
      * {@link PollingConsumer#receiveNoWait()} or {@link PollingConsumer#receive(long)} whenever it is ready to do so
-     * rather than using the <a href="http://camel.apache.org/event-driven-consumer.html">Event Based Consumer</a>
+     * rather than using the <a href="https://camel.apache.org/event-driven-consumer.html">Event Based Consumer</a>
      * returned by {@link #createConsumer(Processor)}
      *
      * Important: Do not do any initialization in the constructor of the {@link PollingConsumer}. Instead use

--- a/core/camel-api/src/main/java/org/apache/camel/EndpointInject.java
+++ b/core/camel-api/src/main/java/org/apache/camel/EndpointInject.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * Used to indicate an injection point of an {@link Endpoint}, {@link Producer} or {@link ProducerTemplate} into a POJO.
  *
- * A <a href="http://camel.apache.org/uris.html">URI</a> for an endpoint can be specified on this annotation, or a name
+ * A <a href="https://camel.apache.org/uris.html">URI</a> for an endpoint can be specified on this annotation, or a name
  * can be specified which is resolved in the {@link org.apache.camel.spi.Registry} such as in your Spring
  * ApplicationContext.
  *

--- a/core/camel-api/src/main/java/org/apache/camel/Exchange.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Exchange.java
@@ -46,7 +46,7 @@ import org.jspecify.annotations.Nullable;
  * <p/>
  * To access or modify the current message, use the {@link #getMessage()} method. Camel uses {@link #getMessage()} to
  * obtain the current message during routing. If a {@link Processor} modifies the message, those changes are visible to
- * subsequent processors.
+ * subsequent processors. The {@link ExchangePattern} determines whether a reply is expected (InOut) or not (InOnly).
  */
 @ConstantProvider("org.apache.camel.ExchangeConstantProvider")
 public interface Exchange extends VariableAware {

--- a/core/camel-api/src/main/java/org/apache/camel/Exchange.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Exchange.java
@@ -28,9 +28,9 @@ import org.jspecify.annotations.Nullable;
  * An Exchange is the message container holding the information during the entire routing of a {@link Message} received
  * by a {@link Consumer}.
  * <p/>
- * During processing down the {@link Processor} chain, the {@link Exchange} provides access to the current (not the
- * original) request and response {@link Message} messages. The {@link Exchange} also holds meta-data during its entire
- * lifetime stored as properties accessible using the various {@link #getProperty(String)} methods. The
+ * During processing down the {@link Processor} chain, the {@link Exchange} provides access to the current
+ * {@link Message} via {@link #getMessage()}. The {@link Exchange} also holds meta-data during its entire lifetime
+ * stored as properties accessible using the various {@link #getProperty(String)} methods. The
  * {@link #setProperty(String, Object)} is used to store a property. For example, you can use this to store security,
  * SLA related data or any other information deemed useful throughout processing. If an {@link Exchange} failed during
  * routing the {@link Exception} that caused the failure is stored and accessible via the {@link #getException()}
@@ -39,28 +39,14 @@ import org.jspecify.annotations.Nullable;
  * An Exchange is created when a {@link Consumer} receives a request. A new {@link Message} is created, the request is
  * set as the body of the {@link Message} and depending on the {@link Consumer} other {@link Endpoint} and protocol
  * related information is added as headers on the {@link Message}. Then an Exchange is created and the newly created
- * {@link Message} is set as the in on the Exchange. Therefore, an Exchange starts its life in a {@link Consumer}. The
- * Exchange is then sent down the {@link Route} for processing along a {@link Processor} chain. The {@link Processor} as
- * the name suggests is what processes the {@link Message} in the Exchange and Camel, in addition to providing
- * out-of-the-box a large number of useful processors, it also allows you to create your own. The rule Camel uses is to
- * take the out {@link Message} produced by the previous {@link Processor} and set it as the in for the next
- * {@link Processor}. If the previous {@link Processor} did not produce an out, then the in of the previous
- * {@link Processor} is sent as the next in. At the end of the processing chain, depending on the {@link ExchangePattern
- * Message Exchange Pattern} (or MEP) the last out (or in of no out available) is sent by the {@link Consumer} back to
- * the original caller.
+ * {@link Message} is set on the Exchange. Therefore, an Exchange starts its life in a {@link Consumer}. The Exchange is
+ * then sent down the {@link Route} for processing along a {@link Processor} chain. The {@link Processor} as the name
+ * suggests is what processes the {@link Message} in the Exchange. Camel provides a large number of useful processors
+ * out-of-the-box, and it also allows you to create your own.
  * <p/>
- * Camel, in addition to providing out-of-the-box a large number of useful processors, it also allows you to implement
- * and use your own. When the Exchange is passed to a {@link Processor}, it always contains an in {@link Message} and no
- * out {@link Message}. The {@link Processor} <b>may</b> produce an out, depending on the nature of the
- * {@link Processor}. The in {@link Message} can be accessed using the {@link #getIn()} method. Since the out message is
- * null when entering the {@link Processor}, the {@link #getOut()} method is actually a convenient factory method that
- * will lazily instantiate a {@link org.apache.camel.support.DefaultMessage} which you could populate. As an alternative
- * you could also instantiate your specialized {@link Message} and set it on the exchange using the
- * {@link #setOut(org.apache.camel.Message)} method. Please note that a {@link Message} contains not only the body but
- * also headers and attachments. If you are creating a new {@link Message} the headers and attachments of the in
- * {@link Message} are not automatically copied to the out by Camel, and you'll have to set the headers and attachments
- * you need yourself. If your {@link Processor} is not producing a different {@link Message} but only needs to slightly
- * modify the in, you can simply update the in {@link Message} returned by {@link #getIn()}.
+ * To access or modify the current message, use the {@link #getMessage()} method. Camel uses {@link #getMessage()} to
+ * obtain the current message during routing. If a {@link Processor} modifies the message, those changes are visible to
+ * subsequent processors.
  */
 @ConstantProvider("org.apache.camel.ExchangeConstantProvider")
 public interface Exchange extends VariableAware {

--- a/core/camel-api/src/main/java/org/apache/camel/Expression.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Expression.java
@@ -19,7 +19,7 @@ package org.apache.camel;
 import org.jspecify.annotations.Nullable;
 
 /**
- * An <a href="http://camel.apache.org/expression.html">expression</a> provides a plugin strategy for evaluating
+ * An <a href="https://camel.apache.org/expression.html">expression</a> provides a plugin strategy for evaluating
  * expressions on a message exchange.
  *
  * An expression should be thread-safe and be able to evaluate concurrently by different threads with different

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToCreateConsumerException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToCreateConsumerException.java
@@ -27,24 +27,41 @@ public class FailedToCreateConsumerException extends RuntimeCamelException {
 
     private final String uri;
 
+    /**
+     * @param endpointURI the URI of the endpoint for which consumer creation failed
+     * @param cause       the cause of the failure
+     */
     public FailedToCreateConsumerException(String endpointURI, Throwable cause) {
         super("Failed to create Consumer for endpoint for: " + sanitizeUri(Objects.requireNonNull(endpointURI, "endpointURI"))
               + ". Reason: " + Objects.requireNonNull(cause, "cause"), cause);
         this.uri = sanitizeUri(endpointURI);
     }
 
+    /**
+     * @param endpoint the endpoint for which consumer creation failed
+     * @param cause    the cause of the failure
+     */
     public FailedToCreateConsumerException(Endpoint endpoint, Throwable cause) {
         super("Failed to create Consumer for endpoint: " + Objects.requireNonNull(endpoint, "endpoint") + ". Reason: "
               + Objects.requireNonNull(cause, "cause"), cause);
         this.uri = sanitizeUri(endpoint.getEndpointUri());
     }
 
+    /**
+     * @param endpoint the endpoint for which consumer creation failed
+     * @param message  the detail message
+     * @param cause    the cause of the failure
+     */
     public FailedToCreateConsumerException(Endpoint endpoint, String message, Throwable cause) {
         super("Failed to create Consumer for endpoint: " + Objects.requireNonNull(endpoint, "endpoint") + ". Reason: "
               + Objects.requireNonNull(message, "message"), Objects.requireNonNull(cause, "cause"));
         this.uri = sanitizeUri(endpoint.getEndpointUri());
     }
 
+    /**
+     * @param endpoint the endpoint for which consumer creation failed
+     * @param message  the detail message
+     */
     public FailedToCreateConsumerException(Endpoint endpoint, String message) {
         super("Failed to create Consumer for endpoint: " + Objects.requireNonNull(endpoint, "endpoint") + ". Reason: "
               + Objects.requireNonNull(message, "message"));

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToCreateProducerException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToCreateProducerException.java
@@ -27,6 +27,10 @@ public class FailedToCreateProducerException extends RuntimeCamelException {
 
     private final String uri;
 
+    /**
+     * @param endpoint the endpoint for which producer creation failed
+     * @param cause    the cause of the failure
+     */
     public FailedToCreateProducerException(Endpoint endpoint, Throwable cause) {
         super("Failed to create Producer for endpoint: " + Objects.requireNonNull(endpoint, "endpoint") + ". Reason: "
               + Objects.requireNonNull(cause, "cause"), cause);

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToCreateRouteException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToCreateRouteException.java
@@ -29,12 +29,21 @@ public class FailedToCreateRouteException extends RuntimeCamelException {
     private final @Nullable String routeId;
     private final @Nullable String location;
 
+    /**
+     * @param cause the error message describing why route creation failed
+     */
     public FailedToCreateRouteException(String cause) {
         super("Failed to create route because: " + Objects.requireNonNull(cause, "cause"));
         this.routeId = null;
         this.location = null;
     }
 
+    /**
+     * @param routeId  the ID of the route that failed to be created
+     * @param location the source location of the route definition, or {@code null} if unknown
+     * @param route    the route definition string
+     * @param cause    the error message describing why route creation failed
+     */
     public FailedToCreateRouteException(String routeId, @Nullable String location, String route, String cause) {
         super("Failed to create route: " + Objects.requireNonNull(routeId, "routeId")
               + (location != null ? " (source: " + location + ")" : "") + ": "
@@ -44,6 +53,12 @@ public class FailedToCreateRouteException extends RuntimeCamelException {
         this.location = location;
     }
 
+    /**
+     * @param routeId  the ID of the route that failed to be created
+     * @param location the source location of the route definition, or {@code null} if unknown
+     * @param route    the route definition string
+     * @param cause    the cause of the failure
+     */
     public FailedToCreateRouteException(String routeId, @Nullable String location, String route, Throwable cause) {
         super("Failed to create route: " + Objects.requireNonNull(routeId, "routeId")
               + (location != null ? " (source: " + location + ")" : "") + ": "
@@ -54,6 +69,13 @@ public class FailedToCreateRouteException extends RuntimeCamelException {
         this.location = location;
     }
 
+    /**
+     * @param routeId  the ID of the route that failed to be created
+     * @param location the source location of the route definition, or {@code null} if unknown
+     * @param route    the route definition string
+     * @param at       the location in the route definition where the error occurred
+     * @param cause    the cause of the failure
+     */
     public FailedToCreateRouteException(String routeId, @Nullable String location, String route, String at, Throwable cause) {
         super("Failed to create route: " + Objects.requireNonNull(routeId, "routeId")
               + (location != null ? " (source: " + location + ")" : "") + " at: >>> "

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToCreateRouteException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToCreateRouteException.java
@@ -30,7 +30,7 @@ public class FailedToCreateRouteException extends RuntimeCamelException {
     private final @Nullable String location;
 
     /**
-     * @param cause the error message describing why route creation failed
+     * @param cause a description of why route creation failed
      */
     public FailedToCreateRouteException(String cause) {
         super("Failed to create route because: " + Objects.requireNonNull(cause, "cause"));

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToStartComponentException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToStartComponentException.java
@@ -25,6 +25,11 @@ public class FailedToStartComponentException extends RuntimeCamelException {
 
     private final String componentName;
 
+    /**
+     * @param componentName the name of the component that failed to start
+     * @param message       the detail message describing the failure
+     * @param cause         the cause of the failure
+     */
     public FailedToStartComponentException(String componentName, String message, Throwable cause) {
         super("Failed to start component " + Objects.requireNonNull(componentName, "componentName") + " because of "
               + Objects.requireNonNull(message, "message"), Objects.requireNonNull(cause, "cause"));

--- a/core/camel-api/src/main/java/org/apache/camel/FluentProducerTemplate.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FluentProducerTemplate.java
@@ -84,8 +84,8 @@ import org.jspecify.annotations.Nullable;
  * the template.<br/>
  * <p/>
  * <b>Important note on usage:</b> See this
- * <a href="http://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html">FAQ entry</a> before
- * using.
+ * <a href="https://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html">FAQ entry</a>
+ * before using.
  *
  * @see ProducerTemplate
  * @see ConsumerTemplate

--- a/core/camel-api/src/main/java/org/apache/camel/InOnly.java
+++ b/core/camel-api/src/main/java/org/apache/camel/InOnly.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 /**
  * Marks methods as being {@link ExchangePattern#InOnly} for one way asynchronous invocation when using
- * <a href="http://camel.apache.org/bean-integration.html">Bean Integration</a> to overload the default value which is
+ * <a href="https://camel.apache.org/bean-integration.html">Bean Integration</a> to overload the default value which is
  * {@link ExchangePattern#InOut} for request/reply if no annotations are used.
  *
  * This annotation can be added to individual methods or added to a class or interface to act as a default for all

--- a/core/camel-api/src/main/java/org/apache/camel/InOut.java
+++ b/core/camel-api/src/main/java/org/apache/camel/InOut.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a method as being {@link ExchangePattern#InOut} when a class or interface has been annotated with
- * {@link InOnly} when using <a href="http://camel.apache.org/bean-integration.html">Bean Integration</a>.
+ * {@link InOnly} when using <a href="https://camel.apache.org/bean-integration.html">Bean Integration</a>.
  *
  * This annotation is only intended to be used on methods which the class or interface has been annotated with a default
  * exchange pattern annotation such as {@link InOnly} or {@link Pattern}

--- a/core/camel-api/src/main/java/org/apache/camel/InvalidPayloadException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/InvalidPayloadException.java
@@ -27,10 +27,19 @@ public class InvalidPayloadException extends CamelExchangeException {
 
     private final transient @Nullable Class<?> type;
 
+    /**
+     * @param exchange the exchange that caused the error
+     * @param type     the expected body type
+     */
     public InvalidPayloadException(Exchange exchange, Class<?> type) {
         this(exchange, type, exchange.getIn());
     }
 
+    /**
+     * @param exchange the exchange that caused the error
+     * @param type     the expected body type
+     * @param message  the message whose body could not be converted
+     */
     public InvalidPayloadException(Exchange exchange, Class<?> type, Message message) {
         super("No body available of type: " + Objects.requireNonNull(type, "type").getCanonicalName()
               + NoSuchPropertyException.valueDescription(Objects.requireNonNull(message, "message").getBody())
@@ -38,6 +47,12 @@ public class InvalidPayloadException extends CamelExchangeException {
         this.type = type;
     }
 
+    /**
+     * @param exchange the exchange that caused the error
+     * @param type     the expected body type
+     * @param message  the message whose body could not be converted
+     * @param cause    the cause of the failure
+     */
     public InvalidPayloadException(Exchange exchange, Class<?> type, Message message, Throwable cause) {
         super("No body available of type: " + Objects.requireNonNull(type, "type").getCanonicalName()
               + NoSuchPropertyException.valueDescription(Objects.requireNonNull(message, "message").getBody())

--- a/core/camel-api/src/main/java/org/apache/camel/InvalidPayloadException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/InvalidPayloadException.java
@@ -38,7 +38,7 @@ public class InvalidPayloadException extends CamelExchangeException {
     /**
      * @param exchange the exchange that caused the error
      * @param type     the expected body type
-     * @param message  the message whose body could not be converted
+     * @param message  the message with the invalid or missing payload
      */
     public InvalidPayloadException(Exchange exchange, Class<?> type, Message message) {
         super("No body available of type: " + Objects.requireNonNull(type, "type").getCanonicalName()
@@ -50,7 +50,7 @@ public class InvalidPayloadException extends CamelExchangeException {
     /**
      * @param exchange the exchange that caused the error
      * @param type     the expected body type
-     * @param message  the message whose body could not be converted
+     * @param message  the message with the invalid or missing payload
      * @param cause    the cause of the failure
      */
     public InvalidPayloadException(Exchange exchange, Class<?> type, Message message, Throwable cause) {

--- a/core/camel-api/src/main/java/org/apache/camel/InvalidPayloadRuntimeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/InvalidPayloadRuntimeException.java
@@ -47,7 +47,7 @@ public class InvalidPayloadRuntimeException extends RuntimeExchangeException {
     /**
      * @param exchange the exchange that caused the error
      * @param type     the expected body type
-     * @param message  the message whose body could not be converted
+     * @param message  the message with the invalid or missing payload
      */
     public InvalidPayloadRuntimeException(Exchange exchange, Class<?> type, Message message) {
         super("No body available of type: " + Objects.requireNonNull(type, "type").getName()
@@ -59,7 +59,7 @@ public class InvalidPayloadRuntimeException extends RuntimeExchangeException {
     /**
      * @param exchange the exchange that caused the error
      * @param type     the expected body type
-     * @param message  the message whose body could not be converted
+     * @param message  the message with the invalid or missing payload
      * @param cause    the cause of the failure
      */
     public InvalidPayloadRuntimeException(Exchange exchange, Class<?> type, Message message, Throwable cause) {

--- a/core/camel-api/src/main/java/org/apache/camel/InvalidPayloadRuntimeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/InvalidPayloadRuntimeException.java
@@ -27,14 +27,28 @@ public class InvalidPayloadRuntimeException extends RuntimeExchangeException {
 
     private final transient @Nullable Class<?> type;
 
+    /**
+     * @param exchange the exchange that caused the error
+     * @param type     the expected body type
+     */
     public InvalidPayloadRuntimeException(Exchange exchange, Class<?> type) {
         this(exchange, type, exchange.getIn());
     }
 
+    /**
+     * @param exchange the exchange that caused the error
+     * @param type     the expected body type
+     * @param cause    the cause of the failure
+     */
     public InvalidPayloadRuntimeException(Exchange exchange, Class<?> type, Throwable cause) {
         this(exchange, type, exchange.getIn(), cause);
     }
 
+    /**
+     * @param exchange the exchange that caused the error
+     * @param type     the expected body type
+     * @param message  the message whose body could not be converted
+     */
     public InvalidPayloadRuntimeException(Exchange exchange, Class<?> type, Message message) {
         super("No body available of type: " + Objects.requireNonNull(type, "type").getName()
               + NoSuchPropertyException.valueDescription(Objects.requireNonNull(message, "message").getBody())
@@ -42,6 +56,12 @@ public class InvalidPayloadRuntimeException extends RuntimeExchangeException {
         this.type = type;
     }
 
+    /**
+     * @param exchange the exchange that caused the error
+     * @param type     the expected body type
+     * @param message  the message whose body could not be converted
+     * @param cause    the cause of the failure
+     */
     public InvalidPayloadRuntimeException(Exchange exchange, Class<?> type, Message message, Throwable cause) {
         super("No body available of type: " + Objects.requireNonNull(type, "type").getName()
               + NoSuchPropertyException.valueDescription(Objects.requireNonNull(message, "message").getBody())

--- a/core/camel-api/src/main/java/org/apache/camel/Message.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Message.java
@@ -24,7 +24,7 @@ import org.apache.camel.trait.message.MessageTrait;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Implements the <a href="http://camel.apache.org/message.html">Message</a> pattern and represents an inbound or
+ * Implements the <a href="https://camel.apache.org/message.html">Message</a> pattern and represents an inbound or
  * outbound message as part of an {@link Exchange}.
  * <p/>
  * Headers are represented in Camel using a {@link org.apache.camel.util.CaseInsensitiveMap CaseInsensitiveMap}. The
@@ -232,7 +232,7 @@ public interface Message {
      * Notice if the message body is stream based then calling this method multiple times may lead to the stream not
      * being able to be re-read again. You can enable stream caching and call the {@link StreamCache#reset()} method to
      * reset the stream to be able to re-read again (if possible). See more details about
-     * <a href="http://camel.apache.org/stream-caching.html">stream caching</a>.
+     * <a href="https://camel.apache.org/stream-caching.html">stream caching</a>.
      *
      * @return the body, can be <tt>null</tt>
      */
@@ -244,7 +244,7 @@ public interface Message {
      * <p/>
      * Notice if the message body is stream based then calling this method multiple times may lead to the stream not
      * being able to be re-read again. See more details about
-     * <a href="http://camel.apache.org/stream-caching.html">stream caching</a>.
+     * <a href="https://camel.apache.org/stream-caching.html">stream caching</a>.
      *
      * @return                         the body, is never <tt>null</tt>
      * @throws InvalidPayloadException Is thrown if the body being <tt>null</tt> or wrong class type
@@ -257,7 +257,7 @@ public interface Message {
      * Notice if the message body is stream based then calling this method multiple times may lead to the stream not
      * being able to be re-read again. You can enable stream caching and call the {@link StreamCache#reset()} method to
      * reset the stream to be able to re-read again (if possible). See more details about
-     * <a href="http://camel.apache.org/stream-caching.html">stream caching</a>.
+     * <a href="https://camel.apache.org/stream-caching.html">stream caching</a>.
      * <p/>
      * The helper method {@link org.apache.camel.support.ExchangeHelper#getBodyAndResetStreamCache(Exchange, Class)} can
      * be used instead that gets the body, convert to the given type, and ensures to reset the body if its stream based.
@@ -277,7 +277,7 @@ public interface Message {
      * Notice if the message body is stream based then calling this method multiple times may lead to the stream not
      * being able to be re-read again. You can enable stream caching and call the {@link StreamCache#reset()} method to
      * reset the stream to be able to re-read again (if possible). See more details about
-     * <a href="http://camel.apache.org/stream-caching.html">stream caching</a>.
+     * <a href="https://camel.apache.org/stream-caching.html">stream caching</a>.
      * <p/>
      * The helper method {@link org.apache.camel.support.ExchangeHelper#getBodyAndResetStreamCache(Exchange, Class)} can
      * be used instead that gets the body, convert to the given type, and ensures to reset the body if its stream based.

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchBeanException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchBeanException.java
@@ -27,11 +27,18 @@ public class NoSuchBeanException extends RuntimeCamelException {
 
     private final @Nullable String name;
 
+    /**
+     * @param name the bean name that could not be found
+     */
     public NoSuchBeanException(String name) {
         super("No bean could be found in the registry for: " + Objects.requireNonNull(name, "name"));
         this.name = name;
     }
 
+    /**
+     * @param name the bean name that was looked up
+     * @param size the number of matching beans found (0 means none, &gt;1 means ambiguous)
+     */
     public NoSuchBeanException(String name, int size) {
         super(size > 0
                 ? "Found " + size + " beans for: " + Objects.requireNonNull(name, "name")
@@ -40,18 +47,31 @@ public class NoSuchBeanException extends RuntimeCamelException {
         this.name = name;
     }
 
+    /**
+     * @param name the bean name that could not be found, or {@code null} if only the type matters
+     * @param type the required bean type
+     */
     public NoSuchBeanException(@Nullable String name, String type) {
         super("No bean could be found in the registry" + (name != null ? " for: " + name : "") + " of type: "
               + Objects.requireNonNull(type, "type"));
         this.name = name;
     }
 
+    /**
+     * @param name  the bean name that could not be found
+     * @param cause the cause of the failure
+     */
     public NoSuchBeanException(String name, Throwable cause) {
         super("No bean could be found in the registry for: " + Objects.requireNonNull(name, "name") + ". Cause: "
               + Objects.requireNonNull(cause, "cause").getMessage(), cause);
         this.name = name;
     }
 
+    /**
+     * @param name    the bean name that could not be found
+     * @param message the detail message
+     * @param cause   the cause of the failure
+     */
     public NoSuchBeanException(String name, String message, Throwable cause) {
         super(Objects.requireNonNull(message, "message"), Objects.requireNonNull(cause, "cause"));
         this.name = Objects.requireNonNull(name, "name");

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchEndpointException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchEndpointException.java
@@ -28,12 +28,19 @@ public class NoSuchEndpointException extends RuntimeCamelException {
 
     private final String uri;
 
+    /**
+     * @param uri the endpoint URI that could not be found
+     */
     public NoSuchEndpointException(String uri) {
         super("No endpoint could be found for: " + sanitizeUri(Objects.requireNonNull(uri, "uri"))
               + ", please check your classpath contains the needed Camel component jar.");
         this.uri = sanitizeUri(uri);
     }
 
+    /**
+     * @param uri           the endpoint URI that could not be found
+     * @param resolveMethod the hint on how to resolve the missing endpoint
+     */
     public NoSuchEndpointException(String uri, String resolveMethod) {
         super("No endpoint could be found for: " + sanitizeUri(Objects.requireNonNull(uri, "uri"))
               + ", please " + Objects.requireNonNull(resolveMethod, "resolveMethod"));

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchEndpointException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchEndpointException.java
@@ -39,7 +39,7 @@ public class NoSuchEndpointException extends RuntimeCamelException {
 
     /**
      * @param uri           the endpoint URI that could not be found
-     * @param resolveMethod the hint on how to resolve the missing endpoint
+     * @param resolveMethod a resolution instruction appended after "please" in the error message
      */
     public NoSuchEndpointException(String uri, String resolveMethod) {
         super("No endpoint could be found for: " + sanitizeUri(Objects.requireNonNull(uri, "uri"))

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchHeaderException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchHeaderException.java
@@ -30,12 +30,22 @@ public class NoSuchHeaderException extends CamelExchangeException {
     private final String headerName;
     private final transient @Nullable Class<?> type;
 
+    /**
+     * @param message    the detail message
+     * @param exchange   the exchange that caused the error
+     * @param headerName the name of the missing header
+     */
     public NoSuchHeaderException(String message, Exchange exchange, String headerName) {
         super(Objects.requireNonNull(message, "message"), Objects.requireNonNull(exchange, "exchange"));
         this.headerName = Objects.requireNonNull(headerName, "headerName");
         this.type = null;
     }
 
+    /**
+     * @param exchange   the exchange that caused the error
+     * @param headerName the name of the missing header
+     * @param type       the expected header type, or {@code null} if no specific type is required
+     */
     public NoSuchHeaderException(Exchange exchange, String headerName, @Nullable Class<?> type) {
         super("No '" + Objects.requireNonNull(headerName, "headerName") + "' header available"
               + (type != null ? " of type: " + type.getName() : "")

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchLanguageException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchLanguageException.java
@@ -27,6 +27,9 @@ public class NoSuchLanguageException extends RuntimeCamelException {
 
     private final String language;
 
+    /**
+     * @param language the language name that could not be resolved
+     */
     public NoSuchLanguageException(String language) {
         super("No language could be found for: " + Objects.requireNonNull(language, "language"));
         this.language = language;

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchPropertyException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchPropertyException.java
@@ -30,10 +30,19 @@ public class NoSuchPropertyException extends CamelExchangeException {
     private final String propertyName;
     private final transient @Nullable Class<?> type;
 
+    /**
+     * @param exchange     the exchange that caused the error
+     * @param propertyName the name of the missing exchange property
+     */
     public NoSuchPropertyException(Exchange exchange, String propertyName) {
         this(exchange, propertyName, null);
     }
 
+    /**
+     * @param exchange     the exchange that caused the error
+     * @param propertyName the name of the missing exchange property
+     * @param type         the expected property type, or {@code null} if no specific type is required
+     */
     public NoSuchPropertyException(Exchange exchange, String propertyName, @Nullable Class<?> type) {
         super("No '" + Objects.requireNonNull(propertyName, "propertyName") + "' exchange property available"
               + (type != null ? " of type: " + type.getName() : "")

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchVariableException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchVariableException.java
@@ -28,6 +28,10 @@ public class NoSuchVariableException extends CamelExchangeException {
     private final String variableName;
     private final transient @Nullable Class<?> type;
 
+    /**
+     * @param exchange     the exchange that caused the error
+     * @param variableName the name of the missing variable
+     */
     public NoSuchVariableException(Exchange exchange, String variableName) {
         super(String.format(
                 "No '%s' variable available", Objects.requireNonNull(variableName, "variableName")),
@@ -36,6 +40,11 @@ public class NoSuchVariableException extends CamelExchangeException {
         this.type = null;
     }
 
+    /**
+     * @param exchange     the exchange that caused the error
+     * @param variableName the name of the missing variable
+     * @param type         the expected variable type
+     */
     public NoSuchVariableException(Exchange exchange, String variableName, Class<?> type) {
         super(String.format(
                 "No '%s' variable available of type: %s",

--- a/core/camel-api/src/main/java/org/apache/camel/NoTypeConversionAvailableException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoTypeConversionAvailableException.java
@@ -28,12 +28,21 @@ public class NoTypeConversionAvailableException extends CamelException {
     private final transient @Nullable Object value;
     private final transient Class<?> type;
 
+    /**
+     * @param value the value for which no type converter was found
+     * @param type  the expected target type
+     */
     public NoTypeConversionAvailableException(@Nullable Object value, Class<?> type) {
         super(createMessage(value, Objects.requireNonNull(type, "type")));
         this.value = value;
         this.type = type;
     }
 
+    /**
+     * @param value the value for which no type converter was found
+     * @param type  the expected target type
+     * @param cause the cause of the failure
+     */
     public NoTypeConversionAvailableException(@Nullable Object value, Class<?> type, Throwable cause) {
         super(createMessage(value, Objects.requireNonNull(type, "type"), Objects.requireNonNull(cause, "cause")), cause);
         this.value = value;

--- a/core/camel-api/src/main/java/org/apache/camel/Pattern.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Pattern.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a method as having a specific kind of {@link ExchangePattern} for use with
- * <a href="http://camel.apache.org/bean-integration.html">Bean Integration</a> to overload the default value which is
+ * <a href="https://camel.apache.org/bean-integration.html">Bean Integration</a> to overload the default value which is
  * {@link ExchangePattern#InOut} for request/reply if no annotations are used.
  *
  * There are abbreviation annotations like {@link InOnly} or {@link InOut} which are typically used for the common

--- a/core/camel-api/src/main/java/org/apache/camel/PollingConsumer.java
+++ b/core/camel-api/src/main/java/org/apache/camel/PollingConsumer.java
@@ -19,7 +19,7 @@ package org.apache.camel;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Represents a <a href="http://camel.apache.org/polling-consumer.html">Polling Consumer</a> where the caller polls for
+ * Represents a <a href="https://camel.apache.org/polling-consumer.html">Polling Consumer</a> where the caller polls for
  * messages when it is ready.
  * <p/>
  * When you are done with the returned {@link Exchange} you must ensure to invoke

--- a/core/camel-api/src/main/java/org/apache/camel/Predicate.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Predicate.java
@@ -17,7 +17,7 @@
 package org.apache.camel;
 
 /**
- * Evaluates a binary <a href="http://camel.apache.org/predicate.html">predicate</a> on the message exchange.
+ * Evaluates a binary <a href="https://camel.apache.org/predicate.html">predicate</a> on the message exchange.
  *
  * A predicate should be thread-safe and be able to evaluate concurrently by different threads with different exchanges.
  *

--- a/core/camel-api/src/main/java/org/apache/camel/Processor.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Processor.java
@@ -17,9 +17,9 @@
 package org.apache.camel;
 
 /**
- * A <a href="http://camel.apache.org/processor.html">processor</a> is used to implement the
- * <a href="http://camel.apache.org/event-driven-consumer.html"> Event Driven Consumer</a> and
- * <a href="http://camel.apache.org/message-translator.html"> Message Translator</a> patterns and to process message
+ * A <a href="https://camel.apache.org/processor.html">processor</a> is used to implement the
+ * <a href="https://camel.apache.org/event-driven-consumer.html"> Event Driven Consumer</a> and
+ * <a href="https://camel.apache.org/message-translator.html"> Message Translator</a> patterns and to process message
  * exchanges.
  * <p/>
  * Notice if you use a {@link Processor} in a Camel route, then make sure to write the {@link Processor} in a

--- a/core/camel-api/src/main/java/org/apache/camel/Produce.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Produce.java
@@ -24,11 +24,11 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a field or property as being a producer to an {@link org.apache.camel.Endpoint} either via its
- * <a href="http://camel.apache.org/uris.html">URI</a> or via the name of the endpoint reference which is then resolved
+ * <a href="https://camel.apache.org/uris.html">URI</a> or via the name of the endpoint reference which is then resolved
  * in a registry such as the Spring Application Context.
  * <p/>
  * Methods invoked on the producer object are then converted to a message {@link org.apache.camel.Exchange} via the
- * <a href="http://camel.apache.org/bean-integration.html">Bean Integration</a> mechanism.
+ * <a href="https://camel.apache.org/bean-integration.html">Bean Integration</a> mechanism.
  *
  * @see InOnly
  */

--- a/core/camel-api/src/main/java/org/apache/camel/ProducerTemplate.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ProducerTemplate.java
@@ -53,8 +53,8 @@ import org.jspecify.annotations.Nullable;
  * the template. <br/>
  * <p/>
  * <b>Important note on usage:</b> See this
- * <a href="http://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html">FAQ entry</a> before
- * using.
+ * <a href="https://camel.apache.org/why-does-camel-use-too-many-threads-with-producertemplate.html">FAQ entry</a>
+ * before using.
  *
  * @see FluentProducerTemplate
  * @see ConsumerTemplate

--- a/core/camel-api/src/main/java/org/apache/camel/PropertyBindingException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/PropertyBindingException.java
@@ -31,6 +31,11 @@ public class PropertyBindingException extends RuntimeCamelException {
     private final @Nullable String optionPrefix;
     private final @Nullable String optionKey;
 
+    /**
+     * @param target       the target bean on which property binding failed
+     * @param propertyName the name of the property that could not be bound, or {@code null}
+     * @param value        the value that could not be bound, or {@code null}
+     */
     public PropertyBindingException(Object target, @Nullable String propertyName, @Nullable Object value) {
         this.target = Objects.requireNonNull(target, "target");
         this.propertyName = propertyName;
@@ -39,6 +44,12 @@ public class PropertyBindingException extends RuntimeCamelException {
         this.optionKey = null;
     }
 
+    /**
+     * @param target       the target bean on which property binding failed
+     * @param propertyName the name of the property that could not be bound, or {@code null}
+     * @param value        the value that could not be bound, or {@code null}
+     * @param e            the cause of the failure
+     */
     public PropertyBindingException(Object target, @Nullable String propertyName, @Nullable Object value, Throwable e) {
         initCause(Objects.requireNonNull(e, "e"));
         this.target = Objects.requireNonNull(target, "target");
@@ -48,6 +59,10 @@ public class PropertyBindingException extends RuntimeCamelException {
         this.optionKey = null;
     }
 
+    /**
+     * @param target the target bean on which property binding failed
+     * @param e      the cause of the failure
+     */
     public PropertyBindingException(Object target, Throwable e) {
         initCause(Objects.requireNonNull(e, "e"));
         this.target = Objects.requireNonNull(target, "target");
@@ -57,6 +72,14 @@ public class PropertyBindingException extends RuntimeCamelException {
         this.optionKey = null;
     }
 
+    /**
+     * @param target       the target bean on which property binding failed
+     * @param propertyName the name of the property that could not be bound, or {@code null}
+     * @param value        the value that could not be bound, or {@code null}
+     * @param optionPrefix the option prefix used when resolving the property, or {@code null}
+     * @param optionKey    the option key used when resolving the property, or {@code null}
+     * @param e            the cause of the failure
+     */
     public PropertyBindingException(Object target, @Nullable String propertyName, @Nullable Object value,
                                     @Nullable String optionPrefix, @Nullable String optionKey, Throwable e) {
         initCause(Objects.requireNonNull(e, "e"));

--- a/core/camel-api/src/main/java/org/apache/camel/PropertyInject.java
+++ b/core/camel-api/src/main/java/org/apache/camel/PropertyInject.java
@@ -23,7 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to indicate an injection point of a <a href="http://camel.apache.org/using-propertyplaceholder.html">property
+ * Used to indicate an injection point of a <a href="https://camel.apache.org/using-propertyplaceholder.html">property
  * placeholder</a> into a POJO.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/camel-api/src/main/java/org/apache/camel/RecipientList.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RecipientList.java
@@ -23,11 +23,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that this method is to be used as a <a href="http://camel.apache.org/recipient-list.html">Dynamic Recipient
- * List</a> routing the incoming message to one or more endpoints.
+ * Indicates that this method is to be used as a <a href="https://camel.apache.org/recipient-list.html">Dynamic
+ * Recipient List</a> routing the incoming message to one or more endpoints.
  *
  * When a message {@link org.apache.camel.Exchange} is received from an {@link org.apache.camel.Endpoint} then the
- * <a href="http://camel.apache.org/bean-integration.html">Bean Integration</a> mechanism is used to map the incoming
+ * <a href="https://camel.apache.org/bean-integration.html">Bean Integration</a> mechanism is used to map the incoming
  * {@link org.apache.camel.Message} to the method parameters.
  *
  * The return value of the method is then converted to either a {@link java.util.Collection} or array of objects where

--- a/core/camel-api/src/main/java/org/apache/camel/Route.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Route.java
@@ -32,7 +32,7 @@ import org.apache.camel.spi.RoutePolicy;
 import org.jspecify.annotations.Nullable;
 
 /**
- * A <a href="http://camel.apache.org/routes.html">Route</a> defines the processing used on an inbound message exchange
+ * A <a href="https://camel.apache.org/routes.html">Route</a> defines the processing used on an inbound message exchange
  * from a specific {@link org.apache.camel.Endpoint} within a {@link org.apache.camel.CamelContext}.
  * <p/>
  * Use the API from {@link org.apache.camel.CamelContext} to control the lifecycle of a route, such as starting and

--- a/core/camel-api/src/main/java/org/apache/camel/RoutingSlip.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RoutingSlip.java
@@ -23,11 +23,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that this method is to be used as a <a href="http://camel.apache.org/routing-slip.html">Routing Slip</a>
+ * Indicates that this method is to be used as a <a href="https://camel.apache.org/routing-slip.html">Routing Slip</a>
  * routing the incoming message through a series of processing steps.
  *
  * When a message {@link org.apache.camel.Exchange} is received from an {@link org.apache.camel.Endpoint} then the
- * <a href="http://camel.apache.org/bean-integration.html">Bean Integration</a> mechanism is used to map the incoming
+ * <a href="https://camel.apache.org/bean-integration.html">Bean Integration</a> mechanism is used to map the incoming
  * {@link org.apache.camel.Message} to the method parameters.
  *
  * The return value of the method is then converted to either a {@link java.util.Collection} or array of objects where

--- a/core/camel-api/src/main/java/org/apache/camel/RuntimeCamelException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RuntimeCamelException.java
@@ -30,14 +30,24 @@ public class RuntimeCamelException extends RuntimeException {
     public RuntimeCamelException() {
     }
 
+    /**
+     * @param message the detail message
+     */
     public RuntimeCamelException(@Nullable String message) {
         super(message);
     }
 
+    /**
+     * @param message the detail message
+     * @param cause   the cause of the failure
+     */
     public RuntimeCamelException(@Nullable String message, @Nullable Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * @param cause the cause of the failure
+     */
     public RuntimeCamelException(@Nullable Throwable cause) {
         super(cause);
     }

--- a/core/camel-api/src/main/java/org/apache/camel/RuntimeExchangeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RuntimeExchangeException.java
@@ -26,11 +26,20 @@ import org.jspecify.annotations.Nullable;
 public class RuntimeExchangeException extends RuntimeCamelException {
     private final transient @Nullable Exchange exchange;
 
+    /**
+     * @param message  the detail message
+     * @param exchange the exchange that caused the error
+     */
     public RuntimeExchangeException(String message, @Nullable Exchange exchange) {
         super(createMessage(Objects.requireNonNull(message, "message"), exchange));
         this.exchange = exchange;
     }
 
+    /**
+     * @param message  the detail message
+     * @param exchange the exchange that caused the error
+     * @param cause    the cause of the failure
+     */
     public RuntimeExchangeException(String message, @Nullable Exchange exchange, Throwable cause) {
         super(createMessage(Objects.requireNonNull(message, "message"), exchange),
               Objects.requireNonNull(cause, "cause"));

--- a/core/camel-api/src/main/java/org/apache/camel/StreamCacheException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/StreamCacheException.java
@@ -20,8 +20,15 @@ import java.util.Objects;
 
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Thrown when stream caching of a message body fails.
+ */
 public class StreamCacheException extends TypeConversionException {
 
+    /**
+     * @param value the message body value that could not be cached
+     * @param cause the cause of the failure
+     */
     public StreamCacheException(@Nullable Object value, Throwable cause) {
         super(value, StreamCache.class, Objects.requireNonNull(cause, "cause"));
     }

--- a/core/camel-api/src/main/java/org/apache/camel/TypeConversionException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/TypeConversionException.java
@@ -28,6 +28,11 @@ public class TypeConversionException extends RuntimeCamelException {
     private final transient @Nullable Object value;
     private final transient Class<?> type;
 
+    /**
+     * @param value the value that could not be converted
+     * @param type  the expected target type
+     * @param cause the cause of the failure
+     */
     public TypeConversionException(@Nullable Object value, Class<?> type, Throwable cause) {
         super(createMessage(value, Objects.requireNonNull(type, "type"), Objects.requireNonNull(cause, "cause")), cause);
         this.value = value;

--- a/core/camel-api/src/main/java/org/apache/camel/TypeConverter.java
+++ b/core/camel-api/src/main/java/org/apache/camel/TypeConverter.java
@@ -19,8 +19,9 @@ package org.apache.camel;
 import org.jspecify.annotations.Nullable;
 
 /**
- * A pluggable strategy to be able to convert objects <a href="http://camel.apache.org/type-converter.html">to different
- * types</a> such as to and from String, InputStream/OutputStream, Reader/Writer, Document, byte[], ByteBuffer etc
+ * A pluggable strategy to be able to convert objects <a href="https://camel.apache.org/type-converter.html">to
+ * different types</a> such as to and from String, InputStream/OutputStream, Reader/Writer, Document, byte[], ByteBuffer
+ * etc
  */
 public interface TypeConverter {
 

--- a/core/camel-api/src/main/java/org/apache/camel/package-info.java
+++ b/core/camel-api/src/main/java/org/apache/camel/package-info.java
@@ -18,7 +18,7 @@
  * The core Camel API.
  */
 @NullMarked
-@XmlSchema(namespace = "https://camel.apache.org/schema/spring",
+@XmlSchema(namespace = "http://camel.apache.org/schema/spring",
            elementFormDefault = XmlNsForm.QUALIFIED)
 package org.apache.camel;
 

--- a/core/camel-api/src/main/java/org/apache/camel/package-info.java
+++ b/core/camel-api/src/main/java/org/apache/camel/package-info.java
@@ -18,7 +18,7 @@
  * The core Camel API.
  */
 @NullMarked
-@XmlSchema(namespace = "http://camel.apache.org/schema/spring",
+@XmlSchema(namespace = "https://camel.apache.org/schema/spring",
            elementFormDefault = XmlNsForm.QUALIFIED)
 package org.apache.camel;
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/AggregationRepository.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/AggregationRepository.java
@@ -23,8 +23,16 @@ import org.apache.camel.Exchange;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Access to a repository to store aggregated exchanges to support pluggable implementations.
+ * Repository for storing aggregated exchanges used by the Aggregator EIP.
+ * <p/>
+ * The aggregation lifecycle is: {@link #get(CamelContext, String)} to retrieve the existing aggregate, then
+ * {@link #add(CamelContext, String, Exchange)} to store the updated aggregate, and finally
+ * {@link #remove(CamelContext, String, Exchange)} when the aggregation is complete.
+ * {@link #confirm(CamelContext, String)} is called after the aggregated exchange has been processed successfully.
+ * <p/>
+ * Implementations must be thread-safe as multiple threads may aggregate concurrently for different correlation keys.
  *
+ * @see org.apache.camel.processor.aggregate.AggregateProcessor
  */
 public interface AggregationRepository {
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/AggregationRepository.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/AggregationRepository.java
@@ -32,7 +32,6 @@ import org.jspecify.annotations.Nullable;
  * <p/>
  * Implementations must be thread-safe as multiple threads may aggregate concurrently for different correlation keys.
  *
- * @see org.apache.camel.processor.aggregate.AggregateProcessor
  */
 public interface AggregationRepository {
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/ClaimCheckRepository.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/ClaimCheckRepository.java
@@ -21,7 +21,7 @@ import org.apache.camel.Service;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Access to a repository of keys to implement the <a href="http://camel.apache.org/claim-check.html">Claim Check</a>
+ * Access to a repository of keys to implement the <a href="https://camel.apache.org/claim-check.html">Claim Check</a>
  * pattern.
  * <p/>
  * The <tt>add</tt> and <tt>contains</tt> methods is operating according to the {@link java.util.Map} contract, and the

--- a/core/camel-api/src/main/java/org/apache/camel/spi/DataFormat.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/DataFormat.java
@@ -26,7 +26,7 @@ import org.apache.camel.Service;
 import org.apache.camel.util.IOHelper;
 
 /**
- * Represents a <a href="http://camel.apache.org/data-format.html">data format</a> used to marshal objects to and from
+ * Represents a <a href="https://camel.apache.org/data-format.html">data format</a> used to marshal objects to and from
  * streams such as Java Serialization or using JAXB2 to encode/decode objects using XML or using SOAP encoding.
  */
 public interface DataFormat extends Service {

--- a/core/camel-api/src/main/java/org/apache/camel/spi/DataFormatFactory.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/DataFormatFactory.java
@@ -17,7 +17,10 @@
 package org.apache.camel.spi;
 
 /**
- * A factory to create {@link org.apache.camel.spi.DataFormat}.
+ * A factory for creating {@link DataFormat} instances. The factory is used when a data format needs custom
+ * instantiation logic beyond the default resolution mechanism.
+ * <p/>
+ * Each call to {@link #newInstance()} should return a new data format instance.
  */
 @FunctionalInterface
 public interface DataFormatFactory {

--- a/core/camel-api/src/main/java/org/apache/camel/spi/IdempotentRepository.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/IdempotentRepository.java
@@ -21,7 +21,7 @@ import org.apache.camel.Service;
 
 /**
  * Access to a repository of Message IDs to implement the
- * <a href="http://camel.apache.org/idempotent-consumer.html">Idempotent Consumer</a> pattern.
+ * <a href="https://camel.apache.org/idempotent-consumer.html">Idempotent Consumer</a> pattern.
  * <p/>
  * The <tt>add</tt> and <tt>contains</tt> methods is operating according to the {@link java.util.Set} contract.
  * <p/>

--- a/core/camel-api/src/main/java/org/apache/camel/spi/Language.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/Language.java
@@ -20,7 +20,10 @@ import org.apache.camel.Expression;
 import org.apache.camel.Predicate;
 
 /**
- * Represents a language to be used for {@link Expression} or {@link Predicate} instances
+ * Represents a language to be used for creating {@link Expression} or {@link Predicate} instances.
+ * <p/>
+ * Languages are resolved by name via the {@link org.apache.camel.CamelContext#resolveLanguage(String)} method.
+ * Implementations must be thread-safe as expressions and predicates may be evaluated concurrently.
  */
 public interface Language {
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/RestApiConsumerFactory.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/RestApiConsumerFactory.java
@@ -32,7 +32,7 @@ import org.apache.camel.Processor;
 public interface RestApiConsumerFactory {
 
     /**
-     * Creates a new REST API <a href="http://camel.apache.org/event-driven-consumer.html">Event Driven Consumer</a>,
+     * Creates a new REST API <a href="https://camel.apache.org/event-driven-consumer.html">Event Driven Consumer</a>,
      * which provides API listing of the REST services
      *
      * @param  camelContext  the camel context

--- a/core/camel-api/src/main/java/org/apache/camel/spi/RestApiProcessorFactory.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/RestApiProcessorFactory.java
@@ -31,7 +31,7 @@ import org.apache.camel.Processor;
 public interface RestApiProcessorFactory {
 
     /**
-     * Creates a new REST API <a href="http://camel.apache.org/processor.html">Processor </a>, which provides API
+     * Creates a new REST API <a href="https://camel.apache.org/processor.html">Processor </a>, which provides API
      * listing of the REST services
      *
      * @param  camelContext  the camel context

--- a/core/camel-api/src/main/java/org/apache/camel/spi/RestConsumerFactory.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/RestConsumerFactory.java
@@ -26,7 +26,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * Allows SPI to plugin a {@link RestConsumerFactory} that creates the Camel {@link Consumer} responsible for handling
  * incoming HTTP requests from clients that request to access REST services which has been created using the
- * <a href="http://camel.apache.org/rest-dsl">rest-dsl</a>.
+ * <a href="https://camel.apache.org/rest-dsl">rest-dsl</a>.
  *
  * @see RestApiConsumerFactory
  * @see RestOpenApiConsumerFactory
@@ -35,7 +35,7 @@ import org.jspecify.annotations.Nullable;
 public interface RestConsumerFactory {
 
     /**
-     * Creates a new REST <a href="http://camel.apache.org/event-driven-consumer.html">Event Driven Consumer</a>, which
+     * Creates a new REST <a href="https://camel.apache.org/event-driven-consumer.html">Event Driven Consumer</a>, which
      * consumes messages from the endpoint using the given processor
      *
      * @param  camelContext  the camel context

--- a/core/camel-api/src/main/java/org/apache/camel/spi/RestOpenApiConsumerFactory.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/RestOpenApiConsumerFactory.java
@@ -25,7 +25,7 @@ import org.apache.camel.Processor;
 /**
  * Allows SPI to plugin a {@link RestOpenApiConsumerFactory} that creates the Camel {@link Consumer} responsible for
  * handling incoming HTTP requests from clients that request to access REST services which has been created using the
- * <a href="http://camel.apache.org/rest-dsl">rest-dsl</a> for an entire open-api specification.
+ * <a href="https://camel.apache.org/rest-dsl">rest-dsl</a> for an entire open-api specification.
  *
  * @see RestApiConsumerFactory
  * @see RestOpenApiConsumerFactory
@@ -34,7 +34,7 @@ import org.apache.camel.Processor;
 public interface RestOpenApiConsumerFactory {
 
     /**
-     * Creates a new REST <a href="http://camel.apache.org/event-driven-consumer.html">Event Driven Consumer</a>, which
+     * Creates a new REST <a href="https://camel.apache.org/event-driven-consumer.html">Event Driven Consumer</a>, which
      * consumes messages from the endpoint using the given processor
      *
      * @param  camelContext  the camel context

--- a/core/camel-api/src/main/java/org/apache/camel/spi/RestRegistry.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/RestRegistry.java
@@ -24,7 +24,7 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * A registry of all REST services running within the {@link org.apache.camel.CamelContext} which have been defined and
- * created using the <a href="http://camel.apache.org/rest-dsl">Rest DSL</a>.
+ * created using the <a href="https://camel.apache.org/rest-dsl">Rest DSL</a>.
  */
 public interface RestRegistry extends StaticService {
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/RouteStartupOrder.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/RouteStartupOrder.java
@@ -31,7 +31,7 @@ public interface RouteStartupOrder {
     /**
      * Get the order this route should be started.
      * <p/>
-     * See more at <a href="http://camel.apache.org/configuring-route-startup-ordering-and-autostartup.html">
+     * See more at <a href="https://camel.apache.org/configuring-route-startup-ordering-and-autostartup.html">
      * configuring route startup ordering</a>.
      *
      * @return the order

--- a/core/camel-api/src/main/java/org/apache/camel/spi/StreamCachingStrategy.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/StreamCachingStrategy.java
@@ -26,7 +26,7 @@ import org.apache.camel.StreamCache;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Strategy for using <a href="http://camel.apache.org/stream-caching.html">stream caching</a>.
+ * Strategy for using <a href="https://camel.apache.org/stream-caching.html">stream caching</a>.
  */
 public interface StreamCachingStrategy extends StaticService {
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/Synchronization.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/Synchronization.java
@@ -22,7 +22,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * Provides a hook for custom {@link org.apache.camel.Processor} or {@link org.apache.camel.Component} instances to
  * respond to completed or failed processing of an {@link Exchange} rather like Spring's
- * {@code TransactionSynchronization}
+ * {@code org.springframework.transaction.support.TransactionSynchronization}
  */
 public interface Synchronization {
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/Synchronization.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/Synchronization.java
@@ -22,8 +22,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * Provides a hook for custom {@link org.apache.camel.Processor} or {@link org.apache.camel.Component} instances to
  * respond to completed or failed processing of an {@link Exchange} rather like Spring's
- * <a href="http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/transaction/
- * support/TransactionSynchronization.html">TransactionSynchronization</a>
+ * {@code TransactionSynchronization}
  */
 public interface Synchronization {
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/ThreadPoolProfile.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/ThreadPoolProfile.java
@@ -28,7 +28,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * A profile which defines thread pool settings.
  * <p/>
- * See more details at <a href="http://camel.apache.org/threading-model.html">threading model</a>
+ * See more details at <a href="https://camel.apache.org/threading-model.html">threading model</a>
  */
 public class ThreadPoolProfile implements Serializable, Cloneable {
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/Transformer.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/Transformer.java
@@ -26,7 +26,7 @@ import org.apache.camel.util.ObjectHelper;
 import org.jspecify.annotations.Nullable;
 
 /**
- * <a href="http://camel.apache.org/transformer.html">Transformer</a> performs message transformation according to the
+ * <a href="https://camel.apache.org/transformer.html">Transformer</a> performs message transformation according to the
  * declared data type. {@link org.apache.camel.processor.ContractAdvice} looks for a required Transformer and apply if
  * input/output type declared on a route is different from current message type.
  *

--- a/core/camel-api/src/main/java/org/apache/camel/spi/Validator.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/Validator.java
@@ -26,7 +26,7 @@ import org.apache.camel.support.service.ServiceSupport;
 import org.jspecify.annotations.Nullable;
 
 /**
- * <a href="http://camel.apache.org/validator.html">Validator</a> performs message content validation according to the
+ * <a href="https://camel.apache.org/validator.html">Validator</a> performs message content validation according to the
  * declared data type. {@link org.apache.camel.processor.ContractAdvice} applies Validator if input/output type is
  * declared on a route with validation enabled.
  *


### PR DESCRIPTION
## Summary

Third batch of Javadoc improvements for the camel-api module:

- **HTTPS URLs**: Update all 67 `http://camel.apache.org` URLs to `https://` across 39 Javadoc comments (excluding XML namespace URIs)
- **Broken link fix**: Replace dead Spring 2.5.x API link in `Synchronization.java` with `{@code}` FQCN reference
- **Exchange rewrite**: Rewrite class-level Javadoc to lead with `getMessage()` instead of deprecated `getIn()/getOut()` pattern, with `ExchangePattern` mention preserved
- **SPI contracts**: Add contract documentation to `Language`, `AggregationRepository`, and `DataFormatFactory` explaining lifecycle, thread-safety, and usage
- **Exception constructors**: Add `@param` tags to constructors of 20 most important exception classes
- **StreamCacheException**: Add missing class-level Javadoc

All changes are Javadoc-only — no functional code modified.

## Test plan

- [x] `mvn install -pl core/camel-api -DskipTests` passes
- [x] Formatter applied (`mvn formatter:format impsort:sort`)
- [x] No generated file changes needed
- [x] `@XmlSchema` namespace URI preserved as `http://` (XML identifier, not web URL)