### PR TITLE
CAMEL-23510: flag camel-jgroups header rename as potential breaking change in 4.21 upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -377,7 +377,7 @@ previous code path silently produced `null` whenever a route mixed `converse` an
 calls. If you were not setting the guardrail identifier via header, the endpoint-level
 `guardrailIdentifier` option continues to work without changes.
 
-=== camel-jgroups
+=== camel-jgroups - potential breaking change
 
 The Exchange header constants in `JGroupsConstants` have been renamed to follow
 the Camel naming convention used across the rest of the component catalog. The
@@ -392,11 +392,12 @@ Java field names are unchanged; only the header string values have changed:
 | `JGroupsConstants.HEADER_JGROUPS_ORIGINAL_MESSAGE` | `JGROUPS_ORIGINAL_MESSAGE` | `CamelJGroupsOriginalMessage`
 |===
 
-Routes that reference the constant symbolically (for example
-`setHeader(JGroupsConstants.HEADER_JGROUPS_DEST, ...)`) continue to work
-without changes. Routes that set the header by its literal string value
-(for example `setHeader("JGROUPS_DEST", ...)`) must be updated to use the
-new value (`setHeader("CamelJGroupsDest", ...)`).
+This is a breaking change for routes that read or write these headers by
+their literal string value. Routes that reference the constant symbolically
+(for example `setHeader(JGroupsConstants.HEADER_JGROUPS_DEST, ...)`) continue
+to work without changes. Routes that set the header by its literal string
+value (for example `setHeader("JGROUPS_DEST", ...)`) must be updated to use
+the new value (`setHeader("CamelJGroupsDest", ...)`).
 
 === camel-elasticsearch-rest-client
 


### PR DESCRIPTION
## Summary

Follow-up to #23209 ([CAMEL-23510](https://issues.apache.org/jira/browse/CAMEL-23510)).

@apupier pointed out on the 4.14 doc-sync PR (#23422) that the JGroups header-rename upgrade-guide entry does not explicitly highlight that the rename is a breaking change for routes that use the headers by their literal string value.

> due to that, shouldn't we highlight that it is a breaking change?

This PR updates the `=== camel-jgroups` section in the **4.21** upgrade guide (the entry originally added by #23209) to call this out clearly, keeping it consistent with the equivalent change made to the 4.14 guide on `camel-4.14.x` (#23441).

## Changes

- `docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc`:
  - Section heading: `=== camel-jgroups` → `=== camel-jgroups - potential breaking change`, matching the existing `=== camel-grok - potential breaking change` convention earlier in the same guide.
  - Prose: prepend an explicit "This is a breaking change for routes that read or write these headers by their literal string value." sentence before the existing symbolic-vs-literal guidance.

No code changes; pure docs update (7 insertions, 6 deletions).

## Related

- Original PR (4.21 guide entry): #23209 (merged)
- Equivalent 4.14-guide wording change on `camel-4.14.x`: #23441
- 4.14 doc-sync PR where the feedback was raised: #23422

## Test plan

- [x] Diff is a small docs-only change.
- [x] Heading style matches the existing `=== camel-grok - potential breaking change` convention.

---

_Claude Code on behalf of Andrea Cosentino_