### PR TITLE
CAMEL-23504: camel-keycloak - include IS_ACTIVE check in parseAndVerifyAccessToken

### DIFF
--- a/components/camel-keycloak/src/main/java/org/apache/camel/component/keycloak/security/KeycloakSecurityHelper.java
+++ b/components/camel-keycloak/src/main/java/org/apache/camel/component/keycloak/security/KeycloakSecurityHelper.java
@@ -63,6 +63,7 @@ public final class KeycloakSecurityHelper {
                 .publicKey(publicKey)
                 .withChecks(
                         TokenVerifier.SUBJECT_EXISTS_CHECK,
+                        TokenVerifier.IS_ACTIVE,
                         new TokenVerifier.RealmUrlCheck(expectedIssuer));
 
         AccessToken token = verifier.verify().getToken();

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityHelperTest.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityHelperTest.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.keycloak.common.VerificationException;
+import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.representations.AccessToken;
 import org.mockito.Mockito;
 
@@ -174,6 +175,52 @@ public class KeycloakSecurityHelperTest {
         assertThrows(VerificationException.class, () -> {
             KeycloakSecurityHelper.parseAndVerifyAccessToken(invalidToken, publicKey, null);
         });
+    }
+
+    @Test
+    void testParseAndVerifyAccessTokenRejectsExpiredToken() throws Exception {
+        String expectedIssuer = "http://localhost:8080/realms/test";
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+
+        AccessToken token = new AccessToken();
+        token.issuer(expectedIssuer);
+        token.subject("user-123");
+        token.exp(System.currentTimeMillis() / 1000 - 3600);
+
+        String signed = new JWSBuilder()
+                .type("JWT")
+                .jsonContent(token)
+                .rsa256(keyPair.getPrivate());
+
+        assertThrows(VerificationException.class,
+                () -> KeycloakSecurityHelper.parseAndVerifyAccessToken(signed, keyPair.getPublic(), expectedIssuer));
+    }
+
+    @Test
+    void testParseAndVerifyAccessTokenAcceptsValidToken() throws Exception {
+        String expectedIssuer = "http://localhost:8080/realms/test";
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+
+        AccessToken token = new AccessToken();
+        token.issuer(expectedIssuer);
+        token.subject("user-123");
+        token.exp(System.currentTimeMillis() / 1000 + 3600);
+
+        String signed = new JWSBuilder()
+                .type("JWT")
+                .jsonContent(token)
+                .rsa256(keyPair.getPrivate());
+
+        AccessToken verified
+                = KeycloakSecurityHelper.parseAndVerifyAccessToken(signed, keyPair.getPublic(), expectedIssuer);
+        assertEquals("user-123", verified.getSubject());
+        assertEquals(expectedIssuer, verified.getIssuer());
     }
 
     @Test


### PR DESCRIPTION
## Summary

`KeycloakSecurityHelper.parseAndVerifyAccessToken` built its `TokenVerifier`
with only `SUBJECT_EXISTS_CHECK` and a `RealmUrlCheck`. Keycloak's
`TokenVerifier` starts with an empty internal check list and
`withChecks(...)` appends rather than replacing a default set, so the
built-in `IS_ACTIVE` predicate (which validates the `exp` and `nbf` claims)
was not part of the verification chain.

This PR adds `TokenVerifier.IS_ACTIVE` to the `withChecks(...)` invocation
so the helper enforces the token's validity window in addition to
signature, subject, and issuer.

Tracking issue: https://issues.apache.org/jira/browse/CAMEL-23504

## Changes

- `KeycloakSecurityHelper.java`: include `TokenVerifier.IS_ACTIVE` in the
  `.withChecks(...)` call.
- `KeycloakSecurityHelperTest.java`: two new tests
  - `testParseAndVerifyAccessTokenRejectsExpiredToken` — signs a token whose
    `exp` claim is one hour in the past with an RSA key and asserts that
    `parseAndVerifyAccessToken` throws `VerificationException`.
  - `testParseAndVerifyAccessTokenAcceptsValidToken` — signs an unexpired
    token and asserts verification returns the parsed claims (happy-path
    regression test).

## Test plan

- [x] `mvn install` in `components/camel-keycloak` — 16/16 tests pass
- [x] `mvn clean install -DskipTests -Dquickly` from repo root — BUILD SUCCESS

---

_Claude Code on behalf of Andrea Cosentino_