### PR TITLE
CAMEL-23639: Publish the Camel JBang MCP server as a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "camel-marketplace",
+  "description": "Apache Camel plugins for Claude Code, including the Camel MCP server.",
+  "owner": {
+    "name": "Apache Camel",
+    "email": "dev@camel.apache.org",
+    "url": "https://camel.apache.org"
+  },
+  "plugins": [
+    {
+      "name": "camel-mcp",
+      "source": "./plugins/camel-mcp",
+      "description": "Apache Camel MCP server: exposes the Camel Catalog plus specialized tools (catalog exploration, route and YAML DSL validation, security hardening, error diagnosis, dependency check, OpenAPI contract-first scaffolding, and version-to-version migration) to AI coding assistants over the Model Context Protocol. Requires JBang on the PATH."
+    }
+  ]
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-mcp.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-mcp.adoc
@@ -438,7 +438,7 @@ configuration):
       "command": "jbang",
       "args": [
         "-Dquarkus.log.level=WARN",
-        "org.apache.camel:camel-jbang-mcp:4.18.0:runner"
+        "org.apache.camel:camel-jbang-mcp:LATEST:runner"
       ]
     }
   }
@@ -457,7 +457,7 @@ Add the server to your MCP configuration:
       "command": "jbang",
       "args": [
         "-Dquarkus.log.level=WARN",
-        "org.apache.camel:camel-jbang-mcp:4.18.0:runner"
+        "org.apache.camel:camel-jbang-mcp:LATEST:runner"
       ]
     }
   }
@@ -476,7 +476,7 @@ Configure MCP servers in your `.vscode/mcp.json` or in the user settings:
       "command": "jbang",
       "args": [
         "-Dquarkus.log.level=WARN",
-        "org.apache.camel:camel-jbang-mcp:4.18.0:runner"
+        "org.apache.camel:camel-jbang-mcp:LATEST:runner"
       ]
     }
   }
@@ -496,7 +496,7 @@ Settings > Tools > AI Assistant > MCP Servers, or create an `.junie/mcp.json` fi
       "command": "jbang",
       "args": [
         "-Dquarkus.log.level=WARN",
-        "org.apache.camel:camel-jbang-mcp:4.18.0:runner"
+        "org.apache.camel:camel-jbang-mcp:LATEST:runner"
       ]
     }
   }
@@ -509,7 +509,7 @@ Any MCP client that supports the STDIO transport can launch the server directly:
 
 [source,bash]
 ----
-jbang org.apache.camel:camel-jbang-mcp:4.18.0:runner
+jbang org.apache.camel:camel-jbang-mcp:LATEST:runner
 ----
 
 === HTTP/SSE Transport
@@ -518,7 +518,7 @@ To start the server with the HTTP/SSE transport enabled:
 
 [source,bash]
 ----
-jbang -Dquarkus.http.host-enabled=true -Dquarkus.http.port=8080 org.apache.camel:camel-jbang-mcp:4.18.0:runner
+jbang -Dquarkus.http.host-enabled=true -Dquarkus.http.port=8080 org.apache.camel:camel-jbang-mcp:LATEST:runner
 ----
 
 If you have built Camel locally, you can also run the uber-JAR directly:

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-mcp.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-mcp.adoc
@@ -410,7 +410,25 @@ The MCP server requires https://www.jbang.dev/[JBang] to be installed and availa
 
 === Claude Code
 
-Add the following to your project's `.mcp.json` (or `~/.claude/mcp.json` for global configuration):
+==== Install as a plugin (recommended)
+
+Claude Code can install the Camel MCP server from the marketplace defined in the `apache/camel`
+repository, so you do not have to edit any configuration file by hand. JBang must still be installed
+and available on your PATH.
+
+[source,bash]
+----
+claude plugin marketplace add apache/camel
+claude plugin install camel-mcp@camel-marketplace
+----
+
+The first command registers the marketplace; the second installs the `camel-mcp` plugin, which ships
+the MCP server configuration. The server is launched on demand over STDIO via JBang.
+
+==== Manual configuration
+
+Alternatively, add the following to your project's `.mcp.json` (or `~/.claude/mcp.json` for global
+configuration):
 
 [source,json]
 ----

