### PR TITLE
CAMEL-22504: camel-jasypt - Deprecate Main CLI entrypoint

### DIFF
--- a/components/camel-jasypt/src/main/docs/jasypt.adoc
+++ b/components/camel-jasypt/src/main/docs/jasypt.adoc
@@ -34,6 +34,13 @@ for this component:
 
 == Tooling
 
+[WARNING]
+====
+The command line utility shipped with `camel-jasypt` (the `Main` class) is *deprecated* and will be removed in a
+future Camel release. Use the official link:http://www.jasypt.org/cli.html[Jasypt CLI] instead — it is the
+supported tool for the same encrypt/decrypt workflow and removes the duplicated implementation maintained here.
+====
+
 The Jasypt component is a runnable JAR that provides a command line utility to encrypt or decrypt values.
 
 The usage documentation can be output to the console to describe the syntax and options it provides:

--- a/components/camel-jasypt/src/main/docs/jasypt.adoc
+++ b/components/camel-jasypt/src/main/docs/jasypt.adoc
@@ -37,8 +37,9 @@ for this component:
 [WARNING]
 ====
 The command line utility shipped with `camel-jasypt` (the `Main` class) is *deprecated* and will be removed in a
-future Camel release. Use the official link:http://www.jasypt.org/cli.html[Jasypt CLI] instead — it is the
-supported tool for the same encrypt/decrypt workflow and removes the duplicated implementation maintained here.
+future Camel release. Use the standalone CLI scripts (`encrypt.sh` / `decrypt.sh` / `digest.sh`) shipped in the
+upstream link:https://github.com/jasypt/jasypt/releases/tag/jasypt-1.9.3[jasypt-1.9.3 distribution] instead — they
+cover the same encrypt/decrypt workflow and let us drop the duplicated implementation maintained here.
 ====
 
 The Jasypt component is a runnable JAR that provides a command line utility to encrypt or decrypt values.

--- a/components/camel-jasypt/src/main/java/org/apache/camel/component/jasypt/Main.java
+++ b/components/camel-jasypt/src/main/java/org/apache/camel/component/jasypt/Main.java
@@ -29,9 +29,10 @@ import org.jasypt.salt.RandomSaltGenerator;
  * Command line entrypoint for the camel-jasypt component, kept around so the {@code camel-jasypt} jar can be invoked
  * directly (e.g. with JBang) to encrypt or decrypt property values.
  * <p>
