### PR TITLE
CAMEL-23500: Document camel-openai usage with OpenAI-compatible providers

### DIFF
--- a/components/camel-ai/camel-openai/src/main/docs/openai-component.adoc
+++ b/components/camel-ai/camel-openai/src/main/docs/openai-component.adoc
@@ -511,7 +511,13 @@ set `apiKey` if it requires one, and use the same operations and options as with
 
 === Ollama (local)
 
-Ollama runs models locally and does not require an API key.
+https://ollama.com[Ollama] runs models locally and does not require an API key. Install Ollama and
+pull the model used in the example below:
+
+[source,bash]
+----
+ollama run llama3.2
+----
 
 [tabs]
 ====
@@ -542,7 +548,8 @@ Provider* table below).
 
 === LM Studio (local)
 
-LM Studio serves the model currently loaded in the app. Set `model` to the identifier shown in its UI.
+https://lmstudio.ai[LM Studio] serves the model currently loaded in the app. Set `model` to the
+identifier shown in its UI.
 
 [source,java]
 ----
@@ -552,6 +559,14 @@ from("direct:chat")
 
 === vLLM (self-hosted)
 
+https://docs.vllm.ai[vLLM] is a high-throughput LLM serving engine. Install it with `pip install vllm`
+and start the model used in the example below:
+
+[source,bash]
+----
+vllm serve meta-llama/Llama-3.1-8B-Instruct --port 8000
+----
+
 [source,java]
 ----
 from("direct:chat")
@@ -560,6 +575,13 @@ from("direct:chat")
 ----
 
 If vLLM was started with `--api-key`, pass the same value via the `apiKey` option.
+
+On Apple Silicon, the `vllm-mlx` variant uses Apple's MLX framework and runs the same way:
+
+[source,bash]
+----
+vllm-mlx serve mlx-community/Qwen2.5-7B-Instruct-4bit --port 8000
+----
 
 === OpenRouter
 

--- a/components/camel-ai/camel-openai/src/main/docs/openai-component.adoc
+++ b/components/camel-ai/camel-openai/src/main/docs/openai-component.adoc
@@ -492,6 +492,113 @@ String-valued fields are set directly. Non-string fields (numbers, booleans, obj
 
 NOTE: This maps fields from the response message's additional properties (fields not part of the standard schema). Standard response fields like `content`, `role`, and `tool_calls` are not accessible through this option.
 
+== OpenAI-Compatible Providers
+
+Because the component speaks the OpenAI API, you do not need a separate component to use third-party
+gateways or local model servers that expose an OpenAI-compatible API. Point `baseUrl` at the provider,
+set `apiKey` if it requires one, and use the same operations and options as with OpenAI.
+
+[cols="1,2,2",options="header"]
+|===
+| Provider | `baseUrl` | Notes
+
+| OpenAI | `https://api.openai.com/v1` | Default; `baseUrl` can be omitted
+| OpenRouter | `https://openrouter.ai/api/v1` | Multi-model gateway with provider routing and fallbacks
+| Ollama | `http://localhost:11434/v1` | Local LLM server
+| LM Studio | `http://localhost:1234/v1` | Local model runner
+| vLLM | `http://localhost:8000/v1` | High-throughput, self-hosted serving engine
+|===
+
+=== Ollama (local)
+
+Ollama runs models locally and does not require an API key.
+
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:chat")
+    .setBody(constant("What is Apache Camel?"))
+    .to("openai:chat-completion?baseUrl=http://localhost:11434/v1&model=llama3.2");
+----
+
+YAML::
++
+[source,yaml]
+----
+- to:
+    uri: openai:chat-completion
+    parameters:
+      baseUrl: http://localhost:11434/v1
+      model: llama3.2
+      userMessage: What is Apache Camel?
+----
+====
+
+For local embeddings, use an embedding model such as `nomic-embed-text` (see the *Embedding Models by
+Provider* table below).
+
+=== LM Studio (local)
+
+LM Studio serves the model currently loaded in the app. Set `model` to the identifier shown in its UI.
+
+[source,java]
+----
+from("direct:chat")
+    .to("openai:chat-completion?baseUrl=http://localhost:1234/v1&model=local-model");
+----
+
+=== vLLM (self-hosted)
+
+[source,java]
+----
+from("direct:chat")
+    .to("openai:chat-completion?baseUrl=http://localhost:8000/v1"
+        + "&model=meta-llama/Llama-3.1-8B-Instruct");
+----
+
+If vLLM was started with `--api-key`, pass the same value via the `apiKey` option.
+
+=== OpenRouter
+
+https://openrouter.ai[OpenRouter] is an OpenAI-compatible gateway that routes requests across many
+model providers. Set `baseUrl` to its endpoint and select a model with a cross-provider identifier:
+
+[source,java]
+----
+from("direct:chat")
+    .to("openai:chat-completion?baseUrl=https://openrouter.ai/api/v1"
+        + "&apiKey={{openrouter.api.key}}"
+        + "&model=anthropic/claude-sonnet-4-20250514");
+----
+
+==== Provider Routing
+
+OpenRouter accepts a `provider` object in the request body to control routing order and fallbacks.
+Pass it through the `additionalBodyProperty` option as a JSON value — the component parses JSON-valued
+properties and adds them to the request body:
+
+[source,yaml]
+----
+- to:
+    uri: openai:chat-completion
+    parameters:
+      baseUrl: https://openrouter.ai/api/v1
+      apiKey: "{{openrouter.api.key}}"
+      model: anthropic/claude-sonnet-4-20250514
+      additionalBodyProperty.provider: '{"order":["anthropic","google"],"allow_fallbacks":false}'
+----
+
+[NOTE]
+====
+OpenRouter's optional attribution headers (`HTTP-Referer` and `X-Title`, which identify your app on
+the OpenRouter rankings) are sent as HTTP request headers, not body properties. The component does not
+currently expose a way to set custom HTTP request headers, so they cannot be configured today. They
+are optional and do not affect chat completions.
+====
+
 == Compatibility
 
 This component works with any OpenAI API-compatible endpoint by setting the `baseUrl` parameter. This includes:

