### PR TITLE
[backport camel-4.14.x] CAMEL-23506: align aws2-sqs/sns HeaderFilterStrategy with siblings

### DIFF
--- a/components/camel-aws/camel-aws2-sns/src/main/java/org/apache/camel/component/aws2/sns/Sns2HeaderFilterStrategy.java
+++ b/components/camel-aws/camel-aws2-sns/src/main/java/org/apache/camel/component/aws2/sns/Sns2HeaderFilterStrategy.java
@@ -28,5 +28,6 @@ public class Sns2HeaderFilterStrategy extends DefaultHeaderFilterStrategy {
 
         // filter headers begin with "Camel" or "org.apache.camel"
         setOutFilterPattern("(breadcrumbId|Camel|org\\.apache\\.camel)[\\.|a-z|A-z|0-9]*");
+        setInFilterStartsWith(CAMEL_FILTER_STARTS_WITH);
     }
 }

--- a/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/Sns2HeaderFilterStrategyTest.java
+++ b/components/camel-aws/camel-aws2-sns/src/test/java/org/apache/camel/component/aws2/sns/Sns2HeaderFilterStrategyTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.sns;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Sns2HeaderFilterStrategyTest {
+
+    private final Sns2HeaderFilterStrategy strategy = new Sns2HeaderFilterStrategy();
+
+    @Test
+    void inboundFiltersCamelPrefixedHeaders() {
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelHttpUri", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelFileName", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("camelfoo", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CAMELFOO", "value", null));
+    }
+
+    @Test
+    void inboundAllowsNonCamelHeaders() {
+        assertFalse(strategy.applyFilterToExternalHeaders("X-Custom", "value", null));
+        assertFalse(strategy.applyFilterToExternalHeaders("subject", "hello", null));
+    }
+
+    @Test
+    void outboundFiltersCamelAndBreadcrumbHeaders() {
+        assertTrue(strategy.applyFilterToCamelHeaders("CamelHttpUri", "value", null));
+        assertTrue(strategy.applyFilterToCamelHeaders("org.apache.camel.internal", "value", null));
+        assertTrue(strategy.applyFilterToCamelHeaders("breadcrumbId", "value", null));
+    }
+
+    @Test
+    void outboundAllowsUserHeaders() {
+        assertFalse(strategy.applyFilterToCamelHeaders("X-Custom", "value", null));
+    }
+}

--- a/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2HeaderFilterStrategy.java
+++ b/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2HeaderFilterStrategy.java
@@ -27,6 +27,6 @@ public class Sqs2HeaderFilterStrategy extends DefaultHeaderFilterStrategy {
         setLowerCase(true);
         // filter headers begin with "Camel" or "org.apache.camel"
         setOutFilterPattern("(breadcrumbId|Camel|org\\.apache\\.camel)[\\.|a-z|A-z|0-9]*");
-
+        setInFilterStartsWith(CAMEL_FILTER_STARTS_WITH);
     }
 }

--- a/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/Sqs2HeaderFilterStrategyTest.java
+++ b/components/camel-aws/camel-aws2-sqs/src/test/java/org/apache/camel/component/aws2/sqs/Sqs2HeaderFilterStrategyTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.sqs;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Sqs2HeaderFilterStrategyTest {
+
+    private final Sqs2HeaderFilterStrategy strategy = new Sqs2HeaderFilterStrategy();
+
+    @Test
+    void inboundFiltersCamelPrefixedHeaders() {
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelSqlQuery", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelHttpUri", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CamelFileName", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("camelfoo", "value", null));
+        assertTrue(strategy.applyFilterToExternalHeaders("CAMELFOO", "value", null));
+    }
+
+    @Test
+    void inboundAllowsNonCamelHeaders() {
+        assertFalse(strategy.applyFilterToExternalHeaders("X-Custom", "value", null));
+        assertFalse(strategy.applyFilterToExternalHeaders("orderId", "12345", null));
+    }
+
+    @Test
+    void outboundFiltersCamelAndBreadcrumbHeaders() {
+        assertTrue(strategy.applyFilterToCamelHeaders("CamelHttpUri", "value", null));
+        assertTrue(strategy.applyFilterToCamelHeaders("org.apache.camel.internal", "value", null));
+        assertTrue(strategy.applyFilterToCamelHeaders("breadcrumbId", "value", null));
+    }
+
+    @Test
+    void outboundAllowsUserHeaders() {
+        assertFalse(strategy.applyFilterToCamelHeaders("X-Custom", "value", null));
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -336,3 +336,22 @@ WebSocket query parameters before mapping them into the Camel message headers. T
 default `HttpHeaderFilterStrategy` filters headers starting with `Camel` / `camel`
 (case-insensitive). Routes that relied on receiving `Camel`-prefixed header names from WebSocket
 query parameters can supply a custom `headerFilterStrategy` to restore the previous behaviour.
+
+=== camel-aws2-sqs
+
+`Sqs2HeaderFilterStrategy` now also configures an inbound filter aligned with the existing
+outbound regex. Headers starting with `Camel` / `camel` (case-insensitive), `breadcrumbId` and
+`org.apache.camel.*` are now filtered in both the inbound and outbound directions, aligning the
+component with the rest of the Camel component catalog (`camel-kafka`, `camel-mail`,
+`camel-coap`, `camel-google-pubsub`, ...). Routes that relied on receiving these header names
+from inbound SQS messages can supply a custom `headerFilterStrategy` to restore the previous
+behaviour.
+
+=== camel-aws2-sns
+
+`Sns2HeaderFilterStrategy` now also configures an inbound filter aligned with the existing
+outbound regex. Headers starting with `Camel` / `camel` (case-insensitive), `breadcrumbId` and
+`org.apache.camel.*` are now filtered in both the inbound and outbound directions, aligning the
+component with the rest of the Camel component catalog. Routes that relied on receiving these
+header names on inbound SNS messages can supply a custom `headerFilterStrategy` to restore the
+previous behaviour.


### PR DESCRIPTION
## Summary

Backport of [#23221](https://github.com/apache/camel/pull/23221) onto `camel-4.14.x`.

`Sqs2HeaderFilterStrategy` and `Sns2HeaderFilterStrategy` only configured an outbound filter.
This change adds `setInFilterStartsWith(CAMEL_FILTER_STARTS_WITH)` so the inbound direction is
aligned with the sibling strategies (Kafka, Mail, CoAP, Google Pub/Sub, ...). The existing
outbound regex (which also catches `breadcrumbId` and `org.apache.camel.*`) is unchanged.

Includes:
- The strategy fix in both `camel-aws2-sqs` and `camel-aws2-sns`.
- Focused unit tests in both modules.
- The matching `camel-4x-upgrade-guide-4_14.adoc` entry (sibling doc-sync PR #23372 syncs the
  same entry into `main`).

Sibling backport on 4.18.x: #23357.

Original PR: #23221
Original author: @oscerd
Jira: https://issues.apache.org/jira/browse/CAMEL-23506

## Test plan

- [x] `mvn clean install -DskipTests` from the worktree root — passes (exit 0).
- [x] Cherry-pick applied cleanly (no conflict resolution required).
- [x] Upgrade-guide entry appended after the existing `camel-atmosphere-websocket` section.

_Claude Code on behalf of Andrea Cosentino_