### PR TITLE
camel-openai: close OpenAI client on endpoint stop to prevent OkHttp thread leak

### DIFF
--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEndpoint.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEndpoint.java
@@ -138,6 +138,7 @@ public class OpenAIEndpoint extends DefaultEndpoint {
             returnDirectTools.clear();
         }
         if (client != null) {
+            client.close();
             client = null;
         }
         super.doStop();


### PR DESCRIPTION
## Summary

- Call `client.close()` in `OpenAIEndpoint.doStop()` before nulling the reference so that OkHttp's dispatcher executor, connection pool, and cache are properly shut down.
- Without this, OkHttp threads (`OkHttp Dispatcher`, `OkHttp ConnectionPool`) linger after route stop, especially visible under `exec:java` or Camel JBang dev mode where the JVM does not exit.