- * Deprecated in favour of the upstream <a href="http://www.jasypt.org/cli.html">Jasypt CLI</a>, which is the supported
- * tool for this workflow and removes the need to maintain a duplicate implementation here. This class is scheduled for
- * removal in a future Camel release.
+ * Deprecated in favour of the standalone Jasypt CLI scripts (encrypt.sh / decrypt.sh / digest.sh) shipped in the
+ * upstream <a href="https://github.com/jasypt/jasypt/releases/tag/jasypt-1.9.3">jasypt-1.9.3 distribution</a>, which
+ * remove the need to maintain a duplicate implementation here. This class is scheduled for removal in a future Camel
+ * release.
  */
 @Deprecated(since = "4.21")
 public class Main {

--- a/components/camel-jasypt/src/main/java/org/apache/camel/component/jasypt/Main.java
+++ b/components/camel-jasypt/src/main/java/org/apache/camel/component/jasypt/Main.java
@@ -25,6 +25,15 @@ import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.jasypt.iv.RandomIvGenerator;
 import org.jasypt.salt.RandomSaltGenerator;
 
+/**
+ * Command line entrypoint for the camel-jasypt component, kept around so the {@code camel-jasypt} jar can be invoked
+ * directly (e.g. with JBang) to encrypt or decrypt property values.
+ * <p>
+ * Deprecated in favour of the upstream <a href="http://www.jasypt.org/cli.html">Jasypt CLI</a>, which is the supported
+ * tool for this workflow and removes the need to maintain a duplicate implementation here. This class is scheduled for
+ * removal in a future Camel release.
+ */
+@Deprecated(since = "4.21")
 public class Main {
 
     private final StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();

--- a/components/camel-jasypt/src/test/java/org/apache/camel/component/jasypt/MainTest.java
+++ b/components/camel-jasypt/src/test/java/org/apache/camel/component/jasypt/MainTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+@SuppressWarnings("deprecation")
 public class MainTest {
 
     @Test

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -778,6 +778,16 @@ The component camel-irc is deprecated. The library used had no stable release si
 
 The component camel-iec-60870 is deprecated. The library used to implement it NeoScada is no more maintained since 2021. There are no alternatives in Java with compatible license.
 
+=== Deprecation of camel-jasypt CLI entrypoint
+
+The `org.apache.camel.component.jasypt.Main` class — the command line entrypoint that lets the `camel-jasypt`
+jar be invoked directly (e.g. via JBang) to encrypt or decrypt property values — is now deprecated and will be
+removed in a future Camel release.
+
+Use the upstream link:http://www.jasypt.org/cli.html[Jasypt CLI] instead. It is the supported tool for the same
+workflow and lets us drop the duplicate implementation maintained inside `camel-jasypt`. The component itself
+(property-source decryption at runtime) is unaffected.
+
 === Deprecation of camel-paho
 
 The components camel-paho is deprecated. There were no new release since 2020 of the Java client, last non-regulatory commit was in 2022.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -784,9 +784,10 @@ The `org.apache.camel.component.jasypt.Main` class — the command line entrypoi
 jar be invoked directly (e.g. via JBang) to encrypt or decrypt property values — is now deprecated and will be
 removed in a future Camel release.
 
-Use the upstream link:http://www.jasypt.org/cli.html[Jasypt CLI] instead. It is the supported tool for the same
-workflow and lets us drop the duplicate implementation maintained inside `camel-jasypt`. The component itself
-(property-source decryption at runtime) is unaffected.
+Use the standalone CLI scripts (`encrypt.sh` / `decrypt.sh` / `digest.sh`) shipped in the upstream
+link:https://github.com/jasypt/jasypt/releases/tag/jasypt-1.9.3[jasypt-1.9.3 distribution] instead. They cover
+the same workflow and let us drop the duplicate implementation maintained inside `camel-jasypt`. The component
+itself (property-source decryption at runtime) is unaffected.
 
 === Deprecation of camel-paho
 


### PR DESCRIPTION
# Description

Fixes https://issues.apache.org/jira/browse/CAMEL-22504.

`org.apache.camel.component.jasypt.Main` — the command line entrypoint that lets the
`camel-jasypt` jar be invoked directly (e.g. via JBang) to encrypt or decrypt property
values — is a small but real maintenance burden because it duplicates functionality
already provided by the upstream supported [Jasypt CLI](http://www.jasypt.org/cli.html).

Per the Jira description, the goal is to deprecate **only** the CLI entrypoint (not the
component itself — runtime property-source decryption is unaffected).

## Changes

* `Main.java` — annotated `@Deprecated(since = "4.21")` with a class-level Javadoc
  explaining the replacement.
* `MainTest.java` — added `@SuppressWarnings("deprecation")` so the existing unit tests
  for `Main` keep compiling cleanly without contributing new deprecation noise to the
  build.
* `jasypt.adoc` — added an asciidoc `WARNING` admonition to the Tooling section
  pointing readers at the Jasypt CLI.
* `camel-4x-upgrade-guide-4_21.adoc` — added a "Deprecation of camel-jasypt CLI
  entrypoint" entry alongside the other 4.21 deprecations, with a link to the Jasypt
  CLI replacement.

## Out of scope

This PR does **not** remove the `<mainClass>` entry in `camel-jasypt/pom.xml`, the
runnable-jar manifest, or the `Main` class itself. The Jira's
"eventually drop" follow-up is intentionally left for a later release once the
deprecation window has elapsed.

## Verification

* `mvn -pl components/camel-jasypt formatter:format impsort:sort` — clean
  (`Already Sorted: 12`, `Formatted: 0`).
* `mvn -pl components/camel-jasypt -am install -DskipTests` — BUILD SUCCESS.
* `mvn -pl components/camel-jasypt test` — **Tests run: 25, Failures: 0, Errors: 0,
  Skipped: 0** (all 6 `MainTest` cases still pass under the `@SuppressWarnings`).

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-22504) filed for the change.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn formatter:format impsort:sort` locally on the affected module (no changes needed).
