### PR TITLE
CAMEL-23610: Normalize YAML DSL in documentation to canonical form

### DIFF
--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/bean-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/bean-eip.adoc
@@ -90,17 +90,19 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:start
-    steps:
-      - bean:
-          ref: myBean
-          method: myMethod
-- from:
-    uri: direct:start
-    steps:
-      - bean:
-          ref: myBean
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - bean:
+            ref: myBean
+            method: myMethod
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - bean:
+            ref: myBean
 - beans:
     - name: myBean
       type: com.foo.ExampleBean
@@ -150,22 +152,25 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:foo
-    steps:
-      - bean:
-          beanType: com.foo.ExampleBean
-          method: myMethod
-- from:
-    uri: direct:bar
-    steps:
-      - bean:
-          beanType: com.foo.ExampleBean
-- from:
-    uri: direct:cheese
-    steps:
-      - bean:
-          beanType: com.foo.ExampleBean
+- route:
+    from:
+      uri: direct:foo
+      steps:
+        - bean:
+            beanType: com.foo.ExampleBean
+            method: myMethod
+- route:
+    from:
+      uri: direct:bar
+      steps:
+        - bean:
+            beanType: com.foo.ExampleBean
+- route:
+    from:
+      uri: direct:cheese
+      steps:
+        - bean:
+            beanType: com.foo.ExampleBean
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/choice-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/choice-eip.adoc
@@ -73,23 +73,28 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:a
-    steps:
-      - choice:
-          when:
-            - simple: "${header.foo} == 'bar'"
+- route:
+    from:
+      uri: direct:a
+      steps:
+        - choice:
+            when:
+              - expression:
+                  simple:
+                    expression: "${header.foo} == 'bar'"
+                steps:
+                  - to:
+                      uri: direct:b
+              - expression:
+                  simple:
+                    expression: "${header.foo} == 'cheese'"
+                steps:
+                  - to:
+                      uri: direct:c
+            otherwise:
               steps:
                 - to:
-                    uri: direct:b
-            - simple: "${header.foo} == 'cheese'"
-              steps:
-                - to:
-                    uri: direct:c
-          otherwise:
-            steps:
-              - to:
-                  uri: direct:d
+                    uri: direct:d
 ----
 ====
 
@@ -248,21 +253,29 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: "direct:a"
-    steps:
-      - choice:
-          precondition: true
-          when:
-            - simple: "{{?foo}}"
+- route:
+    from:
+      uri: direct:a
+      steps:
+        - choice:
+            precondition: true
+            when:
+              - expression:
+                  simple:
+                    expression: "{{?foo}}"
+                steps:
+                  - to:
+                      uri: direct:foo
+              - expression:
+                  simple:
+                    expression: "{{?bar}}"
+                steps:
+                  - to:
+                      uri: direct:bar
+            otherwise:
               steps:
-                - to: "direct:foo"
-            - simple: "{{?bar}}"
-              steps:
-                - to: "direct:bar"
-          otherwise:
-            steps:
-              - to: "direct:other"
+                - to:
+                    uri: direct:other
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/claimCheck-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/claimCheck-eip.adoc
@@ -274,21 +274,22 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:start
-    steps:
-      - to: mock:a
-      - claimCheck:
-          operation: Push
-      - transform:
-          expression:
-            constant: Bye World
-      - to:
-          uri: mock:b
-      - claimCheck:
-          operation: Pop
-      - to:
-          uri: mock:c
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to: mock:a
+        - claimCheck:
+            operation: Push
+        - transform:
+            expression:
+              constant: Bye World
+        - to:
+            uri: mock:b
+        - claimCheck:
+            operation: Pop
+        - to:
+            uri: mock:c
 ----
 ====
 
@@ -344,33 +345,34 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:start
-    steps:
-      - to: mock:a
-      - claimCheck:
-          operation: Set
-          key: foo
-      - transform:
-          expression:
-            constant: Bye World
-      - to:
-          uri: mock:b
-      - claimCheck:
-          operation: Get
-          key: foo
-      - to:
-          uri: mock:c
-      - transform:
-          expression:
-            constant: Hi World
-      - to:
-          uri: mock:d
-      - claimCheck:
-          operation: Get
-          key: foo
-      - to:
-          uri: mock:e
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to: mock:a
+        - claimCheck:
+            operation: Set
+            key: foo
+        - transform:
+            expression:
+              constant: Bye World
+        - to:
+            uri: mock:b
+        - claimCheck:
+            operation: Get
+            key: foo
+        - to:
+            uri: mock:c
+        - transform:
+            expression:
+              constant: Hi World
+        - to:
+            uri: mock:d
+        - claimCheck:
+            operation: Get
+            key: foo
+        - to:
+            uri: mock:e
 ----
 ====
 
@@ -423,28 +425,29 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:start
-    steps:
-      - to: 
-          uri: mock:a
-      - claimCheck:
-          operation: Push
-      - transform:
-          expression:
-            constant: ByeWorld
-      - setHeader:
-          name: foo
-          expression:
-            constant: 456
-      - removeHeader:
-          name: bar
-      - to:
-          uri: mock:b
-      - claimCheck:
-          operation: Pop
-          filter: "header:(foo|bar)"
-      - to:
-          uri: mock:c
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: mock:a
+        - claimCheck:
+            operation: Push
+        - transform:
+            expression:
+              constant: ByeWorld
+        - setHeader:
+            name: foo
+            expression:
+              constant: 456
+        - removeHeader:
+            name: bar
+        - to:
+            uri: mock:b
+        - claimCheck:
+            operation: Pop
+            filter: "header:(foo|bar)"
+        - to:
+            uri: mock:c
 ----
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/competing-consumers.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/competing-consumers.adoc
@@ -47,13 +47,14 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: jms:MyQueue
-    parameters:
-      concurrentConsumers: 5
-    steps:
-      - to:
-          uri: bean:someBean
+- route:
+    from:
+      uri: jms:MyQueue
+      parameters:
+        concurrentConsumers: 5
+      steps:
+        - to:
+            uri: bean:someBean
 ----
 ====
 
