### PR TITLE
CAMEL-23597: camel-solr - align Exchange header prefix constants with Camel naming convention (4.14.x backport)

### DIFF
--- a/components/camel-solr/src/main/docs/solr-component.adoc
+++ b/components/camel-solr/src/main/docs/solr-component.adoc
@@ -69,7 +69,7 @@ the following. Some operations also require the message body to be set.
 |=======================================================================
 |Operation |Message body |Description
 
-|`INSERT` | n/a |inserts/updates a document using message headers (solr fields must be prefixed with "SolrField.")
+|`INSERT` | n/a |inserts/updates a document using message headers (solr fields must be prefixed with "CamelSolrField.")
 |`INSERT` | File |inserts/updates a document or documents using the given File (using ContentStreamUpdateRequest)
 |`INSERT` | SolrInputDocument or Collection<SolrInputDocument>|inserts/updates a document or documents based on the given (collection of) SolrInputDocument
 |`INSERT` | bean or Collection<bean> |inserts/updates a document or documents based on values in an http://wiki.apache.org/solr/Solrj#Directly_adding_POJOs_to_Solr[annotated bean]
@@ -110,7 +110,7 @@ from("direct:search")
     <setHeader name="CamelSolrOperation">
         <constant>INSERT</constant>
     </setHeader>
-    <setHeader name="SolrField.id">
+    <setHeader name="CamelSolrField.id">
         <simple>${body}</simple>
     </setHeader>
     <to uri="solr://localhost:8983/solr"/>
@@ -136,8 +136,8 @@ delete routes and then call the commit route.
 
 [source,java]
 -----------------------------------------------
-template.sendBodyAndHeader("direct:insert", "1234", "SolrParam.commit", true);
-template.sendBodyAndHeader("direct:delete", "1234", "SolrParam.commit", true);
+template.sendBodyAndHeader("direct:insert", "1234", "CamelSolrParam.commit", true);
+template.sendBodyAndHeader("direct:delete", "1234", "CamelSolrParam.commit", true);
 template.sendBody("direct:search", "id:1234");
 -----------------------------------------------
 

