### PR TITLE
chore: clarify documentation requirements in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ When creating a PR, **always identify and request reviews** from the most releva
   command or component documentation page. This includes: changed defaults, new auto-detection
   behavior, removed or renamed options, changed header names or values, API/SPI signature changes,
   removed or deprecated components, migrated libraries, and renamed documentation pages.
+  For backported changes, the upgrade guide entry must be added on the `main` branch (not on the
+  maintenance branch where the fix is backported).
 - All code must pass formatting checks (`mvn formatter:format impsort:sort`) before pushing.
 - All generated files must be regenerated and committed (CI checks for uncommitted changes).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,10 +73,11 @@ When creating a PR, **always identify and request reviews** from the most releva
 
 - Every PR must include tests for new functionality or bug fixes.
 - Every PR must include documentation updates where applicable.
-  Behavioral changes to user-facing commands or components (new defaults, auto-detection, removed
-  options, changed headers) must be documented in the upgrade guide
+  Any user-visible change must be documented in the upgrade guide
   (`docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_XX.adoc`) and in the relevant
-  command or component documentation page.
+  command or component documentation page. This includes: changed defaults, new auto-detection
+  behavior, removed or renamed options, changed header names or values, API/SPI signature changes,
+  removed or deprecated components, migrated libraries, and renamed documentation pages.
 - All code must pass formatting checks (`mvn formatter:format impsort:sort`) before pushing.
 - All generated files must be regenerated and committed (CI checks for uncommitted changes).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,10 @@ When creating a PR, **always identify and request reviews** from the most releva
 
 - Every PR must include tests for new functionality or bug fixes.
 - Every PR must include documentation updates where applicable.
+  Behavioral changes to user-facing commands or components (new defaults, auto-detection, removed
+  options, changed headers) must be documented in the upgrade guide
+  (`docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_XX.adoc`) and in the relevant
+  command or component documentation page.
 - All code must pass formatting checks (`mvn formatter:format impsort:sort`) before pushing.
 - All generated files must be regenerated and committed (CI checks for uncommitted changes).
 


### PR DESCRIPTION
## Summary

- Expand the documentation bullet in the Code Quality section to explicitly call out the upgrade guide and component/command docs
- Ensures behavioral changes (new defaults, auto-detection, removed options, changed headers) are not shipped without user-facing documentation

This was prompted by a review on #22192 where upgrade guide and jbang doc updates were requested after the initial implementation.

## Test plan

- [x] Documentation-only change, no code impact