@@ -91,11 +92,14 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: "file://inbox?move=../backup-${date:now:yyyyMMdd}"
-    steps:
-      - to:
-          uri: bean:calculateBean
+- route:
+    from:
+      uri: file://inbox
+      parameters:
+        move: "../backup-${date:now:yyyyMMdd}"
+      steps:
+        - to:
+            uri: bean:calculateBean
 ----
 ====
 
@@ -147,13 +151,16 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: "file://inbox?move=../backup-${date:now:yyyyMMdd}"
-    steps:
-      - threads:
-          poolSize: 10
-      - to:
-          uri: bean:calculateBean
+- route:
+    from:
+      uri: file://inbox
+      parameters:
+        move: "../backup-${date:now:yyyyMMdd}"
+      steps:
+        - threads:
+            poolSize: 10
+        - to:
+            uri: bean:calculateBean
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/content-enricher.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/content-enricher.adoc
@@ -51,13 +51,14 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: activemq:My.Queue
-    steps:
-      - to:
-          uri: velocity:com/acme/MyResponse.vm
-      - to:
-          uri: activemq:Another.Queue
+- route:
+    from:
+      uri: activemq:My.Queue
+      steps:
+        - to:
+            uri: velocity:com/acme/MyResponse.vm
+        - to:
+            uri: activemq:Another.Queue
 ----
 ====
 
@@ -229,14 +230,15 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: activemq:Input
-    steps:
-      - bean:
-          ref: myBeanName
-          method: doTransform
-      - to:
-          uri: activemq:Output
+- route:
+    from:
+      uri: activemq:Input
+      steps:
+        - bean:
+            ref: myBeanName
+            method: doTransform
+        - to:
+            uri: activemq:Output
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/content-filter-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/content-filter-eip.adoc
@@ -127,14 +127,15 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: activemq:Input
-    steps:
-      - bean:
-          ref: myBeanName
-          method: doFilter
-      - to:
-          uri: activemq:Output
+- route:
+    from:
+      uri: activemq:Input
+      steps:
+        - bean:
+            ref: myBeanName
+            method: doFilter
+        - to:
+            uri: activemq:Output
 ----
 ====
 
@@ -173,13 +174,14 @@ YAML::
 +
 [source,yaml]
 ----
-- from: 
-    uri: activemq:Input
-    steps:
-      - setBody:
-          expression:
-            xpath: //foo:bar
-      - to:
-          uri: activemq:Output
+- route:
+    from:
+      uri: activemq:Input
+      steps:
+        - setBody:
+            expression:
+              xpath: //foo:bar
+        - to:
+            uri: activemq:Output
 ----
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/convertBodyTo-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/convertBodyTo-eip.adoc
@@ -52,12 +52,13 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: file:inbox
-    steps:
-      - convertBodyTo:
-          type: String
-      - log:
-          message: "The file content: ${body}"
+- route:
+    from:
+      uri: file:inbox
+      steps:
+        - convertBodyTo:
+            type: String
+        - log:
+            message: "The file content: ${body}"
 ----
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/convertHeaderTo-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/convertHeaderTo-eip.adoc
@@ -52,14 +52,15 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:foo
-    steps:
-      - convertHeaderTo:
-          name: foo
-          type: String
-      - log:
-          message: "The header content: ${header.foo}"
+- route:
+    from:
+      uri: seda:foo
+      steps:
+        - convertHeaderTo:
+            name: foo
+            type: String
+        - log:
+            message: "The header content: ${header.foo}"
 ----
 ====
 
@@ -94,15 +95,16 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:foo
-    steps:
-      - convertHeaderTo:
-          name: foo
-          toName: bar
-          type: String
-      - log:
-          message: "The header content: ${header.bar}"
+- route:
+    from:
+      uri: seda:foo
+      steps:
+        - convertHeaderTo:
+            name: foo
+            toName: bar
+            type: String
+        - log:
+            message: "The header content: ${header.bar}"
 ----
 ====
 
@@ -147,13 +149,14 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:foo
-    steps:
-      - convertHeaderTo:
-          name: ${header.region}
-          type: String
-      - log:
-          message: "Order from EMEA: ${header.emea}"
+- route:
+    from:
+      uri: seda:foo
+      steps:
+        - convertHeaderTo:
+            name: ${header.region}
+            type: String
+        - log:
+            message: "Order from EMEA: ${header.emea}"
 ----
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/convertVariableTo-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/convertVariableTo-eip.adoc
@@ -52,14 +52,15 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:foo
-    steps:
-      - convertVariableTo:
-          name: foo
-          type: String
-      - log:
-          message: "The variable content: ${variable.foo}"
+- route:
+    from:
+      uri: seda:foo
+      steps:
+        - convertVariableTo:
+            name: foo
+            type: String
+        - log:
+            message: "The variable content: ${variable.foo}"
 ----
 ====
 
@@ -94,15 +95,16 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:foo
-    steps:
-      - convertVariableTo:
-          name: foo
-          toName: bar
-          type: String
-      - log:
-          message: "The variable content: ${variable.bar}"
+- route:
+    from:
+      uri: seda:foo
+      steps:
+        - convertVariableTo:
+            name: foo
+            toName: bar
+            type: String
+        - log:
+            message: "The variable content: ${variable.bar}"
 ----
 ====
 
