### PR TITLE
CAMEL-23522: doc-sync 4.18 upgrade guide for camel-mail mail.smtp.* gating

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -210,6 +210,29 @@ this pattern now fails fast with an `IllegalArgumentException` (wrapped in a
 `Neo4jOperationException`) instead of producing a malformed query. Property values continue to be
 passed as bound query parameters and are unaffected.
 
+=== camel-mail
+
+The SMTP producer no longer extracts dynamic JavaMail session properties from message headers by
+default. Previously any message header whose key started with `mail.smtp.` (or `mail.smtps.`) was
+applied to a per-message `JavaMailSender`, which meant an upstream producer that mapped untrusted
+input into the exchange header map (for example `platform-http` query parameters, JMS or Kafka
+messages from untrusted producers) could override transport-security settings such as
+`mail.smtp.ssl.trust` or `mail.smtp.starttls.enable`, or redirect the SMTP connection.
+
+This behaviour is now disabled by default. Routes that legitimately rely on per-message
+`mail.smtp.*` / `mail.smtps.*` headers must opt back in on the endpoint:
+
+[source,java]
+----
+.to("smtp://mymailserver:1234?useJavaMailSessionPropertiesFromHeaders=true");
+----
+
+Even with the opt-in, route authors should still strip the namespace with
+`removeHeaders("mail.smtp.*", "mail.smtps.*")` between any untrusted ingress and the mail producer.
+
+In addition, the inbound `MailHeaderFilterStrategy` now blocks the `mail.smtp.` / `mail.smtps.`
+prefix as well, so an external mail message can no longer inject these into a downstream exchange.
+
 == Upgrading from 4.18.0 to 4.18.1
 
 === camel-bom


### PR DESCRIPTION
## Summary

Doc-sync of the camel-mail `mail.smtp.*` / `mail.smtps.*` gating entry from `camel-4.18.x` onto `main`'s copy of `camel-4x-upgrade-guide-4_18.adoc`, per the project's backport upgrade-guide policy in `CLAUDE.md`:

> The `camel-4x-upgrade-guide-4_XX.adoc` files for ALL versions live on `main` and act as the canonical history across all releases. When a PR is backported to a maintenance branch and adds an upgrade-guide note for that release line, the corresponding entry must ALSO be added to the matching `camel-4x-upgrade-guide-4_XX.adoc` file on `main`.

This PR mirrors the entry added in #23381 (backport to `camel-4.18.x`) onto main, immediately after the existing `camel-neo4j` entry in the "Upgrading from 4.18.1 to 4.18.3" section.

## Linked

- Main PR: #23362 — CAMEL-23522: camel-mail - gate JavaMail session properties from headers behind opt-in (merged)
- Backport PR: #23381 — `[backport camel-4.18.x]` (open)
- Jira: https://issues.apache.org/jira/browse/CAMEL-23522
- Family precedent: CAMEL-23222 / CVE-2025-27636

## Test plan

- [x] Single docs file added; no code changes.
- [x] Identical wording to the same section on the `camel-4.18.x` branch.

---
_Claude Code on behalf of Andrea Cosentino_