--- a/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrConstants.java
+++ b/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrConstants.java
@@ -42,8 +42,8 @@ public interface SolrConstants {
     @Metadata(description = "The content type is used to identify the type when inserting files.", javaType = "String")
     String PARAM_CONTENT_TYPE = Exchange.CONTENT_TYPE;
 
-    String HEADER_FIELD_PREFIX = "SolrField.";
-    String HEADER_PARAM_PREFIX = "SolrParam.";
+    String HEADER_FIELD_PREFIX = "CamelSolrField.";
+    String HEADER_PARAM_PREFIX = "CamelSolrParam.";
 
     String PROPERTY_ACTION_CONTEXT = "SolrActionContext";
 

--- a/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrProducer.java
+++ b/components/camel-solr/src/main/java/org/apache/camel/component/solr/SolrProducer.java
@@ -69,7 +69,7 @@ public class SolrProducer extends DefaultAsyncProducer {
                 ? message.getHeader(SolrConstants.PARAM_REQUEST_HANDLER, String.class)
                 : configuration.getRequestHandler();
 
-        // Retrieve all SolrParams: SolrParams header and SolrParam.xxx headers
+        // Retrieve all SolrParams: SolrParams header and CamelSolrParam.xxx headers
         ModifiableSolrParams modifiableSolrParams = getAndGroupedSolrParams(message);
         boolean hasSolrParams = modifiableSolrParams.size() > 0;
 
@@ -130,7 +130,7 @@ public class SolrProducer extends DefaultAsyncProducer {
         ModifiableSolrParams modifiableSolrParams = solrParams instanceof ModifiableSolrParams
                 ? (ModifiableSolrParams) solrParams
                 : new ModifiableSolrParams(solrParams);
-        // add possible headers that start with "SolrParam." prefix
+        // add possible headers that start with "CamelSolrParam." prefix
         message.getHeaders().entrySet().stream()
                 .filter(entry -> entry.getKey().startsWith(SolrConstants.HEADER_PARAM_PREFIX))
                 .forEach(entry -> {

--- a/components/camel-solr/src/main/java/org/apache/camel/component/solr/converter/SolrRequestConverter.java
+++ b/components/camel-solr/src/main/java/org/apache/camel/component/solr/converter/SolrRequestConverter.java
@@ -226,14 +226,14 @@ public final class SolrRequestConverter {
             docs.ifPresent(updateRequest::add);
             return updateRequest;
         }
-        // Map: gather solr fields from body and merge with solr fields from headers (gathered from SolrField.xxx headers)
+        // Map: gather solr fields from body and merge with solr fields from headers (gathered from CamelSolrField.xxx headers)
         //      The header solr fields have priority
         Map<String, Object> map = new LinkedHashMap<>(getMapFromBody(body));
         map.putAll(getMapFromHeaderSolrFields(exchange));
         if (!map.isEmpty()) {
             body = map;
         }
-        // Map: translate to SolrInputDocument (possibly gathered from SolrField.xxx headers
+        // Map: translate to SolrInputDocument (possibly gathered from CamelSolrField.xxx headers
         Optional<SolrInputDocument> doc = getOptionalSolrInputDocumentFromMap(body, exchange);
         if (doc.isPresent()) {
             updateRequest.add(doc.get());

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/integration/SolrInsertAndDeleteTest.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/integration/SolrInsertAndDeleteTest.java
@@ -191,7 +191,7 @@ public class SolrInsertAndDeleteTest extends SolrTestSupport {
     public void testInsertStreaming() {
         // TODO rename method
         ExchangeBuilder builder = ExchangeBuilder.anExchange(camelContext())
-                .withHeader("SolrField.id", "MA147LL/A");
+                .withHeader("CamelSolrField.id", "MA147LL/A");
         executeInsert(builder.build());
 
         QueryResponse response = executeSolrQuery("id:MA147LL/A");
@@ -202,7 +202,7 @@ public class SolrInsertAndDeleteTest extends SolrTestSupport {
     @Test
     public void indexSingleDocumentOnlyWithId() {
         ExchangeBuilder builder = ExchangeBuilder.anExchange(camelContext())
-                .withHeader("SolrField.id", "MA147LL/A");
+                .withHeader("CamelSolrField.id", "MA147LL/A");
         executeInsert(builder.build());
 
         // Check things were indexed.
@@ -223,9 +223,9 @@ public class SolrInsertAndDeleteTest extends SolrTestSupport {
     public void setHeadersAsSolrFields() {
         ExchangeBuilder builder = ExchangeBuilder.anExchange(camelContext())
                 .withBody("Body is ignored")
-                .withHeader("SolrField.id", "MA147LL/A")
-                .withHeader("SolrField.name_s", "Apple 60 GB iPod with Video Playback Black")
-                .withHeader("SolrField.manu_s", "Apple Computer Inc.");
+                .withHeader("CamelSolrField.id", "MA147LL/A")
+                .withHeader("CamelSolrField.name_s", "Apple 60 GB iPod with Video Playback Black")
+                .withHeader("CamelSolrField.manu_s", "Apple Computer Inc.");
         executeInsert(builder.build());
 
         QueryResponse response = executeSolrQuery("id:MA147LL/A");
@@ -242,8 +242,8 @@ public class SolrInsertAndDeleteTest extends SolrTestSupport {
         String[] categories = { "electronics", "apple" };
         ExchangeBuilder builder = ExchangeBuilder.anExchange(camelContext())
                 .withBody("Test body for iPod.")
-                .withHeader("SolrField.id", "MA147LL/A")
-                .withHeader("SolrField.cat", categories);
+                .withHeader("CamelSolrField.id", "MA147LL/A")
+                .withHeader("CamelSolrField.cat", categories);
         executeInsert(builder.build());
 
         // Check things were indexed.
@@ -259,9 +259,9 @@ public class SolrInsertAndDeleteTest extends SolrTestSupport {
     @Test
     public void indexDocumentsAndThenCommit() {
         ExchangeBuilder builder = ExchangeBuilder.anExchange(camelContext())
-                .withHeader("SolrField.id", "MA147LL/A")
-                .withHeader("SolrField.name", "Apple 60 GB iPod with Video Playback Black")
-                .withHeader("SolrField.manu", "Apple Computer Inc.");
+                .withHeader("CamelSolrField.id", "MA147LL/A")
+                .withHeader("CamelSolrField.name", "Apple 60 GB iPod with Video Playback Black")
+                .withHeader("CamelSolrField.manu", "Apple Computer Inc.");
         executeInsert(builder.build(), false);
 
         QueryResponse response = executeSolrQuery("*:*");
@@ -279,7 +279,7 @@ public class SolrInsertAndDeleteTest extends SolrTestSupport {
     public void indexWithAutoCommit() {
         // new exchange - not autocommit route
         ExchangeBuilder builder = ExchangeBuilder.anExchange(camelContext())
-                .withHeader("SolrField.content", "NO_AUTO_COMMIT");
+                .withHeader("CamelSolrField.content", "NO_AUTO_COMMIT");
         executeInsert(DEFAULT_START_ENDPOINT, builder.build(), false);
         // not committed
         QueryResponse response = executeSolrQuery("*:*");
@@ -292,7 +292,7 @@ public class SolrInsertAndDeleteTest extends SolrTestSupport {
 
         // new exchange - autocommit route
         builder = ExchangeBuilder.anExchange(camelContext())
-                .withHeader("SolrField.content", "AUTO_COMMIT");
+                .withHeader("CamelSolrField.content", "AUTO_COMMIT");
         executeInsert(DEFAULT_START_ENDPOINT_AUTO_COMMIT, builder.build(), false);
         // should be committed
         response = executeSolrQuery("*:*");
@@ -303,9 +303,9 @@ public class SolrInsertAndDeleteTest extends SolrTestSupport {
     @Test
     public void invalidSolrParametersAreIgnored() {
         ExchangeBuilder builder = ExchangeBuilder.anExchange(camelContext())
-                .withHeader("SolrField.id", "MA147LL/A")
-                .withHeader("SolrField.name", "Apple 60 GB iPod with Video Playback Black")
-                .withHeader("SolrParam.invalid-param", "this is ignored");
+                .withHeader("CamelSolrField.id", "MA147LL/A")
+                .withHeader("CamelSolrField.name", "Apple 60 GB iPod with Video Playback Black")
+                .withHeader("CamelSolrParam.invalid-param", "this is ignored");
         executeInsert(builder.build());
 
         QueryResponse response = executeSolrQuery("*:*");
@@ -374,9 +374,9 @@ public class SolrInsertAndDeleteTest extends SolrTestSupport {
         ExchangeBuilder builder = ExchangeBuilder.anExchange(camelContext())
                 .withBody(new File("src/test/resources/data/books.csv"))
                 .withHeader(SolrConstants.PARAM_CONTENT_TYPE, "text/csv")
-                .withHeader("SolrParam.fieldnames", "id,cat,name,price,inStock,author_t,series_t,sequence_i,genre_s")
-                .withHeader("SolrParam.skip", "cat,sequence_i,genre_s")
-                .withHeader("SolrParam.skipLines", 1);
+                .withHeader("CamelSolrParam.fieldnames", "id,cat,name,price,inStock,author_t,series_t,sequence_i,genre_s")
+                .withHeader("CamelSolrParam.skip", "cat,sequence_i,genre_s")
+                .withHeader("CamelSolrParam.skipLines", 1);
         executeInsert(builder.build());
         QueryResponse response = executeSolrQuery("*:*");
         assertEquals(0, response.getStatus());
@@ -392,7 +392,7 @@ public class SolrInsertAndDeleteTest extends SolrTestSupport {
 
         ExchangeBuilder builder = ExchangeBuilder.anExchange(camelContext())
                 .withBody(new File("src/test/resources/data/tutorial.pdf"))
-                .withHeader("SolrParam.literal.id", "tutorial.pdf");
+                .withHeader("CamelSolrParam.literal.id", "tutorial.pdf");
         executeInsert(builder.build());
 
         QueryResponse response = executeSolrQuery("*:*");

--- a/components/camel-solr/src/test/java/org/apache/camel/component/solr/integration/SolrTestSupport.java
+++ b/components/camel-solr/src/test/java/org/apache/camel/component/solr/integration/SolrTestSupport.java
@@ -147,7 +147,7 @@ public abstract class SolrTestSupport implements CamelTestSupportHelper, Configu
     protected void solrInsertTestEntry(String id) {
         Map<String, Object> headers = new HashMap<>();
         headers.put(SolrConstants.PARAM_OPERATION, SolrConstants.OPERATION_INSERT);
-        headers.put("SolrField.id", id);
+        headers.put("CamelSolrField.id", id);
         template.sendBodyAndHeaders(DEFAULT_START_ENDPOINT, "", headers);
     }
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -181,6 +181,37 @@ As a consequence, the generated Endpoint DSL header accessors on
 * `linkType()` -> `jiraLinkType()`
 * `minutesSpent()` -> `jiraMinutesSpent()`
 
+=== camel-solr
+
+The two Exchange header prefix constants in `SolrConstants` have been renamed to
+follow the Camel naming convention already used by the other constants in the
+same file (which were renamed in 4.10 under CAMEL-21697). The Java field names
+are unchanged; only the prefix string values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `SolrConstants.HEADER_FIELD_PREFIX` | `SolrField.` | `CamelSolrField.`
+| `SolrConstants.HEADER_PARAM_PREFIX` | `SolrParam.` | `CamelSolrParam.`
+|===
+
+Routes that reference the constants symbolically (for example
+`setHeader(SolrConstants.HEADER_FIELD_PREFIX + "id", ...)`) continue to work
+without changes. Routes that set the headers by their literal string value
+(for example `setHeader("SolrField.id", ...)` or
+`setHeader("SolrParam.commit", ...)`) must be updated to use the new prefix
+(`CamelSolrField.id`, `CamelSolrParam.commit`).
+
+Because the renamed prefixes now begin with `Camel`, they are stripped by the
+standard transport `HeaderFilterStrategy` (`HttpHeaderFilterStrategy`, etc.)
+when crossing a transport boundary, by design — `Camel*` headers are
+framework-internal and are not propagated over the wire. Routes that bridge an
+external transport (HTTP, JMS, ...) into a `solr:` producer and want to drive
+Solr document fields or query parameters from a header supplied by the sender
+must therefore carry the value in a non-`Camel`-prefixed application header and
+map it to the appropriate `CamelSolrField.*` / `CamelSolrParam.*` header in the
+route between the transport `from` and the `solr:` `to`.
+
 == Upgrading from 4.14.5 to 4.14.6
 
 === camel-platform-http-main


### PR DESCRIPTION
## Summary

Backport to `camel-4.14.x` of the `camel-solr` Exchange header prefix alignment merged to `main` in #23410.

Renames the two prefix constants in `SolrConstants`:

- `SolrConstants.HEADER_FIELD_PREFIX` value: `"SolrField."` -> `"CamelSolrField."`
- `SolrConstants.HEADER_PARAM_PREFIX` value: `"SolrParam."` -> `"CamelSolrParam."`

The Java field names are unchanged, so routes referencing the constants symbolically are unaffected. Routes that set the headers by their literal string value must adopt the new prefix — documented in the 4.14 upgrade-guide entry added by this PR.

Completes the `CamelSolrXxx` alignment started in CAMEL-21697 (which renamed the other `SolrConstants` Exchange header constants but missed the two prefix constants). Consistent with the alignment applied to sibling components in CAMEL-23506, CAMEL-23522, CAMEL-23526 and CAMEL-23532. Companion of the 4.18.x backport in #23483.

## What changed

- `SolrConstants.java`: prefix values renamed.
- `SolrProducer.java` / `SolrRequestConverter.java`: inline javadoc comments updated.
- `SolrInsertAndDeleteTest`, `SolrTestSupport`: integration-test header literals updated.
- `solr-component.adoc`: documentation snippets updated.
- `camel-4x-upgrade-guide-4_14.adoc`: new `=== camel-solr` entry under the 4.14.7 -> 4.14.8 section.

The comment-rename hunk in `SolrPingAndSearchTest` does not apply on this branch because the corresponding `testQueryWithMultipleFilters` test was added on `main` as part of CAMEL-22465 and is not present here.

> Note: the canonical `camel-4x-upgrade-guide-4_14.adoc` on `main` will be updated with the same entry in a follow-up doc-sync PR, per the backport upgrade-guide policy.

## Test plan

- [x] `mvn -DskipTests formatter:format impsort:sort install` in `components/camel-solr` — BUILD SUCCESS.
- [x] Cherry-pick of the `main` squash commit (`4578a9014a6`); the upgrade-guide note was redirected from the `4_21` guide to the `4_14` guide, and the `testQueryWithMultipleFilters` hunk in `SolrPingAndSearchTest` was dropped (test not present on this branch).
- [ ] CI green.

---

_Claude Code on behalf of Andrea Cosentino_