### PR TITLE
CAMEL-23532: docs - sync camel-vertx-websocket / camel-atmosphere-websocket / camel-iggy 4.18 upgrade-guide entry to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -499,3 +499,32 @@ behaviour.
 
 The `camel-olingo2` and `camel-olingo4` component are deprecated.
 This is due the Apache Olingo project is EOL and has been moved to the attic and is no longer maintained.
+
+=== camel-vertx-websocket
+
+The `vertx-websocket` consumer now applies a `HeaderFilterStrategy` to the WebSocket query and
+path parameters before mapping them into the Camel message headers. The new default
+`VertxWebsocketHeaderFilterStrategy` filters headers starting with `Camel` / `camel`
+(case-insensitive) in both the inbound and outbound directions, aligning the component with the
+rest of the Camel component catalog (`camel-coap`, `camel-kafka`, `camel-nats`, ...). A new
+`headerFilterStrategy` endpoint option is available; routes that relied on receiving
+`Camel`-prefixed header names from WebSocket query or path parameters can supply a custom
+`headerFilterStrategy` to restore the previous behaviour.
+
+=== camel-atmosphere-websocket
+
+The `atmosphere-websocket` consumer now applies the endpoint `HeaderFilterStrategy` to the
+WebSocket query parameters before mapping them into the Camel message headers. The inherited
+default `HttpHeaderFilterStrategy` filters headers starting with `Camel` / `camel`
+(case-insensitive). Routes that relied on receiving `Camel`-prefixed header names from WebSocket
+query parameters can supply a custom `headerFilterStrategy` to restore the previous behaviour.
+
+=== camel-iggy
+
+The `iggy` consumer now applies a `HeaderFilterStrategy` to the Iggy message user-headers before
+mapping them into the Camel message headers. The new default `IggyHeaderFilterStrategy` filters
+headers starting with `Camel` / `camel` (case-insensitive) in both the inbound and outbound
+directions, aligning the component with the rest of the Camel component catalog. A new
+`headerFilterStrategy` endpoint option is available; routes that relied on receiving
+`Camel`-prefixed user-header names from Iggy messages can supply a custom `headerFilterStrategy`
+to restore the previous behaviour.


### PR DESCRIPTION
## CAMEL-23532 — doc-sync: 4.18 upgrade-guide entry to main

Companion to the 4.18.x backport #23313.

Per the project policy, the version-specific `camel-4x-upgrade-guide-4_XX.adoc` files on `main` act as the **canonical history across all releases**. The original PR #23285 only added the note to `camel-4x-upgrade-guide-4_21.adoc` on `main`; the 4.18.x backport (#23313) adds it to `camel-4x-upgrade-guide-4_18.adoc` on the `camel-4.18.x` branch. This PR adds the **same** `camel-vertx-websocket` / `camel-atmosphere-websocket` / `camel-iggy` entry to `camel-4x-upgrade-guide-4_18.adoc` on `main` so the main-side 4.18 guide stays in sync with what ships on `camel-4.18.x`.

Docs-only change (one `.adoc` file, +29 lines). No code, no behaviour change.

**Related:** #23285 (original, merged), #23313 (4.18.x backport)

---
_Claude Code on behalf of Andrea Cosentino_
