### PR TITLE
CAMEL-23610: Normalize YAML DSL in component documentation to canonical form

### DIFF
--- a/components/camel-ai/camel-docling/src/main/docs/docling-component.adoc
+++ b/components/camel-ai/camel-docling/src/main/docs/docling-component.adoc
@@ -152,14 +152,14 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 
@@ -185,12 +185,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_HTML"
+          uri: docling:CONVERT_TO_HTML
           parameters:
             contentInBody: true
       - process:
@@ -228,12 +228,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:EXTRACT_STRUCTURED_DATA"
+          uri: docling:EXTRACT_STRUCTURED_DATA
           parameters:
             useDoclingServe: true
             contentInBody: true
@@ -270,32 +270,32 @@ YAML::
 # CLI mode
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             enableOCR: false
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 
 # API mode
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             useDoclingServe: true
             doOcr: false
             contentInBody: true
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 
@@ -321,7 +321,7 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
@@ -335,9 +335,9 @@ YAML::
           name: "CamelDoclingOCRLanguage"
           constant: "es"
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"  # Operation will be overridden by header
+          uri: docling:CONVERT_TO_MARKDOWN  # Operation will be overridden by header
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 
@@ -364,7 +364,7 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
@@ -375,9 +375,9 @@ YAML::
               ref: "customArgsBean"
               method: "createCustomArgs"
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 
@@ -467,14 +467,16 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:EXTRACT_METADATA"
-      - log: "Document: ${header.CamelDoclingMetadataTitle} by ${header.CamelDoclingMetadataAuthor}"
-      - log: "Pages: ${header.CamelDoclingMetadataPageCount}"
+          uri: docling:EXTRACT_METADATA
+      - log:
+          message: "Document: ${header.CamelDoclingMetadataTitle} by ${header.CamelDoclingMetadataAuthor}"
+      - log:
+          message: "Pages: ${header.CamelDoclingMetadataPageCount}"
       - process:
           ref: "metadataProcessor"
 ----
@@ -507,12 +509,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:EXTRACT_METADATA"
+          uri: docling:EXTRACT_METADATA
           parameters:
             includeRawMetadata: true
       - process:
@@ -551,29 +553,42 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:EXTRACT_METADATA"
+          uri: docling:EXTRACT_METADATA
       - choice:
           when:
-            - simple: "${header.CamelDoclingMetadataPageCount} > 100"
+            - expression:
+                simple:
+                  expression: "${header.CamelDoclingMetadataPageCount} > 100"
               steps:
-                - log: "Large document with ${header.CamelDoclingMetadataPageCount} pages"
-                - to: "file:///data/large-docs"
-            - simple: "${header.CamelDoclingMetadataLanguage} == 'fr'"
+                - log:
+                    message: "Large document with ${header.CamelDoclingMetadataPageCount} pages"
+                - to:
+                    uri: file:///data/large-docs
+            - expression:
+                simple:
+                  expression: "${header.CamelDoclingMetadataLanguage} == 'fr'"
               steps:
-                - log: "French document"
-                - to: "file:///data/french-docs"
-            - simple: "${header.CamelDoclingMetadataAuthor} contains 'Smith'"
+                - log:
+                    message: "French document"
+                - to:
+                    uri: file:///data/french-docs
+            - expression:
+                simple:
+                  expression: "${header.CamelDoclingMetadataAuthor} contains 'Smith'"
               steps:
-                - log: "Document by Smith"
-                - to: "file:///data/smith-docs"
+                - log:
+                    message: "Document by Smith"
+                - to:
+                    uri: file:///data/smith-docs
           otherwise:
             steps:
-              - to: "file:///data/other-docs"
+              - to:
+                  uri: file:///data/other-docs
 ----
 ====
 
@@ -602,12 +617,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:EXTRACT_METADATA"
+          uri: docling:EXTRACT_METADATA
           parameters:
             includeMetadataInHeaders: false
       - process:
@@ -647,12 +662,12 @@ YAML::
 # Get content directly in body (file is automatically deleted)
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             contentInBody: true
       - process:
@@ -661,12 +676,12 @@ YAML::
 # Get file path (file is preserved)
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             contentInBody: false
       - process:
@@ -811,27 +826,36 @@ YAML::
 - route:
     id: batch-convert
     from:
-      uri: "direct:documents"
+      uri: direct:documents
     steps:
       - to:
-          uri: "docling:convert"
+          uri: docling:convert
           parameters:
             operation: "BATCH_CONVERT_TO_MARKDOWN"
             useDoclingServe: true
             batchParallelism: 4
             batchFailOnFirstError: true
-      - log: "Processed ${header.CamelDoclingBatchSuccessCount}/${header.CamelDoclingBatchTotalDocuments} documents successfully"
+      - log:
+          message: "Processed ${header.CamelDoclingBatchSuccessCount}/${header.CamelDoclingBatchTotalDocuments} documents successfully"
       - split:
-          simple: "${body.results}"
+          expression:
+            simple:
+              expression: "${body.results}"
           steps:
             - choice:
                 when:
-                  - simple: "${body.success}"
+                  - expression:
+                      simple:
+                        expression: "${body.success}"
                     steps:
-                      - to: "file:///data/output?fileName=${body.documentId}.md"
+                      - to:
+                          uri: file:///data/output
+                          parameters:
+                            fileName: "${body.documentId}.md"
                 otherwise:
                   steps:
-                    - log: "Failed: ${body.originalPath} - ${body.errorMessage}"
+                    - log:
+                        message: "Failed: ${body.originalPath} - ${body.errorMessage}"
 ----
 ====
 
@@ -901,7 +925,7 @@ YAML::
 # Route 1: Collect documents
 - route:
     from:
-      uri: "file:///data/incoming"
+      uri: file:///data/incoming
       parameters:
         noop: true
         maxMessagesPerPoll: 50
@@ -910,16 +934,18 @@ YAML::
           type: "java.lang.String"
       - setHeader:
           name: "documentPath"
-          simple: "${body}"
+          expression:
+            simple:
+              expression: "${body}"
       - to:
-          uri: "seda:document-queue"
+          uri: seda:document-queue
           parameters:
             waitForTaskToComplete: "Never"
 
 # Route 2: Aggregate into batches
 - route:
     from:
-      uri: "seda:document-queue"
+      uri: seda:document-queue
       parameters:
         concurrentConsumers: 1
     steps:
@@ -930,31 +956,42 @@ YAML::
             constant: true
           completionSize: 10
           completionTimeout: 5000
-      - to: "direct:batch-process"
+      - to:
+          uri: direct:batch-process
 
 # Route 3: Process batch
 - route:
     from:
-      uri: "direct:batch-process"
+      uri: direct:batch-process
     steps:
       - to:
-          uri: "docling:convert"
+          uri: docling:convert
           parameters:
             operation: "BATCH_CONVERT_TO_MARKDOWN"
             useDoclingServe: true
             batchParallelism: 5
             batchFailOnFirstError: false
       - split:
-          simple: "${body.results}"
+          expression:
+            simple:
+              expression: "${body.results}"
           steps:
             - choice:
                 when:
-                  - simple: "${body.success}"
+                  - expression:
+                      simple:
+                        expression: "${body.success}"
                     steps:
-                      - to: "file:///data/output?fileName=${body.documentId}.md"
+                      - to:
+                          uri: file:///data/output
+                          parameters:
+                            fileName: "${body.documentId}.md"
                 otherwise:
                   steps:
-                    - to: "file:///data/failed?fileName=${body.documentId}.error"
+                    - to:
+                        uri: file:///data/failed
+                        parameters:
+                          fileName: "${body.documentId}.error"
 ----
 ====
 
@@ -1032,41 +1069,52 @@ YAML::
 - route:
     id: batch-strict
     from:
-      uri: "direct:batch-strict"
+      uri: direct:batch-strict
     steps:
       - to:
-          uri: "docling:convert"
+          uri: docling:convert
           parameters:
             operation: "BATCH_CONVERT_TO_MARKDOWN"
             useDoclingServe: true
             batchFailOnFirstError: true
-      - log: "All documents converted successfully"
+      - log:
+          message: "All documents converted successfully"
 
 # Continue on errors and process failures
 - route:
     id: batch-lenient
     from:
-      uri: "direct:batch-lenient"
+      uri: direct:batch-lenient
     steps:
       - to:
-          uri: "docling:convert"
+          uri: docling:convert
           parameters:
             operation: "BATCH_CONVERT_TO_MARKDOWN"
             useDoclingServe: true
             batchFailOnFirstError: false
-      - log: "Batch completed: ${header.CamelDoclingBatchSuccessCount} succeeded, ${header.CamelDoclingBatchFailureCount} failed"
+      - log:
+          message: "Batch completed: ${header.CamelDoclingBatchSuccessCount} succeeded, ${header.CamelDoclingBatchFailureCount} failed"
       - choice:
           when:
-            - simple: "${header.CamelDoclingBatchFailureCount} > 0"
+            - expression:
+                simple:
+                  expression: "${header.CamelDoclingBatchFailureCount} > 0"
               steps:
                 - split:
-                    simple: "${body.failed}"
+                    expression:
+                      simple:
+                        expression: "${body.failed}"
                     steps:
-                      - log: "Failed document: ${body.originalPath} - ${body.errorMessage}"
-                      - to: "file:///data/failed?fileName=${body.documentId}.error"
+                      - log:
+                          message: "Failed document: ${body.originalPath} - ${body.errorMessage}"
+                      - to:
+                          uri: file:///data/failed
+                          parameters:
+                            fileName: "${body.documentId}.error"
           otherwise:
             steps:
-              - log: "All documents processed successfully"
+              - log:
+                  message: "All documents processed successfully"
 ----
 ====
 
@@ -1278,37 +1326,49 @@ YAML::
 # Example 1: Split and route based on success
 - route:
     from:
-      uri: "direct:batch-with-split"
+      uri: direct:batch-with-split
     steps:
       - to:
-          uri: "docling:convert"
+          uri: docling:convert
           parameters:
             operation: "BATCH_CONVERT_TO_MARKDOWN"
             useDoclingServe: true
             splitBatchResults: true
             contentInBody: true
       - split:
-          simple: "${body}"
+          expression:
+            simple:
+              expression: "${body}"
           steps:
             - choice:
                 when:
-                  - simple: "${body.success}"
+                  - expression:
+                      simple:
+                        expression: "${body.success}"
                     steps:
-                      - log: "Success: ${body.documentId}"
-                      - to: "file:///data/success?fileName=${body.documentId}.md"
+                      - log:
+                          message: "Success: ${body.documentId}"
+                      - to:
+                          uri: file:///data/success
+                          parameters:
+                            fileName: "${body.documentId}.md"
                 otherwise:
                   steps:
-                    - log: "Failed: ${body.documentId}"
-                    - to: "file:///data/failed?fileName=${body.documentId}.error"
+                    - log:
+                        message: "Failed: ${body.documentId}"
+                    - to:
+                        uri: file:///data/failed
+                        parameters:
+                          fileName: "${body.documentId}.error"
 
 # Example 2: Split with parallel processing
 - route:
     id: batch-split-parallel
     from:
-      uri: "direct:batch-parallel"
+      uri: direct:batch-parallel
     steps:
       - to:
-          uri: "docling:convert"
+          uri: docling:convert
           parameters:
             operation: "BATCH_CONVERT_TO_MARKDOWN"
             useDoclingServe: true
@@ -1316,20 +1376,33 @@ YAML::
             batchParallelism: 4
             contentInBody: true
       - split:
-          simple: "${body}"
+          expression:
+            simple:
+              expression: "${body}"
           parallelProcessing: true
           steps:
-            - log: "Processing document ${body.documentId} (index ${body.batchIndex})"
+            - log:
+                message: "Processing document ${body.documentId} (index ${body.batchIndex})"
             - choice:
                 when:
-                  - simple: "${body.success}"
+                  - expression:
+                      simple:
+                        expression: "${body.success}"
                     steps:
-                      - log: "Successfully converted ${body.documentId}"
-                      - to: "file:///data/processed?fileName=${body.documentId}.md"
+                      - log:
+                          message: "Successfully converted ${body.documentId}"
+                      - to:
+                          uri: file:///data/processed
+                          parameters:
+                            fileName: "${body.documentId}.md"
                 otherwise:
                   steps:
-                    - log: "Failed to convert ${body.documentId}: ${body.errorMessage}"
-                    - to: "file:///data/errors?fileName=${body.documentId}.error"
+                    - log:
+                        message: "Failed to convert ${body.documentId}: ${body.errorMessage}"
+                    - to:
+                        uri: file:///data/errors
+                        parameters:
+                          fileName: "${body.documentId}.error"
 ----
 ====
 
