### PR TITLE
CAMEL-23526: docs - flag camel-cxf 4.18/4.14 upgrade-guide entries as potential breaking change

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -368,7 +368,7 @@ component with the rest of the Camel component catalog. Routes that relied on re
 header names on inbound SNS messages can supply a custom `headerFilterStrategy` to restore the
 previous behaviour.
 
-=== camel-cxf
+=== camel-cxf - potential breaking change
 
 The Exchange header constants in `CxfConstants` (module `camel-cxf-common`, shared
 by `camel-cxf` and `camel-cxfrs`) have been renamed to follow the Camel naming

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -590,7 +590,7 @@ component with the rest of the Camel component catalog. Routes that relied on re
 header names on inbound SNS messages can supply a custom `headerFilterStrategy` to restore the
 previous behaviour.
 
-=== camel-cxf
+=== camel-cxf - potential breaking change
 
 The Exchange header constants in `CxfConstants` (module `camel-cxf-common`, shared
 by `camel-cxf` and `camel-cxfrs`) have been renamed to follow the Camel naming


### PR DESCRIPTION
Flags the `camel-cxf` entries in both `camel-4x-upgrade-guide-4_18.adoc` and
`camel-4x-upgrade-guide-4_14.adoc` on `main` as a potential breaking change,
matching the existing `camel-grok - potential breaking change` convention and
keeping main's canonical multi-version upgrade-guide history in sync with the
matching changes on the `camel-4.18.x` and `camel-4.14.x` maintenance branches.

The CXF Exchange-header constant rename (CAMEL-23526) changes header *values*
and alters cross-transport propagation — a behaviour change worth flagging in
the section title.

Docs-only; no code change. Per CLAUDE.md's backport upgrade-guide policy.

JIRA: https://issues.apache.org/jira/browse/CAMEL-23526

---
_PR prepared by Claude Code on behalf of Andrea Cosentino._
