### PR TITLE
CAMEL-23592: camel-itest - update ShiroOverJmsTest for renamed Shiro security headers

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -910,6 +910,44 @@ work without changes. Routes that set the header by its literal string value
 (for example `setHeader("SHIRO_SECURITY_USERNAME", ...)`) must be updated to
 use the new value (`setHeader("CamelShiroSecurityUsername", ...)`).
 
+Because the three header values are now in the `Camel*` namespace, transports
+that filter Camel-internal headers by default (JMS, CXF, HTTP, etc.) will
+strip the serialized Shiro authentication token before publishing. This is
+the intended behavior for untrusted producers. Trusted Shiro-over-transport
+routes that previously relied on the token surviving the boundary must opt
+those three headers back in via a custom `HeaderFilterStrategy`, for example:
+
+[source,java]
+----
+public class ShiroFriendlyJmsHeaderFilterStrategy extends JmsHeaderFilterStrategy {
+    @Override
+    public boolean applyFilterToCamelHeaders(String name, Object value, Exchange ex) {
+        if (isShiroSecurityHeader(name)) {
+            return false;
+        }
+        return super.applyFilterToCamelHeaders(name, value, ex);
+    }
+
+    @Override
+    public boolean applyFilterToExternalHeaders(String name, Object value, Exchange ex) {
+        if (isShiroSecurityHeader(name)) {
+            return false;
+        }
+        return super.applyFilterToExternalHeaders(name, value, ex);
+    }
+
+    private static boolean isShiroSecurityHeader(String name) {
+        return ShiroSecurityConstants.SHIRO_SECURITY_TOKEN.equalsIgnoreCase(name)
+                || ShiroSecurityConstants.SHIRO_SECURITY_USERNAME.equalsIgnoreCase(name)
+                || ShiroSecurityConstants.SHIRO_SECURITY_PASSWORD.equalsIgnoreCase(name);
+    }
+}
+
+jmsComponent.setHeaderFilterStrategy(new ShiroFriendlyJmsHeaderFilterStrategy());
+----
+
+A worked example is in `ShiroOverJmsTest` in the `camel-itest` module.
+
 
 === camel-web3j - potential breaking change
 

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/shiro/ShiroOverJmsTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/shiro/ShiroOverJmsTest.java
@@ -19,8 +19,10 @@ package org.apache.camel.itest.shiro;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.JmsComponent;
+import org.apache.camel.component.jms.JmsHeaderFilterStrategy;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.shiro.security.ShiroSecurityConstants;
 import org.apache.camel.component.shiro.security.ShiroSecurityPolicy;
