### PR TITLE
[backport camel-4.18.x] CAMEL-23590: camel-milo - align Exchange header constant names with Camel naming convention

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/milo-client.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/milo-client.json
@@ -53,7 +53,7 @@
   },
   "headers": {
     "CamelMiloNodeIds": { "index": 0, "kind": "header", "displayName": "", "group": "producer", "label": "producer", "required": false, "javaType": "List", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The node ids.", "constantName": "org.apache.camel.component.milo.MiloConstants#HEADER_NODE_IDS" },
-    "await": { "index": 1, "kind": "header", "displayName": "", "group": "producer", "label": "producer", "required": false, "javaType": "Boolean", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The await setting for writes.", "constantName": "org.apache.camel.component.milo.MiloConstants#HEADER_AWAIT" }
+    "CamelMiloAwait": { "index": 1, "kind": "header", "displayName": "", "group": "producer", "label": "producer", "required": false, "javaType": "Boolean", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The await setting for writes.", "constantName": "org.apache.camel.component.milo.MiloConstants#HEADER_AWAIT" }
   },
   "properties": {
     "endpointUri": { "index": 0, "kind": "path", "displayName": "Endpoint Uri", "group": "common", "label": "", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The OPC UA server endpoint" },

--- a/components/camel-milo/src/generated/resources/META-INF/org/apache/camel/component/milo/client/milo-client.json
+++ b/components/camel-milo/src/generated/resources/META-INF/org/apache/camel/component/milo/client/milo-client.json
@@ -53,7 +53,7 @@
   },
   "headers": {
     "CamelMiloNodeIds": { "index": 0, "kind": "header", "displayName": "", "group": "producer", "label": "producer", "required": false, "javaType": "List", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The node ids.", "constantName": "org.apache.camel.component.milo.MiloConstants#HEADER_NODE_IDS" },
-    "await": { "index": 1, "kind": "header", "displayName": "", "group": "producer", "label": "producer", "required": false, "javaType": "Boolean", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The await setting for writes.", "constantName": "org.apache.camel.component.milo.MiloConstants#HEADER_AWAIT" }
+    "CamelMiloAwait": { "index": 1, "kind": "header", "displayName": "", "group": "producer", "label": "producer", "required": false, "javaType": "Boolean", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The await setting for writes.", "constantName": "org.apache.camel.component.milo.MiloConstants#HEADER_AWAIT" }
   },
   "properties": {
     "endpointUri": { "index": 0, "kind": "path", "displayName": "Endpoint Uri", "group": "common", "label": "", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "deprecationNote": "", "autowired": false, "secret": false, "description": "The OPC UA server endpoint" },

--- a/components/camel-milo/src/main/docs/milo-client-component.adoc
+++ b/components/camel-milo/src/main/docs/milo-client-component.adoc
@@ -136,7 +136,7 @@ Example:
 ----
 from("direct:start")
     .setHeader("CamelMiloNodeIds", constant(Arrays.asList("nsu=urn:org:apache:camel;s=myitem1")))
-    .setHeader("await", constant(true)) // await: parameter "defaultAwaitWrites"
+    .setHeader("CamelMiloAwait", constant(true)) // CamelMiloAwait: parameter "defaultAwaitWrites"
         .enrich("milo-client:opc.tcp://localhost:4334", new AggregationStrategy() {
 
             @Override

--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/MiloConstants.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/MiloConstants.java
@@ -29,7 +29,7 @@ public final class MiloConstants {
     public static final String HEADER_NODE_IDS = "CamelMiloNodeIds";
     @Metadata(label = "producer", description = "The \"await\" setting for writes.", javaType = "Boolean",
               applicableFor = SCHEME_CLIENT)
-    public static final String HEADER_AWAIT = "await";
+    public static final String HEADER_AWAIT = "CamelMiloAwait";
 
     private MiloConstants() {
 

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/WriteClientTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/WriteClientTest.java
@@ -171,6 +171,6 @@ public class WriteClientTest extends AbstractMiloServerTest {
 
     private static void sendValue(final ProducerTemplate producerTemplate, final Variant variant) {
         // we always write synchronously since we do need the message order
-        producerTemplate.sendBodyAndHeader(variant, "await", true);
+        producerTemplate.sendBodyAndHeader(variant, "CamelMiloAwait", true);
     }
 }

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/call/CallClientTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/call/CallClientTest.java
@@ -208,6 +208,6 @@ public class CallClientTest extends AbstractMiloServerTest {
 
     private static void doCall(final ProducerTemplate producerTemplate, final Object input) {
         // we always write synchronously since we do need the message order
-        producerTemplate.sendBodyAndHeader(input, "await", true);
+        producerTemplate.sendBodyAndHeader(input, "CamelMiloAwait", true);
     }
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -579,3 +579,29 @@ between the transport `from` and the `cxf:` `to`:
 The same pattern applies to HTTP-based bridges (`platform-http`/`jetty`/`netty
 -http`/`http` -> `cxf:`) and any other transport whose default
 `HeaderFilterStrategy` filters `Camel*` headers.
+
+=== camel-milo - potential breaking change
+
+The `MiloConstants.HEADER_AWAIT` constant, which controls whether milo-client
+writes are awaited, used the header value `await` — outside the `Camel`
+namespace and therefore not filtered by the default `HeaderFilterStrategy`. It
+has been renamed to follow the Camel naming convention. The Java field name is
+unchanged; only the header string value has changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `MiloConstants.HEADER_AWAIT` | `await` | `CamelMiloAwait`
+|===
+
+`MiloConstants.HEADER_NODE_IDS` was already `Camel`-prefixed
+(`CamelMiloNodeIds`) and is unchanged.
+
+Routes that reference the constant symbolically (for example
+`setHeader(MiloConstants.HEADER_AWAIT, ...)`) continue to work without changes.
+Routes that set the header by its literal string value (for example
+`setHeader("await", ...)`) must be updated to use the new value
+(`setHeader("CamelMiloAwait", ...)`).
+
+As a consequence, the generated Endpoint DSL header accessor `await()` on
+`MiloClientHeaderNameBuilder` has been renamed to `miloAwait()`.

--- a/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/MiloClientEndpointBuilderFactory.java
+++ b/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/MiloClientEndpointBuilderFactory.java
@@ -2351,10 +2351,10 @@ public interface MiloClientEndpointBuilderFactory {
          * 
          * Group: producer
          * 
-         * @return the name of the header {@code await}.
+         * @return the name of the header {@code MiloAwait}.
          */
-        public String await() {
-            return "await";
+        public String miloAwait() {
+            return "CamelMiloAwait";
         }
     }
     static MiloClientEndpointBuilder endpointBuilder(String componentName, String path) {


### PR DESCRIPTION
## Backport of #23474

Cherry-pick of #23474 onto `camel-4.18.x`.

- **Original PR:** apache/camel#23474 — *CAMEL-23590: camel-milo - align Exchange header constant names with Camel naming convention*
- **Squash merge cherry-picked:** `09d38da3ef2`
- **Target branch:** `camel-4.18.x`
- **Original author:** @oscerd
- **camel-4.14.x:** N/A — `camel-milo` does not exist on the 4.14 line (the component was removed and later reinstated).

### Manual adjustments during cherry-pick

- **Upgrade-guide entry moved** from `camel-4x-upgrade-guide-4_21.adoc` (does not
  exist on this branch) to `camel-4x-upgrade-guide-4_18.adoc`, preserving the
  full content including the `- potential breaking change` flag. The matching
  `4_18.adoc` entry on `main` should be synced in a follow-up PR per
  CLAUDE.md's backport upgrade-guide policy.
- **Regenerated** component metadata, catalog, and endpoint DSL using
  4.18.x's generators (full reactor build, `-DskipTests`).

### Change summary

Renames `MiloConstants.HEADER_AWAIT` header string value from `"await"` to
`"CamelMiloAwait"`. The Java field name is unchanged so routes referencing the
constant symbolically continue to work; routes using the literal string value
must be updated. Also updates the two tests that set the header by literal
value, and the generated endpoint DSL header accessor (`await()` → `miloAwait()`).
`MiloConstants.HEADER_NODE_IDS` was already `Camel`-prefixed and is unchanged.

JIRA: https://issues.apache.org/jira/browse/CAMEL-23590

---
_Backport prepared by Claude Code on behalf of Andrea Cosentino._
