### PR TITLE
CAMEL-23528: document camel-neo4j property name validation in the 4.18 upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -200,6 +200,16 @@ work without changes. Routes that set the header by its literal string value
 (for example `setHeader("SEARCH_QUERY", ...)`) must be updated to use the
 new value (`setHeader("CamelElasticsearchSearchQuery", ...)`).
 
+=== camel-neo4j
+
+When using the `RETRIEVE_NODES` or `DELETE_NODE` operations with the `CamelNeo4jMatchProperties`
+header, the property names provided in the JSON match map are now validated before the `MATCH` /
+`DELETE` `WHERE` clause is built. Property names must be valid identifiers matching
+`[A-Za-z_][A-Za-z0-9_]*`. A request whose match map contains a property name that does not match
+this pattern now fails fast with an `IllegalArgumentException` (wrapped in a
+`Neo4jOperationException`) instead of producing a malformed query. Property values continue to be
+passed as bound query parameters and are unaffected.
+
 == Upgrading from 4.18.0 to 4.18.1
 
 === camel-bom


### PR DESCRIPTION
## Sync the 4.18 upgrade-guide entry to `main`

The `camel-4.18.x` backport apache/camel#23294 adds a `camel-neo4j` entry to `camel-4x-upgrade-guide-4_18.adoc`. The canonical `camel-4x-upgrade-guide-4_XX.adoc` files for all versions live on `main`, so this PR mirrors the same entry into main's copy, keeping the version-specific upgrade guides on `main` in sync with what ships on `camel-4.18.x`.

Docs-only. No code change.

**Related:** apache/camel#23258, backport apache/camel#23294
**Jira:** https://issues.apache.org/jira/browse/CAMEL-23528

---
_Claude Code on behalf of Andrea Cosentino_
