### PR TITLE
[CAMEL-23481] replace retired Apache Derby with H2 in camel-jpa tests

### DIFF
--- a/components/camel-jpa/pom.xml
+++ b/components/camel-jpa/pom.xml
@@ -90,15 +90,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>${derby-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbytools</artifactId>
-            <version>${derby-version}</version>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2-version}</version>
             <scope>test</scope>
         </dependency>        
         <dependency>
@@ -250,7 +244,7 @@
             <dependencies>
                 <dependency>
                     <groupId>org.hibernate</groupId>
-                    <artifactId>hibernate-core-jakarta</artifactId>
+                    <artifactId>hibernate-core</artifactId>
                     <version>${hibernate-version}</version>
                     <scope>test</scope>
                 </dependency>

--- a/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaRouteSkipLockedEntityTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaRouteSkipLockedEntityTest.java
@@ -118,7 +118,7 @@ public class JpaRouteSkipLockedEntityTest extends AbstractJpaTest {
         entityManager.getTransaction().begin();
         Connection connection = entityManager.unwrap(Connection.class);
         connection.createStatement()
-                .execute("CALL SYSCS_UTIL.SYSCS_SET_DATABASE_PROPERTY('derby.locks.waitTimeout', '" + timeout + "')");
+                .execute("SET LOCK_TIMEOUT " + timeout);
         entityManager.getTransaction().commit();
     }
 

--- a/components/camel-jpa/src/test/resources/META-INF/persistence.xml
+++ b/components/camel-jpa/src/test/resources/META-INF/persistence.xml
@@ -40,8 +40,8 @@
     <class>org.apache.camel.examples.Order</class>
 
     <properties>
-      <property name="openjpa.ConnectionURL" value="jdbc:derby:target/derby;create=true"/>
-      <property name="openjpa.ConnectionDriverName" value="org.apache.derby.jdbc.EmbeddedDriver"/>
+      <property name="openjpa.ConnectionURL" value="jdbc:h2:./target/h2;DB_CLOSE_DELAY=-1"/>
+      <property name="openjpa.ConnectionDriverName" value="org.h2.Driver"/>
       <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema"/>
       <!-- <property name="openjpa.Log" value="DefaultLevel=WARN, Tool=INFO, SQL=TRACE"/> -->
       <property name="openjpa.Log" value="DefaultLevel=WARN, Tool=INFO"/>
@@ -54,8 +54,8 @@
     <class>org.apache.camel.examples.SendEmail</class>
 
     <properties>
-      <property name="openjpa.ConnectionURL" value="jdbc:derby:target/custom;create=true"/>
-      <property name="openjpa.ConnectionDriverName" value="org.apache.derby.jdbc.EmbeddedDriver"/>
+      <property name="openjpa.ConnectionURL" value="jdbc:h2:./target/custom;DB_CLOSE_DELAY=-1"/>
+      <property name="openjpa.ConnectionDriverName" value="org.h2.Driver"/>
       <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema"/>
       <property name="openjpa.Log" value="DefaultLevel=WARN, Tool=INFO"/>
       <property name="openjpa.Multithreaded" value="true"/>
@@ -67,8 +67,8 @@
 
     <properties>
       <property name="openjpa.ConnectionProperties"
-                value="DriverClassName=org.apache.derby.jdbc.EmbeddedDriver,
-                   Url=jdbc:derby:target/custom;create=true,
+                value="DriverClassName=org.h2.Driver,
+                   Url=jdbc:h2:./target/custom;DB_CLOSE_DELAY=-1,
                    MaxTotal=1,
                    MaxWaitMillis=1000,
                    TestOnBorrow=true"/>
@@ -84,8 +84,8 @@
     <class>org.apache.camel.processor.idempotent.jpa.MessageProcessed</class>
 
     <properties>