@@ -1416,15 +1489,17 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - setHeader:
           name: CamelDoclingInputFilePath
-          simple: "${file:absolute.path}"
+          expression:
+            simple:
+              expression: "${file:absolute.path}"
       - to:
-          uri: "docling:CHUNK_HYBRID"
+          uri: docling:CHUNK_HYBRID
           parameters:
             useDoclingServe: true
             contentInBody: true
@@ -1432,9 +1507,12 @@ YAML::
             chunkingMaxTokens: 128
             chunkingMergePeers: true
       - split:
-          simple: "${body}"
+          expression:
+            simple:
+              expression: "${body}"
           steps:
-            - log: "Chunk ${body.chunkIndex}: ${body.text}"
+            - log:
+                message: "Chunk ${body.chunkIndex}: ${body.text}"
 ----
 ====
 
@@ -1471,13 +1549,15 @@ YAML::
 - route:
     id: ingest-pdf
     from:
-      uri: "direct:ingest-pdf"
+      uri: direct:ingest-pdf
     steps:
       - setHeader:
           name: CamelDoclingInputFilePath
-          simple: "${header.pdfFilePath}"
+          expression:
+            simple:
+              expression: "${header.pdfFilePath}"
       - to:
-          uri: "docling:CHUNK_HYBRID"
+          uri: docling:CHUNK_HYBRID
           parameters:
             useDoclingServe: true
             contentInBody: true
@@ -1485,15 +1565,20 @@ YAML::
             chunkingMaxTokens: "{{embedding.max-tokens}}"
             chunkingMergePeers: true
       - split:
-          simple: "${body}"
+          expression:
+            simple:
+              expression: "${body}"
           steps:
             - setBody:
-                simple: "${body.text}"
+                expression:
+                  simple:
+                    expression: "${body.text}"
             - to:
-                uri: "openai:embeddings"
+                uri: openai:embeddings
                 parameters:
                   embeddingModel: "{{embedding.model}}"
-            - to: "direct:store-embedding"
+            - to:
+                uri: direct:store-embedding
 ----
 ====
 
@@ -1523,22 +1608,27 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - setHeader:
           name: CamelDoclingInputFilePath
-          simple: "${file:absolute.path}"
+          expression:
+            simple:
+              expression: "${file:absolute.path}"
       - to:
-          uri: "docling:CHUNK_HIERARCHICAL"
+          uri: docling:CHUNK_HIERARCHICAL
           parameters:
             useDoclingServe: true
             contentInBody: true
       - split:
-          simple: "${body}"
+          expression:
+            simple:
+              expression: "${body}"
           steps:
-            - log: "Section [${body.headings}] page ${body.pageNumbers}: ${body.text}"
+            - log:
+                message: "Section [${body.headings}] page ${body.pageNumbers}: ${body.text}"
 ----
 ====
 
@@ -1573,12 +1663,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             useDoclingServe: true
             useAsyncMode: true
@@ -1586,7 +1676,7 @@ YAML::
             asyncTimeout: 300000
             contentInBody: true
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 
@@ -1616,12 +1706,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/large-documents"
+      uri: file:///data/large-documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             useDoclingServe: true
             useAsyncMode: true
@@ -1629,7 +1719,7 @@ YAML::
             asyncTimeout: 600000
             contentInBody: true
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 
@@ -1662,19 +1752,19 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - process:
           ref: "asyncDecisionProcessor"
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             useDoclingServe: true
             contentInBody: true
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 
@@ -1812,24 +1902,29 @@ YAML::
 - route:
     id: async-with-custom-polling
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
-      - log: "Starting async conversion for: ${header.CamelFileName}"
+      - log:
+          message: "Starting async conversion for: ${header.CamelFileName}"
       - to:
-          uri: "docling:convert"
+          uri: docling:convert
           parameters:
             operation: "SUBMIT_ASYNC_CONVERSION"
             useDoclingServe: true
-      - log: "Submitted conversion with task ID: ${body}"
+      - log:
+          message: "Submitted conversion with task ID: ${body}"
       - setHeader:
           name: "taskId"
-          simple: "${body}"
+          expression:
+            simple:
+              expression: "${body}"
       # For YAML, simpler to use Java processor bean or built-in async mode
       - to:
-          uri: "bean:asyncPollingProcessor"
-      - to: "file:///data/output"
+          uri: bean:asyncPollingProcessor
+      - to:
+          uri: file:///data/output
 ----
 ====
 
@@ -1912,12 +2007,12 @@ YAML::
 
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:convert"
+          uri: docling:convert
           parameters:
             operation: "CONVERT_TO_MARKDOWN"
             useDoclingServe: true
@@ -1926,7 +2021,7 @@ YAML::
             asyncTimeout: 120000
             contentInBody: true
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
           parameters:
             fileName: "${header.CamelFileName}"
 ----
@@ -1958,12 +2053,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             useDoclingServe: true
             doclingServeUrl: "http://localhost:5001"
@@ -1995,19 +2090,19 @@ YAML::
 ----
 - route:
     from:
-      uri: "timer:convert"
+      uri: timer:convert
       parameters:
         repeatCount: 1
     steps:
       - setBody:
           constant: "https://arxiv.org/pdf/2501.17887"
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             useDoclingServe: true
             contentInBody: true
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 
@@ -2030,18 +2125,18 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.(pdf|docx)"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_HTML"
+          uri: docling:CONVERT_TO_HTML
           parameters:
             useDoclingServe: true
             doclingServeUrl: "http://localhost:5001"
             contentInBody: true
       - to:
-          uri: "file:///data/converted"
+          uri: file:///data/converted
           parameters:
             fileName: "${file:name.noext}.html"
 ----
@@ -2075,12 +2170,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             useDoclingServe: true
             doclingServeUrl: "http://localhost:5001"
@@ -2088,7 +2183,7 @@ YAML::
             authenticationToken: "your-bearer-token-here"
             contentInBody: true
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 
@@ -2117,12 +2212,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             useDoclingServe: true
             doclingServeUrl: "http://localhost:5001"
@@ -2131,7 +2226,7 @@ YAML::
             apiKeyHeader: "X-API-Key"
             contentInBody: true
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 
@@ -2162,12 +2257,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             useDoclingServe: true
             doclingServeUrl: "http://localhost:5001"
@@ -2176,7 +2271,7 @@ YAML::
             apiKeyHeader: "X-Custom-API-Key"
             contentInBody: true
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 
@@ -2206,12 +2301,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             useDoclingServe: true
             doclingServeUrl: "{{docling.serve.url}}"
@@ -2219,7 +2314,7 @@ YAML::
             authenticationToken: "{{docling.serve.token}}"
             contentInBody: true
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 
@@ -2393,12 +2488,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:EXTRACT_STRUCTURED_DATA"
+          uri: docling:EXTRACT_STRUCTURED_DATA
           parameters:
             useDoclingServe: true
             doOcr: true
@@ -2455,12 +2550,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/documents"
+      uri: file:///data/documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_JSON"
+          uri: docling:CONVERT_TO_JSON
           parameters:
             useDoclingServe: true
             contentInBody: true
@@ -2550,12 +2645,12 @@ YAML::
 ----
 - route:
     from:
-      uri: "file:///data/large-documents"
+      uri: file:///data/large-documents
       parameters:
         include: ".*\\.pdf"
     steps:
       - to:
-          uri: "docling:CONVERT_TO_MARKDOWN"
+          uri: docling:CONVERT_TO_MARKDOWN
           parameters:
             useDoclingServe: true
             useAsyncMode: true
@@ -2563,7 +2658,7 @@ YAML::
             asyncTimeout: 600000
             contentInBody: true
       - to:
-          uri: "file:///data/output"
+          uri: file:///data/output
 ----
 ====
 

--- a/components/camel-ai/camel-langchain4j-embeddings/src/main/docs/langchain4j-embeddings-component.adoc
+++ b/components/camel-ai/camel-langchain4j-embeddings/src/main/docs/langchain4j-embeddings-component.adoc
@@ -96,10 +96,10 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:embeddings"
+      uri: direct:embeddings
     steps:
       - to:
-          uri: "langchain4j-embeddings:test"
+          uri: langchain4j-embeddings:test
           parameters:
             embeddingModel: "#embeddingModel"
 ----
@@ -174,10 +174,10 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:embeddings"
+      uri: direct:embeddings
     steps:
       - to:
-          uri: "langchain4j-embeddings:test"
+          uri: langchain4j-embeddings:test
           parameters:
             embeddingModel: "#myEmbeddingModel"
 ----
@@ -211,9 +211,10 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:store"
+      uri: direct:store
     steps:
-      - to: "langchain4j-embeddings:embed"
+      - to:
+          uri: langchain4j-embeddings:embed
       - setHeader:
           name: CamelQdrantAction
           constant: UPSERT
@@ -222,7 +223,8 @@ YAML::
           constant: 1
       - transform:
           dataType: "qdrant:embeddings"
-      - to: "qdrant:myCollection"
+      - to:
+          uri: qdrant:myCollection
 ----
 ====
 
@@ -251,9 +253,10 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:search"
+      uri: direct:search
     steps:
-      - to: "langchain4j-embeddings:embed"
+      - to:
+          uri: langchain4j-embeddings:embed
       - transform:
           dataType: "qdrant:embeddings"
       - setHeader:
@@ -262,7 +265,8 @@ YAML::
       - setHeader:
           name: CamelQdrantIncludePayload
           constant: true
-      - to: "qdrant:myCollection"
+      - to:
+          uri: qdrant:myCollection
       - transform:
           dataType: "qdrant:rag"
 ----
@@ -291,15 +295,17 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:store"
+      uri: direct:store
     steps:
-      - to: "langchain4j-embeddings:embed"
+      - to:
+          uri: langchain4j-embeddings:embed
       - setHeader:
           name: CamelPgVectorAction
           constant: UPSERT
       - transform:
           dataType: "pgvector:embeddings"
-      - to: "pgvector:myCollection"
+      - to:
+          uri: pgvector:myCollection
 ----
 ====
 
@@ -325,15 +331,17 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:search"
+      uri: direct:search
     steps:
-      - to: "langchain4j-embeddings:embed"
+      - to:
+          uri: langchain4j-embeddings:embed
       - transform:
           dataType: "pgvector:embeddings"
       - setHeader:
           name: CamelPgVectorAction
           constant: SIMILARITY_SEARCH
-      - to: "pgvector:myCollection"
+      - to:
+          uri: pgvector:myCollection
       - transform:
           dataType: "pgvector:rag"
 ----
@@ -364,16 +372,26 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:store"
+      uri: direct:store
     steps:
-      - to: "langchain4j-embeddings:embed"
-      - to: "langchain4j-embeddingstore:myStore?action=ADD"
+      - to:
+          uri: langchain4j-embeddings:embed
+      - to:
+          uri: langchain4j-embeddingstore:myStore
+          parameters:
+            action: ADD
 
 - route:
     from:
-      uri: "direct:search"
+      uri: direct:search
     steps:
-      - to: "langchain4j-embeddings:embed"
-      - to: "langchain4j-embeddingstore:myStore?action=SEARCH&maxResults=5&returnTextContent=true"
+      - to:
+          uri: langchain4j-embeddings:embed
+      - to:
+          uri: langchain4j-embeddingstore:myStore
+          parameters:
+            action: SEARCH
+            maxResults: 5
+            returnTextContent: true
 ----
 ====

--- a/components/camel-ai/camel-langchain4j-embeddingstore/src/main/docs/langchain4j-embeddingstore-component.adoc
+++ b/components/camel-ai/camel-langchain4j-embeddingstore/src/main/docs/langchain4j-embeddingstore-component.adoc
@@ -94,10 +94,14 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:store"
+      uri: direct:store
     steps:
-      - to: "langchain4j-embeddings:embed"
-      - to: "langchain4j-embeddingstore:myStore?action=ADD"
+      - to:
+          uri: langchain4j-embeddings:embed
+      - to:
+          uri: langchain4j-embeddingstore:myStore
+          parameters:
+            action: ADD
 ----
 ====
 
@@ -124,10 +128,16 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:search"
+      uri: direct:search
     steps:
-      - to: "langchain4j-embeddings:embed"
-      - to: "langchain4j-embeddingstore:myStore?action=SEARCH&maxResults=5&minScore=0.7"
+      - to:
+          uri: langchain4j-embeddings:embed
+      - to:
+          uri: langchain4j-embeddingstore:myStore
+          parameters:
+            action: SEARCH
+            maxResults: 5
+            minScore: 0.7
 ----
 ====
 
