### PR TITLE
CAMEL-23608: camel-jbang - avoid JLine for terminal width detection

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/TerminalWidthHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/TerminalWidthHelper.java
@@ -16,15 +16,16 @@
  */
 package org.apache.camel.dsl.jbang.core.common;
 
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-
 /**
  * Helper for detecting the terminal width to adapt table and command output.
  *
  * <p>
- * Uses JLine to query the actual terminal size. Falls back to a default width when the terminal size cannot be
- * determined (e.g., when output is piped or redirected).
+ * Uses the {@code COLUMNS} environment variable or {@code stty size} to detect the terminal width. Falls back to a
+ * default width when the terminal size cannot be determined (e.g., when output is piped or redirected).
+ *
+ * <p>
+ * Avoids using JLine's {@code TerminalBuilder} for width detection because it sends escape sequence queries (DA1, CPR)
+ * to the terminal that can leak into the shell output when the terminal is closed before responses arrive.
  */
 public final class TerminalWidthHelper {
 
@@ -38,20 +39,40 @@ public final class TerminalWidthHelper {
      * Returns the current terminal width in columns.
      *
      * <p>
-     * Attempts to detect the terminal width using JLine. Returns {@value #DEFAULT_WIDTH} if detection fails or if the
-     * output is not connected to a terminal.
+     * Tries {@code COLUMNS} environment variable first, then {@code stty size}. Returns {@value #DEFAULT_WIDTH} if
+     * detection fails or if the output is not connected to a terminal.
      */
     public static int getTerminalWidth() {
-        try (Terminal terminal = TerminalBuilder.builder()
-                .system(true)
-                .dumb(true)
-                .build()) {
-            int width = terminal.getWidth();
-            if (width > 0) {
-                return Math.max(width, MIN_WIDTH);
+        // Try COLUMNS env var first (set by most shells)
+        String cols = System.getenv("COLUMNS");
+        if (cols != null) {
+            try {
+                int w = Integer.parseInt(cols.trim());
+                if (w > 0) {
+                    return Math.max(w, MIN_WIDTH);
+                }
+            } catch (NumberFormatException e) {
+                // ignore
+            }
+        }
+        // Fall back to stty which reads the terminal size without escape sequences
+        try {
+            Process p = new ProcessBuilder("stty", "size")
+                    .redirectInput(ProcessBuilder.Redirect.INHERIT)
+                    .start();
+            String output = new String(p.getInputStream().readAllBytes()).trim();
+            p.waitFor();
+            if (!output.isEmpty()) {
+                String[] parts = output.split("\\s+");
+                if (parts.length >= 2) {
+                    int w = Integer.parseInt(parts[1]);
+                    if (w > 0) {
+                        return Math.max(w, MIN_WIDTH);
+                    }
+                }
             }
         } catch (Exception e) {
-            // ignore
+            // ignore — stty not available (e.g. Windows)
         }
         return DEFAULT_WIDTH;
     }


### PR DESCRIPTION
## Summary

- Replace JLine `TerminalBuilder` with `COLUMNS` env var / `stty size` for terminal width detection in `TerminalWidthHelper`
- Fixes escape sequence leak (DA1 and CPR responses) into shell output after CLI commands like `camel ps`

## Root Cause

`TerminalWidthHelper.getTerminalWidth()` was introduced in CAMEL-23237 (#22219). It creates a JLine `Terminal` with `system(true)` which sends escape sequence queries to the terminal. The terminal responses arrive asynchronously and can leak into the shell after the `Terminal` is closed:

```
  PID   NAME             READY  STATUS   AGE   TOTAL  FAIL  INFLIGHT
 89933  circuit-breaker   1/1   Running  2m1s    119    32         0
^[[?64;1;2;4;6;17;18;21;22;52c^[[2;1R%
```

## Approach

Use `COLUMNS` env var (set by most shells) and `stty size` (POSIX) instead. These detect terminal width without sending escape sequences. Falls back to the default 120 columns if neither is available.

## Test plan

- [ ] Run `camel ps` — output should be clean, no trailing escape sequences
- [ ] Resize terminal, run `camel ps` — table should adapt to new width
- [ ] Pipe output (`camel ps | cat`) — should use default width (120)

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)