### PR TITLE
camel-jbang - Download GitHub examples to local temp dir before running

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -482,47 +482,30 @@ public class Run extends CamelCommand {
 
     private int runGithubExample(JsonObject entry) throws Exception {
         String eName = entry.getString("name");
-        String url = ExampleHelper.getGithubUrl(entry);
+        List<String> exampleFiles = ExampleHelper.getFiles(entry);
 
         printer().println("Fetching example from GitHub: " + eName);
         if (ExampleHelper.requiresDocker(entry)) {
             printer().println("Note: this example requires Docker/Podman");
         }
 
-        StringJoiner routes = new StringJoiner(",");
-        StringJoiner kamelets = new StringJoiner(",");
-        StringJoiner properties = new StringJoiner(",");
+        Path tempDir;
         try {
-            fetchGithubUrls(url, routes, kamelets, properties);
+            tempDir = ExampleHelper.downloadGithubExample(entry);
         } catch (Exception e) {
             printer().printErr("Failed to fetch example from GitHub: " + e.getMessage());
             printer().printErr("This example requires an internet connection.");
             return 1;
         }
 
-        if (routes.length() == 0 && kamelets.length() == 0 && properties.length() == 0) {
-            printer().printErr("No files found for example: " + eName);
-            return 1;
-        }
-
-        if (routes.length() > 0) {
-            for (String r : routes.toString().split(",")) {
-                files.add(r);
-            }
-        }
-        if (kamelets.length() > 0) {
-            for (String k : kamelets.toString().split(",")) {
-                files.add(k);
-            }
-        }
-        if (properties.length() > 0) {
-            for (String p : properties.toString().split(",")) {
-                files.add(p);
-            }
+        for (String f : exampleFiles) {
+            files.add(tempDir.resolve(f).toString());
         }
         if ("CamelJBang".equals(name)) {
             name = eName;
         }
+
+        exportBaseDir = tempDir;
 
         if (!exportRun) {
             printConfigurationValues("Running integration with the following configuration:");
@@ -1137,7 +1120,7 @@ public class Run extends CamelCommand {
             });
             StringBuilder locations = new StringBuilder();
             for (String file : names) {
-                if (!file.startsWith("file:")) {
+                if (!file.startsWith("file:") && !file.startsWith("github:") && !file.startsWith("gist:")) {
                     if (!file.startsWith("/")) {
                         file = Paths.get(FileSystems.getDefault().getPath("").toAbsolutePath().toString(), file).toString();
                     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionList.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/version/VersionList.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -567,7 +568,7 @@ public class VersionList extends CamelCommand {
         String gitUrl = String.format(RuntimeType.quarkus == runtime ? GIT_CAMEL_QUARKUS_URL : GIT_CAMEL_URL, coreVersion);
 
         try {
-            HttpClient hc = HttpClient.newHttpClient();
+            HttpClient hc = HttpClient.newBuilder().proxy(ProxySelector.getDefault()).build();
             HttpResponse<String> res = hc.send(HttpRequest.newBuilder(new URI(gitUrl)).timeout(Duration.ofSeconds(20)).build(),
                     HttpResponse.BodyHandlers.ofString());
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/ExampleHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/ExampleHelper.java
@@ -17,6 +17,7 @@
 package org.apache.camel.dsl.jbang.core.common;
 
 import java.io.InputStream;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -174,7 +175,7 @@ public final class ExampleHelper {
         List<String> fileNames = getFiles(entry);
         Path tempDir = Files.createTempDirectory("camel-example-");
 
-        HttpClient hc = HttpClient.newHttpClient();
+        HttpClient hc = HttpClient.newBuilder().proxy(ProxySelector.getDefault()).build();
         for (String fileName : fileNames) {
             String rawUrl = String.format(GITHUB_RAW_URL, name, fileName);
             HttpResponse<String> res = hc.send(

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/ExampleHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/ExampleHelper.java
@@ -17,8 +17,13 @@
 package org.apache.camel.dsl.jbang.core.common;
 
 import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -33,6 +38,8 @@ public final class ExampleHelper {
     private static final String CATALOG_RESOURCE = "examples/camel-jbang-example-catalog.json";
     private static final String GITHUB_EXAMPLES_URL
             = "https://github.com/apache/camel-jbang-examples/tree/main/";
+    private static final String GITHUB_RAW_URL
+            = "https://raw.githubusercontent.com/apache/camel-jbang-examples/main/%s/%s";
 
     private ExampleHelper() {
     }
@@ -155,6 +162,30 @@ public final class ExampleHelper {
                     targetFile.toFile().deleteOnExit();
                     targetFile.getParent().toFile().deleteOnExit();
                 }
+            }
+        }
+
+        tempDir.toFile().deleteOnExit();
+        return tempDir;
+    }
+
+    public static Path downloadGithubExample(JsonObject entry) throws Exception {
+        String name = entry.getString("name");
+        List<String> fileNames = getFiles(entry);
+        Path tempDir = Files.createTempDirectory("camel-example-");
+
+        HttpClient hc = HttpClient.newHttpClient();
+        for (String fileName : fileNames) {
+            String rawUrl = String.format(GITHUB_RAW_URL, name, fileName);
+            HttpResponse<String> res = hc.send(
+                    HttpRequest.newBuilder(new URI(rawUrl)).timeout(Duration.ofSeconds(20)).build(),
+                    HttpResponse.BodyHandlers.ofString());
+            if (res.statusCode() == 200) {
+                Path targetFile = tempDir.resolve(fileName);
+                Files.createDirectories(targetFile.getParent());
+                Files.writeString(targetFile, res.body());
+                targetFile.toFile().deleteOnExit();
+                targetFile.getParent().toFile().deleteOnExit();
             }
         }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/GistHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/GistHelper.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.dsl.jbang.core.common;
 
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -83,7 +84,7 @@ public final class GistHelper {
             throws Exception {
 
         // use JDK http client to call github api
-        HttpClient hc = HttpClient.newHttpClient();
+        HttpClient hc = HttpClient.newBuilder().proxy(ProxySelector.getDefault()).build();
         HttpResponse<String> res = hc.send(HttpRequest.newBuilder(new URI(url)).timeout(Duration.ofSeconds(20)).build(),
                 HttpResponse.BodyHandlers.ofString());
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/GitHubHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/GitHubHelper.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.dsl.jbang.core.common;
 
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -104,7 +105,7 @@ public final class GitHubHelper {
             throws Exception {
 
         // use JDK http client to call github api
-        HttpClient hc = HttpClient.newHttpClient();
+        HttpClient hc = HttpClient.newBuilder().proxy(ProxySelector.getDefault()).build();
         HttpResponse<String> res = hc.send(HttpRequest.newBuilder(new URI(url)).timeout(Duration.ofSeconds(20)).build(),
                 HttpResponse.BodyHandlers.ofString());
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/QuarkusHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/QuarkusHelper.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -206,10 +207,10 @@ public final class QuarkusHelper {
                 }
             }
 
-            HttpClient hc = HttpClient.newHttpClient();
+            HttpClient hc = HttpClient.newBuilder().proxy(ProxySelector.getDefault()).build();
             HttpResponse<String> res = hc.send(
                     HttpRequest.newBuilder(uri)
-                            .timeout(Duration.ofSeconds(2))
+                            .timeout(Duration.ofSeconds(20))
                             .build(),
                     HttpResponse.BodyHandlers.ofString());
 


### PR DESCRIPTION
## Summary

- Download all GitHub example files to a local temp directory before running, instead of using `github:` scheme URLs at runtime. This follows the same pattern as bundled examples (`extractBundledExample`), making GitHub examples run reliably as local files.
- Also fix `github:` and `gist:` scheme properties files being incorrectly wrapped with `file://` prefix in the general `camel run <github-url>` path.

**Root cause:** `runGithubExample` was passing `github:` scheme URLs as file references. The properties component's `FilePropertiesSource` tried to resolve these as local file paths, causing `FileNotFoundException`.

**Fix:** Use the example catalog's `files` list to download each file from `raw.githubusercontent.com` to a temp directory, set `exportBaseDir` to that directory (so `application.properties` auto-detection works), and add files as local paths.

## Test plan

- [x] `camel run --example sql` — works (was failing with `FileNotFoundException`)
- [ ] `camel run --example timer-log` — bundled example still works
- [ ] `camel run --example mqtt` — GitHub example with nested files (`infra/mosquitto.conf`)

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)