### PR TITLE
CAMEL-21122: camel-test - release AvailablePortFinder.Port after each test for non-static @RegisterExtension fields

### DIFF
--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/BaseJettyTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/BaseJettyTest.java
@@ -23,7 +23,6 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.http.common.HttpHeaderFilterStrategy;
 import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public abstract class BaseJettyTest extends CamelTestSupport {
@@ -35,13 +34,6 @@ public abstract class BaseJettyTest extends CamelTestSupport {
 
     @RegisterExtension
     protected AvailablePortFinder.Port port2 = AvailablePortFinder.find();
-
-    // Due to CAMEL-21122 ports are never released. So, force them to be released.
-    @AfterEach
-    void cleanupPorts() {
-        port1.release();
-        port2.release();
-    }
 
     @Override
     protected CamelContext createCamelContext() throws Exception {

--- a/components/camel-test/camel-test-junit5/pom.xml
+++ b/components/camel-test/camel-test-junit5/pom.xml
@@ -164,6 +164,11 @@
             <artifactId>junit-jupiter-params</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito-version}</version>

--- a/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/AvailablePortFinder.java
+++ b/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/AvailablePortFinder.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
@@ -36,10 +38,12 @@ public final class AvailablePortFinder {
 
     private static final AvailablePortFinder INSTANCE = new AvailablePortFinder();
 
-    public class Port implements BeforeEachCallback, AfterAllCallback, AutoCloseable {
+    public class Port
+            implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback, AutoCloseable {
         final int port;
         String testClass;
         final Throwable creation;
+        private volatile boolean classScoped;
 
         public Port(int port) {
             this.port = port;
@@ -60,9 +64,25 @@ public final class AvailablePortFinder {
         }
 
         @Override
+        public void beforeAll(ExtensionContext context) throws Exception {
+            // beforeAll only fires when @RegisterExtension is on a static field,
+            // so use it as the signal that this Port lives for the whole test class.
+            classScoped = true;
+        }
+
+        @Override
         public void beforeEach(ExtensionContext context) throws Exception {
             testClass = context.getTestClass().map(Class::getName).orElse(null);
             LOG.info("Registering port {} for test {}", port, testClass);
+        }
+
+        @Override
+        public void afterEach(ExtensionContext context) throws Exception {
+            if (!classScoped) {
+                // Non-static @RegisterExtension: afterAll is never invoked by JUnit Jupiter,
+                // so release here to keep the port mapping bounded.
+                release();
+            }
         }
 
         @Override
@@ -118,6 +138,10 @@ public final class AvailablePortFinder {
 
     synchronized void release(Port port) {
         INSTANCE.portMapping.remove(port.getPort(), port);
+    }
+
+    static boolean isRegistered(Port port) {
+        return INSTANCE.portMapping.get(port.getPort()) == port;
     }
 
     /**

--- a/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/AvailablePortFinderLifecycleTest.java
+++ b/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/AvailablePortFinderLifecycleTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Drives nested test classes through the JUnit Platform launcher to verify that {@link AvailablePortFinder.Port} reacts
+ * correctly to all three combinations of {@code @RegisterExtension} placement and {@code @TestInstance} lifecycle. The
+ * pre-existing leak (CAMEL-21122) only manifested under the real JUnit lifecycle, so this test exercises it directly
+ * instead of calling callbacks by hand.
+ */
+public class AvailablePortFinderLifecycleTest {
+
+    static final List<AvailablePortFinder.Port> SEEN = new ArrayList<>();
+
+    public static class PerMethodNonStaticContainer {
+        @RegisterExtension
+        AvailablePortFinder.Port port = AvailablePortFinder.find();
+
+        @Test
+        void t1() {
+            SEEN.add(port);
+        }
+
+        @Test
+        void t2() {
+            SEEN.add(port);
+        }
+    }
+
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    public static class PerClassNonStaticContainer {
+        @RegisterExtension
+        AvailablePortFinder.Port port = AvailablePortFinder.find();
+
+        @Test
+        void t1() {
+            SEEN.add(port);
+        }
+
+        @Test
+        void t2() {
+            SEEN.add(port);
+        }
+    }
+
+    public static class StaticContainer {
+        @RegisterExtension
+        static AvailablePortFinder.Port PORT = AvailablePortFinder.find();
+
+        @Test
+        void t1() {
+            SEEN.add(PORT);
+        }
+
+        @Test
+        void t2() {
+            SEEN.add(PORT);
+        }
+    }
+
+    @Test
+    public void perMethodNonStaticPortReleasesAfterEach() {
+        SEEN.clear();
+        run(PerMethodNonStaticContainer.class);
+
+        // Default lifecycle: JUnit constructs a fresh test instance per method,
+        // so each method sees its own Port. Both must be released after their test.
+        assertEquals(2, SEEN.size(), "two test methods should have observed a Port each");
+        assertNotSame(SEEN.get(0), SEEN.get(1), "PER_METHOD lifecycle must allocate a new Port per method");
+        assertFalse(AvailablePortFinder.isRegistered(SEEN.get(0)), "first method's port must be released");
+        assertFalse(AvailablePortFinder.isRegistered(SEEN.get(1)), "second method's port must be released");
+    }
+
+    @Test
+    public void perClassNonStaticPortSurvivesAndReleasesOnAfterAll() {
+        SEEN.clear();
+        run(PerClassNonStaticContainer.class);
+
+        // PER_CLASS reuses the single test instance, so both methods share the same Port.
+        // JUnit also delivers BeforeAllCallback/AfterAllCallback to instance extensions
+        // under PER_CLASS, so classScoped is set, afterEach is a no-op, and afterAll
+        // releases the port exactly once.
+        assertEquals(2, SEEN.size(), "two test methods should have observed a Port each");
+        assertSame(SEEN.get(0), SEEN.get(1), "PER_CLASS lifecycle must share a single Port across methods");
+        assertFalse(AvailablePortFinder.isRegistered(SEEN.get(0)), "shared port must be released on afterAll");
+    }
+
+    @Test
+    public void staticPortSurvivesAndReleasesOnAfterAll() {
+        SEEN.clear();
+        run(StaticContainer.class);
+
+        assertEquals(2, SEEN.size(), "two test methods should have observed a Port each");
+        assertSame(SEEN.get(0), SEEN.get(1), "static @RegisterExtension must share a single Port across methods");
+        assertFalse(AvailablePortFinder.isRegistered(SEEN.get(0)), "static port must be released on afterAll");
+    }
+
+    private static void run(Class<?> testClass) {
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(DiscoverySelectors.selectClass(testClass))
+                .build();
+        LauncherFactory.create().execute(request);
+    }
+}

--- a/components/camel-test/camel-test-junit6/src/main/java/org/apache/camel/test/AvailablePortFinder.java
+++ b/components/camel-test/camel-test-junit6/src/main/java/org/apache/camel/test/AvailablePortFinder.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
@@ -36,10 +38,12 @@ public final class AvailablePortFinder {
 
     private static final AvailablePortFinder INSTANCE = new AvailablePortFinder();
 
-    public class Port implements BeforeEachCallback, AfterAllCallback, AutoCloseable {
+    public class Port
+            implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback, AutoCloseable {
         final int port;
         String testClass;
         final Throwable creation;
+        private volatile boolean classScoped;
 
         public Port(int port) {
             this.port = port;
@@ -60,9 +64,25 @@ public final class AvailablePortFinder {
         }
 
         @Override
+        public void beforeAll(ExtensionContext context) throws Exception {
+            // beforeAll only fires when @RegisterExtension is on a static field,
+            // so use it as the signal that this Port lives for the whole test class.
+            classScoped = true;
+        }
+
+        @Override
         public void beforeEach(ExtensionContext context) throws Exception {
             testClass = context.getTestClass().map(Class::getName).orElse(null);
             LOG.info("Registering port {} for test {}", port, testClass);
+        }
+
+        @Override
+        public void afterEach(ExtensionContext context) throws Exception {
+            if (!classScoped) {
+                // Non-static @RegisterExtension: afterAll is never invoked by JUnit Jupiter,
+                // so release here to keep the port mapping bounded.
+                release();
+            }
         }
 
         @Override
@@ -118,6 +138,10 @@ public final class AvailablePortFinder {
 
     synchronized void release(Port port) {
         INSTANCE.portMapping.remove(port.getPort(), port);
+    }
+
+    static boolean isRegistered(Port port) {
+        return INSTANCE.portMapping.get(port.getPort()) == port;
     }
 
     /**

--- a/components/camel-test/camel-test-junit6/src/test/java/org/apache/camel/test/AvailablePortFinderLifecycleTest.java
+++ b/components/camel-test/camel-test-junit6/src/test/java/org/apache/camel/test/AvailablePortFinderLifecycleTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Drives nested test classes through the JUnit Platform launcher to verify that {@link AvailablePortFinder.Port} reacts
+ * correctly to all three combinations of {@code @RegisterExtension} placement and {@code @TestInstance} lifecycle. The
+ * pre-existing leak (CAMEL-21122) only manifested under the real JUnit lifecycle, so this test exercises it directly
+ * instead of calling callbacks by hand.
+ */
+public class AvailablePortFinderLifecycleTest {
+
+    static final List<AvailablePortFinder.Port> SEEN = new ArrayList<>();
+
+    public static class PerMethodNonStaticContainer {
+        @RegisterExtension
+        AvailablePortFinder.Port port = AvailablePortFinder.find();
+
+        @Test
+        void t1() {
+            SEEN.add(port);
+        }
+
+        @Test
+        void t2() {
+            SEEN.add(port);
+        }
+    }
+
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    public static class PerClassNonStaticContainer {
+        @RegisterExtension
+        AvailablePortFinder.Port port = AvailablePortFinder.find();
+
+        @Test
+        void t1() {
+            SEEN.add(port);
+        }
+
+        @Test
+        void t2() {
+            SEEN.add(port);
+        }
+    }
+
+    public static class StaticContainer {
+        @RegisterExtension
+        static AvailablePortFinder.Port PORT = AvailablePortFinder.find();
+
+        @Test
+        void t1() {
+            SEEN.add(PORT);
+        }
+
+        @Test
+        void t2() {
+            SEEN.add(PORT);
+        }
+    }
+
+    @Test
+    public void perMethodNonStaticPortReleasesAfterEach() {
+        SEEN.clear();
+        run(PerMethodNonStaticContainer.class);
+
+        // Default lifecycle: JUnit constructs a fresh test instance per method,
+        // so each method sees its own Port. Both must be released after their test.
+        assertEquals(2, SEEN.size(), "two test methods should have observed a Port each");
+        assertNotSame(SEEN.get(0), SEEN.get(1), "PER_METHOD lifecycle must allocate a new Port per method");
+        assertFalse(AvailablePortFinder.isRegistered(SEEN.get(0)), "first method's port must be released");
+        assertFalse(AvailablePortFinder.isRegistered(SEEN.get(1)), "second method's port must be released");
+    }
+
+    @Test
+    public void perClassNonStaticPortSurvivesAndReleasesOnAfterAll() {
+        SEEN.clear();
+        run(PerClassNonStaticContainer.class);
+
+        // PER_CLASS reuses the single test instance, so both methods share the same Port.
+        // JUnit also delivers BeforeAllCallback/AfterAllCallback to instance extensions
+        // under PER_CLASS, so classScoped is set, afterEach is a no-op, and afterAll
+        // releases the port exactly once.
+        assertEquals(2, SEEN.size(), "two test methods should have observed a Port each");
+        assertSame(SEEN.get(0), SEEN.get(1), "PER_CLASS lifecycle must share a single Port across methods");
+        assertFalse(AvailablePortFinder.isRegistered(SEEN.get(0)), "shared port must be released on afterAll");
+    }
+
+    @Test
+    public void staticPortSurvivesAndReleasesOnAfterAll() {
+        SEEN.clear();
+        run(StaticContainer.class);
+
+        assertEquals(2, SEEN.size(), "two test methods should have observed a Port each");
+        assertSame(SEEN.get(0), SEEN.get(1), "static @RegisterExtension must share a single Port across methods");
+        assertFalse(AvailablePortFinder.isRegistered(SEEN.get(0)), "static port must be released on afterAll");
+    }
+
+    private static void run(Class<?> testClass) {
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(DiscoverySelectors.selectClass(testClass))
+                .build();
+        LauncherFactory.create().execute(request);
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -1356,6 +1356,16 @@ for the embedded HTTP server:
 Both default to unset. When both are unset, JWT validation behaviour is unchanged (signature plus the
 default `exp` / `nbf` checks).
 
+=== camel-test
+
+`org.apache.camel.test.AvailablePortFinder.Port` now also implements
+`AfterEachCallback` and `BeforeAllCallback`. When the `Port` is registered as a
+non-static `@RegisterExtension` field, it is automatically released after each
+test method, instead of leaking until JVM exit. The previous behaviour for
+static `@RegisterExtension` fields (port reserved for the whole class, released
+on `afterAll`) is preserved. Tests that manually called `port.release()` from an
+`@AfterEach` method to work around CAMEL-21122 no longer need that workaround.
+
 === camel-mongodb-gridfs
 
 The Exchange header values exposed by `GridFsConstants` have been renamed to follow the standard


### PR DESCRIPTION
# Description

`AvailablePortFinder.Port` leaked its global port-mapping entry whenever used as a non-static `@RegisterExtension` field under the default PER_METHOD lifecycle, because JUnit Jupiter does not fire `AfterAllCallback` in that case. Long camel-jetty runs accumulated stale entries and flaked. `Port` now also implements `BeforeAllCallback` + `AfterEachCallback`: `beforeAll` sets a flag that suppresses the new `afterEach` release, so method-scoped non-static fields self-release per test while static / PER_CLASS behaviour stays the same. Drops the `BaseJettyTest @AfterEach cleanupPorts()` workaround. Mirrored across `camel-test-junit5` and `camel-test-junit6`; documented in `camel-4x-upgrade-guide-4_21.adoc`. Lifecycle covered by a new `AvailablePortFinderLifecycleTest` driven through the JUnit Platform launcher.

Resolves https://issues.apache.org/jira/browse/CAMEL-21122

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

