### PR TITLE
CAMEL-23581: restore camel-elasticsearch / camel-opensearch section in 4_14 upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -515,6 +515,63 @@ A new accessor `web3jOperation()` is also generated for `Web3jConstants.OPERATIO
 previously, so no DSL accessor renaming applies to it.
 
 
+=== camel-elasticsearch / camel-opensearch - potential breaking change
+
+The Exchange header constants in `ElasticsearchConstants` and
+`OpensearchConstants` have been renamed to follow the Camel naming convention
+used across the rest of the component catalog. The Java field names are
+unchanged; only the header string values have changed.
+
+`ElasticsearchConstants`:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `ElasticsearchConstants.PARAM_OPERATION` | `operation` | `CamelElasticsearchOperation`
+| `ElasticsearchConstants.PARAM_INDEX_ID` | `indexId` | `CamelElasticsearchIndexId`
+| `ElasticsearchConstants.PARAM_INDEX_NAME` | `indexName` | `CamelElasticsearchIndexName`
+| `ElasticsearchConstants.PARAM_DOCUMENT_CLASS` | `documentClass` | `CamelElasticsearchDocumentClass`
+| `ElasticsearchConstants.PARAM_WAIT_FOR_ACTIVE_SHARDS` | `waitForActiveShards` | `CamelElasticsearchWaitForActiveShards`
+| `ElasticsearchConstants.PARAM_SCROLL_KEEP_ALIVE_MS` | `scrollKeepAliveMs` | `CamelElasticsearchScrollKeepAliveMs`
+| `ElasticsearchConstants.PARAM_SCROLL` | `useScroll` | `CamelElasticsearchUseScroll`
+| `ElasticsearchConstants.PARAM_SIZE` | `size` | `CamelElasticsearchSize`
+| `ElasticsearchConstants.PARAM_FROM` | `from` | `CamelElasticsearchFrom`
+| `ElasticsearchConstants.PARAM_DOCUMENT_MODE` | `enableDocumentOnlyMode` | `CamelElasticsearchEnableDocumentOnlyMode`
+|===
+
+`OpensearchConstants`:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `OpensearchConstants.PARAM_OPERATION` | `operation` | `CamelOpensearchOperation`
+| `OpensearchConstants.PARAM_INDEX_ID` | `indexId` | `CamelOpensearchIndexId`
+| `OpensearchConstants.PARAM_INDEX_NAME` | `indexName` | `CamelOpensearchIndexName`
+| `OpensearchConstants.PARAM_DOCUMENT_CLASS` | `documentClass` | `CamelOpensearchDocumentClass`
+| `OpensearchConstants.PARAM_WAIT_FOR_ACTIVE_SHARDS` | `waitForActiveShards` | `CamelOpensearchWaitForActiveShards`
+| `OpensearchConstants.PARAM_SCROLL_KEEP_ALIVE_MS` | `scrollKeepAliveMs` | `CamelOpensearchScrollKeepAliveMs`
+| `OpensearchConstants.PARAM_SCROLL` | `useScroll` | `CamelOpensearchUseScroll`
+| `OpensearchConstants.PARAM_SIZE` | `size` | `CamelOpensearchSize`
+| `OpensearchConstants.PARAM_FROM` | `from` | `CamelOpensearchFrom`
+|===
+
+`ElasticsearchConstants.PROPERTY_SCROLL_ES_QUERY_COUNT` and
+`OpensearchConstants.PROPERTY_SCROLL_OPENSEARCH_QUERY_COUNT` were already
+`Camel`-prefixed (`CamelElasticsearchScrollQueryCount` /
+`CamelOpenSearchScrollQueryCount`) and are unchanged.
+
+Routes that reference the constants symbolically (for example
+`setHeader(ElasticsearchConstants.PARAM_INDEX_NAME, ...)`) continue to work
+without changes. Routes that set the header by its literal string value
+(for example `setHeader("indexName", ...)`) must be updated to use the
+new value (`setHeader("CamelElasticsearchIndexName", ...)`).
+
+The generated Endpoint DSL header accessors on
+`ElasticsearchHeaderNameBuilder` and `OpensearchHeaderNameBuilder` have
+been renamed accordingly (`operation()` -> `elasticsearchOperation()` /
+`opensearchOperation()`, `indexId()` -> `elasticsearchIndexId()` /
+`opensearchIndexId()`, etc.).
+
 === camel-google-functions / camel-google-secret-manager - potential breaking change
 
 The Exchange header constants in these Google Cloud components carried a


### PR DESCRIPTION
## Motivation

The 4.14.x backport of CAMEL-23581 (camel-elasticsearch + camel-opensearch header constant rename, PR #23571, merge commit 468e421bf37) landed without the corresponding upgrade-guide section.

Root cause: the cascade-rebase helper used to resolve the shared upgrade-guide anchor across all in-flight 4.14 backports extracted the prior section by heading, and the helper's heading literal used ` + ` as the component separator while the actual heading uses ` / `. The extractor returned a zero-line section, so the rebased commit's net diff for `camel-4x-upgrade-guide-4_14.adoc` was a single added blank line, and the merge therefore did not carry the documentation entry.

## What this PR does

Adds the missing `=== camel-elasticsearch / camel-opensearch - potential breaking change` section (57 lines) to `docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc`, inserted after the camel-web3j section and before the camel-google-functions / camel-google-secret-manager section. The content matches what the original backport PR carried before its final rebase, and is consistent with the equivalent 4.21 guide entry on main produced by PR #23442.

No code changes are made by this PR — documentation only.

## Reviewers

@davsclaus @gnodet

🤖 Generated with [Claude Code](https://claude.com/claude-code)