### PR TITLE
CAMEL-23509: document 4.14.8 camel-lucene header rename in upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -99,6 +99,23 @@ Hazelcast topic, queue, map, list, set, or in one of the repositories
 above must provide their own `Config` with a
 `JavaSerializationFilterConfig` configured for their class names.
 
+=== camel-lucene
+
+The Exchange header values exposed by `LuceneConstants` have been renamed to follow the standard
+Camel naming convention. The field names are unchanged, so routes referencing the constants
+(`LuceneConstants.HEADER_QUERY`, `LuceneConstants.HEADER_RETURN_LUCENE_DOCS`) continue to work
+without modification. However, routes that set or read these headers using the raw string values
+must be updated:
+
+* `QUERY` -> `CamelLuceneQuery`
+* `RETURN_LUCENE_DOCS` -> `CamelLuceneReturnLuceneDocs`
+
+As a consequence, the generated Endpoint DSL header accessors on `LuceneHeaderNameBuilder`
+have been renamed accordingly:
+
+* `qUERY()` -> `luceneQuery()`
+* `returnLuceneDocs()` -> `luceneReturnLuceneDocs()`
+
 == Upgrading from 4.14.2 to 4.14.3
 
 === camel-tika


### PR DESCRIPTION
## Summary

Companion to the backport #23232 (`camel-4.14.x`). Adds a 4.14.8 entry to `camel-4x-upgrade-guide-4_14.adoc` on `main` so that the canonical version-specific upgrade history stays in sync with what is shipping on the maintenance branch, per the project's backport upgrade-guide policy in `CLAUDE.md`.

The maintenance-branch backport itself intentionally does not touch any upgrade-guide file — those files live on `main` and act as the canonical history across all releases.

## Related

* Original PR (4.21.0): #23208
* Backport PR (4.14.8): #23232
* Sibling upgrade-guide PR (4.18.3): #23222

JIRA: https://issues.apache.org/jira/browse/CAMEL-23509

_Claude Code on behalf of Andrea Cosentino_