### PR TITLE
CAMEL-23594: Fix property resolution issues in kamelet endpoint URIs

### DIFF
--- a/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/KameletComponent.java
+++ b/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/KameletComponent.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.kamelet;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -131,6 +133,18 @@ public class KameletComponent extends DefaultComponent {
         parameters.remove(PARAM_ROUTE_ID);
         parameters.remove(PARAM_LOCATION);
         parameters.remove(PARAM_UUID);
+
+        // URL-decode non-RAW parameter values. The YAML DSL URL-encodes property values
+        // when building query strings (via URISupport.createQueryString), but useRawUri=true
+        // prevents automatic decoding during URI parsing. Decode here so values like
+        // "application/json" are not left as "application%2Fjson".
+        for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+            if (entry.getValue() instanceof String s
+                    && !s.startsWith(URISupport.RAW_TOKEN_PREFIX + "(")
+                    && !s.startsWith(URISupport.RAW_TOKEN_PREFIX + "{")) {
+                entry.setValue(URLDecoder.decode(s, StandardCharsets.UTF_8));
+            }
+        }
 
         // manually need to resolve raw parameters as input to the kamelet because
         // resolveRawParameterValues is false

--- a/core/camel-base/src/main/java/org/apache/camel/component/properties/DefaultPropertiesParser.java
+++ b/core/camel-base/src/main/java/org/apache/camel/component/properties/DefaultPropertiesParser.java
@@ -514,7 +514,7 @@ public class DefaultPropertiesParser implements PropertiesParser {
             if (answer == null) {
                 answer = value;
             }
-            return answer;
+            return answer != null ? answer.trim() : null;
         }
     }
 


### PR DESCRIPTION
## Problem

Kamelet integration tests were failing due to two property resolution issues:

1. **Trailing whitespace in property values** — YAML literal block scalars (`|`) preserve trailing newlines, which cause `URISyntaxException` when the property value is resolved into an endpoint URI string.

2. **URL-encoded property values** — The YAML DSL uses `URISupport.createQueryString()` to build kamelet URIs, which URL-encodes property values (e.g., `application/json` → `application%2Fjson`). Since `KameletComponent` uses `useRawUri()=true` to preserve sensitive values, automatic URL-decoding during URI parsing is skipped, leaving encoded values like `application%2Fjson` to be passed to kamelet templates.

## Solution

### Fix 1: Trim whitespace in DefaultPropertiesParser

**File:** `core/camel-base/src/main/java/org/apache/camel/component/properties/DefaultPropertiesParser.java`

Added `.trim()` when returning resolved property values in `doGetPropertyValue()`. This strips leading/trailing whitespace, which is safe since no legitimate property value depends on surrounding whitespace.

### Fix 2: URL-decode kamelet parameters

**File:** `components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/KameletComponent.java`

Added URL-decoding for non-RAW string parameter values in `createEndpoint()`, between extraction and RAW resolution. This reverses the encoding done by `URISupport.createQueryString()` while preserving RAW-wrapped sensitive values (which use `RAW()` syntax and skip URL encoding).

## Testing

- ✅ All 91 property component tests pass (`org.apache.camel.component.properties.*Test`)
- ✅ All 81 kamelet component tests pass
- ✅ All 337 YAML DSL tests pass

These fixes resolve kamelet integration test failures where:
- Property values with trailing newlines caused `URISyntaxException`
- URL-encoded values like `application%2Fjson` were incorrectly passed as `Content-Type` headers, causing HTTP 415 errors

## Related Issues

CAMEL-23594