### PR TITLE
chore: document running camel-jbang from Maven local repository

### DIFF
--- a/dsl/camel-jbang/README.md
+++ b/dsl/camel-jbang/README.md
@@ -16,3 +16,29 @@ Camel JBang version: 4.21.0-SNAPSHOT
 ```
 
 Alternatively, you can change the version in [`CamelJBang.java`](https://github.com/apache/camel/blob/main/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java#L22)
+
+### Using Maven coordinates from the local repository
+
+After building the project with `mvn install`, you can also run camel-jbang directly from the Maven local repository using Maven coordinates.
+
+One-shot run:
+
+```shell
+jbang run -Drepos=mavenLocal,central \
+    --main=main.CamelJBang \
+    --deps=org.apache.camel:camel-jbang-core:4.21.0-SNAPSHOT \
+    org.apache.camel:camel-jbang-main:4.21.0-SNAPSHOT \
+    version
+```
+
+Or install it as a persistent command:
+
+```shell
+jbang app install --name camel \
+    -Drepos=mavenLocal,central \
+    --main=main.CamelJBang \
+    --deps=org.apache.camel:camel-jbang-core:4.21.0-SNAPSHOT \
+    org.apache.camel:camel-jbang-main:4.21.0-SNAPSHOT
+
+camel version
+```


### PR DESCRIPTION
## Summary

- Add instructions for running locally-built camel-jbang using Maven coordinates (`jbang run` and `jbang app install`) as an alternative to the existing alias-based approach
- Useful when you've done `mvn install` and want to test directly from the local Maven repository

## Test plan

- [ ] Verify `jbang run` command works with a locally-built SNAPSHOT
- [ ] Verify `jbang app install` creates a working `camel` command