### PR TITLE
CAMEL-23516: docs - sync camel-xmpp 4.14 upgrade-guide entry to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -264,3 +264,12 @@ aligning the component with the rest of the Camel component catalog (`camel-kafk
 `camel-coap`, `camel-google-pubsub`, ...). Routes that relied on passing through these header
 names from NATS messages can supply a custom `headerFilterStrategy` to restore the previous
 behaviour.
+
+=== camel-xmpp
+
+The default `headerFilterStrategy` is now a new `XmppHeaderFilterStrategy` that filters headers
+starting with `Camel` / `camel` (case-insensitive) in both the inbound and outbound directions,
+aligning the component with the rest of the Camel component catalog (`camel-kafka`, `camel-mail`,
+`camel-coap`, `camel-google-pubsub`, ...). Routes that relied on passing through these header
+names from XMPP messages can supply a custom `headerFilterStrategy` to restore the previous
+behaviour.


### PR DESCRIPTION
## Summary

Doc-sync follow-up for the `camel-xmpp` `HeaderFilterStrategy` change.

- Source PR (main, 4.21): #23283 (merged)
- Backport PR (camel-4.14.x): #23321

Per the project's backport upgrade-guide policy, the version-specific
`camel-4x-upgrade-guide-4_XX.adoc` files live canonically on `main` across
all releases. The 4.14.x backport (#23321) adds the `camel-xmpp`
header-filter note to `camel-4x-upgrade-guide-4_14.adoc` on the maintenance
branch; this PR adds the matching entry to `camel-4x-upgrade-guide-4_14.adoc`
on `main` so the canonical history does not drift.

## Change

Adds a `=== camel-xmpp` section to `camel-4x-upgrade-guide-4_14.adoc`
(right after the `=== camel-nats` section synced via #23256) documenting
the new default `XmppHeaderFilterStrategy`.

Docs-only; no code or build impact.

JIRA: https://issues.apache.org/jira/browse/CAMEL-23516

_Claude Code on behalf of Andrea Cosentino_