### PR TITLE
CAMEL-23597: docs - sync camel-solr 4.18 upgrade-guide entry to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -319,6 +319,37 @@ have been renamed accordingly:
 * `gridfsObjectid()` -> `gridFsObjectId()`
 * `gridfsFileid()` -> `gridFsFileId()`
 
+=== camel-solr
+
+The two Exchange header prefix constants in `SolrConstants` have been renamed to
+follow the Camel naming convention already used by the other constants in the
+same file (which were renamed in 4.10 under CAMEL-21697). The Java field names
+are unchanged; only the prefix string values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `SolrConstants.HEADER_FIELD_PREFIX` | `SolrField.` | `CamelSolrField.`
+| `SolrConstants.HEADER_PARAM_PREFIX` | `SolrParam.` | `CamelSolrParam.`
+|===
+
+Routes that reference the constants symbolically (for example
+`setHeader(SolrConstants.HEADER_FIELD_PREFIX + "id", ...)`) continue to work
+without changes. Routes that set the headers by their literal string value
+(for example `setHeader("SolrField.id", ...)` or
+`setHeader("SolrParam.commit", ...)`) must be updated to use the new prefix
+(`CamelSolrField.id`, `CamelSolrParam.commit`).
+
+Because the renamed prefixes now begin with `Camel`, they are stripped by the
+standard transport `HeaderFilterStrategy` (`HttpHeaderFilterStrategy`, etc.)
+when crossing a transport boundary, by design — `Camel*` headers are
+framework-internal and are not propagated over the wire. Routes that bridge an
+external transport (HTTP, JMS, ...) into a `solr:` producer and want to drive
+Solr document fields or query parameters from a header supplied by the sender
+must therefore carry the value in a non-`Camel`-prefixed application header and
+map it to the appropriate `CamelSolrField.*` / `CamelSolrParam.*` header in the
+route between the transport `from` and the `solr:` `to`.
+
 == Upgrading from 4.18.0 to 4.18.1
 
 === camel-bom


### PR DESCRIPTION
## Summary

Doc-sync companion to the 4.18.x backport #23483. Adds the `camel-solr` upgrade-guide entry from `camel-4.18.x` to the canonical `camel-4x-upgrade-guide-4_18.adoc` on `main`, so main's per-version guides stay in sync with the matching maintenance-branch guides.

This is the standard backport upgrade-guide policy used for the sibling header-constant alignment work (CAMEL-23506 / #23354, CAMEL-23532 / #23353, etc.): the per-version upgrade-guide files on `main` act as the canonical history across all releases, so any entry added on a maintenance branch must also be added to the matching version's guide on `main`.

## What changed

- `docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc`: new `=== camel-solr` entry appended to the `== Upgrading from 4.18.1 to 4.18.3` section (identical text to the entry added in #23483 on `camel-4.18.x`).

No code changes; no change to any other version's upgrade guide.

## Test plan

- [x] Single doc-only file diff (`+31 / -0`); no other files touched.
- [x] Identical wording to the entry on `camel-4.18.x` so the per-version guide is in lock-step with the maintenance branch.
- [ ] CI green.

---

_Claude Code on behalf of Andrea Cosentino_