-      <property name="openjpa.ConnectionURL" value="jdbc:derby:target/idempotentTest;create=true"/>
-      <property name="openjpa.ConnectionDriverName" value="org.apache.derby.jdbc.EmbeddedDriver"/>
+      <property name="openjpa.ConnectionURL" value="jdbc:h2:./target/idempotentTest;DB_CLOSE_DELAY=-1"/>
+      <property name="openjpa.ConnectionDriverName" value="org.h2.Driver"/>
       <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema"/>
       <property name="openjpa.Log" value="DefaultLevel=WARN, Tool=INFO"/>
       <property name="openjpa.Multithreaded" value="true"/>
@@ -94,16 +94,15 @@
   <!-- END SNIPPET: e1 -->
 
   <persistence-unit name="skipLockedEntiy" transaction-type="RESOURCE_LOCAL">
-  	<provider>org.apache.openjpa.persistence.PersistenceProviderImpl</provider>
+    <provider>org.apache.openjpa.persistence.PersistenceProviderImpl</provider>
     <class>org.apache.camel.examples.VersionedItem</class>
-	
+
   <properties>
-      <property name="openjpa.ConnectionURL" value="jdbc:derby:target/derby;create=true"/>
-      <property name="openjpa.ConnectionDriverName" value="org.apache.derby.jdbc.EmbeddedDriver"/>
+      <property name="openjpa.ConnectionURL" value="jdbc:h2:./target/h2;DB_CLOSE_DELAY=-1"/>
+      <property name="openjpa.ConnectionDriverName" value="org.h2.Driver"/>
       <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema"/>
       <property name="openjpa.Log" value="DefaultLevel=WARN, Tool=INFO"/>
       <property name="openjpa.Multithreaded" value="false"/>
     </properties>
   </persistence-unit>
-  
 </persistence>

--- a/components/camel-jpa/src/test/resources/org/apache/camel/processor/jpa/springJpaRouteSkipLockedTest.xml
+++ b/components/camel-jpa/src/test/resources/org/apache/camel/processor/jpa/springJpaRouteSkipLockedTest.xml
@@ -18,25 +18,25 @@
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<bean id="transactionTemplate" class="org.springframework.transaction.support.TransactionTemplate">
-		<property name="transactionManager" ref="tm"/>
-	</bean>
+    <bean id="transactionTemplate" class="org.springframework.transaction.support.TransactionTemplate">
+        <property name="transactionManager" ref="tm"/>
+    </bean>
 
-	<bean class="org.springframework.orm.jpa.JpaTransactionManager" id="tm">
-		<property name="entityManagerFactory" ref="entityManagerFactory" />
-	</bean>
+    <bean class="org.springframework.orm.jpa.JpaTransactionManager" id="tm">
+        <property name="entityManagerFactory" ref="entityManagerFactory" />
+    </bean>
 
-	<bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalEntityManagerFactoryBean">
-		<property name="persistenceUnitName" value="skipLockedEntiy"/>
-	</bean>
+    <bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalEntityManagerFactoryBean">
+        <property name="persistenceUnitName" value="skipLockedEntiy"/>
+    </bean>
 
-	<bean class="org.apache.camel.component.jpa.JpaComponent" id="jpa">
-		<property name="entityManagerFactory" ref="entityManagerFactory" />
-	</bean>
-	<bean class="org.apache.camel.component.jpa.JpaComponent" id="jpa2">
-		<property name="entityManagerFactory" ref="entityManagerFactory" />
-	</bean>
+    <bean class="org.apache.camel.component.jpa.JpaComponent" id="jpa">
+        <property name="entityManagerFactory" ref="entityManagerFactory" />
+    </bean>
+    <bean class="org.apache.camel.component.jpa.JpaComponent" id="jpa2">
+        <property name="entityManagerFactory" ref="entityManagerFactory" />
+    </bean>
 
 </beans>

--- a/components/camel-jpa/src/test/resources/profiles/hibernate/META-INF/persistence.xml
+++ b/components/camel-jpa/src/test/resources/profiles/hibernate/META-INF/persistence.xml
@@ -32,9 +32,9 @@
     <class>org.apache.camel.examples.Order</class>
 
     <properties>
