### PR TITLE
CAMEL-23542: Restore @Nullable annotations removed by the requireNonNull revert

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/CamelExchangeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelExchangeException.java
@@ -32,7 +32,7 @@ public class CamelExchangeException extends CamelException {
      * @param message  the detail message
      * @param exchange the exchange that caused the error
      */
-    public CamelExchangeException(String message, @Nullable Exchange exchange) {
+    public CamelExchangeException(@Nullable String message, @Nullable Exchange exchange) {
         super(CamelExchangeException.createExceptionMessage(message, exchange, null));
         this.exchange = exchange;
     }
@@ -42,7 +42,7 @@ public class CamelExchangeException extends CamelException {
      * @param exchange the exchange that caused the error
      * @param cause    the cause of the failure
      */
-    public CamelExchangeException(String message, @Nullable Exchange exchange, Throwable cause) {
+    public CamelExchangeException(@Nullable String message, @Nullable Exchange exchange, Throwable cause) {
         super(CamelExchangeException.createExceptionMessage(message, exchange,
                 cause),
               cause);

--- a/core/camel-api/src/main/java/org/apache/camel/CamelExchangeException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/CamelExchangeException.java
@@ -42,7 +42,7 @@ public class CamelExchangeException extends CamelException {
      * @param exchange the exchange that caused the error
      * @param cause    the cause of the failure
      */
-    public CamelExchangeException(@Nullable String message, @Nullable Exchange exchange, Throwable cause) {
+    public CamelExchangeException(@Nullable String message, @Nullable Exchange exchange, @Nullable Throwable cause) {
         super(CamelExchangeException.createExceptionMessage(message, exchange,
                 cause),
               cause);

--- a/core/camel-api/src/main/java/org/apache/camel/ValidationException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ValidationException.java
@@ -38,7 +38,7 @@ public class ValidationException extends CamelExchangeException {
      * @param exchange the exchange that failed validation
      * @param cause    the cause of the failure
      */
-    public ValidationException(@Nullable String message, @Nullable Exchange exchange, Throwable cause) {
+    public ValidationException(@Nullable String message, @Nullable Exchange exchange, @Nullable Throwable cause) {
         super(message, exchange, cause);
     }
 }

--- a/core/camel-api/src/main/java/org/apache/camel/ValidationException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ValidationException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * The base class for any validation exception, such as
  * {@link org.apache.camel.support.processor.validation.SchemaValidationException} so that it is easy to treat all
@@ -27,7 +29,7 @@ public class ValidationException extends CamelExchangeException {
      * @param exchange the exchange that failed validation
      * @param message  the detail message
      */
-    public ValidationException(Exchange exchange, String message) {
+    public ValidationException(@Nullable Exchange exchange, @Nullable String message) {
         super(message, exchange);
     }
 
@@ -36,7 +38,7 @@ public class ValidationException extends CamelExchangeException {
      * @param exchange the exchange that failed validation
      * @param cause    the cause of the failure
      */
-    public ValidationException(String message, Exchange exchange, Throwable cause) {
+    public ValidationException(@Nullable String message, @Nullable Exchange exchange, Throwable cause) {
         super(message, exchange, cause);
     }
 }

--- a/core/camel-api/src/main/java/org/apache/camel/spi/RestConfiguration.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/RestConfiguration.java
@@ -706,7 +706,7 @@ public class RestConfiguration {
     /**
      * Sets the client request validation levels when using camel-openapi-validator.
      */
-    public void setValidationLevels(Map<String, String> validationLevels) {
+    public void setValidationLevels(@Nullable Map<String, String> validationLevels) {
         this.validationLevels = validationLevels;
     }
 }


### PR DESCRIPTION
[CAMEL-23542](https://issues.apache.org/jira/browse/CAMEL-23542)

Follow-up to #23289.

## Summary

The revert in #23289 correctly removed the `Objects.requireNonNull()` runtime checks that broke 3 tests, but also removed the `@Nullable` JSpecify annotations. This PR restores them to accurately document the nullability contracts:

- **`ValidationException`**: `exchange`, `message`, and `cause` parameters are nullable — callers pass null exchange in tests, `e.getMessage()` returns null, and callers may hold a cause in a variable that could be null
- **`CamelExchangeException`**: `message` and `cause` parameters are nullable — consistent with `createExceptionMessage()` which already accepts all-`@Nullable` parameters, and `Exception(String, Throwable)` handles null cause
- **`RestConfiguration.setValidationLevels`**: parameter is nullable — consistent with the field and getter which are already `@Nullable`

_Claude Code on behalf of Guillaume Nodet_