### PR TITLE
CAMEL-23655: Update GitHub topics for better discoverability

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,9 +21,20 @@ github:
   labels:
     - camel
     - integration
-    - eip
-    - microservices
+    - integration-framework
+    - enterprise-integration-patterns
     - java
+    - spring-boot
+    - quarkus
+    - cloud-native
+    - kubernetes
+    - kafka
+    - rest-api
+    - yaml
+    - data-transformation
+    - middleware
+    - microservices
+    - mcp
   dependabot_alerts:  true
   dependabot_updates: true
   autolink_jira:


### PR DESCRIPTION
## Summary

- Expand GitHub topics from 5 to 16 (out of 20 max) to improve discoverability
- Add runtimes: `spring-boot`, `quarkus`
- Add deployment/ecosystem: `cloud-native`, `kubernetes`, `kafka`
- Add capabilities: `rest-api`, `yaml`, `data-transformation`, `middleware`
- Add AI integration: `mcp` (Model Context Protocol)
- Replace abbreviated `eip` with full `enterprise-integration-patterns`
- Add `integration-framework` as a category term
- Keep `camel`, `microservices`, `integration`, `java`

Topics are ordered by significance: identity, platform, deployment, capabilities, emerging.

## Test plan

- [ ] After merge, verify topics appear on https://github.com/apache/camel

_Claude Code on behalf of Claus Ibsen_