### PR TITLE
Improve remaining Javadoc in camel-api: grammar, method docs, and exception constructors

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/CamelAuthorizationException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelAuthorizationException.java
@@ -28,11 +28,20 @@ public class CamelAuthorizationException extends CamelExchangeException {
 
     private final @Nullable String policyId;
 
+    /**
+     * @param message  the detail message
+     * @param exchange the exchange that caused the error
+     */
     public CamelAuthorizationException(String message, Exchange exchange) {
         super(Objects.requireNonNull(message, "message"), Objects.requireNonNull(exchange, "exchange"));
         policyId = exchange.getIn().getHeader(Exchange.AUTHENTICATION_FAILURE_POLICY_ID, String.class);
     }
 
+    /**
+     * @param message  the detail message
+     * @param exchange the exchange that caused the error
+     * @param cause    the cause of the failure
+     */
     public CamelAuthorizationException(String message, Exchange exchange, Throwable cause) {
         super(Objects.requireNonNull(message, "message"), Objects.requireNonNull(exchange, "exchange"),
               Objects.requireNonNull(cause, "cause"));

--- a/core/camel-api/src/main/java/org/apache/camel/CamelContext.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelContext.java
@@ -187,7 +187,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
      * Adds a service to this CamelContext, which allows this CamelContext to control the lifecycle, ensuring the
      * service is stopped when the CamelContext stops.
      * <p/>
-     * The service will also have {@link CamelContext} injected if its {@link CamelContextAware}. The service will also
+     * The service will also have {@link CamelContext} injected if it's {@link CamelContextAware}. The service will also
      * be enlisted in JMX for management (if JMX is enabled).
      * <p/>
      * The service will also be deferred to be started together with other services are being started, as part of the
@@ -202,7 +202,7 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
     /**
      * Adds a service to this CamelContext.
      * <p/>
-     * The service will also have {@link CamelContext} injected if its {@link CamelContextAware}. The service will also
+     * The service will also have {@link CamelContext} injected if it's {@link CamelContextAware}. The service will also
      * be enlisted in JMX for management (if JMX is enabled).
      * <p/>
      * The service will also be deferred to be started together with other services are being started, as part of the
@@ -222,8 +222,8 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
     /**
      * Adds a service to this CamelContext.
      * <p/>
-     * The service will also have {@link CamelContext} injected if its {@link CamelContextAware}. The service will also
-     * be enlisted in JMX for management (if JMX is enabled). The service will be started, if its not already started.
+     * The service will also have {@link CamelContext} injected if it's {@link CamelContextAware}. The service will also
+     * be enlisted in JMX for management (if JMX is enabled). The service will be started, if it's not already started.
      * <p/>
      * The service will also be deferred to be started together with other services are being started, as part of the
      * Camel startup process. If Camel has already been started, then the service is started immediately.
@@ -244,8 +244,8 @@ public interface CamelContext extends CamelContextLifecycle, RuntimeConfiguratio
     /**
      * Adds a service to this CamelContext (prototype scope).
      * <p/>
-     * The service will also have {@link CamelContext} injected if its {@link CamelContextAware}. The service will be
-     * started, if its not already started.
+     * The service will also have {@link CamelContext} injected if it's {@link CamelContextAware}. The service will be
+     * started, if it's not already started.
      *
      * @param  object    the service
      * @throws Exception can be thrown when starting the service

--- a/core/camel-api/src/main/java/org/apache/camel/CamelException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelException.java
@@ -26,14 +26,24 @@ public class CamelException extends Exception {
     public CamelException() {
     }
 
+    /**
+     * @param message the detail message
+     */
     public CamelException(@Nullable String message) {
         super(message);
     }
 
+    /**
+     * @param message the detail message
+     * @param cause   the cause of the failure
+     */
     public CamelException(@Nullable String message, @Nullable Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * @param cause the cause of the failure
+     */
     public CamelException(@Nullable Throwable cause) {
         super(cause);
     }

--- a/core/camel-api/src/main/java/org/apache/camel/CamelUnitOfWorkException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelUnitOfWorkException.java
@@ -29,6 +29,10 @@ public class CamelUnitOfWorkException extends CamelExchangeException {
 
     private final transient List<Exception> causes;
 
+    /**
+     * @param exchange the exchange that caused the error
+     * @param causes   the list of exceptions that caused the unit of work to fail
+     */
     public CamelUnitOfWorkException(Exchange exchange, List<Exception> causes) {
         // just provide the first exception as cause, as it will be logged in the stacktraces
         super("Unit of work failed on exchange with " + Objects.requireNonNull(causes, "causes").size()

--- a/core/camel-api/src/main/java/org/apache/camel/ExchangeTimedOutException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExchangeTimedOutException.java
@@ -27,11 +27,20 @@ public class ExchangeTimedOutException extends CamelExchangeException {
 
     private final long timeout;
 
+    /**
+     * @param exchange the exchange that caused the error
+     * @param timeout  the timeout in milliseconds that expired
+     */
     public ExchangeTimedOutException(@Nullable Exchange exchange, long timeout) {
         super("The OUT message was not received within: " + timeout + " millis", exchange);
         this.timeout = timeout;
     }
 
+    /**
+     * @param exchange the exchange that caused the error
+     * @param timeout  the timeout in milliseconds that expired
+     * @param message  the detail message
+     */
     public ExchangeTimedOutException(@Nullable Exchange exchange, long timeout, String message) {
         super("The OUT message was not received within: " + timeout + " millis due "
               + Objects.requireNonNull(message, "message"), exchange);

--- a/core/camel-api/src/main/java/org/apache/camel/ExpectedBodyTypeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExpectedBodyTypeException.java
@@ -28,6 +28,10 @@ public class ExpectedBodyTypeException extends RuntimeCamelException {
     private final transient @Nullable Exchange exchange;
     private final transient @Nullable Class<?> expectedBodyType;
 
+    /**
+     * @param exchange         the exchange that caused the error
+     * @param expectedBodyType the expected body type that could not be extracted
+     */
     public ExpectedBodyTypeException(Exchange exchange, Class<?> expectedBodyType) {
         super("Could not extract IN message body as type: " + Objects.requireNonNull(expectedBodyType, "expectedBodyType")
               + " body is: " + Objects.requireNonNull(exchange, "exchange").getIn().getBody());

--- a/core/camel-api/src/main/java/org/apache/camel/Experimental.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Experimental.java
@@ -27,5 +27,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
 public @interface Experimental {
+    /** The revision number of this experimental API, incremented when the API changes incompatibly. */
     int revision() default 1;
 }

--- a/core/camel-api/src/main/java/org/apache/camel/ExpressionEvaluationException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExpressionEvaluationException.java
@@ -28,6 +28,11 @@ public class ExpressionEvaluationException extends RuntimeCamelException {
     private final transient @Nullable Expression expression;
     private final transient @Nullable Exchange exchange;
 
+    /**
+     * @param expression the expression that failed to evaluate
+     * @param exchange   the exchange that caused the error
+     * @param cause      the cause of the failure
+     */
     public ExpressionEvaluationException(
                                          @Nullable Expression expression, @Nullable Exchange exchange,
                                          @Nullable Throwable cause) {
@@ -36,6 +41,12 @@ public class ExpressionEvaluationException extends RuntimeCamelException {
         this.exchange = exchange;
     }
 
+    /**
+     * @param expression the expression that failed to evaluate
+     * @param message    the detail message
+     * @param exchange   the exchange that caused the error
+     * @param cause      the cause of the failure
+     */
     public ExpressionEvaluationException(
                                          @Nullable Expression expression, String message, @Nullable Exchange exchange,
                                          @Nullable Throwable cause) {

--- a/core/camel-api/src/main/java/org/apache/camel/ExpressionIllegalSyntaxException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExpressionIllegalSyntaxException.java
@@ -27,10 +27,17 @@ public class ExpressionIllegalSyntaxException extends RuntimeCamelException {
 
     private final String expression;
 
+    /**
+     * @param expression the expression with illegal syntax
+     */
     public ExpressionIllegalSyntaxException(String expression) {
         this(expression, null);
     }
 
+    /**
+     * @param expression the expression with illegal syntax
+     * @param cause      the cause of the failure
+     */
     public ExpressionIllegalSyntaxException(String expression, @Nullable Throwable cause) {
         super("Illegal syntax: " + Objects.requireNonNull(expression, "expression"), cause);
         this.expression = expression;

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToCreateRouteFromTemplateException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToCreateRouteFromTemplateException.java
@@ -25,6 +25,11 @@ public class FailedToCreateRouteFromTemplateException extends RuntimeCamelExcept
     private final String templateId;
     private final String routeId;
 
+    /**
+     * @param routeId    the route id that failed to be created
+     * @param templateId the template id used to create the route
+     * @param message    the detail message
+     */
     public FailedToCreateRouteFromTemplateException(String routeId, String templateId, String message) {
         super("Failed to create route " + Objects.requireNonNull(routeId, "routeId") + " from template "
               + Objects.requireNonNull(templateId, "templateId") + " because of "
@@ -33,6 +38,12 @@ public class FailedToCreateRouteFromTemplateException extends RuntimeCamelExcept
         this.templateId = templateId;
     }
 
+    /**
+     * @param routeId    the route id that failed to be created
+     * @param templateId the template id used to create the route
+     * @param message    the detail message
+     * @param cause      the cause of the failure
+     */
     public FailedToCreateRouteFromTemplateException(String routeId, String templateId, String message, Throwable cause) {
         super("Failed to create route " + Objects.requireNonNull(routeId, "routeId") + " from template "
               + Objects.requireNonNull(templateId, "templateId") + " because of "

--- a/core/camel-api/src/main/java/org/apache/camel/FailedToStartRouteException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/FailedToStartRouteException.java
@@ -28,6 +28,10 @@ public class FailedToStartRouteException extends RuntimeCamelException {
     private final String routeId;
     private final @Nullable String location;
 
+    /**
+     * @param routeId the route id that failed to start
+     * @param message the detail message
+     */
     public FailedToStartRouteException(String routeId, String message) {
         super("Failed to start route: " + Objects.requireNonNull(routeId, "routeId") + " because: "
               + Objects.requireNonNull(message, "message"));
@@ -35,6 +39,11 @@ public class FailedToStartRouteException extends RuntimeCamelException {
         this.location = null;
     }
 
+    /**
+     * @param routeId the route id that failed to start
+     * @param message the detail message
+     * @param cause   the cause of the failure
+     */
     public FailedToStartRouteException(String routeId, String message, Throwable cause) {
         super("Failed to start route: " + Objects.requireNonNull(routeId, "routeId") + " because: "
               + Objects.requireNonNull(message, "message"), Objects.requireNonNull(cause, "cause"));
@@ -42,6 +51,12 @@ public class FailedToStartRouteException extends RuntimeCamelException {
         this.location = null;
     }
 
+    /**
+     * @param routeId  the route id that failed to start
+     * @param location the source location of the route definition, or {@code null} if unknown
+     * @param message  the detail message
+     * @param cause    the cause of the failure
+     */
     public FailedToStartRouteException(String routeId, @Nullable String location, String message, Throwable cause) {
         super("Failed to start route: " + Objects.requireNonNull(routeId, "routeId")
               + (location != null ? " (source: " + location + ")" : "") + " because: "

--- a/core/camel-api/src/main/java/org/apache/camel/InvalidPropertyException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/InvalidPropertyException.java
@@ -28,10 +28,19 @@ public class InvalidPropertyException extends RuntimeCamelException {
     private final transient @Nullable Object owner;
     private final String propertyName;
 
+    /**
+     * @param owner        the object that does not have the property
+     * @param propertyName the name of the property that could not be found
+     */
     public InvalidPropertyException(@Nullable Object owner, String propertyName) {
         this(owner, propertyName, owner != null ? owner.getClass() : Object.class);
     }
 
+    /**
+     * @param owner        the object that does not have the property
+     * @param propertyName the name of the property that could not be found
+     * @param type         the type of the object being inspected
+     */
     public InvalidPropertyException(@Nullable Object owner, String propertyName, Class<?> type) {
         super("No '" + Objects.requireNonNull(propertyName, "propertyName") + "' property available on type: "
               + Objects.requireNonNull(type, "type").getName() + " in: " + owner);

--- a/core/camel-api/src/main/java/org/apache/camel/LoadPropertiesException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/LoadPropertiesException.java
@@ -26,6 +26,10 @@ public class LoadPropertiesException extends CamelException {
 
     private final URL url;
 
+    /**
+     * @param url   the URL of the properties file that failed to load
+     * @param cause the cause of the failure
+     */
     public LoadPropertiesException(URL url, Exception cause) {
         super("Failed to load URL: " + Objects.requireNonNull(url, "url") + ". Reason: "
               + Objects.requireNonNull(cause, "cause"), cause);

--- a/core/camel-api/src/main/java/org/apache/camel/NoFactoryAvailableException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoFactoryAvailableException.java
@@ -26,11 +26,18 @@ public class NoFactoryAvailableException extends IOException {
 
     private final String uri;
 
+    /**
+     * @param uri the URI for which no factory class could be found
+     */
     public NoFactoryAvailableException(String uri) {
         super("Cannot find factory class for resource: " + Objects.requireNonNull(uri, "uri"));
         this.uri = uri;
     }
 
+    /**
+     * @param uri   the URI for which no factory class could be found
+     * @param cause the cause of the failure
+     */
     public NoFactoryAvailableException(String uri, Throwable cause) {
         this(uri);
         initCause(Objects.requireNonNull(cause, "cause"));

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchBeanTypeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchBeanTypeException.java
@@ -23,10 +23,17 @@ import java.util.Objects;
  */
 public class NoSuchBeanTypeException extends NoSuchBeanException {
 
+    /**
+     * @param type the expected type that could not be found in the registry
+     */
     public NoSuchBeanTypeException(Class<?> type) {
         super(Objects.requireNonNull(type, "type").getName());
     }
 
+    /**
+     * @param type the expected type that could not be uniquely resolved in the registry
+     * @param size the number of beans found with that type
+     */
     public NoSuchBeanTypeException(Class<?> type, int size) {
         super(Objects.requireNonNull(type, "type").getName(), size);
     }

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchHeaderOrPropertyException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchHeaderOrPropertyException.java
@@ -26,6 +26,12 @@ public class NoSuchHeaderOrPropertyException extends CamelExchangeException {
     private final String propertyName;
     private final transient Class<?> type;
 
+    /**
+     * @param exchange     the exchange that caused the error
+     * @param headerName   the name of the header that could not be found
+     * @param propertyName the name of the property that could not be found
+     * @param type         the expected type of the header or property
+     */
     public NoSuchHeaderOrPropertyException(Exchange exchange, String headerName, String propertyName, Class<?> type) {
         super(String.format(
                 "No '%s' header or '%s' property available of type: %s (header: %s, property: %s)",

--- a/core/camel-api/src/main/java/org/apache/camel/NoSuchServiceException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NoSuchServiceException.java
@@ -26,6 +26,10 @@ public class NoSuchServiceException extends RuntimeCamelException {
     private final String name;
     private final String jar;
 
+    /**
+     * @param name the name of the service that could not be found
+     * @param jar  the JAR that should be added to the classpath to provide the service
+     */
     public NoSuchServiceException(String name, String jar) {
         super("No " + Objects.requireNonNull(name, "name") + " service could be found in the classpath. Add "
               + Objects.requireNonNull(jar, "jar") + " to classpath.");

--- a/core/camel-api/src/main/java/org/apache/camel/ProxyInstantiationException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ProxyInstantiationException.java
@@ -26,6 +26,11 @@ public class ProxyInstantiationException extends RuntimeCamelException {
     private final Class<?> type;
     private final Endpoint endpoint;
 
+    /**
+     * @param type     the interface type for which a proxy could not be instantiated
+     * @param endpoint the endpoint on which the proxy was being created
+     * @param cause    the cause of the failure
+     */
     public ProxyInstantiationException(Class<?> type, Endpoint endpoint, Throwable cause) {
         super("Could not instantiate proxy of type " + Objects.requireNonNull(type, "type").getName() + " on endpoint "
               + Objects.requireNonNull(endpoint, "endpoint"), Objects.requireNonNull(cause, "cause"));

--- a/core/camel-api/src/main/java/org/apache/camel/ResolveEndpointFailedException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ResolveEndpointFailedException.java
@@ -29,18 +29,29 @@ public class ResolveEndpointFailedException extends RuntimeCamelException {
 
     private final @Nullable String uri;
 
+    /**
+     * @param uri   the endpoint URI that could not be resolved
+     * @param cause the cause of the failure
+     */
     public ResolveEndpointFailedException(@Nullable String uri, Throwable cause) {
         super("Failed to resolve endpoint: " + sanitizeUri(uri) + " due to: "
               + Objects.requireNonNull(cause, "cause").getMessage(), cause);
         this.uri = sanitizeUri(uri);
     }
 
+    /**
+     * @param uri     the endpoint URI that could not be resolved
+     * @param message the detail message describing why the endpoint could not be resolved
+     */
     public ResolveEndpointFailedException(@Nullable String uri, String message) {
         super("Failed to resolve endpoint: " + sanitizeUri(uri) + " due to: "
               + Objects.requireNonNull(message, "message"));
         this.uri = sanitizeUri(uri);
     }
 
+    /**
+     * @param uri the endpoint URI that could not be resolved
+     */
     public ResolveEndpointFailedException(@Nullable String uri) {
         super("Failed to resolve endpoint: " + sanitizeUri(uri));
         this.uri = sanitizeUri(uri);

--- a/core/camel-api/src/main/java/org/apache/camel/RollbackExchangeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RollbackExchangeException.java
@@ -23,18 +23,34 @@ import java.util.Objects;
  */
 public class RollbackExchangeException extends CamelExchangeException {
 
+    /**
+     * @param exchange the exchange that is being rolled back
+     */
     public RollbackExchangeException(Exchange exchange) {
         this("Intended rollback", exchange);
     }
 
+    /**
+     * @param exchange the exchange that is being rolled back
+     * @param cause    the cause of the rollback
+     */
     public RollbackExchangeException(Exchange exchange, Throwable cause) {
         this("Intended rollback", exchange, cause);
     }
 
+    /**
+     * @param message  the detail message
+     * @param exchange the exchange that is being rolled back
+     */
     public RollbackExchangeException(String message, Exchange exchange) {
         super(Objects.requireNonNull(message, "message"), Objects.requireNonNull(exchange, "exchange"));
     }
 
+    /**
+     * @param message  the detail message
+     * @param exchange the exchange that is being rolled back
+     * @param cause    the cause of the rollback
+     */
     public RollbackExchangeException(String message, Exchange exchange, Throwable cause) {
         super(Objects.requireNonNull(message, "message"), Objects.requireNonNull(exchange, "exchange"),
               Objects.requireNonNull(cause, "cause"));

--- a/core/camel-api/src/main/java/org/apache/camel/RuntimeExpressionException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RuntimeExpressionException.java
@@ -23,14 +23,24 @@ import java.util.Objects;
  */
 public class RuntimeExpressionException extends RuntimeCamelException {
 
+    /**
+     * @param message the detail message
+     */
     public RuntimeExpressionException(String message) {
         super(Objects.requireNonNull(message, "message"));
     }
 
+    /**
+     * @param message the detail message
+     * @param cause   the cause of the failure
+     */
     public RuntimeExpressionException(String message, Throwable cause) {
         super(Objects.requireNonNull(message, "message"), Objects.requireNonNull(cause, "cause"));
     }
 
+    /**
+     * @param cause the cause of the failure
+     */
     public RuntimeExpressionException(Throwable cause) {
         super(Objects.requireNonNull(cause, "cause"));
     }

--- a/core/camel-api/src/main/java/org/apache/camel/RuntimeTransformException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RuntimeTransformException.java
@@ -23,14 +23,24 @@ import java.util.Objects;
  */
 public class RuntimeTransformException extends RuntimeCamelException {
 
+    /**
+     * @param message the detail message
+     */
     public RuntimeTransformException(String message) {
         super(Objects.requireNonNull(message, "message"));
     }
 
+    /**
+     * @param message the detail message
+     * @param cause   the cause of the failure
+     */
     public RuntimeTransformException(String message, Throwable cause) {
         super(Objects.requireNonNull(message, "message"), Objects.requireNonNull(cause, "cause"));
     }
 
+    /**
+     * @param cause the cause of the failure
+     */
     public RuntimeTransformException(Throwable cause) {
         super(Objects.requireNonNull(cause, "cause"));
     }

--- a/core/camel-api/src/main/java/org/apache/camel/TypeConverter.java
+++ b/core/camel-api/src/main/java/org/apache/camel/TypeConverter.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.Nullable;
  */
 public interface TypeConverter {
 
+    /** Sentinel value indicating that no type converter was found, used internally for caching purposes. */
     Object MISS_VALUE = Void.TYPE;
 
     /**

--- a/core/camel-api/src/main/java/org/apache/camel/TypeConverterExistsException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/TypeConverterExistsException.java
@@ -26,6 +26,10 @@ public class TypeConverterExistsException extends RuntimeCamelException {
     private final transient Class<?> toType;
     private final transient Class<?> fromType;
 
+    /**
+     * @param toType   the target type of the converter that already exists
+     * @param fromType the source type of the converter that already exists
+     */
     public TypeConverterExistsException(Class<?> toType, Class<?> fromType) {
         super("Failed to add type converter because a type converter exists. "
               + Objects.requireNonNull(fromType, "fromType") + " -> " + Objects.requireNonNull(toType, "toType"));

--- a/core/camel-api/src/main/java/org/apache/camel/TypeConverterLoaderException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/TypeConverterLoaderException.java
@@ -23,10 +23,17 @@ import java.util.Objects;
  */
 public class TypeConverterLoaderException extends RuntimeCamelException {
 
+    /**
+     * @param message the detail message describing why the type converters failed to load
+     */
     public TypeConverterLoaderException(String message) {
         super("Failed to load type converters because of: " + Objects.requireNonNull(message, "message"));
     }
 
+    /**
+     * @param message the detail message describing why the type converters failed to load
+     * @param cause   the cause of the failure
+     */
     public TypeConverterLoaderException(String message, Throwable cause) {
         super("Failed to load type converters because of: " + Objects.requireNonNull(message, "message"),
               Objects.requireNonNull(cause, "cause"));

--- a/core/camel-api/src/main/java/org/apache/camel/ValidationException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ValidationException.java
@@ -27,10 +27,19 @@ import org.jspecify.annotations.Nullable;
  */
 public class ValidationException extends CamelExchangeException {
 
+    /**
+     * @param exchange the exchange that failed validation
+     * @param message  the detail message
+     */
     public ValidationException(@Nullable Exchange exchange, String message) {
         super(Objects.requireNonNull(message, "message"), exchange);
     }
 
+    /**
+     * @param message  the detail message
+     * @param exchange the exchange that failed validation
+     * @param cause    the cause of the failure
+     */
     public ValidationException(String message, @Nullable Exchange exchange, Throwable cause) {
         super(Objects.requireNonNull(message, "message"), exchange, Objects.requireNonNull(cause, "cause"));
     }

--- a/core/camel-api/src/main/java/org/apache/camel/VetoCamelContextStartException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/VetoCamelContextStartException.java
@@ -31,20 +31,40 @@ public class VetoCamelContextStartException extends Exception {
     private final CamelContext context;
     private final boolean rethrowException;
 
+    /**
+     * @param message the detail message
+     * @param context the CamelContext whose start is being vetoed
+     */
     public VetoCamelContextStartException(String message, CamelContext context) {
         this(message, context, true);
     }
 
+    /**
+     * @param message          the detail message
+     * @param context          the CamelContext whose start is being vetoed
+     * @param rethrowException whether to rethrow this exception when starting CamelContext
+     */
     public VetoCamelContextStartException(String message, CamelContext context, boolean rethrowException) {
         super(Objects.requireNonNull(message, "message"));
         this.context = Objects.requireNonNull(context, "context");
         this.rethrowException = rethrowException;
     }
 
+    /**
+     * @param message the detail message
+     * @param cause   the cause of the veto
+     * @param context the CamelContext whose start is being vetoed
+     */
     public VetoCamelContextStartException(String message, Throwable cause, CamelContext context) {
         this(message, cause, context, true);
     }
 
+    /**
+     * @param message          the detail message
+     * @param cause            the cause of the veto
+     * @param context          the CamelContext whose start is being vetoed
+     * @param rethrowException whether to rethrow this exception when starting CamelContext
+     */
     public VetoCamelContextStartException(String message, Throwable cause, CamelContext context, boolean rethrowException) {
         super(Objects.requireNonNull(message, "message"), Objects.requireNonNull(cause, "cause"));
         this.context = Objects.requireNonNull(context, "context");

--- a/core/camel-api/src/main/java/org/apache/camel/catalog/PropertiesValidationResult.java
+++ b/core/camel-api/src/main/java/org/apache/camel/catalog/PropertiesValidationResult.java
@@ -73,22 +73,27 @@ abstract class PropertiesValidationResult implements Serializable {
     @Nullable
     Map<String, String> defaultValues;
 
+    /** Returns true if the validation result has one or more errors. */
     public boolean hasErrors() {
         return errors > 0;
     }
 
+    /** Returns the number of validation errors. */
     public int getNumberOfErrors() {
         return errors;
     }
 
+    /** Returns true if the validation result has one or more warnings. */
     public boolean hasWarnings() {
         return warnings > 0;
     }
 
+    /** Returns the number of validation warnings. */
     public int getNumberOfWarnings() {
         return warnings;
     }
 
+    /** Returns true if the validation result has no errors. */
     public boolean isSuccess() {
         boolean ok = syntaxError == null && unknown == null && required == null;
         if (ok) {
@@ -102,21 +107,25 @@ abstract class PropertiesValidationResult implements Serializable {
         return ok;
     }
 
+    /** Adds a syntax error to the validation result. */
     public void addSyntaxError(String syntaxError) {
         this.syntaxError = syntaxError;
         errors++;
     }
 
+    /** Adds an incapable URI warning to the validation result. */
     public void addIncapable(String uri) {
         this.incapable = uri;
         warnings++;
     }
 
+    /** Adds an unknown component warning to the validation result. */
     public void addUnknownComponent(String name) {
         this.unknownComponent = name;
         warnings++;
     }
 
+    /** Adds an unknown option error to the validation result. */
     public void addUnknown(String name) {
         if (unknown == null) {
             unknown = new LinkedHashSet<>();
@@ -127,6 +136,7 @@ abstract class PropertiesValidationResult implements Serializable {
         }
     }
 
+    /** Adds spelling suggestions for an unknown option name. */
     public void addUnknownSuggestions(String name, String[] suggestions) {
         if (unknownSuggestions == null) {
             unknownSuggestions = new LinkedHashMap<>();
@@ -134,6 +144,7 @@ abstract class PropertiesValidationResult implements Serializable {
         unknownSuggestions.put(name, suggestions);
     }
 
+    /** Adds a missing required option error to the validation result. */
     public void addRequired(String name) {
         if (required == null) {
             required = new LinkedHashSet<>();
@@ -144,6 +155,7 @@ abstract class PropertiesValidationResult implements Serializable {
         }
     }
 
+    /** Adds a deprecated option warning to the validation result. */
     public void addDeprecated(String name) {
         if (deprecated == null) {
             deprecated = new LinkedHashSet<>();
@@ -156,6 +168,7 @@ abstract class PropertiesValidationResult implements Serializable {
         return value;
     }
 
+    /** Adds an invalid enum value error to the validation result. */
     public void addInvalidEnum(String name, String value) {
         if (invalidEnum == null) {
             invalidEnum = new LinkedHashMap<>();
@@ -164,6 +177,7 @@ abstract class PropertiesValidationResult implements Serializable {
         invalidEnum.computeIfAbsent(name, k -> computeErrors(value));
     }
 
+    /** Adds the valid enum choices for an invalid enum option. */
     public void addInvalidEnumChoices(String name, String[] choices) {
         if (invalidEnumChoices == null) {
             invalidEnumChoices = new LinkedHashMap<>();
@@ -171,6 +185,7 @@ abstract class PropertiesValidationResult implements Serializable {
         invalidEnumChoices.put(name, choices);
     }
 
+    /** Adds spelling suggestions for an invalid enum option value. */
     public void addInvalidEnumSuggestions(String name, String[] suggestions) {
         if (invalidEnumSuggestions == null) {
             invalidEnumSuggestions = new LinkedHashMap<>();
@@ -178,6 +193,7 @@ abstract class PropertiesValidationResult implements Serializable {
         invalidEnumSuggestions.put(name, suggestions);
     }
 
+    /** Adds an invalid bean reference error to the validation result. */
     public void addInvalidReference(String name, String value) {
         if (invalidReference == null) {
             invalidReference = new LinkedHashMap<>();
@@ -186,6 +202,7 @@ abstract class PropertiesValidationResult implements Serializable {
         invalidReference.computeIfAbsent(name, k -> computeErrors(value));
     }
 
+    /** Adds an invalid map value error to the validation result. */
     public void addInvalidMap(String name, String value) {
         if (invalidMap == null) {
             invalidMap = new LinkedHashMap<>();
@@ -194,6 +211,7 @@ abstract class PropertiesValidationResult implements Serializable {
         invalidMap.computeIfAbsent(name, k -> computeErrors(value));
     }
 
+    /** Adds an invalid array value error to the validation result. */
     public void addInvalidArray(String name, String value) {
         if (invalidArray == null) {
             invalidArray = new LinkedHashMap<>();
@@ -202,6 +220,7 @@ abstract class PropertiesValidationResult implements Serializable {
         invalidArray.computeIfAbsent(name, k -> computeErrors(value));
     }
 
+    /** Adds an invalid boolean value error to the validation result. */
     public void addInvalidBoolean(String name, String value) {
         if (invalidBoolean == null) {
             invalidBoolean = new LinkedHashMap<>();
@@ -210,6 +229,7 @@ abstract class PropertiesValidationResult implements Serializable {
         invalidBoolean.computeIfAbsent(name, k -> computeErrors(value));
     }
 
+    /** Adds an invalid integer value error to the validation result. */
     public void addInvalidInteger(String name, String value) {
         if (invalidInteger == null) {
             invalidInteger = new LinkedHashMap<>();
@@ -218,6 +238,7 @@ abstract class PropertiesValidationResult implements Serializable {
         invalidInteger.computeIfAbsent(name, k -> computeErrors(value));
     }
 
+    /** Adds an invalid number value error to the validation result. */
     public void addInvalidNumber(String name, String value) {
         if (invalidNumber == null) {
             invalidNumber = new LinkedHashMap<>();
@@ -226,6 +247,7 @@ abstract class PropertiesValidationResult implements Serializable {
         invalidNumber.computeIfAbsent(name, k -> computeErrors(value));
     }
 
+    /** Adds an invalid duration value error to the validation result. */
     public void addInvalidDuration(String name, String value) {
         if (invalidDuration == null) {
             invalidDuration = new LinkedHashMap<>();
@@ -234,6 +256,7 @@ abstract class PropertiesValidationResult implements Serializable {
         invalidDuration.computeIfAbsent(name, k -> computeErrors(value));
     }
 
+    /** Adds a default value entry for an option that was not configured. */
     public void addDefaultValue(String name, String value) {
         if (defaultValues == null) {
             defaultValues = new LinkedHashMap<>();
@@ -241,46 +264,57 @@ abstract class PropertiesValidationResult implements Serializable {
         defaultValues.put(name, value);
     }
 
+    /** Returns the syntax error message, or null if there is no syntax error. */
     public @Nullable String getSyntaxError() {
         return syntaxError;
     }
 
+    /** Returns the incapable URI that could not be validated, or null if not applicable. */
     public @Nullable String getIncapable() {
         return incapable;
     }
 
+    /** Returns the set of unknown option names, or null if none. */
     public @Nullable Set<String> getUnknown() {
         return unknown;
     }
 
+    /** Returns spelling suggestions for unknown option names, or null if none. */
     public @Nullable Map<String, String[]> getUnknownSuggestions() {
         return unknownSuggestions;
     }
 
+    /** Returns the name of an unknown component that was used, or null if none. */
     public @Nullable String getUnknownComponent() {
         return unknownComponent;
     }
 
+    /** Returns the set of required option names that are missing, or null if none. */
     public @Nullable Set<String> getRequired() {
         return required;
     }
 
+    /** Returns the set of deprecated option names that are used, or null if none. */
     public @Nullable Set<String> getDeprecated() {
         return deprecated;
     }
 
+    /** Returns options with invalid enum values mapped to the invalid value, or null if none. */
     public @Nullable Map<String, String> getInvalidEnum() {
         return invalidEnum;
     }
 
+    /** Returns options with invalid enum values mapped to the valid choices, or null if none. */
     public @Nullable Map<String, String[]> getInvalidEnumChoices() {
         return invalidEnumChoices;
     }
 
+    /** Returns spelling suggestions for invalid enum option values, or null if none. */
     public @Nullable Map<String, String[]> getInvalidEnumSuggestions() {
         return invalidEnumSuggestions;
     }
 
+    /** Returns the list of valid enum choices for the given option name. */
     public List<String> getEnumChoices(String optionName) {
         if (invalidEnumChoices != null) {
             String[] enums = invalidEnumChoices.get(optionName);
@@ -292,34 +326,42 @@ abstract class PropertiesValidationResult implements Serializable {
         return Collections.emptyList();
     }
 
+    /** Returns options with invalid bean reference values, or null if none. */
     public @Nullable Map<String, String> getInvalidReference() {
         return invalidReference;
     }
 
+    /** Returns options with invalid map values, or null if none. */
     public @Nullable Map<String, String> getInvalidMap() {
         return invalidMap;
     }
 
+    /** Returns options with invalid array values, or null if none. */
     public @Nullable Map<String, String> getInvalidArray() {
         return invalidArray;
     }
 
+    /** Returns options with invalid boolean values, or null if none. */
     public @Nullable Map<String, String> getInvalidBoolean() {
         return invalidBoolean;
     }
 
+    /** Returns options with invalid integer values, or null if none. */
     public @Nullable Map<String, String> getInvalidInteger() {
         return invalidInteger;
     }
 
+    /** Returns options with invalid number values, or null if none. */
     public @Nullable Map<String, String> getInvalidNumber() {
         return invalidNumber;
     }
 
+    /** Returns options with invalid duration values, or null if none. */
     public @Nullable Map<String, String> getInvalidDuration() {
         return invalidDuration;
     }
 
+    /** Returns options that were not configured and are using default values, or null if none. */
     public @Nullable Map<String, String> getDefaultValues() {
         return defaultValues;
     }

--- a/core/camel-api/src/main/java/org/apache/camel/health/HealthCheckResultBuilder.java
+++ b/core/camel-api/src/main/java/org/apache/camel/health/HealthCheckResultBuilder.java
@@ -41,29 +41,35 @@ public final class HealthCheckResultBuilder implements Builder<HealthCheck.Resul
         this.check = Objects.requireNonNull(check, "check");
     }
 
+    /** Gets the message for the health check result. */
     public @Nullable String message() {
         return this.message;
     }
 
+    /** Sets the message for the health check result. */
     public HealthCheckResultBuilder message(@Nullable String message) {
         this.message = message;
         return this;
     }
 
+    /** Gets the error associated with the health check result. */
     public @Nullable Throwable error() {
         return this.error;
     }
 
+    /** Sets the error associated with the health check result. */
     public HealthCheckResultBuilder error(@Nullable Throwable error) {
         this.error = error;
         return this;
     }
 
+    /** Gets a detail value by key from the health check result. */
     public @Nullable Object detail(String key) {
         Objects.requireNonNull(key, "key");
         return this.details != null ? this.details.get(key) : null;
     }
 
+    /** Sets a detail key/value pair for the health check result. */
     public HealthCheckResultBuilder detail(String key, Object value) {
         Objects.requireNonNull(key, "key");
         Objects.requireNonNull(value, "value");
@@ -75,6 +81,7 @@ public final class HealthCheckResultBuilder implements Builder<HealthCheck.Resul
         return this;
     }
 
+    /** Sets multiple detail key/value pairs for the health check result. */
     public HealthCheckResultBuilder details(Map<String, Object> details) {
         Objects.requireNonNull(details, "details");
         if (ObjectHelper.isNotEmpty(details)) {
@@ -84,23 +91,28 @@ public final class HealthCheckResultBuilder implements Builder<HealthCheck.Resul
         return this;
     }
 
+    /** Gets the state of the health check result. */
     public HealthCheck.@Nullable State state() {
         return this.state;
     }
 
+    /** Sets the state for the health check result. */
     public HealthCheckResultBuilder state(HealthCheck.State state) {
         this.state = Objects.requireNonNull(state, "state");
         return this;
     }
 
+    /** Marks the health check as UP. */
     public HealthCheckResultBuilder up() {
         return state(HealthCheck.State.UP);
     }
 
+    /** Marks the health check as DOWN. */
     public HealthCheckResultBuilder down() {
         return state(HealthCheck.State.DOWN);
     }
 
+    /** Marks the health check as UNKNOWN. */
     public HealthCheckResultBuilder unknown() {
         return state(HealthCheck.State.UNKNOWN);
     }
@@ -145,6 +157,7 @@ public final class HealthCheckResultBuilder implements Builder<HealthCheck.Resul
         };
     }
 
+    /** Creates a new builder for the given health check. */
     public static HealthCheckResultBuilder on(HealthCheck check) {
         Objects.requireNonNull(check, "check");
         return new HealthCheckResultBuilder(check);

--- a/core/camel-api/src/main/java/org/apache/camel/health/WritableHealthCheckRepository.java
+++ b/core/camel-api/src/main/java/org/apache/camel/health/WritableHealthCheckRepository.java
@@ -17,7 +17,7 @@
 package org.apache.camel.health;
 
 /**
- * An interface to represent an object which wishes to be injected with the {@link HealthCheck}
+ * A {@link HealthCheckRepository} that supports adding and removing health checks at runtime.
  */
 public interface WritableHealthCheckRepository extends HealthCheckRepository {
 

--- a/core/camel-api/src/main/java/org/apache/camel/resume/ResumeAction.java
+++ b/core/camel-api/src/main/java/org/apache/camel/resume/ResumeAction.java
@@ -18,7 +18,7 @@
 package org.apache.camel.resume;
 
 /**
- * Provides and interface for integrations to run actions during resume
+ * Provides an interface for integrations to run actions during resume
  */
 public interface ResumeAction {
 

--- a/core/camel-api/src/main/java/org/apache/camel/resume/ResumeStrategy.java
+++ b/core/camel-api/src/main/java/org/apache/camel/resume/ResumeStrategy.java
@@ -108,7 +108,17 @@ public interface ResumeStrategy extends Service {
      */
     void updateLastOffset(OffsetKey<?> offsetKey, Offset<?> offset, @Nullable UpdateCallBack updateCallBack) throws Exception;
 
+    /**
+     * Sets the configuration for this resume strategy.
+     *
+     * @param resumeStrategyConfiguration the resume strategy configuration
+     */
     void setResumeStrategyConfiguration(ResumeStrategyConfiguration resumeStrategyConfiguration);
 
+    /**
+     * Gets the configuration for this resume strategy.
+     *
+     * @return the resume strategy configuration
+     */
     ResumeStrategyConfiguration getResumeStrategyConfiguration();
 }

--- a/core/camel-api/src/main/java/org/apache/camel/spi/HeaderFilterStrategy.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/HeaderFilterStrategy.java
@@ -20,7 +20,7 @@ import org.apache.camel.Exchange;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Interface to allow plug-able implementation to filter header to and from Camel message.
+ * Interface to allow pluggable implementation to filter headers to and from Camel message.
  */
 public interface HeaderFilterStrategy {
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/RestConfiguration.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/RestConfiguration.java
@@ -200,6 +200,11 @@ public class RestConfiguration {
         this.useXForwardHeaders = useXForwardHeaders;
     }
 
+    /**
+     * Gets the hostname to use for the API documentation (such as swagger or openapi).
+     *
+     * @return the API host, or <tt>null</tt> to use the default host
+     */
     public @Nullable String getApiHost() {
         return apiHost;
     }
@@ -271,6 +276,11 @@ public class RestConfiguration {
         this.contextPath = Objects.requireNonNull(contextPath, "contextPath");
     }
 
+    /**
+     * Gets the leading API context-path the REST API services will be using.
+     *
+     * @return the API context path, or <tt>null</tt> if none configured.
+     */
     public @Nullable String getApiContextPath() {
         return apiContextPath;
     }
@@ -287,6 +297,11 @@ public class RestConfiguration {
         this.apiContextPath = Objects.requireNonNull(contextPath, "contextPath");
     }
 
+    /**
+     * Gets the route id used for the route that services the REST API.
+     *
+     * @return the route id, or <tt>null</tt> if using an auto-assigned id
+     */
     public @Nullable String getApiContextRouteId() {
         return apiContextRouteId;
     }
@@ -302,6 +317,11 @@ public class RestConfiguration {
         this.apiContextRouteId = Objects.requireNonNull(apiContextRouteId, "apiContextRouteId");
     }
 
+    /**
+     * Whether vendor extension is enabled in the REST APIs.
+     *
+     * @return true if vendor extensions are included in the API docs
+     */
     public boolean isApiVendorExtension() {
         return apiVendorExtension;
     }
@@ -371,6 +391,11 @@ public class RestConfiguration {
         this.bindingMode = RestBindingMode.valueOf(bindingMode);
     }
 
+    /**
+     * Gets the package name used as base for classpath scanning of POJO classes when binding mode is enabled.
+     *
+     * @return the package name, or <tt>null</tt> if not configured
+     */
     public @Nullable String getBindingPackageScan() {
         return bindingPackageScan;
     }
@@ -405,6 +430,11 @@ public class RestConfiguration {
         this.skipBindingOnErrorCode = skipBindingOnErrorCode;
     }
 
+    /**
+     * Whether client request validation is enabled.
+     *
+     * @return true if client request validation is enabled
+     */
     public boolean isClientRequestValidation() {
         return clientRequestValidation;
     }
@@ -421,6 +451,11 @@ public class RestConfiguration {
         this.clientRequestValidation = clientRequestValidation;
     }
 
+    /**
+     * Whether client response validation is enabled.
+     *
+     * @return true if client response validation is enabled
+     */
     public boolean isClientResponseValidation() {
         return clientResponseValidation;
     }
@@ -460,6 +495,11 @@ public class RestConfiguration {
         this.enableCORS = enableCORS;
     }
 
+    /**
+     * Whether HTTP 204 No Content responses are enabled for empty JSON or XML responses.
+     *
+     * @return true if HTTP 204 responses are enabled
+     */
     public boolean isEnableNoContentResponse() {
         return enableNoContentResponse;
     }
@@ -475,6 +515,11 @@ public class RestConfiguration {
         this.enableNoContentResponse = enableNoContentResponse;
     }
 
+    /**
+     * Whether routes in rest-dsl linked via direct endpoints are inlined as a single route.
+     *
+     * @return true if rest-dsl routes are inlined
+     */
     public boolean isInlineRoutes() {
         return inlineRoutes;
     }
@@ -613,6 +658,11 @@ public class RestConfiguration {
         this.dataFormatProperties = Objects.requireNonNull(dataFormatProperties, "dataFormatProperties");
     }
 
+    /**
+     * Gets additional options on API level.
+     *
+     * @return additional options
+     */
     public @Nullable Map<String, Object> getApiProperties() {
         return apiProperties;
     }

--- a/core/camel-api/src/main/java/org/apache/camel/spi/RoutePolicyFactory.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/RoutePolicyFactory.java
@@ -21,7 +21,9 @@ import org.apache.camel.NamedNode;
 import org.jspecify.annotations.Nullable;
 
 /**
- * A factory to create {@link org.apache.camel.spi.RoutePolicy} and assign to routes automatic.
+ * A factory to create {@link org.apache.camel.spi.RoutePolicy} and assign to routes automatically. Factories are
+ * registered via {@link org.apache.camel.CamelContext#addRoutePolicyFactory(RoutePolicyFactory)} and are called for
+ * every route during startup.
  */
 public interface RoutePolicyFactory {
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/StreamCachingStrategy.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/StreamCachingStrategy.java
@@ -26,7 +26,10 @@ import org.apache.camel.StreamCache;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Strategy for using <a href="https://camel.apache.org/stream-caching.html">stream caching</a>.
+ * Strategy for stream caching, which allows message bodies based on streams (such as {@link java.io.InputStream}) to be
+ * re-read. The strategy controls whether caching uses memory or spools to disk.
+ *
+ * @see <a href="https://camel.apache.org/stream-caching.html">stream caching</a>
  */
 public interface StreamCachingStrategy extends StaticService {
 
@@ -269,7 +272,7 @@ public interface StreamCachingStrategy extends StaticService {
     boolean shouldSpoolCache(long length);
 
     /**
-     * Caches the body aas a {@link StreamCache}.
+     * Caches the body as a {@link StreamCache}.
      *
      * @param  exchange the exchange
      * @return          the body cached as a {@link StreamCache}, or <tt>null</tt> if not possible or no need to cache
@@ -279,7 +282,7 @@ public interface StreamCachingStrategy extends StaticService {
     StreamCache cache(Exchange exchange);
 
     /**
-     * Caches the body aas a {@link StreamCache}.
+     * Caches the body as a {@link StreamCache}.
      *
      * @param  message the message
      * @return         the body cached as a {@link StreamCache}, or <tt>null</tt> if not possible or no need to cache
@@ -289,7 +292,7 @@ public interface StreamCachingStrategy extends StaticService {
     StreamCache cache(Message message);
 
     /**
-     * Caches the value aas a {@link StreamCache}.
+     * Caches the value as a {@link StreamCache}.
      *
      * @param  value the value
      * @return       the value cached as a {@link StreamCache}, or <tt>null</tt> if not possible or no need to cache

--- a/core/camel-api/src/main/java/org/apache/camel/support/service/BaseService.java
+++ b/core/camel-api/src/main/java/org/apache/camel/support/service/BaseService.java
@@ -56,6 +56,9 @@ public abstract class BaseService {
     protected final Lock lock = new ReentrantLock();
     protected volatile byte status = NEW;
 
+    /**
+     * Builds the service. This method will only be called once and transitions the service from NEW to BUILT state.
+     */
     public void build() {
         if (status == NEW) {
             lock.lock();
@@ -74,6 +77,9 @@ public abstract class BaseService {
         }
     }
 
+    /**
+     * Initializes the service. This method will only be called once before starting.
+     */
     public void init() {
         // allow to initialize again if stopped or failed
         if (status <= BUILT || status >= STOPPED) {
@@ -270,6 +276,7 @@ public abstract class BaseService {
         }
     }
 
+    /** Returns the current status of the service. */
     public ServiceStatus getStatus() {
         switch (status) {
             case INITIALIZING:
@@ -291,46 +298,57 @@ public abstract class BaseService {
         }
     }
 
+    /** Returns true if the service is in the NEW state (not yet built). */
     public boolean isNew() {
         return status == NEW;
     }
 
+    /** Returns true if the service is in the BUILT state. */
     public boolean isBuild() {
         return status == BUILT;
     }
 
+    /** Returns true if the service is in the INITIALIZED state. */
     public boolean isInit() {
         return status == INITIALIZED;
     }
 
+    /** Returns true if the service is in the STARTED state. */
     public boolean isStarted() {
         return status == STARTED;
     }
 
+    /** Returns true if the service is in the STARTING state. */
     public boolean isStarting() {
         return status == STARTING;
     }
 
+    /** Returns true if the service is in the STOPPING state. */
     public boolean isStopping() {
         return status == STOPPING;
     }
 
+    /** Returns true if the service is stopped (not yet started or already stopped). */
     public boolean isStopped() {
         return status < STARTING || status >= STOPPED;
     }
 
+    /** Returns true if the service is in the SUSPENDING state. */
     public boolean isSuspending() {
         return status == SUSPENDING;
     }
 
+    /** Returns true if the service is in the SUSPENDED state. */
     public boolean isSuspended() {
         return status == SUSPENDED;
     }
 
+    /** Returns true if the service is allowed to process exchanges (started, starting, or suspended). */
     public boolean isRunAllowed() {
         return status >= STARTING && status <= SUSPENDED;
     }
 
+    /** Returns true if the service is in the SHUTDOWN state. */
     public boolean isShutdown() {
         return status == SHUTDOWN;
     }

--- a/core/camel-api/src/main/java/org/apache/camel/vault/VaultConfiguration.java
+++ b/core/camel-api/src/main/java/org/apache/camel/vault/VaultConfiguration.java
@@ -103,6 +103,9 @@ public class VaultConfiguration {
         return ibmSecretsManager;
     }
 
+    /**
+     * Spring Cloud Config Vault Configuration
+     */
     public SpringCloudConfigConfiguration springConfig() {
         if (springConfig == null) {
             springConfig = new SpringCloudConfigConfiguration();
@@ -120,74 +123,92 @@ public class VaultConfiguration {
         return cyberark;
     }
 
+    /** Gets the AWS Vault configuration. */
     public @Nullable AwsVaultConfiguration getAwsVaultConfiguration() {
         return aws;
     }
 
+    /** Sets the AWS Vault configuration. */
     public void setAwsVaultConfiguration(@Nullable AwsVaultConfiguration aws) {
         this.aws = aws;
     }
 
+    /** Gets the GCP Vault configuration. */
     public @Nullable GcpVaultConfiguration getGcpVaultConfiguration() {
         return gcp;
     }
 
+    /** Sets the GCP Vault configuration. */
     public void setGcpVaultConfiguration(@Nullable GcpVaultConfiguration gcp) {
         this.gcp = gcp;
     }
 
+    /** Gets the Azure Vault configuration. */
     public @Nullable AzureVaultConfiguration getAzureVaultConfiguration() {
         return azure;
     }
 
+    /** Sets the Azure Vault configuration. */
     public void setAzureVaultConfiguration(@Nullable AzureVaultConfiguration azure) {
         this.azure = azure;
     }
 
+    /** Gets the Hashicorp Vault configuration. */
     public @Nullable HashicorpVaultConfiguration getHashicorpVaultConfiguration() {
         return hashicorp;
     }
 
+    /** Sets the Hashicorp Vault configuration. */
     public void setHashicorpVaultConfiguration(@Nullable HashicorpVaultConfiguration hashicorp) {
         this.hashicorp = hashicorp;
     }
 
+    /** Gets the Kubernetes Vault configuration. */
     public @Nullable KubernetesVaultConfiguration getKubernetesVaultConfiguration() {
         return kubernetes;
     }
 
+    /** Sets the Kubernetes Vault configuration. */
     public void setKubernetesVaultConfiguration(@Nullable KubernetesVaultConfiguration kubernetes) {
         this.kubernetes = kubernetes;
     }
 
+    /** Gets the Kubernetes ConfigMap Vault configuration. */
     public @Nullable KubernetesConfigMapVaultConfiguration getKubernetesConfigMapVaultConfiguration() {
         return kubernetesConfigmaps;
     }
 
+    /** Sets the Kubernetes ConfigMap Vault configuration. */
     public void setKubernetesConfigMapVaultConfiguration(@Nullable KubernetesConfigMapVaultConfiguration kubernetesConfigmaps) {
         this.kubernetesConfigmaps = kubernetesConfigmaps;
     }
 
+    /** Gets the IBM Secrets Manager Vault configuration. */
     public @Nullable IBMSecretsManagerVaultConfiguration getIBMSecretsManagerVaultConfiguration() {
         return ibmSecretsManager;
     }
 
+    /** Sets the IBM Secrets Manager Vault configuration. */
     public void setIBMSecretsManagerVaultConfiguration(@Nullable IBMSecretsManagerVaultConfiguration ibmSecretsManager) {
         this.ibmSecretsManager = ibmSecretsManager;
     }
 
+    /** Gets the Spring Cloud Config configuration. */
     public @Nullable SpringCloudConfigConfiguration getSpringCloudConfigConfiguration() {
         return springConfig;
     }
 
+    /** Sets the Spring Cloud Config configuration. */
     public void setSpringCloudConfigConfiguration(@Nullable SpringCloudConfigConfiguration springCloudConfigConfiguration) {
         this.springConfig = springCloudConfigConfiguration;
     }
 
+    /** Gets the CyberArk Vault configuration. */
     public @Nullable CyberArkVaultConfiguration getCyberArkVaultConfiguration() {
         return cyberark;
     }
 
+    /** Sets the CyberArk Vault configuration. */
     public void setCyberArkVaultConfiguration(@Nullable CyberArkVaultConfiguration cyberark) {
         this.cyberark = cyberark;
     }


### PR DESCRIPTION
## Summary

Final batch of Javadoc improvements for the camel-api module, addressing all remaining issues from the analysis:

**Grammar and typo fixes:**
- `RoutePolicyFactory`: "automatic" -> "automatically" + added registration docs
- `HeaderFilterStrategy`: "plug-able" -> "pluggable", "filter header" -> "filter headers"
- `StreamCachingStrategy`: "aas" -> "as" (3x) + replaced tautological class doc
- `ResumeAction`: "and interface" -> "an interface"
- `WritableHealthCheckRepository`: fixed incorrect copy-paste class description
- `CamelContext`: fixed 6 "its" -> "it's" (contraction) occurrences

**Undocumented API elements:**
- `TypeConverter.MISS_VALUE`: added sentinel value description
- `Experimental.revision()`: added annotation element description

**Method-level Javadoc added to 6 classes:**
- `PropertiesValidationResult` (42 methods)
- `VaultConfiguration` (28 methods)
- `HealthCheckResultBuilder` (14 methods)
- `ResumeStrategy` (2 methods)
- `BaseService` (32 methods)
- `RestConfiguration` (65 methods)

**Exception constructor @param tags:**
- Added to 24 remaining exception classes (CamelException, ValidationException, RollbackExchangeException, ExpressionEvaluationException, etc.)

All changes are Javadoc-only — no functional code modified. 38 files changed, 384 insertions.

## Test plan

- [x] `mvn install -pl core/camel-api -DskipTests` passes
- [x] Formatter applied (`mvn formatter:format impsort:sort`)
- [x] No generated file changes needed