@@ -155,11 +165,18 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:search"
+      uri: direct:search
     steps:
-      - to: "langchain4j-embeddings:embed"
-      - to: "langchain4j-embeddingstore:myStore?action=SEARCH&maxResults=5&returnTextContent=true"
-      - log: "Found texts: ${body}"
+      - to:
+          uri: langchain4j-embeddings:embed
+      - to:
+          uri: langchain4j-embeddingstore:myStore
+          parameters:
+            action: SEARCH
+            maxResults: 5
+            returnTextContent: true
+      - log:
+          message: "Found texts: ${body}"
 ----
 ====
 
@@ -184,11 +201,16 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:remove"
+      uri: direct:remove
     steps:
       - setBody:
-          simple: "${header.embeddingId}"
-      - to: "langchain4j-embeddingstore:myStore?action=REMOVE"
+          expression:
+            simple:
+              expression: "${header.embeddingId}"
+      - to:
+          uri: langchain4j-embeddingstore:myStore
+          parameters:
+            action: REMOVE
 ----
 ====
 

--- a/components/camel-ai/camel-openai/src/main/docs/openai-component.adoc
+++ b/components/camel-ai/camel-openai/src/main/docs/openai-component.adoc
@@ -123,7 +123,8 @@ YAML::
             uri: openai:chat-completion
             parameters:
               userMessage: What is Apache Camel?
-        - log: "Response: ${body}"
+        - log:
+            message: "Response: ${body}"
 ----
 ====
 
@@ -186,8 +187,9 @@ When `streaming=true`, the component returns an `Iterator<ChatCompletionChunk>` 
               - log:
                   id: log-6722
                   message: ${body}
-            simple:
-              expression: ${body}
+            expression:
+              simple:
+                expression: ${body}
             streaming: true
 ----
 
@@ -594,7 +596,9 @@ Using the xref:pgvector-component.adoc[PGVector] component:
       steps:
         - setVariable:
             name: text
-            simple: "${body}"
+            expression:
+              simple:
+                expression: "${body}"
         - to:
             uri: openai:embeddings
             parameters:
@@ -604,7 +608,9 @@ Using the xref:pgvector-component.adoc[PGVector] component:
             constant: UPSERT
         - setHeader:
             name: CamelPgVectorTextContent
-            simple: "${variable.text}"
+            expression:
+              simple:
+                expression: "${variable.text}"
         - to:
             uri: pgvector:documents
 
@@ -713,7 +719,8 @@ YAML::
             uri: openai:audio-transcription
             parameters:
               audioModel: whisper-1
-        - log: "Transcription: ${body}"
+        - log:
+            message: "Transcription: ${body}"
 ----
 ====
 
@@ -857,7 +864,8 @@ YAML::
               mcpServer.fs.args: "-y,@modelcontextprotocol/server-filesystem,/tmp"
               mcpServer.weather.transportType: sse
               mcpServer.weather.url: http://localhost:8080
-        - log: "${body}"
+        - log:
+            message: "${body}"
 ----
 ====
 
@@ -936,7 +944,9 @@ YAML::
       steps:
         - setProperty:
             name: originalPrompt
-            simple: "${body}"
+            expression:
+              simple:
+                expression: "${body}"
         - to:
             uri: openai:chat-completion
             parameters:
@@ -946,7 +956,9 @@ YAML::
               mcpServer.api.transportType: streamableHttp
               mcpServer.api.url: http://localhost:9090/mcp
         - loopDoWhile:
-            simple: "${header.CamelOpenAIFinishReason} == 'tool_calls'"
+            expression:
+              simple:
+                expression: "${header.CamelOpenAIFinishReason} == 'tool_calls'"
             steps:
               - to:
                   uri: openai:tool-execution
@@ -961,7 +973,8 @@ YAML::
                     storeFullResponse: true
                     mcpServer.api.transportType: streamableHttp
                     mcpServer.api.url: http://localhost:9090/mcp
-        - log: "Final answer: ${body}"
+        - log:
+            message: "Final answer: ${body}"
 ----
 ====
 
@@ -1029,7 +1042,8 @@ YAML::
               conversationMemory: true
               mcpServer.api.transportType: streamableHttp
               mcpServer.api.url: http://localhost:9090/mcp
-        - log: "${body}"
+        - log:
+            message: "${body}"
 ----
 ====
 

--- a/components/camel-ai/camel-pgvector/src/main/docs/pgvector-component.adoc
+++ b/components/camel-ai/camel-pgvector/src/main/docs/pgvector-component.adoc
@@ -106,7 +106,9 @@ YAML::
     steps:
       - setVariable:
           name: text
-          simple: "${body}"
+          expression:
+            simple:
+              expression: "${body}"
       - to:
           uri: openai:embeddings
           parameters:
@@ -116,8 +118,11 @@ YAML::
           constant: UPSERT
       - setHeader:
           name: CamelPgVectorTextContent
-          simple: "${variable.text}"
-      - to: pgvector:documents
+          expression:
+            simple:
+              expression: "${variable.text}"
+      - to:
+          uri: pgvector:documents
 
 - route:
     from:
@@ -133,7 +138,8 @@ YAML::
       - setHeader:
           name: CamelPgVectorQueryTopK
           constant: 5
-      - to: pgvector:documents
+      - to:
+          uri: pgvector:documents
 ----
 ====
 
@@ -172,27 +178,31 @@ YAML::
 ----
 - route:
     from:
-      uri: "direct:store"
+      uri: direct:store
     steps:
-      - to: "langchain4j-embeddings:embed"
+      - to:
+          uri: langchain4j-embeddings:embed
       - setHeader:
           name: CamelPgVectorAction
           constant: UPSERT
       - transform:
           dataType: "pgvector:embeddings"
-      - to: "pgvector:myCollection"
+      - to:
+          uri: pgvector:myCollection
 
 - route:
     from:
-      uri: "direct:search"
+      uri: direct:search
     steps:
-      - to: "langchain4j-embeddings:embed"
+      - to:
+          uri: langchain4j-embeddings:embed
       - transform:
           dataType: "pgvector:embeddings"
       - setHeader:
           name: CamelPgVectorAction
           constant: SIMILARITY_SEARCH
-      - to: "pgvector:myCollection"
+      - to:
+          uri: pgvector:myCollection
       - transform:
           dataType: "pgvector:rag"
 ----

--- a/components/camel-aws/camel-aws2-s3-vectors/src/main/docs/aws2-s3-vectors-component.adoc
+++ b/components/camel-aws/camel-aws2-s3-vectors/src/main/docs/aws2-s3-vectors-component.adoc
@@ -80,22 +80,23 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:insert
-    steps:
-      - setHeader:
-          name: CamelAwsS3VectorsVectorId
-          constant: doc-001
-      - setBody:
-          constant:
-            - 0.1
-            - 0.2
-            - 0.3
-      - to:
-          uri: aws2-s3-vectors://my-bucket
-          parameters:
-            operation: putVectors
-            vectorIndexName: my-index
+- route:
+    from:
+      uri: direct:insert
+      steps:
+        - setHeader:
+            name: CamelAwsS3VectorsVectorId
+            constant: doc-001
+        - setBody:
+            constant:
+              - 0.1
+              - 0.2
+              - 0.3
+        - to:
+            uri: aws2-s3-vectors://my-bucket
+            parameters:
+              operation: putVectors
+              vectorIndexName: my-index
 ----
 ====
 
@@ -118,23 +119,25 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:search
-    steps:
-      - setBody:
-          constant:
-            - 0.15
-            - 0.25
-            - 0.35
-      - setHeader:
-          name: CamelAwsS3VectorsTopK
-          constant: 5
-      - to:
-          uri: aws2-s3-vectors://my-bucket
-          parameters:
-            operation: queryVectors
-            vectorIndexName: my-index
-      - log: "Found ${body.size} similar vectors"
+- route:
+    from:
+      uri: direct:search
+      steps:
+        - setBody:
+            constant:
+              - 0.15
+              - 0.25
+              - 0.35
+        - setHeader:
+            name: CamelAwsS3VectorsTopK
+            constant: 5
+        - to:
+            uri: aws2-s3-vectors://my-bucket
+            parameters:
+              operation: queryVectors
+              vectorIndexName: my-index
+        - log:
+            message: "Found ${body.size} similar vectors"
 ----
 ====
 
@@ -159,16 +162,19 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: aws2-s3-vectors://my-bucket
-    parameters:
-      vectorIndexName: my-index
-      consumerQueryVector: "0.1,0.2,0.3"
-      delay: 5000
-      maxMessagesPerPoll: 10
-    steps:
-      - log: "Vector ID: ${header.CamelAwsS3VectorsVectorId}"
-      - to: direct:process
+- route:
+    from:
+      uri: aws2-s3-vectors://my-bucket
+      parameters:
+        vectorIndexName: my-index
+        consumerQueryVector: "0.1,0.2,0.3"
+        delay: 5000
+        maxMessagesPerPoll: 10
+      steps:
+        - log:
+            message: "Vector ID: ${header.CamelAwsS3VectorsVectorId}"
+        - to:
+            uri: direct:process
 ----
 ====
 
@@ -191,23 +197,24 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:createIndex
-    steps:
-      - setHeader:
-          name: CamelAwsS3VectorsVectorDimensions
-          constant: 1536
-      - setHeader:
-          name: CamelAwsS3VectorsDataType
-          constant: float32
-      - setHeader:
-          name: CamelAwsS3VectorsDistanceMetric
-          constant: cosine
-      - to:
-          uri: aws2-s3-vectors://my-bucket
-          parameters:
-            operation: createVectorIndex
-            vectorIndexName: my-index
+- route:
+    from:
+      uri: direct:createIndex
+      steps:
+        - setHeader:
+            name: CamelAwsS3VectorsVectorDimensions
+            constant: 1536
+        - setHeader:
+            name: CamelAwsS3VectorsDataType
+            constant: float32
+        - setHeader:
+            name: CamelAwsS3VectorsDistanceMetric
+            constant: cosine
+        - to:
+            uri: aws2-s3-vectors://my-bucket
+            parameters:
+              operation: createVectorIndex
+              vectorIndexName: my-index
 ----
 ====
 

--- a/components/camel-azure/camel-azure-storage-blob/src/main/docs/azure-storage-blob-component.adoc
+++ b/components/camel-azure/camel-azure-storage-blob/src/main/docs/azure-storage-blob-component.adoc
@@ -233,8 +233,10 @@ YAML::
         credentialType: SHARED_ACCOUNT_KEY
         accessKey: "RAW({{azure.accessKey}})"
       steps:
-        - log: "Processing blob: ${header.CamelAzureStorageBlobBlobName}"
-        - to: direct:processBlob
+        - log:
+            message: "Processing blob: ${header.CamelAzureStorageBlobBlobName}"
+        - to:
+            uri: direct:processBlob
 ----
 ====
 
@@ -272,8 +274,10 @@ YAML::
         credentialType: SHARED_ACCOUNT_KEY
         accessKey: "RAW({{azure.accessKey}})"
       steps:
-        - log: "Processing blob: ${header.CamelAzureStorageBlobBlobName}"
-        - to: direct:processBlob
+        - log:
+            message: "Processing blob: ${header.CamelAzureStorageBlobBlobName}"
+        - to:
+            uri: direct:processBlob
 ----
 ====
 
@@ -317,8 +321,10 @@ YAML::
         credentialType: SHARED_ACCOUNT_KEY
         accessKey: "RAW({{azure.accessKey}})"
       steps:
-        - log: "Processing: ${header.CamelAzureStorageBlobBlobName}"
-        - to: direct:processBlob
+        - log:
+            message: "Processing: ${header.CamelAzureStorageBlobBlobName}"
+        - to:
+            uri: direct:processBlob
 ----
 ====
 
@@ -530,9 +536,12 @@ YAML::
 - route:
     id: azure-blob-upload
     from:
-      uri: file://data?noop=true
+      uri: file://data
+      parameters:
+        noop: true
       steps:
-        - log: "Uploading file: ${header.CamelFileName}"
+        - log:
+            message: "Uploading file: ${header.CamelFileName}"
         - toD:
             uri: "azure-storage-blob://{{azure.account}}/{{azure.container}}"
             parameters:
@@ -542,7 +551,8 @@ YAML::
               maxConcurrency: 4          # 4 parallel uploads
               credentialType: SHARED_ACCOUNT_KEY
               accessKey: "RAW({{azure.accessKey}})"
-        - log: "Upload completed: ${header.CamelFileName}"
+        - log:
+            message: "Upload completed: ${header.CamelFileName}"
 ----
 ====
 

