### PR TITLE
CAMEL-23621: filter tool argument headers against declared parameters

### DIFF
--- a/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
@@ -215,12 +215,25 @@ public class LangChain4jAgentProducer extends DefaultProducer {
                             JsonNode jsonNode = objectMapper.readValue(arguments, JsonNode.class);
                             jsonNode.fieldNames()
                                     .forEachRemaining(name -> {
-                                        if (!allowedParams.isEmpty() && !allowedParams.contains(name)) {
+                                        if (!allowedParams.contains(name)) {
                                             LOG.warn("Skipping undeclared tool argument '{}' for tool '{}'",
                                                     name, toolName);
                                             return;
                                         }
-                                        exchange.getMessage().setHeader(name, jsonNode.get(name));
+                                        JsonNode value = jsonNode.get(name);
+                                        Object headerValue;
+                                        if (value.isInt()) {
+                                            headerValue = value.intValue();
+                                        } else if (value.isLong()) {
+                                            headerValue = value.longValue();
+                                        } else if (value.isDouble()) {
+                                            headerValue = value.doubleValue();
+                                        } else if (value.isBoolean()) {
+                                            headerValue = value.booleanValue();
+                                        } else {
+                                            headerValue = value.asText();
+                                        }
+                                        exchange.getMessage().setHeader(name, headerValue);
                                     });
                         }
 

--- a/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.mcp.McpToolProvider;
 import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
@@ -203,9 +204,24 @@ public class LangChain4jAgentProducer extends DefaultProducer {
                         // Parse JSON arguments if provided
                         String arguments = toolExecutionRequest.arguments();
                         if (arguments != null && !arguments.trim().isEmpty()) {
+                            // Get declared parameters from tool specification to filter incoming fields
+                            Set<String> declaredParams = Set.of();
+                            JsonObjectSchema paramSchema = toolSpecification.parameters();
+                            if (paramSchema != null && paramSchema.properties() != null) {
+                                declaredParams = paramSchema.properties().keySet();
+                            }
+                            final Set<String> allowedParams = declaredParams;
+
                             JsonNode jsonNode = objectMapper.readValue(arguments, JsonNode.class);
                             jsonNode.fieldNames()
-                                    .forEachRemaining(name -> exchange.getMessage().setHeader(name, jsonNode.get(name)));
+                                    .forEachRemaining(name -> {
+                                        if (!allowedParams.isEmpty() && !allowedParams.contains(name)) {
+                                            LOG.warn("Skipping undeclared tool argument '{}' for tool '{}'",
+                                                    name, toolName);
+                                            return;
+                                        }
+                                        exchange.getMessage().setHeader(name, jsonNode.get(name));
+                                    });
                         }
 
                         // Set the tool name as a header for route identification

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsProducer.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsProducer.java
@@ -185,7 +185,7 @@ public class LangChain4jToolsProducer extends DefaultProducer {
                 JsonNode jsonNode = objectMapper.readValue(toolExecutionRequest.arguments(), JsonNode.class);
                 jsonNode.fieldNames()
                         .forEachRemaining(name -> {
-                            if (!allowedParams.isEmpty() && !allowedParams.contains(name)) {
+                            if (!allowedParams.contains(name)) {
                                 LOG.warn("Skipping undeclared tool argument '{}' for tool '{}'",
                                         name, toolName);
                                 return;

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsProducer.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsProducer.java
@@ -173,10 +173,23 @@ public class LangChain4jToolsProducer extends DefaultProducer {
             try {
                 TypeConverter typeConverter = endpoint.getCamelContext().getTypeConverter();
 
+                // Get declared parameters from tool specification to filter incoming fields
+                Set<String> declaredParams = Set.of();
+                JsonObjectSchema paramSchema = camelToolSpecification.getToolSpecification().parameters();
+                if (paramSchema != null && paramSchema.properties() != null) {
+                    declaredParams = paramSchema.properties().keySet();
+                }
+                final Set<String> allowedParams = declaredParams;
+
                 // Map Json to Header
                 JsonNode jsonNode = objectMapper.readValue(toolExecutionRequest.arguments(), JsonNode.class);
                 jsonNode.fieldNames()
                         .forEachRemaining(name -> {
+                            if (!allowedParams.isEmpty() && !allowedParams.contains(name)) {
+                                LOG.warn("Skipping undeclared tool argument '{}' for tool '{}'",
+                                        name, toolName);
+                                return;
+                            }
                             final JsonNode value = jsonNode.get(name);
                             Object headerValue;
 

--- a/components/camel-ai/camel-langchain4j-tools/src/test/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolTest.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/test/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolTest.java
@@ -56,6 +56,12 @@ public class LangChain4jToolTest extends CamelTestSupport {
             .withParam("tags", "users")
             .andThenInvokeTool("queryUserBySSN")
             .withParam("ssn", "123-45-6789")
+            .end()
+            .when("Query user 5\n")
+            .invokeTool("QueryUserByNumber")
+            .withParam("number", 5)
+            .withParam("CamelFileName", "../../etc/passwd")
+            .withParam("undeclaredParam", "injected")
             .build();
 
     @Override
@@ -170,6 +176,29 @@ public class LangChain4jToolTest extends CamelTestSupport {
         Assertions.assertThat(result).isNotNull();
         String response = result.getMessage().getBody(String.class);
         Assertions.assertThat(response).isNotNull();
+    }
+
+    @Test
+    public void testUndeclaredToolArgumentsAreNotPropagatedAsHeaders() {
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(new SystemMessage("You provide the requested information using the functions you have available."));
+        messages.add(new UserMessage("Query user 5\n"));
+
+        Exchange exchange = fluentTemplate.to("direct:test").withBody(messages).request(Exchange.class);
+
+        Assertions.assertThat(exchange).isNotNull();
+        Message message = exchange.getMessage();
+
+        // Declared parameter should be set
+        Assertions.assertThat(message.getHeader("number")).isEqualTo(5);
+
+        // Undeclared parameters should NOT be propagated as headers
+        Assertions.assertThat(message.getHeader("CamelFileName"))
+                .as("Undeclared 'CamelFileName' should not be set as header")
+                .isNull();
+        Assertions.assertThat(message.getHeader("undeclaredParam"))
+                .as("Undeclared 'undeclaredParam' should not be set as header")
+                .isNull();
     }
 
     @Test

--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-tools/src/main/java/org/apache/camel/component/springai/tools/SpringAiToolsEndpoint.java
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-tools/src/main/java/org/apache/camel/component/springai/tools/SpringAiToolsEndpoint.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -122,12 +123,23 @@ public class SpringAiToolsEndpoint extends DefaultEndpoint {
         final SpringAiToolsConsumer springAiToolsConsumer = new SpringAiToolsConsumer(this, processor);
         configureConsumer(springAiToolsConsumer);
 
+        // Get declared parameter names to filter incoming arguments
+        final Set<String> declaredParams;
+        if (parameters != null && !parameters.isEmpty()) {
+            declaredParams = parseParameterMetadata(parameters).keySet();
+        } else {
+            declaredParams = Set.of();
+        }
+
         // Create a function that executes the Camel route
         Function<Map<String, Object>, String> function = args -> {
             try {
                 Exchange exchange = createExchange();
-                // Set arguments as headers
+                // Set arguments as headers, filtered against declared parameters
                 for (Map.Entry<String, Object> entry : args.entrySet()) {
+                    if (!declaredParams.isEmpty() && !declaredParams.contains(entry.getKey())) {
+                        continue;
+                    }
                     exchange.getMessage().setHeader(entry.getKey(), entry.getValue());
                 }
 

--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-tools/src/main/java/org/apache/camel/component/springai/tools/SpringAiToolsEndpoint.java
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-tools/src/main/java/org/apache/camel/component/springai/tools/SpringAiToolsEndpoint.java
@@ -137,7 +137,7 @@ public class SpringAiToolsEndpoint extends DefaultEndpoint {
                 Exchange exchange = createExchange();
                 // Set arguments as headers, filtered against declared parameters
                 for (Map.Entry<String, Object> entry : args.entrySet()) {
-                    if (!declaredParams.isEmpty() && !declaredParams.contains(entry.getKey())) {
+                    if (!declaredParams.contains(entry.getKey())) {
                         continue;
                     }
                     exchange.getMessage().setHeader(entry.getKey(), entry.getValue());

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -1486,6 +1486,34 @@ link:https://github.com/jasypt/jasypt/releases/tag/jasypt-1.9.3[jasypt-1.9.3 dis
 the same workflow and let us drop the duplicate implementation maintained inside `camel-jasypt`. The component
 itself (property-source decryption at runtime) is unaffected.
 
+=== camel-langchain4j-tools / camel-langchain4j-agent / camel-spring-ai-tools
+
+Tool argument headers are now filtered against the tool's declared parameter schema. When the LLM returns
+a tool call, only JSON field names that match a declared `parameter.<name>` are set as Exchange headers.
+Undeclared field names are logged at WARN level and skipped.
+
+This is a breaking change for tools defined without explicit `parameter.*` declarations. Previously, all
+LLM-provided argument field names were set as Exchange headers without filtering. Now, tools with no
+declared parameters will have zero argument headers set from the LLM tool call.
+
+For example, a tool defined as:
+
+[source,java]
+----
+from("langchain4j-tools:test1?tags=user&description=Does not really do anything")
+----
+
+will no longer receive any LLM-provided arguments as headers. To restore argument flow, declare the
+expected parameters explicitly:
+
+[source,java]
+----
+from("langchain4j-tools:test1?tags=user&description=Query user by number&parameter.number=integer")
+----
+
+Additionally, `camel-langchain4j-agent` now extracts primitive values (`int`, `long`, `double`, `boolean`,
+`String`) from tool arguments instead of setting raw `JsonNode` objects as headers.
+
 === Deprecation of camel-paho
 
 The components camel-paho is deprecated. There were no new release since 2020 of the Java client, last non-regulatory commit was in 2022.


### PR DESCRIPTION
## Summary
- Filter LLM tool argument field names against the tool's declared parameter schema before setting them as Exchange headers
- Affects camel-langchain4j-tools, camel-langchain4j-agent, and camel-spring-ai-tools
- Undeclared field names are logged at WARN level and skipped
- Fix raw JsonNode values being set as headers in camel-langchain4j-agent — now extracts primitive values

## Behavioral change
Tools defined without parameter.* declarations will now have zero argument headers set from LLM tool calls. Previously, all LLM-provided argument field names were set as Exchange headers without filtering. This is a breaking change for routes that rely on implicit argument passthrough, e.g.: from("langchain4j-tools:test1?tags=user&description=Does not really do anything") Any LLM-provided arguments for such tools will be silently dropped. To restore argument flow, declare the expected parameters explicitly via parameter.<name>=<type>.