@@ -147,13 +149,14 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:foo
-    steps:
-      - convertVariableTo:
-          name: ${variable.region}
-          type: String
-      - log:
-          message: "Order from EMEA: ${variable.emea}"
+- route:
+    from:
+      uri: seda:foo
+      steps:
+        - convertVariableTo:
+            name: ${variable.region}
+            type: String
+        - log:
+            message: "Order from EMEA: ${variable.emea}"
 ----
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/correlation-identifier.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/correlation-identifier.adoc
@@ -73,13 +73,14 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:start
-    steps:
-      - to:
-          uri: jms:queue:foo
-          pattern: InOut
-      - to:
-          uri: mock:result
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: jms:queue:foo
+            pattern: InOut
+        - to:
+            uri: mock:result
 ----
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/delay-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/delay-eip.adoc
@@ -52,14 +52,15 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:b
-    steps:
-      - delay:
-          expression:
-            constant: 1000
-      - to:
-          uri: mock:result
+- route:
+    from:
+      uri: seda:b
+      steps:
+        - delay:
+            expression:
+              constant: "1000"
+        - to:
+            uri: mock:result
 ----
 ====
 
@@ -111,14 +112,16 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:b
-    steps:
-      - delay:
-          expression:
-            simple: "${random(1000,5000)}"
-      - to:
-          uri: mock:result
+- route:
+    from:
+      uri: seda:b
+      steps:
+        - delay:
+            expression:
+              simple:
+                expression: "${random(1000,5000)}"
+        - to:
+            uri: mock:result
 ----
 ====
 
@@ -221,14 +224,15 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: activemq:queue:foo
-    steps:
-      - delay:
-          expression:
-            constant: 1000
-          asyncDelayed: true
-      - to:
-          uri: activemq:aDelayedQueue
+- route:
+    from:
+      uri: activemq:queue:foo
+      steps:
+        - delay:
+            expression:
+              constant: "1000"
+            asyncDelayed: true
+        - to:
+            uri: activemq:aDelayedQueue
 ----
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/durable-subscriber.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/durable-subscriber.adoc
@@ -65,13 +65,19 @@ YAML::
             uri: activemq:topic:foo
 - route:
     from:
-      uri: activemq:topic:foo?clientId=1&durableSubscriptionName=bar1
+      uri: activemq:topic:foo
+      parameters:
+        clientId: 1
+        durableSubscriptionName: bar1
       steps:
         - to:
             uri: mock:result1
 - route:
     from:
-      uri: activemq:topic:foo?clientId=2&durableSubscriptionName=bar2
+      uri: activemq:topic:foo
+      parameters:
+        clientId: 2
+        durableSubscriptionName: bar2
       steps:
         - to:
             uri: mock:result2

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/dynamicRouter-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/dynamicRouter-eip.adoc
@@ -67,14 +67,15 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:start
-    steps:
-      - dynamicRouter:
-          expression:
-            method:
-              beanType: com.foo.MySlipBean
-              method: slip
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - dynamicRouter:
+            expression:
+              method:
+                beanType: com.foo.MySlipBean
+                method: slip
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/enrich-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/enrich-eip.adoc
@@ -109,15 +109,16 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:start
-    steps:
-      - enrich:
-          expression:
-            constant: "http:remoteserver/foo"
-          aggregationStrategy: "#myStrategy"
-      - to: 
-          uri: mock:result
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - enrich:
+            expression:
+              constant: http:remoteserver/foo
+            aggregationStrategy: "#myStrategy"
+        - to:
+            uri: mock:result
 - beans:
     - name: myStrategy
       type: com.foo.ExampleAggregationStrategy
@@ -159,14 +160,15 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:start
-    steps:
-      - enrich:
-          expression:
-            constant: "http:remoteserver/foo"
-      - to: 
-          uri: mock:result
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - enrich:
+            expression:
+              constant: http:remoteserver/foo
+        - to:
+            uri: mock:result
 ----
 ====
 
@@ -198,13 +200,14 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:start
-    steps:
-      - to:
-          uri: http:remoteserver/foo
-      - to:
-          uri: mock:result
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: http:remoteserver/foo
+        - to:
+            uri: mock:result
 ----
 ====
 
@@ -240,14 +243,16 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:start
-    steps:
-      - enrich:
-          expression:
-            simple: "http:myserver/${header.orderId}/order"
-      - to: 
-          uri: mock:result
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - enrich:
+            expression:
+              simple:
+                expression: "http:myserver/${header.orderId}/order"
+        - to:
+            uri: mock:result
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/event-message.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/event-message.adoc
@@ -68,7 +68,9 @@ YAML::
 ----
 - route:
     from:
-      uri: mq:someQueue?exchangePattern=InOnly
+      uri: mq:someQueue
+      parameters:
+        exchangePattern: InOnly
       steps:
         - to:
             uri: activemq:queue:one-way

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/eventDrivenConsumer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/eventDrivenConsumer-eip.adoc
@@ -48,10 +48,11 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: jms:queue:foo
-    steps:
-      - bean:
-          beanType: com.foo.MyBean
+- route:
+    from:
+      uri: jms:queue:foo
+      steps:
+        - bean:
+            beanType: com.foo.MyBean
 ----
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/from-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/from-eip.adoc
@@ -54,10 +54,11 @@ YAML::
 +
 [source,yaml]
 ----
-- from: 
-    uri: file:inbox
-    steps:
-      - to:
-          uri: log:inbox
+- route:
+    from:
+      uri: file:inbox
+      steps:
+        - to:
+            uri: log:inbox
 ----
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/intercept.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/intercept.adoc
@@ -93,7 +93,8 @@ YAML::
 ----
 - intercept:
     steps:
-      - to: "log:hello"
+      - to:
+          uri: log:hello
 - route:
     from:
       uri: jms:queue:order
@@ -159,9 +160,12 @@ YAML::
 ----
 - intercept:
     onWhen:
-      simple: "${body} contains 'Hello'"
+      expression:
+        simple:
+          expression: "${body} contains 'Hello'"
     steps:
-      - to: "log:hello"
+      - to:
+          uri: log:hello
 - route:
     from:
       uri: jms:queue:order
@@ -273,9 +277,12 @@ YAML::
 ----
 - intercept:
     onWhen:
