### PR TITLE
docs: add core router-engine invariants to the security model

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/security-model.adoc
+++ b/docs/user-manual/modules/ROOT/pages/security-model.adoc
@@ -153,6 +153,67 @@ the concrete impact demonstrated. A finding that needs an unusual non-default
 configuration, or whose impact is limited, may score lower than the tier
 suggests; one that chains into full host compromise may score higher.
 
+=== Core router-engine invariants
+
+The table above is the cross-component _impact_ view: each property is broken
+when some component mishandles untrusted input on its way into a route. This
+subsection states the companion _engine_ view - what `camel-core` itself (the
+routing engine, the `Exchange` / `Message` model, the EIP processors, the
+expression, language and property-placeholder resolution, and the
+type-converter and data-format registries) upholds independently of any one
+component. It exists so that a candidate located in a `core/camel-*` module,
+rather than in a component, can be routed to a property and a disposition
+without re-deriving the trust model.
+
+These are not new commitments. Each invariant is the engine-layer projection
+of an _In-scope vulnerability class_ below, or of the trust boundary in _Trust
+model_; it is restated here because a finding against the core is reported
+against core code, and the triager needs the core-side statement to judge it.
+
+[cols="3,3,1",options="header"]
+|===
+| Invariant the router engine upholds on its own (no component-specific configuration)
+| What a violation looks like
+| Indicative severity
+
+| The engine never evaluates an `Exchange` body, header or property as a `simple`, OGNL, bean or scripting expression unless a route author placed an expression or predicate at that point in the route
+| A core processor or language resolves untrusted message content as an expression with no route-author-authored expression referencing it
+| Critical (CVSS 9.0-9.8)
+
+| Untrusted `Exchange` content does not, by the engine's own action, select the endpoint, bean, method or command dispatched to; the dynamic targets of `toD`, `recipientList`, `routingSlip`, the dynamic router and bean-method resolution are computed from the route-author expression and the documented dispatch headers only
+| A value the engine itself promoted from a body or attachment into a dispatch header (`CamelBeanMethodName`, `CamelHttpUri`, `CamelJmsDestinationName`, ...) or into a dynamic-target expression input
+| Critical (CVSS 9.0-9.8)
+
+| The core type-converter registry does not instantiate or deserialise attacker-chosen Java types when a route merely declares a target type (`convertBodyTo`, a typed body, expression coercion); a converter that reads external entities or runs an `ObjectInputStream` is the converting component's responsibility, not an automatic core behaviour
+| A registered core converter instantiating or deserialising arbitrary types from an untrusted body during automatic conversion (historic instance: CVE-2015-0263, the `camel-core` XML converter)
+| Critical when gadget-reachable (9.0-9.8); High otherwise (7.0-8.6)
+
+| Property-placeholder and bean-reference resolution (`{{...}}`, `#bean:`, `#class:`, `#type:`, `#property:`) operates on route and configuration text supplied by the route author or operator, never on `Exchange` content
+| Message body or header content reaches placeholder or `#class:` / `#bean:` resolution and is resolved or instantiated
+| Critical (CVSS 9.0-9.8)
+
+| The engine and the `Exchange` / `Message` model never promote a body field, attachment or transport metadata into the internal `Camel*` / `org.apache.camel.*` header namespace; populating that namespace from untrusted wire input is a _consumer_ responsibility governed by the inbound `HeaderFilterStrategy` (the CVE-2025-27636 family), not an engine action
+| Core machinery, rather than a specific consumer, copies an untrusted-origin value into the internal header namespace
+| Critical (CVSS 9.0-9.8)
+
+| Error handling, dead-letter routing, redelivery and the in-band trace / debug processors do not, on the in-band route path, evaluate untrusted content as code or expose one `Exchange`'s body, headers or secrets to an unprivileged in-band party
+| An `onException`, dead-letter or `BacklogTracer` in-band path turns untrusted content into evaluation or cross-`Exchange` disclosure. Exposure or expression evaluation reached through a _management connection_ (JMX, Jolokia, the developer console) is governed by the management-surface item under _Out of scope_, not by this invariant
+| Medium to Critical, depending on what is reached
+
+| The engine makes no unbounded-resource guarantee
+| Unthrottled routing, unbounded aggregation or recursion under attacker-influenced volume. This is an availability concern the operator bounds (`throttle`, `circuitBreaker`, `resilience4j`, JVM limits); see _Out of scope_. A core finding whose only effect is resource consumption is closed as `not a vulnerability`
+| Out of scope (no engine guarantee)
+|===
+
+A candidate located in a `core/camel-*` module is judged against these
+invariants first. If the engine upheld the invariant and the violation arises
+only because a route author authored an expression or route over untrusted
+input, or wired an untrusted source straight through without
+`removeHeaders("Camel*")`, the disposition is the route-author position in
+_Out of scope_, not a framework vulnerability - the same line the rest of this
+model draws between the route plus its configuration and the data flowing
+through it.
+
 === In-scope vulnerability classes
 
 The classes below are grounded in advisories the Apache Camel PMC has accepted

