### PR TITLE
CAMEL-23521: camel-core - XML route dumping is missing target element closing tags

### DIFF
--- a/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultDumpRoutesStrategy.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultDumpRoutesStrategy.java
@@ -741,12 +741,10 @@ public class DefaultDumpRoutesStrategy extends ServiceSupport implements DumpRou
             ModelToXMLDumper dumper, String replace, String kind, StringBuilder sbLocal, StringBuilder sbLog) {
         try {
             String xml = dumper.dumpModelAsXml(camelContext, def, resolvePlaceholders, generatedIds, false);
-            // remove spring schema xmlns that camel-jaxb dumper includes
-            xml = StringHelper.replaceFirst(xml, " xmlns=\"http://camel.apache.org/schema/spring\">", ">");
             xml = xml.replace("</" + replace + ">", "</" + replace + ">\n");
-            // remove outer tag (routes, rests, etc)
+            // remove outer tag (routes, rests, etc) including any xmlns attributes
             replace = replace + "s";
-            xml = StringHelper.replaceFirst(xml, "<" + replace + ">", "");
+            xml = xml.replaceFirst("<" + replace + "(?:\\s[^>]*)?>", "");
             xml = StringHelper.replaceFirst(xml, "</" + replace + ">", "");
 
             sbLocal.append(xml);

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultDumpRoutesStrategyXmlTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultDumpRoutesStrategyXmlTest.java
@@ -25,9 +25,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.util.IOHelper;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultDumpRoutesStrategyXmlTest extends ContextTestSupport {
 
@@ -50,7 +48,7 @@ public class DefaultDumpRoutesStrategyXmlTest extends ContextTestSupport {
     public void testDumpXmlHasCorrectStructure() throws Exception {
         File dir = testDirectory().toFile();
         File[] files = dir.listFiles();
-        assertNotNull(files, "Expected dump files in " + dir);
+        assertThat(files).as("Expected dump files in %s", dir).isNotNull().isNotEmpty();
 
         StringBuilder all = new StringBuilder();
         for (File f : files) {
@@ -61,18 +59,20 @@ public class DefaultDumpRoutesStrategyXmlTest extends ContextTestSupport {
         String xml = all.toString();
 
         // the dump wraps output in <camel> and strips the outer container elements
-        assertTrue(xml.contains("<camel>"), "Expected <camel> root wrapper");
-        assertTrue(xml.contains("</camel>"), "Expected </camel> root wrapper closing tag");
+        assertThat(xml).as("Expected <camel> root wrapper\nActual xml:\n%s", xml)
+                .contains("<camel>", "</camel>");
 
         // outer container tags must be stripped entirely (both opening and closing) - CAMEL-23521
-        assertFalse(xml.contains("<routes"), "Outer <routes> wrapper must be stripped");
-        assertFalse(xml.contains("<routeTemplates"), "Outer <routeTemplates> wrapper must be stripped");
+        assertThat(xml).as("Outer <routes> wrapper must be stripped\nActual xml:\n%s", xml)
+                .doesNotContain("<routes");
+        assertThat(xml).as("Outer <routeTemplates> wrapper must be stripped\nActual xml:\n%s", xml)
+                .doesNotContain("<routeTemplates");
 
         // individual route elements must be present and properly closed
-        assertTrue(xml.contains("<route "), "Expected individual <route> elements");
-        assertTrue(xml.contains("</route>"), "Expected </route> closing tag");
-        assertTrue(xml.contains("<routeTemplate "), "Expected individual <routeTemplate> elements");
-        assertTrue(xml.contains("</routeTemplate>"), "Expected </routeTemplate> closing tag");
+        assertThat(xml).as("Expected individual <route> elements\nActual xml:\n%s", xml)
+                .contains("<route ", "</route>");
+        assertThat(xml).as("Expected individual <routeTemplate> elements\nActual xml:\n%s", xml)
+                .contains("<routeTemplate ", "</routeTemplate>");
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultDumpRoutesStrategyXmlTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultDumpRoutesStrategyXmlTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.util.IOHelper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DefaultDumpRoutesStrategyXmlTest extends ContextTestSupport {
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        context.setDumpRoutes("xml");
+
+        DefaultDumpRoutesStrategy drd = new DefaultDumpRoutesStrategy();
+        drd.setInclude("routes,routeTemplates");
+        drd.setLog(false);
+        drd.setOutput(testDirectory().toString());
+        drd.setResolvePlaceholders(false);
+        context.addService(drd);
+
+        return context;
+    }
+
+    @Test
+    public void testDumpXmlHasCorrectStructure() throws Exception {
+        File dir = testDirectory().toFile();
+        File[] files = dir.listFiles();
+        assertNotNull(files, "Expected dump files in " + dir);
+
+        StringBuilder all = new StringBuilder();
+        for (File f : files) {
+            if (f.getName().endsWith(".xml")) {
+                all.append(IOHelper.loadText(new FileInputStream(f)));
+            }
+        }
+        String xml = all.toString();
+
+        // the dump wraps output in <camel> and strips the outer container elements
+        assertTrue(xml.contains("<camel>"), "Expected <camel> root wrapper");
+        assertTrue(xml.contains("</camel>"), "Expected </camel> root wrapper closing tag");
+
+        // outer container tags must be stripped entirely (both opening and closing) - CAMEL-23521
+        assertFalse(xml.contains("<routes"), "Outer <routes> wrapper must be stripped");
+        assertFalse(xml.contains("<routeTemplates"), "Outer <routeTemplates> wrapper must be stripped");
+
+        // individual route elements must be present and properly closed
+        assertTrue(xml.contains("<route "), "Expected individual <route> elements");
+        assertTrue(xml.contains("</route>"), "Expected </route> closing tag");
+        assertTrue(xml.contains("<routeTemplate "), "Expected individual <routeTemplate> elements");
+        assertTrue(xml.contains("</routeTemplate>"), "Expected </routeTemplate> closing tag");
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                routeTemplate("myTemplate")
+                        .templateParameter("greeting")
+                        .from("direct:template")
+                        .setBody().simple("{{greeting}} ${body}");
+
+                from("direct:greet").routeId("greet")
+                        .setBody().constant("Hello World");
+            }
+        };
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultDumpRoutesStrategyXmlTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultDumpRoutesStrategyXmlTest.java
@@ -58,21 +58,14 @@ public class DefaultDumpRoutesStrategyXmlTest extends ContextTestSupport {
         }
         String xml = all.toString();
 
-        // the dump wraps output in <camel> and strips the outer container elements
-        assertThat(xml).as("Expected <camel> root wrapper\nActual xml:\n%s", xml)
-                .contains("<camel>", "</camel>");
-
-        // outer container tags must be stripped entirely (both opening and closing) - CAMEL-23521
-        assertThat(xml).as("Outer <routes> wrapper must be stripped\nActual xml:\n%s", xml)
-                .doesNotContain("<routes");
-        assertThat(xml).as("Outer <routeTemplates> wrapper must be stripped\nActual xml:\n%s", xml)
-                .doesNotContain("<routeTemplates");
-
-        // individual route elements must be present and properly closed
-        assertThat(xml).as("Expected individual <route> elements\nActual xml:\n%s", xml)
-                .contains("<route ", "</route>");
-        assertThat(xml).as("Expected individual <routeTemplate> elements\nActual xml:\n%s", xml)
-                .contains("<routeTemplate ", "</routeTemplate>");
+        assertThat(xml)
+                .as("XML dump structure check.\nActual xml:\n%s", xml)
+                // the dump wraps output in <camel> and strips the outer container elements
+                .contains("<camel>", "</camel>")
+                // outer container tags must be stripped entirely (both opening and closing) - CAMEL-23521
+                .doesNotContain("<routes", "<routeTemplates")
+                // individual route elements must be present and properly closed
+                .contains("<route ", "</route>", "<routeTemplate ", "</routeTemplate>");
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes CAMEL-23521: When XML route dumping is performed via `DefaultDumpRoutesStrategy`, the output contains the opening `<routes>`, `<rests>`, or `<routeTemplates>` tag with its namespace attribute but is missing the corresponding closing tag, producing malformed XML.

**Root cause:** `doDumpXml()` strips the outer container element by matching its opening and closing tags via simple string replacement. The old JAXB/Spring dumper emitted `xmlns="http://camel.apache.org/schema/spring"`, which was explicitly stripped first to produce a bare `<routes>`. The lightweight xml-io dumper (`LwModelToXMLDumper`, the current default) uses `xmlns="http://camel.apache.org/schema/xml-io"` instead. Because only the Spring namespace was handled, the regex `<routes>` never matched the opening tag (which still had the xml-io namespace attribute), but `</routes>` (no attributes) was correctly matched and removed — leaving an orphaned opening tag.

**Fix:** Replace the exact `<routes>` string match with a regex `<routes(?:\s[^>]*)?>` that matches the opening tag with or without any namespace/xmlns attributes. This handles both dumpers (xml-io and Spring/JAXB) and any future dumpers regardless of their namespace conventions.

## Changes

- `core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultDumpRoutesStrategy.java` — fix in `doDumpXml()`: use regex to match outer container opening tag with optional attributes
- `core/camel-core/src/test/java/org/apache/camel/impl/DefaultDumpRoutesStrategyXmlTest.java` — new test verifying that dumped XML has correct structure (outer containers stripped, individual elements properly closed, `<camel>` wrapper present)

## Test plan

- [x] New test `DefaultDumpRoutesStrategyXmlTest.testDumpXmlHasCorrectStructure` verifies that routes and routeTemplates dump files are well-structured (outer container stripped, individual elements present and closed, `<camel>` wrapper intact)
- [x] All existing `DumpModel*` tests pass
- [x] Full root build (`mvn clean install -DskipTests`) passes

_Claude Code on behalf of Claus Ibsen_