### PR TITLE
CAMEL-23590: camel-milo - align Exchange header constant names with Camel naming convention

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/milo-client.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/milo-client.json
@@ -53,7 +53,7 @@
   },
   "headers": {
     "CamelMiloNodeIds": { "index": 0, "kind": "header", "displayName": "", "group": "producer", "label": "producer", "required": false, "javaType": "List", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The node ids.", "constantName": "org.apache.camel.component.milo.MiloConstants#HEADER_NODE_IDS" },
-    "await": { "index": 1, "kind": "header", "displayName": "", "group": "producer", "label": "producer", "required": false, "javaType": "Boolean", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The await setting for writes.", "constantName": "org.apache.camel.component.milo.MiloConstants#HEADER_AWAIT" }
+    "CamelMiloAwait": { "index": 1, "kind": "header", "displayName": "", "group": "producer", "label": "producer", "required": false, "javaType": "Boolean", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The await setting for writes.", "constantName": "org.apache.camel.component.milo.MiloConstants#HEADER_AWAIT" }
   },
   "properties": {
     "endpointUri": { "index": 0, "kind": "path", "displayName": "Endpoint Uri", "group": "common", "label": "", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The OPC UA server endpoint" },

--- a/components/camel-milo/src/generated/resources/META-INF/org/apache/camel/component/milo/client/milo-client.json
+++ b/components/camel-milo/src/generated/resources/META-INF/org/apache/camel/component/milo/client/milo-client.json
@@ -53,7 +53,7 @@
   },
   "headers": {
     "CamelMiloNodeIds": { "index": 0, "kind": "header", "displayName": "", "group": "producer", "label": "producer", "required": false, "javaType": "List", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The node ids.", "constantName": "org.apache.camel.component.milo.MiloConstants#HEADER_NODE_IDS" },
-    "await": { "index": 1, "kind": "header", "displayName": "", "group": "producer", "label": "producer", "required": false, "javaType": "Boolean", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The await setting for writes.", "constantName": "org.apache.camel.component.milo.MiloConstants#HEADER_AWAIT" }
+    "CamelMiloAwait": { "index": 1, "kind": "header", "displayName": "", "group": "producer", "label": "producer", "required": false, "javaType": "Boolean", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The await setting for writes.", "constantName": "org.apache.camel.component.milo.MiloConstants#HEADER_AWAIT" }
   },
   "properties": {
     "endpointUri": { "index": 0, "kind": "path", "displayName": "Endpoint Uri", "group": "common", "label": "", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The OPC UA server endpoint" },

--- a/components/camel-milo/src/main/docs/milo-client-component.adoc
+++ b/components/camel-milo/src/main/docs/milo-client-component.adoc
@@ -136,7 +136,7 @@ Example:
 ----
 from("direct:start")
     .setHeader("CamelMiloNodeIds", constant(Arrays.asList("nsu=urn:org:apache:camel;s=myitem1")))
-    .setHeader("await", constant(true)) // await: parameter "defaultAwaitWrites"
+    .setHeader("CamelMiloAwait", constant(true)) // CamelMiloAwait: parameter "defaultAwaitWrites"
         .enrich("milo-client:opc.tcp://localhost:4334", new AggregationStrategy() {
 
             @Override

--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/MiloConstants.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/MiloConstants.java
@@ -29,7 +29,7 @@ public final class MiloConstants {
     public static final String HEADER_NODE_IDS = "CamelMiloNodeIds";
     @Metadata(label = "producer", description = "The \"await\" setting for writes.", javaType = "Boolean",
               applicableFor = SCHEME_CLIENT)
-    public static final String HEADER_AWAIT = "await";
+    public static final String HEADER_AWAIT = "CamelMiloAwait";
 
     private MiloConstants() {
 

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/WriteClientTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/WriteClientTest.java
@@ -171,6 +171,6 @@ public class WriteClientTest extends AbstractMiloServerTest {
 
     private static void sendValue(final ProducerTemplate producerTemplate, final Variant variant) {
         // we always write synchronously since we do need the message order
-        producerTemplate.sendBodyAndHeader(variant, "await", true);
+        producerTemplate.sendBodyAndHeader(variant, "CamelMiloAwait", true);
     }
 }

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/call/CallClientTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/call/CallClientTest.java
@@ -208,6 +208,6 @@ public class CallClientTest extends AbstractMiloServerTest {
 
     private static void doCall(final ProducerTemplate producerTemplate, final Object input) {
         // we always write synchronously since we do need the message order
-        producerTemplate.sendBodyAndHeader(input, "await", true);
+        producerTemplate.sendBodyAndHeader(input, "CamelMiloAwait", true);
     }
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -1320,6 +1320,32 @@ As a consequence, the generated Endpoint DSL header accessors on
 `MailHeaderNameBuilder` have been renamed: `copyTo()` -> `mailCopyTo()`,
 `moveTo()` -> `mailMoveTo()`, and `delete()` -> `mailDelete()`.
 
+=== camel-milo - potential breaking change
+
+The `MiloConstants.HEADER_AWAIT` constant, which controls whether milo-client
+writes are awaited, used the header value `await` — outside the `Camel`
+namespace and therefore not filtered by the default `HeaderFilterStrategy`. It
+has been renamed to follow the Camel naming convention. The Java field name is
+unchanged; only the header string value has changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `MiloConstants.HEADER_AWAIT` | `await` | `CamelMiloAwait`
+|===
+
+`MiloConstants.HEADER_NODE_IDS` was already `Camel`-prefixed
+(`CamelMiloNodeIds`) and is unchanged.
+
+Routes that reference the constant symbolically (for example
+`setHeader(MiloConstants.HEADER_AWAIT, ...)`) continue to work without changes.
+Routes that set the header by its literal string value (for example
+`setHeader("await", ...)`) must be updated to use the new value
+(`setHeader("CamelMiloAwait", ...)`).
+
+As a consequence, the generated Endpoint DSL header accessor `await()` on
+`MiloClientHeaderNameBuilder` has been renamed to `miloAwait()`.
+
 === Jackson dataformat documentation pages renamed
 
 The Jackson 2.x and Jackson 3.x lines ship the same dataformat names (`jackson`, `jacksonXml`,

--- a/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/MiloClientEndpointBuilderFactory.java
+++ b/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/MiloClientEndpointBuilderFactory.java
@@ -2351,10 +2351,10 @@ public interface MiloClientEndpointBuilderFactory {
          * 
          * Group: producer
          * 
-         * @return the name of the header {@code await}.
+         * @return the name of the header {@code MiloAwait}.
          */
-        public String await() {
-            return "await";
+        public String miloAwait() {
+            return "CamelMiloAwait";
         }
     }
     static MiloClientEndpointBuilder endpointBuilder(String componentName, String path) {


### PR DESCRIPTION
## Summary

Renames the `MiloConstants.HEADER_AWAIT` header string value from `await` —
which sits **outside** the `Camel` namespace and is therefore not filtered by
the default `HeaderFilterStrategy` — to `CamelMiloAwait`, following the
convention used across the rest of the Camel component catalog and matching the
pattern established in CAMEL-23526 (`camel-cxf`), CAMEL-23522 (`camel-mail`),
CAMEL-23461 (`camel-aws-bedrock`), CAMEL-23532 (`camel-vertx-websocket` /
`camel-atmosphere-websocket` / `camel-iggy`), and CAMEL-23576 (`camel-jira`).

| Constant | Previous value | New value |
|----------|----------------|-----------|
| `MiloConstants.HEADER_AWAIT` | `await` | `CamelMiloAwait` |

`HEADER_AWAIT` controls whether `milo-client` writes are awaited. The Java
field name is unchanged so routes referencing the constant symbolically
continue to work; routes using the literal string value must be updated
(documented in the 4.21 upgrade guide).

## Already-compliant constants left unchanged

`MiloConstants.HEADER_NODE_IDS` was already `Camel`-prefixed (`CamelMiloNodeIds`).

## Test changes

`WriteClientTest` and `CallClientTest` set the header by its literal value
`"await"`; both are updated to `"CamelMiloAwait"`.

## Generated artifacts

- `components/camel-milo/.../milo-client.json` + catalog mirror
- `dsl/camel-endpointdsl/.../MiloClientEndpointBuilderFactory.java` — DSL header
  accessor renamed (`await()` → `miloAwait()`)

## Backports

- `camel-4.18.x`: `camel-milo` exists with the same legacy value (`await`) —
  backport applies and will be filed as a follow-up PR.
- `camel-4.14.x`: `camel-milo` does **not** exist on that branch (the component
  was removed and later reinstated) — no backport.

## Test plan

- [x] `mvn test` in `components/camel-milo` — 41 tests pass (1 skipped)
- [x] Module + catalog + endpointdsl built cleanly; only `camel-milo` regen
      artifacts included
- [x] The two literal-header tests updated to the new value
- [x] Upgrade guide entry added under `=== camel-milo`

Tracker: CAMEL-23577

_Reported by Claude Code on behalf of Andrea Cosentino_