### PR TITLE
CAMEL-23515: docs - sync camel-nats 4.18 upgrade-guide entry to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -462,6 +462,16 @@ to the API specification.
 All together this would make Camel behave similar for Rest DSL for both _code first_ and _contract first_ style.
 
 
+=== camel-nats
+
+The default `headerFilterStrategy` is now a new `NatsHeaderFilterStrategy` that filters headers
+starting with `Camel` / `camel` (case-insensitive) in both the inbound and outbound directions,
+aligning the component with the rest of the Camel component catalog (`camel-kafka`, `camel-mail`,
+`camel-coap`, `camel-google-pubsub`, ...). Routes that relied on passing through these header
+names from NATS messages can supply a custom `headerFilterStrategy` to restore the previous
+behaviour.
+
+
 === Component deprecation
 
 The `camel-olingo2` and `camel-olingo4` component are deprecated.


### PR DESCRIPTION
## Summary

Doc-sync follow-up for the `camel-nats` `HeaderFilterStrategy` change.

- Source PR (main, 4.21): #23233 (merged)
- Backport PR (camel-4.18.x): #23250

Per the project's backport upgrade-guide policy, the version-specific
`camel-4x-upgrade-guide-4_XX.adoc` files live canonically on `main` across
all releases. The 4.18.x backport (#23250) adds the `camel-nats` header-filter
note to `camel-4x-upgrade-guide-4_18.adoc` on the maintenance branch; this PR
adds the matching entry to `camel-4x-upgrade-guide-4_18.adoc` on `main` so the
canonical history does not drift.

## Change

Adds a `=== camel-nats` section to `camel-4x-upgrade-guide-4_18.adoc`
documenting the new default `NatsHeaderFilterStrategy`.

Docs-only; no code or build impact.

> Note: `camel-4x-upgrade-guide-4_18.adoc` on `main` currently has no
> `=== camel-nats` section at all, so the pre-existing 4.18.x JetStream
> pull-fix note is also missing from main's copy (separate pre-existing
> drift, intentionally left out of scope here to keep this PR focused).

JIRA: https://issues.apache.org/jira/browse/CAMEL-23515

_Claude Code on behalf of Andrea Cosentino_