### PR TITLE
CAMEL-23633: TUI auto-reselect integration after restart

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -423,6 +423,7 @@ public class CamelMonitor extends CamelCommand {
                 }
                 if (ctx.selectedPid != null) {
                     ctx.selectedPid = null;
+                    ctx.lastSelectedName = null;
                     return true;
                 }
                 return true;
@@ -792,6 +793,7 @@ public class CamelMonitor extends CamelCommand {
         }
         if (newPid != null && !newPid.equals(ctx.selectedPid)) {
             ctx.selectedPid = newPid;
+            ctx.lastSelectedName = null;
             resetIntegrationTabState();
         }
     }
@@ -805,6 +807,7 @@ public class CamelMonitor extends CamelCommand {
         }
         if (newPid != null && !newPid.equals(ctx.selectedPid)) {
             ctx.selectedPid = newPid;
+            ctx.lastSelectedName = null;
             resetIntegrationTabState();
         }
     }
@@ -1953,6 +1956,13 @@ public class CamelMonitor extends CamelCommand {
                 boolean stillAlive = infos.stream()
                         .anyMatch(i -> ctx.selectedPid.equals(i.pid) && !i.vanishing);
                 if (!stillAlive) {
+                    // Remember the name for auto-reselect when the integration restarts
+                    IntegrationInfo gone = infos.stream()
+                            .filter(i -> ctx.selectedPid.equals(i.pid))
+                            .findFirst().orElse(null);
+                    if (gone != null) {
+                        ctx.lastSelectedName = gone.name;
+                    }
                     ctx.selectedPid = null;
                 }
             }
@@ -1964,7 +1974,19 @@ public class CamelMonitor extends CamelCommand {
                     if (!info.vanishing && autoSelect.equalsIgnoreCase(info.name)) {
                         ctx.selectedPid = info.pid;
                         ctx.infraTableFocused = false;
+                        ctx.lastSelectedName = null;
                         actionsPopup.clearPendingAutoSelect();
+                        break;
+                    }
+                }
+            }
+
+            // Auto-reselect by remembered name when the integration restarts
+            if (ctx.selectedPid == null && ctx.lastSelectedName != null && !ctx.infraTableFocused) {
+                for (IntegrationInfo info : infos) {
+                    if (!info.vanishing && ctx.lastSelectedName.equalsIgnoreCase(info.name)) {
+                        ctx.selectedPid = info.pid;
+                        ctx.lastSelectedName = null;
                         break;
                     }
                 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorContext.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorContext.java
@@ -49,6 +49,7 @@ class MonitorContext {
     TuiRunner runner;
 
     String selectedPid;
+    String lastSelectedName;
     boolean infraTableFocused;
 
     MonitorContext(


### PR DESCRIPTION
## Summary

When a user selects an integration in the TUI, stops it, and starts it again, the selection is lost because the PID changes. The user has to manually re-select it every time.

This adds auto-reselect: when a selected integration disappears, its name is remembered. When a process with the same name reappears and nothing else has been explicitly selected, the TUI automatically reselects it. This lets users stay on detail tabs (Routes, HTTP, etc.) while restarting their integrations.

The remembered name is cleared on:
- Explicit deselection (Escape key)
- Manual selection of a different integration

_Claude Code on behalf of Claus Ibsen_

## Test plan

- Start TUI, run an integration, select it, switch to a detail tab
- Stop the integration — selection clears
- Start the same integration again — should auto-reselect
- Press Escape to deselect, then restart — should NOT auto-reselect
- Select integration A, then manually select integration B — `lastSelectedName` clears, no stale reselect