### PR TITLE
CAMEL-23615: Force colored logging when TUI launches examples

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ActionsPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ActionsPopup.java
@@ -923,6 +923,7 @@ class ActionsPopup {
             List<String> cmd = new ArrayList<>(LauncherHelper.getCamelCommand());
             cmd.add("run");
             cmd.add("--example=" + exampleName);
+            cmd.add("--logging-color=true");
             cmd.addAll(extraArgs);
             Path outputFile = Files.createTempFile("camel-example-", ".log");
             outputFile.toFile().deleteOnExit();
@@ -1089,6 +1090,7 @@ class ActionsPopup {
             List<String> cmd = new ArrayList<>(LauncherHelper.getCamelCommand());
             cmd.add("run");
             cmd.add("--example=" + exampleName);
+            cmd.add("--logging-color=true");
             Path outputFile = Files.createTempFile("camel-example-", ".log");
             outputFile.toFile().deleteOnExit();
             ProcessBuilder pb = new ProcessBuilder(cmd);


### PR DESCRIPTION
## Summary
- When the TUI launches examples (via F2 → Run), stdout is redirected to a log file, so the child `camel run` process detects no TTY and disables ANSI colors
- Fix: pass `--logging-color=true` explicitly in both launch paths (`launchWithName()` and `launchSelectedExample()`)
- The TUI's `LogTab` already parses ANSI escape sequences via `TuiHelper.ansiToLine()`, so the colored output renders correctly

## Test plan
- [x] Compiles
- [ ] Launch an example from TUI via F2 and verify logs are displayed with colors

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Claus Ibsen