### PR TITLE
CAMEL-23509: document 4.18.3 camel-lucene header rename in upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -130,6 +130,23 @@ without changes. Routes that set the header by its literal string value
 (for example `setHeader("JGROUPS_DEST", ...)`) must be updated to use the
 new value (`setHeader("CamelJGroupsDest", ...)`).
 
+=== camel-lucene
+
+The Exchange header values exposed by `LuceneConstants` have been renamed to follow the standard
+Camel naming convention. The field names are unchanged, so routes referencing the constants
+(`LuceneConstants.HEADER_QUERY`, `LuceneConstants.HEADER_RETURN_LUCENE_DOCS`) continue to work
+without modification. However, routes that set or read these headers using the raw string values
+must be updated:
+
+* `QUERY` -> `CamelLuceneQuery`
+* `RETURN_LUCENE_DOCS` -> `CamelLuceneReturnLuceneDocs`
+
+As a consequence, the generated Endpoint DSL header accessors on `LuceneHeaderNameBuilder`
+have been renamed accordingly:
+
+* `qUERY()` -> `luceneQuery()`
+* `returnLuceneDocs()` -> `luceneReturnLuceneDocs()`
+
 == Upgrading from 4.18.0 to 4.18.1
 
 === camel-bom


### PR DESCRIPTION
## Summary

Companion to the backport #23220 (`camel-4.18.x`). Adds a 4.18.3 entry to `camel-4x-upgrade-guide-4_18.adoc` on `main` so that the canonical version-specific upgrade history stays in sync with what is shipping on the maintenance branch, per the project's backport upgrade-guide policy in `CLAUDE.md`.

The maintenance-branch backport itself intentionally does not touch any upgrade-guide file — those files live on `main` and act as the canonical history across all releases.

## Related

* Original PR (4.21.0): #23208
* Backport PR (4.18.3): #23220

JIRA: https://issues.apache.org/jira/browse/CAMEL-23509

_Claude Code on behalf of Andrea Cosentino_