### PR TITLE
CAMEL-23505: camel-splunk-hec: align hostname verification with system default in SplunkHECProducer

### DIFF
--- a/components/camel-splunk-hec/src/main/java/org/apache/camel/component/splunkhec/SplunkHECProducer.java
+++ b/components/camel-splunk-hec/src/main/java/org/apache/camel/component/splunkhec/SplunkHECProducer.java
@@ -69,7 +69,7 @@ public class SplunkHECProducer extends DefaultProducer {
             connManager = new PoolingHttpClientConnectionManager(registryBuilder.build());
         } else {
             SSLConnectionSocketFactory sslsf
-                    = new SSLConnectionSocketFactory(endpoint.provideSSLContext(), NoopHostnameVerifier.INSTANCE);
+                    = new SSLConnectionSocketFactory(endpoint.provideSSLContext());
             RegistryBuilder<ConnectionSocketFactory> registryBuilder = RegistryBuilder.create();
             registryBuilder.register("https", sslsf);
 


### PR DESCRIPTION
## Summary
- Backport of #23214 to `camel-4.14.x`
- Removes `NoopHostnameVerifier.INSTANCE` from the `SSLConnectionSocketFactory` in the `skipTlsVerify=false` branch of `SplunkHECProducer.doStart()`, so hostname verification uses the system default when custom `SSLContextParameters` are configured

## Test plan
- [x] Cherry-pick applied cleanly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Federico Mariani