### PR TITLE
CAMEL-23632: Add CLI usage examples (footer) to commands

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyCopy.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyCopy.java
@@ -33,7 +33,10 @@ import picocli.CommandLine;
 
 @CommandLine.Command(name = "copy",
                      description = "Copies all Camel dependencies required to run to a specific directory", sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel dependency copy --output-directory=lib/" })
 public class DependencyCopy extends DependencyList {
 
     private static final Set<String> EXCLUDED_GROUP_IDS = Set.of("org.fusesource.jansi", "org.apache.logging.log4j");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyRuntime.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyRuntime.java
@@ -32,7 +32,10 @@ import org.apache.maven.model.Repository;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "runtime", description = "Display Camel runtime and version for given Maven project",
-                     sortOptions = false, showDefaultValues = true)
+                     sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel dependency runtime" })
 public class DependencyRuntime extends CamelCommand {
 
     @CommandLine.Parameters(description = "The pom.xml to analyze", arity = "1", paramLabel = "<pom.xml>")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyUpdate.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyUpdate.java
@@ -42,7 +42,10 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "update",
                      description = "Updates dependencies in Maven pom.xml or Java source files (JBang style)",
                      sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel dependency update" })
 public class DependencyUpdate extends DependencyList {
 
     @CommandLine.Parameters(description = "Maven pom.xml or Java source files (JBang Style with //DEPS) to have dependencies updated."

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Doctor.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Doctor.java
@@ -31,7 +31,10 @@ import org.apache.camel.util.StringHelper;
 import picocli.CommandLine.Command;
 
 @Command(name = "doctor", description = "Checks the environment and reports potential issues",
-         sortOptions = false, showDefaultValues = true)
+         sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel doctor" })
 public class Doctor extends CamelCommand {
 
     public Doctor(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/TransformDataWeave.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/TransformDataWeave.java
@@ -29,7 +29,10 @@ import picocli.CommandLine.Command;
 
 @Command(name = "dataweave",
          description = "Convert DataWeave scripts to DataSonnet format",
-         sortOptions = false, showDefaultValues = true)
+         sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel transform dataweave --input=script.dwl --output=script.ds" })
 public class TransformDataWeave extends CamelCommand {
 
     @CommandLine.Option(names = { "--input", "-i" },

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelBeanDump.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelBeanDump.java
@@ -35,7 +35,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "bean", description = "List beans in a running Camel integration", sortOptions = false,
-         showDefaultValues = true)
+         showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel cmd bean",
+                 "  camel cmd bean --filter=myBean" })
 public class CamelBeanDump extends ActionBaseCommand {
 
     public static class NameTypeCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelBrowseAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelBrowseAction.java
@@ -39,7 +39,11 @@ import org.fusesource.jansi.Ansi;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "browse",
-                     description = "Browse pending messages on endpoints", sortOptions = false, showDefaultValues = true)
+                     description = "Browse pending messages on endpoints", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd browse --endpoint=seda:foo",
+                             "  camel cmd browse --endpoint=seda:foo --limit=10" })
 public class CamelBrowseAction extends ActionBaseCommand {
 
     public static class UriSizeCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelGCAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelGCAction.java
@@ -25,7 +25,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "gc",
-                     description = "Trigger Java Memory Garbage Collector", sortOptions = false, showDefaultValues = true)
+                     description = "Trigger Java Memory Garbage Collector", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd gc" })
 public class CamelGCAction extends ActionBaseCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration. (default selects all)", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelLoadAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelLoadAction.java
@@ -32,7 +32,10 @@ import picocli.CommandLine;
 
 @CommandLine.Command(name = "load",
                      description = "Loads new source files into an existing Camel", sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd load --source=myRoute.yaml" })
 public class CamelLoadAction extends ActionBaseCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelProcessorDisableAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelProcessorDisableAction.java
@@ -21,7 +21,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "disable-processor",
-                     description = "Disable Camel processor", sortOptions = false, showDefaultValues = true)
+                     description = "Disable Camel processor", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd disable-processor myId" })
 public class CamelProcessorDisableAction extends CamelProcessorAction {
 
     public CamelProcessorDisableAction(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelProcessorEnableAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelProcessorEnableAction.java
@@ -21,7 +21,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "enable-processor",
-                     description = "Enable Camel processor", sortOptions = false, showDefaultValues = true)
+                     description = "Enable Camel processor", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd enable-processor myId" })
 public class CamelProcessorEnableAction extends CamelProcessorAction {
 
     public CamelProcessorEnableAction(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelReceiveAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelReceiveAction.java
@@ -66,7 +66,11 @@ import static org.apache.camel.dsl.jbang.core.common.CamelCommandHelper.valueAsS
 
 @CommandLine.Command(name = "receive",
                      description = "Receive and dump messages from remote endpoints", sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd receive --endpoint=seda:foo",
+                             "  camel cmd receive --endpoint=seda:foo --timeout=30000" })
 public class CamelReceiveAction extends ActionBaseCommand {
 
     private static final int NAME_MAX_WIDTH = 25;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelReloadAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelReloadAction.java
@@ -25,7 +25,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "reload",
-                     description = "Trigger reloading Camel", sortOptions = false, showDefaultValues = true)
+                     description = "Trigger reloading Camel", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd reload" })
 public class CamelReloadAction extends ActionBaseCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration. (default selects all)", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelResetStatsAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelResetStatsAction.java
@@ -25,7 +25,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "reset-stats",
-                     description = "Reset performance statistics", sortOptions = false, showDefaultValues = true)
+                     description = "Reset performance statistics", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd reset-stats" })
 public class CamelResetStatsAction extends ActionBaseCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration. (default selects all)", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteDumpAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteDumpAction.java
@@ -36,7 +36,11 @@ import picocli.CommandLine.Command;
 import static org.apache.camel.support.LoggerHelper.stripSourceLocationLineNumber;
 
 @Command(name = "route-dump", description = "Dump Camel route in XML or YAML format", sortOptions = false,
-         showDefaultValues = true)
+         showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel cmd route-dump",
+                 "  camel cmd route-dump --format=yaml" })
 public class CamelRouteDumpAction extends ActionBaseCommand {
 
     public static class NameIdCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteGroupStartAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteGroupStartAction.java
@@ -21,7 +21,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "start-group",
-                     description = "Start Camel route groups", sortOptions = false, showDefaultValues = true)
+                     description = "Start Camel route groups", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd start-group myGroup" })
 public class CamelRouteGroupStartAction extends CamelRouteAction {
 
     public CamelRouteGroupStartAction(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteGroupStopAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteGroupStopAction.java
@@ -21,7 +21,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "stop-group",
-                     description = "Stop Camel route groups", sortOptions = false, showDefaultValues = true)
+                     description = "Stop Camel route groups", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd stop-group myGroup" })
 public class CamelRouteGroupStopAction extends CamelRouteAction {
 
     public CamelRouteGroupStopAction(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteResumeAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteResumeAction.java
@@ -21,7 +21,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "resume-route",
-                     description = "Resume Camel routes", sortOptions = false, showDefaultValues = true)
+                     description = "Resume Camel routes", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd resume-route myRoute" })
 public class CamelRouteResumeAction extends CamelRouteAction {
 
     public CamelRouteResumeAction(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteStartAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteStartAction.java
@@ -21,7 +21,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "start-route",
-                     description = "Start Camel routes", sortOptions = false, showDefaultValues = true)
+                     description = "Start Camel routes", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd start-route myRoute" })
 public class CamelRouteStartAction extends CamelRouteAction {
 
     public CamelRouteStartAction(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteStopAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteStopAction.java
@@ -21,7 +21,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "stop-route",
-                     description = "Stop Camel routes", sortOptions = false, showDefaultValues = true)
+                     description = "Stop Camel routes", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd stop-route myRoute" })
 public class CamelRouteStopAction extends CamelRouteAction {
 
     public CamelRouteStopAction(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteStructureAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteStructureAction.java
@@ -42,7 +42,11 @@ import picocli.CommandLine.Command;
 import static org.apache.camel.support.LoggerHelper.stripSourceLocationLineNumber;
 
 @Command(name = "route-structure", description = "Dump Camel route structure", sortOptions = false,
-         showDefaultValues = true)
+         showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel cmd route-structure",
+                 "  camel cmd route-structure --filter=myRoute" })
 public class CamelRouteStructureAction extends ActionBaseCommand {
 
     public static class NameIdCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteSuspendAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteSuspendAction.java
@@ -21,7 +21,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "suspend-route",
-                     description = "Suspend Camel routes", sortOptions = false, showDefaultValues = true)
+                     description = "Suspend Camel routes", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd suspend-route myRoute" })
 public class CamelRouteSuspendAction extends CamelRouteAction {
 
     public CamelRouteSuspendAction(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSourceAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSourceAction.java
@@ -33,7 +33,11 @@ import picocli.CommandLine.Command;
 
 import static org.apache.camel.support.LoggerHelper.stripSourceLocationLineNumber;
 
-@Command(name = "source", description = "Display Camel route source code", sortOptions = false, showDefaultValues = true)
+@Command(name = "source", description = "Display Camel route source code", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel cmd source",
+                 "  camel cmd source --filter=myRoute" })
 public class CamelSourceAction extends ActionBaseCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSourceTop.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSourceTop.java
@@ -31,7 +31,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "source", description = "List top processors (source) in a running Camel integration", sortOptions = false,
-         showDefaultValues = true)
+         showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel top source",
+                 "  camel top source --limit=5" })
 public class CamelSourceTop extends ActionWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelStartupRecorderAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelStartupRecorderAction.java
@@ -36,7 +36,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "startup-recorder",
-                     description = "Display startup recording", sortOptions = false, showDefaultValues = true)
+                     description = "Display startup recording", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd startup-recorder" })
 public class CamelStartupRecorderAction extends ActionWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelStubAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelStubAction.java
@@ -40,7 +40,11 @@ import org.fusesource.jansi.Ansi;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-@Command(name = "stub", description = "Browse stub endpoints", sortOptions = false, showDefaultValues = true)
+@Command(name = "stub", description = "Browse stub endpoints", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel cmd stub",
+                 "  camel cmd stub --browse" })
 public class CamelStubAction extends ActionWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelThreadDump.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelThreadDump.java
@@ -38,7 +38,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "thread-dump", description = "List threads in a running Camel integration", sortOptions = false,
-         showDefaultValues = true)
+         showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel cmd thread-dump",
+                 "  camel cmd thread-dump --trace" })
 public class CamelThreadDump extends ActionWatchCommand {
 
     public static class IdNameStateCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/EvalExpressionCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/EvalExpressionCommand.java
@@ -37,7 +37,10 @@ import picocli.CommandLine;
 
 @CommandLine.Command(name = "expression",
                      description = "Evaluates Camel expression", sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd expression --language=simple --exp='${body}'" })
 public class EvalExpressionCommand extends ActionWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/LoggerAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/LoggerAction.java
@@ -37,7 +37,11 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "logger",
-                     description = "List or change logging levels", sortOptions = false, showDefaultValues = true)
+                     description = "List or change logging levels", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd logger",
+                             "  camel cmd logger --logging-level=DEBUG --logger=org.apache.camel" })
 public class LoggerAction extends ActionBaseCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/RouteControllerAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/RouteControllerAction.java
