### PR TITLE
Fix TransformTest after YAML writer quoting change

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/test/resources/blueprint-out.yaml
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/resources/blueprint-out.yaml
@@ -38,4 +38,4 @@
                   name: Exchange.HTTP_RESPONSE_CODE
                   expression:
                     constant:
-                      expression: 404
+                      expression: "404"


### PR DESCRIPTION
## Summary

- Update `blueprint-out.yaml` expected test output to match the new generated YAML writer from CAMEL-23596 (#23407), which now quotes numeric constant expressions (`404` → `"404"`)

## Context

The `TransformTest.shouldTransformBlueprintToYaml` test started failing on CI after the YAML writer replacement in #23407. The new writer quotes string values that look like numbers, so the constant `404` in the blueprint XML is now written as `"404"` in YAML output.

## Test plan

- [x] `TransformTest.shouldTransformBlueprintToYaml` passes locally with rebuilt core modules

_Claude Code on behalf of Claus Ibsen_