### PR TITLE
chore: fix bundled example not loading application.properties

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -86,6 +86,12 @@ In addition to `http://` and `https://`, it also accepts `file://` URIs.
 Those may come in handy when cannot access the internet.
 Append `.json` to the resource path when you store it locally.
 
+The internal Maven downloader used by Camel JBang now defaults to preferring locally cached
+artifacts over remote ones (`preferLocal = true`). Previously the default was `false`, meaning
+the downloader would always check remote repositories first. With the new default, already-resolved
+artifacts in the local Maven repository are used directly without contacting remote repositories.
+Use `--fresh` to force re-downloading from remote repositories when needed.
+
 ==== camel-jbang-mcp
 
 The `camel_catalog_component_doc` tool no longer returns every component option by default. Two new

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -465,6 +465,9 @@ public class Run extends CamelCommand {
             name = eName;
         }
 
+        // use the temp dir as base so run() loads the example's application.properties
+        exportBaseDir = tempDir;
+
         if (!exportRun) {
             printConfigurationValues("Running integration with the following configuration:");
         }


### PR DESCRIPTION
## Summary

- When running `camel run --example groovy`, the example's `application.properties` was extracted to a temp directory but `profileProperties` was loaded from the current working directory (`.`), so `camel.jbang.dependencies` and other properties were never picked up by the runtime.
- Fixed by setting `exportBaseDir = tempDir` in `runBundledExample()` so `run()` uses the temp directory as `baseDir`, making `loadProfileProperties` find the correct `application.properties`.

## Test plan

- [x] Run `camel run --example groovy --verbose` and verify `commons-validator:commons-validator:1.10.1` is resolved and the example runs without errors
- [ ] Full reactor build passes (`mvn clean install -DskipTests`)

_Claude Code on behalf of Claus Ibsen_