### PR TITLE
CAMEL-23565: CI skip Scalpel analysis for root pom.xml changes

### DIFF
--- a/.github/CI-ARCHITECTURE.md
+++ b/.github/CI-ARCHITECTURE.md
@@ -158,6 +158,8 @@ Scalpel is configured permanently in `.mvn/extensions.xml` (version `0.1.0`). On
 
 Note: the script overrides `fullBuildTriggers` to empty (`-Dscalpel.fullBuildTriggers=`) because Scalpel's default (`.mvn/**`) would trigger a full build whenever `.mvn/extensions.xml` itself changes (e.g., Dependabot bumping Scalpel).
 
+Scalpel is only invoked when a **subdirectory** `pom.xml` is changed (e.g. `parent/pom.xml`, `components/camel-kafka/pom.xml`). Changes to the **root** `pom.xml` are excluded because it contains build-infrastructure config (license plugin, checkstyle, etc.) that does not affect module compilation or test behavior. Without this filter, Scalpel would report every module as affected since they all inherit from the root POM.
+
 ## Manual Integration Test Advisories
 
 Some modules are excluded from CI's `-amd` expansion (the `EXCLUSION_LIST`) because they are generated code, meta-modules, or expensive integration test suites. When a contributor changes one of these modules, CI cannot automatically test all downstream effects.

--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -562,10 +562,14 @@ main() {
     done <<< "$pom_files"
   fi
 
-  # Step 2b: Scalpel detection (parallel, for any pom.xml change)
+  # Step 2b: Scalpel detection (for parent or module pom.xml changes)
   # Scalpel uses effective POM model comparison — catches managed deps,
   # plugin changes, and transitive impacts that grep misses.
-  if echo "$diff_body" | grep -q '^diff --git a/.*pom\.xml'; then
+  # Skip when only the root pom.xml changed — it contains build-infrastructure
+  # config (license plugin, checkstyle, etc.) that doesn't affect module
+  # compilation or test behavior. Without this filter, Scalpel reports every
+  # module as affected because they all inherit from the root POM.
+  if echo "$diff_body" | sed -n 's|^diff --git a/\(.*\) b/.*|\1|p' | grep -q '.*/pom\.xml$'; then
     echo ""
     echo "Running Scalpel POM analysis..."
     runScalpelDetection


### PR DESCRIPTION
## Summary

- Skip Scalpel POM analysis when only the root `pom.xml` changes (not `parent/pom.xml` or module-level `pom.xml` files)
- The root `pom.xml` contains build-infrastructure config (license plugin, checkstyle, etc.) that doesn't affect module compilation or test behavior
- Without this filter, Scalpel reports every module as affected because they all inherit from the root POM, causing CI to test the entire project unnecessarily (as seen in PR #23364)

## Changes

- `.github/actions/incremental-build/incremental-build.sh`: Changed Scalpel trigger condition to only fire when a subdirectory `pom.xml` changes — extracts file paths from the diff with `sed` and checks for paths containing at least one directory level before `pom.xml`
- `.github/CI-ARCHITECTURE.md`: Document the root `pom.xml` exclusion behavior

## Test plan

- [x] Verified grep logic handles all edge cases:
  - Root `pom.xml` only → Scalpel skipped
  - `parent/pom.xml` → Scalpel runs
  - Module `pom.xml` (e.g. `components/camel-kafka/pom.xml`) → Scalpel runs
  - Root + module `pom.xml` → Scalpel runs
  - No `pom.xml` changes → Scalpel skipped
- [ ] CI run on this PR should only test CI-related files (not every module)

_Claude Code on behalf of Claus Ibsen_