### PR TITLE
CAMEL-23575: docs - sync camel-mongodb-gridfs 4.14 upgrade-guide entry to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -262,6 +262,31 @@ As a consequence, the generated Endpoint DSL header accessors on
 * `linkType()` -> `jiraLinkType()`
 * `minutesSpent()` -> `jiraMinutesSpent()`
 
+=== camel-mongodb-gridfs - potential breaking change
+
+The Exchange header values exposed by `GridFsConstants` have been renamed to follow the standard
+Camel naming convention, bringing `camel-mongodb-gridfs` in line with the parent `camel-mongodb`
+component (`MongoDbConstants.OPERATION_HEADER = "CamelMongoDbOperation"`). The Java field names
+are unchanged, so routes referencing the constants symbolically
+(e.g. `GridFsConstants.GRIDFS_OPERATION`, `GridFsConstants.GRIDFS_OBJECT_ID`) continue to work
+without modification. However, routes that set or read these headers using the raw string values
+must be updated:
+
+* `gridfs.operation` -> `CamelGridFsOperation`
+* `gridfs.metadata` -> `CamelGridFsMetadata`
+* `gridfs.chunksize` -> `CamelGridFsChunkSize`
+* `gridfs.objectid` -> `CamelGridFsObjectId`
+* `gridfs.fileid` -> `CamelGridFsFileId`
+
+As a consequence, the generated Endpoint DSL header accessors on `GridFsHeaderNameBuilder`
+have been renamed accordingly:
+
+* `gridfsOperation()` -> `gridFsOperation()`
+* `gridfsMetadata()` -> `gridFsMetadata()`
+* `gridfsChunksize()` -> `gridFsChunkSize()`
+* `gridfsObjectid()` -> `gridFsObjectId()`
+* `gridfsFileid()` -> `gridFsFileId()`
+
 == Upgrading from 4.14.2 to 4.14.3
 
 === camel-tika


### PR DESCRIPTION
## Summary

Doc-sync companion to the #23413 / CAMEL-23575 backport to `camel-4.14.x` (#23486).

Per the backport upgrade-guide policy in `CLAUDE.md`, the version-specific `camel-4x-upgrade-guide-4_XX.adoc` files for **all** release lines live on `main` as the canonical history. The code fix for CAMEL-23575 is backported to the `camel-4.14.x` maintenance branch (4.14.8), so the matching upgrade-guide entry must also be present in `camel-4x-upgrade-guide-4_14.adoc` **on `main`** — otherwise main's 4.14 guide drifts out of sync with what ships on 4.14.x.

This PR adds the `=== camel-mongodb-gridfs - potential breaking change` note to the "Upgrading from 4.14.3 to 4.14.8" section, documenting:

- the `gridfs.*` -> `CamelGridFs*` header constant value renames, and
- the cascading `GridFsHeaderNameBuilder` Endpoint DSL accessor renames.

Routes referencing the constants symbolically are unaffected; only routes using the literal string keys or the fluent builder methods need updating.

The "- potential breaking change" heading suffix is added for consistency with the neighbouring camel-jira / camel-cxf / camel-jgroups entries in the same release section (CAMEL-23577 sweep convention).

### Related

- Main fix (4.21): #23413 (merged, CAMEL-23575)
- Backport (4.18.x): #23473
- Doc-sync (4.18): #23477
- Backport (4.14.x): #23486

Docs-only change — no build required.

_Prepared by Claude Code on behalf of Andrea Cosentino._