### PR TITLE
CAMEL-23614: Add getFromRouteGroup() to Exchange API

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/Exchange.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Exchange.java
@@ -773,6 +773,13 @@ public interface Exchange extends VariableAware {
     String getFromRouteId();
 
     /**
+     * Returns the route group of the route that originated this message exchange, or <tt>null</tt> if the route has no
+     * group or if this exchange was not created by a route consumer.
+     */
+    @Nullable
+    String getFromRouteGroup();
+
+    /**
      * Returns the unit of work that this exchange belongs to; which may map to zero, one or more physical transactions
      */
     @Nullable

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaFromRouteGroupTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaFromRouteGroupTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.seda;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class SedaFromRouteGroupTest extends ContextTestSupport {
+
+    @Test
+    public void testFromRouteGroup() throws Exception {
+        MockEndpoint foo = getMockEndpoint("mock:foo");
+        foo.expectedMessageCount(1);
+
+        MockEndpoint bar = getMockEndpoint("mock:bar");
+        bar.expectedMessageCount(1);
+
+        template.sendBody("seda:foo", "Hello World");
+
+        assertMockEndpointsSatisfied();
+
+        assertEquals("myGroup", foo.getReceivedExchanges().get(0).getFromRouteGroup());
+        assertNull(bar.getReceivedExchanges().get(0).getFromRouteGroup());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("seda:foo").routeId("foo").routeGroup("myGroup").to("mock:foo").to("seda:bar");
+
+                from("seda:bar").routeId("bar").to("mock:bar");
+            }
+        };
+    }
+}

--- a/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
@@ -33,6 +33,7 @@ import org.apache.camel.ExchangePattern;
 import org.apache.camel.ExchangePropertyKey;
 import org.apache.camel.Message;
 import org.apache.camel.MessageHistory;
+import org.apache.camel.Route;
 import org.apache.camel.SafeCopyProperty;
 import org.apache.camel.spi.UnitOfWork;
 import org.apache.camel.spi.VariableRepository;
@@ -610,6 +611,18 @@ abstract class AbstractExchange implements Exchange {
     @Override
     public String getFromRouteId() {
         return privateExtension.getFromRouteId();
+    }
+
+    @Override
+    public String getFromRouteGroup() {
+        String routeId = getFromRouteId();
+        if (routeId != null) {
+            Route route = getContext().getRoute(routeId);
+            if (route != null) {
+                return route.getGroup();
+            }
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Adds `getFromRouteGroup()` method to the `Exchange` interface, allowing users to retrieve the route group of the originating route
- Implementation in `AbstractExchange` resolves the group via `getFromRouteId()` → `getContext().getRoute(id).getGroup()` with null-safe checks
- Includes unit test `SedaFromRouteGroupTest` verifying group is propagated and null when not set

## Test plan
- [x] `SedaFromRouteGroupTest` passes — verifies `getFromRouteGroup()` returns `"myGroup"` for grouped route and `null` for ungrouped route
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)