--- a/components/camel-camunda/src/main/docs/camunda-component.adoc
+++ b/components/camel-camunda/src/main/docs/camunda-component.adoc
@@ -149,7 +149,7 @@ YAML::
         - setBody:
             simple: '{"process_id":"processId","variables":${body}}'
         - to:
-            uri: "camunda://startProcess"
+            uri: camunda://startProcess
 ----
 
 XML::
@@ -220,7 +220,7 @@ YAML::
         - setBody:
             simple: '{"process_instance_key": 123}'
         - to:
-            uri: "camunda://cancelProcess"
+            uri: camunda://cancelProcess
 ----
 
 XML::
@@ -268,7 +268,7 @@ YAML::
         - setBody:
             simple: '{"name":"MessageName","correlation_key":"messageKey","time_to_live":100,"variables":{}}'
         - to:
-            uri: "camunda://publishMessage"
+            uri: camunda://publishMessage
 ----
 
 XML::
@@ -313,7 +313,7 @@ YAML::
             name: CamelCamundaResourceName
             simple: "process.bpmn"
         - to:
-            uri: "camunda://deployResource"
+            uri: camunda://deployResource
 ----
 
 XML::
@@ -378,7 +378,10 @@ YAML::
 ----
 - route:
     from:
-      uri: "camunda://worker?jobType=myJobType&timeout=20"
+      uri: camunda://worker
+      parameters:
+        jobType: myJobType
+        timeout: 20
       steps:
         - log:
             message: "Received job ${header.CamelCamundaJobKey}"
@@ -417,7 +420,10 @@ YAML::
 ----
 - route:
     from:
-      uri: "camunda://worker?jobType=myJobType&timeout=20"
+      uri: camunda://worker
+      parameters:
+        jobType: myJobType
+        timeout: 20
       steps:
         - setBody:
             constant:
@@ -464,7 +470,10 @@ YAML::
 ----
 - route:
     from:
-      uri: "camunda://worker?jobType=myJobType&timeout=20"
+      uri: camunda://worker
+      parameters:
+        jobType: myJobType
+        timeout: 20
       steps:
         - setHeader:
             name: CamelCamundaErrorCode
@@ -473,7 +482,7 @@ YAML::
             name: CamelCamundaErrorMessage
             simple: "Data validation failed"
         - to:
-            uri: "camunda://throwError"
+            uri: camunda://throwError
 ----
 
 XML::

--- a/components/camel-dfdl/src/main/docs/dfdl-dataformat.adoc
+++ b/components/camel-dfdl/src/main/docs/dfdl-dataformat.adoc
@@ -53,13 +53,15 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:unmarshal
+- route:
+    from:
+      uri: direct:unmarshal
     steps:
       - unmarshal:
           dfdl:
             schemaUri: X12-837P.dfdl.xsd
-      - log: "Unmarshalled X12 837P message: ${body}"
+      - log:
+          message: "Unmarshalled X12 837P message: ${body}"
 ----
 ====
 
@@ -81,13 +83,15 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:marshal
+- route:
+    from:
+      uri: direct:marshal
     steps:
       - marshal:
           dfdl:
             schemaUri: X12-837P.dfdl.xsd
-      - log: "Marshalled X12 837P message: ${body}"
+      - log:
+          message: "Marshalled X12 837P message: ${body}"
 ----
 ====
 

--- a/components/camel-dhis2/camel-dhis2-component/src/main/docs/dhis2-component.adoc
+++ b/components/camel-dhis2/camel-dhis2-component/src/main/docs/dhis2-component.adoc
@@ -69,8 +69,9 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:getResource
+- route:
+    from:
+      uri: direct:getResource
     steps:
       - to:
           uri: dhis2:get/resource
@@ -112,8 +113,9 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:getCollection
+- route:
+    from:
+      uri: direct:getCollection
     steps:
       - to:
           uri: dhis2:get/collection
@@ -124,11 +126,14 @@ YAML::
             password: district
             baseApiUrl: https://play.im.dhis2.org/stable-2-40-5/api
       - split:
-          simple: ${body}
+          expression:
+            simple:
+              expression: ${body}
           steps:
             - convertBodyTo:
                 type: org.hisp.dhis.api.model.v40_2_2.OrganisationUnit
-            - log: ${body}
+            - log:
+                message: ${body}
 ----
 ====
 
@@ -159,8 +164,9 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:getCollection
+- route:
+    from:
+      uri: direct:getCollection
     steps:
       - to:
           uri: dhis2:get/collection
@@ -172,11 +178,14 @@ YAML::
             baseApiUrl: https://play.im.dhis2.org/stable-2-40-5/api
             fields: code
       - split:
-          simple: ${body}
+          expression:
+            simple:
+              expression: ${body}
           steps:
             - convertBodyTo:
                 type: org.hisp.dhis.api.model.v40_2_2.OrganisationUnit
-            - log: ${body}
+            - log:
+                message: ${body}
 ----
 ====
 
@@ -208,8 +217,9 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:getCollection
+- route:
+    from:
+      uri: direct:getCollection
     steps:
       - to:
           uri: dhis2:get/collection
@@ -221,11 +231,14 @@ YAML::
             baseApiUrl: https://play.im.dhis2.org/stable-2-40-5/api
             filter: "phoneNumber:!null:"
       - split:
-          simple: ${body}
+          expression:
+            simple:
+              expression: ${body}
           steps:
             - convertBodyTo:
                 type: org.hisp.dhis.api.model.v40_2_2.User
-            - log: ${body}
+            - log:
+                message: ${body}
 ----
 ====
 
@@ -275,8 +288,9 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:postResource
+- route:
+    from:
+      uri: direct:postResource
     steps:
       - setBody:
           groovy: |
@@ -340,8 +354,9 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:putResource
+- route:
+    from:
+      uri: direct:putResource
     steps:
       - setBody:
           groovy: |
@@ -399,8 +414,9 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:deleteResource
+- route:
+    from:
+      uri: direct:deleteResource
     steps:
       - to:
           uri: dhis2:delete/resource
@@ -446,8 +462,9 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:resourceTablesAnalytics
+- route:
+    from:
+      uri: direct:resourceTablesAnalytics
     steps:
       - to:
           uri: dhis2:resourceTables/analytics
@@ -498,8 +515,9 @@ YAML::
     script: >
       org.hisp.dhis.integration.sdk.Dhis2ClientBuilder.newClient('https://play.im.dhis2.org/stable-2-40-5/api', 'admin', 'district').build()
 
-- from:
-    uri: direct:resourceTablesAnalytics
+- route:
+    from:
+      uri: direct:resourceTablesAnalytics
     steps:
       - to:
           uri: dhis2:resourceTables/analytics
@@ -539,8 +557,9 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:clearCache
+- route:
+    from:
+      uri: direct:clearCache
     steps:
       - setHeader:
           name: CamelDhis2.queryParams

--- a/components/camel-event/src/main/docs/event-component.adoc
+++ b/components/camel-event/src/main/docs/event-component.adoc
@@ -381,26 +381,29 @@ Create a file called `event-monitor.yaml`:
 ----
 - route:
     from:
-      uri: "event:Route*"
+      uri: event:Route*
       steps:
-        - log: "Route event: ${header.CamelEventType} - route ${header.CamelEventRouteId}"
+        - log:
+            message: "Route event: ${header.CamelEventType} - route ${header.CamelEventRouteId}"
 
 - route:
     from:
-      uri: "event:ExchangeCompleted,ExchangeFailed"
+      uri: event:ExchangeCompleted,ExchangeFailed
       steps:
-        - log: "Exchange ${header.CamelEventExchangeId} on route ${header.CamelEventRouteId}: ${header.CamelEventType}"
+        - log:
+            message: "Exchange ${header.CamelEventExchangeId} on route ${header.CamelEventRouteId}: ${header.CamelEventType}"
 
 - route:
     id: myRoute
     from:
-      uri: "timer:tick"
+      uri: timer:tick
       parameters:
-        period: "5000"
+        period: 5000
       steps:
         - setBody:
             constant: "Hello from myRoute!"
-        - log: "${body}"
+        - log:
+            message: "${body}"
 ----
 
 Then run it:

--- a/components/camel-ibm/camel-ibm-watsonx-ai/src/main/docs/ibm-watsonx-ai-component.adoc
+++ b/components/camel-ibm/camel-ibm-watsonx-ai/src/main/docs/ibm-watsonx-ai-component.adoc
@@ -422,13 +422,16 @@ YAML::
       - loop:
           id: loop-4459
           doWhile: true
-          simple:
-            expression: ${header.CamelIBMWatsonxAiHasToolCalls} == true
+          expression:
+            simple:
+              expression: ${header.CamelIBMWatsonxAiHasToolCalls} == true
           steps:
             - log:
                 message: Executing tool calls...
             - to:
-                uri: ibm-watsonx-ai:tools?operation=processToolCalls
+                uri: ibm-watsonx-ai:tools
+                parameters:
+                  operation: processToolCalls
             - to:
                 uri: ibm-watsonx-ai:chat
                 parameters:

--- a/components/camel-kafka/src/main/docs/kafka-component.adoc
+++ b/components/camel-kafka/src/main/docs/kafka-component.adoc
@@ -609,9 +609,9 @@ YAML::
 ----
 - route:
     from:
-      uri: "kafka:topic"
+      uri: kafka:topic
       parameters:
-        groupId: "myGroup"
+        groupId: myGroup
         pollTimeoutMs: 1000
         batching: true
         maxPollRecords: 10
@@ -619,8 +619,9 @@ YAML::
         autoCommitEnable: true
     steps:
       - process:
-          ref: "batchProcessor"
-      - to: "mock:result"
+          ref: batchProcessor
+      - to:
+          uri: mock:result
 ----
 
 Processor Implementation::
@@ -704,25 +705,26 @@ YAML::
 ----
 - route:
     on-exception:
-      - exception: "java.lang.Exception"
+      - exception: java.lang.Exception
         handled: false
         steps:
           - process:
-              ref: "errorCommitProcessor"
+              ref: errorCommitProcessor
     from:
-      uri: "kafka:topic"
+      uri: kafka:topic
       parameters:
-        groupId: "myGroup"
+        groupId: myGroup
         batching: true
         breakOnFirstError: true
         autoCommitEnable: false
         allowManualCommit: true
     steps:
       - process:
-          ref: "batchProcessorManual"
+          ref: batchProcessorManual
       - process:
-          ref: "successCommitProcessor"
-      - to: "mock:result"
+          ref: successCommitProcessor
+      - to:
+          uri: mock:result
 ----
 
 Processor Implementations::

--- a/components/camel-kamelet/src/main/docs/kamelet-component.adoc
+++ b/components/camel-kamelet/src/main/docs/kamelet-component.adoc
@@ -59,9 +59,10 @@ Which means you will se a WARN being logged.
         deadLetterUri: log:dead?level=WARN
     id: myRoute
     from:
-      uri: "kamelet:my-error-source/source"
+      uri: kamelet:my-error-source/source
       steps:
-        - log: "${body}"
+        - log:
+            message: "${body}"
 ----
 
 For sink kamelets then error handling also allows to perform retries.
@@ -79,11 +80,12 @@ So suppose you have the following route:
           redeliveryDelay: "5000"
     id: myRoute
     from:
-      uri: "direct:start"
+      uri: direct:start
       steps:
         - to:
-            uri: "kamelet:my-error-sink/sink"
-        - log: "${body}"
+            uri: kamelet:my-error-sink/sink
+        - log:
+            message: "${body}"
 ----
 
 Then notice the error handler has been configured to do redeliveries up till 5 times with 5 sec delay between.
@@ -121,9 +123,12 @@ spec:
   - "camel:kamelet"
   template:
     from:
-      uri: "kamelet:source"
+      uri: kamelet:source
       steps:
-      - to: "kamelet:log-sink?level={{log-level}}"
+      - to:
+          uri: kamelet:log-sink
+          parameters:
+            level: "{{log-level}}"
 ----
 
 According to the specification, this Kamelet expects a parameter, _log-level_ which we will use as a further parameter for the downstream call to the `log-sink` Kamelet.
@@ -132,14 +137,18 @@ The usage of this Kamelet into a Camel route is going to be the same as any othe
 
 [source,yaml]
 ----
-- from:
-    uri: "timer:yaml"
-    parameters:
-      period: "5000"
+- route:
+    from:
+      uri: timer:yaml
+      parameters:
+        period: "5000"
     steps:
       - setBody:
           simple: "Hello Camel from ${routeId}"
