### PR TITLE
[backport camel-4.18.x] CAMEL-23504: camel-keycloak - include IS_ACTIVE check in parseAndVerifyAccessToken

### DIFF
--- a/components/camel-keycloak/src/main/java/org/apache/camel/component/keycloak/security/KeycloakSecurityHelper.java
+++ b/components/camel-keycloak/src/main/java/org/apache/camel/component/keycloak/security/KeycloakSecurityHelper.java
@@ -62,6 +62,7 @@ public final class KeycloakSecurityHelper {
                 .publicKey(publicKey)
                 .withChecks(
                         TokenVerifier.SUBJECT_EXISTS_CHECK,
+                        TokenVerifier.IS_ACTIVE,
                         new TokenVerifier.RealmUrlCheck(expectedIssuer));
 
         AccessToken token = verifier.verify().getToken();

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityHelperTest.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityHelperTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.keycloak.common.VerificationException;
+import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.representations.AccessToken;
 import org.mockito.Mockito;
 
@@ -171,6 +172,52 @@ public class KeycloakSecurityHelperTest {
         assertThrows(VerificationException.class, () -> {
             KeycloakSecurityHelper.parseAndVerifyAccessToken(invalidToken, publicKey, null);
         });
+    }
+
+    @Test
+    void testParseAndVerifyAccessTokenRejectsExpiredToken() throws Exception {
+        String expectedIssuer = "http://localhost:8080/realms/test";
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+
+        AccessToken token = new AccessToken();
+        token.issuer(expectedIssuer);
+        token.subject("user-123");
+        token.exp(System.currentTimeMillis() / 1000 - 3600);
+
+        String signed = new JWSBuilder()
+                .type("JWT")
+                .jsonContent(token)
+                .rsa256(keyPair.getPrivate());
+
+        assertThrows(VerificationException.class,
+                () -> KeycloakSecurityHelper.parseAndVerifyAccessToken(signed, keyPair.getPublic(), expectedIssuer));
+    }
+
+    @Test
+    void testParseAndVerifyAccessTokenAcceptsValidToken() throws Exception {
+        String expectedIssuer = "http://localhost:8080/realms/test";
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+
+        AccessToken token = new AccessToken();
+        token.issuer(expectedIssuer);
+        token.subject("user-123");
+        token.exp(System.currentTimeMillis() / 1000 + 3600);
+
+        String signed = new JWSBuilder()
+                .type("JWT")
+                .jsonContent(token)
+                .rsa256(keyPair.getPrivate());
+
+        AccessToken verified
+                = KeycloakSecurityHelper.parseAndVerifyAccessToken(signed, keyPair.getPublic(), expectedIssuer);
+        assertEquals("user-123", verified.getSubject());
+        assertEquals(expectedIssuer, verified.getIssuer());
     }
 
     @Test


### PR DESCRIPTION
## Backport of #23197

Cherry-pick of #23197 onto `camel-4.18.x`.

**Original PR:** #23197 — CAMEL-23504: camel-keycloak - include IS_ACTIVE check in parseAndVerifyAccessToken
**Original author:** @oscerd
**Target branch:** `camel-4.18.x`
**Tracking issue:** https://issues.apache.org/jira/browse/CAMEL-23504

The bug exists on `camel-4.18.x` with the same code shape as on `main` — `KeycloakSecurityHelper.parseAndVerifyAccessToken` builds a `TokenVerifier` with only `SUBJECT_EXISTS_CHECK` and a `RealmUrlCheck`, and Keycloak's `TokenVerifier.withChecks(...)` appends rather than replacing defaults, so `TokenVerifier.IS_ACTIVE` (the `exp`/`nbf` predicate) is never applied. Cherry-pick applied cleanly with auto-merge.

`camel-4.14.x` is not affected because the `camel-keycloak` component does not exist on that line (it was introduced in 4.15.0).

### Verification

- [x] `git cherry-pick 82fd4094b70` — clean auto-merge, no manual conflict resolution
- [x] `mvn clean install -DskipTests -Dquickly` from repo root — BUILD SUCCESS

### Original description

See #23197.

---

_Claude Code on behalf of Andrea Cosentino_