### PR TITLE
CAMEL-23532: docs - sync camel-vertx-websocket / camel-atmosphere-websocket 4.14 upgrade-guide entry to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -283,3 +283,22 @@ aligning the component with the rest of the Camel component catalog (`camel-kafk
 `camel-coap`, `camel-google-pubsub`, ...). Routes that relied on passing through these header
 names from XMPP messages can supply a custom `headerFilterStrategy` to restore the previous
 behaviour.
+
+=== camel-vertx-websocket
+
+The `vertx-websocket` consumer now applies a `HeaderFilterStrategy` to the WebSocket query and
+path parameters before mapping them into the Camel message headers. The new default
+`VertxWebsocketHeaderFilterStrategy` filters headers starting with `Camel` / `camel`
+(case-insensitive) in both the inbound and outbound directions, aligning the component with the
+rest of the Camel component catalog (`camel-coap`, `camel-kafka`, `camel-nats`, ...). A new
+`headerFilterStrategy` endpoint option is available; routes that relied on receiving
+`Camel`-prefixed header names from WebSocket query or path parameters can supply a custom
+`headerFilterStrategy` to restore the previous behaviour.
+
+=== camel-atmosphere-websocket
+
+The `atmosphere-websocket` consumer now applies the endpoint `HeaderFilterStrategy` to the
+WebSocket query parameters before mapping them into the Camel message headers. The inherited
+default `HttpHeaderFilterStrategy` filters headers starting with `Camel` / `camel`
+(case-insensitive). Routes that relied on receiving `Camel`-prefixed header names from WebSocket
+query parameters can supply a custom `headerFilterStrategy` to restore the previous behaviour.


### PR DESCRIPTION
## CAMEL-23532 — doc-sync: 4.14 upgrade-guide entry to main

Companion to the 4.14.x backport #23352.

Per project policy, the version-specific `camel-4x-upgrade-guide-4_XX.adoc` files on `main` act as the **canonical history across all releases**. The 4.14.x backport (#23352) adds the `camel-vertx-websocket` / `camel-atmosphere-websocket` entry to `camel-4x-upgrade-guide-4_14.adoc` on the `camel-4.14.x` branch. This PR adds the **same** entry to `camel-4x-upgrade-guide-4_14.adoc` on `main` so the main-side 4.14 guide stays in sync with what ships on `camel-4.14.x`.

`camel-iggy` is intentionally **not** part of this entry because the component does not exist on the 4.14.x branch (its 4.18.x backport is #23313 and its main-side doc-sync was #23315).

Docs-only change (one `.adoc` file). No code, no behaviour change.

**Related:** #23285 (original, merged), #23352 (4.14.x backport), #23313/#23315 (4.18.x backport + 4_18 doc-sync, both merged).

---
_Claude Code on behalf of Andrea Cosentino_