-      - to: "kamelet:nested-sink?log-level=INFO"
+      - to:
+          uri: kamelet:nested-sink
+          parameters:
+            log-level: INFO
 ----
 
 WARNING: beware of any potential circular reference you may introduce when using chain of Kamelets, in which case, the runtime will likely be idle consuming a high amount of resources.

--- a/components/camel-keycloak/src/main/docs/keycloak-component.adoc
+++ b/components/camel-keycloak/src/main/docs/keycloak-component.adoc
@@ -277,13 +277,20 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakRoleName
-            simple: "${body[roleName]}"
+            expression:
+              simple:
+                expression: "${body[roleName]}"
         - setHeader:
             name: CamelKeycloakRoleDescription
-            simple: "${body[description]}"
+            expression:
+              simple:
+                expression: "${body[description]}"
         - to:
-            uri: keycloak:admin?operation=createRole
-        - log: "Created role: ${header.CamelKeycloakRoleName}"
+            uri: keycloak:admin
+            parameters:
+              operation: createRole
+        - log:
+            message: "Created role: ${header.CamelKeycloakRoleName}"
 
 # Get role route
 - route:
@@ -295,10 +302,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakRoleName
-            simple: "${body[roleName]}"
+            expression:
+              simple:
+                expression: "${body[roleName]}"
         - to:
-            uri: keycloak:admin?operation=getRole
-        - log: "Role info: ${body}"
+            uri: keycloak:admin
+            parameters:
+              operation: getRole
+        - log:
+            message: "Role info: ${body}"
 
 # Assign role to user route
 - route:
@@ -310,13 +322,20 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUsername
-            simple: "${body[username]}"
+            expression:
+              simple:
+                expression: "${body[username]}"
         - setHeader:
             name: CamelKeycloakRoleName
-            simple: "${body[roleName]}"
+            expression:
+              simple:
+                expression: "${body[roleName]}"
         - to:
-            uri: keycloak:admin?operation=assignRoleToUser
-        - log: "Assigned role ${header.CamelKeycloakRoleName} to user ${header.CamelKeycloakUsername}"
+            uri: keycloak:admin
+            parameters:
+              operation: assignRoleToUser
+        - log:
+            message: "Assigned role ${header.CamelKeycloakRoleName} to user ${header.CamelKeycloakUsername}"
 
 # Delete role route
 - route:
@@ -328,10 +347,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakRoleName
-            simple: "${body[roleName]}"
+            expression:
+              simple:
+                expression: "${body[roleName]}"
         - to:
-            uri: keycloak:admin?operation=deleteRole
-        - log: "Deleted role: ${header.CamelKeycloakRoleName}"
+            uri: keycloak:admin
+            parameters:
+              operation: deleteRole
+        - log:
+            message: "Deleted role: ${header.CamelKeycloakRoleName}"
 ----
 ====
 
@@ -389,7 +413,9 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakClientId
-            simple: "${body[clientId]}"
+            expression:
+              simple:
+                expression: "${body[clientId]}"
         - setHeader:
             name: CamelKeycloakClientSecretRequired
             constant: true
@@ -397,8 +423,11 @@ YAML::
             name: CamelKeycloakClientDirectAccessGrantsEnabled
             constant: true
         - to:
-            uri: keycloak:admin?operation=createClient
-        - log: "Created client: ${header.CamelKeycloakClientId}"
+            uri: keycloak:admin
+            parameters:
+              operation: createClient
+        - log:
+            message: "Created client: ${header.CamelKeycloakClientId}"
 
 # Get client route
 - route:
@@ -410,10 +439,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakClientId
-            simple: "${body[clientId]}"
+            expression:
+              simple:
+                expression: "${body[clientId]}"
         - to:
-            uri: keycloak:admin?operation=getClient
-        - log: "Client info: ${body}"
+            uri: keycloak:admin
+            parameters:
+              operation: getClient
+        - log:
+            message: "Client info: ${body}"
 
 # Get client secret route
 - route:
@@ -425,10 +459,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakClientId
-            simple: "${body[clientId]}"
+            expression:
+              simple:
+                expression: "${body[clientId]}"
         - to:
-            uri: keycloak:admin?operation=getClientSecret
-        - log: "Client secret retrieved for: ${header.CamelKeycloakClientId}"
+            uri: keycloak:admin
+            parameters:
+              operation: getClientSecret
+        - log:
+            message: "Client secret retrieved for: ${header.CamelKeycloakClientId}"
 
 # Delete client route
 - route:
@@ -440,10 +479,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakClientId
-            simple: "${body[clientId]}"
+            expression:
+              simple:
+                expression: "${body[clientId]}"
         - to:
-            uri: keycloak:admin?operation=deleteClient
-        - log: "Deleted client: ${header.CamelKeycloakClientId}"
+            uri: keycloak:admin
+            parameters:
+              operation: deleteClient
+        - log:
+            message: "Deleted client: ${header.CamelKeycloakClientId}"
 ----
 ====
 
@@ -503,10 +547,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakGroupName
-            simple: "${body[groupName]}"
+            expression:
+              simple:
+                expression: "${body[groupName]}"
         - to:
-            uri: keycloak:admin?operation=createGroup
-        - log: "Created group: ${header.CamelKeycloakGroupName}"
+            uri: keycloak:admin
+            parameters:
+              operation: createGroup
+        - log:
+            message: "Created group: ${header.CamelKeycloakGroupName}"
 
 # List groups route
 - route:
@@ -517,8 +566,11 @@ YAML::
             name: CamelKeycloakRealmName
             constant: "my-realm"
         - to:
-            uri: keycloak:admin?operation=listGroups
-        - log: "Groups: ${body}"
+            uri: keycloak:admin
+            parameters:
+              operation: listGroups
+        - log:
+            message: "Groups: ${body}"
 
 # Add user to group route
 - route:
@@ -530,13 +582,20 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - setHeader:
             name: CamelKeycloakGroupId
-            simple: "${body[groupId]}"
+            expression:
+              simple:
+                expression: "${body[groupId]}"
         - to:
-            uri: keycloak:admin?operation=addUserToGroup
-        - log: "Added user ${header.CamelKeycloakUserId} to group"
+            uri: keycloak:admin
+            parameters:
+              operation: addUserToGroup
+        - log:
+            message: "Added user ${header.CamelKeycloakUserId} to group"
 
 # List user groups route
 - route:
@@ -548,10 +607,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - to:
-            uri: keycloak:admin?operation=listUserGroups
-        - log: "User groups: ${body}"
+            uri: keycloak:admin
+            parameters:
+              operation: listUserGroups
+        - log:
+            message: "User groups: ${body}"
 ----
 ====
 
@@ -596,16 +660,25 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - setHeader:
             name: CamelKeycloakUserPassword
-            simple: "${body[password]}"
+            expression:
+              simple:
+                expression: "${body[password]}"
         - setHeader:
             name: CamelKeycloakPasswordTemporary
-            simple: "${body[temporary]}"
+            expression:
+              simple:
+                expression: "${body[temporary]}"
         - to:
-            uri: keycloak:admin?operation=resetUserPassword
-        - log: "Password reset for user ${header.CamelKeycloakUserId}"
+            uri: keycloak:admin
+            parameters:
+              operation: resetUserPassword
+        - log:
+            message: "Password reset for user ${header.CamelKeycloakUserId}"
 
 # Reset with temporary password
 - route:
@@ -617,16 +690,23 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - setHeader:
             name: CamelKeycloakUserPassword
-            simple: "${body[password]}"
+            expression:
+              simple:
+                expression: "${body[password]}"
         - setHeader:
             name: CamelKeycloakPasswordTemporary
             constant: true
         - to:
-            uri: keycloak:admin?operation=resetUserPassword
-        - log: "Temporary password set for user ${header.CamelKeycloakUserId}"
+            uri: keycloak:admin
+            parameters:
+              operation: resetUserPassword
+        - log:
+            message: "Temporary password set for user ${header.CamelKeycloakUserId}"
 ----
 ====
 
@@ -677,10 +757,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakSearchQuery
-            simple: "${body[query]}"
+            expression:
+              simple:
+                expression: "${body[query]}"
         - to:
-            uri: keycloak:admin?operation=searchUsers
-        - log: "Search results: ${body}"
+            uri: keycloak:admin
+            parameters:
+              operation: searchUsers
+        - log:
+            message: "Search results: ${body}"
 
 # Search with pagination
 - route:
@@ -692,16 +777,25 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakSearchQuery
-            simple: "${body[query]}"
+            expression:
+              simple:
+                expression: "${body[query]}"
         - setHeader:
             name: CamelKeycloakFirstResult
-            simple: "${body[offset]}"
+            expression:
+              simple:
+                expression: "${body[offset]}"
         - setHeader:
             name: CamelKeycloakMaxResults
-            simple: "${body[limit]}"
+            expression:
+              simple:
+                expression: "${body[limit]}"
         - to:
-            uri: keycloak:admin?operation=searchUsers
-        - log: "Found ${body.size} users"
+            uri: keycloak:admin
+            parameters:
+              operation: searchUsers
+        - log:
+            message: "Found ${body.size} users"
 
 # Get user roles route
 - route:
@@ -713,10 +807,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - to:
-            uri: keycloak:admin?operation=getUserRoles
-        - log: "User roles: ${body}"
+            uri: keycloak:admin
+            parameters:
+              operation: getUserRoles
+        - log:
+            message: "User roles: ${body}"
 ----
 ====
 
@@ -777,16 +876,25 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakClientUuid
-            simple: "${body[clientUuid]}"
+            expression:
+              simple:
+                expression: "${body[clientUuid]}"
         - setHeader:
             name: CamelKeycloakRoleName
-            simple: "${body[roleName]}"
+            expression:
+              simple:
+                expression: "${body[roleName]}"
         - setHeader:
             name: CamelKeycloakRoleDescription
-            simple: "${body[description]}"
+            expression:
+              simple:
+                expression: "${body[description]}"
         - to:
-            uri: keycloak:admin?operation=createClientRole
-        - log: "Created client role: ${header.CamelKeycloakRoleName}"
+            uri: keycloak:admin
+            parameters:
+              operation: createClientRole
+        - log:
+            message: "Created client role: ${header.CamelKeycloakRoleName}"
 
 # List client roles route
 - route:
@@ -798,10 +906,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakClientUuid
-            simple: "${body[clientUuid]}"
+            expression:
+              simple:
+                expression: "${body[clientUuid]}"
         - to:
-            uri: keycloak:admin?operation=listClientRoles
-        - log: "Client roles: ${body}"
+            uri: keycloak:admin
+            parameters:
+              operation: listClientRoles
+        - log:
+            message: "Client roles: ${body}"
 
 # Assign client role to user
 - route:
@@ -813,16 +926,25 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - setHeader:
             name: CamelKeycloakClientUuid
-            simple: "${body[clientUuid]}"
+            expression:
+              simple:
+                expression: "${body[clientUuid]}"
         - setHeader:
             name: CamelKeycloakRoleName
-            simple: "${body[roleName]}"
+            expression:
+              simple:
+                expression: "${body[roleName]}"
         - to:
-            uri: keycloak:admin?operation=assignClientRoleToUser
-        - log: "Assigned client role to user"
+            uri: keycloak:admin
+            parameters:
+              operation: assignClientRoleToUser
+        - log:
+            message: "Assigned client role to user"
 ----
 ====
 
@@ -864,10 +986,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - to:
-            uri: keycloak:admin?operation=listUserSessions
-        - log: "User sessions: ${body}"
+            uri: keycloak:admin
+            parameters:
+              operation: listUserSessions
+        - log:
+            message: "User sessions: ${body}"
 
 # Logout user route
 - route:
@@ -879,10 +1006,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - to:
-            uri: keycloak:admin?operation=logoutUser
-        - log: "User logged out: ${header.CamelKeycloakUserId}"
+            uri: keycloak:admin
+            parameters:
+              operation: logoutUser
+        - log:
+            message: "User logged out: ${header.CamelKeycloakUserId}"
 ----
 ====
 
@@ -934,10 +1066,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakClientScopeName
-            simple: "${body[scopeName]}"
+            expression:
+              simple:
+                expression: "${body[scopeName]}"
         - to:
-            uri: keycloak:admin?operation=createClientScope
-        - log: "Created client scope: ${header.CamelKeycloakClientScopeName}"
+            uri: keycloak:admin
+            parameters:
+              operation: createClientScope
+        - log:
+            message: "Created client scope: ${header.CamelKeycloakClientScopeName}"
 
 # List client scopes route
 - route:
@@ -948,8 +1085,11 @@ YAML::
             name: CamelKeycloakRealmName
             constant: "my-realm"
         - to:
