### PR TITLE
CAMEL-23593: Fix YAML dump for REST DSL and routeConfigurations

### DIFF
--- a/core/camel-yaml-io/src/main/java/org/apache/camel/yaml/io/YamlWriter.java
+++ b/core/camel-yaml-io/src/main/java/org/apache/camel/yaml/io/YamlWriter.java
@@ -228,6 +228,10 @@ public class YamlWriter extends ServiceSupport implements CamelContextAware {
                         && ("batchConfig".equals(name) || "streamConfig".equals(name))) {
                     // special for resequence
                     setMetadata(parent, "resequenceConfig", last);
+                } else if ("circuitBreaker".equals(parent.getName())
+                        && ("resilience4jConfiguration".equals(name)
+                                || "faultToleranceConfiguration".equals(name))) {
+                    setMetadata(parent, name, last);
                 } else if (parent.isOutput()) {
                     List<EipModel> list = (List<EipModel>) parent.getMetadata().get("_output");
                     if (list == null) {
@@ -356,6 +360,21 @@ public class YamlWriter extends ServiceSupport implements CamelContextAware {
                     node.addOutput(asNode(m));
                 }
             } else if ("resequence".equals(node.getName()) && "resequenceConfig".equals(key)) {
+                EipModel config = (EipModel) entry.getValue();
+                JsonObject jo = new JsonObject();
+                for (var o : config.getOptions()) {
+                    String n = o.getName();
+                    Object v = config.getMetadata().get(n);
+                    if (v != null) {
+                        jo.put(n, v);
+                    }
+                }
+                if (!jo.isEmpty()) {
+                    node.addProperty(config.getName(), jo);
+                }
+            } else if ("circuitBreaker".equals(node.getName())
+                    && ("resilience4jConfiguration".equals(key)
+                            || "faultToleranceConfiguration".equals(key))) {
                 EipModel config = (EipModel) entry.getValue();
                 JsonObject jo = new JsonObject();
                 for (var o : config.getOptions()) {

--- a/core/camel-yaml-io/src/main/java/org/apache/camel/yaml/io/YamlWriter.java
+++ b/core/camel-yaml-io/src/main/java/org/apache/camel/yaml/io/YamlWriter.java
@@ -106,8 +106,8 @@ public class YamlWriter extends ServiceSupport implements CamelContextAware {
     }
 
     public void startElement(String name) throws IOException {
-        if ("routes".equals(name) || "dataFormats".equals(name)) {
-            // special for routes or dataFormats
+        if ("routes".equals(name) || "rests".equals(name) || "routeConfigurations".equals(name)
+                || "dataFormats".equals(name)) {
             routesIsRoot = true;
             return;
         }
@@ -138,8 +138,8 @@ public class YamlWriter extends ServiceSupport implements CamelContextAware {
     }
 
     public void endElement(String name) throws IOException {
-        if ("routes".equals(name) || "dataFormats".equals(name)) {
-            // we are done
+        if ("routes".equals(name) || "rests".equals(name) || "routeConfigurations".equals(name)
+                || "dataFormats".equals(name)) {
             writer.write(toYaml());
             return;
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-validate/src/main/java/org/apache/camel/dsl/jbang/core/commands/validate/YamlNormalizeCommand.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-validate/src/main/java/org/apache/camel/dsl/jbang/core/commands/validate/YamlNormalizeCommand.java
@@ -26,6 +26,7 @@ import java.util.Stack;
 
 import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.MavenResolverMixin;
 import org.apache.camel.dsl.jbang.core.commands.Run;
 import org.apache.camel.dsl.jbang.core.common.CamelJBangConstants;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
@@ -40,6 +41,9 @@ import picocli.CommandLine;
 public class YamlNormalizeCommand extends CamelCommand {
 
     private static final String IGNORE_FILE = "application";
+
+    @CommandLine.Mixin
+    MavenResolverMixin mavenResolver;
 
     @CommandLine.Option(names = { "--output" },
                         description = "File or directory to write normalized output. If not specified, output is printed to console.")
@@ -86,6 +90,7 @@ public class YamlNormalizeCommand extends CamelCommand {
                 main.addInitialProperty("camel.language.bean.validate", "false");
             }
         };
+        run.mavenResolver = mavenResolver;
         run.files = matched;
         run.executionLimitOptions.maxSeconds = 1;
         Integer exit = run.runTransform(true);


### PR DESCRIPTION
## Summary

- Fix `YamlWriter` to recognize `rests` and `routeConfigurations` as root container elements alongside `routes` and `dataFormats`. Without this, the YAML dump produces empty objects like `rests: {}` or `routeConfigurations: {}`, which breaks `camel validate normalize` for files containing REST DSL or routeConfiguration blocks.
- Fix `YamlWriter` to place `resilience4jConfiguration` and `faultToleranceConfiguration` as direct properties of `circuitBreaker` instead of incorrectly putting them inside `steps`.
- Fix NPE in `YamlNormalizeCommand` by wiring up the `MavenResolverMixin` (needed after CAMEL-23560 changes to `Run.java`).

## Test plan

- [x] All 82 existing `camel-yaml-io` tests pass
- [x] `camel validate normalize` correctly normalizes REST DSL files
- [x] `camel validate normalize` correctly normalizes routeConfiguration files
- [x] `camel validate normalize` correctly normalizes circuitBreaker with resilience4j config
- [x] `camel validate normalize` still works for regular route files

_Claude Code on behalf of Claus Ibsen_