### PR TITLE
CAMEL-23548: camel-aws2-s3 - allow Simple expressions in destinationB…

### DIFF
--- a/components/camel-aws/camel-aws2-s3/src/main/docs/aws2-s3-component.adoc
+++ b/components/camel-aws/camel-aws2-s3/src/main/docs/aws2-s3-component.adoc
@@ -1128,19 +1128,35 @@ This will require specifying the destinationBucket option. As example:
 
 In this case, the objects consumed will be moved to _myothercamelbucket_ bucket and deleted from the original one (because of deleteAfterRead set to true as default).
 
-You have also the possibility of using a key prefix/suffix while moving the file to a different bucket. The options are destinationBucketPrefix and destinationBucketSuffix.
+You have also the possibility of using a key prefix/suffix while moving the file to a different bucket.
+The options are `destinationBucketPrefix` and `destinationBucketSuffix`.
 
-Taking the above example, you could do something like:
+Both options support the xref:languages:simple-language.adoc[Simple] expression language.
+Wrap an expression in `RAW()` to prevent the Camel URI parser from interpreting special characters:
 
 [source,java]
 --------------------------------------------------------------------------------
-  from("aws2-s3://mycamelbucket?amazonS3Client=#amazonS3Client&moveAfterRead=true&destinationBucket=myothercamelbucket&destinationBucketPrefix=RAW(pre-)&destinationBucketSuffix=RAW(-suff)")
+  from("aws2-s3://mycamelbucket?amazonS3Client=#amazonS3Client&moveAfterRead=true"
+     + "&destinationBucket=myothercamelbucket"
+     + "&destinationBucketPrefix=RAW(pre-)&destinationBucketSuffix=RAW(-suff)")
   .to("mock:result");
 --------------------------------------------------------------------------------
 
-In this case, the objects consumed will be moved to _myothercamelbucket_ bucket and deleted from the original one (because of deleteAfterRead set to true as default).
+In this case, an object named `test` is moved to `myothercamelbucket` with the key `pre-test-suff`.
 
-So if the file name is test, in the _myothercamelbucket_ you should see a file called pre-test-suff.
+Using a Simple expression, you can build dynamic paths at runtime.
+The following example organises moved objects by date:
+
+[source,java]
+--------------------------------------------------------------------------------
+  from("aws2-s3://mycamelbucket?amazonS3Client=#amazonS3Client&moveAfterRead=true"
+     + "&destinationBucket=myothercamelbucket"
+     + "&destinationBucketPrefix=RAW(${date:now:yyyy/MM/dd}/)")
+  .to("mock:result");
+--------------------------------------------------------------------------------
+
+An object named `report.csv` consumed on 2026-05-19 is moved with the key `2026/05/19/report.csv`.
+Expressions are evaluated once per exchange, so each message can produce a different destination key.
 
 === Additional Consumer Examples
 

--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Consumer.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Consumer.java
@@ -31,6 +31,7 @@ import org.apache.camel.ExchangePropertyKey;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.component.aws2.s3.utils.AWS2S3Utils;
 import org.apache.camel.spi.Synchronization;
 import org.apache.camel.support.ScheduledBatchPollingConsumer;
 import org.apache.camel.support.SynchronizationAdapter;
