### PR TITLE
[backport camel-4.18.x] CAMEL-23515: camel-nats - Use dedicated HeaderFilterStrategy aligned with sibling components

### DIFF
--- a/components/camel-nats/src/main/java/org/apache/camel/component/nats/NatsConfiguration.java
+++ b/components/camel-nats/src/main/java/org/apache/camel/component/nats/NatsConfiguration.java
@@ -29,7 +29,6 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriParams;
 import org.apache.camel.spi.UriPath;
-import org.apache.camel.support.DefaultHeaderFilterStrategy;
 import org.apache.camel.support.jsse.SSLContextParameters;
 import org.apache.camel.util.ObjectHelper;
 
@@ -114,7 +113,7 @@ public class NatsConfiguration implements Cloneable {
     @UriParam(label = "advanced")
     private boolean traceConnection;
     @UriParam(label = "advanced")
-    private HeaderFilterStrategy headerFilterStrategy = new DefaultHeaderFilterStrategy();
+    private HeaderFilterStrategy headerFilterStrategy = new NatsHeaderFilterStrategy();
 
     public NatsConfiguration copy() {
         try {

--- a/components/camel-nats/src/main/java/org/apache/camel/component/nats/NatsHeaderFilterStrategy.java
+++ b/components/camel-nats/src/main/java/org/apache/camel/component/nats/NatsHeaderFilterStrategy.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.nats;
+
+import org.apache.camel.support.DefaultHeaderFilterStrategy;
+
+public class NatsHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
+
+    public NatsHeaderFilterStrategy() {
+        initialize();
+    }
+
+    protected void initialize() {
+        setLowerCase(true);
+        // filter headers begin with "Camel" or "org.apache.camel"
+        setOutFilterStartsWith(CAMEL_FILTER_STARTS_WITH);
+        setInFilterStartsWith(CAMEL_FILTER_STARTS_WITH);
+    }
+
+}

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/NatsHeaderFilterStrategyTest.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/NatsHeaderFilterStrategyTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.nats;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NatsHeaderFilterStrategyTest {
+
+    private final NatsHeaderFilterStrategy strategy = new NatsHeaderFilterStrategy();
+
+    @Test
+    void inboundCamelHeadersAreFiltered() {
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelHttpUri", "http://evil.example", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelFileName", "../../etc/passwd", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelBeanMethodName", "evilMethod", null));
+    }
+
+    @Test
+    void inboundLowercaseCamelHeadersAreFiltered() {
+        assertTrue(strategy.applyFilterToExternalHeaders("camelHttpUri", "http://evil.example", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("camelfilename", "../../etc/passwd", null));
+    }
+
+    @Test
+    void outboundCamelHeadersAreFiltered() {
+        assertTrue(strategy.applyFilterToCamelHeaders("CamelHttpUri", "value", null));
+        assertTrue(strategy.applyFilterToCamelHeaders("camelHttpUri", "value", null));
+    }
+
+    @Test
+    void nonCamelHeadersPassThrough() {
+        assertFalse(strategy.applyFilterToExternalHeaders("Content-Type", "application/json", null));
+        assertFalse(strategy.applyFilterToExternalHeaders("X-Request-Id", "abc-123", null));
+        assertFalse(strategy.applyFilterToCamelHeaders("Content-Type", "application/json", null));
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -278,6 +278,13 @@ Two new endpoint options have been added to control the pull fetch loop:
 * `pullBatchSize` (default `10`) — maximum number of messages to fetch per pull request.
 * `pullFetchTimeout` (default `1000` ms) — maximum time to wait for a batch on each fetch.
 
+The default `headerFilterStrategy` is now a new `NatsHeaderFilterStrategy` that filters headers
+starting with `Camel` / `camel` (case-insensitive) in both the inbound and outbound directions,
+aligning the component with the rest of the Camel component catalog (`camel-kafka`, `camel-mail`,
+`camel-coap`, `camel-google-pubsub`, ...). Routes that relied on passing through these header
+names from NATS messages can supply a custom `headerFilterStrategy` to restore the previous
+behaviour.
+
 === camel-couchdb
 
 The Exchange header values exposed by `CouchDbConstants` have been renamed to follow the standard


### PR DESCRIPTION
## Backport of #23233

Cherry-pick of #23233 onto `camel-4.18.x`.

**Original PR:** #23233 - CAMEL-23515: camel-nats - Use dedicated HeaderFilterStrategy aligned with sibling components
**Original author:** @oscerd
**Target branch:** `camel-4.18.x`

### Conflict resolution

The original commit added the note to `camel-4x-upgrade-guide-4_21.adoc`, which does not exist on
`camel-4.18.x` (modify/delete conflict). Resolved by dropping the 4.21 guide change and adding the
equivalent note to the existing `=== camel-nats` section in `camel-4x-upgrade-guide-4_18.adoc` on
this branch. The corresponding `camel-4x-upgrade-guide-4_18.adoc` entry on `main` is being added in
a separate doc-sync PR per the project's backport upgrade-guide policy.

### Original description

`camel-nats` defaulted its `headerFilterStrategy` to a bare `new DefaultHeaderFilterStrategy()`,
which passes every inbound NATS header (including `Camel*` / `camel*` / `org.apache.camel.*`) onto
the Exchange. This introduces `NatsHeaderFilterStrategy` (following the `KafkaHeaderFilterStrategy`
/ `MailHeaderFilterStrategy` shape) and switches the default to use it, aligning `camel-nats` with
the rest of the component catalog. Includes a unit test and the upgrade-guide note.

JIRA: https://issues.apache.org/jira/browse/CAMEL-23515 (fixVersions include 4.18.3)

_Claude Code on behalf of Andrea Cosentino_