### PR TITLE
CAMEL-23510: docs - sync camel-jgroups 4.14 upgrade-guide entry to main (flagged as potential breaking change)

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -418,3 +418,24 @@ between the transport `from` and the `cxf:` `to`:
 The same pattern applies to HTTP-based bridges (`platform-http`/`jetty`/`netty
 -http`/`http` -> `cxf:`) and any other transport whose default
 `HeaderFilterStrategy` filters `Camel*` headers.
+
+=== camel-jgroups
+
+The Exchange header constants in `JGroupsConstants` have been renamed to follow
+the Camel naming convention used across the rest of the component catalog. The
+Java field names are unchanged; only the header string values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `JGroupsConstants.HEADER_JGROUPS_CHANNEL_ADDRESS` | `JGROUPS_CHANNEL_ADDRESS` | `CamelJGroupsChannelAddress`
+| `JGroupsConstants.HEADER_JGROUPS_DEST` | `JGROUPS_DEST` | `CamelJGroupsDest`
+| `JGroupsConstants.HEADER_JGROUPS_SRC` | `JGROUPS_SRC` | `CamelJGroupsSrc`
+| `JGroupsConstants.HEADER_JGROUPS_ORIGINAL_MESSAGE` | `JGROUPS_ORIGINAL_MESSAGE` | `CamelJGroupsOriginalMessage`
+|===
+
+Routes that reference the constant symbolically (for example
+`setHeader(JGroupsConstants.HEADER_JGROUPS_DEST, ...)`) continue to work
+without changes. Routes that set the header by its literal string value
+(for example `setHeader("JGROUPS_DEST", ...)`) must be updated to use the
+new value (`setHeader("CamelJGroupsDest", ...)`).

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -419,7 +419,7 @@ The same pattern applies to HTTP-based bridges (`platform-http`/`jetty`/`netty
 -http`/`http` -> `cxf:`) and any other transport whose default
 `HeaderFilterStrategy` filters `Camel*` headers.
 
-=== camel-jgroups
+=== camel-jgroups - potential breaking change
 
 The Exchange header constants in `JGroupsConstants` have been renamed to follow
 the Camel naming convention used across the rest of the component catalog. The
@@ -434,8 +434,9 @@ Java field names are unchanged; only the header string values have changed:
 | `JGroupsConstants.HEADER_JGROUPS_ORIGINAL_MESSAGE` | `JGROUPS_ORIGINAL_MESSAGE` | `CamelJGroupsOriginalMessage`
 |===
 
-Routes that reference the constant symbolically (for example
-`setHeader(JGroupsConstants.HEADER_JGROUPS_DEST, ...)`) continue to work
-without changes. Routes that set the header by its literal string value
-(for example `setHeader("JGROUPS_DEST", ...)`) must be updated to use the
-new value (`setHeader("CamelJGroupsDest", ...)`).
+This is a breaking change for routes that read or write these headers by
+their literal string value. Routes that reference the constant symbolically
+(for example `setHeader(JGroupsConstants.HEADER_JGROUPS_DEST, ...)`) continue
+to work without changes. Routes that set the header by its literal string
+value (for example `setHeader("JGROUPS_DEST", ...)`) must be updated to use
+the new value (`setHeader("CamelJGroupsDest", ...)`).


### PR DESCRIPTION
## Summary

Docs-only sync of the 4.14 upgrade-guide entry for the `camel-jgroups` header constant rename.

[CAMEL-23510](https://issues.apache.org/jira/browse/CAMEL-23510) (PR #23209) renamed the four `JGroupsConstants.HEADER_JGROUPS_*` header string values to follow the `CamelJGroups*` naming convention. The original PR added the upgrade-guide entry to `camel-4x-upgrade-guide-4_21.adoc` on `main`.

The backport to `camel-4.14.x` (#23421) places the corresponding entry in `camel-4x-upgrade-guide-4_14.adoc` on the maintenance branch, since the rename ships on that release line.

Per the upgrade-guide backport policy in `CLAUDE.md`:

> the `docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_XX.adoc` files for ALL versions live on `main` and act as the canonical history across all releases. When a PR is backported to a maintenance branch and adds an upgrade-guide note for that release line, the corresponding entry must ALSO be added to the matching `camel-4x-upgrade-guide-4_XX.adoc` file on `main`.

This PR keeps `main`'s 4.14 upgrade guide in sync with what ships on `camel-4.14.x`.

## Changes

- `docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc` — add the `=== camel-jgroups` section under the "Upgrading from 4.14.5 to 4.14.6" window, after the existing `=== camel-cxf` section.

### Update — breaking change wording (addresses @apupier review)

Following @apupier's review comment, the entry now explicitly flags the rename as a breaking change for routes that use the headers by their literal string value:

- Heading: `=== camel-jgroups` → `=== camel-jgroups - potential breaking change` (matching the existing `=== camel-grok - potential breaking change` convention).
- Prose: leads with an explicit "This is a breaking change for routes that read or write these headers by their literal string value." sentence.

The same wording is applied consistently on:
- `camel-4.14.x` (the merged backport entry): #23441
- the 4.21 guide on `main` (the entry from #23209): #23451

No code changes; doc-only.

## Test plan

- [x] Section heading and table format match the sibling `=== camel-cxf` / `=== camel-grok` entries.
- [x] Wording is identical to the equivalent change on #23441 and #23451.

## Related

- Backport PR (merged): #23421
- Original PR (main, 4.21 guide): #23209
- 4.14-guide breaking-change wording on `camel-4.14.x`: #23441
- 4.21-guide breaking-change wording on `main`: #23451

---

_Claude Code on behalf of Andrea Cosentino_