### PR TITLE
CAMEL-23576: docs - sync camel-jira upgrade-guide entry to main (4_18 / 4_14) and flag as potential breaking change

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -202,6 +202,66 @@ Even with the opt-in, route authors should still strip the namespace with
 In addition, the inbound `MailHeaderFilterStrategy` now blocks the `mail.smtp.` / `mail.smtps.`
 prefix as well, so an external mail message can no longer inject these into a downstream exchange.
 
+=== camel-jira - potential breaking change
+
+The Exchange header constants in `JiraConstants` have been renamed to follow the
+Camel naming convention used across the rest of the component catalog. The Java
+field names are unchanged; only the header string values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `JiraConstants.ISSUE_ASSIGNEE_ID` | `IssueAssigneeId` | `CamelJiraIssueAssigneeId`
+| `JiraConstants.ISSUE_ASSIGNEE` | `IssueAssignee` | `CamelJiraIssueAssignee`
+| `JiraConstants.ISSUE_COMPONENTS` | `IssueComponents` | `CamelJiraIssueComponents`
+| `JiraConstants.ISSUE_COMMENT` | `IssueComment` | `CamelJiraIssueComment`
+| `JiraConstants.ISSUE_CHANGED` | `IssueChanged` | `CamelJiraIssueChanged`
+| `JiraConstants.ISSUE_KEY` | `IssueKey` | `CamelJiraIssueKey`
+| `JiraConstants.ISSUE_PRIORITY_ID` | `IssuePriorityId` | `CamelJiraIssuePriorityId`
+| `JiraConstants.ISSUE_PRIORITY_NAME` | `IssuePriorityName` | `CamelJiraIssuePriorityName`
+| `JiraConstants.ISSUE_PROJECT_KEY` | `ProjectKey` | `CamelJiraIssueProjectKey`
+| `JiraConstants.ISSUE_SUMMARY` | `IssueSummary` | `CamelJiraIssueSummary`
+| `JiraConstants.ISSUE_TRANSITION_ID` | `IssueTransitionId` | `CamelJiraIssueTransitionId`
+| `JiraConstants.ISSUE_TYPE_ID` | `IssueTypeId` | `CamelJiraIssueTypeId`
+| `JiraConstants.ISSUE_TYPE_NAME` | `IssueTypeName` | `CamelJiraIssueTypeName`
+| `JiraConstants.ISSUE_WATCHED_ISSUES` | `IssueWatchedIssues` | `CamelJiraIssueWatchedIssues`
+| `JiraConstants.ISSUE_WATCHERS_ADD` | `IssueWatchersAdd` | `CamelJiraIssueWatchersAdd`
+| `JiraConstants.ISSUE_WATCHERS_REMOVE` | `IssueWatchersRemove` | `CamelJiraIssueWatchersRemove`
+| `JiraConstants.PARENT_ISSUE_KEY` | `ParentIssueKey` | `CamelJiraParentIssueKey`
+| `JiraConstants.CHILD_ISSUE_KEY` | `ChildIssueKey` | `CamelJiraChildIssueKey`
+| `JiraConstants.LINK_TYPE` | `linkType` | `CamelJiraLinkType`
+| `JiraConstants.MINUTES_SPENT` | `minutesSpent` | `CamelJiraMinutesSpent`
+|===
+
+Routes that reference the constants symbolically (for example
+`setHeader(JiraConstants.ISSUE_KEY, ...)`) continue to work without changes.
+Routes that set the header by its literal string value (for example
+`setHeader("IssueKey", ...)`) must be updated to use the new value
+(`setHeader("CamelJiraIssueKey", ...)`).
+
+As a consequence, the generated Endpoint DSL header accessors on
+`JiraHeaderNameBuilder` have been renamed accordingly:
+
+* `issueAssigneeId()` -> `jiraIssueAssigneeId()`
+* `issueAssignee()` -> `jiraIssueAssignee()`
+* `issueComponents()` -> `jiraIssueComponents()`
+* `issueChanged()` -> `jiraIssueChanged()`
+* `issueKey()` -> `jiraIssueKey()`
+* `issuePriorityId()` -> `jiraIssuePriorityId()`
+* `issuePriorityName()` -> `jiraIssuePriorityName()`
+* `projectKey()` -> `jiraIssueProjectKey()`
+* `issueSummary()` -> `jiraIssueSummary()`
+* `issueTransitionId()` -> `jiraIssueTransitionId()`
+* `issueTypeId()` -> `jiraIssueTypeId()`
+* `issueTypeName()` -> `jiraIssueTypeName()`
+* `issueWatchedIssues()` -> `jiraIssueWatchedIssues()`
+* `issueWatchersAdd()` -> `jiraIssueWatchersAdd()`
+* `issueWatchersRemove()` -> `jiraIssueWatchersRemove()`
+* `parentIssueKey()` -> `jiraParentIssueKey()`
+* `childIssueKey()` -> `jiraChildIssueKey()`
+* `linkType()` -> `jiraLinkType()`
+* `minutesSpent()` -> `jiraMinutesSpent()`
+
 == Upgrading from 4.14.2 to 4.14.3
 
 === camel-tika

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -233,6 +233,66 @@ Even with the opt-in, route authors should still strip the namespace with
 In addition, the inbound `MailHeaderFilterStrategy` now blocks the `mail.smtp.` / `mail.smtps.`
 prefix as well, so an external mail message can no longer inject these into a downstream exchange.
 
