### PR TITLE
CAMEL-23663: camel-jbang - Add config to turn off plugin banner in --help

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelJBangMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/CamelJBangMain.java
@@ -293,7 +293,19 @@ public class CamelJBangMain implements Callable<Integer> {
         return false;
     }
 
-    private void printAvailablePlugins() {
+    void printAvailablePlugins() {
+        // check if the plugin banner is disabled via global config
+        boolean[] enabled = { true };
+        CommandLineHelper.loadProperties(properties -> {
+            String v = properties.getProperty("camel.jbang.plugin.banner");
+            if ("false".equalsIgnoreCase(v)) {
+                enabled[0] = false;
+            }
+        });
+        if (!enabled[0]) {
+            return;
+        }
+
         Set<String> installed = new HashSet<>();
         JsonObject config = PluginHelper.getPluginConfig();
         if (config != null) {
@@ -330,6 +342,7 @@ public class CamelJBangMain implements Callable<Integer> {
             out.println();
             out.println("Tip: Install with: camel plugin add <name>");
             out.println("     Bundled plugins are auto-installed on first use.");
+            out.println("     Turn off: camel config set camel.jbang.plugin.banner=false");
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/CamelJBangMainTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/CamelJBangMainTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
+import org.apache.camel.dsl.jbang.core.common.PluginHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CamelJBangMainTest extends CamelCommandBaseTestSupport {
+
+    private CamelJBangMain main;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+
+        CommandLineHelper.useHomeDir("target");
+        PluginHelper.createPluginConfig();
+
+        main = new CamelJBangMain().withPrinter(printer);
+
+        // set the static commandLine field so printAvailablePlugins() can check subcommands
+        Field f = CamelJBangMain.class.getDeclaredField("commandLine");
+        f.setAccessible(true);
+        f.set(null, new CommandLine(main));
+    }
+
+    @Test
+    public void shouldShowPluginBannerByDefault() throws Exception {
+        UserConfigHelper.createUserConfig("");
+
+        main.printAvailablePlugins();
+
+        List<String> output = printer.getLines();
+        assertTrue(output.stream().anyMatch(l -> l.contains("Plugins (not installed):")));
+        assertTrue(output.stream().anyMatch(l -> l.contains("Turn off: camel config set camel.jbang.plugin.banner=false")));
+    }
+
+    @Test
+    public void shouldHidePluginBannerWhenDisabled() throws Exception {
+        UserConfigHelper.createUserConfig("camel.jbang.plugin.banner=false");
+
+        main.printAvailablePlugins();
+
+        List<String> output = printer.getLines();
+        assertFalse(output.stream().anyMatch(l -> l.contains("Plugins (not installed):")));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `camel.jbang.plugin.banner` config option (stored in global user config) to disable the "Plugins (not installed)" banner shown on every `--help` invocation
- When the banner is shown, a new hint line tells users how to turn it off: `Turn off: camel config set camel.jbang.plugin.banner=false`
- Users can disable via: `camel config set camel.jbang.plugin.banner=false`
- Users can re-enable via: `camel config set camel.jbang.plugin.banner=true`

## Test plan

- [x] New test: `CamelJBangMainTest.shouldShowPluginBannerByDefault` — verifies banner shows by default
- [x] New test: `CamelJBangMainTest.shouldHidePluginBannerWhenDisabled` — verifies banner is hidden when config is false

_Claude Code on behalf of Claus Ibsen_