### PR TITLE
CAMEL-23616: Add stepId to producer MBeans and dev console

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/spi/StepIdAware.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/StepIdAware.java
@@ -14,22 +14,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.api.management.mbean;
+package org.apache.camel.spi;
 
-import org.apache.camel.api.management.ManagedAttribute;
+import org.jspecify.annotations.Nullable;
 
-public interface ManagedProducerMBean extends ManagedServiceMBean {
+/**
+ * To allow objects to be injected with the step id
+ * <p/>
+ * This allows access to the step id at runtime, to know which step its associated with.
+ *
+ * @since 4.21
+ */
+public interface StepIdAware {
 
-    @ManagedAttribute(description = "Step ID")
+    /**
+     * Gets the step id
+     *
+     * @since 4.21
+     */
+    @Nullable
     String getStepId();
 
-    @ManagedAttribute(description = "Endpoint URI", mask = true)
-    String getEndpointUri();
-
-    @ManagedAttribute(description = "Singleton")
-    boolean isSingleton();
-
-    @ManagedAttribute(description = "Whether this producer connects to remote or local systems")
-    boolean isRemoteEndpoint();
+    /**
+     * Sets the step id
+     *
+     * @param stepId the step id
+     * @since        4.21
+     */
+    void setStepId(String stepId);
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ProducerDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ProducerDevConsole.java
@@ -64,6 +64,9 @@ public class ProducerDevConsole extends AbstractDevConsole {
                         if (mp.getRouteId() != null) {
                             sb.append(String.format("%n    Route Id: %s", mp.getRouteId()));
                         }
+                        if (mp.getStepId() != null) {
+                            sb.append(String.format("%n    Step Id: %s", mp.getStepId()));
+                        }
                     }
                 }
             } catch (Exception e) {
@@ -100,6 +103,9 @@ public class ProducerDevConsole extends AbstractDevConsole {
                         jo.put("singleton", mp.isSingleton());
                         if (mp.getRouteId() != null) {
                             jo.put("routeId", mp.getRouteId());
+                        }
+                        if (mp.getStepId() != null) {
+                            jo.put("stepId", mp.getStepId());
                         }
                         list.add(jo);
                     }

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/AbstractThrottler.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/AbstractThrottler.java
@@ -26,11 +26,13 @@ import org.apache.camel.Expression;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class AbstractThrottler extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, Throttler {
+public abstract class AbstractThrottler extends BaseProcessorSupport
+        implements Traceable, IdAware, RouteIdAware, StepIdAware, Throttler {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractThrottler.class);
 
@@ -43,6 +45,7 @@ public abstract class AbstractThrottler extends BaseProcessorSupport implements 
     protected final Expression correlationExpression;
     protected String id;
     protected String routeId;
+    protected String stepId;
     protected boolean rejectExecution;
     protected boolean asyncDelayed;
     protected boolean callerRunsWhenRejected = true;
@@ -117,6 +120,16 @@ public abstract class AbstractThrottler extends BaseProcessorSupport implements 
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/CatchProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/CatchProcessor.java
@@ -33,6 +33,7 @@ import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.InterceptableProcessor;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.EventHelper;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.util.ObjectHelper;
@@ -43,13 +44,14 @@ import org.slf4j.LoggerFactory;
  * A processor which catches exceptions.
  */
 public class CatchProcessor extends BaseDelegateProcessorSupport
-        implements Traceable, IdAware, RouteIdAware, InterceptableProcessor {
+        implements Traceable, IdAware, RouteIdAware, StepIdAware, InterceptableProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(CatchProcessor.class);
 
     private final CamelContext camelContext;
     private String id;
     private String routeId;
+    private String stepId;
     private final List<Class<? extends Throwable>> exceptions;
     private boolean extendedStatistics;
     // to capture how many different exceptions has been caught
@@ -104,6 +106,16 @@ public class CatchProcessor extends BaseDelegateProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/ChoiceProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/ChoiceProcessor.java
@@ -28,6 +28,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncProcessorConverterHelper;
 import org.apache.camel.support.MessageHelper;
 import org.apache.camel.support.service.ServiceHelper;
@@ -40,12 +41,14 @@ import static org.apache.camel.processor.PipelineHelper.continueProcessing;
  * Implements a Choice structure where one or more predicates are used which if they are true their processors are used,
  * with a default otherwise clause used if none match.
  */
-public class ChoiceProcessor extends BaseProcessorSupport implements Navigate<Processor>, Traceable, IdAware, RouteIdAware {
+public class ChoiceProcessor extends BaseProcessorSupport
+        implements Navigate<Processor>, Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(ChoiceProcessor.class);
 
     private String id;
     private String routeId;
+    private String stepId;
     // optimize to use an array
     private final FilterProcessor[] filters;
     private final int len;
@@ -175,6 +178,16 @@ public class ChoiceProcessor extends BaseProcessorSupport implements Navigate<Pr
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/ClaimCheckProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/ClaimCheckProcessor.java
@@ -26,6 +26,7 @@ import org.apache.camel.Expression;
 import org.apache.camel.spi.ClaimCheckRepository;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.LanguageSupport;
 import org.apache.camel.support.service.ServiceHelper;
@@ -41,13 +42,14 @@ import org.slf4j.LoggerFactory;
  * against concurrent and thread-safe issues. For off-memory persistent storage of data, then use any of the many Camel
  * components that support persistent storage, and do not use this Claim Check EIP implementation.
  */
-public class ClaimCheckProcessor extends BaseProcessorSupport implements IdAware, RouteIdAware, CamelContextAware {
+public class ClaimCheckProcessor extends BaseProcessorSupport implements IdAware, RouteIdAware, StepIdAware, CamelContextAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClaimCheckProcessor.class);
 
     private CamelContext camelContext;
     private String id;
     private String routeId;
+    private String stepId;
     private String operation;
     private AggregationStrategy aggregationStrategy;
     private String key;
@@ -82,6 +84,16 @@ public class ClaimCheckProcessor extends BaseProcessorSupport implements IdAware
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public String getOperation() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/Delayer.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/Delayer.java
@@ -25,6 +25,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 
 /**
  * A <a href="http://camel.apache.org/delayer.html">Delayer</a> which delays processing the exchange until the correct
@@ -32,9 +33,10 @@ import org.apache.camel.spi.RouteIdAware;
  * <p/>
  * This implementation will block while waiting.
  */
-public class Delayer extends DelayProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class Delayer extends DelayProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private String routeId;
+    private String stepId;
     private String id;
     private Expression delay;
     private long delayValue;
@@ -68,6 +70,16 @@ public class Delayer extends DelayProcessorSupport implements Traceable, IdAware
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/DisabledProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/DisabledProcessor.java
@@ -20,14 +20,16 @@ import org.apache.camel.AsyncCallback;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 
 /**
  * A disabled EIP that does not do anything
  */
-public class DisabledProcessor extends BaseProcessorSupport implements IdAware, RouteIdAware {
+public class DisabledProcessor extends BaseProcessorSupport implements IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private String nodeType;
 
     @Override
@@ -60,6 +62,16 @@ public class DisabledProcessor extends BaseProcessorSupport implements IdAware, 
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     /**

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/Enricher.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/Enricher.java
@@ -32,6 +32,7 @@ import org.apache.camel.spi.HeadersMapFactory;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.ProcessorExchangeFactory;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.MessageHelper;
@@ -49,11 +50,12 @@ import static org.apache.camel.support.ExchangeHelper.copyResultsPreservePattern
  *
  * @see PollEnricher
  */
-public class Enricher extends BaseProcessorSupport implements IdAware, RouteIdAware, CamelContextAware {
+public class Enricher extends BaseProcessorSupport implements IdAware, RouteIdAware, StepIdAware, CamelContextAware {
 
     private CamelContext camelContext;
     private String id;
     private String routeId;
+    private String stepId;
     private final Expression expression;
     private final String uri;
     private String variableSend;
@@ -102,6 +104,16 @@ public class Enricher extends BaseProcessorSupport implements IdAware, RouteIdAw
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public Expression getExpression() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/ExchangePatternProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/ExchangePatternProcessor.java
@@ -21,14 +21,16 @@ import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 
 /**
  * Processor to set {@link org.apache.camel.ExchangePattern} on the {@link org.apache.camel.Exchange}.
  */
-public class ExchangePatternProcessor extends BaseProcessorSupport implements IdAware, RouteIdAware {
+public class ExchangePatternProcessor extends BaseProcessorSupport implements IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private ExchangePattern exchangePattern = ExchangePattern.InOnly;
 
     public ExchangePatternProcessor() {
@@ -60,6 +62,16 @@ public class ExchangePatternProcessor extends BaseProcessorSupport implements Id
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public ExchangePattern getExchangePattern() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/FilterProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/FilterProcessor.java
@@ -24,6 +24,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.service.ServiceHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,13 +33,14 @@ import org.slf4j.LoggerFactory;
  * The processor which implements the <a href="http://camel.apache.org/message-filter.html">Message Filter</a> EIP
  * pattern.
  */
-public class FilterProcessor extends BaseDelegateProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class FilterProcessor extends BaseDelegateProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(FilterProcessor.class);
 
     private final CamelContext context;
     private String id;
     private String routeId;
+    private String stepId;
     private final Predicate predicate;
     private transient long filtered;
     private String statusPropertyName;
@@ -119,6 +121,16 @@ public class FilterProcessor extends BaseDelegateProcessorSupport implements Tra
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/FinallyProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/FinallyProcessor.java
@@ -24,6 +24,7 @@ import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.InterceptableProcessor;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.ExchangeHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,12 +33,13 @@ import org.slf4j.LoggerFactory;
  * Processor to handle do finally supporting asynchronous routing engine
  */
 public class FinallyProcessor extends BaseDelegateProcessorSupport
-        implements Traceable, IdAware, RouteIdAware, InterceptableProcessor {
+        implements Traceable, IdAware, RouteIdAware, StepIdAware, InterceptableProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(FinallyProcessor.class);
 
     private String id;
     private String routeId;
+    private String stepId;
 
     public FinallyProcessor(Processor processor) {
         super(processor);
@@ -95,6 +97,16 @@ public class FinallyProcessor extends BaseDelegateProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/LogProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/LogProcessor.java
@@ -27,18 +27,20 @@ import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.LogListener;
 import org.apache.camel.spi.MaskingFormatter;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * A processor which evaluates an {@link Expression} and logs it.
  */
-public class LogProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class LogProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(LogProcessor.class);
 
     private String id;
     private String routeId;
+    private String stepId;
     private final Expression expression;
     private final String message;
     private final CamelLogger logger;
@@ -157,6 +159,16 @@ public class LogProcessor extends BaseProcessorSupport implements Traceable, IdA
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public String getMessage() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/LoopProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/LoopProcessor.java
@@ -32,6 +32,7 @@ import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.ReactiveExecutor;
 import org.apache.camel.spi.RouteIdAware;
 import org.apache.camel.spi.ShutdownAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.ExchangeHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,12 +42,14 @@ import static org.apache.camel.processor.PipelineHelper.continueProcessing;
 /**
  * The processor which sends messages in a loop.
  */
-public class LoopProcessor extends BaseDelegateProcessorSupport implements Traceable, IdAware, RouteIdAware, ShutdownAware {
+public class LoopProcessor extends BaseDelegateProcessorSupport
+        implements Traceable, IdAware, RouteIdAware, StepIdAware, ShutdownAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(LoopProcessor.class);
 
     private String id;
     private String routeId;
+    private String stepId;
     private boolean shutdownPending;
     private final ReactiveExecutor reactiveExecutor;
     private final Expression expression;
@@ -261,6 +264,16 @@ public class LoopProcessor extends BaseDelegateProcessorSupport implements Trace
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
@@ -60,6 +60,7 @@ import org.apache.camel.spi.InternalProcessorFactory;
 import org.apache.camel.spi.ProcessorExchangeFactory;
 import org.apache.camel.spi.ReactiveExecutor;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.spi.UnitOfWork;
 import org.apache.camel.support.AsyncProcessorConverterHelper;
 import org.apache.camel.support.AsyncProcessorSupport;
@@ -87,7 +88,7 @@ import static org.apache.camel.util.ObjectHelper.notNull;
  * of the message exchange.
  */
 public class MulticastProcessor extends BaseProcessorSupport
-        implements Navigate<Processor>, Traceable, IdAware, RouteIdAware, ErrorHandlerAware {
+        implements Navigate<Processor>, Traceable, IdAware, RouteIdAware, StepIdAware, ErrorHandlerAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(MulticastProcessor.class);
 
@@ -170,6 +171,7 @@ public class MulticastProcessor extends BaseProcessorSupport
     private Processor errorHandler;
     private String id;
     private String routeId;
+    private String stepId;
     private final Collection<Processor> processors;
     private final AggregationStrategy aggregationStrategy;
     private final boolean parallelProcessing;
@@ -257,6 +259,16 @@ public class MulticastProcessor extends BaseProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/OnCompletionProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/OnCompletionProcessor.java
@@ -33,6 +33,7 @@ import org.apache.camel.Route;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.spi.SynchronizationRouteAware;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.SynchronizationAdapter;
@@ -46,13 +47,14 @@ import static org.apache.camel.util.ObjectHelper.notNull;
 /**
  * Processor implementing <a href="http://camel.apache.org/oncompletion.html">onCompletion</a>.
  */
-public class OnCompletionProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class OnCompletionProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(OnCompletionProcessor.class);
 
     private final CamelContext camelContext;
     private String id;
     private String routeId;
+    private String stepId;
     private final Processor processor;
     private final ExecutorService executorService;
     private final boolean shutdownExecutorService;
@@ -131,6 +133,16 @@ public class OnCompletionProcessor extends BaseProcessorSupport implements Trace
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/PausableProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/PausableProcessor.java
@@ -29,15 +29,17 @@ import org.apache.camel.Navigate;
 import org.apache.camel.Processor;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncProcessorConverterHelper;
 
 public class PausableProcessor extends BaseProcessorSupport
-        implements Navigate<Processor>, CamelContextAware, IdAware, RouteIdAware {
+        implements Navigate<Processor>, CamelContextAware, IdAware, RouteIdAware, StepIdAware {
 
     private final AsyncProcessor processor;
     private CamelContext camelContext;
     private String id;
     private String routeId;
+    private String stepId;
 
     public PausableProcessor(Processor processor) {
         this.processor = AsyncProcessorConverterHelper.convert(processor);
@@ -91,5 +93,15 @@ public class PausableProcessor extends BaseProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 }

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/Pipeline.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/Pipeline.java
@@ -30,6 +30,7 @@ import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.ReactiveExecutor;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncProcessorConverterHelper;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.service.ServiceHelper;
@@ -42,7 +43,8 @@ import static org.apache.camel.processor.PipelineHelper.continueProcessing;
  * Creates a Pipeline pattern where the output of the previous step is sent as input to the next step, reusing the same
  * message exchanges
  */
-public class Pipeline extends BaseProcessorSupport implements Navigate<Processor>, Traceable, IdAware, RouteIdAware {
+public class Pipeline extends BaseProcessorSupport
+        implements Navigate<Processor>, Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(Pipeline.class);
 
@@ -54,6 +56,7 @@ public class Pipeline extends BaseProcessorSupport implements Navigate<Processor
 
     private String id;
     private String routeId;
+    private String stepId;
 
     private final class PipelineTask implements PooledExchangeTask, AsyncCallback {
 
@@ -242,6 +245,16 @@ public class Pipeline extends BaseProcessorSupport implements Navigate<Processor
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/PollEnricher.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/PollEnricher.java
@@ -42,6 +42,7 @@ import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.OptimisedComponentResolver;
 import org.apache.camel.spi.PollDynamicAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.BridgeExceptionHandlerToErrorHandler;
 import org.apache.camel.support.DefaultConsumer;
 import org.apache.camel.support.EndpointHelper;
@@ -66,7 +67,7 @@ import static org.apache.camel.support.ExchangeHelper.copyResultsPreservePattern
  * @see PollProcessor
  * @see Enricher
  */
-public class PollEnricher extends BaseProcessorSupport implements IdAware, RouteIdAware, CamelContextAware {
+public class PollEnricher extends BaseProcessorSupport implements IdAware, RouteIdAware, StepIdAware, CamelContextAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(PollEnricher.class);
 
@@ -77,6 +78,7 @@ public class PollEnricher extends BaseProcessorSupport implements IdAware, Route
     private HeadersMapFactory headersMapFactory;
     private String id;
     private String routeId;
+    private String stepId;
     private String variableReceive;
     private AggregationStrategy aggregationStrategy;
     private final Expression expression;
@@ -141,6 +143,16 @@ public class PollEnricher extends BaseProcessorSupport implements IdAware, Route
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public PollDynamicAware getDynamicAware() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/RecipientList.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/RecipientList.java
@@ -32,6 +32,7 @@ import org.apache.camel.spi.ErrorHandlerAware;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.ProducerCache;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.cache.DefaultProducerCache;
 import org.apache.camel.support.cache.EmptyProducerCache;
 import org.apache.camel.support.service.ServiceHelper;
@@ -46,13 +47,14 @@ import static org.apache.camel.util.ObjectHelper.notNull;
  * Implements a dynamic <a href="http://camel.apache.org/recipient-list.html">Recipient List</a> pattern where the list
  * of actual endpoints to send a message exchange to are dependent on some dynamic expression.
  */
-public class RecipientList extends BaseProcessorSupport implements IdAware, RouteIdAware, ErrorHandlerAware {
+public class RecipientList extends BaseProcessorSupport implements IdAware, RouteIdAware, StepIdAware, ErrorHandlerAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(RecipientList.class);
 
     private final CamelContext camelContext;
     private String id;
     private String routeId;
+    private String stepId;
     private Processor errorHandler;
     private ProducerCache producerCache;
     private final Expression expression;
@@ -156,6 +158,16 @@ public class RecipientList extends BaseProcessorSupport implements IdAware, Rout
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/RemoveHeaderProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/RemoveHeaderProcessor.java
@@ -21,14 +21,16 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 
 /**
  * A processor which removes the header from the IN or OUT message
  */
-public class RemoveHeaderProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class RemoveHeaderProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
     private final String headerName;
     private String id;
     private String routeId;
+    private String stepId;
 
     public RemoveHeaderProcessor(String headerName) {
         this.headerName = headerName;
@@ -74,6 +76,16 @@ public class RemoveHeaderProcessor extends BaseProcessorSupport implements Trace
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public String getHeaderName() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/RemoveHeadersProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/RemoveHeadersProcessor.java
@@ -21,13 +21,15 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 
 /**
  * A processor which removes one ore more headers from the IN or OUT message
  */
-public class RemoveHeadersProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class RemoveHeadersProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
     private String id;
     private String routeId;
+    private String stepId;
     private final String pattern;
     private final String[] excludePattern;
 
@@ -76,6 +78,16 @@ public class RemoveHeadersProcessor extends BaseProcessorSupport implements Trac
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public String getPattern() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/RemovePropertiesProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/RemovePropertiesProcessor.java
@@ -21,13 +21,15 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 
 /**
  * A processor which removes one ore more properties from the exchange
  */
-public class RemovePropertiesProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class RemovePropertiesProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
     private String id;
     private String routeId;
+    private String stepId;
     private final String pattern;
     private final String[] excludePattern;
 
@@ -76,6 +78,16 @@ public class RemovePropertiesProcessor extends BaseProcessorSupport implements T
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public String getPattern() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/RemovePropertyProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/RemovePropertyProcessor.java
@@ -21,13 +21,15 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 
 /**
  * A processor which removes the property from the exchange
  */
-public class RemovePropertyProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class RemovePropertyProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
     private String id;
     private String routeId;
+    private String stepId;
     private final String propertyName;
 
     public RemovePropertyProcessor(String propertyName) {
@@ -74,6 +76,16 @@ public class RemovePropertyProcessor extends BaseProcessorSupport implements Tra
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public String getPropertyName() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/RemoveVariableProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/RemoveVariableProcessor.java
@@ -24,6 +24,7 @@ import org.apache.camel.Expression;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.spi.VariableRepository;
 import org.apache.camel.spi.VariableRepositoryFactory;
 import org.apache.camel.util.StringHelper;
@@ -32,10 +33,11 @@ import org.apache.camel.util.StringHelper;
  * A processor which removes the variable
  */
 public class RemoveVariableProcessor extends BaseProcessorSupport
-        implements Traceable, IdAware, RouteIdAware, CamelContextAware {
+        implements Traceable, IdAware, RouteIdAware, StepIdAware, CamelContextAware {
     private CamelContext camelContext;
     private String id;
     private String routeId;
+    private String stepId;
     private final Expression variableName;
     private VariableRepositoryFactory factory;
 
@@ -112,6 +114,16 @@ public class RemoveVariableProcessor extends BaseProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public String getVariableName() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/Resequencer.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/Resequencer.java
@@ -46,6 +46,7 @@ import org.apache.camel.Traceable;
 import org.apache.camel.spi.ExceptionHandler;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncProcessorConverterHelper;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.ExpressionComparator;
@@ -59,7 +60,8 @@ import org.slf4j.LoggerFactory;
  * An implementation of the <a href="http://camel.apache.org/resequencer.html">Resequencer</a> which can reorder
  * messages within a batch.
  */
-public class Resequencer extends BaseProcessorSupport implements Navigate<Processor>, IdAware, RouteIdAware, Traceable {
+public class Resequencer extends BaseProcessorSupport
+        implements Navigate<Processor>, IdAware, RouteIdAware, StepIdAware, Traceable {
 
     public static final long DEFAULT_BATCH_TIMEOUT = 1000L;
     public static final int DEFAULT_BATCH_SIZE = 100;
@@ -68,6 +70,7 @@ public class Resequencer extends BaseProcessorSupport implements Navigate<Proces
 
     private String id;
     private String routeId;
+    private String stepId;
     private long batchTimeout = DEFAULT_BATCH_TIMEOUT;
     private int batchSize = DEFAULT_BATCH_SIZE;
     private int outBatchSize;
@@ -262,6 +265,16 @@ public class Resequencer extends BaseProcessorSupport implements Navigate<Proces
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     // Implementation methods

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/RollbackProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/RollbackProcessor.java
@@ -22,14 +22,16 @@ import org.apache.camel.RollbackExchangeException;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 
 /**
  * Processor for marking an {@link org.apache.camel.Exchange} to rollback.
  */
-public class RollbackProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class RollbackProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private boolean markRollbackOnly;
     private boolean markRollbackOnlyLast;
     private String message;
@@ -97,6 +99,16 @@ public class RollbackProcessor extends BaseProcessorSupport implements Traceable
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public String getMessage() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/RoutingSlip.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/RoutingSlip.java
@@ -33,6 +33,7 @@ import org.apache.camel.spi.EndpointUtilizationStatistics;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.ProducerCache;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncProcessorSupport;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.MessageHelper;
@@ -55,12 +56,13 @@ import static org.apache.camel.util.ObjectHelper.notNull;
  * the failover load balancer is a specialized pipeline. So the trick is to keep doing the same as the pipeline to
  * ensure it works the same and the async routing engine is flawless.
  */
-public class RoutingSlip extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class RoutingSlip extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(RoutingSlip.class);
 
     protected String id;
     protected String routeId;
+    protected String stepId;
     protected ProducerCache producerCache;
     protected int cacheSize;
     protected boolean ignoreInvalidEndpoints;
@@ -126,6 +128,16 @@ public class RoutingSlip extends BaseProcessorSupport implements Traceable, IdAw
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public Expression getExpression() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/SamplingThrottler.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/SamplingThrottler.java
@@ -27,6 +27,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,12 +40,13 @@ import org.slf4j.LoggerFactory;
  * This kind of throttling can be useful for taking a sample from an exchange stream, rough consolidation of noisy and
  * bursty exchange traffic or where queuing of throttled exchanges is undesirable.
  */
-public class SamplingThrottler extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class SamplingThrottler extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(SamplingThrottler.class);
 
     private String id;
     private String routeId;
+    private String stepId;
     private long messageFrequency;
     private long currentMessageCount;
     private long samplePeriod;
@@ -97,6 +99,16 @@ public class SamplingThrottler extends BaseProcessorSupport implements Traceable
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/ScriptProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/ScriptProcessor.java
@@ -22,15 +22,17 @@ import org.apache.camel.Expression;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.util.ObjectHelper;
 
 /**
  * A processor which executes the script as an expression and does not change the message body.
  */
-public class ScriptProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class ScriptProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private final Expression expression;
 
     public ScriptProcessor(Expression expression) {
@@ -78,6 +80,16 @@ public class ScriptProcessor extends BaseProcessorSupport implements Traceable, 
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public Expression getExpression() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/SendDynamicProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/SendDynamicProcessor.java
@@ -38,6 +38,7 @@ import org.apache.camel.spi.OptimisedComponentResolver;
 import org.apache.camel.spi.ProducerCache;
 import org.apache.camel.spi.RouteIdAware;
 import org.apache.camel.spi.SendDynamicAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.EndpointHelper;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.cache.DefaultProducerCache;
@@ -52,7 +53,8 @@ import org.slf4j.LoggerFactory;
  *
  * @see org.apache.camel.processor.SendProcessor
  */
-public class SendDynamicProcessor extends BaseProcessorSupport implements IdAware, RouteIdAware, CamelContextAware {
+public class SendDynamicProcessor extends BaseProcessorSupport
+        implements IdAware, RouteIdAware, StepIdAware, CamelContextAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(SendDynamicProcessor.class);
 
@@ -68,6 +70,7 @@ public class SendDynamicProcessor extends BaseProcessorSupport implements IdAwar
     protected HeadersMapFactory headersMapFactory;
     protected String id;
     protected String routeId;
+    protected String stepId;
     protected boolean ignoreInvalidEndpoint;
     protected int cacheSize;
     protected boolean allowOptimisedComponents = true;
@@ -101,6 +104,16 @@ public class SendDynamicProcessor extends BaseProcessorSupport implements IdAwar
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/SendProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/SendProcessor.java
@@ -33,6 +33,7 @@ import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.InternalProcessorFactory;
 import org.apache.camel.spi.ProducerCache;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.EndpointHelper;
 import org.apache.camel.support.EventHelper;
 import org.apache.camel.support.ExchangeHelper;
@@ -50,7 +51,8 @@ import org.slf4j.LoggerFactory;
  *
  * @see SendDynamicProcessor
  */
-public class SendProcessor extends BaseProcessorSupport implements Traceable, EndpointAware, IdAware, RouteIdAware {
+public class SendProcessor extends BaseProcessorSupport
+        implements Traceable, EndpointAware, IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(SendProcessor.class);
 
@@ -66,6 +68,7 @@ public class SendProcessor extends BaseProcessorSupport implements Traceable, En
     protected ExchangePattern destinationExchangePattern;
     protected String id;
     protected String routeId;
+    protected String stepId;
     protected boolean extendedStatistics;
     protected final AtomicLong counter = new AtomicLong();
 
@@ -105,6 +108,16 @@ public class SendProcessor extends BaseProcessorSupport implements Traceable, En
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override
@@ -328,6 +341,9 @@ public class SendProcessor extends BaseProcessorSupport implements Traceable, En
             this.producer = pf.createAsyncProducer(destination);
             if (this.producer instanceof RouteIdAware ria) {
                 ria.setRouteId(getRouteId());
+            }
+            if (this.producer instanceof StepIdAware sia) {
+                sia.setStepId(getStepId());
             }
             // ensure the producer is managed and started
             camelContext.addService(this.producer, true, true);

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetBodyProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetBodyProcessor.java
@@ -23,16 +23,18 @@ import org.apache.camel.Message;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.DefaultMessage;
 import org.apache.camel.support.ExchangeHelper;
 
 /**
  * A processor which sets the body on the IN or OUT message with an {@link Expression}
  */
-public class SetBodyProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class SetBodyProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private final Expression expression;
 
     public SetBodyProcessor(Expression expression) {
@@ -103,6 +105,16 @@ public class SetBodyProcessor extends BaseProcessorSupport implements Traceable,
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public Expression getExpression() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetHeaderProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetHeaderProcessor.java
@@ -23,15 +23,17 @@ import org.apache.camel.Message;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.util.ObjectHelper;
 
 /**
  * A processor which sets the header on the IN or OUT message with an {@link org.apache.camel.Expression}
  */
-public class SetHeaderProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class SetHeaderProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private final Expression headerName;
     private final Expression expression;
 
@@ -94,6 +96,16 @@ public class SetHeaderProcessor extends BaseProcessorSupport implements Traceabl
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public String getHeaderName() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetHeadersProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetHeadersProcessor.java
@@ -25,14 +25,16 @@ import org.apache.camel.Message;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 
 /**
  * A processor which sets multiple headers on the IN or OUT message with an {@link org.apache.camel.Expression}
  */
-public class SetHeadersProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class SetHeadersProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private final List<Expression> headerNames;
     private final List<Expression> expressions;
 
@@ -106,6 +108,16 @@ public class SetHeadersProcessor extends BaseProcessorSupport implements Traceab
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public List<Expression> getHeaderNames() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetPropertyProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetPropertyProcessor.java
@@ -22,15 +22,17 @@ import org.apache.camel.Expression;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.util.ObjectHelper;
 
 /**
  * A processor which sets the property on the exchange with an {@link org.apache.camel.Expression}
  */
-public class SetPropertyProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class SetPropertyProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private final Expression propertyName;
     private final Expression expression;
 
@@ -90,6 +92,16 @@ public class SetPropertyProcessor extends BaseProcessorSupport implements Tracea
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public String getPropertyName() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetVariableProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetVariableProcessor.java
@@ -22,16 +22,18 @@ import org.apache.camel.Expression;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.util.ObjectHelper;
 
 /**
  * A processor which sets the variable with an {@link Expression}
  */
-public class SetVariableProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class SetVariableProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private final Expression variableName;
     private final Expression expression;
 
@@ -91,6 +93,16 @@ public class SetVariableProcessor extends BaseProcessorSupport implements Tracea
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public String getVariableName() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetVariablesProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/SetVariablesProcessor.java
@@ -24,15 +24,17 @@ import org.apache.camel.Expression;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.ExchangeHelper;
 
 /**
  * A processor which sets multiple variables on the Exchange with an {@link Expression}
  */
-public class SetVariablesProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class SetVariablesProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private final List<Expression> variableNames;
     private final List<Expression> expressions;
 
@@ -105,6 +107,16 @@ public class SetVariablesProcessor extends BaseProcessorSupport implements Trace
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public List<Expression> getVariableNames() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/SortProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/SortProcessor.java
@@ -25,14 +25,16 @@ import org.apache.camel.Expression;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 
 /**
  * A processor that sorts the expression using a comparator
  */
-public class SortProcessor<T> extends BaseProcessorSupport implements IdAware, RouteIdAware, Traceable {
+public class SortProcessor<T> extends BaseProcessorSupport implements IdAware, RouteIdAware, StepIdAware, Traceable {
 
     private String id;
     private String routeId;
+    private String stepId;
     private final Expression expression;
     private final Comparator<? super T> comparator;
 
@@ -85,6 +87,16 @@ public class SortProcessor<T> extends BaseProcessorSupport implements IdAware, R
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public Expression getExpression() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/StopProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/StopProcessor.java
@@ -20,14 +20,16 @@ import org.apache.camel.AsyncCallback;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 
 /**
  * Stops continue processing the route and marks it as complete.
  */
-public class StopProcessor extends BaseProcessorSupport implements IdAware, RouteIdAware {
+public class StopProcessor extends BaseProcessorSupport implements IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
 
     @Override
     public boolean process(Exchange exchange, AsyncCallback callback) {
@@ -61,6 +63,16 @@ public class StopProcessor extends BaseProcessorSupport implements IdAware, Rout
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
 }

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/StreamCachingProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/StreamCachingProcessor.java
@@ -22,14 +22,16 @@ import org.apache.camel.StreamCache;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 
 /**
  * A processor which converts current message body to a stream cache.
  */
-public class StreamCachingProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class StreamCachingProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
 
     @Override
     public boolean process(Exchange exchange, AsyncCallback callback) {
@@ -74,5 +76,15 @@ public class StreamCachingProcessor extends BaseProcessorSupport implements Trac
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 }

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/StreamResequencer.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/StreamResequencer.java
@@ -37,6 +37,7 @@ import org.apache.camel.processor.resequencer.SequenceSender;
 import org.apache.camel.spi.ExceptionHandler;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.LoggingExceptionHandler;
 import org.apache.camel.support.service.ServiceHelper;
@@ -61,12 +62,13 @@ import org.slf4j.LoggerFactory;
  * @see ResequencerEngine
  */
 public class StreamResequencer extends BaseProcessorSupport
-        implements SequenceSender<Exchange>, Navigate<Processor>, Traceable, IdAware, RouteIdAware {
+        implements SequenceSender<Exchange>, Navigate<Processor>, Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamResequencer.class);
 
     private String id;
     private String routeId;
+    private String stepId;
     private final CamelContext camelContext;
     private final ExceptionHandler exceptionHandler;
     private final ResequencerEngine<Exchange> engine;
@@ -198,6 +200,16 @@ public class StreamResequencer extends BaseProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/ThreadsProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/ThreadsProcessor.java
@@ -26,6 +26,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.concurrent.Rejectable;
 import org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy;
@@ -49,12 +50,13 @@ import org.slf4j.LoggerFactory;
  * be free to process a new exchange, as its processing the current exchange.</li>
  * </ul>
  */
-public class ThreadsProcessor extends BaseProcessorSupport implements IdAware, RouteIdAware {
+public class ThreadsProcessor extends BaseProcessorSupport implements IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(ThreadsProcessor.class);
 
     private String id;
     private String routeId;
+    private String stepId;
     private final CamelContext camelContext;
     private final ExecutorService executorService;
     private final ThreadPoolRejectedPolicy rejectedPolicy;
@@ -176,6 +178,16 @@ public class ThreadsProcessor extends BaseProcessorSupport implements IdAware, R
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public ThreadPoolRejectedPolicy getRejectedPolicy() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/ThrowExceptionProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/ThrowExceptionProcessor.java
@@ -27,16 +27,18 @@ import org.apache.camel.Expression;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.util.ObjectHelper;
 
 /**
  * The processor which sets an {@link Exception} on the {@link Exchange}
  */
 public class ThrowExceptionProcessor extends BaseProcessorSupport
-        implements Traceable, IdAware, RouteIdAware, CamelContextAware {
+        implements Traceable, IdAware, RouteIdAware, StepIdAware, CamelContextAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private CamelContext camelContext;
     private Expression simple;
     private final Exception exception;
@@ -107,6 +109,16 @@ public class ThrowExceptionProcessor extends BaseProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public Exception getException() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/TokenizerProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/TokenizerProcessor.java
@@ -29,6 +29,7 @@ import org.apache.camel.Navigate;
 import org.apache.camel.Processor;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.spi.Tokenizer;
 import org.apache.camel.support.AsyncProcessorConverterHelper;
 
@@ -36,13 +37,14 @@ import org.apache.camel.support.AsyncProcessorConverterHelper;
  * This implements the core processor for handling tokenization
  */
 public class TokenizerProcessor extends BaseProcessorSupport
-        implements Navigate<Processor>, CamelContextAware, IdAware, RouteIdAware {
+        implements Navigate<Processor>, CamelContextAware, IdAware, RouteIdAware, StepIdAware {
 
     private final AsyncProcessor processor;
     private final Tokenizer tokenizer;
     private CamelContext camelContext;
     private String id;
     private String routeId;
+    private String stepId;
 
     public TokenizerProcessor(Processor processor, Tokenizer tokenizer) {
         this.processor = AsyncProcessorConverterHelper.convert(processor);
@@ -101,5 +103,15 @@ public class TokenizerProcessor extends BaseProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 }

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/TransformProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/TransformProcessor.java
@@ -23,6 +23,7 @@ import org.apache.camel.Message;
 import org.apache.camel.Traceable;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.DefaultMessage;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.util.ObjectHelper;
@@ -30,10 +31,11 @@ import org.apache.camel.util.ObjectHelper;
 /**
  * A processor which sets the body on the OUT message with an {@link Expression}.
  */
-public class TransformProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public class TransformProcessor extends BaseProcessorSupport implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private final Expression expression;
 
     public TransformProcessor(Expression expression) {
@@ -110,6 +112,16 @@ public class TransformProcessor extends BaseProcessorSupport implements Traceabl
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     public Expression getExpression() {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/TryProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/TryProcessor.java
@@ -32,6 +32,7 @@ import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.InterceptableProcessor;
 import org.apache.camel.spi.ReactiveExecutor;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncProcessorConverterHelper;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.service.ServiceHelper;
@@ -42,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * Implements try/catch/finally type processing
  */
 public class TryProcessor extends BaseProcessorSupport
-        implements Navigate<Processor>, Traceable, IdAware, RouteIdAware, InterceptableProcessor {
+        implements Navigate<Processor>, Traceable, IdAware, RouteIdAware, StepIdAware, InterceptableProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(TryProcessor.class);
 
@@ -50,6 +51,7 @@ public class TryProcessor extends BaseProcessorSupport
     protected final ReactiveExecutor reactiveExecutor;
     protected String id;
     protected String routeId;
+    protected String stepId;
     protected final Processor tryProcessor;
     protected final List<Processor> catchClauses;
     protected final Processor finallyProcessor;
@@ -198,5 +200,15 @@ public class TryProcessor extends BaseProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 }

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/WireTapProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/WireTapProcessor.java
@@ -38,6 +38,7 @@ import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.ProcessorExchangeFactory;
 import org.apache.camel.spi.RouteIdAware;
 import org.apache.camel.spi.ShutdownAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncProcessorConverterHelper;
 import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.util.ObjectHelper;
@@ -48,12 +49,13 @@ import org.slf4j.LoggerFactory;
  * Processor for wire tapping exchanges to an endpoint destination.
  */
 public class WireTapProcessor extends BaseProcessorSupport
-        implements Traceable, ShutdownAware, IdAware, RouteIdAware, CamelContextAware {
+        implements Traceable, ShutdownAware, IdAware, RouteIdAware, StepIdAware, CamelContextAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(WireTapProcessor.class);
 
     private String id;
     private String routeId;
+    private String stepId;
     private CamelContext camelContext;
     private final SendDynamicProcessor dynamicSendProcessor; // is only used for reporting statistics
     private final String uri;
@@ -143,6 +145,16 @@ public class WireTapProcessor extends BaseProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
@@ -59,6 +59,7 @@ import org.apache.camel.spi.ReactiveExecutor;
 import org.apache.camel.spi.RecoverableAggregationRepository;
 import org.apache.camel.spi.RouteIdAware;
 import org.apache.camel.spi.ShutdownAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.spi.Synchronization;
 import org.apache.camel.support.DefaultTimeoutMap;
 import org.apache.camel.support.ExchangeHelper;
@@ -85,7 +86,7 @@ import org.slf4j.LoggerFactory;
  * message.
  */
 public class AggregateProcessor extends BaseProcessorSupport
-        implements Navigate<Processor>, Traceable, ShutdownAware, IdAware, RouteIdAware {
+        implements Navigate<Processor>, Traceable, ShutdownAware, IdAware, RouteIdAware, StepIdAware {
 
     public static final String AGGREGATE_TIMEOUT_CHECKER = "AggregateTimeoutChecker";
     public static final String AGGREGATE_OPTIMISTIC_LOCKING_EXECUTOR = "AggregateOptimisticLockingExecutor";
@@ -106,6 +107,7 @@ public class AggregateProcessor extends BaseProcessorSupport
     private final AsyncProcessor processor;
     private String id;
     private String routeId;
+    private String stepId;
     private AggregationStrategy aggregationStrategy;
     private boolean preCompletion;
     private Expression correlationExpression;
@@ -312,6 +314,16 @@ public class AggregateProcessor extends BaseProcessorSupport
 
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/idempotent/IdempotentConsumer.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/idempotent/IdempotentConsumer.java
@@ -33,6 +33,7 @@ import org.apache.camel.processor.BaseProcessorSupport;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.IdempotentRepository;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.spi.Synchronization;
 import org.apache.camel.support.AsyncProcessorConverterHelper;
 import org.apache.camel.support.service.ServiceHelper;
@@ -48,13 +49,14 @@ import org.slf4j.LoggerFactory;
  * @see org.apache.camel.spi.IdempotentRepository
  */
 public class IdempotentConsumer extends BaseProcessorSupport
-        implements CamelContextAware, Navigate<Processor>, IdAware, RouteIdAware {
+        implements CamelContextAware, Navigate<Processor>, IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(IdempotentConsumer.class);
 
     private CamelContext camelContext;
     private String id;
     private String routeId;
+    private String stepId;
     private final Expression messageIdExpression;
     private final AsyncProcessor processor;
     private final IdempotentRepository idempotentRepository;
@@ -107,6 +109,16 @@ public class IdempotentConsumer extends BaseProcessorSupport
 
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/loadbalancer/LoadBalancerSupport.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/loadbalancer/LoadBalancerSupport.java
@@ -27,17 +27,19 @@ import org.apache.camel.Processor;
 import org.apache.camel.processor.BaseProcessorSupport;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.service.ServiceHelper;
 
 /**
  * A default base class for a {@link LoadBalancer} implementation.
  */
 public abstract class LoadBalancerSupport extends BaseProcessorSupport
-        implements LoadBalancer, Navigate<Processor>, IdAware, RouteIdAware {
+        implements LoadBalancer, Navigate<Processor>, IdAware, RouteIdAware, StepIdAware {
 
     private final AtomicReference<AsyncProcessor[]> processors = new AtomicReference<>(new AsyncProcessor[0]);
     private String id;
     private String routeId;
+    private String stepId;
 
     @Override
     public void addProcessor(AsyncProcessor processor) {
@@ -110,6 +112,16 @@ public abstract class LoadBalancerSupport extends BaseProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/resume/ResumableProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/resume/ResumableProcessor.java
@@ -32,6 +32,7 @@ import org.apache.camel.processor.BaseProcessorSupport;
 import org.apache.camel.resume.ResumeStrategy;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.spi.Synchronization;
 import org.apache.camel.support.AsyncProcessorConverterHelper;
 import org.slf4j.Logger;
@@ -41,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * Resume EIP
  */
 public class ResumableProcessor extends BaseProcessorSupport
-        implements Navigate<Processor>, CamelContextAware, IdAware, RouteIdAware {
+        implements Navigate<Processor>, CamelContextAware, IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(ResumableProcessor.class);
 
@@ -52,6 +53,7 @@ public class ResumableProcessor extends BaseProcessorSupport
     private final boolean intermittent;
     private String id;
     private String routeId;
+    private String stepId;
 
     public ResumableProcessor(ResumeStrategy resumeStrategy, Processor processor, LoggingLevel loggingLevel,
                               boolean intermittent) {
@@ -113,6 +115,16 @@ public class ResumableProcessor extends BaseProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/saga/SagaProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/saga/SagaProcessor.java
@@ -29,19 +29,22 @@ import org.apache.camel.saga.CamelSagaService;
 import org.apache.camel.saga.CamelSagaStep;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.util.ObjectHelper;
 
 /**
  * Processor for handling sagas.
  */
-public abstract class SagaProcessor extends BaseDelegateProcessorSupport implements Traceable, IdAware, RouteIdAware {
+public abstract class SagaProcessor extends BaseDelegateProcessorSupport
+        implements Traceable, IdAware, RouteIdAware, StepIdAware {
 
     protected final CamelSagaService sagaService;
     protected final CamelSagaStep step;
     protected final SagaCompletionMode completionMode;
     private String id;
     private String routeId;
+    private String stepId;
 
     protected SagaProcessor(CamelContext camelContext, Processor childProcessor, CamelSagaService sagaService,
                             SagaCompletionMode completionMode, CamelSagaStep step) {
@@ -127,6 +130,16 @@ public abstract class SagaProcessor extends BaseDelegateProcessorSupport impleme
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/ProcessorReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/ProcessorReifier.java
@@ -124,6 +124,7 @@ import org.apache.camel.spi.InterceptStrategy;
 import org.apache.camel.spi.NodeIdFactory;
 import org.apache.camel.spi.ProcessorFactory;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.util.ObjectHelper;
@@ -781,6 +782,14 @@ public abstract class ProcessorReifier<T extends ProcessorDefinition<?>> extends
             if (processor instanceof RouteIdAware routeIdAware) {
                 routeIdAware.setRouteId(route.getRouteId());
             }
+            if (processor instanceof StepIdAware stepIdAware) {
+                StepDefinition step = ProcessorDefinitionHelper.findFirstParentOfType(
+                        StepDefinition.class, output, true);
+                if (step != null) {
+                    stepIdAware.setStepId(step.idOrCreate(
+                            camelContext.getCamelContextExtension().getContextPlugin(NodeIdFactory.class)));
+                }
+            }
 
             if (output instanceof Channel && processor == null) {
                 continue;
@@ -858,6 +867,14 @@ public abstract class ProcessorReifier<T extends ProcessorDefinition<?>> extends
             }
             if (processor instanceof RouteIdAware routeIdAware) {
                 routeIdAware.setRouteId(route.getRouteId());
+            }
+            if (processor instanceof StepIdAware stepIdAware) {
+                StepDefinition step = ProcessorDefinitionHelper.findFirstParentOfType(
+                        StepDefinition.class, definition, true);
+                if (step != null) {
+                    stepIdAware.setStepId(step.idOrCreate(
+                            camelContext.getCamelContextExtension().getContextPlugin(NodeIdFactory.class)));
+                }
             }
 
             if (processor == null) {

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedProducer.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedProducer.java
@@ -20,6 +20,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Producer;
 import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.api.management.mbean.ManagedProducerMBean;
+import org.apache.camel.spi.StepIdAware;
 
 @ManagedResource(description = "Managed Producer")
 public class ManagedProducer extends ManagedService implements ManagedProducerMBean {
@@ -32,6 +33,14 @@ public class ManagedProducer extends ManagedService implements ManagedProducerMB
 
     public Producer getProducer() {
         return producer;
+    }
+
+    @Override
+    public String getStepId() {
+        if (producer instanceof StepIdAware sia) {
+            return sia.getStepId();
+        }
+        return null;
     }
 
     @Override

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedProducerStepIdTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedProducerStepIdTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.management;
+
+import java.util.Set;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisabledOnOs(OS.AIX)
+public class ManagedProducerStepIdTest extends ManagementTestSupport {
+
+    @Test
+    public void testProducerStepId() throws Exception {
+        getMockEndpoint("mock:foo").expectedMessageCount(1);
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        template.sendBody("direct:start", "Hello World");
+
+        assertMockEndpointsSatisfied();
+
+        MBeanServer mbeanServer = getMBeanServer();
+
+        Set<ObjectName> set = mbeanServer.queryNames(new ObjectName("*:type=producers,*"), null);
+        assertEquals(3, set.size());
+
+        for (ObjectName on : set) {
+            boolean registered = mbeanServer.isRegistered(on);
+            assertTrue(registered, "Should be registered");
+
+            String uri = (String) mbeanServer.getAttribute(on, "EndpointUri");
+            String stepId = (String) mbeanServer.getAttribute(on, "StepId");
+
+            if ("log://foo".equals(uri) || "mock://foo".equals(uri)) {
+                assertEquals("myStep", stepId, "Producer inside step should have stepId");
+            } else if ("mock://result".equals(uri)) {
+                assertNull(stepId, "Producer outside step should not have stepId");
+            }
+        }
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("route1")
+                        .step("myStep")
+                        .to("log:foo")
+                        .to("mock:foo")
+                        .end()
+                        .to("mock:result");
+            }
+        };
+    }
+
+}

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultConsumer.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultConsumer.java
@@ -31,6 +31,7 @@ import org.apache.camel.spi.ExceptionHandler;
 import org.apache.camel.spi.ExchangeFactory;
 import org.apache.camel.spi.HostedService;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.spi.UnitOfWork;
 import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.support.service.ServiceSupport;
@@ -42,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * A default consumer useful for implementation inheritance.
  */
 public class DefaultConsumer extends ServiceSupport
-        implements Consumer, RouteAware, RouteIdAware, HealthCheckAware, HostedService {
+        implements Consumer, RouteAware, RouteIdAware, StepIdAware, HealthCheckAware, HostedService {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultConsumer.class);
 
@@ -55,6 +56,7 @@ public class DefaultConsumer extends ServiceSupport
     private ExceptionHandler exceptionHandler;
     private Route route;
     private String routeId;
+    private String stepId;
 
     public DefaultConsumer(Endpoint endpoint, Processor processor) {
         this.endpoint = endpoint;
@@ -97,6 +99,16 @@ public class DefaultConsumer extends ServiceSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     /**

--- a/core/camel-support/src/main/java/org/apache/camel/support/DefaultProducer.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/DefaultProducer.java
@@ -19,6 +19,7 @@ package org.apache.camel.support;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Producer;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.URISupport;
 import org.slf4j.Logger;
@@ -27,12 +28,13 @@ import org.slf4j.LoggerFactory;
 /**
  * A default implementation of {@link Producer} for implementation inheritance.
  */
-public abstract class DefaultProducer extends ServiceSupport implements Producer {
+public abstract class DefaultProducer extends ServiceSupport implements Producer, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultProducer.class);
 
     private transient String producerToString;
     private final Endpoint endpoint;
+    private String stepId;
 
     protected DefaultProducer(Endpoint endpoint) {
         this.endpoint = endpoint;
@@ -61,6 +63,16 @@ public abstract class DefaultProducer extends ServiceSupport implements Producer
     @Override
     public boolean isSingleton() {
         return endpoint.isSingleton();
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/CamelLogProcessor.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/CamelLogProcessor.java
@@ -28,6 +28,7 @@ import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.LogListener;
 import org.apache.camel.spi.MaskingFormatter;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncProcessorSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,12 +40,13 @@ import org.slf4j.LoggerFactory;
  * The name <tt>CamelLogger</tt> has been chosen to avoid any name clash with log kits which has a <tt>Logger</tt>
  * class.
  */
-public class CamelLogProcessor extends AsyncProcessorSupport implements IdAware, RouteIdAware {
+public class CamelLogProcessor extends AsyncProcessorSupport implements IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(CamelLogProcessor.class);
 
     private String id;
     private String routeId;
+    private String stepId;
     private final CamelLogger logger;
     private ExchangeFormatter formatter;
     private MaskingFormatter maskingFormatter;
@@ -91,6 +93,16 @@ public class CamelLogProcessor extends AsyncProcessorSupport implements IdAware,
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/ConvertBodyProcessor.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/ConvertBodyProcessor.java
@@ -26,6 +26,7 @@ import org.apache.camel.ExchangePropertyKey;
 import org.apache.camel.Message;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncCallbackToCompletableFutureAdapter;
 import org.apache.camel.support.DefaultMessage;
 import org.apache.camel.support.ExchangeHelper;
@@ -38,9 +39,11 @@ import org.apache.camel.util.ObjectHelper;
  * <p/>
  * If the conversion fails an {@link org.apache.camel.InvalidPayloadException} is thrown.
  */
-public class ConvertBodyProcessor extends ServiceSupport implements AsyncProcessor, IdAware, RouteIdAware, DisabledAware {
+public class ConvertBodyProcessor extends ServiceSupport
+        implements AsyncProcessor, IdAware, RouteIdAware, StepIdAware, DisabledAware {
     private String id;
     private String routeId;
+    private String stepId;
     private boolean disabled;
     private final Class<?> type;
     private final String charset;
@@ -90,6 +93,16 @@ public class ConvertBodyProcessor extends ServiceSupport implements AsyncProcess
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/ConvertHeaderProcessor.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/ConvertHeaderProcessor.java
@@ -28,6 +28,7 @@ import org.apache.camel.Message;
 import org.apache.camel.NoSuchHeaderOrPropertyException;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncCallbackToCompletableFutureAdapter;
 import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.IOHelper;
@@ -36,10 +37,12 @@ import org.apache.camel.util.ObjectHelper;
 /**
  * A processor which converts the message header to be of the given type
  */
-public class ConvertHeaderProcessor extends ServiceSupport implements AsyncProcessor, IdAware, RouteIdAware, DisabledAware {
+public class ConvertHeaderProcessor extends ServiceSupport
+        implements AsyncProcessor, IdAware, RouteIdAware, StepIdAware, DisabledAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private boolean disabled;
     private final String name;
     private final Expression headerName;
@@ -85,6 +88,16 @@ public class ConvertHeaderProcessor extends ServiceSupport implements AsyncProce
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/ConvertVariableProcessor.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/ConvertVariableProcessor.java
@@ -29,6 +29,7 @@ import org.apache.camel.Expression;
 import org.apache.camel.NoSuchVariableException;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.spi.VariableRepository;
 import org.apache.camel.spi.VariableRepositoryFactory;
 import org.apache.camel.support.AsyncCallbackToCompletableFutureAdapter;
@@ -41,12 +42,13 @@ import org.apache.camel.util.StringHelper;
  * A processor which converts the variable to be of the given type
  */
 public class ConvertVariableProcessor extends ServiceSupport
-        implements AsyncProcessor, IdAware, RouteIdAware, CamelContextAware, DisabledAware {
+        implements AsyncProcessor, IdAware, RouteIdAware, StepIdAware, CamelContextAware, DisabledAware {
 
     private CamelContext camelContext;
     private VariableRepositoryFactory factory;
     private String id;
     private String routeId;
+    private String stepId;
     private boolean disabled;
     private final String name;
     private final Expression variableName;
@@ -102,6 +104,16 @@ public class ConvertVariableProcessor extends ServiceSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/MarshalProcessor.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/MarshalProcessor.java
@@ -26,6 +26,7 @@ import org.apache.camel.Traceable;
 import org.apache.camel.spi.DataFormat;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncProcessorSupport;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.builder.OutputStreamBuilder;
@@ -37,10 +38,11 @@ import org.apache.camel.util.ObjectHelper;
  * format</a>
  */
 public class MarshalProcessor extends AsyncProcessorSupport
-        implements Traceable, CamelContextAware, IdAware, RouteIdAware, DisabledAware {
+        implements Traceable, CamelContextAware, IdAware, RouteIdAware, StepIdAware, DisabledAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private CamelContext camelContext;
     private final DataFormat dataFormat;
     private boolean disabled;
@@ -118,6 +120,16 @@ public class MarshalProcessor extends AsyncProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/ThroughputLogger.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/ThroughputLogger.java
@@ -27,6 +27,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.spi.CamelLogger;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncProcessorSupport;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StopWatch;
@@ -36,12 +37,13 @@ import org.slf4j.LoggerFactory;
 /**
  * A logger for logging message throughput.
  */
-public class ThroughputLogger extends AsyncProcessorSupport implements IdAware, RouteIdAware {
+public class ThroughputLogger extends AsyncProcessorSupport implements IdAware, RouteIdAware, StepIdAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(ThroughputLogger.class);
 
     private String id;
     private String routeId;
+    private String stepId;
     private final AtomicLong receivedCounter = new AtomicLong();
     private NumberFormat numberFormat = NumberFormat.getNumberInstance();
     private long groupReceivedCount;
@@ -97,6 +99,16 @@ public class ThroughputLogger extends AsyncProcessorSupport implements IdAware, 
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/UnmarshalProcessor.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/UnmarshalProcessor.java
@@ -30,6 +30,7 @@ import org.apache.camel.Traceable;
 import org.apache.camel.spi.DataFormat;
 import org.apache.camel.spi.IdAware;
 import org.apache.camel.spi.RouteIdAware;
+import org.apache.camel.spi.StepIdAware;
 import org.apache.camel.support.AsyncProcessorSupport;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.service.ServiceHelper;
@@ -41,10 +42,11 @@ import org.apache.camel.util.ObjectHelper;
  * format</a>
  */
 public class UnmarshalProcessor extends AsyncProcessorSupport
-        implements Traceable, CamelContextAware, IdAware, RouteIdAware, DisabledAware {
+        implements Traceable, CamelContextAware, IdAware, RouteIdAware, StepIdAware, DisabledAware {
 
     private String id;
     private String routeId;
+    private String stepId;
     private CamelContext camelContext;
     private boolean disabled;
     private final DataFormat dataFormat;
@@ -155,6 +157,16 @@ public class UnmarshalProcessor extends AsyncProcessorSupport
     @Override
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    @Override
+    public String getStepId() {
+        return stepId;
+    }
+
+    @Override
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Introduces `StepIdAware` interface (mirroring `RouteIdAware`) so runtime objects can carry a step ID
- `DefaultProducer` implements `StepIdAware`, enabling all producers to carry a step ID when created inside a `step` EIP
- `SendProcessor` propagates its step ID to the producer it creates
- `ProcessorReifier` resolves the parent `StepDefinition` and sets the step ID on processors during reification
- `ManagedProducerMBean` exposes `getStepId()` via JMX
- `ProducerDevConsole` displays step ID in both text and JSON output
- Includes test `ManagedProducerStepIdTest` verifying producers inside/outside steps

## Test plan

- [x] `ManagedProducerStepIdTest` — verifies producers inside a step have stepId, producers outside do not
- [x] `ManagedStepTest` — existing test passes (no regression)
- [x] `ManagedProducerTest` — existing test passes (no regression)

_Claude Code on behalf of Claus Ibsen_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>