### PR TITLE
CAMEL-23473: camel-jbang-mcp - drop verbose description from catalog list responses and lower default limit

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -111,6 +111,13 @@ The `groupId`, `artifactId`, and `version` fields have been removed from the `ca
 response. A new `camel_catalog_component_maven` tool returns just those Maven coordinates and should be
 called only when you actually need to add the component as a dependency.
 
+The list-style catalog tools — `camel_catalog_components`, `camel_catalog_dataformats`,
+`camel_catalog_languages`, and `camel_catalog_eips` — no longer return the verbose
+`description` field in their per-item entries. Callers that need the full description should call
+the matching `*_doc` tool. The default `limit` for `camel_catalog_components` and
+`camel_catalog_dataformats` is also lowered from 50 to 20; pass an explicit `limit` to restore the
+previous behaviour.
+
 ==== camel-jbang plugins
 
 Plugins are now loaded lazily. Built-in commands that do not consume plugins

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/CatalogTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/CatalogTools.java
@@ -47,18 +47,19 @@ public class CatalogTools {
      * Tool to list available Camel components.
      */
     @Tool(annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false, openWorldHint = false),
-          description = "List available Camel components from the catalog. " +
-                        "Returns component name, description, and labels. " +
-                        "Use filter to search by name, label to filter by category.")
+          description = "List available Camel components from the catalog. "
+                        + "Returns component name, title, and labels (no description; call "
+                        + "camel_catalog_component_doc for that). "
+                        + "Use filter to search by name, label to filter by category.")
     public ComponentListResult camel_catalog_components(
             @ToolArg(description = "Filter components by name (case-insensitive substring match)") String filter,
             @ToolArg(description = "Filter by category label (e.g., cloud, messaging, database, file)") String label,
-            @ToolArg(description = "Maximum number of results to return (default: 50)") Integer limit,
+            @ToolArg(description = "Maximum number of results to return (default: 20)") Integer limit,
             @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
             @ToolArg(description = ToolArgDocs.VERSION_QUERY) String camelVersion,
             @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
-        int maxResults = limit != null ? limit : 50;
+        int maxResults = limit != null ? limit : 20;
 
         try {
             CamelCatalog cat = catalogService.loadCatalog(runtime, camelVersion, platformBom);
@@ -194,12 +195,12 @@ public class CatalogTools {
                         "(e.g., json, xml, csv, avro, protobuf).")
     public DataFormatListResult camel_catalog_dataformats(
             @ToolArg(description = "Filter by name") String filter,
-            @ToolArg(description = "Maximum results (default: 50)") Integer limit,
+            @ToolArg(description = "Maximum results (default: 20)") Integer limit,
             @ToolArg(description = ToolArgDocs.RUNTIME) String runtime,
             @ToolArg(description = ToolArgDocs.CAMEL_VERSION) String camelVersion,
             @ToolArg(description = ToolArgDocs.PLATFORM_BOM) String platformBom) {
 
-        int maxResults = limit != null ? limit : 50;
+        int maxResults = limit != null ? limit : 20;
 
         try {
             CamelCatalog cat = catalogService.loadCatalog(runtime, camelVersion, platformBom);
@@ -416,7 +417,6 @@ public class CatalogTools {
         return new ComponentInfo(
                 model.getScheme(),
                 model.getTitle(),
-                model.getDescription(),
                 model.getLabel(),
                 model.isDeprecated(),
                 model.getSupportLevel() != null ? model.getSupportLevel().name() : null);
@@ -513,22 +513,19 @@ public class CatalogTools {
         return new DataFormatInfo(
                 model.getName(),
                 model.getTitle(),
-                model.getDescription(),
                 model.isDeprecated());
     }
 
     private LanguageInfo toLanguageInfo(LanguageModel model) {
         return new LanguageInfo(
                 model.getName(),
-                model.getTitle(),
-                model.getDescription());
+                model.getTitle());
     }
 
     private EipInfo toEipInfo(EipModel model) {
         return new EipInfo(
                 model.getName(),
                 model.getTitle(),
-                model.getDescription(),
                 model.getLabel());
     }
 
@@ -609,7 +606,7 @@ public class CatalogTools {
     public record ComponentListResult(int count, String camelVersion, List<ComponentInfo> components) {
     }
 
-    public record ComponentInfo(String name, String title, String description, String label,
+    public record ComponentInfo(String name, String title, String label,
             boolean deprecated, String supportLevel) {
     }
 
@@ -629,19 +626,19 @@ public class CatalogTools {
     public record DataFormatListResult(int count, List<DataFormatInfo> dataFormats) {
     }
 
-    public record DataFormatInfo(String name, String title, String description, boolean deprecated) {
+    public record DataFormatInfo(String name, String title, boolean deprecated) {
     }
 
     public record LanguageListResult(int count, List<LanguageInfo> languages) {
     }
 
-    public record LanguageInfo(String name, String title, String description) {
+    public record LanguageInfo(String name, String title) {
     }
 
     public record EipListResult(int count, List<EipInfo> eips) {
     }
 
-    public record EipInfo(String name, String title, String description, String label) {
+    public record EipInfo(String name, String title, String label) {
     }
 
     public record EipDetailResult(String name, String title, String description, String label,

--- a/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/CatalogToolsTest.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/CatalogToolsTest.java
@@ -50,6 +50,18 @@ class CatalogToolsTest {
     }
 
     @Test
+    void defaultLimitCapsResultsAtTwenty() {
+        // CAMEL-23473: default limit lowered from 50 to 20.
+        CatalogTools tools = createTools(null);
+
+        CatalogTools.ComponentListResult result = tools.camel_catalog_components(null, null, null, null, null, null);
+
+        assertThat(result.components().size())
+                .as("default limit should cap results at 20")
+                .isLessThanOrEqualTo(20);
+    }
+
+    @Test
     void defaultCatalogWithEmptyRepos() {
         CatalogTools tools = createTools("");
 

--- a/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpJsonSerializationTest.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpJsonSerializationTest.java
@@ -18,6 +18,8 @@ package org.apache.camel.dsl.jbang.core.commands.mcp;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
 import java.util.Properties;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -50,7 +52,7 @@ class McpJsonSerializationTest {
         ObjectMapper mapper = newConfiguredObjectMapper();
 
         CatalogTools.ComponentInfo info = new CatalogTools.ComponentInfo(
-                "timer", "Timer", null, null, false, null);
+                "timer", "Timer", null, false, null);
 
         String json = mapper.writeValueAsString(info);
 
@@ -94,6 +96,24 @@ class McpJsonSerializationTest {
         assertThat(json).doesNotContain("\"groupId\"");
         assertThat(json).doesNotContain("\"componentOptions\"");
         assertThat(json).doesNotContain("\"endpointOptions\"");
+    }
+
+    @Test
+    void listInfoRecordsCarryNoDescription() {
+        // CAMEL-23473: list result records must omit the verbose 'description' field. Callers
+        // that want the description should call the corresponding *_doc tool.
+        assertThat(Arrays.stream(CatalogTools.ComponentInfo.class.getRecordComponents())
+                .map(RecordComponent::getName))
+                .doesNotContain("description");
+        assertThat(Arrays.stream(CatalogTools.DataFormatInfo.class.getRecordComponents())
+                .map(RecordComponent::getName))
+                .doesNotContain("description");
+        assertThat(Arrays.stream(CatalogTools.LanguageInfo.class.getRecordComponents())
+                .map(RecordComponent::getName))
+                .doesNotContain("description");
+        assertThat(Arrays.stream(CatalogTools.EipInfo.class.getRecordComponents())
+                .map(RecordComponent::getName))
+                .doesNotContain("description");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Slims down the four catalog list tools ([CAMEL-23473][jira]). Each list response previously
included a multi-sentence `description` per item and could return up to 50 items. The LLM rarely
needs the description in a list — `name` + `title` are enough to decide what to drill into, and
the matching `*_doc` tool already carries the description.

## Changes

* `ComponentInfo`, `DataFormatInfo`, `LanguageInfo`, `EipInfo` records: removed the `description`
  field. Mapping methods updated accordingly.
* `camel_catalog_components` and `camel_catalog_dataformats` default `limit` lowered from 50 to 20.
  `camel_catalog_languages` and `camel_catalog_eips` did not previously expose a `limit` argument
  and are left as-is.
* `camel_catalog_components` tool description updated to reflect the new payload shape and to
  point at `camel_catalog_component_doc` for descriptions.
* Upgrade-guide entry added under `camel-jbang-mcp` in `camel-4x-upgrade-guide-4_21.adoc`.

## Test plan

- [x] `mvn -DskipTests install` in `dsl/camel-jbang/camel-jbang-mcp` (formats + builds)
- [x] `mvn test` in `dsl/camel-jbang/camel-jbang-mcp` — 255 tests pass, including 2 new ones:
    * `listInfoRecordsCarryNoDescription` (reflective check across all four list records)
    * `defaultLimitCapsResultsAtTwenty` (asserts default `limit` returns ≤ 20 items)
- [x] `componentInfoNullFieldsAreOmittedFromJson` updated for the new `ComponentInfo` arity
- [x] `mvn clean install -DskipTests` from repo root — full reactor build green, no uncommitted
      regenerated artifacts

[jira]: https://issues.apache.org/jira/browse/CAMEL-23473

---
_Claude Code on behalf of Andrea Cosentino_