### PR TITLE
Enable simple tracer standby in dev profile

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/ProfileConfigurer.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/ProfileConfigurer.java
@@ -49,6 +49,9 @@ public class ProfileConfigurer {
             if (!enabled) {
                 config.tracerConfig().withStandby(true);
             }
+            if (!config.isTracing()) {
+                config.setTracingStandby(true);
+            }
         }
 
         if ("dev".equals(profile)) {

--- a/core/camel-main/src/test/java/org/apache/camel/main/MainDevProfileTracingStandbyTest.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/MainDevProfileTracingStandbyTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.main;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.Tracer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MainDevProfileTracingStandbyTest {
+
+    @Test
+    public void testDevProfileEnablesTracingStandby() {
+        Main main = new Main();
+        main.configure().withProfile("dev");
+
+        main.start();
+        try {
+            CamelContext context = main.getCamelContext();
+            assertTrue(context.isTracingStandby(),
+                    "dev profile should enable tracing standby");
+        } finally {
+            main.stop();
+        }
+    }
+
+    @Test
+    public void testDevProfileTracingCanBeEnabledAtRuntime() throws Exception {
+        Main main = new Main();
+        main.configure().withProfile("dev");
+        main.configure().addRoutesBuilder(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").to("mock:result");
+            }
+        });
+
+        main.start();
+        try {
+            CamelContext context = main.getCamelContext();
+            Tracer tracer = context.getTracer();
+            assertFalse(tracer.isEnabled(),
+                    "tracer should be in standby (not enabled) by default in dev mode");
+
+            tracer.setEnabled(true);
+            assertTrue(tracer.isEnabled(),
+                    "tracer should be enableable at runtime in dev mode");
+        } finally {
+            main.stop();
+        }
+    }
+
+    @Test
+    public void testProdProfileDoesNotEnableTracingStandby() {
+        Main main = new Main();
+        main.configure().withProfile("prod");
+
+        main.start();
+        try {
+            CamelContext context = main.getCamelContext();
+            assertFalse(context.isTracingStandby(),
+                    "prod profile should not enable tracing standby");
+        } finally {
+            main.stop();
+        }
+    }
+
+}

--- a/docs/user-manual/modules/ROOT/pages/tracer.adoc
+++ b/docs/user-manual/modules/ROOT/pages/tracer.adoc
@@ -45,6 +45,9 @@ camel.main.tracing = true
 By default, Camel optimizes and opt-out tracing. Therefore, you would either have to enable tracing from the startup,
 or turn on standby mode, to allow tracing to be enabled later during runtime.
 
+NOTE: When using Camel Main or Camel JBang with the `dev` profile (the default), tracing standby is automatically enabled.
+This means you can toggle tracing on and off at runtime without needing to restart.
+
 To set tracing in standby mode you can do:
 
 [tabs]


### PR DESCRIPTION
## Summary

- Enable simple log tracer standby (`tracingStandby`) in dev profile, matching how backlog tracer standby is already auto-enabled
- Users can now toggle log-based tracing on/off at runtime in dev mode without restarting (`camel run` or Camel Main)
- Add tests verifying dev profile standby behavior
- Document the automatic standby in tracer.adoc

## Background

The `--trace` flag for `camel run` must be specified at launch time because `TracingAdvice` interceptors are woven into route processor chains only during route initialization. Without standby mode, there is no way to toggle tracing on at runtime.

The backlog tracer already had standby auto-enabled in dev profile (`ProfileConfigurer.java`), but the simple log tracer (what `--trace` controls) was missed.

## Test plan

- [x] `MainDevProfileTracingStandbyTest.testDevProfileEnablesTracingStandby` — verifies dev profile sets `tracingStandby=true`
- [x] `MainDevProfileTracingStandbyTest.testDevProfileTracingCanBeEnabledAtRuntime` — verifies tracer can be toggled on at runtime
- [x] `MainDevProfileTracingStandbyTest.testProdProfileDoesNotEnableTracingStandby` — verifies prod profile does not set standby
- [x] Existing `TracingStandbyTest` and `TracingStandbyNoRouteTest` still pass