+=== camel-jira - potential breaking change
+
+The Exchange header constants in `JiraConstants` have been renamed to follow the
+Camel naming convention used across the rest of the component catalog. The Java
+field names are unchanged; only the header string values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `JiraConstants.ISSUE_ASSIGNEE_ID` | `IssueAssigneeId` | `CamelJiraIssueAssigneeId`
+| `JiraConstants.ISSUE_ASSIGNEE` | `IssueAssignee` | `CamelJiraIssueAssignee`
+| `JiraConstants.ISSUE_COMPONENTS` | `IssueComponents` | `CamelJiraIssueComponents`
+| `JiraConstants.ISSUE_COMMENT` | `IssueComment` | `CamelJiraIssueComment`
+| `JiraConstants.ISSUE_CHANGED` | `IssueChanged` | `CamelJiraIssueChanged`
+| `JiraConstants.ISSUE_KEY` | `IssueKey` | `CamelJiraIssueKey`
+| `JiraConstants.ISSUE_PRIORITY_ID` | `IssuePriorityId` | `CamelJiraIssuePriorityId`
+| `JiraConstants.ISSUE_PRIORITY_NAME` | `IssuePriorityName` | `CamelJiraIssuePriorityName`
+| `JiraConstants.ISSUE_PROJECT_KEY` | `ProjectKey` | `CamelJiraIssueProjectKey`
+| `JiraConstants.ISSUE_SUMMARY` | `IssueSummary` | `CamelJiraIssueSummary`
+| `JiraConstants.ISSUE_TRANSITION_ID` | `IssueTransitionId` | `CamelJiraIssueTransitionId`
+| `JiraConstants.ISSUE_TYPE_ID` | `IssueTypeId` | `CamelJiraIssueTypeId`
+| `JiraConstants.ISSUE_TYPE_NAME` | `IssueTypeName` | `CamelJiraIssueTypeName`
+| `JiraConstants.ISSUE_WATCHED_ISSUES` | `IssueWatchedIssues` | `CamelJiraIssueWatchedIssues`
+| `JiraConstants.ISSUE_WATCHERS_ADD` | `IssueWatchersAdd` | `CamelJiraIssueWatchersAdd`
+| `JiraConstants.ISSUE_WATCHERS_REMOVE` | `IssueWatchersRemove` | `CamelJiraIssueWatchersRemove`
+| `JiraConstants.PARENT_ISSUE_KEY` | `ParentIssueKey` | `CamelJiraParentIssueKey`
+| `JiraConstants.CHILD_ISSUE_KEY` | `ChildIssueKey` | `CamelJiraChildIssueKey`
+| `JiraConstants.LINK_TYPE` | `linkType` | `CamelJiraLinkType`
+| `JiraConstants.MINUTES_SPENT` | `minutesSpent` | `CamelJiraMinutesSpent`
+|===
+
+Routes that reference the constants symbolically (for example
+`setHeader(JiraConstants.ISSUE_KEY, ...)`) continue to work without changes.
+Routes that set the header by its literal string value (for example
+`setHeader("IssueKey", ...)`) must be updated to use the new value
+(`setHeader("CamelJiraIssueKey", ...)`).
+
+As a consequence, the generated Endpoint DSL header accessors on
+`JiraHeaderNameBuilder` have been renamed accordingly:
+
+* `issueAssigneeId()` -> `jiraIssueAssigneeId()`
+* `issueAssignee()` -> `jiraIssueAssignee()`
+* `issueComponents()` -> `jiraIssueComponents()`
+* `issueChanged()` -> `jiraIssueChanged()`
+* `issueKey()` -> `jiraIssueKey()`
+* `issuePriorityId()` -> `jiraIssuePriorityId()`
+* `issuePriorityName()` -> `jiraIssuePriorityName()`
+* `projectKey()` -> `jiraIssueProjectKey()`
+* `issueSummary()` -> `jiraIssueSummary()`
+* `issueTransitionId()` -> `jiraIssueTransitionId()`
+* `issueTypeId()` -> `jiraIssueTypeId()`
+* `issueTypeName()` -> `jiraIssueTypeName()`
+* `issueWatchedIssues()` -> `jiraIssueWatchedIssues()`
+* `issueWatchersAdd()` -> `jiraIssueWatchersAdd()`
+* `issueWatchersRemove()` -> `jiraIssueWatchersRemove()`
+* `parentIssueKey()` -> `jiraParentIssueKey()`
+* `childIssueKey()` -> `jiraChildIssueKey()`
+* `linkType()` -> `jiraLinkType()`
+* `minutesSpent()` -> `jiraMinutesSpent()`
+
 == Upgrading from 4.18.0 to 4.18.1
 
 === camel-bom

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -689,7 +689,7 @@ to work without changes. Routes that set the header by its literal string value
 (for example `setHeader("JGROUPSRAFT_SET_TIMEOUT", ...)`) must be updated to
 use the new value (`setHeader("CamelJGroupsRaftSetTimeout", ...)`).
 