@@ -39,7 +39,10 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "route-controller", description = "List status of route controller",
-         sortOptions = false, showDefaultValues = true)
+         sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel cmd route-controller" })
 public class RouteControllerAction extends ActionWatchCommand {
 
     public static class IdStateCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/TransformMessageAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/TransformMessageAction.java
@@ -40,7 +40,10 @@ import picocli.CommandLine;
 
 @CommandLine.Command(name = "message",
                      description = "Transform message from one format to another via an existing running Camel integration",
-                     sortOptions = false, showDefaultValues = true)
+                     sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel cmd message --body='Hello World'" })
 public class TransformMessageAction extends ActionWatchCommand {
 
     @CommandLine.Option(names = { "--camel-version" },

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogDataFormat.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogDataFormat.java
@@ -24,7 +24,11 @@ import org.apache.camel.tooling.model.DataFormatModel;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "dataformat",
-                     description = "List data formats from the Camel Catalog", sortOptions = false, showDefaultValues = true)
+                     description = "List data formats from the Camel Catalog", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel catalog dataformat",
+                             "  camel catalog dataformat --filter=json" })
 public class CatalogDataFormat extends CatalogBaseCommand {
 
     public CatalogDataFormat(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogDevConsole.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogDevConsole.java
@@ -24,7 +24,10 @@ import org.apache.camel.tooling.model.DevConsoleModel;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "dev-console",
-                     description = "List dev-consoles from the Camel Catalog", sortOptions = false, showDefaultValues = true)
+                     description = "List dev-consoles from the Camel Catalog", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel catalog dev-console" })
 public class CatalogDevConsole extends CatalogBaseCommand {
 
     public CatalogDevConsole(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogLanguage.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogLanguage.java
@@ -25,7 +25,11 @@ import picocli.CommandLine;
 
 @CommandLine.Command(name = "language",
                      description = "List expression languages from the Camel Catalog", sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel catalog language",
+                             "  camel catalog language --filter=simple" })
 public class CatalogLanguage extends CatalogBaseCommand {
 
     public CatalogLanguage(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogOther.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogOther.java
@@ -25,7 +25,10 @@ import picocli.CommandLine;
 
 @CommandLine.Command(name = "other",
                      description = "List miscellaneous components from the Camel Catalog", sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel catalog other" })
 public class CatalogOther extends CatalogBaseCommand {
 
     public CatalogOther(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogTransformer.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogTransformer.java
@@ -25,7 +25,10 @@ import picocli.CommandLine;
 
 @CommandLine.Command(name = "transformer",
                      description = "List data type transformers from the Camel Catalog", sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel catalog transformer" })
 public class CatalogTransformer extends CatalogBaseCommand {
 
     public CatalogTransformer(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigList.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigList.java
@@ -21,7 +21,11 @@ import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "list", description = "Displays user configuration", sortOptions = false, showDefaultValues = true)
+@CommandLine.Command(name = "list", description = "Displays user configuration", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel config list",
+                             "  camel config list --global" })
 public class ConfigList extends CamelCommand {
 
     @CommandLine.Option(names = { "--global" }, description = "Use global or local configuration")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnset.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/config/ConfigUnset.java
@@ -22,7 +22,10 @@ import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "unset",
-                     description = "Remove user configuration value", sortOptions = false, showDefaultValues = true)
+                     description = "Remove user configuration value", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel config unset myKey" })
 public class ConfigUnset extends CamelCommand {
 
     @CommandLine.Parameters(description = "Configuration key", arity = "1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraGet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraGet.java
@@ -24,7 +24,10 @@ import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "get", description = "Displays running service(s) information", sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel infra get kafka" })
 public class InfraGet extends InfraBaseCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running service(s)", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraList.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraList.java
@@ -20,7 +20,10 @@ import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "list", description = "Displays available external services", sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel infra list" })
 public class InfraList extends InfraBaseCommand {
 
     public InfraList(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraLog.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraLog.java
@@ -35,7 +35,10 @@ import org.apache.commons.io.input.TailerListener;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "log", description = "Displays external service logs", sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel infra log kafka" })
 public class InfraLog extends InfraBaseCommand {
 
     @CommandLine.Parameters(description = "Service name", arity = "0..2")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraPs.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraPs.java
@@ -29,7 +29,10 @@ import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "ps", description = "Displays running services", sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel infra ps" })
 public class InfraPs extends InfraBaseCommand {
 
     @CommandLine.Parameters(description = "Service name", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraRun.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraRun.java
@@ -41,7 +41,11 @@ import picocli.CommandLine;
 
 import static org.apache.camel.dsl.jbang.core.commands.RunHelper.addCamelCLICommand;
 
-@CommandLine.Command(name = "run", description = "Run an external service", sortOptions = false, showDefaultValues = true)
+@CommandLine.Command(name = "run", description = "Run an external service", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel infra run kafka",
+                             "  camel infra run kafka --background" })
 public class InfraRun extends InfraBaseCommand {
 
     @CommandLine.Spec

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraStop.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraStop.java
@@ -25,7 +25,10 @@ import org.apache.camel.dsl.jbang.core.common.PathUtils;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "stop",
-                     description = "Shuts down running external services", sortOptions = false, showDefaultValues = true)
+                     description = "Shuts down running external services", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel infra stop kafka" })
 public class InfraStop extends InfraBaseCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running service(s)", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/plugin/PluginAdd.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/plugin/PluginAdd.java
@@ -27,7 +27,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "add",
-                     description = "Add new plugin", sortOptions = false, showDefaultValues = true)
+                     description = "Add new plugin", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel plugin add --command=my-cmd --gav=com.foo:bar:1.0" })
 public class PluginAdd extends PluginBaseCommand {
 
     @CommandLine.Parameters(description = "The Camel plugin to add",

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/plugin/PluginDelete.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/plugin/PluginDelete.java
@@ -21,7 +21,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "delete",
-                     description = "Removes a plugin", sortOptions = false, showDefaultValues = true)
+                     description = "Removes a plugin", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel plugin delete my-cmd" })
 public class PluginDelete extends PluginBaseCommand {
 
     @CommandLine.Parameters(description = "The Camel plugin to remove",

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/plugin/PluginGet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/plugin/PluginGet.java
@@ -31,7 +31,11 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "get",
-                     description = "Get installed plugins", sortOptions = false, showDefaultValues = true)
+                     description = "Get installed plugins", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel plugin get",
+                             "  camel plugin get --all" })
 public class PluginGet extends PluginBaseCommand {
 
     @Deprecated

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/plugin/PluginList.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/plugin/PluginList.java
@@ -26,7 +26,10 @@ import org.apache.camel.util.json.JsonObject;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "list",
-                     description = "List all available plugins", sortOptions = false, showDefaultValues = true)
+                     description = "List all available plugins", sortOptions = false, showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel plugin list" })
 public class PluginList extends PluginGet {
 
     public PluginList(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelContextStatus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelContextStatus.java
@@ -42,7 +42,12 @@ import static org.apache.camel.dsl.jbang.core.common.CamelCommandHelper.extractS
 
 @Command(name = "context",
          description = "Get status of Camel integrations",
-         sortOptions = false, showDefaultValues = true)
+         sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get context",
+                 "  camel get context myApp",
+                 "  camel get context --watch" })
 public class CamelContextStatus extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelContextTop.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelContextTop.java
@@ -40,7 +40,11 @@ import static org.apache.camel.dsl.jbang.core.common.CamelCommandHelper.extractS
 
 @Command(name = "context",
          description = "Top status of Camel integrations",
-         sortOptions = false, showDefaultValues = true)
+         sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel top context",
+                 "  camel top context --watch" })
 public class CamelContextTop extends ProcessWatchCommand {
 
     public static class PidNameMemAgeCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelCount.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelCount.java
@@ -37,7 +37,11 @@ import picocli.CommandLine.Command;
 
 @Command(name = "count",
          description = "Get total and failed exchanges",
-         sortOptions = false, showDefaultValues = true)
+         sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get count",
+                 "  camel get count --watch" })
 public class CamelCount extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelProcessorStatus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelProcessorStatus.java
@@ -41,7 +41,12 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "processor", description = "Get status of Camel processors",
-         sortOptions = false, showDefaultValues = true)
+         sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get processor",
+                 "  camel get processor --source",
+                 "  camel get processor --watch" })
 public class CamelProcessorStatus extends ProcessWatchCommand {
 
     public static class PidNameCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelProcessorTop.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelProcessorTop.java
@@ -20,7 +20,11 @@ import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import picocli.CommandLine.Command;
 
 @Command(name = "processor", description = "Top performing processors",
-         sortOptions = false, showDefaultValues = true)
+         sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel top processor",
+                 "  camel top processor --watch" })
 public class CamelProcessorTop extends CamelProcessorStatus {
 
     public CamelProcessorTop(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelRouteGroupStatus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelRouteGroupStatus.java
@@ -38,7 +38,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "route-group", description = "Get status of Camel route groups",
-         sortOptions = false, showDefaultValues = true)
+         sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get route-group",
+                 "  camel get route-group --watch" })
 public class CamelRouteGroupStatus extends ProcessWatchCommand {
 
     public static class PidNameAgeGroupCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelRouteGroupTop.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelRouteGroupTop.java
@@ -27,7 +27,11 @@ import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import picocli.CommandLine.Command;
 
 @Command(name = "group", description = "Top performing route groups",
-         sortOptions = false, showDefaultValues = true)
+         sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel top group",
+                 "  camel top group --watch" })
 public class CamelRouteGroupTop extends CamelRouteGroupStatus {
 
     public CamelRouteGroupTop(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelRouteTop.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/CamelRouteTop.java
@@ -28,7 +28,11 @@ import org.apache.camel.dsl.jbang.core.common.TerminalWidthHelper;
 import picocli.CommandLine.Command;
 
 @Command(name = "route", description = "Top performing routes",
-         sortOptions = false, showDefaultValues = true)
+         sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel top route",
+                 "  camel top route --watch" })
 public class CamelRouteTop extends CamelRouteStatus {
 
     public CamelRouteTop(CamelJBangMain main) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/Dirty.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/Dirty.java
@@ -27,7 +27,11 @@ import picocli.CommandLine;
 import static org.apache.camel.dsl.jbang.core.common.CommandLineHelper.getCamelDir;
 
 @CommandLine.Command(name = "dirty",
-                     description = "Check if there are dirty files from previous Camel runs that did not terminate gracefully")
+                     description = "Check if there are dirty files from previous Camel runs that did not terminate gracefully",
+                     footer = {
+                             "%nExamples:",
+                             "  camel dirty",
+                             "  camel dirty --clean" })
 public class Dirty extends ProcessBaseCommand {
 
     @CommandLine.Option(names = { "--clean" }, defaultValue = "false",

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/Hawtio.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/Hawtio.java
@@ -31,7 +31,11 @@ import org.apache.camel.tooling.maven.MavenArtifact;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-@Command(name = "hawtio", description = "Launch Hawtio web console", sortOptions = false, showDefaultValues = true)
+@Command(name = "hawtio", description = "Launch Hawtio web console", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel hawtio",
+                 "  camel hawtio --port=8090" })
 public class Hawtio extends CamelCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/Jolokia.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/Jolokia.java
@@ -35,7 +35,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "jolokia", description = "Attach Jolokia JVM Agent to a running Camel integration", sortOptions = false,
-         showDefaultValues = true)
+         showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel jolokia myApp",
+                 "  camel jolokia myApp --stop" })
 public class Jolokia extends ProcessBaseCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListBlocked.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListBlocked.java
@@ -36,7 +36,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "blocked",
-         description = "Get blocked messages of Camel integrations", sortOptions = false, showDefaultValues = true)
+         description = "Get blocked messages of Camel integrations", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get blocked",
+                 "  camel get blocked --watch" })
 public class ListBlocked extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListCircuitBreaker.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListCircuitBreaker.java
