### PR TITLE
CAMEL-23643: Add service version to test-infra metadata

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
@@ -6,7 +6,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-milvus",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "v2.6.17"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -15,7 +16,8 @@
   "aliasImplementation" : [ "kinesis" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -24,7 +26,8 @@
   "aliasImplementation" : [ "transcribe" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -33,7 +36,8 @@
   "aliasImplementation" : [ "cloud-watch" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.iggy.services.IggyInfraService",
   "description" : "Iggy is a persistent message streaming platform",
@@ -42,7 +46,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-iggy",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "0.7.0"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -51,7 +56,8 @@
   "aliasImplementation" : [ "sqs" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.zookeeper.services.ZooKeeperInfraService",
   "description" : "Zookeeper is a server for highly reliable distributed coordination of cloud applications",
@@ -60,7 +66,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-zookeeper",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "3.9.5"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -69,7 +76,8 @@
   "aliasImplementation" : [ "sts" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.redis.services.RedisInfraService",
   "description" : "Redis is an open source in-memory data store",
@@ -78,7 +86,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-redis",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "7.4.9-alpine"
 }, {
   "service" : "org.apache.camel.test.infra.elasticsearch.services.ElasticSearchInfraService",
   "description" : "Elasticsearch is a distributed search and analytics engine",
@@ -87,7 +96,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-elasticsearch",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "9.1.0"
 }, {
   "service" : "org.apache.camel.test.infra.kafka.services.KafkaInfraService",
   "description" : "Apache Kafka, Distributed event streaming platform",
@@ -96,7 +106,8 @@
   "aliasImplementation" : [ "strimzi" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-kafka",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "0.51.0-kafka-4.2.0"
 }, {
   "service" : "org.apache.camel.test.infra.kafka.services.KafkaInfraService",
   "description" : "Apache Kafka, Distributed event streaming platform",
@@ -105,7 +116,8 @@
   "aliasImplementation" : [ "confluent" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-kafka",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "8.2.1"
 }, {
   "service" : "org.apache.camel.test.infra.nats.services.NatsInfraService",
   "description" : "NATS is a high-performance messaging system for cloud native applications",
@@ -114,7 +126,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-nats",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2.12.6"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -123,7 +136,8 @@
   "aliasImplementation" : [ "kms" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.postgres.services.PostgresInfraService",
   "description" : "PostgreSQL is an open source object-relational database",
@@ -132,7 +146,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-postgres",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "17.10-alpine"
 }, {
   "service" : "org.apache.camel.test.infra.kafka.services.KafkaInfraService",
   "description" : "Apache Kafka, Distributed event streaming platform",
@@ -141,7 +156,8 @@
   "aliasImplementation" : [ "redpanda" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-kafka",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "v26.1.9"
 }, {
   "service" : "org.apache.camel.test.infra.hashicorp.vault.services.HashicorpVaultInfraService",
   "description" : "HashiCorp Vault is a tool for securely accessing secrets",
@@ -150,7 +166,8 @@
   "aliasImplementation" : [ "vault" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-hashicorp-vault",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2.0.1"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -159,7 +176,8 @@
   "aliasImplementation" : [ "sns" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.artemis.services.ArtemisInfraService",
   "description" : "Apache Artemis is an open source message broker",
@@ -168,7 +186,8 @@
   "aliasImplementation" : [ "amqp" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-artemis",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "latest"
 }, {
   "service" : "org.apache.camel.test.infra.solr.services.SolrInfraService",
   "description" : "Apache Solr is an open source search platform",
@@ -177,7 +196,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-solr",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "9.10.1-slim"
 }, {
   "service" : "org.apache.camel.test.infra.couchbase.services.CouchbaseInfraService",
   "description" : "Couchbase is a distributed NoSQL cloud database",
@@ -186,7 +206,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-couchbase",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "8.0.0"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -195,7 +216,8 @@
   "aliasImplementation" : [ "dynamodb", "dynamo-db" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.couchdb.services.CouchDbInfraService",
   "description" : "Apache CouchDB is an open source NoSQL document database",
@@ -204,7 +226,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-couchdb",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "3.5.1"
 }, {
   "service" : "org.apache.camel.test.infra.keycloak.services.KeycloakInfraService",
   "description" : "Keycloak is an open source identity and access management solution",
@@ -213,7 +236,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-keycloak",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "26.6.2"
 }, {
   "service" : "org.apache.camel.test.infra.hivemq.services.HiveMQInfraService",
   "description" : "HiveMQ is an MQTT-based messaging platform for IoT",
@@ -222,7 +246,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-hivemq",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2025.5"
 }, {
   "service" : "org.apache.camel.test.infra.ibmmq.services.IbmMQInfraService",
   "description" : "IBM MQ is enterprise messaging middleware for reliable communication",
@@ -231,7 +256,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ibmmq",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "9.4.5.0-r2"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -240,7 +266,8 @@
   "aliasImplementation" : [ "s3" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.smb.services.SmbLocalContainerInfraService",
   "description" : "Samba provides file sharing services using the SMB protocol",
@@ -249,7 +276,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-smb",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "0.14.0"
 }, {
   "service" : "org.apache.camel.test.infra.openldap.services.OpenldapInfraService",
   "description" : "OpenLDAP is an implementation of the Lightweight Directory Access Protocol",
@@ -258,7 +286,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-openldap",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.0"
 }, {
   "service" : "org.apache.camel.test.infra.xmpp.services.XmppInfraService",
   "description" : "XMPP is an open communication protocol for messaging",
@@ -267,7 +296,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-xmpp",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "0.3"
 }, {
   "service" : "org.apache.camel.test.infra.pulsar.services.PulsarInfraService",
   "description" : "Apache Pulsar is a distributed messaging and streaming platform",
@@ -276,7 +306,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-pulsar",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "4.2.1"
 }, {
   "service" : "org.apache.camel.test.infra.artemis.services.ArtemisInfraService",
   "description" : "Apache Artemis is an open source message broker",
@@ -285,7 +316,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-artemis",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "latest"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -294,7 +326,8 @@
   "aliasImplementation" : [ "ssm" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -303,7 +336,8 @@
   "aliasImplementation" : [ "lambda" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.google.pubsub.services.GooglePubSubInfraService",
   "description" : "Google Cloud Pub/Sub is a messaging service for event-driven systems",
@@ -312,7 +346,8 @@
   "aliasImplementation" : [ "pub-sub" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-google-pubsub",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "emulators"
 }, {
   "service" : "org.apache.camel.test.infra.chatscript.services.ChatScriptInfraService",
   "description" : "ChatScript is an open source chatbot engine",
@@ -321,7 +356,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-chatscript",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "latest"
 }, {
   "service" : "org.apache.camel.test.infra.arangodb.services.ArangoDBInfraService",
   "description" : "ArangoDB is a multi-model database for high-performance applications.",
@@ -330,7 +366,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-arangodb",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "3.12.5.2"
 }, {
   "service" : "org.apache.camel.test.infra.ignite.services.IgniteInfraService",
   "description" : "Apache Ignite is a distributed database for high-performance computing",
@@ -339,7 +376,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ignite",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2.18.0"
 }, {
   "service" : "org.apache.camel.test.infra.rabbitmq.services.RabbitMQInfraService",
   "description" : "RabbitMQ is an open source message and streaming broker",
@@ -348,7 +386,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-rabbitmq",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "4.2.5-management"
 }, {
   "service" : "org.apache.camel.test.infra.mosquitto.services.MosquittoInfraService",
   "description" : "Mosquitto is a message broker that implements MQTT protocol",
@@ -357,7 +396,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-mosquitto",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2.0.22"
 }, {
   "service" : "org.apache.camel.test.infra.neo4j.services.Neo4jInfraService",
   "description" : "Neo4j is a graph database management system",
@@ -366,7 +406,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-neo4j",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2026.04-community-ubi10"
 }, {
   "service" : "org.apache.camel.test.infra.rocketmq.services.RocketMQInfraService",
   "description" : "Apache RocketMQ is a distributed messaging and streaming platform",
@@ -375,7 +416,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-rocketmq",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "5.3.3"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -384,7 +426,8 @@
   "aliasImplementation" : [ "config" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -393,7 +436,8 @@
   "aliasImplementation" : [ "event-bridge" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -402,7 +446,8 @@
   "aliasImplementation" : [ "secrets-manager" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.cassandra.services.CassandraInfraService",
   "description" : "Apache Cassandra is a distributed NoSQL database",
@@ -411,7 +456,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-cassandra",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "5.0.8"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -420,7 +466,8 @@
   "aliasImplementation" : [ "ec2" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.hazelcast.services.HazelcastInfraService",
   "description" : "Hazelcast is a distributed in-memory computing platform",
@@ -429,7 +476,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-hazelcast",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "5.4.0"
 }, {
   "service" : "org.apache.camel.test.infra.hivemq.services.HiveMQInfraService",
   "description" : "HiveMQ is an MQTT-based messaging platform for IoT",
@@ -438,7 +486,8 @@
   "aliasImplementation" : [ "sparkplug" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-hivemq",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "camel"
 }, {
   "service" : "org.apache.camel.test.infra.postgres.services.PostgresInfraService",
   "description" : "PostgreSQL with pgvector extension for vector similarity search",
@@ -447,7 +496,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-postgres",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "pg18"
 }, {
   "service" : "org.apache.camel.test.infra.microprofile.lra.services.MicroprofileLRAInfraService",
   "description" : "Transaction Manager for microservices that is based on the SAGA pattern for distributed transaction.",
@@ -456,7 +506,8 @@
   "aliasImplementation" : [ "lra" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-microprofile-lra",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "5.13.1.Final-2.16.6.Final"
 }, {
   "service" : "org.apache.camel.test.infra.minio.services.MinioInfraService",
   "description" : "MinIO is a high-performance S3 compatible object storage",
@@ -465,7 +516,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-minio",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "RELEASE.2025-09-07T16-13-09Z-cpuv1"
 }, {
   "service" : "org.apache.camel.test.infra.kafka.services.KafkaInfraService",
   "description" : "Apache Kafka, Distributed event streaming platform",
@@ -474,7 +526,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-kafka",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "4.3.0"
 }, {
   "service" : "org.apache.camel.test.infra.azure.common.services.AzureInfraService",
   "description" : "Local Azure services with Azurite",
@@ -483,7 +536,8 @@
   "aliasImplementation" : [ "storage-queue" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-azure-storage-queue",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "3.35.0"
 }, {
   "service" : "org.apache.camel.test.infra.ftp.services.FtpInfraService",
   "description" : "Embedded SFTP Server",
@@ -492,7 +546,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ftp",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2.18.0"
 }, {
   "service" : "org.apache.camel.test.infra.infinispan.services.InfinispanInfraService",
   "description" : "Infinispan is a distributed in-memory key/value data store",
@@ -501,7 +556,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-infinispan",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "16.2"
 }, {
   "service" : "org.apache.camel.test.infra.weaviate.services.WeaviateInfraService",
   "description" : "Weaviate is an open source vector database",
@@ -510,7 +566,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-weaviate",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.37.4"
 }, {
   "service" : "org.apache.camel.test.infra.consul.services.ConsulInfraService",
   "description" : "Consul is a service networking solution",
@@ -519,7 +576,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-consul",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2.0.0"
 }, {
   "service" : "org.apache.camel.test.infra.qdrant.services.QdrantInfraService",
   "description" : "Qdrant is a vector similarity search engine and database",
@@ -528,7 +586,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-qdrant",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "v1.18.0-unprivileged"
 }, {
   "service" : "org.apache.camel.test.infra.ftp.services.FtpInfraService",
   "description" : "Embedded FTPS Server",
@@ -537,7 +596,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ftp",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.2.1"
 }, {
   "service" : "org.apache.camel.test.infra.ollama.services.OllamaInfraService",
   "description" : "Ollama is a tool for running large language models locally",
@@ -546,7 +606,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ollama",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "0.12.5"
 }, {
   "service" : "org.apache.camel.test.infra.azure.common.services.AzureInfraService",
   "description" : "Local Azure services with Azurite",
@@ -555,7 +616,8 @@
   "aliasImplementation" : [ "storage-blob" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-azure-storage-blob",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "3.35.0"
 }, {
   "service" : "org.apache.camel.test.infra.docling.services.DoclingInfraService",
   "description" : "Docling is a document processing and conversion toolkit",
@@ -564,7 +626,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-docling",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "v1.18.0"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -573,7 +636,8 @@
   "aliasImplementation" : [ "iam" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.fhir.services.FhirInfraService",
   "description" : "HAPI FHIR RESTful test server",
@@ -582,7 +646,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-fhir",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "v8.10.0-1"
 }, {
   "service" : "org.apache.camel.test.infra.pinecone.services.PineconeInfraService",
   "description" : "Pinecone is a vector database for machine learning applications",
@@ -591,7 +656,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-pinecone",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "v1.0.0.rc0"
 }, {
   "service" : "org.apache.camel.test.infra.ftp.services.FtpInfraService",
   "description" : "Embedded FTP Server",
@@ -600,7 +666,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ftp",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.2.1"
 }, {
   "service" : "org.apache.camel.test.infra.mongodb.services.MongoDBInfraService",
   "description" : "MongoDB is a document-oriented NoSQL database",
@@ -609,5 +676,6 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-mongodb",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "7.0.31-jammy"
 } ]

--- a/core/camel-api/src/generated/java/org/apache/camel/spi/annotations/InfraService.java
+++ b/core/camel-api/src/generated/java/org/apache/camel/spi/annotations/InfraService.java
@@ -69,4 +69,16 @@ public @interface InfraService {
      * @return
      */
     String[] serviceImplementationAlias() default {};
+
+    /**
+     * The version of the infrastructure service (e.g., "7.4.9" for Redis, "2.54.0" for Artemis).
+     *
+     * For container-based services, the version is auto-detected from the container image tag in container.properties
+     * at build time and does not need to be set here.
+     *
+     * For embedded services (no container), set this to the library version manually.
+     *
+     * @return
+     */
+    String serviceVersion() default "";
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraBaseCommand.java
@@ -245,7 +245,8 @@ public abstract class InfraBaseCommand extends CamelCommand {
             List<String> aliasImplementation,
             String groupId,
             String artifactId,
-            String version) {
+            String version,
+            String serviceVersion) {
     }
 
     record Row(String pid, String alias, String aliasImplementation, String description, String serviceData) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraRun.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/infra/InfraRun.java
@@ -205,6 +205,10 @@ public class InfraRun extends InfraBaseCommand {
             }
         }
 
+        if (testInfraService.serviceVersion() != null && !testInfraService.serviceVersion().isEmpty()) {
+            properties.put("serviceVersion", testInfraService.serviceVersion());
+        }
+
         String jsonProperties = jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(properties);
         printer().println(jsonProperties);
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -1253,19 +1253,6 @@ public class CamelMonitor extends CamelCommand {
             } else {
                 Style statusStyle = info.alive ? Style.EMPTY.fg(Color.GREEN) : Style.EMPTY.fg(Color.LIGHT_RED);
                 String statusText = info.alive ? "Running" : "Stopped";
-                String port = objToString(info.properties.get("getPort"));
-                String host = objToString(info.properties.get("getHost"));
-                if (host.isEmpty()) {
-                    host = objToString(info.properties.get("getHostname"));
-                }
-                String portHost = "";
-                if (!port.isEmpty() && !host.isEmpty()) {
-                    portHost = host + ":" + port;
-                } else if (!port.isEmpty()) {
-                    portHost = ":" + port;
-                } else if (!host.isEmpty()) {
-                    portHost = host;
-                }
                 String infraAlias = "🔧  " + info.alias;
                 String version = info.serviceVersion != null ? info.serviceVersion : "";
                 rows.add(Row.from(
@@ -1280,7 +1267,7 @@ public class CamelMonitor extends CamelCommand {
                         Cell.from(""),
                         Cell.from(""),
                         Cell.from(""),
-                        Cell.from(portHost)));
+                        Cell.from("")));
             }
         }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -1267,10 +1267,11 @@ public class CamelMonitor extends CamelCommand {
                     portHost = host;
                 }
                 String infraAlias = "🔧  " + info.alias;
+                String version = info.serviceVersion != null ? info.serviceVersion : "";
                 rows.add(Row.from(
                         Cell.from(info.pid),
                         Cell.from(Span.styled(infraAlias, Style.EMPTY.fg(Color.MAGENTA))),
-                        Cell.from(""),
+                        Cell.from(version),
                         Cell.from(""),
                         Cell.from(Span.styled(statusText, statusStyle)),
                         Cell.from(""),
@@ -2240,6 +2241,7 @@ public class CamelMonitor extends CamelCommand {
                         } catch (Exception e) {
                             // ignore parse errors
                         }
+                        info.serviceVersion = objToString(info.properties.get("serviceVersion"));
                         infraInfos.add(info);
                     }
                 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InfraInfo.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InfraInfo.java
@@ -23,6 +23,7 @@ class InfraInfo {
     String pid;
     String alias;
     String description;
+    String serviceVersion;
     Map<String, Object> properties = new TreeMap<>();
     boolean alive;
     boolean vanishing;

--- a/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
+++ b/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
@@ -6,7 +6,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-milvus",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "v2.6.17"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -15,7 +16,8 @@
   "aliasImplementation" : [ "kinesis" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -24,7 +26,8 @@
   "aliasImplementation" : [ "transcribe" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -33,7 +36,8 @@
   "aliasImplementation" : [ "cloud-watch" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.iggy.services.IggyInfraService",
   "description" : "Iggy is a persistent message streaming platform",
@@ -42,7 +46,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-iggy",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "0.7.0"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -51,7 +56,8 @@
   "aliasImplementation" : [ "sqs" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.zookeeper.services.ZooKeeperInfraService",
   "description" : "Zookeeper is a server for highly reliable distributed coordination of cloud applications",
@@ -60,7 +66,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-zookeeper",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "3.9.5"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -69,7 +76,8 @@
   "aliasImplementation" : [ "sts" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.redis.services.RedisInfraService",
   "description" : "Redis is an open source in-memory data store",
@@ -78,7 +86,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-redis",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "7.4.9-alpine"
 }, {
   "service" : "org.apache.camel.test.infra.elasticsearch.services.ElasticSearchInfraService",
   "description" : "Elasticsearch is a distributed search and analytics engine",
@@ -87,7 +96,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-elasticsearch",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "9.1.0"
 }, {
   "service" : "org.apache.camel.test.infra.kafka.services.KafkaInfraService",
   "description" : "Apache Kafka, Distributed event streaming platform",
@@ -96,7 +106,8 @@
   "aliasImplementation" : [ "strimzi" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-kafka",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "0.51.0-kafka-4.2.0"
 }, {
   "service" : "org.apache.camel.test.infra.kafka.services.KafkaInfraService",
   "description" : "Apache Kafka, Distributed event streaming platform",
@@ -105,7 +116,8 @@
   "aliasImplementation" : [ "confluent" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-kafka",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "8.2.1"
 }, {
   "service" : "org.apache.camel.test.infra.nats.services.NatsInfraService",
   "description" : "NATS is a high-performance messaging system for cloud native applications",
@@ -114,7 +126,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-nats",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2.12.6"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -123,7 +136,8 @@
   "aliasImplementation" : [ "kms" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.postgres.services.PostgresInfraService",
   "description" : "PostgreSQL is an open source object-relational database",
@@ -132,7 +146,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-postgres",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "17.10-alpine"
 }, {
   "service" : "org.apache.camel.test.infra.kafka.services.KafkaInfraService",
   "description" : "Apache Kafka, Distributed event streaming platform",
@@ -141,7 +156,8 @@
   "aliasImplementation" : [ "redpanda" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-kafka",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "v26.1.9"
 }, {
   "service" : "org.apache.camel.test.infra.hashicorp.vault.services.HashicorpVaultInfraService",
   "description" : "HashiCorp Vault is a tool for securely accessing secrets",
@@ -150,7 +166,8 @@
   "aliasImplementation" : [ "vault" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-hashicorp-vault",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2.0.1"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -159,7 +176,8 @@
   "aliasImplementation" : [ "sns" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.artemis.services.ArtemisInfraService",
   "description" : "Apache Artemis is an open source message broker",
@@ -168,7 +186,8 @@
   "aliasImplementation" : [ "amqp" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-artemis",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "latest"
 }, {
   "service" : "org.apache.camel.test.infra.solr.services.SolrInfraService",
   "description" : "Apache Solr is an open source search platform",
@@ -177,7 +196,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-solr",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "9.10.1-slim"
 }, {
   "service" : "org.apache.camel.test.infra.couchbase.services.CouchbaseInfraService",
   "description" : "Couchbase is a distributed NoSQL cloud database",
@@ -186,7 +206,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-couchbase",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "8.0.0"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -195,7 +216,8 @@
   "aliasImplementation" : [ "dynamodb", "dynamo-db" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.couchdb.services.CouchDbInfraService",
   "description" : "Apache CouchDB is an open source NoSQL document database",
@@ -204,7 +226,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-couchdb",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "3.5.1"
 }, {
   "service" : "org.apache.camel.test.infra.keycloak.services.KeycloakInfraService",
   "description" : "Keycloak is an open source identity and access management solution",
@@ -213,7 +236,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-keycloak",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "26.6.2"
 }, {
   "service" : "org.apache.camel.test.infra.hivemq.services.HiveMQInfraService",
   "description" : "HiveMQ is an MQTT-based messaging platform for IoT",
@@ -222,7 +246,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-hivemq",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2025.5"
 }, {
   "service" : "org.apache.camel.test.infra.ibmmq.services.IbmMQInfraService",
   "description" : "IBM MQ is enterprise messaging middleware for reliable communication",
@@ -231,7 +256,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ibmmq",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "9.4.5.0-r2"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -240,7 +266,8 @@
   "aliasImplementation" : [ "s3" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.smb.services.SmbLocalContainerInfraService",
   "description" : "Samba provides file sharing services using the SMB protocol",
@@ -249,7 +276,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-smb",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "0.14.0"
 }, {
   "service" : "org.apache.camel.test.infra.openldap.services.OpenldapInfraService",
   "description" : "OpenLDAP is an implementation of the Lightweight Directory Access Protocol",
@@ -258,7 +286,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-openldap",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.0"
 }, {
   "service" : "org.apache.camel.test.infra.xmpp.services.XmppInfraService",
   "description" : "XMPP is an open communication protocol for messaging",
@@ -267,7 +296,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-xmpp",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "0.3"
 }, {
   "service" : "org.apache.camel.test.infra.pulsar.services.PulsarInfraService",
   "description" : "Apache Pulsar is a distributed messaging and streaming platform",
@@ -276,7 +306,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-pulsar",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "4.2.1"
 }, {
   "service" : "org.apache.camel.test.infra.artemis.services.ArtemisInfraService",
   "description" : "Apache Artemis is an open source message broker",
@@ -285,7 +316,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-artemis",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "latest"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -294,7 +326,8 @@
   "aliasImplementation" : [ "ssm" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -303,7 +336,8 @@
   "aliasImplementation" : [ "lambda" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.google.pubsub.services.GooglePubSubInfraService",
   "description" : "Google Cloud Pub/Sub is a messaging service for event-driven systems",
@@ -312,7 +346,8 @@
   "aliasImplementation" : [ "pub-sub" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-google-pubsub",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "emulators"
 }, {
   "service" : "org.apache.camel.test.infra.chatscript.services.ChatScriptInfraService",
   "description" : "ChatScript is an open source chatbot engine",
@@ -321,7 +356,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-chatscript",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "latest"
 }, {
   "service" : "org.apache.camel.test.infra.arangodb.services.ArangoDBInfraService",
   "description" : "ArangoDB is a multi-model database for high-performance applications.",
@@ -330,7 +366,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-arangodb",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "3.12.5.2"
 }, {
   "service" : "org.apache.camel.test.infra.ignite.services.IgniteInfraService",
   "description" : "Apache Ignite is a distributed database for high-performance computing",
@@ -339,7 +376,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ignite",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2.18.0"
 }, {
   "service" : "org.apache.camel.test.infra.rabbitmq.services.RabbitMQInfraService",
   "description" : "RabbitMQ is an open source message and streaming broker",
@@ -348,7 +386,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-rabbitmq",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "4.2.5-management"
 }, {
   "service" : "org.apache.camel.test.infra.mosquitto.services.MosquittoInfraService",
   "description" : "Mosquitto is a message broker that implements MQTT protocol",
@@ -357,7 +396,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-mosquitto",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2.0.22"
 }, {
   "service" : "org.apache.camel.test.infra.neo4j.services.Neo4jInfraService",
   "description" : "Neo4j is a graph database management system",
@@ -366,7 +406,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-neo4j",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2026.04-community-ubi10"
 }, {
   "service" : "org.apache.camel.test.infra.rocketmq.services.RocketMQInfraService",
   "description" : "Apache RocketMQ is a distributed messaging and streaming platform",
@@ -375,7 +416,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-rocketmq",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "5.3.3"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -384,7 +426,8 @@
   "aliasImplementation" : [ "config" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -393,7 +436,8 @@
   "aliasImplementation" : [ "event-bridge" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -402,7 +446,8 @@
   "aliasImplementation" : [ "secrets-manager" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.cassandra.services.CassandraInfraService",
   "description" : "Apache Cassandra is a distributed NoSQL database",
@@ -411,7 +456,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-cassandra",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "5.0.8"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -420,7 +466,8 @@
   "aliasImplementation" : [ "ec2" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.hazelcast.services.HazelcastInfraService",
   "description" : "Hazelcast is a distributed in-memory computing platform",
@@ -429,7 +476,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-hazelcast",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "5.4.0"
 }, {
   "service" : "org.apache.camel.test.infra.hivemq.services.HiveMQInfraService",
   "description" : "HiveMQ is an MQTT-based messaging platform for IoT",
@@ -438,7 +486,8 @@
   "aliasImplementation" : [ "sparkplug" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-hivemq",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "camel"
 }, {
   "service" : "org.apache.camel.test.infra.postgres.services.PostgresInfraService",
   "description" : "PostgreSQL with pgvector extension for vector similarity search",
@@ -447,7 +496,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-postgres",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "pg18"
 }, {
   "service" : "org.apache.camel.test.infra.microprofile.lra.services.MicroprofileLRAInfraService",
   "description" : "Transaction Manager for microservices that is based on the SAGA pattern for distributed transaction.",
@@ -456,7 +506,8 @@
   "aliasImplementation" : [ "lra" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-microprofile-lra",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "5.13.1.Final-2.16.6.Final"
 }, {
   "service" : "org.apache.camel.test.infra.minio.services.MinioInfraService",
   "description" : "MinIO is a high-performance S3 compatible object storage",
@@ -465,7 +516,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-minio",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "RELEASE.2025-09-07T16-13-09Z-cpuv1"
 }, {
   "service" : "org.apache.camel.test.infra.kafka.services.KafkaInfraService",
   "description" : "Apache Kafka, Distributed event streaming platform",
@@ -474,7 +526,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-kafka",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "4.3.0"
 }, {
   "service" : "org.apache.camel.test.infra.azure.common.services.AzureInfraService",
   "description" : "Local Azure services with Azurite",
@@ -483,7 +536,8 @@
   "aliasImplementation" : [ "storage-queue" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-azure-storage-queue",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "3.35.0"
 }, {
   "service" : "org.apache.camel.test.infra.ftp.services.FtpInfraService",
   "description" : "Embedded SFTP Server",
@@ -492,7 +546,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ftp",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2.18.0"
 }, {
   "service" : "org.apache.camel.test.infra.infinispan.services.InfinispanInfraService",
   "description" : "Infinispan is a distributed in-memory key/value data store",
@@ -501,7 +556,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-infinispan",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "16.2"
 }, {
   "service" : "org.apache.camel.test.infra.weaviate.services.WeaviateInfraService",
   "description" : "Weaviate is an open source vector database",
@@ -510,7 +566,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-weaviate",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.37.4"
 }, {
   "service" : "org.apache.camel.test.infra.consul.services.ConsulInfraService",
   "description" : "Consul is a service networking solution",
@@ -519,7 +576,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-consul",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "2.0.0"
 }, {
   "service" : "org.apache.camel.test.infra.qdrant.services.QdrantInfraService",
   "description" : "Qdrant is a vector similarity search engine and database",
@@ -528,7 +586,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-qdrant",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "v1.18.0-unprivileged"
 }, {
   "service" : "org.apache.camel.test.infra.ftp.services.FtpInfraService",
   "description" : "Embedded FTPS Server",
@@ -537,7 +596,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ftp",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.2.1"
 }, {
   "service" : "org.apache.camel.test.infra.ollama.services.OllamaInfraService",
   "description" : "Ollama is a tool for running large language models locally",
@@ -546,7 +606,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ollama",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "0.12.5"
 }, {
   "service" : "org.apache.camel.test.infra.azure.common.services.AzureInfraService",
   "description" : "Local Azure services with Azurite",
@@ -555,7 +616,8 @@
   "aliasImplementation" : [ "storage-blob" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-azure-storage-blob",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "3.35.0"
 }, {
   "service" : "org.apache.camel.test.infra.docling.services.DoclingInfraService",
   "description" : "Docling is a document processing and conversion toolkit",
@@ -564,7 +626,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-docling",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "v1.18.0"
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",
   "description" : "Local AWS Services with LocalStack",
@@ -573,7 +636,8 @@
   "aliasImplementation" : [ "iam" ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-aws-v2",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.5.18"
 }, {
   "service" : "org.apache.camel.test.infra.fhir.services.FhirInfraService",
   "description" : "HAPI FHIR RESTful test server",
@@ -582,7 +646,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-fhir",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "v8.10.0-1"
 }, {
   "service" : "org.apache.camel.test.infra.pinecone.services.PineconeInfraService",
   "description" : "Pinecone is a vector database for machine learning applications",
@@ -591,7 +656,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-pinecone",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "v1.0.0.rc0"
 }, {
   "service" : "org.apache.camel.test.infra.ftp.services.FtpInfraService",
   "description" : "Embedded FTP Server",
@@ -600,7 +666,8 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ftp",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "1.2.1"
 }, {
   "service" : "org.apache.camel.test.infra.mongodb.services.MongoDBInfraService",
   "description" : "MongoDB is a document-oriented NoSQL database",
@@ -609,5 +676,6 @@
   "aliasImplementation" : [ ],
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-mongodb",
-  "version" : "4.21.0-SNAPSHOT"
+  "version" : "4.21.0-SNAPSHOT",
+  "serviceVersion" : "7.0.31-jammy"
 } ]

--- a/test-infra/camel-test-infra-ftp/src/main/resources/META-INF/infra-service.properties
+++ b/test-infra/camel-test-infra-ftp/src/main/resources/META-INF/infra-service.properties
@@ -1,0 +1,20 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+# Maps service alias to Maven groupId:artifactId for automatic version detection
+ftp=org.apache.ftpserver:ftpserver-core
+ftps=org.apache.ftpserver:ftpserver-core
+sftp=org.apache.sshd:sshd-sftp

--- a/test-infra/camel-test-infra-hazelcast/src/main/resources/META-INF/infra-service.properties
+++ b/test-infra/camel-test-infra-hazelcast/src/main/resources/META-INF/infra-service.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+# Maps service alias to Maven groupId:artifactId for automatic version detection
+hazelcast=com.hazelcast:hazelcast

--- a/test-infra/camel-test-infra-ignite/src/main/resources/META-INF/infra-service.properties
+++ b/test-infra/camel-test-infra-ignite/src/main/resources/META-INF/infra-service.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+# Maps service alias to Maven groupId:artifactId for automatic version detection
+ignite=org.apache.ignite:ignite-core

--- a/test-infra/camel-test-infra-smb/pom.xml
+++ b/test-infra/camel-test-infra-smb/pom.xml
@@ -45,6 +45,12 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-junit6</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.hierynomus</groupId>
+            <artifactId>smbj</artifactId>
+            <version>${smbj-version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test-infra/camel-test-infra-smb/src/main/resources/META-INF/infra-service.properties
+++ b/test-infra/camel-test-infra-smb/src/main/resources/META-INF/infra-service.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+# Maps service alias to Maven groupId:artifactId for automatic version detection
+smb=com.hierynomus:smbj

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/CamelTestInfraGenerateMetadataMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/CamelTestInfraGenerateMetadataMojo.java
@@ -18,11 +18,15 @@ package org.apache.camel.maven.packaging;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
+import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 import javax.inject.Inject;
@@ -71,6 +75,9 @@ public class CamelTestInfraGenerateMetadataMojo extends AbstractGeneratorMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         Set<InfrastructureServiceModel> models = new LinkedHashSet<>();
 
+        // Collect infra-service.properties from all dependency JARs once (for embedded service GA hints)
+        Properties infraServiceProps = collectInfraServiceProperties();
+
         for (AnnotationInstance ai : PackagePluginUtils.readJandexIndexQuietly(project).getAnnotations(INFRA_SERVICE)) {
 
             InfrastructureServiceModel infrastructureServiceModel = new InfrastructureServiceModel();
@@ -93,15 +100,41 @@ public class CamelTestInfraGenerateMetadataMojo extends AbstractGeneratorMojo {
                 throw new RuntimeException("Error reading jar file", e);
             }
 
+            String annotationServiceVersion = null;
+            List<String> serviceAliases = new ArrayList<>();
+            List<String> implAliases = new ArrayList<>();
+
             for (AnnotationValue av : ai.values()) {
                 if (av.name().equals("service")) {
                     infrastructureServiceModel.setService(av.asString());
                 } else if (av.name().equals("serviceAlias")) {
-                    infrastructureServiceModel.setAlias(Arrays.asList(av.asStringArray()));
+                    List<String> aliases = Arrays.asList(av.asStringArray());
+                    infrastructureServiceModel.setAlias(aliases);
+                    serviceAliases.addAll(aliases);
                 } else if (av.name().equals("serviceImplementationAlias")) {
-                    infrastructureServiceModel.getAliasImplementation().addAll(Arrays.asList(av.asStringArray()));
+                    List<String> aliases = Arrays.asList(av.asStringArray());
+                    infrastructureServiceModel.getAliasImplementation().addAll(aliases);
+                    implAliases.addAll(aliases);
                 } else if (av.name().equals("description")) {
                     infrastructureServiceModel.setDescription(av.asString());
+                } else if (av.name().equals("serviceVersion")) {
+                    annotationServiceVersion = av.asString();
+                }
+            }
+
+            // Resolve service version: annotation > container.properties > infra-service.properties GA hint
+            if (annotationServiceVersion != null && !annotationServiceVersion.isEmpty()) {
+                infrastructureServiceModel.setServiceVersion(annotationServiceVersion);
+            } else {
+                String detectedVersion = detectServiceVersionFromContainer(
+                        targetClass, infrastructureServiceModel, implAliases, serviceAliases);
+                if (detectedVersion != null) {
+                    infrastructureServiceModel.setServiceVersion(detectedVersion);
+                } else {
+                    String infraVersion = resolveVersionFromGAHint(infraServiceProps, implAliases, serviceAliases);
+                    if (infraVersion != null) {
+                        infrastructureServiceModel.setServiceVersion(infraVersion);
+                    }
                 }
             }
 
@@ -125,6 +158,207 @@ public class CamelTestInfraGenerateMetadataMojo extends AbstractGeneratorMojo {
         }
     }
 
+    private String detectServiceVersionFromContainer(
+            String targetClass, InfrastructureServiceModel model,
+            List<String> implAliases, List<String> serviceAliases) {
+
+        // Collect container.properties from all dependency JARs to handle
+        // cross-module cases (e.g., Azure storage-queue using azure-common's properties)
+        Properties allProps = new Properties();
+
+        for (Artifact artifact : project.getArtifacts()) {
+            File file = artifact.getFile();
+            if (file == null || !file.exists()) {
+                continue;
+            }
+
+            if (file.isDirectory()) {
+                collectContainerPropertiesFromDirectory(file, file, allProps);
+            } else {
+                collectContainerPropertiesFromJar(file, allProps);
+            }
+        }
+
+        if (allProps.isEmpty()) {
+            return null;
+        }
+
+        return extractVersionFromProperties(allProps, implAliases, serviceAliases);
+    }
+
+    private void collectContainerPropertiesFromDirectory(File root, File dir, Properties target) {
+        File[] files = dir.listFiles();
+        if (files == null) {
+            return;
+        }
+        for (File f : files) {
+            if (f.isDirectory()) {
+                collectContainerPropertiesFromDirectory(root, f, target);
+            } else if (f.getName().equals("container.properties")) {
+                try (InputStream is = java.nio.file.Files.newInputStream(f.toPath())) {
+                    target.load(is);
+                } catch (IOException e) {
+                    // skip
+                }
+            }
+        }
+    }
+
+    private void collectContainerPropertiesFromJar(File jarPath, Properties target) {
+        try (JarFile jarFile = new JarFile(jarPath)) {
+            Enumeration<JarEntry> entries = jarFile.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry entry = entries.nextElement();
+                if (entry.getName().endsWith("/container.properties")) {
+                    try (InputStream is = jarFile.getInputStream(entry)) {
+                        target.load(is);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            // skip
+        }
+    }
+
+    private String extractVersionFromProperties(
+            Properties props, List<String> implAliases, List<String> serviceAliases) {
+
+        // Determine which alias to match against property keys
+        // Prefer implementation alias (e.g., "redpanda" for Kafka Redpanda)
+        List<String> aliasesToMatch = new ArrayList<>();
+        if (!implAliases.isEmpty()) {
+            aliasesToMatch.addAll(implAliases);
+        }
+        aliasesToMatch.addAll(serviceAliases);
+
+        for (String alias : aliasesToMatch) {
+            String normalizedAlias = normalizeForMatching(alias);
+
+            for (String key : props.stringPropertyNames()) {
+                String lowerKey = key.toLowerCase();
+
+                // Skip platform-specific keys
+                if (lowerKey.endsWith(".ppc64le") || lowerKey.endsWith(".s390x")
+                        || lowerKey.endsWith(".aarch64") || lowerKey.endsWith(".amd64")) {
+                    continue;
+                }
+                // Skip version metadata keys
+                if (lowerKey.contains(".version.exclude") || lowerKey.contains(".version.include")
+                        || lowerKey.contains(".version.freeze")) {
+                    continue;
+                }
+                // Must reference a container
+                if (!lowerKey.contains("container")) {
+                    continue;
+                }
+                // Skip keys ending with .version (handled separately for RocketMQ pattern)
+                if (lowerKey.endsWith(".version")) {
+                    continue;
+                }
+
+                // Extract prefix before first ".container" occurrence
+                int containerIdx = lowerKey.indexOf(".container");
+                if (containerIdx <= 0) {
+                    continue;
+                }
+                String prefix = lowerKey.substring(0, containerIdx);
+                String normalizedPrefix = normalizeForMatching(prefix);
+
+                // Match: normalized prefix must equal the normalized alias,
+                // or end with the normalized alias (for compound names like hivemq.sparkplug)
+                if (!normalizedPrefix.equals(normalizedAlias)
+                        && !normalizedPrefix.endsWith(normalizedAlias)) {
+                    continue;
+                }
+
+                String imageRef = props.getProperty(key);
+                if (imageRef == null || imageRef.isEmpty()) {
+                    continue;
+                }
+
+                // Value must look like a container image reference (contains '/')
+                if (!imageRef.contains("/")) {
+                    continue;
+                }
+
+                // Extract version from image tag (after last ':')
+                int colonIdx = imageRef.lastIndexOf(':');
+                if (colonIdx > 0 && colonIdx < imageRef.length() - 1) {
+                    return imageRef.substring(colonIdx + 1);
+                }
+
+                // No tag in image reference — check for a separate .version property (RocketMQ pattern)
+                String versionKey = key + ".version";
+                String separateVersion = props.getProperty(versionKey);
+                if (separateVersion != null && !separateVersion.isEmpty()) {
+                    return separateVersion;
+                }
+            }
+        }
+        return null;
+    }
+
+    private Properties collectInfraServiceProperties() {
+        Properties allProps = new Properties();
+        for (Artifact artifact : project.getArtifacts()) {
+            File file = artifact.getFile();
+            if (file == null || !file.exists()) {
+                continue;
+            }
+            if (file.isDirectory()) {
+                File propsFile = new File(file, "META-INF/infra-service.properties");
+                if (propsFile.exists()) {
+                    try (InputStream is = java.nio.file.Files.newInputStream(propsFile.toPath())) {
+                        allProps.load(is);
+                    } catch (IOException e) {
+                        // skip
+                    }
+                }
+            } else {
+                try (JarFile jarFile = new JarFile(file)) {
+                    JarEntry entry = jarFile.getJarEntry("META-INF/infra-service.properties");
+                    if (entry != null) {
+                        try (InputStream is = jarFile.getInputStream(entry)) {
+                            allProps.load(is);
+                        }
+                    }
+                } catch (IOException e) {
+                    // skip
+                }
+            }
+        }
+        return allProps;
+    }
+
+    private String resolveVersionFromGAHint(
+            Properties infraProps, List<String> implAliases, List<String> serviceAliases) {
+
+        List<String> aliasesToTry = new ArrayList<>();
+        aliasesToTry.addAll(implAliases);
+        aliasesToTry.addAll(serviceAliases);
+
+        for (String alias : aliasesToTry) {
+            String ga = infraProps.getProperty(alias);
+            if (ga == null || ga.isEmpty()) {
+                continue;
+            }
+            String[] parts = ga.split(":");
+            if (parts.length != 2) {
+                continue;
+            }
+            for (Artifact artifact : project.getArtifacts()) {
+                if (parts[0].equals(artifact.getGroupId()) && parts[1].equals(artifact.getArtifactId())) {
+                    return artifact.getVersion();
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String normalizeForMatching(String s) {
+        return s.replace("-", "").replace(".", "").toLowerCase();
+    }
+
     private boolean classExistsInDependency(String classPath, File dependency) throws IOException {
         if (dependency.isDirectory()) {
             return new File(dependency, classPath).exists();
@@ -143,6 +377,7 @@ public class CamelTestInfraGenerateMetadataMojo extends AbstractGeneratorMojo {
         private String groupId;
         private String artifactId;
         private String version;
+        private String serviceVersion;
 
         public String getService() {
             return service;
@@ -206,6 +441,14 @@ public class CamelTestInfraGenerateMetadataMojo extends AbstractGeneratorMojo {
 
         public void setVersion(String version) {
             this.version = version;
+        }
+
+        public String getServiceVersion() {
+            return serviceVersion;
+        }
+
+        public void setServiceVersion(String serviceVersion) {
+            this.serviceVersion = serviceVersion;
         }
     }
 }

--- a/tooling/spi-annotations/src/main/java/org/apache/camel/spi/annotations/InfraService.java
+++ b/tooling/spi-annotations/src/main/java/org/apache/camel/spi/annotations/InfraService.java
@@ -69,4 +69,16 @@ public @interface InfraService {
      * @return
      */
     String[] serviceImplementationAlias() default {};
+
+    /**
+     * The version of the infrastructure service (e.g., "7.4.9" for Redis, "2.54.0" for Artemis).
+     *
+     * For container-based services, the version is auto-detected from the container image tag in container.properties
+     * at build time and does not need to be set here.
+     *
+     * For embedded services (no container), set this to the library version manually.
+     *
+     * @return
+     */
+    String serviceVersion() default "";
 }


### PR DESCRIPTION
## Summary

- Add `serviceVersion` field to `@InfraService` annotation and generated `metadata.json`
- Auto-detect service version from container image tags in `container.properties` (65 container-based services)
- Auto-detect service version from Maven dependency resolution via `META-INF/infra-service.properties` GA hints (6 embedded/special services: FTP, FTPS, SFTP, Hazelcast, Ignite, SMB)
- All 68 test-infra services now report their service version in metadata

## How it works

Three-tier version detection in `CamelTestInfraGenerateMetadataMojo`:

1. **Annotation override** — `@InfraService(serviceVersion = "...")` for manual specification
2. **Container image tag** — scans `container.properties` from dependency JARs, matches alias to image key, extracts version from Docker image tag (handles cross-module properties, multi-image modules like Kafka, RocketMQ's separate `.version` pattern)
3. **GA hint lookup** — reads `META-INF/infra-service.properties` files that map service alias to Maven `groupId:artifactId`, then resolves the artifact version from the dependency tree. Zero maintenance on version bumps.

## Test plan

- [x] Build `camel-package-maven-plugin` and `camel-test-infra-all`
- [x] Verify all 68 services have `serviceVersion` in generated `metadata.json`
- [x] Verify container-based services extract correct image tags (Kafka=4.3.0, Redpanda=v26.1.9, Redis=7.4.9-alpine, etc.)
- [x] Verify embedded services resolve from Maven dependencies (FTP=1.2.1, SFTP=2.18.0, Hazelcast=5.4.0, Ignite=2.18.0, SMB=0.14.0)
- [x] Verify multi-image modules match correct per-implementation version (Kafka 4 variants, HiveMQ 2 variants)

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)