### PR TITLE
[backport camel-4.18.x] CAMEL-23592: camel-shiro - align Exchange header constant names with Camel naming convention

### DIFF
--- a/components/camel-shiro/src/main/java/org/apache/camel/component/shiro/security/ShiroSecurityConstants.java
+++ b/components/camel-shiro/src/main/java/org/apache/camel/component/shiro/security/ShiroSecurityConstants.java
@@ -21,9 +21,9 @@ package org.apache.camel.component.shiro.security;
  */
 public final class ShiroSecurityConstants {
 
-    public static final String SHIRO_SECURITY_TOKEN = "SHIRO_SECURITY_TOKEN";
-    public static final String SHIRO_SECURITY_USERNAME = "SHIRO_SECURITY_USERNAME";
-    public static final String SHIRO_SECURITY_PASSWORD = "SHIRO_SECURITY_PASSWORD";
+    public static final String SHIRO_SECURITY_TOKEN = "CamelShiroSecurityToken";
+    public static final String SHIRO_SECURITY_USERNAME = "CamelShiroSecurityUsername";
+    public static final String SHIRO_SECURITY_PASSWORD = "CamelShiroSecurityPassword";
 
     private ShiroSecurityConstants() {
     }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -656,6 +656,33 @@ The generated Endpoint DSL header accessors on each component's
 
 
 
+=== camel-shiro - potential breaking change
+
+The three Exchange header constants in `ShiroSecurityConstants` that drive
+Shiro authentication used header values outside the `Camel` namespace
+(`SHIRO_SECURITY_TOKEN`, `SHIRO_SECURITY_USERNAME`, `SHIRO_SECURITY_PASSWORD`)
+and were therefore not filtered by the default `HeaderFilterStrategy`. They
+have been renamed to follow the Camel naming convention. The Java field names
+are unchanged; only the header string values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `ShiroSecurityConstants.SHIRO_SECURITY_TOKEN` | `SHIRO_SECURITY_TOKEN` | `CamelShiroSecurityToken`
+| `ShiroSecurityConstants.SHIRO_SECURITY_USERNAME` | `SHIRO_SECURITY_USERNAME` | `CamelShiroSecurityUsername`
+| `ShiroSecurityConstants.SHIRO_SECURITY_PASSWORD` | `SHIRO_SECURITY_PASSWORD` | `CamelShiroSecurityPassword`
+|===
+
+These headers carry credentials and a serialized authentication token, so
+filtering them at transport boundaries by default is particularly important.
+
+Routes that reference the constants symbolically (for example
+`setHeader(ShiroSecurityConstants.SHIRO_SECURITY_USERNAME, ...)`) continue to
+work without changes. Routes that set the header by its literal string value
+(for example `setHeader("SHIRO_SECURITY_USERNAME", ...)`) must be updated to
+use the new value (`setHeader("CamelShiroSecurityUsername", ...)`).
+
+
 === camel-web3j - potential breaking change
 
 The Exchange header constants in `Web3jConstants` have been renamed to follow the

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -682,6 +682,44 @@ work without changes. Routes that set the header by its literal string value
 (for example `setHeader("SHIRO_SECURITY_USERNAME", ...)`) must be updated to
 use the new value (`setHeader("CamelShiroSecurityUsername", ...)`).
 
+Because the three header values are now in the `Camel*` namespace, transports
+that filter Camel-internal headers by default (JMS, CXF, HTTP, etc.) will
+strip the serialized Shiro authentication token before publishing. This is
+the intended behavior for untrusted producers. Trusted Shiro-over-transport
+routes that previously relied on the token surviving the boundary must opt
+those three headers back in via a custom `HeaderFilterStrategy`, for example:
+
+[source,java]
+----
+public class ShiroFriendlyJmsHeaderFilterStrategy extends JmsHeaderFilterStrategy {
+    @Override
+    public boolean applyFilterToCamelHeaders(String name, Object value, Exchange ex) {
+        if (isShiroSecurityHeader(name)) {
+            return false;
+        }
+        return super.applyFilterToCamelHeaders(name, value, ex);
+    }
+
+    @Override
+    public boolean applyFilterToExternalHeaders(String name, Object value, Exchange ex) {
+        if (isShiroSecurityHeader(name)) {
+            return false;
+        }
+        return super.applyFilterToExternalHeaders(name, value, ex);
+    }
+
+    private static boolean isShiroSecurityHeader(String name) {
+        return ShiroSecurityConstants.SHIRO_SECURITY_TOKEN.equalsIgnoreCase(name)
+                || ShiroSecurityConstants.SHIRO_SECURITY_USERNAME.equalsIgnoreCase(name)
+                || ShiroSecurityConstants.SHIRO_SECURITY_PASSWORD.equalsIgnoreCase(name);
+    }
+}
+
+jmsComponent.setHeaderFilterStrategy(new ShiroFriendlyJmsHeaderFilterStrategy());
+----
+
+A worked example is in `ShiroOverJmsTest` in the `camel-itest` module.
+
 
 === camel-web3j - potential breaking change
 

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/shiro/ShiroOverJmsTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/shiro/ShiroOverJmsTest.java
@@ -19,8 +19,10 @@ package org.apache.camel.itest.shiro;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.JmsComponent;
+import org.apache.camel.component.jms.JmsHeaderFilterStrategy;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.shiro.security.ShiroSecurityConstants;
 import org.apache.camel.component.shiro.security.ShiroSecurityPolicy;
@@ -61,7 +63,40 @@ public class ShiroOverJmsTest extends CamelTestSupport {
 
         amq.setCamelContext(context);
 
+        // After CAMEL-23592 the Shiro security headers live in the CamelShiroSecurity* namespace,
+        // which the default JmsHeaderFilterStrategy filters at the transport boundary. For a
+        // trusted Shiro-over-JMS route, the operator must opt those three headers back in.
+        amq.setHeaderFilterStrategy(new ShiroFriendlyJmsHeaderFilterStrategy());
+
         registry.bind("jms", amq);
+    }
+
+    /**
+     * Allows the three Shiro security headers (token, username, password) to cross the JMS transport boundary while
+     * still filtering every other Camel-internal header.
+     */
+    private static final class ShiroFriendlyJmsHeaderFilterStrategy extends JmsHeaderFilterStrategy {
+        @Override
+        public boolean applyFilterToCamelHeaders(String headerName, Object headerValue, Exchange exchange) {
+            if (isShiroSecurityHeader(headerName)) {
+                return false;
+            }
+            return super.applyFilterToCamelHeaders(headerName, headerValue, exchange);
+        }
+
+        @Override
+        public boolean applyFilterToExternalHeaders(String headerName, Object headerValue, Exchange exchange) {
+            if (isShiroSecurityHeader(headerName)) {
+                return false;
+            }
+            return super.applyFilterToExternalHeaders(headerName, headerValue, exchange);
+        }
+
+        private static boolean isShiroSecurityHeader(String headerName) {
+            return ShiroSecurityConstants.SHIRO_SECURITY_TOKEN.equalsIgnoreCase(headerName)
+                    || ShiroSecurityConstants.SHIRO_SECURITY_USERNAME.equalsIgnoreCase(headerName)
+                    || ShiroSecurityConstants.SHIRO_SECURITY_PASSWORD.equalsIgnoreCase(headerName);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Motivation

Backport of CAMEL-23592 (main: #23506 / `aeb5fd9d`) to `camel-4.18.x`. Renames the
three Exchange header **values** in `ShiroSecurityConstants` that drive Shiro
authentication into the canonical `Camel*` namespace, so they fall under the default
`HeaderFilterStrategy` like every other Camel internal header. Java field names are
unchanged; only the header string values change.

| Constant | Previous value | New value |
| --- | --- | --- |
| `ShiroSecurityConstants.SHIRO_SECURITY_TOKEN` | `SHIRO_SECURITY_TOKEN` | `CamelShiroSecurityToken` |
| `ShiroSecurityConstants.SHIRO_SECURITY_USERNAME` | `SHIRO_SECURITY_USERNAME` | `CamelShiroSecurityUsername` |
| `ShiroSecurityConstants.SHIRO_SECURITY_PASSWORD` | `SHIRO_SECURITY_PASSWORD` | `CamelShiroSecurityPassword` |

These headers carry credentials and a serialized authentication token, so filtering
them at transport boundaries by default is particularly important.

## Commits in this PR

1. `CAMEL-23592: camel-shiro - align Exchange header constant names with Camel naming convention (#23506)`
   - The actual constant rename + 4.18 upgrade guide entry.
2. `CAMEL-23592: camel-itest - update ShiroOverJmsTest for renamed Shiro security headers` (new)
   - Pulls the same fix being applied on main as PR #23592 — the test on this branch
     was failing because the renamed headers are now filtered by the default
     `JmsHeaderFilterStrategy`, so the consumer-side `ShiroSecurityPolicy` could no
     longer read the auth token and the message ended up at the dead-letter mock.
   - Adds a small private subclass of `JmsHeaderFilterStrategy` in the test that opts
     the three Shiro security headers back through the transport boundary while
     leaving every other `Camel*`-prefixed filter rule untouched. This is the
     opt-in pattern end-users need post-CAMEL-23592 for trusted Shiro-over-JMS
     routes.
   - Extends the existing camel-shiro entry in `camel-4x-upgrade-guide-4_18.adoc`
     with a worked `HeaderFilterStrategy` opt-in example.

## Compatibility

Backport of an already-documented breaking change (literal string value of the
three headers). Symbolic references to `ShiroSecurityConstants.SHIRO_SECURITY_*`
continue to work; literal-string references must be updated. The new commit is
test + doc only.

## Test plan

- [x] `mvn -pl tests/camel-itest test -Dtest=ShiroOverJmsTest` passes locally on
      this branch (was failing on CI before the second commit).
- [x] Full reactor build from root succeeds: `mvn clean install -DskipTests` (8m53s).
- [x] No regen artifacts touched (verified via `git status` post-build).

## Related

- JIRA: https://issues.apache.org/jira/browse/CAMEL-23592
- Main PR (rename): #23506 (merged)
- Main PR (test fix): #23592
- Future backport to 4.14.x: pending

---
_Claude Code on behalf of Andrea Cosentino_