@@ -36,7 +36,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "circuit-breaker",
-         description = "Get status of Circuit Breaker EIPs", sortOptions = false, showDefaultValues = true)
+         description = "Get status of Circuit Breaker EIPs", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get circuit-breaker",
+                 "  camel get circuit-breaker --watch" })
 public class ListCircuitBreaker extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListConsumer.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListConsumer.java
@@ -38,7 +38,12 @@ import org.apache.camel.util.json.Jsoner;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-@Command(name = "consumer", description = "Get status of Camel consumers", sortOptions = false, showDefaultValues = true)
+@Command(name = "consumer", description = "Get status of Camel consumers", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get consumer",
+                 "  camel get consumer --scheduled",
+                 "  camel get consumer --watch" })
 public class ListConsumer extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListEndpoint.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListEndpoint.java
@@ -38,7 +38,12 @@ import org.apache.camel.util.json.Jsoner;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-@Command(name = "endpoint", description = "Get usage of Camel endpoints", sortOptions = false, showDefaultValues = true)
+@Command(name = "endpoint", description = "Get usage of Camel endpoints", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get endpoint",
+                 "  camel get endpoint --filter=kafka*",
+                 "  camel get endpoint --watch" })
 public class ListEndpoint extends ProcessWatchCommand {
 
     public static class PidNameAgeTotalCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListEvent.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListEvent.java
@@ -36,7 +36,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "event",
-         description = "Get latest events of Camel integrations", sortOptions = false, showDefaultValues = true)
+         description = "Get latest events of Camel integrations", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get event",
+                 "  camel get event --watch" })
 public class ListEvent extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListGroovy.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListGroovy.java
