### PR TITLE
CAMEL-23508: docs - sync camel-elasticsearch-rest-client 4.14 upgrade-guide entry to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -156,6 +156,29 @@ this pattern now fails fast with an `IllegalArgumentException` (wrapped in a
 `Neo4jOperationException`) instead of producing a malformed query. Property values continue to be
 passed as bound query parameters and are unaffected.
 
+=== camel-elasticsearch-rest-client
+
+The Exchange header constants in `ElasticSearchRestClientConstant` have been
+renamed to follow the Camel naming convention used across the rest of the
+component catalog. The Java field names are unchanged; only the header string
+values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `ElasticSearchRestClientConstant.ID` | `ID` | `CamelElasticsearchId`
+| `ElasticSearchRestClientConstant.SEARCH_QUERY` | `SEARCH_QUERY` | `CamelElasticsearchSearchQuery`
+| `ElasticSearchRestClientConstant.INDEX_SETTINGS` | `INDEX_SETTINGS` | `CamelElasticsearchIndexSettings`
+| `ElasticSearchRestClientConstant.INDEX_NAME` | `INDEX_NAME` | `CamelElasticsearchIndexName`
+| `ElasticSearchRestClientConstant.OPERATION` | `OPERATION` | `CamelElasticsearchOperation`
+|===
+
+Routes that reference the constant symbolically (for example
+`setHeader(ElasticSearchRestClientConstant.SEARCH_QUERY, ...)`) continue to
+work without changes. Routes that set the header by its literal string value
+(for example `setHeader("SEARCH_QUERY", ...)`) must be updated to use the
+new value (`setHeader("CamelElasticsearchSearchQuery", ...)`).
+
 == Upgrading from 4.14.2 to 4.14.3
 
 === camel-tika


### PR DESCRIPTION
## Summary

Sync the `camel-elasticsearch-rest-client` header-rename upgrade-guide entry into the
`camel-4x-upgrade-guide-4_14.adoc` file on `main`, alongside the corresponding
backport to `camel-4.14.x` (#23360 - cherry-pick of #23212).

Per the project's backport upgrade-guide policy: the version-specific upgrade
guides on `main` are the canonical cross-release history. When a fix is
backported to a maintenance branch and adds an upgrade-guide note for that
release line, the matching `camel-4x-upgrade-guide-4_XX.adoc` on `main` must
be updated in lockstep so it does not drift out of sync with what is shipping
on the maintenance branch.

## Changes

Adds the `camel-elasticsearch-rest-client` section to the
\"Upgrading from 4.14.3 to 4.14.8\" block in
`docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc`,
mirroring the entry added to the 4.21 upgrade guide in #23212 (and the
sibling 4.14 entries already merged via #23217, #23222, #23234).

JIRA: https://issues.apache.org/jira/browse/CAMEL-23508

## Related

- Original PR (main, 4.21): #23212
- Backport to camel-4.14.x: #23360

---

_Claude Code (Opus 4.7) on behalf of @oscerd._