### PR TITLE
CAMEL-23674: camel-jbang - Register ExportTypeConverter for Duration and Short types

### DIFF
--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/KameletMain.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/KameletMain.java
@@ -18,6 +18,7 @@ package org.apache.camel.main;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -812,7 +813,9 @@ public class KameletMain extends MainCommandLineSupport {
         answer.getTypeConverterRegistry().addTypeConverter(Double.class, String.class, ec);
         answer.getTypeConverterRegistry().addTypeConverter(Float.class, String.class, ec);
         answer.getTypeConverterRegistry().addTypeConverter(Byte.class, String.class, ec);
+        answer.getTypeConverterRegistry().addTypeConverter(Short.class, String.class, ec);
         answer.getTypeConverterRegistry().addTypeConverter(Boolean.class, String.class, ec);
+        answer.getTypeConverterRegistry().addTypeConverter(Duration.class, String.class, ec);
         answer.getTypeConverterRegistry().addFallbackTypeConverter(ec, false);
 
         // turn of validator in onException during export


### PR DESCRIPTION
## Summary

Fixes [CAMEL-23674](https://issues.apache.org/jira/browse/CAMEL-23674): The export silent run fails on non-stubbed components (like `timer`) when property placeholders resolve to `@@CamelMagicValue@@` and the target type is `java.time.Duration`.

## Root Cause

The `ExportTypeConverter` already handles `Duration` conversion, but it was only registered as a **fallback** converter. The built-in `DurationConverter` (a direct `@Converter`) runs first and throws `NumberFormatException` when trying to parse `@@CamelMagicValue@@`, preventing the fallback from ever being tried.

## Fix

Register the `ExportTypeConverter` explicitly for `Duration.class` (and `Short.class` which was also missing) so it takes priority over the built-in converters during export, matching the existing pattern for `Integer`, `Long`, `Double`, `Float`, `Byte`, and `Boolean`.

## Test Plan

- [x] `ExportTest.shouldGenerateJavaContent` — previously failing on all 3 runtime variants (Quarkus, Spring Boot, Camel Main), now passes
- [x] Full reactor build passes

_Claude Code on behalf of Claus Ibsen_