### PR TITLE
CAMEL-23627: fixed response error check in SlackProducer

### DIFF
--- a/components/camel-slack/src/main/java/org/apache/camel/component/slack/SlackProducer.java
+++ b/components/camel-slack/src/main/java/org/apache/camel/component/slack/SlackProducer.java
@@ -95,7 +95,7 @@ public class SlackProducer extends DefaultAsyncProducer {
             callback.done(true);
         }
 
-        return false;
+        return true;
     }
 
     private ChatPostMessageResponse sendLegacySlackMessage(SlackMessage slackMessage) throws IOException, SlackApiException {
@@ -145,7 +145,7 @@ public class SlackProducer extends DefaultAsyncProducer {
             callback.done(true);
         }
 
-        return false;
+        return true;
     }
 
     private Message addEndPointOptions(Message slackMessage) {

--- a/components/camel-slack/src/main/java/org/apache/camel/component/slack/SlackProducer.java
+++ b/components/camel-slack/src/main/java/org/apache/camel/component/slack/SlackProducer.java
@@ -84,15 +84,15 @@ public class SlackProducer extends DefaultAsyncProducer {
                 slackMessage.setText(exchange.getIn().getBody(String.class));
                 response = sendLegacySlackMessage(slackMessage);
             }
+            if (!response.isOk()) {
+                exchange.setException(
+                        new CamelExchangeException("Error POSTing to Slack API: " + response, exchange));
+            }
         } catch (Exception e) {
             exchange.setException(e);
             return true;
         } finally {
             callback.done(true);
-        }
-
-        if (!response.isOk()) {
-            exchange.setException(new CamelExchangeException("Error POSTing to Slack API: " + response.toString(), exchange));
         }
 
         return false;
@@ -134,15 +134,15 @@ public class SlackProducer extends DefaultAsyncProducer {
         WebhookResponse response;
         try {
             response = slack.send(slackEndpoint.getWebhookUrl(), json);
+            if (response.getCode() < 200 || response.getCode() > 299) {
+                exchange.setException(
+                        new CamelExchangeException("Error POSTing to Slack API: " + response, exchange));
+            }
         } catch (IOException e) {
             exchange.setException(e);
             return true;
         } finally {
             callback.done(true);
-        }
-
-        if (response.getCode() < 200 || response.getCode() > 299) {
-            exchange.setException(new CamelExchangeException("Error POSTing to Slack API: " + response.toString(), exchange));
         }
 
         return false;


### PR DESCRIPTION
# Description

Currently a possible Slack erorr is checked and set only after `callback.done(true)` has been called. This makes the route complete before checking whether an exception has been set, leading said exception to bubble up and not get caught by any `onException` policy.

# Target

- [X] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