--- a/components/camel-ai/camel-openai/src/main/docs/openai-component.adoc
+++ b/components/camel-ai/camel-openai/src/main/docs/openai-component.adoc
@@ -256,17 +256,6 @@ from("direct:conversation")
     .log("Second response: ${body}"); // Will remember "Alice"
 ----
 
-=== Using Third-Party or Local OpenAI-Compatible Endpoint
-
-.Usage example:
-[source,java]
-----
-from("direct:local")
-    .setBody(constant("Hello from local LLM"))
-    .to("openai:chat-completion?baseUrl=http://localhost:1234/v1&model=local-model")
-    .log("${body}");
-----
-
 == Input Handling
 
 The component accepts the following types of input in the message body:
@@ -498,6 +487,9 @@ Because the component speaks the OpenAI API, you do not need a separate componen
 gateways or local model servers that expose an OpenAI-compatible API. Point `baseUrl` at the provider,
 set `apiKey` if it requires one, and use the same operations and options as with OpenAI.
 
+NOTE: Ensure the provider supports the chat completions and/or embeddings endpoint format you use.
+Authentication requirements and minor API variations differ between providers.
+
 [cols="1,2,2",options="header"]
 |===
 | Provider | `baseUrl` | Notes
@@ -619,19 +611,6 @@ OpenRouter's optional attribution headers (`HTTP-Referer` and `X-Title`, which i
 the OpenRouter rankings) are sent as HTTP request headers, not body properties. The component does not
 currently expose a way to set custom HTTP request headers, so they cannot be configured today. They
 are optional and do not affect chat completions.
-====
-
-== Compatibility
-
-This component works with any OpenAI API-compatible endpoint by setting the `baseUrl` parameter. This includes:
-
-- OpenAI official API (`https://api.openai.com/v1`)
-- Local LLM servers (e.g., Ollama, LM Studio, LocalAI)
-- Third-party OpenAI-compatible providers
-
-[NOTE]
-====
-When using local or third-party providers, ensure they support the chat completions and/or embeddings API endpoint format. Some providers may have different authentication requirements or API variations.
 ====
 
 === Embedding Models by Provider


### PR DESCRIPTION
## Summary

Adds an "OpenAI-Compatible Providers" section to the OpenAI component documentation, with `baseUrl`-based configuration examples for OpenRouter, Ollama, LM Studio, and vLLM. This makes it discoverable that no separate component is needed to use third-party gateways or local model servers.

## Changes

- New `== OpenAI-Compatible Providers` section in `openai-component.adoc`:
  - Provider → `baseUrl` reference table (OpenAI, OpenRouter, Ollama, LM Studio, vLLM)
  - Per-provider examples (Ollama, LM Studio, vLLM)
  - OpenRouter: cross-provider model identifiers and provider routing/fallbacks via `additionalBodyProperty` (a JSON body value)

Docs-only; no code changes. The `docs/components/.../openai-component.adoc` page is a symlink to the component source, so only the source file changes.

## On the OpenRouter attribution headers

The ticket also asked to document setting OpenRouter's `HTTP-Referer` / `X-Title` attribution headers via exchange headers. After checking the code, the component does not currently expose a way to set custom HTTP request headers: the client is built with only `apiKey`/`baseUrl`/SSL and the producer calls `.create(params)` without `RequestOptions`. So I documented this as a current limitation rather than referencing a non-existent option. I'd suggest a small follow-up enhancement to add a custom request-header option (e.g. `additionalRequestHeader.`), which the `openai-java` SDK supports via `RequestOptions.putHeader` — happy to take that on.

## On a dedicated OpenRouter kamelet

The ticket asked to evaluate one. Given `baseUrl` reduces OpenRouter to a one-line configuration, a dedicated kamelet adds little value over the documented approach, so I'd lean against it.

_Reported by Claude Code on behalf of Karol Krawczyk_