-      <property name="hibernate.dialect" value="org.hibernate.dialect.DerbyTenSevenDialect"/>
-      <property name="hibernate.connection.driver_class" value="org.apache.derby.jdbc.EmbeddedDriver"/>
-      <property name="hibernate.connection.url" value="jdbc:derby:target/derby;create=true"/>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+      <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
+      <property name="hibernate.connection.url" value="jdbc:h2:./target/h2;DB_CLOSE_DELAY=-1"/>
       <property name="hibernate.hbm2ddl.auto" value="create"/>
     </properties>
   </persistence-unit>
@@ -46,9 +46,9 @@
     <class>org.apache.camel.examples.SendEmail</class>
 
     <properties>
-      <property name="hibernate.dialect" value="org.hibernate.dialect.DerbyTenSevenDialect"/>
-      <property name="hibernate.connection.driver_class" value="org.apache.derby.jdbc.EmbeddedDriver"/>
-      <property name="hibernate.connection.url" value="jdbc:derby:target/custom;create=true"/>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+      <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
+      <property name="hibernate.connection.url" value="jdbc:h2:./target/custom;DB_CLOSE_DELAY=-1"/>
       <property name="hibernate.hbm2ddl.auto" value="create"/>
     </properties>
   </persistence-unit>
@@ -59,9 +59,9 @@
     <class>org.apache.camel.examples.SendEmail</class>
 
     <properties>
-      <property name="hibernate.dialect" value="org.hibernate.dialect.DerbyTenSevenDialect"/>
-      <property name="hibernate.connection.driver_class" value="org.apache.derby.jdbc.EmbeddedDriver"/>
-      <property name="hibernate.connection.url" value="jdbc:derby:target/custom;create=true"/>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+      <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
+      <property name="hibernate.connection.url" value="jdbc:h2:./target/custom;DB_CLOSE_DELAY=-1"/>
       <property name="hibernate.hbm2ddl.auto" value="create"/>
     </properties>
   </persistence-unit>
@@ -72,9 +72,9 @@
     <class>org.apache.camel.processor.idempotent.jpa.MessageProcessed</class>
 
     <properties>
-      <property name="hibernate.dialect" value="org.hibernate.dialect.DerbyTenSevenDialect"/>
-      <property name="hibernate.connection.driver_class" value="org.apache.derby.jdbc.EmbeddedDriver"/>
-      <property name="hibernate.connection.url" value="jdbc:derby:target/idempotentTest;create=true"/>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+      <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
+      <property name="hibernate.connection.url" value="jdbc:h2:./target/idempotentTest;DB_CLOSE_DELAY=-1"/>
       <property name="hibernate.hbm2ddl.auto" value="create"/>
     </properties>
   </persistence-unit>
@@ -85,11 +85,10 @@
     <class>org.apache.camel.examples.VersionedItem</class>
 
     <properties>
-      <property name="hibernate.dialect" value="org.hibernate.dialect.DerbyTenSevenDialect"/>
-      <property name="hibernate.connection.driver_class" value="org.apache.derby.jdbc.EmbeddedDriver"/>
-      <property name="hibernate.connection.url" value="jdbc:derby:target/derby;create=true"/>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+      <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
+      <property name="hibernate.connection.url" value="jdbc:h2:./target/h2;DB_CLOSE_DELAY=-1"/>
       <property name="hibernate.hbm2ddl.auto" value="create"/>
     </properties>
   </persistence-unit>
-  
 </persistence>


### PR DESCRIPTION
Replace Derby test dependencies with H2 database. Update `persistence.xml` files for both OpenJPA and Hibernate profiles to use H2 driver, dialect, and JDBC URLs. Replace Derby-specific SQL syntax in lock timeout test.

All tests pass with H2, also on profiles `openjpa`, `hibernate` and `full`.

Made with help from AI tools.