@@ -36,7 +36,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "groovy", description = "Groovy Sources used of Camel integrations", sortOptions = false,
-         showDefaultValues = true)
+         showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get groovy",
+                 "  camel get groovy --watch" })
 public class ListGroovy extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListInflight.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListInflight.java
@@ -37,7 +37,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "inflight",
-         description = "Get inflight messages of Camel integrations", sortOptions = false, showDefaultValues = true)
+         description = "Get inflight messages of Camel integrations", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get inflight",
+                 "  camel get inflight --watch" })
 public class ListInflight extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListInternalTask.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListInternalTask.java
@@ -37,7 +37,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "internal-tasks",
-         description = "List internal tasks of Camel integrations", sortOptions = false, showDefaultValues = true)
+         description = "List internal tasks of Camel integrations", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get internal-tasks",
+                 "  camel get internal-tasks --watch" })
 public class ListInternalTask extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListKafka.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListKafka.java
@@ -43,7 +43,12 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "kafka",
-         description = "List Kafka consumers of Camel integrations", sortOptions = false, showDefaultValues = true)
+         description = "List Kafka consumers of Camel integrations", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get kafka",
+                 "  camel get kafka --committed",
+                 "  camel get kafka --watch" })
 public class ListKafka extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListMetric.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListMetric.java
