### PR TITLE
CAMEL-23509: document 4.14.8 camel-lucene header rename in upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -99,6 +99,23 @@ Hazelcast topic, queue, map, list, set, or in one of the repositories
 above must provide their own `Config` with a
 `JavaSerializationFilterConfig` configured for their class names.
 
+=== camel-lucene
+
+The Exchange header values exposed by `LuceneConstants` have been renamed to follow the standard
+Camel naming convention. The field names are unchanged, so routes referencing the constants
+(`LuceneConstants.HEADER_QUERY`, `LuceneConstants.HEADER_RETURN_LUCENE_DOCS`) continue to work
+without modification. However, routes that set or read these headers using the raw string values
+must be updated:
+
+* `QUERY` -> `CamelLuceneQuery`
+* `RETURN_LUCENE_DOCS` -> `CamelLuceneReturnLuceneDocs`
+
+As a consequence, the generated Endpoint DSL header accessors on `LuceneHeaderNameBuilder`
+have been renamed accordingly:
+
+* `qUERY()` -> `luceneQuery()`
+* `returnLuceneDocs()` -> `luceneReturnLuceneDocs()`
+
 == Upgrading from 4.14.2 to 4.14.3
 
 === camel-tika


### PR DESCRIPTION
## Summary

Doc-sync for the [camel-4.14.x backport](https://github.com/apache/camel/pull/23232) of #23208 (CAMEL-23509). The maintenance-branch backport intentionally did not touch the upgrade guide — per the project policy, the version-specific upgrade-guide files for ALL release lines live on `main`, so this PR adds the matching entry to `camel-4x-upgrade-guide-4_14.adoc` here.

The note documents the `camel-lucene` header-value rename that ships in 4.14.8 (`QUERY` -> `CamelLuceneQuery`, `RETURN_LUCENE_DOCS` -> `CamelLuceneReturnLuceneDocs`, plus the consequent Endpoint DSL accessor renames), under the existing `== Upgrading from 4.14.3 to 4.14.8` section.

## Related

- Original PR (main): #23208
- Backport PR (camel-4.14.x): #23232
- Sibling doc-sync (4.18 guide): #23241 (for the matching 4.18.3 entry)
- JIRA: https://issues.apache.org/jira/browse/CAMEL-23509

_Claude Code on behalf of Andrea Cosentino_