### PR TITLE
[CAMEL-23481] replace retired Apache Derby with H2 in camel-jcr tests

### DIFF
--- a/components/camel-jcr/pom.xml
+++ b/components/camel-jcr/pom.xml
@@ -64,16 +64,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>${derby-version}</version>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2-version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbytools</artifactId>
-            <version>${derby-version}</version>
-            <scope>test</scope>
-        </dependency>        
+
     </dependencies>
 </project>

--- a/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrAuthTestBase.java
+++ b/components/camel-jcr/src/test/java/org/apache/camel/component/jcr/JcrAuthTestBase.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.component.jcr;
 
-import java.io.File;
-
 import javax.jcr.Repository;
 import javax.jcr.SimpleCredentials;
 import javax.jcr.security.AccessControlList;
@@ -42,9 +40,11 @@ public abstract class JcrAuthTestBase extends CamelTestSupport {
 
     protected static final String BASE_REPO_PATH = "/home/test";
 
+    protected static final String CONFIG_FILE = "target/test-classes/repository.xml";
+
     protected static final String REPO_PATH = "target/repository";
 
-    private static Repository repository = new TransientRepository(new File(REPO_PATH));
+    private static Repository repository = new TransientRepository(CONFIG_FILE, REPO_PATH);
 
     @BeforeAll
     public static void cleanupDirectory() {

--- a/components/camel-jcr/src/test/resources/repository.xml
+++ b/components/camel-jcr/src/test/resources/repository.xml
@@ -21,9 +21,15 @@
           PUBLIC "-//The Apache Software Foundation//DTD Jackrabbit 2.0//EN"
           "http://jackrabbit.apache.org/dtd/repository-2.0.dtd">
 
-<!-- Example Repository Configuration File
-     Used by
-     - org.apache.jackrabbit.core.config.RepositoryConfigTest.java
+<!--
+    Repository Configuration for Authentication Tests
+
+    This configuration is used by JcrAuthTestBase (and its subclasses: JcrAuthLoginTest,
+    JcrAuthLoginFailureTest). It differs from repository-simple-security.xml in that it uses
+    DefaultSecurityManager instead of SimpleSecurityManager, because the auth tests need to
+    programmatically create users via the UserManager API, which is not supported by
+    SimpleSecurityManager. Both configurations use H2PersistenceManager for database-backed
+    storage (replacing the retired Apache Derby).
 -->
 <Repository>
     <!--
@@ -47,24 +53,15 @@
             security manager:
             class: FQN of class implementing the JackrabbitSecurityManager interface
         -->
-        <SecurityManager class="org.apache.jackrabbit.core.security.simple.SimpleSecurityManager" workspaceName="security">
-            <!--
-            workspace access:
-            class: FQN of class implementing the WorkspaceAccessManager interface
-            -->
-            <!-- <WorkspaceAccessManager class="..."/> -->
-            <!-- <param name="config" value="${rep.home}/security.xml"/> -->
-        </SecurityManager>
+        <SecurityManager class="org.apache.jackrabbit.core.DefaultSecurityManager" workspaceName="security"/>
 
         <!--
             access manager:
             class: FQN of class implementing the AccessManager interface
         -->
-        <AccessManager class="org.apache.jackrabbit.core.security.simple.SimpleAccessManager">
-            <!-- <param name="config" value="${rep.home}/access.xml"/> -->
-        </AccessManager>
+        <AccessManager class="org.apache.jackrabbit.core.security.DefaultAccessManager"/>
 
-        <LoginModule class="org.apache.jackrabbit.core.security.simple.SimpleLoginModule">
+        <LoginModule class="org.apache.jackrabbit.core.security.authentication.DefaultLoginModule">
            <!--
               anonymous user name ('anonymous' is the default value)
             -->
@@ -142,12 +139,5 @@
         <param name="path" value="${rep.home}/repository/index"/>
         <param name="supportHighlighting" value="true"/>
     </SearchIndex>
-
-    <!--
-        Run with a cluster journal
-    -->
-    <Cluster id="node1">
-        <Journal class="org.apache.jackrabbit.core.journal.MemoryJournal"/>
-    </Cluster>
 
 </Repository>


### PR DESCRIPTION
- Replace Derby dependencies with H2 in `pom.xml`
- Update repository configurations to use `H2PersistenceManager`
- Add `repository.xml` for auth tests requiring `DefaultSecurityManager`
- Update `JcrAuthTestBase` to use explicit configuration file

All tests pass with H2 database.

Made with help from AI tools.