@@ -38,7 +38,12 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "metric",
-         description = "Get metrics (micrometer) of running Camel integrations", sortOptions = false, showDefaultValues = true)
+         description = "Get metrics (micrometer) of running Camel integrations", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get metric",
+                 "  camel get metric --filter=timer*",
+                 "  camel get metric --watch" })
 public class ListMetric extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration",

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListPlatformHttp.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListPlatformHttp.java
@@ -37,7 +37,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "platform-http",
-         description = "Get embedded HTTP services of Camel integrations", sortOptions = false, showDefaultValues = true)
+         description = "Get embedded HTTP services of Camel integrations", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get platform-http",
+                 "  camel get platform-http --all" })
 public class ListPlatformHttp extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListProducer.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListProducer.java
@@ -37,7 +37,11 @@ import org.apache.camel.util.json.Jsoner;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-@Command(name = "producer", description = "Get status of Camel producers", sortOptions = false, showDefaultValues = true)
+@Command(name = "producer", description = "Get status of Camel producers", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get producer",
+                 "  camel get producer --watch" })
 public class ListProducer extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListProperties.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListProperties.java
@@ -37,7 +37,11 @@ import org.apache.camel.util.json.Jsoner;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-@Command(name = "properties", description = "List configuration properties", sortOptions = false, showDefaultValues = true)
+@Command(name = "properties", description = "List configuration properties", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get properties",
+                 "  camel get properties --verbose" })
 public class ListProperties extends ProcessWatchCommand {
 
     public static class PidNameKeyCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListRest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListRest.java
@@ -39,7 +39,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "rest",
-         description = "Get REST services of Camel integrations", sortOptions = false, showDefaultValues = true)
+         description = "Get REST services of Camel integrations", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get rest",
+                 "  camel get rest --verbose" })
 public class ListRest extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListService.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListService.java
