### PR TITLE
CAMEL-23506: align aws2-sqs/sns HeaderFilterStrategy with siblings

### DIFF
--- a/components/camel-aws/camel-aws2-sns/src/main/java/org/apache/camel/component/aws2/sns/Sns2HeaderFilterStrategy.java
+++ b/components/camel-aws/camel-aws2-sns/src/main/java/org/apache/camel/component/aws2/sns/Sns2HeaderFilterStrategy.java
@@ -28,5 +28,6 @@ public class Sns2HeaderFilterStrategy extends DefaultHeaderFilterStrategy {
 
         // filter headers begin with "Camel" or "org.apache.camel"
         setOutFilterPattern("(breadcrumbId|Camel|org\\.apache\\.camel)[\\.|a-z|A-z|0-9]*");
+        setInFilterStartsWith(CAMEL_FILTER_STARTS_WITH);
     }
 }

--- a/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/Sns2HeaderFilterStrategyTest.java
+++ b/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/Sns2HeaderFilterStrategyTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.sns;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Sns2HeaderFilterStrategyTest {
+
+    private final Sns2HeaderFilterStrategy strategy = new Sns2HeaderFilterStrategy();
+
+    @Test
+    void inboundFiltersCamelPrefixedHeaders() {
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelHttpUri", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelFileName", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("camelfoo", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CAMELFOO", "value", null));
+    }
+
+    @Test
+    void inboundAllowsNonCamelHeaders() {
+        assertFalse(strategy.applyFilterToExternalHeaders("X-Custom", "value", null));
+        assertFalse(strategy.applyFilterToExternalHeaders("subject", "hello", null));
+    }
+
+    @Test
+    void outboundFiltersCamelAndBreadcrumbHeaders() {
+        assertTrue(strategy.applyFilterToCamelHeaders("CamelHttpUri", "value", null));
+        assertTrue(strategy.applyFilterToCamelHeaders("org.apache.camel.internal", "value", null));
+        assertTrue(strategy.applyFilterToCamelHeaders("breadcrumbId", "value", null));
+    }
+
+    @Test
+    void outboundAllowsUserHeaders() {
+        assertFalse(strategy.applyFilterToCamelHeaders("X-Custom", "value", null));
+    }
+}

--- a/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2HeaderFilterStrategy.java
+++ b/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2HeaderFilterStrategy.java
@@ -27,6 +27,6 @@ public class Sqs2HeaderFilterStrategy extends DefaultHeaderFilterStrategy {
         setLowerCase(true);
         // filter headers begin with "Camel" or "org.apache.camel"
         setOutFilterPattern("(breadcrumbId|Camel|org\\.apache\\.camel)[\\.|a-z|A-z|0-9]*");
-
+        setInFilterStartsWith(CAMEL_FILTER_STARTS_WITH);
     }
 }

--- a/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/Sqs2HeaderFilterStrategyTest.java
+++ b/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/Sqs2HeaderFilterStrategyTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.sqs;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Sqs2HeaderFilterStrategyTest {
+
+    private final Sqs2HeaderFilterStrategy strategy = new Sqs2HeaderFilterStrategy();
+
+    @Test
+    void inboundFiltersCamelPrefixedHeaders() {
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelSqlQuery", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelHttpUri", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelFileName", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("camelfoo", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CAMELFOO", "value", null));
+    }
+
+    @Test
+    void inboundAllowsNonCamelHeaders() {
+        assertFalse(strategy.applyFilterToExternalHeaders("X-Custom", "value", null));
+        assertFalse(strategy.applyFilterToExternalHeaders("orderId", "12345", null));
+    }
+
+    @Test
+    void outboundFiltersCamelAndBreadcrumbHeaders() {
+        assertTrue(strategy.applyFilterToCamelHeaders("CamelHttpUri", "value", null));
+        assertTrue(strategy.applyFilterToCamelHeaders("org.apache.camel.internal", "value", null));
+        assertTrue(strategy.applyFilterToCamelHeaders("breadcrumbId", "value", null));
+    }
+
+    @Test
+    void outboundAllowsUserHeaders() {
+        assertFalse(strategy.applyFilterToCamelHeaders("X-Custom", "value", null));
+    }
+}


### PR DESCRIPTION
## Summary

- `Sqs2HeaderFilterStrategy` and `Sns2HeaderFilterStrategy` only configured an outbound filter. Added `setInFilterStartsWith(CAMEL_FILTER_STARTS_WITH)` so the inbound direction is aligned with the sibling strategies (Kafka, Mail, CoAP, Google Pub/Sub, …).
- The existing outbound regex (which also catches `breadcrumbId` and `org.apache.camel.*`) is unchanged.
- Added focused unit tests in both modules: `Sqs2HeaderFilterStrategyTest`, `Sns2HeaderFilterStrategyTest`.

Jira: https://issues.apache.org/jira/browse/CAMEL-23506

## Test plan

- [x] `mvn -DskipTests install` in `components/camel-aws/camel-aws2-sqs` — passes
- [x] `mvn -DskipTests install` in `components/camel-aws/camel-aws2-sns` — passes
- [x] `mvn test -Dtest=Sqs2HeaderFilterStrategyTest` — 4/4 pass
- [x] `mvn test -Dtest=Sns2HeaderFilterStrategyTest` — 4/4 pass
- [x] Full root `mvn clean install -DskipTests` — passes (no stray regen artifacts)

_Claude Code on behalf of Andrea Cosentino_