### PR TITLE
CAMEL-23528: document camel-neo4j property name validation in the 4.14 upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -146,6 +146,16 @@ to work without changes. Routes that set the header by its literal string value
 (for example `setHeader("JGROUPSRAFT_SET_TIMEOUT", ...)`) must be updated to
 use the new value (`setHeader("CamelJGroupsRaftSetTimeout", ...)`).
 
+=== camel-neo4j
+
+When using the `RETRIEVE_NODES` or `DELETE_NODE` operations with the `CamelNeo4jMatchProperties`
+header, the property names provided in the JSON match map are now validated before the `MATCH` /
+`DELETE` `WHERE` clause is built. Property names must be valid identifiers matching
+`[A-Za-z_][A-Za-z0-9_]*`. A request whose match map contains a property name that does not match
+this pattern now fails fast with an `IllegalArgumentException` (wrapped in a
+`Neo4jOperationException`) instead of producing a malformed query. Property values continue to be
+passed as bound query parameters and are unaffected.
+
 == Upgrading from 4.14.2 to 4.14.3
 
 === camel-tika


### PR DESCRIPTION
## Sync the 4.14 upgrade-guide entry to `main`

The `camel-4.14.x` backport apache/camel#23323 adds a `camel-neo4j` entry to `camel-4x-upgrade-guide-4_14.adoc`. The canonical `camel-4x-upgrade-guide-4_XX.adoc` files for all versions live on `main`, so this PR mirrors the same entry into main's copy, keeping the version-specific upgrade guides on `main` in sync with what ships on `camel-4.14.x`.

Docs-only. No code change.

**Related:** apache/camel#23258, backport apache/camel#23323
**Jira:** https://issues.apache.org/jira/browse/CAMEL-23528

---
_Claude Code on behalf of Andrea Cosentino_
