### PR TITLE
CAMEL-23508: doc-sync 4.18 upgrade guide for camel-elasticsearch-rest-client header rename

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -177,6 +177,29 @@ to work without changes. Routes that set the header by its literal string value
 (for example `setHeader("JGROUPSRAFT_SET_TIMEOUT", ...)`) must be updated to
 use the new value (`setHeader("CamelJGroupsRaftSetTimeout", ...)`).
 
+=== camel-elasticsearch-rest-client
+
+The Exchange header constants in `ElasticSearchRestClientConstant` have been
+renamed to follow the Camel naming convention used across the rest of the
+component catalog. The Java field names are unchanged; only the header string
+values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `ElasticSearchRestClientConstant.ID` | `ID` | `CamelElasticsearchId`
+| `ElasticSearchRestClientConstant.SEARCH_QUERY` | `SEARCH_QUERY` | `CamelElasticsearchSearchQuery`
+| `ElasticSearchRestClientConstant.INDEX_SETTINGS` | `INDEX_SETTINGS` | `CamelElasticsearchIndexSettings`
+| `ElasticSearchRestClientConstant.INDEX_NAME` | `INDEX_NAME` | `CamelElasticsearchIndexName`
+| `ElasticSearchRestClientConstant.OPERATION` | `OPERATION` | `CamelElasticsearchOperation`
+|===
+
+Routes that reference the constant symbolically (for example
+`setHeader(ElasticSearchRestClientConstant.SEARCH_QUERY, ...)`) continue to
+work without changes. Routes that set the header by its literal string value
+(for example `setHeader("SEARCH_QUERY", ...)`) must be updated to use the
+new value (`setHeader("CamelElasticsearchSearchQuery", ...)`).
+
 == Upgrading from 4.18.0 to 4.18.1
 
 === camel-bom


### PR DESCRIPTION
## Summary

Doc-sync companion to the [camel-4.18.x backport PR #23244](https://github.com/apache/camel/pull/23244) for [CAMEL-23508](https://issues.apache.org/jira/browse/CAMEL-23508).

Per the project policy in `CLAUDE.md`:

> The `camel-4x-upgrade-guide-4_XX.adoc` files for ALL versions live on `main`
> and act as the canonical history across all releases. When a PR is backported
> to a maintenance branch and adds an upgrade-guide note for that release line,
> the corresponding entry must ALSO be added to the matching
> `camel-4x-upgrade-guide-4_XX.adoc` file on `main`.

This PR adds the `camel-elasticsearch-rest-client` entry to
`docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc`
under the `Upgrading from 4.18.1 to 4.18.3` section, documenting the rename
of the `ElasticSearchRestClientConstant` Exchange header string values to the
`CamelElasticsearch*` convention.

## Related

- Original PR (main): #23212
- Backport PR (camel-4.18.x): #23244

## Test plan

- [x] No code changes; doc-only.

---

_Claude Code on behalf of Andrea Cosentino_