### PR TITLE
CAMEL-19527: remove unnecessary Thread.sleep from JMX monitor tests

### DIFF
--- a/components/camel-jmx/src/test/java/org/apache/camel/component/jmx/JMXMonitorTypeGaugeTest.java
+++ b/components/camel-jmx/src/test/java/org/apache/camel/component/jmx/JMXMonitorTypeGaugeTest.java
@@ -36,9 +36,7 @@ public class JMXMonitorTypeGaugeTest extends SimpleBeanFixture {
 
         getMockFixture().getMockEndpoint().setExpectedMessageCount(1);
         simpleBean.setMonitorNumber(90);
-        Thread.sleep(600);
         simpleBean.setMonitorNumber(60);
-        Thread.sleep(600);
         simpleBean.setMonitorNumber(40);
         getMockFixture().waitForMessages();
         getMockFixture().assertMessageReceived(new File("src/test/resources/monitor-consumer/gaugeNotification-low.xml"));

--- a/components/camel-jmx/src/test/java/org/apache/camel/component/jmx/JMXMonitorTypeStringMatchesTest.java
+++ b/components/camel-jmx/src/test/java/org/apache/camel/component/jmx/JMXMonitorTypeStringMatchesTest.java
@@ -29,7 +29,6 @@ public class JMXMonitorTypeStringMatchesTest extends SimpleBeanFixture {
         ISimpleMXBean simpleBean = getSimpleMXBean();
 
         simpleBean.setStringValue("bogus");
-        Thread.sleep(600);
         simpleBean.setStringValue("initial");
         getMockFixture().waitForMessages();
         getMockFixture().assertMessageReceived(new File("src/test/resources/monitor-consumer/stringMatches.xml"));


### PR DESCRIPTION
# Description

This change removes unnecessary `Thread.sleep()` calls from the following JMX monitor tests:

* `JMXMonitorTypeGaugeTest`
* `JMXMonitorTypeStringMatchesTest`

The original implementation used fixed delays between updates to monitored attributes before asserting that the expected JMX notifications were received. After investigating the tests, the delays were found to be unnecessary for correct test execution.

The sleeps were removed and the tests were executed repeatedly to verify that notifications were still generated and received correctly. The tests continued to pass consistently without the delays, indicating that synchronization was already being handled by the existing test infrastructure (`MockEndpointFixture.waitForMessages()`), which waits for the expected messages to arrive before performing assertions.

The JIRA issue suggests several possible approaches for handling `Thread.sleep()` usage, including:

* Awaitility
* Java synchronization mechanisms
* Removing the sleep entirely when it is not required

For these two tests, introducing Awaitility would effectively replace a fixed wait with another form of waiting without providing additional synchronization benefits. Since the tests pass reliably without any delay, the sleeps were removed rather than replaced.

As part of the investigation, `JMXRobustRemoteConnectionTest` was also reviewed. That test relies on asynchronous JMX connection and reconnection behavior, and the existing sleeps appear to be coordinating with actual reconnect timing. Therefore, no changes were made to that test in this pull request.

## Validation performed

* `./mvnw -pl components/camel-jmx -am test`
* `./mvnw -pl components/camel-jmx -am test -Dtest=JMXMonitorTypeGaugeTest,JMXMonitorTypeStringMatchesTest`
* `./mvnw -pl components/camel-jmx -am test -Dtest=JMXMonitorTypeGaugeTest,JMXMonitorTypeStringMatchesTest -Dsurefire.rerunFailingTestsCount=20`
* `./mvnw -pl components/camel-jmx -am clean install -DskipTests`

# Target

* [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

* [x] I checked that there is a JIRA issue filed for this change: CAMEL-19527

# Apache Camel coding standards and style

* [x] I checked that each commit in the pull request has a meaningful subject line and body.

* [x] I have run `./mvnw -pl components/camel-jmx -am clean install -DskipTests` locally and verified that no additional changes were generated.
