### PR TITLE
CAMEL-23551: camel-jbang - Strip spring-boot-starter deps from camel-main export

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang.adoc
@@ -2858,6 +2858,10 @@ You would then also need to add the JAR dependency with Maven coordinates: `org.
 
 ==== Using a Spring Boot JDBC data source
 
+NOTE: The `spring.datasource.` configuration is intended for rapid prototyping with Camel JBang,
+and for users who plan to export to the Spring Boot runtime.
+It is not supported when exporting to the default Camel Main runtime or Camel Quarkus.
+
 In `application.properties` you can set up the datasource such as:
 
 [source,properties]

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
@@ -278,6 +278,8 @@ class ExportCamelMain extends Export {
         answer.removeIf(s -> s.contains("camel-core"));
         answer.removeIf(s -> s.contains("camel-main"));
         answer.removeIf(s -> s.contains("camel-health"));
+        // spring-boot-starter JARs are not usable in camel-main runtime
+        answer.removeIf(s -> s.contains("spring-boot-starter"));
 
         if (profile != null && Files.exists(profile)) {
             Properties prop = new CamelCaseOrderedProperties();


### PR DESCRIPTION
## Summary

- Filter out `spring-boot-starter-*` dependencies in `ExportCamelMain.resolveDependencies()` to prevent log4j circular dependency conflicts (`log4j-slf4j2-impl` vs `log4j-to-slf4j`) when exporting to camel-main runtime.
- Add a NOTE in the JDBC datasource section of `camel-jbang.adoc` clarifying that `spring.datasource.` configuration is intended for Camel JBang prototyping and Spring Boot export only, not for Camel Main or Camel Quarkus.

## Test plan

- [ ] Export a JBang project using `spring.datasource.*` properties to camel-main and verify `spring-boot-starter-jdbc` is no longer in the generated pom.xml
- [ ] Export the same project to Spring Boot and verify `spring-boot-starter-jdbc` is still present

_Claude Code on behalf of Claus Ibsen_