### PR TITLE
CAMEL-23526: docs - flag camel-cxf 4.14 upgrade-guide entry as potential breaking change

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -379,7 +379,7 @@ component with the rest of the Camel component catalog. Routes that relied on re
 header names on inbound SNS messages can supply a custom `headerFilterStrategy` to restore the
 previous behaviour.
 
-=== camel-cxf
+=== camel-cxf - potential breaking change
 
 The Exchange header constants in `CxfConstants` (module `camel-cxf-common`, shared
 by `camel-cxf` and `camel-cxfrs`) have been renamed to follow the Camel naming


### PR DESCRIPTION
Flags the `camel-cxf` entry in `camel-4x-upgrade-guide-4_14.adoc` as a potential
breaking change, matching the existing `camel-grok - potential breaking change`
convention. The CXF Exchange-header constant rename (CAMEL-23526, shipped on
this line via #23376) changes header *values* and alters cross-transport
propagation — a behaviour change worth flagging in the section title so readers
scanning the guide notice it.

Docs-only; no code change.

JIRA: https://issues.apache.org/jira/browse/CAMEL-23526

---
_PR prepared by Claude Code on behalf of Andrea Cosentino._
