### PR TITLE
CAMEL-23659: camel-main - Stub mode should ignore property bindings for stubbed components

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
@@ -2873,12 +2873,18 @@ public abstract class BaseMainSupport extends BaseService {
         }
 
         for (Map.Entry<PropertyOptionKey, OrderedLocationProperties> entry : properties.entrySet()) {
+            Object instance = entry.getKey().getInstance();
+            boolean failFast = mainConfigurationProperties.isAutoConfigurationFailFast();
+            // stubbed components do not have the same properties as the original component
+            if ("StubComponent".equals(instance.getClass().getSimpleName())) {
+                failFast = false;
+            }
             setPropertiesOnTarget(
                     camelContext,
-                    entry.getKey().getInstance(),
+                    instance,
                     entry.getValue(),
                     entry.getKey().getOptionPrefix(),
-                    mainConfigurationProperties.isAutoConfigurationFailFast(),
+                    failFast,
                     true,
                     autoConfiguredProperties);
         }

--- a/core/camel-main/src/main/java/org/apache/camel/main/MainHelper.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/MainHelper.java
@@ -376,8 +376,9 @@ public final class MainHelper {
 
             if (failIfNotSet) {
                 // enrich the error with more precise details with option prefix and key
+                Throwable cause = e.getCause() != null ? e.getCause() : e;
                 throw new PropertyBindingException(
-                        e.getTarget(), e.getPropertyName(), e.getValue(), optionPrefix, key, e.getCause());
+                        e.getTarget(), e.getPropertyName(), e.getValue(), optionPrefix, key, cause);
             } else {
                 LOG.debug(
                         "Error configuring property ({}) with name: {}) on bean: {} with value: {}. This exception is ignored as failIfNotSet=false.",


### PR DESCRIPTION
## Summary

- When using `--stub=kafka` (or other components), if `application.properties` contains component-level configuration like `camel.component.kafka.brokers=localhost:9092`, the stub component does not have those properties and a `PropertyBindingException` (NPE) is thrown.
- Stub mode now gracefully ignores property bindings for stubbed components by disabling fail-fast when the target is a `StubComponent`.
- Also fixed a latent NPE in `MainHelper` where `e.getCause()` could be null when re-throwing an enriched `PropertyBindingException`.

## Test plan

- [ ] Run with `camel run --stub=kafka` and `camel.component.kafka.brokers=localhost:9092` in properties — should no longer throw
- [ ] Run existing `camel-main` tests — all pass

_Claude Code on behalf of Claus Ibsen_