### PR TITLE
[backport camel-4.18.x] CAMEL-23516: camel-xmpp - Use dedicated HeaderFilterStrategy aligned with sibling components

### DIFF
--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppBinding.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppBinding.java
@@ -22,7 +22,6 @@ import java.util.Set;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.HeaderFilterStrategy;
-import org.apache.camel.support.DefaultHeaderFilterStrategy;
 import org.apache.camel.util.ObjectHelper;
 import org.jivesoftware.smack.packet.DefaultExtensionElement;
 import org.jivesoftware.smack.packet.ExtensionElement;
@@ -44,7 +43,7 @@ public class XmppBinding {
     private HeaderFilterStrategy headerFilterStrategy;
 
     public XmppBinding() {
-        this.headerFilterStrategy = new DefaultHeaderFilterStrategy();
+        this.headerFilterStrategy = new XmppHeaderFilterStrategy();
     }
 
     public XmppBinding(HeaderFilterStrategy headerFilterStrategy) {

--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppEndpoint.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppEndpoint.java
@@ -34,7 +34,6 @@ import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriPath;
 import org.apache.camel.support.DefaultEndpoint;
-import org.apache.camel.support.DefaultHeaderFilterStrategy;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StringHelper;
 import org.jivesoftware.smack.ConnectionConfiguration;
@@ -103,7 +102,7 @@ public class XmppEndpoint extends DefaultEndpoint implements HeaderFilterStrateg
     @UriParam(label = "consumer", defaultValue = "10")
     private int connectionPollDelay = 10;
     @UriParam(label = "filter")
-    private HeaderFilterStrategy headerFilterStrategy = new DefaultHeaderFilterStrategy();
+    private HeaderFilterStrategy headerFilterStrategy = new XmppHeaderFilterStrategy();
     @UriParam(label = "advanced")
     private ConnectionConfiguration connectionConfig;
 

--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppHeaderFilterStrategy.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppHeaderFilterStrategy.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.xmpp;
+
+import org.apache.camel.support.DefaultHeaderFilterStrategy;
+
+public class XmppHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
+
+    public XmppHeaderFilterStrategy() {
+        initialize();
+    }
+
+    protected void initialize() {
+        setLowerCase(true);
+        // filter headers begin with "Camel" or "org.apache.camel"
+        setOutFilterStartsWith(CAMEL_FILTER_STARTS_WITH);
+        setInFilterStartsWith(CAMEL_FILTER_STARTS_WITH);
+    }
+
+}

--- a/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/XmppHeaderFilterStrategyTest.java
+++ b/components/camel-xmpp/src/test/java/org/apache/camel/component/xmpp/XmppHeaderFilterStrategyTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.xmpp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class XmppHeaderFilterStrategyTest {
+
+    private final XmppHeaderFilterStrategy strategy = new XmppHeaderFilterStrategy();
+
+    @Test
+    void inboundCamelHeadersAreFiltered() {
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelHttpUri", "http://evil.example", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelFileName", "../../etc/passwd", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelBeanMethodName", "evilMethod", null));
+    }
+
+    @Test
+    void inboundLowercaseCamelHeadersAreFiltered() {
+        assertTrue(strategy.applyFilterToExternalHeaders("camelHttpUri", "http://evil.example", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("camelfilename", "../../etc/passwd", null));
+    }
+
+    @Test
+    void outboundCamelHeadersAreFiltered() {
+        assertTrue(strategy.applyFilterToCamelHeaders("CamelHttpUri", "value", null));
+        assertTrue(strategy.applyFilterToCamelHeaders("camelHttpUri", "value", null));
+    }
+
+    @Test
+    void nonCamelHeadersPassThrough() {
+        assertFalse(strategy.applyFilterToExternalHeaders("Content-Type", "application/json", null));
+        assertFalse(strategy.applyFilterToExternalHeaders("X-Request-Id", "abc-123", null));
+        assertFalse(strategy.applyFilterToCamelHeaders("Content-Type", "application/json", null));
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -285,6 +285,15 @@ aligning the component with the rest of the Camel component catalog (`camel-kafk
 names from NATS messages can supply a custom `headerFilterStrategy` to restore the previous
 behaviour.
 
+=== camel-xmpp
+
+The default `headerFilterStrategy` is now a new `XmppHeaderFilterStrategy` that filters headers
+starting with `Camel` / `camel` (case-insensitive) in both the inbound and outbound directions,
+aligning the component with the rest of the Camel component catalog (`camel-kafka`, `camel-mail`,
+`camel-coap`, `camel-google-pubsub`, ...). Routes that relied on passing through these header
+names from XMPP messages can supply a custom `headerFilterStrategy` to restore the previous
+behaviour.
+
 === camel-couchdb
 
 The Exchange header values exposed by `CouchDbConstants` have been renamed to follow the standard


### PR DESCRIPTION
## Backport of #23283

Cherry-pick of #23283 onto `camel-4.18.x`.

**Original PR:** #23283 - CAMEL-23516: camel-xmpp - Use dedicated HeaderFilterStrategy aligned with sibling components
**Original author:** @oscerd
**Target branch:** `camel-4.18.x`

### Conflict resolution

`camel-4x-upgrade-guide-4_21.adoc` does not exist on `camel-4.18.x`
(modify/delete). Resolved by dropping the 4.21 change and adding the
equivalent `=== camel-xmpp` note to `camel-4x-upgrade-guide-4_18.adoc`
on this branch (right after the existing `=== camel-nats` section from
the CAMEL-23515 backport). The matching `camel-4x-upgrade-guide-4_18.adoc`
entry on `main` is added in a separate doc-sync PR per the project's
backport upgrade-guide policy. Code files (`XmppEndpoint`, `XmppBinding`,
new `XmppHeaderFilterStrategy` + test) cherry-picked cleanly.

The `camel-xmpp` module + new unit test build cleanly on `camel-4.18.x`
(validated locally); the full reactor build hits the pre-existing
`core/camel-xml-io` schemagen JDK 21 environment issue that also affected
#23283 and the CAMEL-23515 backports.

### Original description

`camel-xmpp` defaulted its `headerFilterStrategy` to a bare
`new DefaultHeaderFilterStrategy()` (in `XmppEndpoint` and the
`XmppBinding` no-arg constructor), passing inbound XMPP message
properties — including `Camel*` / `camel*` / `org.apache.camel.*` —
onto the Exchange. Introduces `XmppHeaderFilterStrategy` (following the
`KafkaHeaderFilterStrategy` / `MailHeaderFilterStrategy` shape) and
switches both defaults to it, aligning `camel-xmpp` with the rest of the
component catalog. Includes a unit test and the upgrade-guide note.

JIRA: https://issues.apache.org/jira/browse/CAMEL-23516 (fixVersions include 4.18.3)

_Claude Code on behalf of Andrea Cosentino_