-      simple: "${body} contains 'Hello'"
+      expression:
+        simple:
+          expression: "${body} contains 'Hello'"
     steps:
-      - to: "log:test"
+      - to:
+          uri: log:test
       - stop: {}
 - route:
     from:
@@ -339,7 +346,8 @@ YAML::
 ----
 - interceptFrom:
     steps:
-      - to: "log:incoming"
+      - to:
+          uri: log:incoming
 - route:
     from:
       uri: jms:queue:order
@@ -398,7 +406,8 @@ YAML::
 - interceptFrom:
     uri: "jms*"
     steps:
-      - to: "log:incoming"
+      - to:
+          uri: log:incoming
 - route:
     from:
       uri: jms:queue:order
@@ -481,7 +490,8 @@ YAML::
 - interceptSendToEndpoint:
     uri: "kafka*"
     steps:
-      - to: "bean:beforeKafka"
+      - to:
+          uri: bean:beforeKafka
 - route:
     from:
       uri: jms:queue:order
@@ -539,7 +549,8 @@ YAML::
     uri: "kafka*"
     afterUri: "bean:afterKafka"
     steps:
-      - to: "bean:beforeKafka"
+      - to:
+          uri: bean:beforeKafka
 - route:
     from:
       uri: jms:queue:order
@@ -600,7 +611,8 @@ YAML::
     uri: "kafka*"
     skipSendToOriginalEndpoint: true
     steps:
-      - to: "mock:kafka"
+      - to:
+          uri: mock:kafka
 - route:
     from:
       uri: jms:queue:order
@@ -662,7 +674,9 @@ YAML::
     uri: "kafka*"
     skipSendToOriginalEndpoint: true
     onWhen:
-      simple: "${header.biztype} == 'TEST'"
+      expression:
+        simple:
+          expression: "${header.biztype} == 'TEST'"
     steps:
       - log:
           message: "TEST message detected - is NOT send to kafka"
@@ -721,7 +735,8 @@ YAML::
 - interceptSendToEndpoint:
     uri: "jms:queue:cheese"
     steps:
-      - to: "log:smelly"
+      - to:
+          uri: log:smelly
 ----
 ====
 
@@ -758,7 +773,8 @@ YAML::
 - interceptFrom:
     uri: "file:*"
     steps:
-      - to: "log:from-file"
+      - to:
+          uri: log:from-file
 ----
 ====
 
@@ -795,7 +811,8 @@ YAML::
 - interceptFrom:
     uri: "file:order/inbox/*"
     steps:
-      - to: "log:new-file-orders"
+      - to:
+          uri: log:new-file-orders
 ----
 ====
 
@@ -832,6 +849,7 @@ YAML::
 - interceptFrom:
     uri: "jms:queue:(gold|silver)"
     steps:
-      - to: "seda:handleFast"
+      - to:
+          uri: seda:handleFast
 ----
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/kamelet-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/kamelet-eip.adoc
@@ -78,7 +78,9 @@ YAML::
       uri: direct:start
       steps:
         - to:
-            uri: kamelet:my-aggregate?count=5
+            uri: kamelet:my-aggregate
+            parameters:
+              count: 5
         - to:
             uri: log:info
         - to:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/marshal-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/marshal-eip.adoc
@@ -62,16 +62,17 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: file:inbox/xml
-    steps:
-      - unmarshal:
-          jaxb: {}
-      - to:
-          uri: bean:validateOrder
-      - marshal:
-          jaxb: {}
-      - to:
-          uri: jms:queue:order 
+- route:
+    from:
+      uri: file:inbox/xml
+      steps:
+        - unmarshal:
+            jaxb: {}
+        - to:
+            uri: bean:validateOrder
+        - marshal:
+            jaxb: {}
+        - to:
+            uri: jms:queue:order
 ----
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-expiration.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-expiration.adoc
@@ -49,6 +49,8 @@ YAML::
       uri: direct:cheese
       steps:
         - to:
-            uri: jms:queue:cheese?timeToLive=5000
+            uri: jms:queue:cheese
+            parameters:
+              timeToLive: 5000
 ----
 ====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/normalizer.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/normalizer.adoc
@@ -74,13 +74,17 @@ YAML::
                     expression: /employee
                 steps:
                   - to:
-                      uri: bean:normalizer?method=employeeToPerson
+                      uri: bean:normalizer
+                      parameters:
+                        method: employeeToPerson
               - expression:
                   xpath:
                     expression: /customer
                 steps:
                   - to:
-                      uri: bean:normalizer?method=customerToPerson
+                      uri: bean:normalizer
+                      parameters:
+                        method: customerToPerson
         - to:
             uri: mock:result
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/poll-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/poll-eip.adoc
@@ -95,7 +95,9 @@ YAML::
       uri: direct:payload
       steps:
         - poll:
-            uri: ftp:myserver.com/myfolder?fileName=report-file.pdf
+            uri: ftp:myserver.com/myfolder
+            parameters:
+              fileName: report-file.pdf
 ----
 ====
 
@@ -130,7 +132,9 @@ YAML::
       uri: direct:payload
       steps:
         - poll:
-            uri: "ftp:myserver.com/myfolder?fileName=report-${header.id}.pdf"
+            uri: ftp:myserver.com/myfolder
+            parameters:
+              fileName: "report-${header.id}.pdf"
 ----
 ====
 
@@ -184,7 +188,11 @@ YAML::
       uri: direct:payload
       steps:
         - poll:
-            uri: aws-s3:xavier-dev?amazonS3Client=#s3client&deleteAfterRead=false&fileName=report-file.pdf
+            uri: aws-s3:xavier-dev
+            parameters:
+              amazonS3Client: "#s3client"
+              deleteAfterRead: false
+              fileName: report-file.pdf
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/pollEnrich-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/pollEnrich-eip.adoc
@@ -210,7 +210,9 @@ YAML::
       uri: direct:report
       steps:
         - pollEnrich:
-            uri: aws-s3:xavier-dev?amazonS3Client=#s3client&amp;deleteAfterRead=false&amp;fileName=report-file.pdf
+            expression:
+              constant:
+                expression: "aws-s3:xavier-dev?amazonS3Client=#s3client&deleteAfterRead=false&fileName=report-file.pdf"
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/removeHeader-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/removeHeader-eip.adoc
@@ -50,13 +50,14 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:b
-    steps:
-      - removeHeader:
-          name: myHeader
-      - to:
-          uri: mock:result
+- route:
+    from:
+      uri: seda:b
+      steps:
+        - removeHeader:
+            name: myHeader
+        - to:
+            uri: mock:result
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/removeHeaders-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/removeHeaders-eip.adoc
@@ -60,13 +60,14 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:b
-    steps:
-      - removeHeaders:
-          pattern: "*"
-      - to:
-          uri: mock:result
+- route:
+    from:
+      uri: seda:b
+      steps:
+        - removeHeaders:
+            pattern: "*"
+        - to:
+            uri: mock:result
 ----
 ====
 
@@ -100,12 +101,13 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:b
-    steps:
-      - removeHeaders: "Camel*"
-      - to:
-          uri: mock:result
+- route:
+    from:
+      uri: seda:b
+      steps:
+        - removeHeaders: "Camel*"
+        - to:
+            uri: mock:result
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/removeProperties-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/removeProperties-eip.adoc
@@ -60,13 +60,14 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:b
-    steps:
-      - removeProperties:
-          pattern: "*"
-      - to:
-          uri: mock:result
+- route:
+    from:
+      uri: seda:b
+      steps:
+        - removeProperties:
+            pattern: "*"
+        - to:
+            uri: mock:result
 ----
 ====
 
@@ -104,13 +105,14 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: seda:b
-    steps:
-      - removeProperties:
-          pattern: "Foo*"
-      - to:
-          uri: mock:result
+- route:
+    from:
+      uri: seda:b
+      steps:
+        - removeProperties:
+            pattern: "Foo*"
+        - to:
+            uri: mock:result
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/requestReply-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/requestReply-eip.adoc
@@ -71,7 +71,9 @@ YAML::
 ----
 - route:
     from:
-      uri: jms:someQueue?exchangePattern=InOut
+      uri: jms:someQueue
+      parameters:
+        exchangePattern: InOut
       steps:
         - to:
             uri: bean:processMessage

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/return-address.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/return-address.adoc
@@ -87,7 +87,9 @@ YAML::
       uri: direct:foo
       steps:
         - to:
-            uri: jms:queue:cheese?replyTo=myReplyQueue
+            uri: jms:queue:cheese
+            parameters:
+              replyTo: myReplyQueue
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/setHeaders-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/setHeaders-eip.adoc
@@ -58,17 +58,18 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:a
-    steps:
-      - setHeaders:
-          headers:
-            - name: myHeader
-              constant: test
-            - name: otherHeader
-              constant: other
-      - to: 
-          uri:direct:b
+- route:
+    from:
+      uri: direct:a
+      steps:
+        - setHeaders:
+            headers:
+              - name: myHeader
+                constant: test
+              - name: otherHeader
+                constant: other
+        - to:
+            uri: direct:b
 ----
 ====
 
@@ -109,17 +110,22 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:a
-    steps:
-      - setHeaders:
-          headers:
-            - name: randomNumber
-              simple: "${random(1,100)}"
-            - name: body
-              simple: "${body}"
-      - to: 
-          uri:direct:b
+- route:
+    from:
+      uri: direct:a
+      steps:
+        - setHeaders:
+            headers:
+              - name: randomNumber
+                expression:
+                  simple:
+                    expression: "${random(1,100)}"
+              - name: body
+                expression:
+                  simple:
+                    expression: "${body}"
+        - to:
+            uri: direct:b
 ----
 ====
 
@@ -161,19 +167,23 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:a
-    steps:
-      - setHeaders:
-          headers:
-            - name: foo
-              simple: "${body}"
-            - name: bar
-              simple:
-                expression: "${header.foo} > 10"
-                resultType: "boolean"       
-      - to: 
-          uri:direct:b
+- route:
+    from:
+      uri: direct:a
+      steps:
+        - setHeaders:
+            headers:
+              - name: foo
+                expression:
+                  simple:
+                    expression: "${body}"
+              - name: bar
+                expression:
+                  simple:
+                    expression: "${header.foo} > 10"
+                    resultType: boolean
+        - to:
+            uri: direct:b
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/setVariables-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/setVariables-eip.adoc
@@ -58,17 +58,18 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:a
-    steps:
-      - setVariables:
-          variables:
-            - name: myVar
-              constant: test
-            - name: otherVar
-              constant: other
-      - to: 
-          uri: direct:b
+- route:
+    from:
+      uri: direct:a
+      steps:
+        - setVariables:
+            variables:
+              - name: myVar
+                constant: test
+              - name: otherVar
+                constant: other
+        - to:
+            uri: direct:b
 ----
 ====
 
@@ -109,17 +110,22 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:a
-    steps:
-      - setVariables:
-          variables:
-            - name: randomNumber
-              simple: "${random(1,100)}"
-            - name: body
-              simple: "${body}"
-      - to: 
-          uri:direct:b
+- route:
+    from:
+      uri: direct:a
+      steps:
+        - setVariables:
+            variables:
+              - name: randomNumber
+                expression:
+                  simple:
+                    expression: "${random(1,100)}"
+              - name: body
+                expression:
+                  simple:
+                    expression: "${body}"
+        - to:
+            uri: direct:b
 ----
 ====
 
