### PR TITLE
camel-core - Fix endpoint utilization statistics double-counting input hits

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultRuntimeEndpointRegistry.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultRuntimeEndpointRegistry.java
@@ -263,21 +263,6 @@ public class DefaultRuntimeEndpointRegistry extends EventNotifierSupport impleme
             if (endpoint != null) {
                 String routeId = ece.getExchange().getFromRouteId();
                 String uri = endpoint.getEndpointUri();
-                // some components (e.g. rest-openapi) delegate to an underlying consumer (e.g. platform-http)
-                // whose exchange may not carry a fromRouteId; fall back to scanning inputs by URI
-                if (routeId == null) {
-                    for (Map.Entry<String, Set<String>> entry : inputs.entrySet()) {
-                        if (entry.getValue().contains(uri)) {
-                            routeId = entry.getKey();
-                            break;
-                        }
-                    }
-                }
-                // ensure the actual consumer URI is in inputs so getEndpointStatistics() can find it
-                Set<String> routeInputs = inputs.get(routeId);
-                if (routeInputs != null) {
-                    routeInputs.add(uri);
-                }
                 String key = asUtilizationKey(routeId, uri);
                 if (key != null) {
                     inputUtilization.onHit(key);


### PR DESCRIPTION
## Summary

- Remove the fallback `fromRouteId` scan and dynamic inputs addition from the `ExchangeCreatedEvent` handler in `DefaultRuntimeEndpointRegistry`
- This workaround was added for rest-openapi exchanges missing `fromRouteId`, but that root cause has since been properly fixed by propagating `routeId` through `DefaultPlatformHttpConsumer.setRouteId()`
- The fallback incorrectly matched `ProducerTemplate` exchanges (which legitimately have null `fromRouteId`) to route inputs, doubling the input hit count

## Test plan

- [x] `ManagedEndpointUtilizationStatisticsTest` now passes (was failing with `expected: <4> but was: <8>`)
- [x] Full `camel-management` test suite passes with no regressions

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)