### PR TITLE
CAMEL-23511: document 4.14.8 camel-jgroups-raft header rename in upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -116,6 +116,36 @@ have been renamed accordingly:
 * `qUERY()` -> `luceneQuery()`
 * `returnLuceneDocs()` -> `luceneReturnLuceneDocs()`
 
+=== camel-jgroups-raft
+
+The Exchange header constants in `JGroupsRaftConstants` have been renamed to
+follow the Camel naming convention used across the rest of the component
+catalog. The Java field names are unchanged; only the header string values
+have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_LOG_SIZE` | `JGROUPSRAFT_LOG_SIZE` | `CamelJGroupsRaftLogSize`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_COMMIT_INDEX` | `JGROUPSRAFT_COMMIT_INDEX` | `CamelJGroupsRaftCommitIndex`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_CURRENT_TERM` | `JGROUPSRAFT_CURRENT_TERM` | `CamelJGroupsRaftCurrentTerm`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_IS_LEADER` | `JGROUPSRAFT_IS_LEADER` | `CamelJGroupsRaftIsLeader`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_LAST_APPLIED` | `JGROUPSRAFT_LAST_APPLIED` | `CamelJGroupsRaftLastApplied`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_LEADER_ADDRESS` | `JGROUPSRAFT_LEADER_ADDRESS` | `CamelJGroupsRaftLeaderAddress`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_RAFT_ID` | `JGROUPSRAFT_RAFT_ID` | `CamelJGroupsRaftRaftId`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_EVENT_TYPE` | `JGROUPSRAFT_EVENT_TYPE` | `CamelJGroupsRaftEventType`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_SET_OFFSET` | `JGROUPSRAFT_SET_OFFSET` | `CamelJGroupsRaftSetOffset`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_SET_LENGTH` | `JGROUPSRAFT_SET_LENGTH` | `CamelJGroupsRaftSetLength`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_SET_TIMEOUT` | `JGROUPSRAFT_SET_TIMEOUT` | `CamelJGroupsRaftSetTimeout`
+| `JGroupsRaftConstants.HEADER_JGROUPSRAFT_SET_TIMEUNIT` | `JGROUPSRAFT_SET_TIMEUNIT` | `CamelJGroupsRaftSetTimeUnit`
+|===
+
+Routes that reference the constant symbolically (for example
+`setHeader(JGroupsRaftConstants.HEADER_JGROUPSRAFT_SET_TIMEOUT, ...)`) continue
+to work without changes. Routes that set the header by its literal string value
+(for example `setHeader("JGROUPSRAFT_SET_TIMEOUT", ...)`) must be updated to
+use the new value (`setHeader("CamelJGroupsRaftSetTimeout", ...)`).
+
 == Upgrading from 4.14.2 to 4.14.3
 
 === camel-tika


### PR DESCRIPTION
## Summary

Doc-sync for the [camel-4.14.x backport](https://github.com/apache/camel/pull/23245) of #23210 (CAMEL-23511). The maintenance-branch backport intentionally did not touch the upgrade guide — per project policy, the version-specific upgrade-guide files for ALL release lines live on `main`, so this PR adds the matching entry to `camel-4x-upgrade-guide-4_14.adoc` here.

The note documents the `camel-jgroups-raft` header-value rename shipping in 4.14.8 (`JGROUPSRAFT_*` -> `CamelJGroupsRaft*`, with the field names unchanged), placed under the existing `== Upgrading from 4.14.3 to 4.14.8` section, after the matching `camel-lucene` entry.

## Related

- Original PR (main): #23210
- Backport PR (camel-4.14.x): #23245
- Sibling doc-sync (4.18 guide): #23227 (matching 4.18.3 entry, merged)
- JIRA: https://issues.apache.org/jira/browse/CAMEL-23511 (fixVersions include 4.14.8)

_Claude Code on behalf of Andrea Cosentino_