### PR TITLE
CAMEL-23572: camel-tui: Add F2 actions menu with example browser

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ActionsPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ActionsPopup.java
@@ -1,0 +1,475 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.tui;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.Clear;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.list.ListItem;
+import dev.tamboui.widgets.list.ListState;
+import dev.tamboui.widgets.list.ListWidget;
+import dev.tamboui.widgets.list.ScrollMode;
+import org.apache.camel.dsl.jbang.core.common.ExampleHelper;
+import org.apache.camel.dsl.jbang.core.common.LauncherHelper;
+import org.apache.camel.util.json.JsonObject;
+
+import static org.apache.camel.dsl.jbang.core.commands.tui.MonitorContext.hint;
+import static org.apache.camel.dsl.jbang.core.commands.tui.MonitorContext.hintLast;
+
+class ActionsPopup {
+
+    private boolean showActionsMenu;
+    private final ListState actionsMenuState = new ListState();
+
+    private boolean showExampleBrowser;
+    private final ListState exampleBrowserState = new ListState();
+    private List<JsonObject> exampleCatalog;
+
+    private final List<PendingLaunch> pendingLaunches = new ArrayList<>();
+    private String launchNotification;
+    private boolean launchNotificationError;
+    private long launchNotificationExpiry;
+
+    boolean isVisible() {
+        return showActionsMenu || showExampleBrowser;
+    }
+
+    void open() {
+        showActionsMenu = true;
+        actionsMenuState.select(0);
+    }
+
+    void close() {
+        showActionsMenu = false;
+        showExampleBrowser = false;
+    }
+
+    String notification() {
+        return launchNotification;
+    }
+
+    boolean notificationError() {
+        return launchNotificationError;
+    }
+
+    boolean handleKeyEvent(KeyEvent ke) {
+        if (showExampleBrowser) {
+            if (ke.isCancel()) {
+                showExampleBrowser = false;
+                showActionsMenu = true;
+            } else if (ke.isUp()) {
+                navigateExampleBrowser(-1);
+            } else if (ke.isDown()) {
+                navigateExampleBrowser(1);
+            } else if (ke.isPageUp() || ke.isKey(KeyCode.PAGE_UP)) {
+                navigateExampleBrowser(-10);
+            } else if (ke.isPageDown() || ke.isKey(KeyCode.PAGE_DOWN)) {
+                navigateExampleBrowser(10);
+            } else if (ke.isConfirm()) {
+                launchSelectedExample();
+            }
+            return true;
+        }
+        if (showActionsMenu) {
+            if (ke.isCancel()) {
+                showActionsMenu = false;
+            } else if (ke.isUp()) {
+                actionsMenuState.selectPrevious();
+            } else if (ke.isDown()) {
+                actionsMenuState.selectNext(1);
+            } else if (ke.isConfirm()) {
+                openExampleBrowser();
+            }
+            return true;
+        }
+        return false;
+    }
+
+    void render(Frame frame, Rect area) {
+        if (showActionsMenu) {
+            renderActionsMenu(frame, area);
+        }
+        if (showExampleBrowser) {
+            renderExampleBrowser(frame, area);
+        }
+    }
+
+    void renderFooter(List<Span> spans) {
+        if (showExampleBrowser) {
+            hint(spans, "↑↓", "navigate");
+            hint(spans, "Enter", "run");
+            hintLast(spans, "Esc", "back");
+            return;
+        }
+        if (showActionsMenu) {
+            hint(spans, "↑↓", "navigate");
+            hint(spans, "Enter", "select");
+            hintLast(spans, "Esc", "cancel");
+        }
+    }
+
+    void tick(long now) {
+        monitorPendingLaunches(now);
+        if (launchNotification != null && now > launchNotificationExpiry) {
+            launchNotification = null;
+        }
+    }
+
+    // ---- Rendering ----
+
+    private void renderActionsMenu(Frame frame, Rect area) {
+        int popupW = 32;
+        int popupH = 3;
+        int x = area.left() + Math.max(0, (area.width() - popupW) / 2);
+        int y = area.top() + Math.max(0, (area.height() - popupH) / 2);
+        Rect popup = new Rect(x, y, Math.min(popupW, area.width()), Math.min(popupH, area.height()));
+
+        frame.renderWidget(Clear.INSTANCE, popup);
+        ListWidget list = ListWidget.builder()
+                .items(ListItem.from("  Run an example..."))
+                .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
+                .highlightSymbol("")
+                .scrollMode(ScrollMode.NONE)
+                .block(Block.builder()
+                        .borderType(BorderType.ROUNDED)
+                        .title(" Actions ")
+                        .build())
+                .build();
+        frame.renderStatefulWidget(list, popup, actionsMenuState);
+    }
+
+    private void renderExampleBrowser(Frame frame, Rect area) {
+        if (exampleCatalog == null || exampleCatalog.isEmpty()) {
+            return;
+        }
+        int popupW = Math.min(100, area.width() - 4);
+        int popupH = Math.min(exampleCatalog.size() + 10, Math.min(28, area.height() - 4));
+        int x = area.left() + Math.max(0, (area.width() - popupW) / 2);
+        int y = area.top() + Math.max(0, (area.height() - popupH) / 2);
+        Rect popup = new Rect(x, y, Math.min(popupW, area.width()), Math.min(popupH, area.height()));
+
+        frame.renderWidget(Clear.INSTANCE, popup);
+
+        List<ListItem> items = buildExampleListItems(popupW - 4);
+        ListWidget list = ListWidget.builder()
+                .items(items.toArray(ListItem[]::new))
+                .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
+                .highlightSymbol("")
+                .scrollMode(ScrollMode.AUTO_SCROLL)
+                .block(Block.builder()
+                        .borderType(BorderType.ROUNDED)
+                        .title(" Run an Example (" + exampleCatalog.size() + ") ")
+                        .build())
+                .build();
+        frame.renderStatefulWidget(list, popup, exampleBrowserState);
+    }
+
+    private List<ListItem> buildExampleListItems(int width) {
+        List<ListItem> items = new ArrayList<>();
+        String currentLevel = null;
+        for (JsonObject ex : exampleCatalog) {
+            String level = ex.getStringOrDefault("level", "beginner");
+            if (!level.equals(currentLevel)) {
+                currentLevel = level;
+                String header = "── " + capitalize(level) + " ──";
+                items.add(ListItem.from(header).style(Style.EMPTY.dim()));
+            }
+            String name = ex.getStringOrDefault("name", "");
+            String desc = ex.getStringOrDefault("description", "");
+            boolean docker = ExampleHelper.requiresDocker(ex);
+            boolean bundled = ExampleHelper.isBundled(ex);
+
+            String icons = (bundled ? "📦" : "🌐") + (docker ? "🐳" : "  ");
+            int nameCol = Math.min(30, width / 3);
+            String padded = String.format("%-" + nameCol + "s", TuiHelper.truncate(name, nameCol));
+            String prefix = " " + icons + " " + padded + " ";
+            int descCol = Math.max(10, width - prefix.length());
+
+            Style style = bundled ? Style.EMPTY : Style.EMPTY.dim();
+            if (desc.length() <= descCol) {
+                items.add(ListItem.from(prefix + desc).style(style));
+            } else {
+                String indent = " ".repeat(prefix.length());
+                List<Line> lines = new ArrayList<>();
+                List<String> wrapped = wrapWords(desc, descCol);
+                lines.add(Line.from(prefix + wrapped.get(0)));
+                for (int w = 1; w < wrapped.size(); w++) {
+                    lines.add(Line.from(indent + wrapped.get(w)));
+                }
+                items.add(ListItem.from(Text.from(lines.toArray(Line[]::new))).style(style));
+            }
+        }
+        items.add(ListItem.from(""));
+        items.add(ListItem.from(" 📦 = bundled (offline)  🌐 = online (GitHub)  🐳 = Docker")
+                .style(Style.EMPTY.dim()));
+        return items;
+    }
+
+    // ---- Example Browser Navigation ----
+
+    private void openExampleBrowser() {
+        showActionsMenu = false;
+        if (exampleCatalog == null) {
+            exampleCatalog = loadAndSortExamples();
+        }
+        if (exampleCatalog.isEmpty()) {
+            launchNotification = "No examples found";
+            launchNotificationError = true;
+            launchNotificationExpiry = System.currentTimeMillis() + 5000;
+            return;
+        }
+        showExampleBrowser = true;
+        exampleBrowserState.select(1);
+    }
+
+    private List<JsonObject> loadAndSortExamples() {
+        List<JsonObject> catalog = ExampleHelper.loadCatalog();
+        catalog.sort((a, b) -> {
+            int la = levelOrder(a.getStringOrDefault("level", "beginner"));
+            int lb = levelOrder(b.getStringOrDefault("level", "beginner"));
+            if (la != lb) {
+                return Integer.compare(la, lb);
+            }
+            return a.getStringOrDefault("name", "").compareTo(b.getStringOrDefault("name", ""));
+        });
+        return catalog;
+    }
+
+    private static int levelOrder(String level) {
+        return switch (level) {
+            case "beginner" -> 0;
+            case "intermediate" -> 1;
+            case "advanced" -> 2;
+            default -> 3;
+        };
+    }
+
+    private void navigateExampleBrowser(int direction) {
+        if (exampleCatalog == null || exampleCatalog.isEmpty()) {
+            return;
+        }
+        int totalItems = countExampleListItems();
+        Integer current = exampleBrowserState.selected();
+        if (current == null) {
+            current = 0;
+        }
+        int next = current + direction;
+        if (next < 0) {
+            next = 0;
+        }
+        if (next >= totalItems) {
+            next = totalItems - 1;
+        }
+        while (isSeparatorIndex(next) && next > 0 && next < totalItems - 1) {
+            next += direction;
+        }
+        if (next < 0) {
+            next = 0;
+        }
+        if (next >= totalItems) {
+            next = totalItems - 1;
+        }
+        if (isSeparatorIndex(next)) {
+            return;
+        }
+        exampleBrowserState.select(next);
+    }
+
+    private int countExampleListItems() {
+        if (exampleCatalog == null) {
+            return 0;
+        }
+        int count = 0;
+        String currentLevel = null;
+        for (JsonObject ex : exampleCatalog) {
+            String level = ex.getStringOrDefault("level", "beginner");
+            if (!level.equals(currentLevel)) {
+                currentLevel = level;
+                count++;
+            }
+            count++;
+        }
+        return count + 2;
+    }
+
+    private boolean isSeparatorIndex(int index) {
+        if (exampleCatalog == null) {
+            return false;
+        }
+        int pos = 0;
+        String currentLevel = null;
+        for (JsonObject ex : exampleCatalog) {
+            String level = ex.getStringOrDefault("level", "beginner");
+            if (!level.equals(currentLevel)) {
+                currentLevel = level;
+                if (pos == index) {
+                    return true;
+                }
+                pos++;
+            }
+            if (pos == index) {
+                return false;
+            }
+            pos++;
+        }
+        return true;
+    }
+
+    private JsonObject getExampleAtListIndex(int index) {
+        if (exampleCatalog == null) {
+            return null;
+        }
+        int pos = 0;
+        String currentLevel = null;
+        for (JsonObject ex : exampleCatalog) {
+            String level = ex.getStringOrDefault("level", "beginner");
+            if (!level.equals(currentLevel)) {
+                currentLevel = level;
+                pos++;
+            }
+            if (pos == index) {
+                return ex;
+            }
+            pos++;
+        }
+        return null;
+    }
+
+    // ---- Process Launch & Monitoring ----
+
+    private void launchSelectedExample() {
+        Integer sel = exampleBrowserState.selected();
+        if (sel == null || isSeparatorIndex(sel)) {
+            return;
+        }
+        JsonObject example = getExampleAtListIndex(sel);
+        if (example == null) {
+            return;
+        }
+        String exampleName = example.getStringOrDefault("name", "");
+        showExampleBrowser = false;
+        try {
+            List<String> cmd = new ArrayList<>(LauncherHelper.getCamelCommand());
+            cmd.add("run");
+            cmd.add("--example=" + exampleName);
+            Path outputFile = Files.createTempFile("camel-example-", ".log");
+            outputFile.toFile().deleteOnExit();
+            ProcessBuilder pb = new ProcessBuilder(cmd);
+            pb.redirectErrorStream(true);
+            pb.redirectOutput(outputFile.toFile());
+            Process process = pb.start();
+            pendingLaunches.add(new PendingLaunch(exampleName, process, outputFile, System.currentTimeMillis()));
+            launchNotification = "Starting: " + exampleName;
+            launchNotificationError = false;
+            launchNotificationExpiry = System.currentTimeMillis() + 5000;
+        } catch (Exception e) {
+            launchNotification = "Failed to start: " + exampleName + " - " + e.getMessage();
+            launchNotificationError = true;
+            launchNotificationExpiry = System.currentTimeMillis() + 10000;
+        }
+    }
+
+    private void monitorPendingLaunches(long now) {
+        Iterator<PendingLaunch> it = pendingLaunches.iterator();
+        while (it.hasNext()) {
+            PendingLaunch pl = it.next();
+            if (!pl.process().isAlive()) {
+                int exitCode = pl.process().exitValue();
+                if (exitCode == 0) {
+                    launchNotification = "Started: " + pl.name();
+                    launchNotificationError = false;
+                    launchNotificationExpiry = now + 5000;
+                } else {
+                    String detail = readFirstLine(pl.outputFile());
+                    launchNotification = "Failed: " + pl.name()
+                                         + (detail != null ? " - " + detail : "");
+                    launchNotificationError = true;
+                    launchNotificationExpiry = now + 10000;
+                }
+                it.remove();
+            } else if (now - pl.startTime() > 8000) {
+                launchNotification = "Started: " + pl.name();
+                launchNotificationError = false;
+                launchNotificationExpiry = now + 5000;
+                it.remove();
+            }
+        }
+    }
+
+    // ---- Utilities ----
+
+    private static String readFirstLine(Path file) {
+        try {
+            List<String> lines = Files.readAllLines(file);
+            for (String line : lines) {
+                String trimmed = line.trim();
+                if (!trimmed.isEmpty()) {
+                    return TuiHelper.truncate(trimmed, 60);
+                }
+            }
+        } catch (IOException e) {
+            // ignore
+        }
+        return null;
+    }
+
+    private static String capitalize(String s) {
+        if (s == null || s.isEmpty()) {
+            return s;
+        }
+        return Character.toUpperCase(s.charAt(0)) + s.substring(1);
+    }
+
+    private static List<String> wrapWords(String text, int maxWidth) {
+        List<String> lines = new ArrayList<>();
+        StringBuilder line = new StringBuilder();
+        for (String word : text.split(" ")) {
+            if (line.isEmpty()) {
+                line.append(word);
+            } else if (line.length() + 1 + word.length() <= maxWidth) {
+                line.append(' ').append(word);
+            } else {
+                lines.add(line.toString());
+                line.setLength(0);
+                line.append(word);
+            }
+        }
+        if (!line.isEmpty()) {
+            lines.add(line.toString());
+        }
+        return lines;
+    }
+
+    private record PendingLaunch(String name, Process process, Path outputFile, long startTime) {
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ActionsPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ActionsPopup.java
@@ -22,6 +22,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
 
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
@@ -35,10 +37,14 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Title;
+import dev.tamboui.widgets.input.TextInput;
+import dev.tamboui.widgets.input.TextInputState;
 import dev.tamboui.widgets.list.ListItem;
 import dev.tamboui.widgets.list.ListState;
 import dev.tamboui.widgets.list.ListWidget;
 import dev.tamboui.widgets.list.ScrollMode;
+import dev.tamboui.widgets.paragraph.Paragraph;
 import org.apache.camel.dsl.jbang.core.common.ExampleHelper;
 import org.apache.camel.dsl.jbang.core.common.LauncherHelper;
 import org.apache.camel.util.json.JsonObject;
@@ -48,6 +54,8 @@ import static org.apache.camel.dsl.jbang.core.commands.tui.MonitorContext.hintLa
 
 class ActionsPopup {
 
+    private final Supplier<Set<String>> runningNames;
+
     private boolean showActionsMenu;
     private final ListState actionsMenuState = new ListState();
 
@@ -55,13 +63,21 @@ class ActionsPopup {
     private final ListState exampleBrowserState = new ListState();
     private List<JsonObject> exampleCatalog;
 
+    private boolean showNameInput;
+    private TextInputState nameInputState;
+    private JsonObject selectedExample;
+
     private final List<PendingLaunch> pendingLaunches = new ArrayList<>();
     private String launchNotification;
     private boolean launchNotificationError;
     private long launchNotificationExpiry;
 
+    ActionsPopup(Supplier<Set<String>> runningNames) {
+        this.runningNames = runningNames;
+    }
+
     boolean isVisible() {
-        return showActionsMenu || showExampleBrowser;
+        return showActionsMenu || showExampleBrowser || showNameInput;
     }
 
     void open() {
@@ -72,6 +88,7 @@ class ActionsPopup {
     void close() {
         showActionsMenu = false;
         showExampleBrowser = false;
+        showNameInput = false;
     }
 
     String notification() {
@@ -83,6 +100,29 @@ class ActionsPopup {
     }
 
     boolean handleKeyEvent(KeyEvent ke) {
+        if (showNameInput) {
+            if (ke.isCancel()) {
+                showNameInput = false;
+                showExampleBrowser = true;
+            } else if (ke.isConfirm()) {
+                launchWithName();
+            } else if (ke.isDeleteBackward()) {
+                nameInputState.deleteBackward();
+            } else if (ke.isDeleteForward()) {
+                nameInputState.deleteForward();
+            } else if (ke.isLeft()) {
+                nameInputState.moveCursorLeft();
+            } else if (ke.isRight()) {
+                nameInputState.moveCursorRight();
+            } else if (ke.isHome()) {
+                nameInputState.moveCursorToStart();
+            } else if (ke.isEnd()) {
+                nameInputState.moveCursorToEnd();
+            } else if (ke.code() == KeyCode.CHAR) {
+                nameInputState.insert(ke.character());
+            }
+            return true;
+        }
         if (showExampleBrowser) {
             if (ke.isCancel()) {
                 showExampleBrowser = false;
@@ -95,6 +135,8 @@ class ActionsPopup {
                 navigateExampleBrowser(-10);
             } else if (ke.isPageDown() || ke.isKey(KeyCode.PAGE_DOWN)) {
                 navigateExampleBrowser(10);
+            } else if (ke.isChar('r')) {
+                openNameInput();
             } else if (ke.isConfirm()) {
                 launchSelectedExample();
             }
@@ -122,12 +164,21 @@ class ActionsPopup {
         if (showExampleBrowser) {
             renderExampleBrowser(frame, area);
         }
+        if (showNameInput) {
+            renderNameInput(frame, area);
+        }
     }
 
     void renderFooter(List<Span> spans) {
+        if (showNameInput) {
+            hint(spans, "Enter", "launch");
+            hintLast(spans, "Esc", "back");
+            return;
+        }
         if (showExampleBrowser) {
             hint(spans, "↑↓", "navigate");
             hint(spans, "Enter", "run");
+            hint(spans, "n", "name");
             hintLast(spans, "Esc", "back");
             return;
         }
@@ -173,7 +224,7 @@ class ActionsPopup {
             return;
         }
         int popupW = Math.min(100, area.width() - 4);
-        int popupH = Math.min(exampleCatalog.size() + 10, Math.min(28, area.height() - 4));
+        int popupH = Math.min(exampleCatalog.size() + 10, Math.min(22, area.height() - 6));
         int x = area.left() + Math.max(0, (area.width() - popupW) / 2);
         int y = area.top() + Math.max(0, (area.height() - popupH) / 2);
         Rect popup = new Rect(x, y, Math.min(popupW, area.width()), Math.min(popupH, area.height()));
@@ -189,6 +240,11 @@ class ActionsPopup {
                 .block(Block.builder()
                         .borderType(BorderType.ROUNDED)
                         .title(" Run an Example (" + exampleCatalog.size() + ") ")
+                        .titleBottom(Title.from(Line.from(
+                                Span.styled(" Enter", MonitorContext.HINT_KEY_STYLE), Span.raw(" run │"),
+                                Span.styled(" r", MonitorContext.HINT_KEY_STYLE), Span.raw(" run... │"),
+                                Span.styled(" ↑↓", MonitorContext.HINT_KEY_STYLE), Span.raw(" navigate │"),
+                                Span.styled(" Esc", MonitorContext.HINT_KEY_STYLE), Span.raw(" back "))))
                         .build())
                 .build();
         frame.renderStatefulWidget(list, popup, exampleBrowserState);
@@ -233,6 +289,99 @@ class ActionsPopup {
         items.add(ListItem.from(" 📦 = bundled (offline)  🌐 = online (GitHub)  🐳 = Docker")
                 .style(Style.EMPTY.dim()));
         return items;
+    }
+
+    private void renderNameInput(Frame frame, Rect area) {
+        int popupW = Math.min(50, area.width() - 4);
+        int popupH = 4;
+        int x = area.left() + Math.max(0, (area.width() - popupW) / 2);
+        int y = area.top() + Math.max(0, (area.height() - popupH) / 2);
+        Rect popup = new Rect(x, y, Math.min(popupW, area.width()), Math.min(popupH, area.height()));
+
+        frame.renderWidget(Clear.INSTANCE, popup);
+
+        Block block = Block.builder()
+                .borderType(BorderType.ROUNDED)
+                .title(" Name ")
+                .titleBottom(Title.from(Line.from(
+                        Span.styled(" Enter", MonitorContext.HINT_KEY_STYLE), Span.raw(" launch │"),
+                        Span.styled(" Esc", MonitorContext.HINT_KEY_STYLE), Span.raw(" back "))))
+                .build();
+        frame.renderWidget(block, popup);
+
+        Rect inner = new Rect(popup.left() + 2, popup.top() + 1, popup.width() - 4, 1);
+        frame.renderWidget(Paragraph.from(Line.from(
+                Span.styled("Name for the integration:", Style.EMPTY.dim()))), inner);
+
+        Rect inputArea = new Rect(popup.left() + 2, popup.top() + 2, popup.width() - 4, 1);
+        TextInput textInput = TextInput.builder()
+                .cursorStyle(Style.EMPTY.reversed())
+                .build();
+        frame.renderStatefulWidget(textInput, inputArea, nameInputState);
+    }
+
+    // ---- Name Input ----
+
+    private void openNameInput() {
+        Integer sel = exampleBrowserState.selected();
+        if (sel == null || isSeparatorIndex(sel)) {
+            return;
+        }
+        JsonObject example = getExampleAtListIndex(sel);
+        if (example == null) {
+            return;
+        }
+        selectedExample = example;
+        String baseName = example.getStringOrDefault("name", "");
+        String autoName = generateUniqueName(baseName);
+        showExampleBrowser = false;
+        showNameInput = true;
+        nameInputState = new TextInputState(autoName);
+    }
+
+    private String generateUniqueName(String baseName) {
+        Set<String> names = runningNames.get();
+        if (!names.contains(baseName)) {
+            return baseName;
+        }
+        for (int i = 2;; i++) {
+            String candidate = baseName + i;
+            if (!names.contains(candidate)) {
+                return candidate;
+            }
+        }
+    }
+
+    private void launchWithName() {
+        if (selectedExample == null || nameInputState == null) {
+            return;
+        }
+        String customName = nameInputState.text().trim();
+        String exampleName = selectedExample.getStringOrDefault("name", "");
+        showNameInput = false;
+        try {
+            List<String> cmd = new ArrayList<>(LauncherHelper.getCamelCommand());
+            cmd.add("run");
+            cmd.add("--example=" + exampleName);
+            if (!customName.isEmpty() && !customName.equals(exampleName)) {
+                cmd.add("--name=" + customName);
+            }
+            Path outputFile = Files.createTempFile("camel-example-", ".log");
+            outputFile.toFile().deleteOnExit();
+            ProcessBuilder pb = new ProcessBuilder(cmd);
+            pb.redirectErrorStream(true);
+            pb.redirectOutput(outputFile.toFile());
+            Process process = pb.start();
+            String displayName = customName.isEmpty() ? exampleName : customName;
+            pendingLaunches.add(new PendingLaunch(displayName, process, outputFile, System.currentTimeMillis()));
+            launchNotification = "Starting: " + displayName;
+            launchNotificationError = false;
+            launchNotificationExpiry = System.currentTimeMillis() + 5000;
+        } catch (Exception e) {
+            launchNotification = "Failed to start: " + exampleName + " - " + e.getMessage();
+            launchNotificationError = true;
+            launchNotificationExpiry = System.currentTimeMillis() + 10000;
+        }
     }
 
     // ---- Example Browser Navigation ----

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -298,6 +298,10 @@ public class CamelMonitor extends CamelCommand {
                     navigateExampleBrowser(-1);
                 } else if (ke.isDown()) {
                     navigateExampleBrowser(1);
+                } else if (ke.isPageUp() || ke.isKey(KeyCode.PAGE_UP)) {
+                    navigateExampleBrowser(-10);
+                } else if (ke.isPageDown() || ke.isKey(KeyCode.PAGE_DOWN)) {
+                    navigateExampleBrowser(10);
                 } else if (ke.isConfirm()) {
                     launchSelectedExample();
                 }
@@ -1527,8 +1531,8 @@ public class CamelMonitor extends CamelCommand {
         if (exampleCatalog == null || exampleCatalog.isEmpty()) {
             return;
         }
-        int popupW = Math.min(80, area.width() - 4);
-        int popupH = Math.min(exampleCatalog.size() + 5, Math.min(24, area.height() - 4));
+        int popupW = Math.min(100, area.width() - 4);
+        int popupH = Math.min(exampleCatalog.size() + 10, Math.min(28, area.height() - 4));
         int x = area.left() + Math.max(0, (area.width() - popupW) / 2);
         int y = area.top() + Math.max(0, (area.height() - popupH) / 2);
         Rect popup = new Rect(x, y, Math.min(popupW, area.width()), Math.min(popupH, area.height()));
@@ -1540,7 +1544,7 @@ public class CamelMonitor extends CamelCommand {
                 .items(items.toArray(ListItem[]::new))
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSymbol("")
-                .scrollMode(ScrollMode.NONE)
+                .scrollMode(ScrollMode.AUTO_SCROLL)
                 .block(Block.builder()
                         .borderType(BorderType.ROUNDED)
                         .title(" Run an Example (" + exampleCatalog.size() + ") ")
@@ -1561,18 +1565,32 @@ public class CamelMonitor extends CamelCommand {
             }
             String name = ex.getStringOrDefault("name", "");
             String desc = ex.getStringOrDefault("description", "");
-            boolean docker = Boolean.TRUE.equals(ex.get("requiresDocker"));
-            boolean bundled = Boolean.TRUE.equals(ex.get("bundled"));
+            boolean docker = ExampleHelper.requiresDocker(ex);
+            boolean bundled = ExampleHelper.isBundled(ex);
 
-            String tag = docker ? " [docker]" : "";
-            int nameCol = Math.min(28, width / 3);
-            String padded = String.format("  %-" + nameCol + "s", TuiHelper.truncate(name + tag, nameCol));
-            int remaining = Math.max(10, width - padded.length() - 1);
-            String line = padded + " " + TuiHelper.truncate(desc, remaining);
+            String icons = (bundled ? "📦" : "🌐") + (docker ? "🐳" : "  ");
+            int nameCol = Math.min(30, width / 3);
+            String padded = String.format("%-" + nameCol + "s", TuiHelper.truncate(name, nameCol));
+            String prefix = " " + icons + " " + padded + " ";
+            int descCol = Math.max(10, width - prefix.length());
 
             Style style = bundled ? Style.EMPTY : Style.EMPTY.dim();
-            items.add(ListItem.from(line).style(style));
+            if (desc.length() <= descCol) {
+                items.add(ListItem.from(prefix + desc).style(style));
+            } else {
+                String indent = " ".repeat(prefix.length());
+                List<Line> lines = new ArrayList<>();
+                List<String> wrapped = wrapWords(desc, descCol);
+                lines.add(Line.from(prefix + wrapped.get(0)));
+                for (int w = 1; w < wrapped.size(); w++) {
+                    lines.add(Line.from(indent + wrapped.get(w)));
+                }
+                items.add(ListItem.from(Text.from(lines.toArray(Line[]::new))).style(style));
+            }
         }
+        items.add(ListItem.from(""));
+        items.add(ListItem.from(" 📦 = bundled (offline)  🌐 = online (GitHub)  🐳 = Docker")
+                .style(Style.EMPTY.dim()));
         return items;
     }
 
@@ -1581,6 +1599,26 @@ public class CamelMonitor extends CamelCommand {
             return s;
         }
         return Character.toUpperCase(s.charAt(0)) + s.substring(1);
+    }
+
+    private static List<String> wrapWords(String text, int maxWidth) {
+        List<String> lines = new ArrayList<>();
+        StringBuilder line = new StringBuilder();
+        for (String word : text.split(" ")) {
+            if (line.isEmpty()) {
+                line.append(word);
+            } else if (line.length() + 1 + word.length() <= maxWidth) {
+                line.append(' ').append(word);
+            } else {
+                lines.add(line.toString());
+                line.setLength(0);
+                line.append(word);
+            }
+        }
+        if (!line.isEmpty()) {
+            lines.add(line.toString());
+        }
+        return lines;
     }
 
     private void openExampleBrowser() {
@@ -1636,14 +1674,17 @@ public class CamelMonitor extends CamelCommand {
         if (next >= totalItems) {
             next = totalItems - 1;
         }
-        if (isSeparatorIndex(next)) {
+        while (isSeparatorIndex(next) && next > 0 && next < totalItems - 1) {
             next += direction;
-            if (next < 0) {
-                next = 0;
-            }
-            if (next >= totalItems) {
-                next = totalItems - 1;
-            }
+        }
+        if (next < 0) {
+            next = 0;
+        }
+        if (next >= totalItems) {
+            next = totalItems - 1;
+        }
+        if (isSeparatorIndex(next)) {
+            return;
         }
         exampleBrowserState.select(next);
     }
@@ -1662,7 +1703,7 @@ public class CamelMonitor extends CamelCommand {
             }
             count++;
         }
-        return count;
+        return count + 2;
     }
 
     private boolean isSeparatorIndex(int index) {
@@ -1685,7 +1726,7 @@ public class CamelMonitor extends CamelCommand {
             }
             pos++;
         }
-        return false;
+        return true;
     }
 
     private JsonObject getExampleAtListIndex(int index) {
@@ -1809,6 +1850,7 @@ public class CamelMonitor extends CamelCommand {
             return;
         }
         hint(spans, "q", "quit");
+        hint(spans, "F2", "actions");
         if (ctx.selectedPid != null) {
             hint(spans, "Esc", ctx.infraTableFocused ? "integrations" : "unselect");
         }
@@ -1834,7 +1876,6 @@ public class CamelMonitor extends CamelCommand {
             hint(spans, "x", "stop");
             hint(spans, "X", "kill");
         }
-        hint(spans, "F2", "actions");
         hint(spans, isInfraSelected() ? "1-2" : "1-9", "tabs");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -193,7 +193,11 @@ public class CamelMonitor extends CamelCommand {
     private volatile long lastRefresh;
     private boolean showKillConfirm;
 
-    private final ActionsPopup actionsPopup = new ActionsPopup();
+    private final ActionsPopup actionsPopup = new ActionsPopup(
+            () -> data.get().stream()
+                    .filter(i -> !i.vanishing && i.name != null)
+                    .map(i -> i.name)
+                    .collect(Collectors.toSet()));
 
     private final AtomicBoolean refreshInProgress = new AtomicBoolean(false);
     private TuiRunner runner;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -62,6 +62,10 @@ import dev.tamboui.widgets.barchart.BarGroup;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.block.Title;
+import dev.tamboui.widgets.list.ListItem;
+import dev.tamboui.widgets.list.ListState;
+import dev.tamboui.widgets.list.ListWidget;
+import dev.tamboui.widgets.list.ScrollMode;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
@@ -72,6 +76,8 @@ import dev.tamboui.widgets.tabs.TabsState;
 import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
+import org.apache.camel.dsl.jbang.core.common.ExampleHelper;
+import org.apache.camel.dsl.jbang.core.common.LauncherHelper;
 import org.apache.camel.dsl.jbang.core.common.PathUtils;
 import org.apache.camel.dsl.jbang.core.common.ProcessHelper;
 import org.apache.camel.dsl.jbang.core.common.VersionHelper;
@@ -193,6 +199,19 @@ public class CamelMonitor extends CamelCommand {
     private volatile long lastRefresh;
     private boolean showKillConfirm;
 
+    // F2 actions menu
+    private boolean showActionsMenu;
+    private final ListState actionsMenuState = new ListState();
+    // Example browser
+    private boolean showExampleBrowser;
+    private final ListState exampleBrowserState = new ListState();
+    private List<JsonObject> exampleCatalog;
+    // Async example launches
+    private final List<PendingLaunch> pendingLaunches = new ArrayList<>();
+    private String launchNotification;
+    private boolean launchNotificationError;
+    private long launchNotificationExpiry;
+
     private final AtomicBoolean refreshInProgress = new AtomicBoolean(false);
     private TuiRunner runner;
 
@@ -270,6 +289,33 @@ public class CamelMonitor extends CamelCommand {
 
     private boolean handleEvent(Event event, TuiRunner runner) {
         if (event instanceof KeyEvent ke) {
+            // Example browser popup
+            if (showExampleBrowser) {
+                if (ke.isCancel()) {
+                    showExampleBrowser = false;
+                    showActionsMenu = true;
+                } else if (ke.isUp()) {
+                    navigateExampleBrowser(-1);
+                } else if (ke.isDown()) {
+                    navigateExampleBrowser(1);
+                } else if (ke.isConfirm()) {
+                    launchSelectedExample();
+                }
+                return true;
+            }
+            // Actions menu popup
+            if (showActionsMenu) {
+                if (ke.isCancel()) {
+                    showActionsMenu = false;
+                } else if (ke.isUp()) {
+                    actionsMenuState.selectPrevious();
+                } else if (ke.isDown()) {
+                    actionsMenuState.selectNext(1);
+                } else if (ke.isConfirm()) {
+                    openExampleBrowser();
+                }
+                return true;
+            }
             // Kill confirm dialog: Enter to confirm, Esc/any other key to cancel
             if (showKillConfirm) {
                 if (ke.isConfirm()) {
@@ -481,6 +527,12 @@ public class CamelMonitor extends CamelCommand {
                 showKillConfirm = true;
                 return true;
             }
+            // Overview tab: F2 opens actions menu
+            if (tab == TAB_OVERVIEW && ke.isKey(KeyCode.F2)) {
+                showActionsMenu = true;
+                actionsMenuState.select(0);
+                return true;
+            }
 
             // Delegate remaining keys to active tab
             if (activeTab != null && activeTab.handleKeyEvent(ke)) {
@@ -489,6 +541,10 @@ public class CamelMonitor extends CamelCommand {
         }
         if (event instanceof TickEvent) {
             long now = System.currentTimeMillis();
+            monitorPendingLaunches(now);
+            if (launchNotification != null && now > launchNotificationExpiry) {
+                launchNotification = null;
+            }
             long interval = routesTab.isShowDiagram() ? Math.max(refreshInterval, 1000) : refreshInterval;
             if (now - lastRefresh >= interval) {
                 refreshData();
@@ -634,6 +690,12 @@ public class CamelMonitor extends CamelCommand {
         if (showKillConfirm) {
             renderKillConfirm(frame, mainChunks.get(4));
         }
+        if (showActionsMenu) {
+            renderActionsMenu(frame, mainChunks.get(4));
+        }
+        if (showExampleBrowser) {
+            renderExampleBrowser(frame, mainChunks.get(4));
+        }
         renderFooter(frame, mainChunks.get(5));
     }
 
@@ -661,6 +723,11 @@ public class CamelMonitor extends CamelCommand {
             } else {
                 titleSpans.add(Span.styled("selected: " + selectedName(), Style.EMPTY.fg(Color.YELLOW)));
             }
+        }
+        if (launchNotification != null) {
+            titleSpans.add(Span.raw("  "));
+            Style style = launchNotificationError ? Style.EMPTY.fg(Color.RED) : Style.EMPTY.fg(Color.GREEN);
+            titleSpans.add(Span.styled(launchNotification, style));
         }
         Line titleLine = Line.from(titleSpans);
 
@@ -1433,6 +1500,288 @@ public class CamelMonitor extends CamelCommand {
                 inner);
     }
 
+    // ---- Actions Menu / Example Browser ----
+
+    private void renderActionsMenu(Frame frame, Rect area) {
+        int popupW = 32;
+        int popupH = 3;
+        int x = area.left() + Math.max(0, (area.width() - popupW) / 2);
+        int y = area.top() + Math.max(0, (area.height() - popupH) / 2);
+        Rect popup = new Rect(x, y, Math.min(popupW, area.width()), Math.min(popupH, area.height()));
+
+        frame.renderWidget(Clear.INSTANCE, popup);
+        ListWidget list = ListWidget.builder()
+                .items(ListItem.from("  Run an example..."))
+                .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
+                .highlightSymbol("")
+                .scrollMode(ScrollMode.NONE)
+                .block(Block.builder()
+                        .borderType(BorderType.ROUNDED)
+                        .title(" Actions ")
+                        .build())
+                .build();
+        frame.renderStatefulWidget(list, popup, actionsMenuState);
+    }
+
+    private void renderExampleBrowser(Frame frame, Rect area) {
+        if (exampleCatalog == null || exampleCatalog.isEmpty()) {
+            return;
+        }
+        int popupW = Math.min(80, area.width() - 4);
+        int popupH = Math.min(exampleCatalog.size() + 5, Math.min(24, area.height() - 4));
+        int x = area.left() + Math.max(0, (area.width() - popupW) / 2);
+        int y = area.top() + Math.max(0, (area.height() - popupH) / 2);
+        Rect popup = new Rect(x, y, Math.min(popupW, area.width()), Math.min(popupH, area.height()));
+
+        frame.renderWidget(Clear.INSTANCE, popup);
+
+        List<ListItem> items = buildExampleListItems(popupW - 4);
+        ListWidget list = ListWidget.builder()
+                .items(items.toArray(ListItem[]::new))
+                .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
+                .highlightSymbol("")
+                .scrollMode(ScrollMode.NONE)
+                .block(Block.builder()
+                        .borderType(BorderType.ROUNDED)
+                        .title(" Run an Example (" + exampleCatalog.size() + ") ")
+                        .build())
+                .build();
+        frame.renderStatefulWidget(list, popup, exampleBrowserState);
+    }
+
+    private List<ListItem> buildExampleListItems(int width) {
+        List<ListItem> items = new ArrayList<>();
+        String currentLevel = null;
+        for (JsonObject ex : exampleCatalog) {
+            String level = ex.getStringOrDefault("level", "beginner");
+            if (!level.equals(currentLevel)) {
+                currentLevel = level;
+                String header = "── " + capitalize(level) + " ──";
+                items.add(ListItem.from(header).style(Style.EMPTY.dim()));
+            }
+            String name = ex.getStringOrDefault("name", "");
+            String desc = ex.getStringOrDefault("description", "");
+            boolean docker = Boolean.TRUE.equals(ex.get("requiresDocker"));
+            boolean bundled = Boolean.TRUE.equals(ex.get("bundled"));
+
+            String tag = docker ? " [docker]" : "";
+            int nameCol = Math.min(28, width / 3);
+            String padded = String.format("  %-" + nameCol + "s", TuiHelper.truncate(name + tag, nameCol));
+            int remaining = Math.max(10, width - padded.length() - 1);
+            String line = padded + " " + TuiHelper.truncate(desc, remaining);
+
+            Style style = bundled ? Style.EMPTY : Style.EMPTY.dim();
+            items.add(ListItem.from(line).style(style));
+        }
+        return items;
+    }
+
+    private static String capitalize(String s) {
+        if (s == null || s.isEmpty()) {
+            return s;
+        }
+        return Character.toUpperCase(s.charAt(0)) + s.substring(1);
+    }
+
+    private void openExampleBrowser() {
+        showActionsMenu = false;
+        if (exampleCatalog == null) {
+            exampleCatalog = loadAndSortExamples();
+        }
+        if (exampleCatalog.isEmpty()) {
+            launchNotification = "No examples found";
+            launchNotificationError = true;
+            launchNotificationExpiry = System.currentTimeMillis() + 5000;
+            return;
+        }
+        showExampleBrowser = true;
+        exampleBrowserState.select(1);
+    }
+
+    private List<JsonObject> loadAndSortExamples() {
+        List<JsonObject> catalog = ExampleHelper.loadCatalog();
+        catalog.sort((a, b) -> {
+            int la = levelOrder(a.getStringOrDefault("level", "beginner"));
+            int lb = levelOrder(b.getStringOrDefault("level", "beginner"));
+            if (la != lb) {
+                return Integer.compare(la, lb);
+            }
+            return a.getStringOrDefault("name", "").compareTo(b.getStringOrDefault("name", ""));
+        });
+        return catalog;
+    }
+
+    private static int levelOrder(String level) {
+        return switch (level) {
+            case "beginner" -> 0;
+            case "intermediate" -> 1;
+            case "advanced" -> 2;
+            default -> 3;
+        };
+    }
+
+    private void navigateExampleBrowser(int direction) {
+        if (exampleCatalog == null || exampleCatalog.isEmpty()) {
+            return;
+        }
+        int totalItems = countExampleListItems();
+        Integer current = exampleBrowserState.selected();
+        if (current == null) {
+            current = 0;
+        }
+        int next = current + direction;
+        if (next < 0) {
+            next = 0;
+        }
+        if (next >= totalItems) {
+            next = totalItems - 1;
+        }
+        if (isSeparatorIndex(next)) {
+            next += direction;
+            if (next < 0) {
+                next = 0;
+            }
+            if (next >= totalItems) {
+                next = totalItems - 1;
+            }
+        }
+        exampleBrowserState.select(next);
+    }
+
+    private int countExampleListItems() {
+        if (exampleCatalog == null) {
+            return 0;
+        }
+        int count = 0;
+        String currentLevel = null;
+        for (JsonObject ex : exampleCatalog) {
+            String level = ex.getStringOrDefault("level", "beginner");
+            if (!level.equals(currentLevel)) {
+                currentLevel = level;
+                count++;
+            }
+            count++;
+        }
+        return count;
+    }
+
+    private boolean isSeparatorIndex(int index) {
+        if (exampleCatalog == null) {
+            return false;
+        }
+        int pos = 0;
+        String currentLevel = null;
+        for (JsonObject ex : exampleCatalog) {
+            String level = ex.getStringOrDefault("level", "beginner");
+            if (!level.equals(currentLevel)) {
+                currentLevel = level;
+                if (pos == index) {
+                    return true;
+                }
+                pos++;
+            }
+            if (pos == index) {
+                return false;
+            }
+            pos++;
+        }
+        return false;
+    }
+
+    private JsonObject getExampleAtListIndex(int index) {
+        if (exampleCatalog == null) {
+            return null;
+        }
+        int pos = 0;
+        String currentLevel = null;
+        for (JsonObject ex : exampleCatalog) {
+            String level = ex.getStringOrDefault("level", "beginner");
+            if (!level.equals(currentLevel)) {
+                currentLevel = level;
+                pos++;
+            }
+            if (pos == index) {
+                return ex;
+            }
+            pos++;
+        }
+        return null;
+    }
+
+    private void launchSelectedExample() {
+        Integer sel = exampleBrowserState.selected();
+        if (sel == null || isSeparatorIndex(sel)) {
+            return;
+        }
+        JsonObject example = getExampleAtListIndex(sel);
+        if (example == null) {
+            return;
+        }
+        String exampleName = example.getStringOrDefault("name", "");
+        showExampleBrowser = false;
+        try {
+            List<String> cmd = new ArrayList<>(LauncherHelper.getCamelCommand());
+            cmd.add("run");
+            cmd.add("--example=" + exampleName);
+            Path outputFile = Files.createTempFile("camel-example-", ".log");
+            outputFile.toFile().deleteOnExit();
+            ProcessBuilder pb = new ProcessBuilder(cmd);
+            pb.redirectErrorStream(true);
+            pb.redirectOutput(outputFile.toFile());
+            Process process = pb.start();
+            pendingLaunches.add(new PendingLaunch(exampleName, process, outputFile, System.currentTimeMillis()));
+            launchNotification = "Starting: " + exampleName;
+            launchNotificationError = false;
+            launchNotificationExpiry = System.currentTimeMillis() + 5000;
+        } catch (Exception e) {
+            launchNotification = "Failed to start: " + exampleName + " - " + e.getMessage();
+            launchNotificationError = true;
+            launchNotificationExpiry = System.currentTimeMillis() + 10000;
+        }
+    }
+
+    private void monitorPendingLaunches(long now) {
+        Iterator<PendingLaunch> it = pendingLaunches.iterator();
+        while (it.hasNext()) {
+            PendingLaunch pl = it.next();
+            if (!pl.process().isAlive()) {
+                int exitCode = pl.process().exitValue();
+                if (exitCode == 0) {
+                    launchNotification = "Started: " + pl.name();
+                    launchNotificationError = false;
+                    launchNotificationExpiry = now + 5000;
+                } else {
+                    String detail = readFirstLine(pl.outputFile());
+                    launchNotification = "Failed: " + pl.name()
+                                         + (detail != null ? " - " + detail : "");
+                    launchNotificationError = true;
+                    launchNotificationExpiry = now + 10000;
+                }
+                it.remove();
+            } else if (now - pl.startTime() > 8000) {
+                launchNotification = "Started: " + pl.name();
+                launchNotificationError = false;
+                launchNotificationExpiry = now + 5000;
+                it.remove();
+            }
+        }
+    }
+
+    private static String readFirstLine(Path file) {
+        try {
+            List<String> lines = Files.readAllLines(file);
+            for (String line : lines) {
+                String trimmed = line.trim();
+                if (!trimmed.isEmpty()) {
+                    return TuiHelper.truncate(trimmed, 60);
+                }
+            }
+        } catch (IOException e) {
+            // ignore
+        }
+        return null;
+    }
+
     private void renderFooter(Frame frame, Rect area) {
         List<Span> spans = new ArrayList<>();
         MonitorTab tab = activeTab();
@@ -1447,6 +1796,18 @@ public class CamelMonitor extends CamelCommand {
     }
 
     private void renderOverviewFooter(List<Span> spans) {
+        if (showExampleBrowser) {
+            hint(spans, "↑↓", "navigate");
+            hint(spans, "Enter", "run");
+            hintLast(spans, "Esc", "back");
+            return;
+        }
+        if (showActionsMenu) {
+            hint(spans, "↑↓", "navigate");
+            hint(spans, "Enter", "select");
+            hintLast(spans, "Esc", "cancel");
+            return;
+        }
         hint(spans, "q", "quit");
         if (ctx.selectedPid != null) {
             hint(spans, "Esc", ctx.infraTableFocused ? "integrations" : "unselect");
@@ -1473,6 +1834,7 @@ public class CamelMonitor extends CamelCommand {
             hint(spans, "x", "stop");
             hint(spans, "X", "kill");
         }
+        hint(spans, "F2", "actions");
         hint(spans, isInfraSelected() ? "1-2" : "1-9", "tabs");
     }
 
@@ -2718,5 +3080,8 @@ public class CamelMonitor extends CamelCommand {
     }
 
     record VanishingInfraInfo(InfraInfo info, long startTime) {
+    }
+
+    private record PendingLaunch(String name, Process process, Path outputFile, long startTime) {
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -62,10 +62,6 @@ import dev.tamboui.widgets.barchart.BarGroup;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.block.Title;
-import dev.tamboui.widgets.list.ListItem;
-import dev.tamboui.widgets.list.ListState;
-import dev.tamboui.widgets.list.ListWidget;
-import dev.tamboui.widgets.list.ScrollMode;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
@@ -76,8 +72,6 @@ import dev.tamboui.widgets.tabs.TabsState;
 import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
-import org.apache.camel.dsl.jbang.core.common.ExampleHelper;
-import org.apache.camel.dsl.jbang.core.common.LauncherHelper;
 import org.apache.camel.dsl.jbang.core.common.PathUtils;
 import org.apache.camel.dsl.jbang.core.common.ProcessHelper;
 import org.apache.camel.dsl.jbang.core.common.VersionHelper;
@@ -199,18 +193,7 @@ public class CamelMonitor extends CamelCommand {
     private volatile long lastRefresh;
     private boolean showKillConfirm;
 
-    // F2 actions menu
-    private boolean showActionsMenu;
-    private final ListState actionsMenuState = new ListState();
-    // Example browser
-    private boolean showExampleBrowser;
-    private final ListState exampleBrowserState = new ListState();
-    private List<JsonObject> exampleCatalog;
-    // Async example launches
-    private final List<PendingLaunch> pendingLaunches = new ArrayList<>();
-    private String launchNotification;
-    private boolean launchNotificationError;
-    private long launchNotificationExpiry;
+    private final ActionsPopup actionsPopup = new ActionsPopup();
 
     private final AtomicBoolean refreshInProgress = new AtomicBoolean(false);
     private TuiRunner runner;
@@ -289,36 +272,8 @@ public class CamelMonitor extends CamelCommand {
 
     private boolean handleEvent(Event event, TuiRunner runner) {
         if (event instanceof KeyEvent ke) {
-            // Example browser popup
-            if (showExampleBrowser) {
-                if (ke.isCancel()) {
-                    showExampleBrowser = false;
-                    showActionsMenu = true;
-                } else if (ke.isUp()) {
-                    navigateExampleBrowser(-1);
-                } else if (ke.isDown()) {
-                    navigateExampleBrowser(1);
-                } else if (ke.isPageUp() || ke.isKey(KeyCode.PAGE_UP)) {
-                    navigateExampleBrowser(-10);
-                } else if (ke.isPageDown() || ke.isKey(KeyCode.PAGE_DOWN)) {
-                    navigateExampleBrowser(10);
-                } else if (ke.isConfirm()) {
-                    launchSelectedExample();
-                }
-                return true;
-            }
-            // Actions menu popup
-            if (showActionsMenu) {
-                if (ke.isCancel()) {
-                    showActionsMenu = false;
-                } else if (ke.isUp()) {
-                    actionsMenuState.selectPrevious();
-                } else if (ke.isDown()) {
-                    actionsMenuState.selectNext(1);
-                } else if (ke.isConfirm()) {
-                    openExampleBrowser();
-                }
-                return true;
+            if (actionsPopup.isVisible()) {
+                return actionsPopup.handleKeyEvent(ke);
             }
             // Kill confirm dialog: Enter to confirm, Esc/any other key to cancel
             if (showKillConfirm) {
@@ -533,8 +488,7 @@ public class CamelMonitor extends CamelCommand {
             }
             // Overview tab: F2 opens actions menu
             if (tab == TAB_OVERVIEW && ke.isKey(KeyCode.F2)) {
-                showActionsMenu = true;
-                actionsMenuState.select(0);
+                actionsPopup.open();
                 return true;
             }
 
@@ -545,10 +499,7 @@ public class CamelMonitor extends CamelCommand {
         }
         if (event instanceof TickEvent) {
             long now = System.currentTimeMillis();
-            monitorPendingLaunches(now);
-            if (launchNotification != null && now > launchNotificationExpiry) {
-                launchNotification = null;
-            }
+            actionsPopup.tick(now);
             long interval = routesTab.isShowDiagram() ? Math.max(refreshInterval, 1000) : refreshInterval;
             if (now - lastRefresh >= interval) {
                 refreshData();
@@ -694,12 +645,7 @@ public class CamelMonitor extends CamelCommand {
         if (showKillConfirm) {
             renderKillConfirm(frame, mainChunks.get(4));
         }
-        if (showActionsMenu) {
-            renderActionsMenu(frame, mainChunks.get(4));
-        }
-        if (showExampleBrowser) {
-            renderExampleBrowser(frame, mainChunks.get(4));
-        }
+        actionsPopup.render(frame, mainChunks.get(4));
         renderFooter(frame, mainChunks.get(5));
     }
 
@@ -728,10 +674,10 @@ public class CamelMonitor extends CamelCommand {
                 titleSpans.add(Span.styled("selected: " + selectedName(), Style.EMPTY.fg(Color.YELLOW)));
             }
         }
-        if (launchNotification != null) {
+        if (actionsPopup.notification() != null) {
             titleSpans.add(Span.raw("  "));
-            Style style = launchNotificationError ? Style.EMPTY.fg(Color.RED) : Style.EMPTY.fg(Color.GREEN);
-            titleSpans.add(Span.styled(launchNotification, style));
+            Style style = actionsPopup.notificationError() ? Style.EMPTY.fg(Color.RED) : Style.EMPTY.fg(Color.GREEN);
+            titleSpans.add(Span.styled(actionsPopup.notification(), style));
         }
         Line titleLine = Line.from(titleSpans);
 
@@ -1504,325 +1450,6 @@ public class CamelMonitor extends CamelCommand {
                 inner);
     }
 
-    // ---- Actions Menu / Example Browser ----
-
-    private void renderActionsMenu(Frame frame, Rect area) {
-        int popupW = 32;
-        int popupH = 3;
-        int x = area.left() + Math.max(0, (area.width() - popupW) / 2);
-        int y = area.top() + Math.max(0, (area.height() - popupH) / 2);
-        Rect popup = new Rect(x, y, Math.min(popupW, area.width()), Math.min(popupH, area.height()));
-
-        frame.renderWidget(Clear.INSTANCE, popup);
-        ListWidget list = ListWidget.builder()
-                .items(ListItem.from("  Run an example..."))
-                .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
-                .highlightSymbol("")
-                .scrollMode(ScrollMode.NONE)
-                .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
-                        .title(" Actions ")
-                        .build())
-                .build();
-        frame.renderStatefulWidget(list, popup, actionsMenuState);
-    }
-
-    private void renderExampleBrowser(Frame frame, Rect area) {
-        if (exampleCatalog == null || exampleCatalog.isEmpty()) {
-            return;
-        }
-        int popupW = Math.min(100, area.width() - 4);
-        int popupH = Math.min(exampleCatalog.size() + 10, Math.min(28, area.height() - 4));
-        int x = area.left() + Math.max(0, (area.width() - popupW) / 2);
-        int y = area.top() + Math.max(0, (area.height() - popupH) / 2);
-        Rect popup = new Rect(x, y, Math.min(popupW, area.width()), Math.min(popupH, area.height()));
-
-        frame.renderWidget(Clear.INSTANCE, popup);
-
-        List<ListItem> items = buildExampleListItems(popupW - 4);
-        ListWidget list = ListWidget.builder()
-                .items(items.toArray(ListItem[]::new))
-                .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
-                .highlightSymbol("")
-                .scrollMode(ScrollMode.AUTO_SCROLL)
-                .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
-                        .title(" Run an Example (" + exampleCatalog.size() + ") ")
-                        .build())
-                .build();
-        frame.renderStatefulWidget(list, popup, exampleBrowserState);
-    }
-
-    private List<ListItem> buildExampleListItems(int width) {
-        List<ListItem> items = new ArrayList<>();
-        String currentLevel = null;
-        for (JsonObject ex : exampleCatalog) {
-            String level = ex.getStringOrDefault("level", "beginner");
-            if (!level.equals(currentLevel)) {
-                currentLevel = level;
-                String header = "── " + capitalize(level) + " ──";
-                items.add(ListItem.from(header).style(Style.EMPTY.dim()));
-            }
-            String name = ex.getStringOrDefault("name", "");
-            String desc = ex.getStringOrDefault("description", "");
-            boolean docker = ExampleHelper.requiresDocker(ex);
-            boolean bundled = ExampleHelper.isBundled(ex);
-
-            String icons = (bundled ? "📦" : "🌐") + (docker ? "🐳" : "  ");
-            int nameCol = Math.min(30, width / 3);
-            String padded = String.format("%-" + nameCol + "s", TuiHelper.truncate(name, nameCol));
-            String prefix = " " + icons + " " + padded + " ";
-            int descCol = Math.max(10, width - prefix.length());
-
-            Style style = bundled ? Style.EMPTY : Style.EMPTY.dim();
-            if (desc.length() <= descCol) {
-                items.add(ListItem.from(prefix + desc).style(style));
-            } else {
-                String indent = " ".repeat(prefix.length());
-                List<Line> lines = new ArrayList<>();
-                List<String> wrapped = wrapWords(desc, descCol);
-                lines.add(Line.from(prefix + wrapped.get(0)));
-                for (int w = 1; w < wrapped.size(); w++) {
-                    lines.add(Line.from(indent + wrapped.get(w)));
-                }
-                items.add(ListItem.from(Text.from(lines.toArray(Line[]::new))).style(style));
-            }
-        }
-        items.add(ListItem.from(""));
-        items.add(ListItem.from(" 📦 = bundled (offline)  🌐 = online (GitHub)  🐳 = Docker")
-                .style(Style.EMPTY.dim()));
-        return items;
-    }
-
-    private static String capitalize(String s) {
-        if (s == null || s.isEmpty()) {
-            return s;
-        }
-        return Character.toUpperCase(s.charAt(0)) + s.substring(1);
-    }
-
-    private static List<String> wrapWords(String text, int maxWidth) {
-        List<String> lines = new ArrayList<>();
-        StringBuilder line = new StringBuilder();
-        for (String word : text.split(" ")) {
-            if (line.isEmpty()) {
-                line.append(word);
-            } else if (line.length() + 1 + word.length() <= maxWidth) {
-                line.append(' ').append(word);
-            } else {
-                lines.add(line.toString());
-                line.setLength(0);
-                line.append(word);
-            }
-        }
-        if (!line.isEmpty()) {
-            lines.add(line.toString());
-        }
-        return lines;
-    }
-
-    private void openExampleBrowser() {
-        showActionsMenu = false;
-        if (exampleCatalog == null) {
-            exampleCatalog = loadAndSortExamples();
-        }
-        if (exampleCatalog.isEmpty()) {
-            launchNotification = "No examples found";
-            launchNotificationError = true;
-            launchNotificationExpiry = System.currentTimeMillis() + 5000;
-            return;
-        }
-        showExampleBrowser = true;
-        exampleBrowserState.select(1);
-    }
-
-    private List<JsonObject> loadAndSortExamples() {
-        List<JsonObject> catalog = ExampleHelper.loadCatalog();
-        catalog.sort((a, b) -> {
-            int la = levelOrder(a.getStringOrDefault("level", "beginner"));
-            int lb = levelOrder(b.getStringOrDefault("level", "beginner"));
-            if (la != lb) {
-                return Integer.compare(la, lb);
-            }
-            return a.getStringOrDefault("name", "").compareTo(b.getStringOrDefault("name", ""));
-        });
-        return catalog;
-    }
-
-    private static int levelOrder(String level) {
-        return switch (level) {
-            case "beginner" -> 0;
-            case "intermediate" -> 1;
-            case "advanced" -> 2;
-            default -> 3;
-        };
-    }
-
-    private void navigateExampleBrowser(int direction) {
-        if (exampleCatalog == null || exampleCatalog.isEmpty()) {
-            return;
-        }
-        int totalItems = countExampleListItems();
-        Integer current = exampleBrowserState.selected();
-        if (current == null) {
-            current = 0;
-        }
-        int next = current + direction;
-        if (next < 0) {
-            next = 0;
-        }
-        if (next >= totalItems) {
-            next = totalItems - 1;
-        }
-        while (isSeparatorIndex(next) && next > 0 && next < totalItems - 1) {
-            next += direction;
-        }
-        if (next < 0) {
-            next = 0;
-        }
-        if (next >= totalItems) {
-            next = totalItems - 1;
-        }
-        if (isSeparatorIndex(next)) {
-            return;
-        }
-        exampleBrowserState.select(next);
-    }
-
-    private int countExampleListItems() {
-        if (exampleCatalog == null) {
-            return 0;
-        }
-        int count = 0;
-        String currentLevel = null;
-        for (JsonObject ex : exampleCatalog) {
-            String level = ex.getStringOrDefault("level", "beginner");
-            if (!level.equals(currentLevel)) {
-                currentLevel = level;
-                count++;
-            }
-            count++;
-        }
-        return count + 2;
-    }
-
-    private boolean isSeparatorIndex(int index) {
-        if (exampleCatalog == null) {
-            return false;
-        }
-        int pos = 0;
-        String currentLevel = null;
-        for (JsonObject ex : exampleCatalog) {
-            String level = ex.getStringOrDefault("level", "beginner");
-            if (!level.equals(currentLevel)) {
-                currentLevel = level;
-                if (pos == index) {
-                    return true;
-                }
-                pos++;
-            }
-            if (pos == index) {
-                return false;
-            }
-            pos++;
-        }
-        return true;
-    }
-
-    private JsonObject getExampleAtListIndex(int index) {
-        if (exampleCatalog == null) {
-            return null;
-        }
-        int pos = 0;
-        String currentLevel = null;
-        for (JsonObject ex : exampleCatalog) {
-            String level = ex.getStringOrDefault("level", "beginner");
-            if (!level.equals(currentLevel)) {
-                currentLevel = level;
-                pos++;
-            }
-            if (pos == index) {
-                return ex;
-            }
-            pos++;
-        }
-        return null;
-    }
-
-    private void launchSelectedExample() {
-        Integer sel = exampleBrowserState.selected();
-        if (sel == null || isSeparatorIndex(sel)) {
-            return;
-        }
-        JsonObject example = getExampleAtListIndex(sel);
-        if (example == null) {
-            return;
-        }
-        String exampleName = example.getStringOrDefault("name", "");
-        showExampleBrowser = false;
-        try {
-            List<String> cmd = new ArrayList<>(LauncherHelper.getCamelCommand());
-            cmd.add("run");
-            cmd.add("--example=" + exampleName);
-            Path outputFile = Files.createTempFile("camel-example-", ".log");
-            outputFile.toFile().deleteOnExit();
-            ProcessBuilder pb = new ProcessBuilder(cmd);
-            pb.redirectErrorStream(true);
-            pb.redirectOutput(outputFile.toFile());
-            Process process = pb.start();
-            pendingLaunches.add(new PendingLaunch(exampleName, process, outputFile, System.currentTimeMillis()));
-            launchNotification = "Starting: " + exampleName;
-            launchNotificationError = false;
-            launchNotificationExpiry = System.currentTimeMillis() + 5000;
-        } catch (Exception e) {
-            launchNotification = "Failed to start: " + exampleName + " - " + e.getMessage();
-            launchNotificationError = true;
-            launchNotificationExpiry = System.currentTimeMillis() + 10000;
-        }
-    }
-
-    private void monitorPendingLaunches(long now) {
-        Iterator<PendingLaunch> it = pendingLaunches.iterator();
-        while (it.hasNext()) {
-            PendingLaunch pl = it.next();
-            if (!pl.process().isAlive()) {
-                int exitCode = pl.process().exitValue();
-                if (exitCode == 0) {
-                    launchNotification = "Started: " + pl.name();
-                    launchNotificationError = false;
-                    launchNotificationExpiry = now + 5000;
-                } else {
-                    String detail = readFirstLine(pl.outputFile());
-                    launchNotification = "Failed: " + pl.name()
-                                         + (detail != null ? " - " + detail : "");
-                    launchNotificationError = true;
-                    launchNotificationExpiry = now + 10000;
-                }
-                it.remove();
-            } else if (now - pl.startTime() > 8000) {
-                launchNotification = "Started: " + pl.name();
-                launchNotificationError = false;
-                launchNotificationExpiry = now + 5000;
-                it.remove();
-            }
-        }
-    }
-
-    private static String readFirstLine(Path file) {
-        try {
-            List<String> lines = Files.readAllLines(file);
-            for (String line : lines) {
-                String trimmed = line.trim();
-                if (!trimmed.isEmpty()) {
-                    return TuiHelper.truncate(trimmed, 60);
-                }
-            }
-        } catch (IOException e) {
-            // ignore
-        }
-        return null;
-    }
-
     private void renderFooter(Frame frame, Rect area) {
         List<Span> spans = new ArrayList<>();
         MonitorTab tab = activeTab();
@@ -1837,16 +1464,8 @@ public class CamelMonitor extends CamelCommand {
     }
 
     private void renderOverviewFooter(List<Span> spans) {
-        if (showExampleBrowser) {
-            hint(spans, "↑↓", "navigate");
-            hint(spans, "Enter", "run");
-            hintLast(spans, "Esc", "back");
-            return;
-        }
-        if (showActionsMenu) {
-            hint(spans, "↑↓", "navigate");
-            hint(spans, "Enter", "select");
-            hintLast(spans, "Esc", "cancel");
+        if (actionsPopup.isVisible()) {
+            actionsPopup.renderFooter(spans);
             return;
         }
         hint(spans, "q", "quit");
@@ -3123,6 +2742,4 @@ public class CamelMonitor extends CamelCommand {
     record VanishingInfraInfo(InfraInfo info, long startTime) {
     }
 
-    private record PendingLaunch(String name, Process process, Path outputFile, long startTime) {
-    }
 }


### PR DESCRIPTION
## Summary

- Adds an F2 actions menu to the TUI overview tab with a "Run an example..." action
- Example browser popup shows all 21 curated examples grouped by level (beginner/intermediate/advanced)
- Each example shows bundled/online and Docker icons (📦/🌐/🐳) with a legend
- Long descriptions word-wrap without splitting words
- Selecting an example launches it asynchronously via `camel run --example=<name>`
- Status notifications appear in the header (green on success, red on failure)
- Supports Up/Down, Page Up/Down navigation and auto-scrolling

## Test plan

- [ ] Press F2 on overview tab → actions menu appears centered
- [ ] Select "Run an example..." → example browser shows 21 examples grouped by level
- [ ] Verify emojis and legend display correctly
- [ ] Navigate with Up/Down and Page Up/Down → cursor skips separator lines
- [ ] Select a bundled example (e.g., timer-log) → popup closes, process starts, notification shows
- [ ] Verify launched integration appears in overview after a few seconds
- [ ] Esc from browser → back to actions menu; Esc from actions → closes
- [ ] Footer hints update correctly for each popup state

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)