-            uri: keycloak:admin?operation=listClientScopes
-        - log: "Client scopes: ${body}"
+            uri: keycloak:admin
+            parameters:
+              operation: listClientScopes
+        - log:
+            message: "Client scopes: ${body}"
 
 # Get client scope route
 - route:
@@ -961,10 +1101,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakClientScopeId
-            simple: "${body[scopeId]}"
+            expression:
+              simple:
+                expression: "${body[scopeId]}"
         - to:
-            uri: keycloak:admin?operation=getClientScope
-        - log: "Client scope: ${body}"
+            uri: keycloak:admin
+            parameters:
+              operation: getClientScope
+        - log:
+            message: "Client scope: ${body}"
 ----
 ====
 
@@ -1143,16 +1288,25 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - setHeader:
             name: CamelKeycloakAttributeName
-            simple: "${body[attributeName]}"
+            expression:
+              simple:
+                expression: "${body[attributeName]}"
         - setHeader:
             name: CamelKeycloakAttributeValue
-            simple: "${body[attributeValue]}"
+            expression:
+              simple:
+                expression: "${body[attributeValue]}"
         - to:
-            uri: keycloak:admin?operation=setUserAttribute
-        - log: "Set attribute ${header.CamelKeycloakAttributeName}"
+            uri: keycloak:admin
+            parameters:
+              operation: setUserAttribute
+        - log:
+            message: "Set attribute ${header.CamelKeycloakAttributeName}"
 
 # Get user attributes
 - route:
@@ -1164,10 +1318,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - to:
-            uri: keycloak:admin?operation=getUserAttributes
-        - log: "User attributes: ${body}"
+            uri: keycloak:admin
+            parameters:
+              operation: getUserAttributes
+        - log:
+            message: "User attributes: ${body}"
 
 # Delete user attribute
 - route:
@@ -1179,13 +1338,20 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - setHeader:
             name: CamelKeycloakAttributeName
-            simple: "${body[attributeName]}"
+            expression:
+              simple:
+                expression: "${body[attributeName]}"
         - to:
-            uri: keycloak:admin?operation=deleteUserAttribute
-        - log: "Deleted attribute ${header.CamelKeycloakAttributeName}"
+            uri: keycloak:admin
+            parameters:
+              operation: deleteUserAttribute
+        - log:
+            message: "Deleted attribute ${header.CamelKeycloakAttributeName}"
 ----
 ====
 
@@ -1262,10 +1428,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - to:
-            uri: keycloak:admin?operation=getUserCredentials
-        - log: "User credentials: ${body}"
+            uri: keycloak:admin
+            parameters:
+              operation: getUserCredentials
+        - log:
+            message: "User credentials: ${body}"
 
 # Send verification email
 - route:
@@ -1277,10 +1448,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - to:
-            uri: keycloak:admin?operation=sendVerifyEmail
-        - log: "Verification email sent to user ${header.CamelKeycloakUserId}"
+            uri: keycloak:admin
+            parameters:
+              operation: sendVerifyEmail
+        - log:
+            message: "Verification email sent to user ${header.CamelKeycloakUserId}"
 
 # Send password reset email
 - route:
@@ -1292,10 +1468,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - to:
-            uri: keycloak:admin?operation=sendPasswordResetEmail
-        - log: "Password reset email sent"
+            uri: keycloak:admin
+            parameters:
+              operation: sendPasswordResetEmail
+        - log:
+            message: "Password reset email sent"
 
 # Add required action
 - route:
@@ -1307,13 +1488,18 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - setHeader:
             name: CamelKeycloakRequiredAction
             constant: "VERIFY_EMAIL"
         - to:
-            uri: keycloak:admin?operation=addRequiredAction
-        - log: "Added required action VERIFY_EMAIL"
+            uri: keycloak:admin
+            parameters:
+              operation: addRequiredAction
+        - log:
+            message: "Added required action VERIFY_EMAIL"
 
 # Execute actions email
 - route:
@@ -1325,7 +1511,9 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - setHeader:
             name: CamelKeycloakActions
             constant:
@@ -1338,8 +1526,11 @@ YAML::
             name: CamelKeycloakLifespan
             constant: 3600
         - to:
-            uri: keycloak:admin?operation=executeActionsEmail
-        - log: "Sent actions email to user"
+            uri: keycloak:admin
+            parameters:
+              operation: executeActionsEmail
+        - log:
+            message: "Sent actions email to user"
 ----
 ====
 
@@ -1390,10 +1581,15 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakClientUuid
-            simple: "${body[clientUuid]}"
+            expression:
+              simple:
+                expression: "${body[clientUuid]}"
         - to:
-            uri: keycloak:admin?operation=getClientSecret
-        - log: "Retrieved client secret"
+            uri: keycloak:admin
+            parameters:
+              operation: getClientSecret
+        - log:
+            message: "Retrieved client secret"
 
 # Regenerate client secret
 - route:
@@ -1405,11 +1601,17 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakClientUuid
-            simple: "${body[clientUuid]}"
+            expression:
+              simple:
+                expression: "${body[clientUuid]}"
         - to:
-            uri: keycloak:admin?operation=regenerateClientSecret
-        - log: "Regenerated client secret: ${body.value}"
-        - to: "direct:notify-secret-rotation"
+            uri: keycloak:admin
+            parameters:
+              operation: regenerateClientSecret
+        - log:
+            message: "Regenerated client secret: ${body.value}"
+        - to:
+            uri: direct:notify-secret-rotation
 ----
 ====
 
@@ -1590,7 +1792,9 @@ YAML::
       steps:
         - setHeader:
             name: CamelKeycloakAccessToken
-            simple: "${header.Authorization.substring(7)}"  # Extract from Bearer token
+            expression:
+              simple:
+                expression: "${header.Authorization.substring(7)}"
         - setHeader:
             name: CamelKeycloakPermissionsOnly
             constant: true
@@ -1602,7 +1806,8 @@ YAML::
               clientId={{keycloak.client-id}}&
               clientSecret={{keycloak.client-secret}}&
               operation=evaluatePermission
-        - log: "User has ${body[permissionCount]} permissions, access granted: ${body[granted]}"
+        - log:
+            message: "User has ${body[permissionCount]} permissions, access granted: ${body[granted]}"
 
 # Check specific resource access
 - route:
@@ -1612,10 +1817,14 @@ YAML::
       steps:
         - setHeader:
             name: CamelKeycloakAccessToken
-            simple: "${header.Authorization.substring(7)}"
+            expression:
+              simple:
+                expression: "${header.Authorization.substring(7)}"
         - setHeader:
             name: CamelKeycloakPermissionResourceNames
-            simple: "${body[resourceName]}"
+            expression:
+              simple:
+                expression: "${body[resourceName]}"
         - setHeader:
             name: CamelKeycloakPermissionScopes
             constant: "read,write"
@@ -1632,13 +1841,18 @@ YAML::
               operation=evaluatePermission
         - choice:
             when:
-              - simple: "${body[granted]} == true"
+              - expression:
+                  simple:
+                    expression: "${body[granted]} == true"
                 steps:
-                  - log: "Access granted for resource ${body[resourceName]}"
-                  - to: "direct:process-resource"
+                  - log:
+                      message: "Access granted for resource ${body[resourceName]}"
+                  - to:
+                      uri: direct:process-resource
             otherwise:
               steps:
-                - log: "Access denied for resource ${body[resourceName]}"
+                - log:
+                    message: "Access denied for resource ${body[resourceName]}"
                 - setHeader:
                     name: CamelHttpResponseCode
                     constant: 403
@@ -1653,7 +1867,9 @@ YAML::
       steps:
         - setHeader:
             name: CamelKeycloakPermissionResourceNames
-            simple: "${body[resources]}"
+            expression:
+              simple:
+                expression: "${body[resources]}"
         - to:
             uri: >
               keycloak:authz?
@@ -1664,7 +1880,8 @@ YAML::
               username={{service.username}}&
               password={{service.password}}&
               operation=evaluatePermission
-        - log: "RPT token obtained, expires in: ${body[expiresIn]} seconds"
+        - log:
+            message: "RPT token obtained, expires in: ${body[expiresIn]} seconds"
 ----
 ====
 
@@ -1827,8 +2044,11 @@ YAML::
             name: CamelKeycloakContinueOnError
             constant: true
         - to:
-            uri: keycloak:admin?operation=bulkCreateUsers
-        - log: "Created ${body[success]} out of ${body[total]} users"
+            uri: keycloak:admin
+            parameters:
+              operation: bulkCreateUsers
+        - log:
+            message: "Created ${body[success]} out of ${body[total]} users"
 ----
 ====
 
@@ -1878,13 +2098,18 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUsernames
-            simple: "${body}"  # List of usernames
+            expression:
+              simple:
+                expression: "${body}"
         - setHeader:
             name: CamelKeycloakContinueOnError
             constant: true
         - to:
-            uri: keycloak:admin?operation=bulkDeleteUsers
-        - log: "Deleted ${body[success]} out of ${body[total]} users"
+            uri: keycloak:admin
+            parameters:
+              operation: bulkDeleteUsers
+        - log:
+            message: "Deleted ${body[success]} out of ${body[total]} users"
 ----
 ====
 
@@ -1933,16 +2158,23 @@ YAML::
             constant: "my-realm"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - setHeader:
             name: CamelKeycloakRoleNames
-            simple: "${body[roles]}"  # List of role names
+            expression:
+              simple:
+                expression: "${body[roles]}"
         - setHeader:
             name: CamelKeycloakContinueOnError
             constant: true
         - to:
-            uri: keycloak:admin?operation=bulkAssignRolesToUser
-        - log: "Assigned ${body[assigned]} roles to user"
+            uri: keycloak:admin
+            parameters:
+              operation: bulkAssignRolesToUser
+        - log:
+            message: "Assigned ${body[assigned]} roles to user"
 ----
 ====
 
@@ -1996,13 +2228,18 @@ YAML::
             constant: "developer"
         - setHeader:
             name: CamelKeycloakUsernames
-            simple: "${body}"  # List of usernames
+            expression:
+              simple:
+                expression: "${body}"
         - setHeader:
             name: CamelKeycloakContinueOnError
             constant: true
         - to:
-            uri: keycloak:admin?operation=bulkAssignRoleToUsers
-        - log: "Assigned role to ${body[success]} out of ${body[total]} users"
+            uri: keycloak:admin
+            parameters:
+              operation: bulkAssignRoleToUsers
+        - log:
+            message: "Assigned role to ${body[success]} out of ${body[total]} users"
 ----
 ====
 
@@ -2064,8 +2301,11 @@ YAML::
             name: CamelKeycloakContinueOnError
             constant: true
         - to:
-            uri: keycloak:admin?operation=bulkUpdateUsers
-        - log: "Updated ${body[success]} out of ${body[total]} users"
+            uri: keycloak:admin
+            parameters:
+              operation: bulkUpdateUsers
+        - log:
+            message: "Updated ${body[success]} out of ${body[total]} users"
 ----
 ====
 
@@ -2238,9 +2478,12 @@ YAML::
 - route:
     id: bulk-user-provisioning
     from:
-      uri: file:data/incoming?noop=true
+      uri: file:data/incoming
+      parameters:
+        noop: "true"
       steps:
-        - log: "Processing user provisioning file: ${header.CamelFileName}"
+        - log:
+            message: "Processing user provisioning file: ${header.CamelFileName}"
         - unmarshal:
             csv: {}
         - process:
@@ -2252,8 +2495,11 @@ YAML::
             name: CamelKeycloakContinueOnError
             constant: true
         - to:
-            uri: keycloak:admin?operation=bulkCreateUsers
-        - log: "Provisioning completed: ${body[success]} succeeded, ${body[failed]} failed"
+            uri: keycloak:admin
+            parameters:
+              operation: bulkCreateUsers
+        - log:
+            message: "Provisioning completed: ${body[success]} succeeded, ${body[failed]} failed"
 
 # Bulk role assignment API
 - rest:
@@ -2270,17 +2516,25 @@ YAML::
             json: {}
         - setHeader:
             name: CamelKeycloakRealmName
-            simple: "${body[realm]}"
+            expression:
+              simple:
+                expression: "${body[realm]}"
         - setHeader:
             name: CamelKeycloakUserId
-            simple: "${body[userId]}"
+            expression:
+              simple:
+                expression: "${body[userId]}"
         - setBody:
-            simple: "${body[roles]}"
+            expression:
+              simple:
+                expression: "${body[roles]}"
         - setHeader:
             name: CamelKeycloakContinueOnError
             constant: true
         - to:
