### PR TITLE
Fix trace action handler to forward dump parameter to DevConsole

### DIFF
--- a/dsl/camel-cli-connector/src/main/java/org/apache/camel/cli/connector/LocalCliConnector.java
+++ b/dsl/camel-cli-connector/src/main/java/org/apache/camel/cli/connector/LocalCliConnector.java
@@ -763,13 +763,16 @@ public class LocalCliConnector extends ServiceSupport implements CliConnector, C
         DevConsole dc = camelContext.getCamelContextExtension().getContextPlugin(DevConsoleRegistry.class)
                 .resolveById("trace");
         if (dc != null) {
+            Map<String, Object> params = new HashMap<>();
             String enabled = root.getString("enabled");
-            JsonObject json;
             if (enabled != null) {
-                json = (JsonObject) dc.call(DevConsole.MediaType.JSON, Map.of("enabled", enabled));
-            } else {
-                json = (JsonObject) dc.call(DevConsole.MediaType.JSON);
+                params.put("enabled", enabled);
             }
+            String dump = root.getString("dump");
+            if (dump != null) {
+                params.put("dump", dump);
+            }
+            JsonObject json = (JsonObject) dc.call(DevConsole.MediaType.JSON, params);
             LOG.trace("Updating output file: {}", outputFile);
             IOHelper.writeText(json.toJson(), outputFile);
         } else {


### PR DESCRIPTION
## Summary

- Fix `doActionTraceTask()` in `LocalCliConnector` to forward the `dump` parameter to `TraceDevConsole`
- Without this, requesting a trace dump via action file IPC only returned status metadata (enabled, counter, queueSize) instead of the actual traced messages

The `TraceDevConsole` already supports the `dump` parameter — the periodic `traceTask()` uses it correctly via `Map.of("dump", "true")`. The action handler simply never wired it through.

## Test plan

- [x] `mvn install -B -pl dsl/camel-cli-connector -DskipTests` builds clean
- [ ] Manual: enable tracing, send messages, call trace dump via action file — verify traced messages are returned