-=== camel-jira
+=== camel-jira - potential breaking change
 
 The Exchange header constants in `JiraConstants` have been renamed to follow the
 Camel naming convention used across the rest of the component catalog. The Java


### PR DESCRIPTION
Documentation-only follow-up to #23417 (merged) and its backports #23460 (4.18.x) / #23472 (4.14.x).

## What

Per the project **backport upgrade-guide policy**, the `camel-4x-upgrade-guide-4_XX.adoc` files for all versions live on `main` as the canonical history across releases. This PR:

1. Adds the `camel-jira` header-rename entry to **`camel-4x-upgrade-guide-4_18.adoc`** on main (mirrors the 4.18.x backport #23460, target 4.18.3).
2. Adds the same entry to **`camel-4x-upgrade-guide-4_14.adoc`** on main (mirrors the 4.14.x backport #23472, target 4.14.8).
3. Flags the existing **4.21** `camel-jira` entry as a **potential breaking change** in its heading, consistent with the other header-rename entries (`camel-grok`, `camel-jgroups`) and to make the literal-string-value migration risk explicit.

## Why

Without this sync, `main`'s version-specific 4.18/4.14 guides would drift out of sync with what actually ships on the maintenance branches.

No code changes; docs only.

_Reported by Claude Code on behalf of Andrea Cosentino_