-            uri: keycloak:admin?operation=bulkAssignRolesToUser
+            uri: keycloak:admin
+            parameters:
+              operation: bulkAssignRolesToUser
         - marshal:
             json: {}
 
@@ -2288,25 +2542,35 @@ YAML::
 - route:
     id: cleanup-inactive-users
     from:
-      uri: timer:cleanup?period=86400000
+      uri: timer:cleanup
+      parameters:
+        period: "86400000"
       steps:
-        - log: "Starting inactive user cleanup"
+        - log:
+            message: "Starting inactive user cleanup"
         - setHeader:
             name: CamelKeycloakRealmName
             constant: "my-realm"
         - to:
-            uri: keycloak:admin?operation=listUsers
+            uri: keycloak:admin
+            parameters:
+              operation: listUsers
         - process:
             ref: identifyInactiveUsersProcessor
         - filter:
-            simple: "${body.size} > 0"
+            expression:
+              simple:
+                expression: "${body.size} > 0"
             steps:
               - setHeader:
                   name: CamelKeycloakContinueOnError
                   constant: true
               - to:
-                  uri: keycloak:admin?operation=bulkDeleteUsers
-              - log: "Deleted ${body[success]} inactive users"
+                  uri: keycloak:admin
+                  parameters:
+                    operation: bulkDeleteUsers
+              - log:
+                  message: "Deleted ${body[success]} inactive users"
 ----
 ====
 
@@ -2434,15 +2698,19 @@ YAML::
     from:
       uri: direct:setup-user-environment
       steps:
-        - log: "Setting up user environment..."
+        - log:
+            message: "Setting up user environment..."
 
         # Step 1: Create realm
         - setHeader:
             name: CamelKeycloakRealmName
             constant: "my-company"
         - to:
-            uri: keycloak:admin?operation=createRealm
-        - log: "Created realm: my-company"
+            uri: keycloak:admin
+            parameters:
+              operation: createRealm
+        - log:
+            message: "Created realm: my-company"
 
         # Step 2: Create admin role
         - setHeader:
@@ -2452,8 +2720,11 @@ YAML::
             name: CamelKeycloakRoleDescription
             constant: "Administrator role"
         - to:
-            uri: keycloak:admin?operation=createRole
-        - log: "Created admin role"
+            uri: keycloak:admin
+            parameters:
+              operation: createRole
+        - log:
+            message: "Created admin role"
 
         # Step 3: Create user role
         - setHeader:
@@ -2463,8 +2734,11 @@ YAML::
             name: CamelKeycloakRoleDescription
             constant: "Standard user role"
         - to:
-            uri: keycloak:admin?operation=createRole
-        - log: "Created user role"
+            uri: keycloak:admin
+            parameters:
+              operation: createRole
+        - log:
+            message: "Created user role"
 
         # Step 4: Create client
         - setHeader:
@@ -2477,8 +2751,11 @@ YAML::
             name: CamelKeycloakClientDirectAccessGrantsEnabled
             constant: true
         - to:
-            uri: keycloak:admin?operation=createClient
-        - log: "Created client: my-app"
+            uri: keycloak:admin
+            parameters:
+              operation: createClient
+        - log:
+            message: "Created client: my-app"
 
         # Step 5: Create admin user
         - setHeader:
@@ -2494,8 +2771,11 @@ YAML::
             name: CamelKeycloakUserLastName
             constant: "User"
         - to:
-            uri: keycloak:admin?operation=createUser
-        - log: "Created admin user"
+            uri: keycloak:admin
+            parameters:
+              operation: createUser
+        - log:
+            message: "Created admin user"
 
         # Step 6: Set password
         - setHeader:
@@ -2505,16 +2785,22 @@ YAML::
             name: CamelKeycloakUserPasswordTemporary
             constant: false
         - to:
-            uri: keycloak:admin?operation=setUserPassword
-        - log: "Set admin user password"
+            uri: keycloak:admin
+            parameters:
+              operation: setUserPassword
+        - log:
+            message: "Set admin user password"
 
         # Step 7: Assign role
         - setHeader:
             name: CamelKeycloakRoleName
             constant: "admin"
         - to:
-            uri: keycloak:admin?operation=assignRoleToUser
-        - log: "Assigned admin role to user"
+            uri: keycloak:admin
+            parameters:
+              operation: assignRoleToUser
+        - log:
+            message: "Assigned admin role to user"
 
         - transform:
             constant: "User environment setup completed successfully"
@@ -2541,7 +2827,8 @@ YAML::
     from:
       uri: direct:create-user-api
       steps:
-        - log: "Creating user: ${body}"
+        - log:
+            message: "Creating user: ${body}"
         - setHeader:
             name: CamelKeycloakRealmName
             constant: "my-company"
@@ -2558,7 +2845,9 @@ YAML::
             name: CamelKeycloakUserLastName
             jsonpath: "$.lastName"
         - to:
-            uri: keycloak:admin?operation=createUser
+            uri: keycloak:admin
+            parameters:
+              operation: createUser
         - setHeader:
             name: Content-Type
             constant: "application/json"
@@ -2570,12 +2859,15 @@ YAML::
     from:
       uri: direct:list-users-api
       steps:
-        - log: "Listing users"
+        - log:
+            message: "Listing users"
         - setHeader:
             name: CamelKeycloakRealmName
             constant: "my-company"
         - to:
-            uri: keycloak:admin?operation=listUsers
+            uri: keycloak:admin
+            parameters:
+              operation: listUsers
         - setHeader:
             name: Content-Type
             constant: "application/json"
@@ -2585,7 +2877,8 @@ YAML::
     from:
       uri: direct:delete-user-api
       steps:
-        - log: "Deleting user: ${header.username}"
+        - log:
+            message: "Deleting user: ${header.username}"
         - setHeader:
             name: CamelKeycloakRealmName
             constant: "my-company"
@@ -2593,7 +2886,9 @@ YAML::
             name: CamelKeycloakUsername
             header: "username"
         - to:
-            uri: keycloak:admin?operation=deleteUser
+            uri: keycloak:admin
+            parameters:
+              operation: deleteUser
         - setHeader:
             name: Content-Type
             constant: "application/json"
@@ -2749,22 +3044,34 @@ YAML::
         initialDelay=1000&
         delay=5000
       steps:
-        - log: "Received admin event: ${body}"
+        - log:
+            message: "Received admin event: ${body}"
         - choice:
             when:
-              - simple: "${body.operationType} == 'CREATE'"
+              - expression:
+                  simple:
+                    expression: "${body.operationType} == 'CREATE'"
                 steps:
-                  - log: "Resource created: ${body.resourceType} at ${body.resourcePath}"
-              - simple: "${body.operationType} == 'UPDATE'"
+                  - log:
+                      message: "Resource created: ${body.resourceType} at ${body.resourcePath}"
+              - expression:
+                  simple:
+                    expression: "${body.operationType} == 'UPDATE'"
                 steps:
-                  - log: "Resource updated: ${body.resourceType}"
-              - simple: "${body.operationType} == 'DELETE'"
+                  - log:
+                      message: "Resource updated: ${body.resourceType}"
+              - expression:
+                  simple:
+                    expression: "${body.operationType} == 'DELETE'"
                 steps:
-                  - log: "Resource deleted: ${body.resourceType}"
+                  - log:
+                      message: "Resource deleted: ${body.resourceType}"
             otherwise:
               steps:
-                - log: "Other operation: ${body.operationType}"
-        - to: "direct:process-admin-event"
+                - log:
+                    message: "Other operation: ${body.operationType}"
+        - to:
+            uri: direct:process-admin-event
 
 # Process admin events
 - route:
@@ -2772,8 +3079,12 @@ YAML::
     from:
       uri: direct:process-admin-event
       steps:
-        - log: "Processing admin event: ${body.operationType} on ${body.resourceType}"
-        - to: "bean:auditService?method=recordAdminEvent"
+        - log:
+            message: "Processing admin event: ${body.operationType} on ${body.resourceType}"
+        - to:
+            uri: bean:auditService
+            parameters:
+              method: recordAdminEvent
 ----
 ====
 
@@ -2857,28 +3168,46 @@ YAML::
         initialDelay=1000&
         delay=5000
       steps:
-        - log: "Received user event: ${body}"
+        - log:
+            message: "Received user event: ${body}"
         - choice:
             when:
-              - simple: "${body.type} == 'LOGIN'"
+              - expression:
+                  simple:
+                    expression: "${body.type} == 'LOGIN'"
                 steps:
-                  - log: "User logged in: ${body.userId} from IP ${body.ipAddress}"
-                  - to: "direct:handle-login"
-              - simple: "${body.type} == 'LOGIN_ERROR'"
+                  - log:
+                      message: "User logged in: ${body.userId} from IP ${body.ipAddress}"
+                  - to:
+                      uri: direct:handle-login
+              - expression:
+                  simple:
+                    expression: "${body.type} == 'LOGIN_ERROR'"
                 steps:
-                  - log: "Failed login attempt: ${body.userId}"
-                  - to: "direct:handle-failed-login"
-              - simple: "${body.type} == 'LOGOUT'"
+                  - log:
+                      message: "Failed login attempt: ${body.userId}"
+                  - to:
+                      uri: direct:handle-failed-login
+              - expression:
+                  simple:
+                    expression: "${body.type} == 'LOGOUT'"
                 steps:
-                  - log: "User logged out: ${body.userId}"
-                  - to: "direct:handle-logout"
-              - simple: "${body.type} == 'REGISTER'"
+                  - log:
+                      message: "User logged out: ${body.userId}"
+                  - to:
+                      uri: direct:handle-logout
+              - expression:
+                  simple:
+                    expression: "${body.type} == 'REGISTER'"
                 steps:
-                  - log: "New user registered: ${body.userId}"
-                  - to: "direct:handle-registration"
+                  - log:
+                      message: "New user registered: ${body.userId}"
+                  - to:
+                      uri: direct:handle-registration
             otherwise:
               steps:
-                - log: "Other event: ${body.type}"
+                - log:
+                    message: "Other event: ${body.type}"
 
 # Handle login events
 - route:
@@ -2886,8 +3215,12 @@ YAML::
     from:
       uri: direct:handle-login
       steps:
-        - log: "Processing login event for user ${body.userId}"
-        - to: "bean:analyticsService?method=recordLogin"
+        - log:
+            message: "Processing login event for user ${body.userId}"
+        - to:
+            uri: bean:analyticsService
+            parameters:
+              method: recordLogin
 
 # Handle failed login
 - route:
@@ -2895,8 +3228,12 @@ YAML::
     from:
       uri: direct:handle-failed-login
       steps:
-        - log: "Processing failed login from ${body.ipAddress}"
-        - to: "bean:securityService?method=checkFailedAttempts"
+        - log:
+            message: "Processing failed login from ${body.ipAddress}"
+        - to:
+            uri: bean:securityService
+            parameters:
+              method: checkFailedAttempts
 ----
 ====
 
@@ -2960,7 +3297,8 @@ YAML::
         operationTypes=CREATE,UPDATE,DELETE&
         maxResults=100
       steps:
-        - log: "Filtered admin event: ${body}"
+        - log:
+            message: "Filtered admin event: ${body}"
 
 # Filter user events by type
 - route:
@@ -2972,7 +3310,8 @@ YAML::
         types=LOGIN,LOGOUT,REGISTER&
         maxResults=100
       steps:
-        - log: "Filtered user event: ${body}"
+        - log:
+            message: "Filtered user event: ${body}"
 
 # Filter by date range
 - route:
@@ -2985,7 +3324,8 @@ YAML::
         dateTo=1640995200000&
         maxResults=100
       steps:
-        - log: "Events in date range: ${body}"
+        - log:
+            message: "Events in date range: ${body}"
 
 # Filter by user and client
 - route:
@@ -2999,7 +3339,8 @@ YAML::
         ipAddress=192.168.1.100&
         maxResults=50
       steps:
-        - log: "Specific user events: ${body}"
+        - log:
+            message: "Specific user events: ${body}"
 ----
 ====
 
@@ -3067,8 +3408,14 @@ YAML::
               }
         - marshal:
             json: {}
-        - to: "kafka:audit-trail?brokers=localhost:9092"
-        - to: "jdbc:dataSource?useHeadersAsParameters=true"
+        - to:
+            uri: kafka:audit-trail
+            parameters:
+              brokers: "localhost:9092"
+        - to:
+            uri: jdbc:dataSource
+            parameters:
+              useHeadersAsParameters: true
 ----
 ====
 
