### PR TITLE
CAMEL-23513: Fix completeAllOnStop() not completing aggregations with completionInterval()

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
@@ -1725,7 +1725,7 @@ public class AggregateProcessor extends BaseProcessorSupport
         // but only do this when forced=false, as that is when we have chance to
         // send out new messages to be routed by Camel. When forced=true, then
         // we have to shutdown in a hurry
-        if (!forced && forceCompletionOnStop) {
+        if (!forced && (forceCompletionOnStop || completeAllOnStop)) {
             doForceCompletionOnStop();
         }
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompleteAllOnStopWithIntervalTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompleteAllOnStopWithIntervalTest.java
@@ -31,20 +31,28 @@ public class AggregateCompleteAllOnStopWithIntervalTest extends ContextTestSuppo
 
     @Test
     public void testCompleteAllOnStopWithCompletionInterval() throws Exception {
+        // Set shutdown timeout shorter than the completion interval (60s)
+        // so the interval timer will never fire — force completion must handle it
         context.getShutdownStrategy().setTimeout(5);
 
         MockEndpoint mock = getMockEndpoint("mock:aggregated");
+        // We expect the incomplete aggregation to be completed on shutdown
+        // The aggregation should contain 3 messages: A, B, C
         mock.expectedMessageCount(1);
 
         MockEndpoint input = getMockEndpoint("mock:input");
         input.expectedMessageCount(3);
 
+        // Send 3 messages with the same correlation key
+        // completionSize is 10, so this won't trigger size-based completion
         template.sendBodyAndHeader("direct:start", "A", "aggregateKey", "group1");
         template.sendBodyAndHeader("direct:start", "B", "aggregateKey", "group1");
         template.sendBodyAndHeader("direct:start", "C", "aggregateKey", "group1");
 
         input.assertIsSatisfied();
 
+        // Stop the context without waiting for completionInterval
+        // With completeAllOnStop(), the aggregation must be force-completed during shutdown
         context.stop();
 
         mock.assertIsSatisfied();

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompleteAllOnStopWithIntervalTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateCompleteAllOnStopWithIntervalTest.java
@@ -24,33 +24,27 @@ import org.junit.jupiter.api.Test;
 
 /**
  * This test verifies that completeAllOnStop() properly completes aggregations on shutdown when using
- * completionInterval.
+ * completionInterval. Uses a very long interval (60s) so the interval timer will never fire during the short shutdown
+ * timeout — force completion in prepareShutdown must handle it.
  */
 public class AggregateCompleteAllOnStopWithIntervalTest extends ContextTestSupport {
 
     @Test
-    public void testCompleteAllOnStopWithCompletionIntervalOnly() throws Exception {
-        // Set shutdown timeout to 5x the completion interval (1 second)
+    public void testCompleteAllOnStopWithCompletionInterval() throws Exception {
         context.getShutdownStrategy().setTimeout(5);
 
         MockEndpoint mock = getMockEndpoint("mock:aggregated");
-        // We expect the incomplete aggregation to be completed on shutdown
-        // The aggregation should contain 3 messages: A, B, C
         mock.expectedMessageCount(1);
 
         MockEndpoint input = getMockEndpoint("mock:input");
         input.expectedMessageCount(3);
 
-        // Send 3 messages with the same correlation key
-        // completionSize is 10, so this won't trigger size-based completion
         template.sendBodyAndHeader("direct:start", "A", "aggregateKey", "group1");
         template.sendBodyAndHeader("direct:start", "B", "aggregateKey", "group1");
         template.sendBodyAndHeader("direct:start", "C", "aggregateKey", "group1");
 
         input.assertIsSatisfied();
 
-        // Stop the route immediately without waiting for completionInterval
-        // With completeAllOnStop(), we expect the aggregation to be completed
         context.stop();
 
         mock.assertIsSatisfied();
@@ -66,7 +60,7 @@ public class AggregateCompleteAllOnStopWithIntervalTest extends ContextTestSuppo
                         .aggregate(new GroupedBodyAggregationStrategy())
                         .simple("${in.header.aggregateKey}")
                         .completionSize(10)
-                        .completionInterval(1000)
+                        .completionInterval(60000)
                         .completeAllOnStop()
                         .to("mock:aggregated");
             }


### PR DESCRIPTION
[CAMEL-23513](https://issues.apache.org/jira/browse/CAMEL-23513)

## Summary

- Fix `completeAllOnStop()` not reliably completing in-flight aggregations when used with `completionInterval()`
- `AggregateProcessor.prepareShutdown()` now also force-completes all groups when `completeAllOnStop` is set, not just when `forceCompletionOnStop` is set
- Fix the flaky `testCompleteAllOnStopWithCompletionIntervalOnly` test by addressing the underlying race, and update it to use a 60-second interval so it deterministically validates force completion rather than relying on the interval timer to race against shutdown

## Root Cause

`prepareShutdown()` only checked `forceCompletionOnStop` to trigger `doForceCompletionOnStop()`. With `completeAllOnStop`, the shutdown relied on the `AggregationIntervalTask` firing during the shutdown window — a race condition that caused the `AggregateCompleteAllOnStopWithIntervalTest` to fail intermittently.

## Test plan

- [x] `AggregateCompleteAllOnStopWithIntervalTest` passes deterministically (20/20 runs)
- [x] Full aggregator test suite (`org.apache.camel.processor.aggregator.*`) passes with no regressions