@@ -38,7 +38,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "service",
-         description = "Get services of Camel integrations", sortOptions = false, showDefaultValues = true)
+         description = "Get services of Camel integrations", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get service",
+                 "  camel get service --metadata" })
 public class ListService extends ProcessWatchCommand {
 
     @CommandLine.Parameters(description = "Name or pid of running Camel integration", arity = "0..1")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListTransformer.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListTransformer.java
@@ -36,7 +36,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "transformer", description = "Get list of data type transformers", sortOptions = false,
-         showDefaultValues = true)
+         showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get transformer",
+                 "  camel get transformer --watch" })
 public class ListTransformer extends ProcessBaseCommand {
 
     public static class PidNameAgeTotalCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListVariable.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListVariable.java
@@ -35,7 +35,11 @@ import org.apache.camel.util.json.Jsoner;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-@Command(name = "variable", description = "List variables of Camel integrations", sortOptions = false, showDefaultValues = true)
+@Command(name = "variable", description = "List variables of Camel integrations", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get variable",
+                 "  camel get variable --watch" })
 public class ListVariable extends ProcessWatchCommand {
 
     public static class PidNameKeyCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListVault.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListVault.java
@@ -37,7 +37,10 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "vault",
-         description = "List secrets from security vaults", sortOptions = false, showDefaultValues = true)
+         description = "List secrets from security vaults", sortOptions = false, showDefaultValues = true,
+         footer = {
+                 "%nExamples:",
+                 "  camel get vault" })
 public class ListVault extends ProcessWatchCommand {
 
     public static class PidNameCompletionCandidates implements Iterable<String> {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/update/UpdateList.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/update/UpdateList.java
@@ -84,7 +84,10 @@ import picocli.CommandLine;
  * @see org.apache.camel.dsl.jbang.core.commands.CamelJBangMain
  */
 @CommandLine.Command(name = "list",
-                     description = "List available update versions for Camel and its runtime variants")
+                     description = "List available update versions for Camel and its runtime variants",
+                     footer = {
+                             "%nExamples:",
+                             "  camel update list" })
 public class UpdateList extends CamelCommand {
 
     @CommandLine.Option(names = { "--repo", "--repos" },

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/update/UpdateRun.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/update/UpdateRun.java
@@ -38,7 +38,10 @@ import picocli.CommandLine;
  * runtimes such as Camel Main, Spring Boot, and Quarkus. It uses Maven and OpenRewrite to apply the necessary updates.
  */
 @CommandLine.Command(name = "run",
-                     description = "Update Camel project")
+                     description = "Update Camel project",
+                     footer = {
+                             "%nExamples:",
+                             "  camel update run" })
 public class UpdateRun extends CamelCommand {
 
     @CommandLine.Mixin

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionGet.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionGet.java
@@ -25,7 +25,10 @@ import org.apache.camel.dsl.jbang.core.common.VersionHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "get", description = "Displays current Camel version", sortOptions = false,
-                     showDefaultValues = true)
+                     showDefaultValues = true,
+                     footer = {
+                             "%nExamples:",
+                             "  camel version get" })
 public class VersionGet extends CamelCommand {
 
     @CommandLine.Option(names = { "--global" }, description = "Use global or local configuration")


### PR DESCRIPTION
## Summary

- Adds picocli `footer` with usage examples to 80 camel-jbang CLI commands that were missing them
- Commands across all groups now show examples when running `--help`: `camel get`, `camel top`, `camel cmd`, `camel catalog`, `camel config`, `camel dependency`, `camel plugin`, `camel infra`, `camel version`, `camel update`, and standalone commands (`hawtio`, `jolokia`, `dirty`, `doctor`)
- Follows the existing pattern used by commands like `camel ps`, `camel get route`, `camel trace`

## Test plan

- [ ] Verify `camel get context --help` shows usage examples in footer
- [ ] Verify `camel cmd start-route --help` shows usage examples in footer
- [ ] Verify `camel catalog component --help` still shows its existing footer (no regression)
- [ ] Build passes

_Claude Code on behalf of Claus Ibsen_