--- a/plugins/camel-mcp/.claude-plugin/plugin.json
+++ b/plugins/camel-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "camel-mcp",
+  "version": "0.1.0",
+  "description": "Apache Camel MCP server for AI coding assistants. Launches the Camel JBang MCP server (org.apache.camel:camel-jbang-mcp) over STDIO, exposing the Camel Catalog and tools for catalog exploration, route and YAML DSL validation, security hardening, error diagnosis, dependency check, OpenAPI contract-first scaffolding, and migration. Requires JBang on the PATH.",
+  "author": {
+    "name": "Apache Camel",
+    "email": "dev@camel.apache.org",
+    "url": "https://camel.apache.org"
+  },
+  "homepage": "https://camel.apache.org/manual/camel-jbang-mcp.html",
+  "repository": "https://github.com/apache/camel",
+  "license": "Apache-2.0",
+  "keywords": [
+    "camel",
+    "mcp",
+    "model-context-protocol",
+    "integration",
+    "jbang",
+    "catalog"
+  ]
+}

--- a/plugins/camel-mcp/.claude-plugin/plugin.json
+++ b/plugins/camel-mcp/.claude-plugin/plugin.json
@@ -12,10 +12,13 @@
   "license": "Apache-2.0",
   "keywords": [
     "camel",
+    "java",
+    "integration",
     "mcp",
     "model-context-protocol",
-    "integration",
     "jbang",
+    "spring-boot",
+    "quarkus",
     "catalog"
   ]
 }

--- a/plugins/camel-mcp/.mcp.json
+++ b/plugins/camel-mcp/.mcp.json
@@ -4,7 +4,7 @@
       "command": "jbang",
       "args": [
         "-Dquarkus.log.level=WARN",
-        "org.apache.camel:camel-jbang-mcp:4.20.0:runner"
+        "org.apache.camel:camel-jbang-mcp:LATEST:runner"
       ]
     }
   }

--- a/plugins/camel-mcp/.mcp.json
+++ b/plugins/camel-mcp/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "camel": {
+      "command": "jbang",
+      "args": [
+        "-Dquarkus.log.level=WARN",
+        "org.apache.camel:camel-jbang-mcp:4.20.0:runner"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Claude Code plugin marketplace to the repository so users can install the Camel MCP server with two commands instead of hand-editing `.mcp.json`:

```
claude plugin marketplace add apache/camel
claude plugin install camel-mcp@camel-marketplace
```

## Changes

- `.claude-plugin/marketplace.json` — defines the `camel-marketplace` marketplace at the repo root
- `plugins/camel-mcp/.claude-plugin/plugin.json` — plugin manifest (Apache-2.0)
- `plugins/camel-mcp/.mcp.json` — launches the server over STDIO via JBang (`org.apache.camel:camel-jbang-mcp:LATEST:runner`); auto-loaded when the plugin is enabled
- docs: new "Install as a plugin (recommended)" subsection in `camel-jbang-mcp.adoc`; the manual `.mcp.json` setup is kept as an alternative. The existing setup examples were also switched to `LATEST`.

No Java/source changes — configuration and documentation only. JBang remains a prerequisite, which the docs call out.

## Versioning

Per review feedback, the server is referenced as `LATEST` rather than a pinned version. JBang resolves `LATEST` to the newest release on Maven Central, so the file does not need a bump on each Camel release. Verified locally that `jbang ...:camel-jbang-mcp:LATEST:runner` resolves and the MCP server starts and lists its tools.

## Testing

- `claude plugin validate` passes for both the marketplace and the plugin manifest
- Adding the marketplace from a local path loads the `camel-mcp` plugin
- The MCP server starts via JBang (`LATEST`) and `tools/list` returns the expected tools

_Reported by Claude Code on behalf of Karol Krawczyk_