### PR TITLE
CAMEL-23592: camel-shiro - align Exchange header constant names with Camel naming convention

### DIFF
--- a/components/camel-shiro/src/main/java/org/apache/camel/component/shiro/security/ShiroSecurityConstants.java
+++ b/components/camel-shiro/src/main/java/org/apache/camel/component/shiro/security/ShiroSecurityConstants.java
@@ -21,9 +21,9 @@ package org.apache.camel.component.shiro.security;
  */
 public final class ShiroSecurityConstants {
 
-    public static final String SHIRO_SECURITY_TOKEN = "SHIRO_SECURITY_TOKEN";
-    public static final String SHIRO_SECURITY_USERNAME = "SHIRO_SECURITY_USERNAME";
-    public static final String SHIRO_SECURITY_PASSWORD = "SHIRO_SECURITY_PASSWORD";
+    public static final String SHIRO_SECURITY_TOKEN = "CamelShiroSecurityToken";
+    public static final String SHIRO_SECURITY_USERNAME = "CamelShiroSecurityUsername";
+    public static final String SHIRO_SECURITY_PASSWORD = "CamelShiroSecurityPassword";
 
     private ShiroSecurityConstants() {
     }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -849,6 +849,33 @@ directions, aligning the component with the rest of the Camel component catalog.
 `Camel`-prefixed user-header names from Iggy messages can supply a custom `headerFilterStrategy`
 to restore the previous behaviour.
 
+=== camel-shiro - potential breaking change
+
+The three Exchange header constants in `ShiroSecurityConstants` that drive
+Shiro authentication used header values outside the `Camel` namespace
+(`SHIRO_SECURITY_TOKEN`, `SHIRO_SECURITY_USERNAME`, `SHIRO_SECURITY_PASSWORD`)
+and were therefore not filtered by the default `HeaderFilterStrategy`. They
+have been renamed to follow the Camel naming convention. The Java field names
+are unchanged; only the header string values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `ShiroSecurityConstants.SHIRO_SECURITY_TOKEN` | `SHIRO_SECURITY_TOKEN` | `CamelShiroSecurityToken`
+| `ShiroSecurityConstants.SHIRO_SECURITY_USERNAME` | `SHIRO_SECURITY_USERNAME` | `CamelShiroSecurityUsername`
+| `ShiroSecurityConstants.SHIRO_SECURITY_PASSWORD` | `SHIRO_SECURITY_PASSWORD` | `CamelShiroSecurityPassword`
+|===
+
+These headers carry credentials and a serialized authentication token, so
+filtering them at transport boundaries by default is particularly important.
+
+Routes that reference the constants symbolically (for example
+`setHeader(ShiroSecurityConstants.SHIRO_SECURITY_USERNAME, ...)`) continue to
+work without changes. Routes that set the header by its literal string value
+(for example `setHeader("SHIRO_SECURITY_USERNAME", ...)`) must be updated to
+use the new value (`setHeader("CamelShiroSecurityUsername", ...)`).
+
+
 === camel-web3j - potential breaking change
 
 The Exchange header constants in `Web3jConstants` have been renamed to follow the


### PR DESCRIPTION
## Summary

Renames the three Exchange header string values in `ShiroSecurityConstants`
that drive Shiro authentication (`SHIRO_SECURITY_TOKEN`,
`SHIRO_SECURITY_USERNAME`, `SHIRO_SECURITY_PASSWORD`) to
`CamelShiroSecurity<Name>`, following the convention used across the rest of
the Camel component catalog and matching the pattern established in
CAMEL-23526 (`camel-cxf`), CAMEL-23522 (`camel-mail`), CAMEL-23461
(`camel-aws-bedrock`), CAMEL-23532 (`camel-vertx-websocket` /
`camel-atmosphere-websocket` / `camel-iggy`), and CAMEL-23576 (`camel-jira`).

| Constant | Previous value | New value |
|----------|----------------|-----------|
| `ShiroSecurityConstants.SHIRO_SECURITY_TOKEN` | `SHIRO_SECURITY_TOKEN` | `CamelShiroSecurityToken` |
| `ShiroSecurityConstants.SHIRO_SECURITY_USERNAME` | `SHIRO_SECURITY_USERNAME` | `CamelShiroSecurityUsername` |
| `ShiroSecurityConstants.SHIRO_SECURITY_PASSWORD` | `SHIRO_SECURITY_PASSWORD` | `CamelShiroSecurityPassword` |

These headers carry credentials and a serialized authentication token, so
filtering them at transport boundaries by default is particularly important
(Cluster A — auth/credential/signing exposure — in the CAMEL-23577 epic).

The Java field names are unchanged so routes referencing the constants
symbolically continue to work; routes using the literal string values must
be updated (documented in the 4.21 upgrade guide).

## Generated artifacts

`ShiroSecurityConstants` has no `@Metadata` annotations (this is a
`SecurityPolicy`-style component, not a producer/consumer-style component
that surfaces headers in the catalog), so no catalog JSON or endpoint DSL
regeneration is needed. The diff is exactly the constants file + the upgrade
guide entry.

## Backports

`camel-shiro` exists on `camel-4.18.x` and `camel-4.14.x` with the same
legacy values — backports apply and will be filed as follow-up PRs.

## Test plan

- [x] `mvn test` in `components/camel-shiro` — 21 tests pass
- [x] No literal string usages of these constants in tests or in the shiro
      adoc (all references are symbolic via `ShiroSecurityConstants.XXX`)
- [x] Upgrade guide entry added under `=== camel-shiro - potential breaking
      change` (consistent with the suffix convention adopted by camel-jira /
      camel-jgroups / camel-dns / camel-milo and the in-flight #23505 suffix
      follow-up for the other 9 CAMEL-23577 sub-task entries)

Tracker: CAMEL-23577

_Reported by Claude Code on behalf of Andrea Cosentino_