### PR TITLE
CAMEL-23622: Exclude camel.jbang properties from startup summary

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
@@ -3105,10 +3105,11 @@ public abstract class BaseMainSupport extends BaseService {
                     String k = entry.getKey().toString();
                     Object v = entry.getValue();
                     Object dv = propertyPlaceholders.getDefaultValue(k);
-                    // skip logging configurations that are using default-value
-                    // or a kamelet that uses templateId as a parameter
+                    // skip logging configurations that are using default-value,
+                    // a kamelet that uses templateId as a parameter,
+                    // or internal camel-jbang properties
                     boolean same = ObjectHelper.equal(v, dv);
-                    boolean skip = "templateId".equals(k);
+                    boolean skip = "templateId".equals(k) || k.startsWith("camel.jbang.");
                     if (!same && !skip) {
                         if (header) {
                             LOG.info("Property-placeholders summary");


### PR DESCRIPTION
## Summary

- Filter out `camel.jbang.*` properties from the property-placeholder startup summary log
- These are internal JBang properties (e.g. `camel.jbang.readmeFiles`) not meaningful to end users

## Test plan

- [ ] Manual: run `camel run` with a project that has a README.md and verify the summary no longer shows `camel.jbang.readmeFiles`

_Claude Code on behalf of Claus Ibsen_