### PR TITLE
[backport camel-4.18.x] CAMEL-23547: camel-core - Properties component should eager start custom functions resolver

### DIFF
--- a/core/camel-base/src/main/java/org/apache/camel/component/properties/DefaultPropertiesFunctionResolver.java
+++ b/core/camel-base/src/main/java/org/apache/camel/component/properties/DefaultPropertiesFunctionResolver.java
@@ -123,6 +123,12 @@ public class DefaultPropertiesFunctionResolver extends ServiceSupport
     }
 
     @Override
+    protected void doBuild() throws Exception {
+        super.doBuild();
+        ServiceHelper.buildService(functions.values());
+    }
+
+    @Override
     protected void doInit() throws Exception {
         functions.values().forEach(f -> CamelContextAware.trySetCamelContext(f, camelContext));
         ServiceHelper.initService(functions.values());

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/KameletMain.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/KameletMain.java
@@ -450,7 +450,10 @@ public class KameletMain extends MainCommandLineSupport {
             setupExport(answer, export);
         } else {
             PropertiesComponent pc = (PropertiesComponent) answer.getPropertiesComponent();
-            pc.setPropertiesFunctionResolver(new DependencyDownloaderPropertiesFunctionResolver(answer, false));
+            // create resolver that can download dependencies for known functions
+            var resolver = new DependencyDownloaderPropertiesFunctionResolver(answer, false);
+            resolver.start();
+            pc.setPropertiesFunctionResolver(resolver);
         }
 
         // groovy scripts
@@ -788,8 +791,10 @@ public class KameletMain extends MainCommandLineSupport {
         addInitialProperty("camel.component.properties.ignore-missing-location", "true");
         PropertiesComponent pc = (PropertiesComponent) answer.getPropertiesComponent();
         pc.setPropertiesParser(new ExportPropertiesParser(answer));
-        pc.setPropertiesFunctionResolver(new DependencyDownloaderPropertiesFunctionResolver(answer, export));
-
+        // create resolver that can download dependencies for known functions
+        var resolver = new DependencyDownloaderPropertiesFunctionResolver(answer, export);
+        resolver.start();
+        pc.setPropertiesFunctionResolver(resolver);
         // override default type converters with our export converter that is more flexible during exporting
         ExportTypeConverter ec = new ExportTypeConverter();
         answer.getTypeConverterRegistry().setTypeConverterExists(TypeConverterExists.Override);


### PR DESCRIPTION
## Backport of d1afebe772fe onto camel-4.18.x

Cherry-pick of commit d1afebe772fea171e0bb99ac4d6fd462ed12dcfb onto `camel-4.18.x`.

**Original commit:** d1afebe772fe - CAMEL-23547: camel-core - Properties component should eager start custom functions resolver. Same for jbang that has a custom resolver.
**Target branch:** `camel-4.18.x`

### Changes

- `DefaultPropertiesFunctionResolver`: added `doBuild()` lifecycle method that calls `ServiceHelper.buildService()` on the registered functions, so they are properly built before use.
- `KameletMain`: the `DependencyDownloaderPropertiesFunctionResolver` is now eagerly started (via `resolver.start()`) before being set on the `PropertiesComponent`, ensuring the custom functions resolver is fully initialised before properties resolution begins. Applied to both the normal and export code paths.

### Conflict resolution notes

The backport required minor adaptation: the 3-argument constructor added on `main` does not exist on `camel-4.18.x`, so the existing 2-argument constructor is used instead. The function registration in the constructor (which was moved to `doBuild()` on `main`) is left as-is on 4.18.x to minimise the delta.

_Claude Code on behalf of Claus Ibsen_