### PR TITLE
CAMEL-23652: Fix route template local bean not found when param value matches bean name

### DIFF
--- a/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
+++ b/core/camel-core-engine/src/main/java/org/apache/camel/impl/DefaultCamelContext.java
@@ -690,6 +690,7 @@ public class DefaultCamelContext extends SimpleCamelContext implements ModelCame
                     // no side-effect from previously used values that Camel may use in its endpoint
                     // registry and elsewhere
                     if (bbr != null && !bbr.isEmpty()) {
+                        Map<String, String> beanNameMappings = new HashMap<>();
                         for (Map.Entry<String, Object> param : params.entrySet()) {
                             Object value = param.getValue();
                             if (value instanceof String oldKey) {
@@ -701,7 +702,16 @@ public class DefaultCamelContext extends SimpleCamelContext implements ModelCame
                                             routeDefinition.getId(), oldKey, newKey);
                                     bbrCopy.put(newKey, bbr.remove(oldKey));
                                     param.setValue(newKey);
+                                    beanNameMappings.put(oldKey, newKey);
                                 }
+                            }
+                        }
+                        // ensure bean names removed during clash detection are still
+                        // available as template parameters so they can be referenced
+                        // directly in routes via {{beanName}}
+                        for (Map.Entry<String, String> mapping : beanNameMappings.entrySet()) {
+                            if (!params.containsKey(mapping.getKey())) {
+                                params.put(mapping.getKey(), mapping.getValue());
                             }
                         }
                         // the remainder of the local beans must also have their ids made global unique

--- a/core/camel-core/src/test/java/org/apache/camel/builder/RouteTemplateLocalBeanTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/builder/RouteTemplateLocalBeanTest.java
@@ -949,4 +949,36 @@ public class RouteTemplateLocalBeanTest extends ContextTestSupport {
         return answer;
     }
 
+    @Test
+    public void testLocalBeanWithParamValueClash() throws Exception {
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                routeTemplate("myTemplate")
+                        .templateParameter("foo")
+                        .templateParameter("scheme")
+                        .templateBean("counter").typeClass(AtomicInteger.class).end()
+                        .from("direct:{{foo}}")
+                        .to("bean:{{counter}}?method=getAndIncrement");
+            }
+        });
+
+        context.start();
+
+        TemplatedRouteBuilder.builder(context, "myTemplate")
+                .parameter("foo", "one")
+                .parameter("scheme", "counter")
+                .routeId("myRoute")
+                .add();
+
+        assertEquals(1, context.getRoutes().size());
+
+        Object out = template.requestBody("direct:one", "World");
+        assertEquals(0, out);
+        out = template.requestBody("direct:one", "World");
+        assertEquals(1, out);
+
+        context.stop();
+    }
+
 }


### PR DESCRIPTION
## Summary

- Fix bug where route template local beans (e.g., from kamelets) could not be referenced via `{{beanName}}` when a template parameter value coincidentally matched the bean name
- When `doStartRouteDefinitions()` processes local beans for uniqueness, the first loop detects "clashes" where a parameter value matches a bean key (e.g., `scheme=counter` where `counter` is a bean name). It removes the bean from the registry and renames it, but failed to add the original bean name as a template parameter — leaving `{{beanName}}` references unresolvable
- Added test `testLocalBeanWithParamValueClash` covering this scenario

## Test plan

- [x] Existing 72 route template tests pass (now 73 with the new test)
- [x] External reproducer project from JIRA issue passes
- [x] New test verifies the exact scenario: local bean referenced via `{{counter}}` with a parameter `scheme=counter` that coincidentally matches

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)