@@ -63,7 +65,40 @@ public class ShiroOverJmsTest extends CamelTestSupport {
 
         amq.setCamelContext(context);
 
+        // After CAMEL-23592 the Shiro security headers live in the CamelShiroSecurity* namespace,
+        // which the default JmsHeaderFilterStrategy filters at the transport boundary. For a
+        // trusted Shiro-over-JMS route, the operator must opt those three headers back in.
+        amq.setHeaderFilterStrategy(new ShiroFriendlyJmsHeaderFilterStrategy());
+
         registry.bind("jms", amq);
+    }
+
+    /**
+     * Allows the three Shiro security headers (token, username, password) to cross the JMS transport boundary while
+     * still filtering every other Camel-internal header.
+     */
+    private static final class ShiroFriendlyJmsHeaderFilterStrategy extends JmsHeaderFilterStrategy {
+        @Override
+        public boolean applyFilterToCamelHeaders(String headerName, Object headerValue, Exchange exchange) {
+            if (isShiroSecurityHeader(headerName)) {
+                return false;
+            }
+            return super.applyFilterToCamelHeaders(headerName, headerValue, exchange);
+        }
+
+        @Override
+        public boolean applyFilterToExternalHeaders(String headerName, Object headerValue, Exchange exchange) {
+            if (isShiroSecurityHeader(headerName)) {
+                return false;
+            }
+            return super.applyFilterToExternalHeaders(headerName, headerValue, exchange);
+        }
+
+        private static boolean isShiroSecurityHeader(String headerName) {
+            return ShiroSecurityConstants.SHIRO_SECURITY_TOKEN.equalsIgnoreCase(headerName)
+                    || ShiroSecurityConstants.SHIRO_SECURITY_USERNAME.equalsIgnoreCase(headerName)
+                    || ShiroSecurityConstants.SHIRO_SECURITY_PASSWORD.equalsIgnoreCase(headerName);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Motivation

CAMEL-23592 (#23506) renamed three `ShiroSecurityConstants` header **values** from
non-Camel-prefixed (`SHIRO_SECURITY_TOKEN`, `SHIRO_SECURITY_USERNAME`,
`SHIRO_SECURITY_PASSWORD`) into the canonical Camel prefix
(`CamelShiroSecurityToken` etc.). The intent — quoting the upgrade-guide entry — is
that "these headers carry credentials and a serialized authentication token, so
filtering them at transport boundaries by default is particularly important."

The default `JmsHeaderFilterStrategy` (and similarly for CXF/HTTP) filters every
`Camel*` header (case-insensitive) on both inbound and outbound. So with the rename,
a trusted Shiro-over-JMS route that was passing the serialized token through JMS
suddenly loses that token at the JMS producer, the consumer-side `ShiroSecurityPolicy`
sees no token, throws an authentication failure exception, and the message lands on
the dead-letter mock.

`ShiroOverJmsTest` in `camel-itest` is exactly this pattern and started failing on
the 4.18.x backport PR (#23552):

```
mock://ShiroOverJmsTestError Received message count. Expected: <0> but was: <1>
```

The same regression is **latent on main**: CAMEL-23592 merged earlier today
([commit aeb5fd9d](https://github.com/apache/camel/commit/aeb5fd9d)) and the post-merge
[main CI run](https://github.com/apache/camel/actions/runs/26499088355) reported
success, but its incremental-build only ran tests for `camel-shiro` itself — `camel-itest`
was built but its tests were not executed. Anyone running
`mvn -pl tests/camel-itest test -Dtest=ShiroOverJmsTest` on `main` will reproduce
the same failure.

## What this changes

This PR keeps the rename (the underlying security improvement) but updates the
integration test, and documents the new opt-in pattern users need to apply.

### `ShiroOverJmsTest`

Adds a small subclass of `JmsHeaderFilterStrategy` (private to the test) that opts
the three Shiro security headers back through the transport boundary while leaving
every other `Camel*`-prefixed filter rule untouched:

```java
private static final class ShiroFriendlyJmsHeaderFilterStrategy extends JmsHeaderFilterStrategy {
    @Override
    public boolean applyFilterToCamelHeaders(String headerName, Object headerValue, Exchange exchange) {
        if (isShiroSecurityHeader(headerName)) {
            return false; // allow through
        }
        return super.applyFilterToCamelHeaders(headerName, headerValue, exchange);
    }
    // applyFilterToExternalHeaders mirrors the same logic
    // isShiroSecurityHeader does a case-insensitive equals against the three constants
}
amq.setHeaderFilterStrategy(new ShiroFriendlyJmsHeaderFilterStrategy());
```

This demonstrates the exact configuration end-users need to keep Shiro-over-JMS
routes working post-CAMEL-23592.

### 4.21 upgrade guide

Extends the existing `=== camel-shiro - potential breaking change` entry with the
new HeaderFilterStrategy opt-in pattern and a worked code example. Points to
`ShiroOverJmsTest` as a worked example.

## Compatibility

- **Test only**: no production code change.
- **Doc only**: extends an existing upgrade-guide section, no schema/catalog
  regen needed.
- **No security regression**: the new pattern is opt-in and scoped to three
  specific named headers — the default filter still blocks every other `Camel*`
  header at the JMS boundary.

## Test plan

- [x] `mvn -pl tests/camel-itest test -Dtest=ShiroOverJmsTest` passes locally
      (was failing on the 4.18.x backport without this change).
- [x] Full reactor build from root succeeds: `mvn clean install -DskipTests`.
- [x] No regen artifacts touched (verified via `git status` post-build).

## Follow-on

Once merged on `main`, the same fix needs to be cherry-picked into the
in-flight backport PRs:

- [#23552](https://github.com/apache/camel/pull/23552) — backport of CAMEL-23592
  to `camel-4.18.x` (currently red on this exact test).
- A future backport to `camel-4.14.x` (when CAMEL-23592 is backported there).

## Related

- JIRA: https://issues.apache.org/jira/browse/CAMEL-23592
- Underlying rename PR (already merged): #23506
- 4.18.x backport (red on this test): #23552

---
_Claude Code on behalf of Andrea Cosentino_