### PR TITLE
[backport camel-4.18.x] CAMEL-23627: fixed response error check in SlackProducer

### DIFF
--- a/components/camel-slack/src/main/java/org/apache/camel/component/slack/SlackProducer.java
+++ b/components/camel-slack/src/main/java/org/apache/camel/component/slack/SlackProducer.java
@@ -84,6 +84,10 @@ public class SlackProducer extends DefaultAsyncProducer {
                 slackMessage.setText(exchange.getIn().getBody(String.class));
                 response = sendLegacySlackMessage(slackMessage);
             }
+            if (!response.isOk()) {
+                exchange.setException(
+                        new CamelExchangeException("Error POSTing to Slack API: " + response, exchange));
+            }
         } catch (Exception e) {
             exchange.setException(e);
             return true;
@@ -91,11 +95,7 @@ public class SlackProducer extends DefaultAsyncProducer {
             callback.done(true);
         }
 
-        if (!response.isOk()) {
-            exchange.setException(new CamelExchangeException("Error POSTing to Slack API: " + response.toString(), exchange));
-        }
-
-        return false;
+        return true;
     }
 
     private ChatPostMessageResponse sendLegacySlackMessage(SlackMessage slackMessage) throws IOException, SlackApiException {
@@ -134,6 +134,10 @@ public class SlackProducer extends DefaultAsyncProducer {
         WebhookResponse response;
         try {
             response = slack.send(slackEndpoint.getWebhookUrl(), json);
+            if (response.getCode() < 200 || response.getCode() > 299) {
+                exchange.setException(
+                        new CamelExchangeException("Error POSTing to Slack API: " + response, exchange));
+            }
         } catch (IOException e) {
             exchange.setException(e);
             return true;
@@ -141,11 +145,7 @@ public class SlackProducer extends DefaultAsyncProducer {
             callback.done(true);
         }
 
-        if (response.getCode() < 200 || response.getCode() > 299) {
-            exchange.setException(new CamelExchangeException("Error POSTing to Slack API: " + response.toString(), exchange));
-        }
-
-        return false;
+        return true;
     }
 
     private Message addEndPointOptions(Message slackMessage) {


### PR DESCRIPTION
## Backport of #23567

Cherry-pick of #23567 onto `camel-4.18.x`.

**Original PR:** #23567 - CAMEL-23627: fixed response error check in SlackProducer
**Original author:** @Xadhoodin
**Target branch:** `camel-4.18.x`

### Original description

Move the Slack API error response check inside the try block so the exception is set
on the exchange before callback.done(true) fires. Previously the check happened after
the callback, causing onException policies to miss the error. Also fix both methods
to return true since SlackProducer is fully synchronous.