### PR TITLE
Revert JLine from 4.1.0 to 4.0.15 to fix camel shell immediate exit

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -296,7 +296,7 @@
         <jgroups-raft-version>1.1.4.Final</jgroups-raft-version>
         <jira-rest-client-api-version>6.0.2</jira-rest-client-api-version>
         <jira-sal-api-version>7.2.1</jira-sal-api-version>
-        <jline-version>4.1.0</jline-version>
+        <jline-version>4.0.15</jline-version>
         <libthrift-version>0.23.0</libthrift-version>
         <jodatime2-version>2.14.2</jodatime2-version>
         <jolokia-version>2.6.0</jolokia-version>


### PR DESCRIPTION
## Summary

- Reverts JLine from 4.1.0 to 4.0.15 to fix `camel shell` exiting immediately after printing the banner.

## Root cause

JLine 4.1.0 introduced `AbstractUnixSysTerminal`, which bypasses the PTY abstraction and reads directly from `new FileInputStream(FileDescriptor.in)`. Combined with a latent bug in `enterRawMode()` that sets `VMIN=0, VTIME=1` (instead of the POSIX `cfmakeraw` defaults `VMIN=1, VTIME=0`), the kernel returns 0 bytes from `read()` after 100ms idle. Java's `FileInputStream.read()` translates a 0-byte return into `-1` (EOF), causing JLine's `readLine()` to throw `EndOfFileException` and the shell REPL to exit silently.

JLine 4.0.15 uses PTY-backed I/O (`pty.getSlaveInput()`) which handles 0-byte returns correctly, so the shell works as expected.

The upstream fix is in [JLine PR #1871](https://github.com/jline/jline3/pull/1871) (`VMIN=1, VTIME=0`) but has not been released yet. Once a JLine release includes this fix, we can upgrade again.

## Test plan

- [x] `camel shell` stays open and accepts commands (tested with both 4.0.15 and the SNAPSHOT with the fix)
- [ ] CI passes

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)