### PR TITLE
CAMEL-23652: Add tests for bean EIP ref with local template beans

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/KameletLoaderTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/KameletLoaderTest.groovy
@@ -451,6 +451,62 @@ class KameletLoaderTest extends YamlTestSupport {
             }
     }
 
+    def "kamelet with local bean via bean ref"() {
+        setup:
+            loadKamelets '''
+                apiVersion: camel.apache.org/v1
+                kind: Kamelet
+                metadata:
+                  name: counter-action
+                  labels:
+                    camel.apache.org/kamelet.type: action
+                spec:
+                  definition:
+                    title: "Counter Action"
+                    properties:
+                      start:
+                        title: Start
+                        description: The starting value for the counter
+                        type: integer
+                        default: 0
+                  template:
+                    beans:
+                      - name: counter
+                        type: java.util.concurrent.atomic.AtomicInteger
+                        constructors:
+                          "0": "{{start}}"
+                    from:
+                      uri: kamelet:source
+                      steps:
+                        - bean:
+                            ref: "{{counter}}"
+                            method: getAndIncrement
+                        - to: "kamelet:sink"
+            '''
+
+            loadRoutes """
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - kamelet:
+                          name: "counter-action"
+                      - to: "mock:result"
+            """
+
+            withMock('mock:result') {
+                expectedBodiesReceived '0'
+            }
+
+        when:
+            context.start()
+
+            withTemplate {
+                to('direct:start').withBody('hello').send()
+            }
+        then:
+            MockEndpoint.assertIsSatisfied(context)
+    }
+
     def "kamelet with bean constructors"() {
         when:
         loadKamelets('''

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/KameletTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/KameletTest.groovy
@@ -291,6 +291,40 @@ class KameletTest extends YamlTestSupport {
             MockEndpoint.assertIsSatisfied(context)
     }
 
+    def "kamelet (definition with local bean via bean ref)"() {
+        setup:
+            loadRoutes '''
+                - routeTemplate:
+                    id: "myTemplate"
+                    beans:
+                      - name: "myCounter"
+                        type: java.util.concurrent.atomic.AtomicInteger
+                    from:
+                      uri: "kamelet:source"
+                      steps:
+                        - bean:
+                            ref: "{{myCounter}}"
+                            method: "getAndIncrement"
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - to: "kamelet:myTemplate"
+                      - to: "mock:result"
+            '''
+
+            withMock('mock:result') {
+                expectedMessageCount 1
+                expectedBodiesReceived '0'
+            }
+        when:
+            withTemplate {
+                to('direct:start').withBody('hello').send()
+            }
+
+        then:
+            MockEndpoint.assertIsSatisfied(context)
+    }
+
     def "kamelet (definition with default parameters)"() {
         setup:
             loadRoutes """


### PR DESCRIPTION
## Summary
- Add test coverage for using `bean: ref: "{{beanName}}"` to reference local template beans in kamelets and route templates
- Tests verify the scenario reported in CAMEL-23652 where `bean` EIP `ref` references a template-scoped bean
- Both tests pass, confirming this works correctly in the current codebase

## Tests Added
- **`KameletTest`** — `"kamelet (definition with local bean via bean ref)"`: Tests `bean: ref: "{{myCounter}}"` in a YAML `routeTemplate` with an `AtomicInteger` template bean
- **`KameletLoaderTest`** — `"kamelet with local bean via bean ref"`: Tests the full kamelet YAML format (`apiVersion`/`kind`/`spec`) with `template.beans` defining an `AtomicInteger` with constructor parameter `{{start}}`, and `bean: ref: "{{counter}}"` referencing it — matching the exact scenario from the JIRA issue

## Test plan
- [x] `mvn test -pl dsl/camel-yaml-dsl/camel-yaml-dsl -Dtest="KameletLoaderTest,KameletTest"` — all 23 tests pass

_Claus Ibsen using Claude Code on behalf of Claus Ibsen_