### PR TITLE
CAMEL-23506: docs - sync camel-aws2-sqs / camel-aws2-sns 4.18 upgrade-guide entry to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -547,3 +547,22 @@ directions, aligning the component with the rest of the Camel component catalog.
 `headerFilterStrategy` endpoint option is available; routes that relied on receiving
 `Camel`-prefixed user-header names from Iggy messages can supply a custom `headerFilterStrategy`
 to restore the previous behaviour.
+
+=== camel-aws2-sqs
+
+`Sqs2HeaderFilterStrategy` now also configures an inbound filter aligned with the existing
+outbound regex. Headers starting with `Camel` / `camel` (case-insensitive), `breadcrumbId` and
+`org.apache.camel.*` are now filtered in both the inbound and outbound directions, aligning the
+component with the rest of the Camel component catalog (`camel-kafka`, `camel-mail`,
+`camel-coap`, `camel-google-pubsub`, ...). Routes that relied on receiving these header names
+from inbound SQS messages can supply a custom `headerFilterStrategy` to restore the previous
+behaviour.
+
+=== camel-aws2-sns
+
+`Sns2HeaderFilterStrategy` now also configures an inbound filter aligned with the existing
+outbound regex. Headers starting with `Camel` / `camel` (case-insensitive), `breadcrumbId` and
+`org.apache.camel.*` are now filtered in both the inbound and outbound directions, aligning the
+component with the rest of the Camel component catalog. Routes that relied on receiving these
+header names on inbound SNS messages can supply a custom `headerFilterStrategy` to restore the
+previous behaviour.


### PR DESCRIPTION
## Summary

The 4.18.x backport [#23357](https://github.com/apache/camel/pull/23357) of [#23221](https://github.com/apache/camel/pull/23221) adds the `Sqs2HeaderFilterStrategy` /
`Sns2HeaderFilterStrategy` upgrade-guide note to `camel-4x-upgrade-guide-4_18.adoc` on the
`camel-4.18.x` branch. Per the project policy, the version-specific upgrade guides on `main`
are the canonical history across all releases, so the same entry must also be added to
`camel-4x-upgrade-guide-4_18.adoc` on `main`.

This PR adds the matching entry on `main` so the `4.18` upgrade guide does not drift.

Jira: https://issues.apache.org/jira/browse/CAMEL-23506

## Test plan

- [x] AsciiDoc renders cleanly (visually inspected, only an append after the existing
      `camel-iggy` section).
- [x] No code changes — docs-only.

_Claude Code on behalf of Andrea Cosentino_