### PR TITLE
CAMEL-23510: flag camel-jgroups header rename as potential breaking change in 4.18 upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -109,7 +109,7 @@ Hazelcast topic, queue, map, list, set, or in one of the repositories
 above must provide their own `Config` with a
 `JavaSerializationFilterConfig` configured for their class names.
 
-=== camel-jgroups
+=== camel-jgroups - potential breaking change
 
 The Exchange header constants in `JGroupsConstants` have been renamed to follow
 the Camel naming convention used across the rest of the component catalog. The
@@ -124,11 +124,12 @@ Java field names are unchanged; only the header string values have changed:
 | `JGroupsConstants.HEADER_JGROUPS_ORIGINAL_MESSAGE` | `JGROUPS_ORIGINAL_MESSAGE` | `CamelJGroupsOriginalMessage`
 |===
 
-Routes that reference the constant symbolically (for example
-`setHeader(JGroupsConstants.HEADER_JGROUPS_DEST, ...)`) continue to work
-without changes. Routes that set the header by its literal string value
-(for example `setHeader("JGROUPS_DEST", ...)`) must be updated to use the
-new value (`setHeader("CamelJGroupsDest", ...)`).
+This is a breaking change for routes that read or write these headers by
+their literal string value. Routes that reference the constant symbolically
+(for example `setHeader(JGroupsConstants.HEADER_JGROUPS_DEST, ...)`) continue
+to work without changes. Routes that set the header by its literal string
+value (for example `setHeader("JGROUPS_DEST", ...)`) must be updated to use
+the new value (`setHeader("CamelJGroupsDest", ...)`).
 
 === camel-lucene
 


### PR DESCRIPTION
## Summary

Follow-up to #23209 ([CAMEL-23510](https://issues.apache.org/jira/browse/CAMEL-23510)) completing the breaking-change labelling across **all** affected upgrade guides.

The JGroups header constant rename was also backported to `camel-4.18.x` (#23213) and documented on `main`'s `camel-4x-upgrade-guide-4_18.adoc` via the doc-sync #23219. Like the 4.14 and 4.21 guides, that entry did not explicitly flag the rename as a breaking change — which @apupier asked for on #23422.

This PR applies the same wording to the 4.18 guide entry.

## Changes

- `docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc`:
  - Heading: `=== camel-jgroups` → `=== camel-jgroups - potential breaking change` (matching the existing `=== camel-grok - potential breaking change` convention).
  - Prose: prepend an explicit "This is a breaking change for routes that read or write these headers by their literal string value." sentence.

No code changes; pure docs update (7 insertions, 6 deletions).

## Consistency across all guides

The identical wording now applies to every place the JGroups rename is documented:

| Guide | Branch | PR |
|-------|--------|-----|
| 4.14 | `camel-4.14.x` | #23441 |
| 4.14 | `main` | #23422 (merged) |
| 4.18 | `main` | **this PR** |
| 4.21 | `main` | #23451 (merged) |

> Note: the 4.18 rename backport (#23213) did not add an entry to `camel-4x-upgrade-guide-4_18.adoc` on the `camel-4.18.x` maintenance branch — the 4.18 note lives only on `main` (added by #23219), consistent with the "upgrade-guide entry on `main`, not the maintenance branch" convention. So no maintenance-branch change is needed here.

## Related

- Original PR: #23209 (merged)
- 4.18 rename backport: #23213 (merged)
- 4.18 doc-sync to main: #23219 (merged)

## Test plan

- [x] Docs-only change.
- [x] Heading style matches the existing `=== camel-grok - potential breaking change` convention.

---

_Claude Code on behalf of Andrea Cosentino_