### PR TITLE
chore: fail with clear error when script EIP has empty expression body

### DIFF
--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/ScriptReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/ScriptReifier.java
@@ -21,7 +21,9 @@ import org.apache.camel.Processor;
 import org.apache.camel.Route;
 import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.model.ScriptDefinition;
+import org.apache.camel.model.language.ExpressionDefinition;
 import org.apache.camel.processor.ScriptProcessor;
+import org.apache.camel.util.ObjectHelper;
 
 public class ScriptReifier extends ExpressionReifier<ScriptDefinition> {
 
@@ -31,7 +33,11 @@ public class ScriptReifier extends ExpressionReifier<ScriptDefinition> {
 
     @Override
     public Processor createProcessor() throws Exception {
-        Expression expr = createExpression(definition.getExpression());
+        ExpressionDefinition exp = definition.getExpression();
+        if (exp == null || ObjectHelper.isEmpty(exp.getExpression())) {
+            throw new IllegalArgumentException("Script has no script code configured in " + definition);
+        }
+        Expression expr = createExpression(exp);
         ScriptProcessor answer = new ScriptProcessor(expr);
         answer.setDisabled(isDisabled(camelContext, definition));
         return answer;


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Claus Ibsen_

When `camel-xml-io-dsl` parses a whitespace-only expression body (e.g., `<groovy>\n</groovy>`), the expression text ends up as `null`. At runtime, `GroovyLanguage.getScriptFromCache(null)` calls `ConcurrentHashMap.get(null)`, which throws an unhelpful `NullPointerException`.

This PR adds validation in `ScriptReifier.createProcessor()` to detect null/empty script code early and throw a clear `IllegalArgumentException` with the message: *"Script has no script code configured in ..."*

This is the intended behavior — an empty tag is regarded as null by `camel-xml-io-dsl` (by design), but the NPE error message was confusing.

Reported on Zulip: https://camel.zulipchat.com/#narrow/channel/257298-camel/topic/camel-xml-io.20drops.20whitespace-only.20expression.20bodies

## Changes

- `core/camel-core-reifier/src/main/java/org/apache/camel/reifier/ScriptReifier.java` — Added null/empty check on the expression definition before creating the runtime expression and processor

## Test plan

- [x] Full reactor build passes (`mvn clean install -DskipTests`)
- [x] Code formatting verified (`mvn formatter:format impsort:sort`)
- [ ] Verify with a route containing `<groovy></groovy>` that the error message is clear instead of NPE

🤖 Generated with [Claude Code](https://claude.com/claude-code)