### PR TITLE
CAMEL-23553: Fix RestRegistry lazy plugin resolution

### DIFF
--- a/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpConsumer.java
+++ b/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpConsumer.java
@@ -116,9 +116,7 @@ public class VertxPlatformHttpConsumer extends DefaultConsumer
         super.doInit();
 
         // camel-rest is optional
-        if (getEndpoint().getCamelContext().getCamelContextExtension().isContextPluginInUse(RestRegistry.class)) {
-            restRegistry = PluginHelper.getRestRegistry(getEndpoint().getCamelContext());
-        }
+        restRegistry = PluginHelper.getRestRegistry(getEndpoint().getCamelContext());
 
         methods = Method.parseList(getEndpoint().getHttpMethodRestrict());
         path = configureEndpointPath(getEndpoint());  // in vertx-web we should replace path parameters from {xxx} to :xxx syntax

--- a/components/camel-webhook/src/main/java/org/apache/camel/component/webhook/MultiRestConsumer.java
+++ b/components/camel-webhook/src/main/java/org/apache/camel/component/webhook/MultiRestConsumer.java
@@ -52,8 +52,9 @@ public class MultiRestConsumer extends DefaultConsumer {
                     null, null, null, config, Collections.emptyMap());
             configurer.configure(consumer);
 
-            if (context.getCamelContextExtension().isContextPluginInUse(RestRegistry.class)) {
-                PluginHelper.getRestRegistry(context).addRestService(consumer, false, url, url, path, null, method,
+            RestRegistry rr = PluginHelper.getRestRegistry(context);
+            if (rr != null) {
+                rr.addRestService(consumer, false, url, url, path, null, method,
                         null, null, null, null, null, null, null, null);
             }
 

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
@@ -4348,6 +4348,9 @@ public abstract class AbstractCamelContext extends BaseService
 
     protected RestRegistry createRestRegistry() {
         RestRegistryFactory factory = camelContextExtension.getRestRegistryFactory();
+        if (factory == null) {
+            return null;
+        }
         return factory.createRegistry();
     }
 

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultCamelContextExtension.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultCamelContextExtension.java
@@ -776,7 +776,10 @@ class DefaultCamelContextExtension implements ExtendedCamelContext {
             lock.lock();
             try {
                 if (restRegistryFactory == null) {
-                    setRestRegistryFactory(camelContext.createRestRegistryFactory());
+                    RestRegistryFactory factory = camelContext.createRestRegistryFactory();
+                    if (factory != null) {
+                        setRestRegistryFactory(factory);
+                    }
                 }
             } finally {
                 lock.unlock();

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultContextPluginManager.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultContextPluginManager.java
@@ -41,7 +41,11 @@ public class DefaultContextPluginManager implements PluginManager {
         }
         if (extension instanceof Supplier supplier) {
             extension = supplier.get();
-            addContextPlugin(type, (T) extension);
+            if (extension != null) {
+                addContextPlugin(type, (T) extension);
+            } else {
+                extensions.remove(type);
+            }
         }
         return (T) extension;
     }

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/SimpleCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/SimpleCamelContext.java
@@ -613,10 +613,10 @@ public class SimpleCamelContext extends AbstractCamelContext {
 
     @Override
     protected RestRegistryFactory createRestRegistryFactory() {
-        return ResolverHelper.resolveMandatoryBootstrapService(getCamelContextReference(),
+        return ResolverHelper.resolveBootstrapService(getCamelContextReference(),
                 RestRegistryFactory.FACTORY,
-                RestRegistryFactory.class,
-                "camel-rest");
+                RestRegistryFactory.class)
+                .orElse(null);
     }
 
     @Override


### PR DESCRIPTION
## Summary

- `RestRegistry` is registered as a lazy plugin via `lazyAddContextPlugin()`, but `isContextPluginInUse()` always returns `false` for lazy plugins. This caused `VertxPlatformHttpConsumer` and `MultiRestConsumer` to never resolve the registry — even when camel-rest was on the classpath — breaking contract-first REST services.
- Make the lazy resolution return `null` gracefully when camel-rest is absent (instead of throwing), so callers can use `PluginHelper.getRestRegistry()` directly with a null-check.

### Changes

| File | Change |
|------|--------|
| `SimpleCamelContext` | Use optional `resolveBootstrapService()` instead of mandatory (returns null when camel-rest absent) |
| `AbstractCamelContext` | Null-check factory in `createRestRegistry()` |
| `DefaultCamelContextExtension` | Handle null from `createRestRegistryFactory()` |
| `DefaultContextPluginManager` | Remove entry when lazy supplier returns null (avoids repeated retries) |
| `VertxPlatformHttpConsumer` | Drop broken `isContextPluginInUse` guard, resolve directly |
| `MultiRestConsumer` | Drop broken `isContextPluginInUse` guard, resolve with null-check |

## Test plan

- [x] `mvn test -pl core/camel-base-engine` — passes
- [x] `mvn test -pl components/camel-platform-http-vertx` — passes
- [x] `mvn test -pl components/camel-webhook` — passes
- [ ] Test contract-first REST DSL with camel-platform-http-vertx to verify services are registered in RestRegistry

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)