@@ -358,13 +359,9 @@ public class AWS2S3Consumer extends ScheduledBatchPollingConsumer {
 
                 StringBuilder builder = new StringBuilder();
 
-                if (ObjectHelper.isNotEmpty(getConfiguration().getDestinationBucketPrefix())) {
-                    builder.append(getConfiguration().getDestinationBucketPrefix());
-                }
+                builder.append(AWS2S3Utils.evaluateDestinationBucketPrefix(exchange, getConfiguration()));
                 builder.append(key);
-                if (ObjectHelper.isNotEmpty(getConfiguration().getDestinationBucketSuffix())) {
-                    builder.append(getConfiguration().getDestinationBucketSuffix());
-                }
+                builder.append(AWS2S3Utils.evaluateDestinationBucketSuffix(exchange, getConfiguration()));
 
                 String destinationKey = builder.toString();
                 if (getConfiguration().isRemovePrefixOnMove()) {

--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/utils/AWS2S3Utils.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/utils/AWS2S3Utils.java
@@ -150,6 +150,30 @@ public final class AWS2S3Utils {
         return key;
     }
 
+    public static String evaluateDestinationBucketPrefix(final Exchange exchange, AWS2S3Configuration configuration) {
+        String prefix = configuration.getDestinationBucketPrefix();
+        if (ObjectHelper.isEmpty(prefix)) {
+            return "";
+        }
+        if (hasSimpleFunction(prefix)) {
+            Language simple = exchange.getContext().resolveLanguage("simple");
+            prefix = simple.createExpression(prefix).evaluate(exchange, String.class);
+        }
+        return prefix;
+    }
+
+    public static String evaluateDestinationBucketSuffix(final Exchange exchange, AWS2S3Configuration configuration) {
+        String suffix = configuration.getDestinationBucketSuffix();
+        if (ObjectHelper.isEmpty(suffix)) {
+            return "";
+        }
+        if (hasSimpleFunction(suffix)) {
+            Language simple = exchange.getContext().resolveLanguage("simple");
+            suffix = simple.createExpression(suffix).evaluate(exchange, String.class);
+        }
+        return suffix;
+    }
+
     public static void setEncryption(
             CreateMultipartUploadRequest.Builder createMultipartUploadRequest, AWS2S3Configuration configuration) {
         if (configuration.isUseAwsKMS()) {

--- a/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/utils/AWS2S3UtilsTest.java
+++ b/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/utils/AWS2S3UtilsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.s3.utils;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.component.aws2.s3.AWS2S3Configuration;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AWS2S3UtilsTest extends CamelTestSupport {
+
+    // ---- evaluateDestinationBucketPrefix ----
+
+    @Test
+    void prefixLiteralStringPassesThroughUnchanged() {
+        Exchange exchange = createExchangeWithBody("body");
+        AWS2S3Configuration config = new AWS2S3Configuration();
+        config.setDestinationBucketPrefix("archive/");
+
+        assertEquals("archive/", AWS2S3Utils.evaluateDestinationBucketPrefix(exchange, config));
+    }
+
+    @Test
+    void prefixSimpleExpressionIsEvaluated() {
+        Exchange exchange = createExchangeWithBody("body");
+        exchange.getIn().setHeader("folder", "2026/05");
+        AWS2S3Configuration config = new AWS2S3Configuration();
+        config.setDestinationBucketPrefix("${header.folder}/");
+
+        assertEquals("2026/05/", AWS2S3Utils.evaluateDestinationBucketPrefix(exchange, config));
+    }
+
+    @Test
+    void prefixNullOrEmptyReturnsEmptyString() {
+        Exchange exchange = createExchangeWithBody("body");
+        AWS2S3Configuration config = new AWS2S3Configuration();
+        // no prefix set — null
+
+        assertEquals("", AWS2S3Utils.evaluateDestinationBucketPrefix(exchange, config));
+    }
+
+    // ---- evaluateDestinationBucketSuffix ----
+
+    @Test
+    void suffixLiteralStringPassesThroughUnchanged() {
+        Exchange exchange = createExchangeWithBody("body");
+        AWS2S3Configuration config = new AWS2S3Configuration();
+        config.setDestinationBucketSuffix(".processed");
+
+        assertEquals(".processed", AWS2S3Utils.evaluateDestinationBucketSuffix(exchange, config));
+    }
+
+    @Test
+    void suffixSimpleExpressionIsEvaluated() {
+        Exchange exchange = createExchangeWithBody("body");
+        exchange.getIn().setHeader("env", "prod");
+        AWS2S3Configuration config = new AWS2S3Configuration();
+        config.setDestinationBucketSuffix("-${header.env}");
+
+        assertEquals("-prod", AWS2S3Utils.evaluateDestinationBucketSuffix(exchange, config));
+    }
+
+    @Test
+    void suffixNullOrEmptyReturnsEmptyString() {
+        Exchange exchange = createExchangeWithBody("body");
+        AWS2S3Configuration config = new AWS2S3Configuration();
+        // no suffix set — null
+
+        assertEquals("", AWS2S3Utils.evaluateDestinationBucketSuffix(exchange, config));
+    }
+}


### PR DESCRIPTION
# Description

The `camel-aws2-s3` consumer supports a `moveAfterRead` option that copies consumed objects to a destination bucket. The `destinationBucketPrefix` and `destinationBucketSuffix` options allow customising the destination key, but previously only accepted literal strings.

This PR adds Simple expression language support to both options, following the same pattern already used by `AWS2S3Utils.determineKey()` and `AWS2S3Utils.determineBucketName()`: `LanguageSupport.hasSimpleFunction()` detects whether the value contains a `${...}` expression; if so, the `"simple"` language is resolved from the Camel context and evaluated against the current exchange.

Literal strings and `null`/empty values continue to behave exactly as before, so existing routes using `RAW(somePrefix)` are unaffected.

A practical use case is organising moved objects by date:
```
aws2-s3://mybucket?moveAfterRead=true&destinationBucket=archive
  &destinationBucketPrefix=RAW(${date:now:yyyy/MM/dd}/)
```

Changes:
- `AWS2S3Utils`: two new static helpers `evaluateDestinationBucketPrefix` / `evaluateDestinationBucketSuffix`
- `AWS2S3Consumer.processCommit()`: uses the new helpers instead of plain string concatenation
- `AWS2S3UtilsTest`: 6 new unit tests (literal pass-through, Simple expression evaluation, null/empty for prefix and suffix)
- `aws2-s3-component.adoc`: documents expression support with a static and a dynamic date example

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-23548) filed for the change.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.