### PR TITLE
CAMEL-23527: Link API-based component docs to the security model

### DIFF
--- a/components/camel-as2/camel-as2-component/src/main/docs/as2-component.adoc
+++ b/components/camel-as2/camel-as2-component/src/main/docs/as2-component.adoc
@@ -48,5 +48,14 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
+++ b/components/camel-box/camel-box-component/src/main/docs/box-component.adoc
@@ -46,6 +46,15 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 == Usage
 
 === Connection Authentication Types

--- a/components/camel-braintree/src/main/docs/braintree-component.adoc
+++ b/components/camel-braintree/src/main/docs/braintree-component.adoc
@@ -41,6 +41,15 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 == Examples
 
 [source,java]

--- a/components/camel-dhis2/camel-dhis2-component/src/main/docs/dhis2-component.adoc
+++ b/components/camel-dhis2/camel-dhis2-component/src/main/docs/dhis2-component.adoc
@@ -40,6 +40,15 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 == Examples
 
 * Fetch an organisation unit by ID:

--- a/components/camel-fhir/camel-fhir-component/src/main/docs/fhir-component.adoc
+++ b/components/camel-fhir/camel-fhir-component/src/main/docs/fhir-component.adoc
@@ -62,5 +62,14 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-google/camel-google-calendar/src/main/docs/google-calendar-component.adoc
+++ b/components/camel-google/camel-google-calendar/src/main/docs/google-calendar-component.adoc
@@ -55,6 +55,15 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-google/camel-google-drive/src/main/docs/google-drive-component.adoc
+++ b/components/camel-google/camel-google-drive/src/main/docs/google-drive-component.adoc
@@ -63,6 +63,15 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 
 == More Information
 

--- a/components/camel-google/camel-google-mail/src/main/docs/google-mail-component.adoc
+++ b/components/camel-google/camel-google-mail/src/main/docs/google-mail-component.adoc
@@ -63,6 +63,15 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 == Data Type Transformer: update-message-labels
 
 The `google-mail:update-message-labels` data type transformer builds a `ModifyMessageRequest` from exchange variables, resolving label names to Gmail label IDs automatically.

--- a/components/camel-google/camel-google-sheets/src/main/docs/google-sheets-component.adoc
+++ b/components/camel-google/camel-google-sheets/src/main/docs/google-sheets-component.adoc
@@ -69,6 +69,15 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 
 == ValueInputOption
 

--- a/components/camel-olingo2/camel-olingo2-component/src/main/docs/olingo2-component.adoc
+++ b/components/camel-olingo2/camel-olingo2-component/src/main/docs/olingo2-component.adoc
@@ -67,6 +67,15 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 == Usage
 
 === Endpoint HTTP Headers

--- a/components/camel-olingo4/camel-olingo4-component/src/main/docs/olingo4-component.adoc
+++ b/components/camel-olingo4/camel-olingo4-component/src/main/docs/olingo4-component.adoc
@@ -62,6 +62,15 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 
 == Usage
 

--- a/components/camel-twilio/src/main/docs/twilio-component.adoc
+++ b/components/camel-twilio/src/main/docs/twilio-component.adoc
@@ -36,6 +36,15 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 == Usage
 
 === Producer Endpoints:

--- a/components/camel-zendesk/src/main/docs/zendesk-component.adoc
+++ b/components/camel-zendesk/src/main/docs/zendesk-component.adoc
@@ -37,6 +37,15 @@ include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
+[NOTE]
+====
+This is an API-based component, so per-call parameters can be supplied through `Camel`-prefixed
+exchange headers in addition to the endpoint options. If the route consumes messages from untrusted
+producers, strip these internal headers at the trust boundary -- for example with
+`removeHeaders("Camel*")` -- before the message reaches this component, so that a sender cannot
+override the API call. See xref:manual::security-model.adoc[the Camel security model] for details.
+====
+
 
 
 include::spring-boot:partial$starter.adoc[]


### PR DESCRIPTION
## Summary

Adds a note to each API-based component's documentation cross-referencing the security model's guidance on stripping `Camel`-internal headers at the trust boundary.

## Context

API-based components let routes override per-call parameters via `Camel`-prefixed exchange headers (e.g. `CamelFhir.*`). This is intentional framework behavior, but a route that consumes messages from untrusted producers should strip those internal headers — for example with `removeHeaders("Camel*")` — at the trust boundary. The component pages did not previously cross-reference this guidance.

## Changes

- Added the same `[NOTE]` with an `xref:manual::security-model.adoc[...]` to 13 API-based component docs, right after the component options block: `as2`, `box`, `braintree`, `dhis2`, `fhir`, `google-calendar`, `google-drive`, `google-mail`, `google-sheets`, `olingo2`, `olingo4`, `twilio`, `zendesk`.
- Docs-only; the `docs/components/...` pages are symlinks to the component sources, so only the 13 source `.adoc` files change.

Approach confirmed with @oscerd on the JIRA ticket (option B: a note per component rather than a shared partial). A page-level xref (no fragment) is used because the *Deployment hardening* section has no explicit anchor, avoiding a cross-version broken link.

_Reported by Claude Code on behalf of Karol Krawczyk_