### PR TITLE
CAMEL-23550: Fix bean lookup in route templates to check local repository

### DIFF
--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/AbstractReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/AbstractReifier.java
@@ -208,6 +208,20 @@ public abstract class AbstractReifier implements BeanRepository {
         if (EndpointHelper.isReferenceParameter(name)) {
             answer = EndpointHelper.resolveReferenceParameter(camelContext, name, type, false);
         }
+        if (answer == null && route != null) {
+            // check local bean repository from route template context first
+            org.apache.camel.NamedNode routeNode = route.getRoute();
+            if (routeNode instanceof org.apache.camel.model.RouteDefinition) {
+                org.apache.camel.model.RouteDefinition routeDef = (org.apache.camel.model.RouteDefinition) routeNode;
+                org.apache.camel.RouteTemplateContext rtc = routeDef.getRouteTemplateContext();
+                if (rtc != null) {
+                    BeanRepository localRepo = rtc.getLocalBeanRepository();
+                    if (localRepo != null) {
+                        answer = localRepo.lookupByNameAndType(name, type);
+                    }
+                }
+            }
+        }
         if (answer == null) {
             // fallback to use registry which allows tooling to influence reifier that uses beans or classes
             answer = getRegistry().lookupByNameAndType(name, type);

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/AbstractReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/AbstractReifier.java
@@ -25,11 +25,14 @@ import java.util.Set;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Expression;
+import org.apache.camel.NamedNode;
 import org.apache.camel.NoSuchBeanException;
 import org.apache.camel.NoSuchEndpointException;
 import org.apache.camel.Predicate;
 import org.apache.camel.Route;
+import org.apache.camel.RouteTemplateContext;
 import org.apache.camel.model.ExpressionSubElementDefinition;
+import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.language.ExpressionDefinition;
 import org.apache.camel.reifier.language.ExpressionReifier;
 import org.apache.camel.spi.BeanRepository;
@@ -210,10 +213,9 @@ public abstract class AbstractReifier implements BeanRepository {
         }
         if (answer == null && route != null) {
             // check local bean repository from route template context first
-            org.apache.camel.NamedNode routeNode = route.getRoute();
-            if (routeNode instanceof org.apache.camel.model.RouteDefinition) {
-                org.apache.camel.model.RouteDefinition routeDef = (org.apache.camel.model.RouteDefinition) routeNode;
-                org.apache.camel.RouteTemplateContext rtc = routeDef.getRouteTemplateContext();
+            NamedNode routeNode = route.getRoute();
+            if (routeNode instanceof RouteDefinition routeDef) {
+                RouteTemplateContext rtc = routeDef.getRouteTemplateContext();
                 if (rtc != null) {
                     BeanRepository localRepo = rtc.getLocalBeanRepository();
                     if (localRepo != null) {

--- a/core/camel-core/src/test/java/org/apache/camel/builder/RouteTemplateLocalBeanTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/builder/RouteTemplateLocalBeanTest.java
@@ -70,6 +70,80 @@ public class RouteTemplateLocalBeanTest extends ContextTestSupport {
     }
 
     @Test
+    public void testLocalBeanFoundByReifier() throws Exception {
+        // Test that AbstractReifier can find a local bean (kamelet scenario)
+        // Local bean is defined via templateBean, NOT in global registry
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                routeTemplate("myTemplate").templateParameter("foo").templateParameter("bar")
+                        .templateBean("myLocalBean",
+                                (Processor) ex -> ex.getMessage().setBody("LocalOnly " + ex.getMessage().getBody()))
+                        .from("direct:{{foo}}")
+                        .to("bean:{{bar}}");
+            }
+        });
+
+        context.start();
+
+        TemplatedRouteBuilder.builder(context, "myTemplate")
+                .parameter("foo", "one")
+                .parameter("bar", "myLocalBean")
+                .routeId("myRoute")
+                .add();
+
+        assertEquals(1, context.getRoutes().size());
+
+        // AbstractReifier should find the local bean and use it
+        Object out = template.requestBody("direct:one", "World");
+        assertEquals("LocalOnly World", out);
+
+        // Bean should NOT be in global registry (kamelet local beans are scoped to route template)
+        assertNull(context.getRegistry().lookupByName("myLocalBean"));
+
+        context.stop();
+    }
+
+    @Test
+    public void testLocalBeanOverridesGlobalBean() throws Exception {
+        // Test that local bean takes precedence when both local and global beans exist with same name
+        // This ensures AbstractReifier checks local repository BEFORE global registry
+
+        // Register a global bean with the same name
+        context.getRegistry().bind("myBar", (Processor) ex -> ex.getMessage().setBody("Global " + ex.getMessage().getBody()));
+
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                routeTemplate("myTemplate").templateParameter("foo").templateParameter("bar")
+                        .from("direct:{{foo}}")
+                        .to("bean:{{bar}}");
+            }
+        });
+
+        context.start();
+
+        // Create route with local bean that has the same name as global bean
+        TemplatedRouteBuilder.builder(context, "myTemplate")
+                .parameter("foo", "one")
+                .parameter("bar", "myBar")
+                .bean("myBar", (Processor) ex -> ex.getMessage().setBody("Local " + ex.getMessage().getBody()))
+                .routeId("myRoute")
+                .add();
+
+        assertEquals(1, context.getRoutes().size());
+
+        // The local bean should take precedence over the global bean
+        Object out = template.requestBody("direct:one", "World");
+        assertEquals("Local World", out);
+
+        // Global bean should still exist in registry
+        assertNotNull(context.getRegistry().lookupByName("myBar"));
+
+        context.stop();
+    }
+
+    @Test
     public void testLocalBeanInBuilder() throws Exception {
         context.addRoutes(new RouteBuilder() {
             @Override


### PR DESCRIPTION
## Summary
Fixes bean lookup in route templates by checking the RouteTemplateContext's local bean repository before falling back to the global registry.

Kamelets defining beans via the `beans:` section store them in a local bean repository scoped to the RouteTemplateContext. Previously, the AbstractReifier only checked EndpointHelper.resolveReferenceParameter and the global registry, causing `NoSuchBeanException` when route templates tried to reference their locally-defined beans.

This fix adds a lookup step that checks the local bean repository (if present) before falling back to the global registry, allowing Kamelets to properly reference their own beans.

## Affected Components
- Multiple Kamelets in the catalog: protobuf-deserialize-action, protobuf-serialize-action, avro-deserialize-action, avro-serialize-action, data-type-action

## Test Plan
- [ ] Build passes with `mvn clean install`
- [ ] Integration tests in camel-kamelets project (ProtobufIT) verify the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Tom Cunningham