### PR TITLE
CAMEL-23506: docs - sync camel-aws2-sqs / camel-aws2-sns 4.14 upgrade-guide entry to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -325,3 +325,22 @@ WebSocket query parameters before mapping them into the Camel message headers. T
 default `HttpHeaderFilterStrategy` filters headers starting with `Camel` / `camel`
 (case-insensitive). Routes that relied on receiving `Camel`-prefixed header names from WebSocket
 query parameters can supply a custom `headerFilterStrategy` to restore the previous behaviour.
+
+=== camel-aws2-sqs
+
+`Sqs2HeaderFilterStrategy` now also configures an inbound filter aligned with the existing
+outbound regex. Headers starting with `Camel` / `camel` (case-insensitive), `breadcrumbId` and
+`org.apache.camel.*` are now filtered in both the inbound and outbound directions, aligning the
+component with the rest of the Camel component catalog (`camel-kafka`, `camel-mail`,
+`camel-coap`, `camel-google-pubsub`, ...). Routes that relied on receiving these header names
+from inbound SQS messages can supply a custom `headerFilterStrategy` to restore the previous
+behaviour.
+
+=== camel-aws2-sns
+
+`Sns2HeaderFilterStrategy` now also configures an inbound filter aligned with the existing
+outbound regex. Headers starting with `Camel` / `camel` (case-insensitive), `breadcrumbId` and
+`org.apache.camel.*` are now filtered in both the inbound and outbound directions, aligning the
+component with the rest of the Camel component catalog. Routes that relied on receiving these
+header names on inbound SNS messages can supply a custom `headerFilterStrategy` to restore the
+previous behaviour.


### PR DESCRIPTION
## Summary

The 4.14.x backport [#23373](https://github.com/apache/camel/pull/23373) of [#23221](https://github.com/apache/camel/pull/23221) adds the `Sqs2HeaderFilterStrategy` /
`Sns2HeaderFilterStrategy` upgrade-guide note to `camel-4x-upgrade-guide-4_14.adoc` on the
`camel-4.14.x` branch. Per the project policy, the version-specific upgrade guides on `main`
are the canonical history across all releases, so the same entry must also be added to
`camel-4x-upgrade-guide-4_14.adoc` on `main`.

This PR adds the matching entry on `main` so the `4.14` upgrade guide does not drift.

Sibling: [#23354](https://github.com/apache/camel/pull/23354) covered the same sync for the 4.18 upgrade guide.

Jira: https://issues.apache.org/jira/browse/CAMEL-23506

## Test plan

- [x] AsciiDoc renders cleanly (visually inspected, only an append after the existing
      `camel-atmosphere-websocket` section).
- [x] No code changes — docs-only.

_Claude Code on behalf of Andrea Cosentino_