### PR TITLE
CAMEL-23511: doc-sync 4.18 upgrade guide for camel-jgroups-raft header rename

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -147,6 +147,36 @@ have been renamed accordingly:
 * `qUERY()` -> `luceneQuery()`
 * `returnLuceneDocs()` -> `luceneReturnLuceneDocs()`
 
+=== camel-jgroups-raft
+
+The Exchange header constants in `JGroupsRaftConstants` have been renamed to
+follow the Camel naming convention used across the rest of the component
+catalog. The Java field names are unchanged; only the header string values
+have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_LOG_SIZE` | `JGROUPSRAFT_LOG_SIZE` | `CamelJGroupsRaftLogSize`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_COMMIT_INDEX` | `JGROUPSRAFT_COMMIT_INDEX` | `CamelJGroupsRaftCommitIndex`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_CURRENT_TERM` | `JGROUPSRAFT_CURRENT_TERM` | `CamelJGroupsRaftCurrentTerm`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_IS_LEADER` | `JGROUPSRAFT_IS_LEADER` | `CamelJGroupsRaftIsLeader`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_LAST_APPLIED` | `JGROUPSRAFT_LAST_APPLIED` | `CamelJGroupsRaftLastApplied`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_LEADER_ADDRESS` | `JGROUPSRAFT_LEADER_ADDRESS` | `CamelJGroupsRaftLeaderAddress`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_RAFT_ID` | `JGROUPSRAFT_RAFT_ID` | `CamelJGroupsRaftRaftId`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_EVENT_TYPE` | `JGROUPSRAFT_EVENT_TYPE` | `CamelJGroupsRaftEventType`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_SET_OFFSET` | `JGROUPSRAFT_SET_OFFSET` | `CamelJGroupsRaftSetOffset`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_SET_LENGTH` | `JGROUPSRAFT_SET_LENGTH` | `CamelJGroupsRaftSetLength`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_SET_TIMEOUT` | `JGROUPSRAFT_SET_TIMEOUT` | `CamelJGroupsRaftSetTimeout`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_SET_TIMEUNIT` | `JGROUPSRAFT_SET_TIMEUNIT` | `CamelJGroupsRaftSetTimeUnit`
+|===
+
+Routes that reference the constant symbolically (for example
+`setHeader(JGroupsRaftConstants.HEADER_JGROUPSRAFT_SET_TIMEOUT, ...)`) continue
+to work without changes. Routes that set the header by its literal string value
+(for example `setHeader("JGROUPSRAFT_SET_TIMEOUT", ...)`) must be updated to
+use the new value (`setHeader("CamelJGroupsRaftSetTimeout", ...)`).
+
 == Upgrading from 4.18.0 to 4.18.1
 
 === camel-bom


### PR DESCRIPTION
## Summary

Doc-sync companion to the [camel-4.18.x backport PR #23226](https://github.com/apache/camel/pull/23226) for [CAMEL-23511](https://issues.apache.org/jira/browse/CAMEL-23511).

Per the project policy in `CLAUDE.md`:

> The `camel-4x-upgrade-guide-4_XX.adoc` files for ALL versions live on `main`
> and act as the canonical history across all releases. When a PR is backported
> to a maintenance branch and adds an upgrade-guide note for that release line,
> the corresponding entry must ALSO be added to the matching
> `camel-4x-upgrade-guide-4_XX.adoc` file on `main`.

This PR adds the `camel-jgroups-raft` entry to
`docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc`
under the `Upgrading from 4.18.1 to 4.18.3` section, documenting the rename
of the JGroupsRaftConstants Exchange header string values to the
`CamelJGroupsRaft*` convention.

## Related

- Original PR (main): #23210
- Backport PR (camel-4.18.x): #23226

## Test plan

- [x] No code changes; doc-only.

---

_Claude Code on behalf of Andrea Cosentino_