@@ -3118,17 +3465,24 @@ YAML::
         delay=5000
       steps:
         - filter:
-            simple: "${body.type} == 'LOGIN_ERROR'"
+            expression:
+              simple:
+                expression: "${body.type} == 'LOGIN_ERROR'"
         - aggregate:
             correlationExpression:
-              simple: "${body.ipAddress}"
+              expression:
+                simple:
+                  expression: "${body.ipAddress}"
             aggregationStrategy: "#arrayListAggregation"
             completionSize: 5
             completionTimeout: 300000
             steps:
-              - log: "SECURITY ALERT: Multiple failed login attempts from ${body[0].ipAddress}"
-              - to: "direct:block-ip"
-              - to: "direct:send-security-alert"
+              - log:
+                  message: "SECURITY ALERT: Multiple failed login attempts from ${body[0].ipAddress}"
+              - to:
+                  uri: direct:block-ip
+              - to:
+                  uri: direct:send-security-alert
 ----
 ====
 
@@ -3193,8 +3547,15 @@ YAML::
                 "ipAddress": "${body.ipAddress}",
                 "sessionId": "${body.sessionId}"
               }
-        - to: "bean:analyticsService?method=recordActivity"
-        - to: "elasticsearch://keycloak-events?operation=Index&indexName=user-activity"
+        - to:
+            uri: bean:analyticsService
+            parameters:
+              method: recordActivity
+        - to:
+            uri: elasticsearch://keycloak-events
+            parameters:
+              operation: Index
+              indexName: user-activity
 ----
 ====
 
@@ -3354,8 +3715,10 @@ camel:
         maxResults=100&
         delay=10000
       steps:
-        - log: "Admin event: ${body.operationType} on ${body.resourceType}"
-        - to: "direct:audit-trail"
+        - log:
+            message: "Admin event: ${body.operationType} on ${body.resourceType}"
+        - to:
+            uri: direct:audit-trail
 
 - route:
     id: user-activity-tracking
@@ -3368,8 +3731,10 @@ camel:
         maxResults=50&
         delay=30000
       steps:
-        - log: "User activity: ${body.type} for user ${body.userId}"
-        - to: "direct:analytics"
+        - log:
+            message: "User activity: ${body.type} for user ${body.userId}"
+        - to:
+            uri: direct:analytics
 
 - route:
     id: security-monitoring
@@ -3382,8 +3747,10 @@ camel:
         maxResults=100&
         delay=5000
       steps:
-        - log: "Failed login from IP: ${body.ipAddress}"
-        - to: "direct:security-check"
+        - log:
+            message: "Failed login from IP: ${body.ipAddress}"
+        - to:
+            uri: direct:security-check
 
 # Processing routes
 - route:
@@ -3393,24 +3760,36 @@ camel:
       steps:
         - marshal:
             json: {}
-        - to: "kafka:admin-audit?brokers=localhost:9092"
-        - to: "log:audit"
+        - to:
+            uri: kafka:admin-audit
+            parameters:
+              brokers: "localhost:9092"
+        - to:
+            uri: log:audit
 
 - route:
     id: process-analytics
     from:
       uri: direct:analytics
       steps:
-        - to: "bean:analyticsService?method=processUserActivity"
-        - to: "log:analytics"
+        - to:
+            uri: bean:analyticsService
+            parameters:
+              method: processUserActivity
+        - to:
+            uri: log:analytics
 
 - route:
     id: process-security-check
     from:
       uri: direct:security-check
       steps:
-        - to: "bean:securityService?method=checkFailedLogin"
-        - to: "log:security"
+        - to:
+            uri: bean:securityService
+            parameters:
+              method: checkFailedLogin
+        - to:
+            uri: log:security
 ----
 ====
 
@@ -3751,7 +4130,9 @@ YAML::
         - policy:
             ref: paymentPolicy
         - to:
-            uri: bean:paymentService?method=processPayment
+            uri: bean:paymentService
+            parameters:
+              method: processPayment
 
 # Regular endpoint with local JWT
 - route:
@@ -3761,7 +4142,9 @@ YAML::
         - policy:
             ref: standardPolicy
         - to:
-            uri: bean:dataService?method=getData
+            uri: bean:dataService
+            parameters:
+              method: getData
 
 # Security policies
 beans:
@@ -3849,7 +4232,9 @@ YAML::
         - policy:
             ref: adminIntrospection
         - to:
-            uri: bean:userService?method=deleteUser
+            uri: bean:userService
+            parameters:
+              method: deleteUser
 
 - route:
     from:
@@ -3858,7 +4243,9 @@ YAML::
         - policy:
             ref: adminIntrospection
         - to:
-            uri: bean:roleService?method=assignRole
+            uri: bean:roleService
+            parameters:
+              method: assignRole
 
 # Read routes with local JWT
 - route:
@@ -3868,7 +4255,9 @@ YAML::
         - policy:
             ref: readPolicy
         - to:
-            uri: bean:userService?method=listUsers
+            uri: bean:userService
+            parameters:
+              method: listUsers
 
 - route:
     from:
@@ -3877,7 +4266,9 @@ YAML::
         - policy:
             ref: readPolicy
         - to:
-            uri: bean:userService?method=getProfile
+            uri: bean:userService
+            parameters:
+              method: getProfile
 
 # Security policies
 beans:
@@ -4502,7 +4893,9 @@ YAML::
         - policy:
             ref: userPolicy
         - to:
-            uri: bean:userService?method=processUser
+            uri: bean:userService
+            parameters:
+              method: processUser
 
 # Bean definition
 beans:
@@ -4693,7 +5086,8 @@ YAML::
           constant: "application/json"
       - transform:
           constant: '{"error": "Access denied", "message": "Insufficient privileges"}'
-      - log: "Authorization failed: ${exception.message}"
+      - log:
+          message: "Authorization failed: ${exception.message}"
 
 # Route-specific error handling
 - route:
@@ -4834,7 +5228,9 @@ YAML::
         - policy:
             ref: adminPolicy
         - to:
-            uri: bean:userService?method=getAllUsers
+            uri: bean:userService
+            parameters:
+              method: getAllUsers
 
 - route:
     from:
@@ -4843,7 +5239,9 @@ YAML::
         - policy:
             ref: userPolicy
         - to:
-            uri: bean:userService?method=getCurrentUser
+            uri: bean:userService
+            parameters:
+              method: getCurrentUser
 
 # Security policy beans
 beans:
@@ -5162,7 +5560,9 @@ YAML::
         - policy:
             ref: strictPolicy
         - to:
-            uri: bean:documentService?method=adminOperations
+            uri: bean:documentService
+            parameters:
+              method: adminOperations
 
 - route:
     from:
@@ -5171,7 +5571,9 @@ YAML::
         - policy:
             ref: flexiblePolicy
         - to:
-            uri: bean:documentService?method=flexibleOperations
+            uri: bean:documentService
+            parameters:
+              method: flexibleOperations
 
 # Bean definitions
 beans:

--- a/components/camel-ocsf/src/main/docs/ocsf-dataformat.adoc
+++ b/components/camel-ocsf/src/main/docs/ocsf-dataformat.adoc
@@ -212,7 +212,7 @@ from("kafka:security-events")
 ----
 - route:
     from:
-      uri: "kafka:security-events"
+      uri: kafka:security-events
     steps:
       - unmarshal:
           ocsf:
@@ -239,11 +239,11 @@ from("kafka:security-events")
             2. Recommended immediate actions
             3. Risk assessment (Critical/High/Medium/Low)
       - to:
-          uri: "langchain4j-chat:security-analyst"
+          uri: langchain4j-chat:security-analyst
           parameters:
             chatModel: "#chatLanguageModel"
       - to:
-          uri: "direct:ai-summary"
+          uri: direct:ai-summary
 ----
 
 == Dependencies

--- a/components/camel-pqc/src/main/docs/pqc-component.adoc
+++ b/components/camel-pqc/src/main/docs/pqc-component.adoc
@@ -1666,16 +1666,21 @@ YAML::
           method: needsRotation('route-signing-key', 90, 10000)
       - choice:
           when:
-            - simple: "${body} == true"
+            - expression:
+                simple:
+                  expression: "${body} == true"
               steps:
-                - log: "Rotating signing key"
+                - log:
+                    message: "Rotating signing key"
                 - bean:
                     ref: keyLifecycleManager
                     method: rotateKey('route-signing-key', 'route-signing-key-new', 'DILITHIUM')
-                - to: log:rotation-complete
+                - to:
+                    uri: log:rotation-complete
           otherwise:
             steps:
-              - log: "Key rotation not needed"
+              - log:
+                  message: "Key rotation not needed"
 ----
 ====
 
@@ -2211,7 +2216,8 @@ from("file:encrypted")
             keyEncapsulationAlgorithm: MLKEM
             symmetricKeyAlgorithm: AES
             symmetricKeyLength: 256
-      - to: file:encrypted
+      - to:
+          uri: file:encrypted
 
 - route:
     id: decrypt-route
@@ -2223,7 +2229,8 @@ from("file:encrypted")
             keyEncapsulationAlgorithm: MLKEM
             symmetricKeyAlgorithm: AES
             symmetricKeyLength: 256
-      - to: direct:decrypted
+      - to:
+          uri: direct:decrypted
 --------------------------------------------------------------------------------
 
 === Configuration Options

--- a/components/camel-smooks/src/main/docs/smooks-component.adoc
+++ b/components/camel-smooks/src/main/docs/smooks-component.adoc
@@ -69,11 +69,16 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: file:inputDir?noop=true
+- route:
+    from:
+      uri: file:inputDir
+      parameters:
+        noop: true
     steps:
-      - to: smooks:smooks-config.xml
-      - to: jms:queue:order
+      - to:
+          uri: smooks:smooks-config.xml
+      - to:
+          uri: jms:queue:order
 ----
 ====
 

--- a/components/camel-smooks/src/main/docs/smooks-dataformat.adoc
+++ b/components/camel-smooks/src/main/docs/smooks-dataformat.adoc
@@ -45,13 +45,15 @@ YAML::
 +
 [source,yaml]
 ----
-- from:
-    uri: direct:unmarshal
+- route:
+    from:
+      uri: direct:unmarshal
     steps:
       - unmarshal:
           smooks:
             smooksConfig: csv-smooks-unmarshal-config.xml
-      - log: "Unmarshalled customers: ${body}"
+      - log:
+          message: "Unmarshalled customers: ${body}"
 ----
 ====
 


### PR DESCRIPTION
## Summary

Follow-up to #23511 (EIP + user manual docs). Normalizes YAML DSL code blocks in 19 component documentation files from classic shorthand form to canonical (normalized) form, consistent with the canonical JSON schema introduced in CAMEL-22987.

**Four shorthand patterns were normalized:**

1. **Shorthand `to:`** — `- to: "direct:foo"` → expanded with nested `uri:` field (67 instances)
2. **Shorthand `log:`** — `- log: "${body}"` → expanded with nested `message:` field (125 instances)
3. **Inline `simple:` expression** — wrapped with canonical `expression:` / `simple:` / `expression:` structure (110 instances)
4. **URI with inline query params** — split into `uri:` + `parameters:` block (73 instances)
5. **Bare `from:` without `route:` wrapper** — wrapped with `- route:` parent (19 instances)

**Files changed (19):**

| Component | Instances | Patterns |
|---|---|---|
| `camel-keycloak` | 254 | all 5 patterns |
| `camel-docling` | 57 | to, log, simple |
| `camel-langchain4j-embeddings` | 12 | to |
| `camel-dhis2` | 12 | bare from, log, simple |
| `camel-openai` | 9 | log, simple |
| `camel-langchain4j-embeddingstore` | 9 | to, log, simple |
| `camel-aws2-s3-vectors` | 7 | bare from, log, to |
| `camel-pgvector` | 6 | to, simple |
| `camel-azure-storage-blob` | 6 | log, to, URI params |
| `camel-kamelet` | 6 | to, log, simple, bare from, URI params |
| `camel-camunda` | 6 | simple, URI params |
| `camel-event` | 6 | log |
| `camel-kafka` | 2 | to |
| `camel-pqc` | 5 | log, simple, to |
| `camel-dfdl` | 4 | bare from, log |
| `camel-ocsf` | 3 | simple |
| `camel-smooks` (component + dataformat) | 4 | bare from, to, URI params, log |
| `camel-ibm-watsonx-ai` | 2 | simple, URI params |

## Test plan

- [ ] Spot-checked representative YAML blocks with `camel validate yaml-dsl` (MCP schema validation)
- [ ] Documentation-only change — no code changes, no test impact

_Claude Code on behalf of Claus Ibsen_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>