### PR TITLE
CAMEL-23515: docs - sync camel-nats 4.14 upgrade-guide entry to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -255,3 +255,12 @@ The addresses, privateFor and Topics parameters for camel-web3j have been define
 
 The `jobLauncher` and `jobRegistry` is now autowired on the component if there is a single instance pre-configured in the application.
 This avoids having to wire this into the Camel component or endpoints.
+
+=== camel-nats
+
+The default `headerFilterStrategy` is now a new `NatsHeaderFilterStrategy` that filters headers
+starting with `Camel` / `camel` (case-insensitive) in both the inbound and outbound directions,
+aligning the component with the rest of the Camel component catalog (`camel-kafka`, `camel-mail`,
+`camel-coap`, `camel-google-pubsub`, ...). Routes that relied on passing through these header
+names from NATS messages can supply a custom `headerFilterStrategy` to restore the previous
+behaviour.


### PR DESCRIPTION
## Summary

Doc-sync follow-up for the `camel-nats` `HeaderFilterStrategy` change.

- Source PR (main, 4.21): #23233 (merged)
- Backport PR (camel-4.14.x): #23255

Per the project's backport upgrade-guide policy, the version-specific
`camel-4x-upgrade-guide-4_XX.adoc` files live canonically on `main` across
all releases. The 4.14.x backport (#23255) adds the `camel-nats`
header-filter note to `camel-4x-upgrade-guide-4_14.adoc` on the maintenance
branch; this PR adds the matching entry to `camel-4x-upgrade-guide-4_14.adoc`
on `main` so the canonical history does not drift.

## Change

Adds a `=== camel-nats` section to `camel-4x-upgrade-guide-4_14.adoc`
documenting the new default `NatsHeaderFilterStrategy`.

Docs-only; no code or build impact.

> Note: `camel-4x-upgrade-guide-4_14.adoc` on `main` is broadly behind the
> `camel-4.14.x` branch copy (several maintenance-branch sections such as
> camel-couchdb / camel-couchbase / Default-deserialization are absent on
> main). That is separate pre-existing drift, intentionally left out of
> scope here to keep this PR focused on the CAMEL-23515 entry only.

JIRA: https://issues.apache.org/jira/browse/CAMEL-23515

_Claude Code on behalf of Andrea Cosentino_