### PR TITLE
CAMEL-23522: doc-sync 4.14 upgrade guide for camel-mail mail.smtp.* gating

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -179,6 +179,29 @@ work without changes. Routes that set the header by its literal string value
 (for example `setHeader("SEARCH_QUERY", ...)`) must be updated to use the
 new value (`setHeader("CamelElasticsearchSearchQuery", ...)`).
 
+=== camel-mail
+
+The SMTP producer no longer extracts dynamic JavaMail session properties from message headers by
+default. Previously any message header whose key started with `mail.smtp.` was applied to a
+per-message `JavaMailSender`, which meant an upstream producer that mapped untrusted input into the
+exchange header map (for example `platform-http` query parameters, JMS or Kafka messages from
+untrusted producers) could override transport-security settings such as `mail.smtp.ssl.trust` or
+`mail.smtp.starttls.enable`, or redirect the SMTP connection.
+
+This behaviour is now disabled by default. Routes that legitimately rely on per-message
+`mail.smtp.*` headers must opt back in on the endpoint:
+
+[source,java]
+----
+.to("smtp://mymailserver:1234?useJavaMailSessionPropertiesFromHeaders=true");
+----
+
+Even with the opt-in, route authors should still strip the namespace with
+`removeHeaders("mail.smtp.*")` between any untrusted ingress and the mail producer.
+
+In addition, the inbound `MailHeaderFilterStrategy` now blocks the `mail.smtp.` / `mail.smtps.`
+prefix as well, so an external mail message can no longer inject these into a downstream exchange.
+
 == Upgrading from 4.14.2 to 4.14.3
 
 === camel-tika


### PR DESCRIPTION
## Summary

Doc-sync of the camel-mail `mail.smtp.*` gating entry from `camel-4.14.x` onto `main`'s copy of `camel-4x-upgrade-guide-4_14.adoc`, per the project's backport upgrade-guide policy in `CLAUDE.md`:

> The `camel-4x-upgrade-guide-4_XX.adoc` files for ALL versions live on `main` and act as the canonical history across all releases. When a PR is backported to a maintenance branch and adds an upgrade-guide note for that release line, the corresponding entry must ALSO be added to the matching `camel-4x-upgrade-guide-4_XX.adoc` file on `main`.

This PR mirrors the entry added in #23416 (backport to `camel-4.14.x`) onto main, immediately after the existing `camel-elasticsearch-rest-client` entry in the "Upgrading from 4.14.3 to 4.14.8" section.

## Linked

- Main PR: #23362 — CAMEL-23522: camel-mail - gate JavaMail session properties from headers behind opt-in (merged)
- 4.18.x backport: #23381 (open)
- 4.18 doc-sync on main: #23383 (open)
- 4.14.x backport: #23416 (open)
- Jira: https://issues.apache.org/jira/browse/CAMEL-23522
- Family precedent: CAMEL-23222 / CVE-2025-27636

## Notes on the 4.14 wording

The 4.14.x branch only extracts `mail.smtp.*` (not `mail.smtps.*`) on the producer side — the `mail.smtps.` fallback was introduced later by CAMEL-22900. The entry therefore references only `mail.smtp.*` for the producer-side gating. The `MailHeaderFilterStrategy` inbound filter on 4.14.x does block both prefixes as forward-looking defense in depth, which is reflected in the last paragraph.

## Test plan

- [x] Single docs file added; no code changes.
- [x] Wording matches the same section on the `camel-4.14.x` branch.

---
_Claude Code on behalf of Andrea Cosentino_