--- a/docs/user-manual/modules/ROOT/pages/security-model.adoc
+++ b/docs/user-manual/modules/ROOT/pages/security-model.adoc
@@ -392,6 +392,19 @@ be closed as `not a vulnerability`.
   `hostnameVerificationEnabled=false`, explicit selection of an
   `ObjectInputStream`-using data format - these are documented opt-ins and the
   operator has signed up for the consequences.
+* *Behaviour that is only present under the non-default `dev` or `test`
+  profile.* Camel defaults to the `prod` profile; the `dev` and `test`
+  profiles (set explicitly via `camel.main.profile`, or selected for you by
+  tooling such as Camel JBang) are development-only and deliberately less
+  guarded - they enable the developer console, debug and trace endpoints, the
+  backlog debugger and more verbose diagnostics, and relax the security policy
+  default from `fail` to `warn`. Camel may, by design, reveal configuration,
+  route and `Exchange` detail in these modes that it would not reveal under
+  `prod`. A report whose impact only manifests under `camel.main.profile = dev`
+  or `test` is out of scope as a non-default, development-only configuration;
+  the production posture against which findings are judged is the default
+  `prod` profile (see _Deployment hardening_ and the `proposals/security.adoc`
+  design document for the profile-aware policy defaults).
 * *Denial of service via resource exhaustion.* Unthrottled routes, unbounded
   aggregators, an HTTP consumer with no rate limit, a JMS consumer that
   accepts arbitrarily large messages - operators must apply `throttle`,


### PR DESCRIPTION
## What

1. Adds a **`Core router-engine invariants`** subsection to the project
   security model (`docs/user-manual/modules/ROOT/pages/security-model.adoc`),
   between the existing *Security properties and violation severity* impact
   table and *In-scope vulnerability classes*.
2. *(added in review — see Review updates)* Adds an **Out of scope** bullet
   scoping the non-default `dev` / `test` profile as development-only by
   design.

## Why

The existing properties table is a **cross-component impact view** — every
row is framed at the point a *component* ingests untrusted input. It does
not separately state the invariants **`camel-core` (the router engine)**
upholds on its own. An automated security-triage pass against the model
flagged this as a soft gap in the "security properties provided" section:
findings located in a `core/camel-*` module (the largest, most-scanned
surface) could not be routed to a property and a disposition without
re-deriving the trust model, leading to systematic over-reporting on core.

This subsection adds the companion **engine view** — what the routing
engine, the `Exchange`/`Message` model, the EIP processors, the
expression / language / property-placeholder resolution, and the
type-converter and data-format registries guarantee independently of any
one component — with the same `property → violation symptom → indicative
severity` shape as the existing table.

## Scope

- **Strict superset. No behavioural or scope change.** Every invariant is
  the engine-layer projection of an in-scope vulnerability class, or of the
  trust boundary, **already ratified in this document** (expression/template
  injection; Camel-header / bean-dispatch abuse; unsafe deserialisation,
  incl. CVE-2015-0263; the CVE-2025-27636 header-promotion family; and the
  management-surface and DoS out-of-scope items, to which it explicitly
  defers).
- **Documentation only**; +74 lines across two commits, single file. Builds
  on the security-model work merged in #23253.
- No new `xref:`/includes/attributes; the table is cloned structurally from
  the existing one, so the camel-website strict Antora build is unaffected.

## Review updates

- **@davsclaus** (review on PR #23282): asked whether it is documented that
  running under the `dev` profile (e.g. as Camel JBang does, or via
  `camel.main.profile=dev`) is development-only and that Camel may reveal
  details not at production scrutiny level. It was present only as a
  *hardening responsibility* (*Deployment hardening* + `proposals/security.adoc`
  profile-aware defaults), not as a *triage rule*. Resolved in commit
  `9f32dc7ca8a` by adding an explicit *Out of scope* bullet: a finding that
  only manifests under `camel.main.profile = dev`/`test` is out of scope as a
  non-default, development-only configuration; the production posture is the
  default `prod` profile. Cross-references *Deployment hardening* and
  `proposals/security.adoc` so the hardening note and the triage rule stay
  consistent. Maps to the `OUT-OF-MODEL: non-default-build` disposition.

## Review note

This is a security-policy document — for **PMC review**. Per the project AI
rules of engagement this PR will **not** be merged or approved by an agent;
human approval is required.

_Claude Code (Opus 4.7) on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
