### PR TITLE
CAMEL-23510: doc-sync 4.18 upgrade guide for camel-jgroups header rename

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -109,6 +109,27 @@ Hazelcast topic, queue, map, list, set, or in one of the repositories
 above must provide their own `Config` with a
 `JavaSerializationFilterConfig` configured for their class names.
 
+=== camel-jgroups
+
+The Exchange header constants in `JGroupsConstants` have been renamed to follow
+the Camel naming convention used across the rest of the component catalog. The
+Java field names are unchanged; only the header string values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `JGroupsConstants.HEADER_JGROUPS_CHANNEL_ADDRESS` | `JGROUPS_CHANNEL_ADDRESS` | `CamelJGroupsChannelAddress`
+| `JGroupsConstants.HEADER_JGROUPS_DEST` | `JGROUPS_DEST` | `CamelJGroupsDest`
+| `JGroupsConstants.HEADER_JGROUPS_SRC` | `JGROUPS_SRC` | `CamelJGroupsSrc`
+| `JGroupsConstants.HEADER_JGROUPS_ORIGINAL_MESSAGE` | `JGROUPS_ORIGINAL_MESSAGE` | `CamelJGroupsOriginalMessage`
+|===
+
+Routes that reference the constant symbolically (for example
+`setHeader(JGroupsConstants.HEADER_JGROUPS_DEST, ...)`) continue to work
+without changes. Routes that set the header by its literal string value
+(for example `setHeader("JGROUPS_DEST", ...)`) must be updated to use the
+new value (`setHeader("CamelJGroupsDest", ...)`).
+
 == Upgrading from 4.18.0 to 4.18.1
 
 === camel-bom


### PR DESCRIPTION
## Summary

Doc-sync companion to the [camel-4.18.x backport PR #23213](https://github.com/apache/camel/pull/23213) for [CAMEL-23510](https://issues.apache.org/jira/browse/CAMEL-23510).

Per the project policy in `CLAUDE.md`:

> The `camel-4x-upgrade-guide-4_XX.adoc` files for ALL versions live on `main`
> and act as the canonical history across all releases. When a PR is backported
> to a maintenance branch and adds an upgrade-guide note for that release line,
> the corresponding entry must ALSO be added to the matching
> `camel-4x-upgrade-guide-4_XX.adoc` file on `main`.

This PR adds the `camel-jgroups` entry to
`docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc`
under the `Upgrading from 4.18.1 to 4.18.3` section, documenting the rename
of the JGroups Exchange header string values to the `CamelJGroups*`
convention.

## Related

- Original PR (main): #23209
- Backport PR (camel-4.18.x): #23213

## Test plan

- [x] No code changes; doc-only.

---

_Claude Code on behalf of Andrea Cosentino_