### PR TITLE
CAMEL-23510: flag camel-jgroups header rename as potential breaking change in 4.14 upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -430,7 +430,7 @@ The same pattern applies to HTTP-based bridges (`platform-http`/`jetty`/`netty
 -http`/`http` -> `cxf:`) and any other transport whose default
 `HeaderFilterStrategy` filters `Camel*` headers.
 
-=== camel-jgroups
+=== camel-jgroups - potential breaking change
 
 The Exchange header constants in `JGroupsConstants` have been renamed to follow
 the Camel naming convention used across the rest of the component catalog. The
@@ -445,8 +445,9 @@ Java field names are unchanged; only the header string values have changed:
 | `JGroupsConstants.HEADER_JGROUPS_ORIGINAL_MESSAGE` | `JGROUPS_ORIGINAL_MESSAGE` | `CamelJGroupsOriginalMessage`
 |===
 
-Routes that reference the constant symbolically (for example
-`setHeader(JGroupsConstants.HEADER_JGROUPS_DEST, ...)`) continue to work
-without changes. Routes that set the header by its literal string value
-(for example `setHeader("JGROUPS_DEST", ...)`) must be updated to use the
-new value (`setHeader("CamelJGroupsDest", ...)`).
+This is a breaking change for routes that read or write these headers by
+their literal string value. Routes that reference the constant symbolically
+(for example `setHeader(JGroupsConstants.HEADER_JGROUPS_DEST, ...)`) continue
+to work without changes. Routes that set the header by its literal string
+value (for example `setHeader("JGROUPS_DEST", ...)`) must be updated to use
+the new value (`setHeader("CamelJGroupsDest", ...)`).


### PR DESCRIPTION
## Summary

Follow-up to #23421 (the camel-4.14.x backport of [CAMEL-23510](https://issues.apache.org/jira/browse/CAMEL-23510) / #23209).

@apupier pointed out on the companion main-side doc-sync PR (#23422) that the JGroups header-rename upgrade-guide entry does not explicitly highlight that the rename is a breaking change for routes that use the headers by their literal string value.

> due to that, shouldn't we highlight that it is a breaking change?

This PR updates the `=== camel-jgroups` section in `docs/.../camel-4x-upgrade-guide-4_14.adoc` (added by #23421) to call this out clearly.

## Changes

- `docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc`:
  - Section heading: `=== camel-jgroups` → `=== camel-jgroups - potential breaking change`, matching the convention already established by the `=== camel-grok - potential breaking change` entry in the 4.21 guide.
  - Prose: prepend an explicit "This is a breaking change for routes that read or write these headers by their literal string value." sentence before the existing symbolic-vs-literal guidance.

No code changes; pure docs update (7 insertions, 6 deletions).

## Related

- Backport that introduced the entry: #23421 (merged)
- Companion main-side doc-sync PR currently in review: #23422
- Original PR on main: #23209
- A separate follow-up PR will apply the same wording change to the 4.21 guide entry on `main` (added by #23209), to keep the wording consistent across all guides.

## Test plan

- [x] Diff is a small docs-only change.
- [x] Heading style matches the existing `=== camel-grok - potential breaking change` convention.

---

_Claude Code on behalf of Andrea Cosentino_