@@ -161,19 +167,23 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:a
-    steps:
-      - setVariables:
-          variables:
-            - name: foo
-              simple: "${body}"
-            - name: bar
-              simple:
-                expression: "${variable.foo} > 10"
-                resultType: "boolean"       
-      - to: 
-          uri:direct:b
+- route:
+    from:
+      uri: direct:a
+      steps:
+        - setVariables:
+            variables:
+              - name: foo
+                expression:
+                  simple:
+                    expression: "${body}"
+              - name: bar
+                expression:
+                  simple:
+                    expression: "${variable.foo} > 10"
+                    resultType: "boolean"
+        - to:
+            uri: direct:b
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/toD-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/toD-eip.adoc
@@ -210,7 +210,9 @@ YAML::
       uri: direct:login
       steps:
         - toD:
-            uri: "http:myloginserver:8080/login?userid=${header.userName}"
+            uri: http:myloginserver:8080/login
+            parameters:
+              userid: "${header.userName}"
             cacheSize: 10
 ----
 ====
@@ -349,7 +351,9 @@ YAML::
       uri: direct:login
       steps:
         - toD:
-            uri: "http:myloginserver:8080/login?userid=${header.userName}"
+            uri: http:myloginserver:8080/login
+            parameters:
+              userid: "${header.userName}"
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/validate-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/validate-eip.adoc
@@ -68,7 +68,9 @@ YAML::
               simple:
                 expression: "${body} regex '^\\w{10}\\,\\d{2}\\,\\w{24}$'"
         - to:
-            uri: bean:myServiceBean?method=processLine
+            uri: bean:myServiceBean
+            parameters:
+              method: processLine
 ----
 ====
 

--- a/docs/user-manual/modules/ROOT/pages/camel-configuration-utilities.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-configuration-utilities.adoc
@@ -413,10 +413,12 @@ YAML::
     keystorePassword: changeit
     trustStore: truststore.p12
     trustStorePassword: changeit
-- from:
-    uri: "direct:ssl"
-    steps:
-      - to: "mock:ssl"
+- route:
+    from:
+      uri: direct:ssl
+      steps:
+        - to:
+            uri: mock:ssl
 ----
 
 Spring Boot::

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
@@ -696,10 +696,14 @@ to run the Camel application on Kubernetes.
 
 [source,yaml]
 ----
-- from:
-    uri: knative:event/camel.evt.type?name=my-broker
-    steps:
-      - to: log:info
+- route:
+    from:
+      uri: knative:event/camel.evt.type
+      parameters:
+        name: my-broker
+      steps:
+        - to:
+            uri: log:info
 ----
 
 The route consumes Knative events of type `camel.evt.type`.
@@ -773,10 +777,12 @@ The Camel route that connects to a Knative channel in order to receive events lo
 
 [source,yaml]
 ----
-- from:
-    uri: knative:channel/my-channel
-    steps:
-      - to: log:info
+- route:
+    from:
+      uri: knative:channel/my-channel
+      steps:
+        - to:
+            uri: log:info
 ----
 
 The Knative channel is referenced by its name.
@@ -853,12 +859,16 @@ The following route produces events on a Knative broker:
 
 [source, yaml]
 ----
-- from:
-    uri: timer:tick
-    steps:
-      - setBody:
-          constant: Hello Camel !!!
-      - to: knative:event/camel.evt.type?name=my-broker
+- route:
+    from:
+      uri: timer:tick
+      steps:
+        - setBody:
+            constant: Hello Camel !!!
+        - to:
+            uri: knative:event/camel.evt.type
+            parameters:
+              name: my-broker
 ----
 
 The route produces events of type `camel.evt.type` and pushes the events to the broker named `my-broker`.

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
@@ -1441,13 +1441,15 @@ And to use the kamelet, you could create the following route:
 
 [source,yaml]
 ----
-- from:
-    uri: "kamelet:cheese-source"
-    parameters:
-      period: "2000"
-      message: "Hello World"
-    steps:
-      - log: "${body}"
+- route:
+    from:
+      uri: kamelet:cheese-source
+      parameters:
+        period: "2000"
+        message: "Hello World"
+      steps:
+        - log:
+            message: "${body}"
 ----
 
 If you want to create a sink kamelet, then you just name it with sink as follows (based on log sink):
@@ -1461,13 +1463,15 @@ You can then change the route to use the wine kamelet as follows:
 
 [source,yaml]
 ----
-- from:
-    uri: "kamelet:cheese-source"
-    parameters:
-      period: "2000"
-      message: "Hello World"
-    steps:
-      - to: "kamelet:wine-sink"
+- route:
+    from:
+      uri: kamelet:cheese-source
+      parameters:
+        period: "2000"
+        message: "Hello World"
+      steps:
+        - to:
+            uri: kamelet:wine-sink
 ----
 
 If you want to create a new Kamelet based on an existing Kamelet, for example, to create a new sink based on the existing MySQL:
@@ -2612,11 +2616,12 @@ running on port 8080. For example, the following route in a file named `server.y
 
 [source,yaml]
 ----
-- from:
-    uri: "platform-http:/hello"
-    steps:
-      - set-body:
-          constant: "Hello World"
+- route:
+    from:
+      uri: platform-http:/hello
+      steps:
+        - set-body:
+            constant: "Hello World"
 ----
 
 Can be run with

--- a/docs/user-manual/modules/ROOT/pages/endpoint.adoc
+++ b/docs/user-manual/modules/ROOT/pages/endpoint.adoc
@@ -85,7 +85,9 @@ YAML::
 ----
 - route:
     from:
-      uri: file:messages/foo?sorter=#bean:mySpecialFileSorter
+      uri: file:messages/foo
+      parameters:
+        sorter: "#bean:mySpecialFileSorter"
       steps:
         - to:
             uri: jms:queue:foo
@@ -242,7 +244,10 @@ YAML::
       uri: file:inbox
       steps:
         - to:
-            uri: ftp:joe@myftpserver.com?password=RAW(se+re?t&23)&binary=true
+            uri: ftp:joe@myftpserver.com
+            parameters:
+              password: "RAW(se+re?t&23)"
+              binary: true
 ----
 
 YAML expanded::
@@ -305,7 +310,10 @@ YAML::
       uri: file:inbox
       steps:
         - to:
-            uri: "ftp:joe@myftpserver.com?password=RAW($simple{env:MY_FTP_PASSWORD})&binary=true"
+            uri: ftp:joe@myftpserver.com
+            parameters:
+              password: "RAW($simple{env:MY_FTP_PASSWORD})"
+              binary: true
 ----
 
 ====
@@ -353,7 +361,10 @@ YAML::
       uri: file:inbox
       steps:
         - to:
-            uri: "ftp:joe@myftpserver.com?password={{myFtpPassword}}&binary=true"
+            uri: ftp:joe@myftpserver.com
+            parameters:
+              password: "{{myFtpPassword}}"
+              binary: true
 ----
 ====
 

--- a/docs/user-manual/modules/ROOT/pages/endpoint.adoc
+++ b/docs/user-manual/modules/ROOT/pages/endpoint.adoc
@@ -244,10 +244,7 @@ YAML::
       uri: file:inbox
       steps:
         - to:
-            uri: ftp:joe@myftpserver.com
-            parameters:
-              password: "RAW(se+re?t&23)"
-              binary: true
+            uri: ftp:joe@myftpserver.com?password=RAW(se+re?t&23)&binary=true
 ----
 
 YAML expanded::

--- a/docs/user-manual/modules/ROOT/pages/parameter-binding-annotations.adoc
+++ b/docs/user-manual/modules/ROOT/pages/parameter-binding-annotations.adoc
@@ -146,7 +146,9 @@ YAML::
       uri: activemq:someQueue
       steps:
         - to:
-            uri: bean:myBean?method=doSomething
+            uri: bean:myBean
+            parameters:
+              method: doSomething
 ----
 ====
 

--- a/docs/user-manual/modules/ROOT/pages/route-configuration.adoc
+++ b/docs/user-manual/modules/ROOT/pages/route-configuration.adoc
@@ -262,10 +262,14 @@ And in the YAML routes you can assign which configurations to use:
     # refer to the route configuration by the id to use for this route
     routeConfigurationId: "yamlError"
     from:
-      uri: "timer:yaml?period=3s"
+      uri: timer:yaml
+      parameters:
+        period: 3s
       steps:
         - setBody:
-            simple: "Timer fired ${header.CamelTimerCounter} times"
+            expression:
+              simple:
+                expression: "Timer fired ${header.CamelTimerCounter} times"
         - to:
             uri: "log:yaml"
             parameters:

--- a/docs/user-manual/modules/ROOT/pages/route-group.adoc
+++ b/docs/user-manual/modules/ROOT/pages/route-group.adoc
@@ -62,7 +62,9 @@ YAML::
       uri: activemq:queue:order.in
       steps:
         - to:
-            uri: bean:orderServer?method=validate
+            uri: bean:orderServer
+            parameters:
+              method: validate
         - to:
             uri: direct:processOrder
 - route:
@@ -72,7 +74,9 @@ YAML::
       uri: direct:processOrder
       steps:
         - to:
-            uri: bean:orderService?method=process
+            uri: bean:orderService
+            parameters:
+              method: process
         - to:
             uri: activemq:queue:order.out
 - route:

--- a/docs/user-manual/modules/ROOT/pages/route-template.adoc
+++ b/docs/user-manual/modules/ROOT/pages/route-template.adoc
@@ -66,7 +66,9 @@ YAML::
       - name: "myPeriod"
         defaultValue: "3s"
     from:
-      uri: "timer:{{name}}?period={{myPeriod}}"
+      uri: "timer:{{name}}"
+      parameters:
+        period: "{{myPeriod}}"
       steps:
         - setBody:
             expression:
@@ -159,14 +161,18 @@ Notice how we use `?` in the replyTo option below:
 ----
 - route:
     from:
-      uri: "timer:{{name}}?period={{myPeriod}}"
+      uri: "timer:{{name}}"
+      parameters:
+        period: "{{myPeriod}}"
       steps:
         - setBody:
             expression:
               simple:
                 expression: "{{greeting}} ${body}"
         - to:
-            uri: "jms:myqueue?replyTo={{?replyToQueue}}"
+            uri: "jms:myqueue"
+            parameters:
+              replyTo: "{{?replyToQueue}}"
 ----
 ====
 
@@ -940,7 +946,9 @@ Notice how the Groovy code can be inlined directly in the route template in DSL 
       uri: direct:s3-store
       steps:
         - to:
-            uri: "aws2-s3:{{bucket}}?amazonS3Client=#{{myClient}}"
+            uri: "aws2-s3:{{bucket}}"
+            parameters:
+              amazonS3Client: "#{{myClient}}"
 ----
 ====
 
@@ -1006,7 +1014,9 @@ and can be omitted. For example in this example as we inject the bean via its be
       uri: direct:s3-store
       steps:
         - to:
-            uri: "aws2-s3:{{bucket}}?amazonS3Client=#{{myClient}}"
+            uri: "aws2-s3:{{bucket}}"
+            parameters:
+              amazonS3Client: "#{{myClient}}"
 ----
 ====
 
@@ -1114,7 +1124,9 @@ YAML::
       uri: direct:s3-store
       steps:
         - to:
-            uri: "aws2-s3:{{bucket}}?amazonS3Client=#{{myClient}}"
+            uri: "aws2-s3:{{bucket}}"
+            parameters:
+              amazonS3Client: "#{{myClient}}"
 ----
 ====
 
@@ -1194,7 +1206,9 @@ YAML::
       uri: direct:s3-store
       steps:
         - to:
-            uri: "aws2-s3:{{bucket}}?amazonS3Client=#{{myClient}}"
+            uri: "aws2-s3:{{bucket}}"
+            parameters:
+              amazonS3Client: "#{{myClient}}"
 ----
 ====
 

--- a/docs/user-manual/modules/ROOT/pages/routes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/routes.adoc
@@ -251,7 +251,8 @@ YAML::
       steps:
         - unmarshal:
             jaxb: {}
-        - to: "direct:out"
+        - to:
+            uri: direct:out
 ----
 ====
 

--- a/docs/user-manual/modules/ROOT/pages/transformer.adoc
+++ b/docs/user-manual/modules/ROOT/pages/transformer.adoc
@@ -194,7 +194,9 @@ YAML::
 ----
 - transformers:
     endpointTransformer:
-      uri: component:componentPathOptions?mappingFile=myMapping.xml
+      uri: component:componentPathOptions
+      parameters:
+        mappingFile: myMapping.xml
       fromType: xml
       toType: json
 ----

--- a/docs/user-manual/modules/ROOT/pages/using-propertyplaceholder.adoc
+++ b/docs/user-manual/modules/ROOT/pages/using-propertyplaceholder.adoc
@@ -272,7 +272,9 @@ YAML::
       uri: direct:start
       steps:
         - to:
-            uri: "file:outbox?bufferSize={{buf}}"
+            uri: file:outbox
+            parameters:
+              bufferSize: "{{buf}}"
 ----
 ====
 
@@ -399,7 +401,9 @@ YAML::
       uri: direct:start
       steps:
         - to:
-            uri: "elasticsearch:foo?query={{myQuery?nested=false}}"
+            uri: elasticsearch:foo
+            parameters:
+              query: "{{myQuery?nested=false}}"
 ----
 ====
 
@@ -483,7 +487,10 @@ YAML::
       uri: direct:start
       steps:
         - to:
-            uri: "log:{{cool.start}}?showBodyType=false&showExchangeId={{cool.showid}}"
+            uri: "log:{{cool.start}}"
+            parameters:
+              showBodyType: "false"
+              showExchangeId: "{{cool.showid}}"
         - to:
             uri: "mock:{{cool.result}}"
 ----
@@ -851,7 +858,9 @@ YAML::
         - choice:
             disabled: "{{boolean:region == 'EMEA'}}"
             when:
-            - simple: "${header.RetryAttempts} == null"
+            - expression:
+                simple:
+                  expression: "${header.RetryAttempts} == null"
               steps:
               - setProperty:
                   name: "HttpMessageMethod"

--- a/docs/user-manual/modules/ROOT/pages/validator.adoc
+++ b/docs/user-manual/modules/ROOT/pages/validator.adoc
@@ -77,7 +77,8 @@ YAML::
     predicateValidator:
       type: csv:CSVOrder
       expression:
-        simple: "${body} contains '{name:XOrder}'"
+        simple:
+          expression: "${body} contains '{name:XOrder}'"
 ----
 ====
 

--- a/docs/user-manual/modules/ROOT/pages/variables.adoc
+++ b/docs/user-manual/modules/ROOT/pages/variables.adoc
@@ -395,8 +395,10 @@ YAML::
     from:
       uri: direct:service
       steps:
-        - to: http:myservice
-        - to: log:after
+        - to:
+            uri: http:myservice
+        - to:
+            uri: log:after
 ----
 ====
 
@@ -442,12 +444,13 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:service"
+      uri: direct:service
       steps:
         - to:
             uri: http:myservice
             variableReceive: myVar
-        - to: "log:after"
+        - to:
+            uri: log:after
 ----
 ====
 
@@ -517,15 +520,21 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:start"
-      variableReceive: "myKey"
+      uri: direct:start
+      variableReceive: myKey
       steps:
         - transform:
-            simple: "Bye ${body}"
-        - to: "mock:foo"
+            expression:
+              simple:
+                expression: "Bye ${body}"
+        - to:
+            uri: mock:foo
         - setBody:
-            variable: "myKey"
-        - to: "mock:result"
+            expression:
+              variable:
+                expression: myKey
+        - to:
+            uri: mock:result
 ----
 ====
 


### PR DESCRIPTION
## Summary

Normalizes 99 YAML DSL code blocks across 46 documentation files from classic shorthand form to canonical (normalized) form, consistent with the canonical JSON schema introduced in CAMEL-22987.

**Four shorthand patterns were normalized:**

1. **Shorthand `to:`** — `- to: "direct:foo"` → expanded to `- to:` with nested `uri:` field
2. **Inline `simple:` expression** — `simple: "${body}"` → wrapped with `expression:` / `simple:` / `expression:` canonical structure
3. **URI with inline query params** — `uri: "file:inbox?move=../backup"` → split into `uri: file:inbox` + `parameters:` block
4. **Bare `from:` without `route:` wrapper** — `- from:` → wrapped with `- route:` parent

**Scope:**
- 33 EIP documentation pages (`core/camel-core-engine/src/main/docs/modules/eips/pages/`)
- 13 user manual pages (`docs/user-manual/modules/ROOT/pages/`)

**Edge cases handled:**
- `RAW()` syntax in passwords (e.g., `RAW(se+re?t&23)`) — `&` inside `RAW()` is not a param separator
- Property placeholders with `?` inside (e.g., `{{myQuery?nested=false}}`) — not a query param separator
- `pollEnrich`/`enrich` EIPs use `expression:` for endpoint URIs, not `uri:`/`parameters:`
- `endpoint.adoc` has an intentional "YAML::" vs "YAML expanded::" contrast showing both compact and decomposed forms — the compact form was preserved

**Not in scope (intentionally):**
- Component documentation pages
- Upgrade guide pages

## Test plan

- [ ] Spot-checked representative YAML blocks with `camel validate yaml-dsl` (MCP schema validation)
- [ ] Verified no YAML blocks that intentionally demonstrate shorthand syntax were normalized
- [ ] Documentation-only change — no code changes, no test impact

_Claude Code on behalf of Claus Ibsen_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>