### PR TITLE
chore: add --enable-native-access=ALL-UNNAMED to CamelJBang launcher

### DIFF
--- a/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
@@ -20,6 +20,7 @@
 //JAVA 21+
 //REPOS central=https://repo1.maven.org/maven2,apache-snapshot=https://repository.apache.org/content/groups/snapshots/
 //JAVA_OPTIONS -Dcamel.jbang.quarkusVersion=3.33.1.1
+//JAVA_OPTIONS --enable-native-access=ALL-UNNAMED
 //DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.18.2}@pom
 //DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.18.2}
 //DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.18.1}

--- a/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
@@ -1,5 +1,4 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-// keep in sync with src/main/jbang/main/CamelJBang.java
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
@@ -1,4 +1,5 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
+// keep in sync with src/main/jbang/main/CamelJBang.java
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
@@ -1,5 +1,4 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-// keep in sync with dist/CamelJBang.java
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
@@ -1,4 +1,5 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
+// keep in sync with dist/CamelJBang.java
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -20,6 +21,7 @@
 //JAVA 21+
 //REPOS central=https://repo1.maven.org/maven2,apache-snapshot=https://repository.apache.org/content/groups/snapshots/
 //JAVA_OPTIONS -Dcamel.jbang.quarkusVersion=3.33.1.1
+//JAVA_OPTIONS --enable-native-access=ALL-UNNAMED
 //DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.18.2}@pom
 //DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.18.2}
 //DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.18.1}


### PR DESCRIPTION
## Summary

- Add `--enable-native-access=ALL-UNNAMED` JBang directive to both CamelJBang launcher copies to suppress JDK 24+ restricted method warnings (JEP 472).
- JLine's FFM and JNI terminal providers call restricted methods like `MemorySegment.reinterpret` and `Linker.downcallHandle`. Without this flag, JDK 24+ prints warnings and JDK 26+ will block these calls with `IllegalCallerException`.
- Since JBang runs everything on the classpath (unnamed module), `ALL-UNNAMED` is the correct value.

## References

- [JEP 472](https://openjdk.org/jeps/472)
- [JLine troubleshooting: JDK 24 restricted method warning](https://jline.org/docs/troubleshooting/#jdk-24-restricted-method-warning)

## Test plan

- [ ] Verify CamelJBang launches without restricted method warnings on JDK 24+
- [ ] Verify no behavioral change on JDK 21-23

🤖 Generated with [Claude Code](https://claude.com/claude-code)