### PR TITLE
CAMEL-23535: camel-api - batch 4: enhance class-level javadoc for routes and builders

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/AsyncCallback.java
+++ b/core/camel-api/src/main/java/org/apache/camel/AsyncCallback.java
@@ -21,7 +21,7 @@ package org.apache.camel;
  * <p/>
  * For example a {@link AsyncProcessor} should invoke the done method when the {@link Exchange} is ready to be continued
  * routed. This allows to implement asynchronous {@link Producer} which can continue routing {@link Exchange} when all
- * the data has been gathered. This allows to build non blocking request/reply communication.
+ * the data has been gathered. This allows to build non-blocking request/reply communication.
  *
  * @see AsyncProcessor
  */
@@ -34,7 +34,7 @@ public interface AsyncCallback extends Runnable {
      * processed will hold the caused exception.
      *
      * @param doneSync is <tt>true</tt> if the processing of the {@link Exchange} was completed by a synchronous thread.
-     *                 Otherwise its <tt>false</tt> to indicate it was completed by an asynchronous thread.
+     *                 Otherwise, its <tt>false</tt> to indicate it was completed by an asynchronous thread.
      */
     void done(boolean doneSync);
 

--- a/core/camel-api/src/main/java/org/apache/camel/AsyncProcessor.java
+++ b/core/camel-api/src/main/java/org/apache/camel/AsyncProcessor.java
@@ -40,7 +40,7 @@ public interface AsyncProcessor extends Processor {
      * @param  callback the {@link AsyncCallback} will be invoked when the processing of the exchange is completed. If
      *                  the exchange is completed synchronously, then the callback is also invoked synchronously. The
      *                  callback should therefore be careful of starting recursive loop.
-     * @return          (doneSync) <tt>true</tt> to continue execute synchronously, <tt>false</tt> to continue being
+     * @return          (doneSync) <tt>true</tt> to continue execution synchronously, <tt>false</tt> to continue being
      *                  executed asynchronously
      */
     boolean process(Exchange exchange, AsyncCallback callback);

--- a/core/camel-api/src/main/java/org/apache/camel/Builder.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Builder.java
@@ -16,6 +16,16 @@
  */
 package org.apache.camel;
 
+/**
+ * Generic builder contract for objects that are assembled in multiple steps before being produced.
+ * <p/>
+ * Implementations collect configuration through setters or a fluent API and then materialize the final object via
+ * {@link #build()}. Being a {@link FunctionalInterface}, it can also be satisfied by a lambda or method reference
+ * wherever a deferred-construction callback is expected (for example in route template bean suppliers).
+ *
+ * @param <T> the type of object produced by this builder
+ * @see       RouteTemplateContext.BeanSupplier
+ */
 @FunctionalInterface
 public interface Builder<T> {
     T build();

--- a/core/camel-api/src/main/java/org/apache/camel/ErrorHandlerFactory.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ErrorHandlerFactory.java
@@ -17,7 +17,20 @@
 package org.apache.camel;
 
 /**
- * Factory for creating {@link org.apache.camel.spi.ErrorHandler}s.
+ * Factory that creates and configures an <a href="https://camel.apache.org/manual/error-handler.html">error handler</a>
+ * for a {@link Route}.
+ * <p/>
+ * Each route gets its own private error handler instance to avoid cross-route interference. The factory is therefore
+ * cloned once per route via {@link #cloneBuilder()} before the route is started. The resulting
+ * {@link org.apache.camel.spi.ErrorHandler} wraps every {@link Processor} in the route's pipeline and intercepts any
+ * exception thrown during processing, applying the configured retry, redelivery, and dead-letter-channel policies.
+ * <p/>
+ * Built-in implementations include the default error handler, the dead letter channel, and the no-error-handler (a
+ * pass-through). Route configurations can override the factory used for a set of routes via
+ * {@link RouteConfigurationsBuilder}.
+ *
+ * @see org.apache.camel.spi.ErrorHandler
+ * @see RouteConfigurationsBuilder
  */
 public interface ErrorHandlerFactory {
 

--- a/core/camel-api/src/main/java/org/apache/camel/ExtendedStartupListener.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExtendedStartupListener.java
@@ -17,10 +17,13 @@
 package org.apache.camel;
 
 /**
- * Extended {@link StartupListener} that is invoked when the {@link CamelContext} is fully started.
+ * A {@link StartupListener} variant whose callback is guaranteed to fire exactly once, after all route consumers are
+ * fully started and the {@link CamelContext} is considered completely running.
  * <p/>
- * <b>Important:</b> You can use this listener to add and start new routes to the {@link CamelContext} which is now
- * supported.
+ * Unlike the base {@link StartupListener} (which fires twice during startup: once before consumers start and once
+ * after), {@code ExtendedStartupListener} provides a single, unambiguous signal that the context is fully operational.
+ * This makes it the correct hook for code that must run after every route is reachable, such as adding and starting
+ * additional routes programmatically.
  *
  * @see StartupListener
  */

--- a/core/camel-api/src/main/java/org/apache/camel/LoggingLevel.java
+++ b/core/camel-api/src/main/java/org/apache/camel/LoggingLevel.java
@@ -19,7 +19,13 @@ package org.apache.camel;
 import jakarta.xml.bind.annotation.XmlEnum;
 
 /**
- * Used to configure the logging levels
+ * Logging severity levels used throughout Camel to control the verbosity of diagnostic output.
+ * <p/>
+ * This enum is used wherever Camel accepts a configurable log level: the
+ * <a href="https://camel.apache.org/manual/log-eip.html">Log EIP</a>, the {@link org.apache.camel.spi.CamelLogger},
+ * error-handler redelivery logging, tracing, the dead-letter channel, and many component-level options. It maps
+ * directly to the SLF4J levels of the same name. {@link #OFF} disables the specific log statement without changing the
+ * logger's overall threshold.
  */
 @XmlEnum
 public enum LoggingLevel {

--- a/core/camel-api/src/main/java/org/apache/camel/ManagementMBeansLevel.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ManagementMBeansLevel.java
@@ -19,8 +19,16 @@ package org.apache.camel;
 import jakarta.xml.bind.annotation.XmlEnum;
 
 /**
- * Level of mbeans for registration
+ * Controls which Camel objects are registered as JMX MBeans for management and monitoring.
+ * <p/>
+ * When JMX management is active, Camel can expose the {@link CamelContext}, its {@link Route}s, and individual
+ * {@link Processor}s as MBeans. Registering many processors improves observability but increases heap usage; this enum
+ * lets operators trade off granularity against overhead.
+ * <p/>
+ * Configure via {@code ManagementAgent.setMBeansLevel(ManagementMBeansLevel)} or the property
+ * {@code camel.main.jmx-management-mbeans-level}.
  *
+ * @see   ManagementStatisticsLevel
  * @since 3.17
  */
 @XmlEnum

--- a/core/camel-api/src/main/java/org/apache/camel/ManagementStatisticsLevel.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ManagementStatisticsLevel.java
@@ -19,7 +19,16 @@ package org.apache.camel;
 import jakarta.xml.bind.annotation.XmlEnum;
 
 /**
- * Level of granularity for performance statistics enabled
+ * Controls the granularity of JMX performance statistics collected for a running {@link CamelContext}.
+ * <p/>
+ * Statistics are collected by the Camel management layer and exposed via MBeans. Finer granularity (down to individual
+ * {@link Processor}s) gives richer observability but uses more memory. {@link #Extended} adds extra counters such as
+ * idle-since timestamps.
+ * <p/>
+ * Configure via {@code ManagementAgent.setStatisticsLevel(ManagementStatisticsLevel)} or the property
+ * {@code camel.main.jmx-management-statistics-level}. The default is {@link #Default}.
+ *
+ * @see ManagementMBeansLevel
  */
 @XmlEnum
 public enum ManagementStatisticsLevel {

--- a/core/camel-api/src/main/java/org/apache/camel/NamedNode.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NamedNode.java
@@ -22,7 +22,18 @@ import java.util.List;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Represents a node in the {@link org.apache.camel.model routes} which is identified by an id.
+ * Represents an identifiable node in the Camel route model.
+ * <p/>
+ * The route model (in the {@code org.apache.camel.model} package) is the abstract syntax tree built by the DSL before
+ * routes are started. Every model element — from the route itself down to individual EIP steps such as
+ * {@code .filter()}, {@code .choice()}, and {@code .to()} — implements {@code NamedNode} so that it can be located by
+ * id, referenced in logs and management output, and traversed by tooling (debuggers, tracers, visualizers).
+ * <p/>
+ * The {@link #getId()} is auto-generated when not explicitly set, and the optional {@link #getNodePrefixId()} is used
+ * when routes share a common id prefix to avoid collisions in composite applications.
+ *
+ * @see NamedRoute
+ * @see Navigate
  */
 public interface NamedNode extends LineNumberAware {
 

--- a/core/camel-api/src/main/java/org/apache/camel/NamedRoute.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NamedRoute.java
@@ -20,8 +20,18 @@ import org.apache.camel.spi.Resource;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Represents a node in the {@link org.apache.camel.model routes} which is identified as a route.
+ * Represents a route-level node in the Camel route model, identified by a route id.
+ * <p/>
+ * While {@link NamedNode} identifies any model node (EIP step, route, etc.) by a generic id, {@code NamedRoute} is more
+ * specific: it marks a top-level route definition. Implementations expose the route id, an optional description, and
+ * the source {@link org.apache.camel.spi.Resource} from which the route was loaded (e.g., a YAML file or an in-memory
+ * string).
+ * <p/>
+ * This interface is used internally by the framework and by management / tooling layers to enumerate routes and map
+ * them back to their definition source.
  *
+ * @see   NamedNode
+ * @see   Route
  * @since 3.0
  */
 public interface NamedRoute {

--- a/core/camel-api/src/main/java/org/apache/camel/Navigate.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Navigate.java
@@ -21,8 +21,19 @@ import java.util.List;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Implementations support navigating a graph where you can traverse forward and each next returns a {@link List} of
- * outputs of type <tt>T</tt> that can contain <tt>0..n</tt> nodes.
+ * Supports forward traversal of a directed graph where each step returns a {@link List} of successor nodes of type
+ * {@code T} (0 to n nodes per step).
+ * <p/>
+ * In the Camel route model the graph is the EIP pipeline tree rooted at each {@link Route}. Every model node that can
+ * have children implements {@code Navigate} so that tools such as the backlog tracer, route visualizer, and the
+ * debugger can walk the entire processing graph without coupling to a specific model class hierarchy.
+ * <p/>
+ * Callers must invoke {@link #next()} and {@link #hasNext()} <em>at most once each</em>: the interface is stateless and
+ * not designed for repeated iteration.
+ *
+ * @param <T> the node type returned by each traversal step
+ * @see       NamedNode
+ * @see       Route
  */
 public interface Navigate<T> {
 

--- a/core/camel-api/src/main/java/org/apache/camel/NonManagedService.java
+++ b/core/camel-api/src/main/java/org/apache/camel/NonManagedService.java
@@ -17,7 +17,14 @@
 package org.apache.camel;
 
 /**
- * A marker to indicate the {@link Service} should not be registered in JMX for management.
+ * Marker interface that excludes a {@link Service} from JMX management registration.
+ * <p/>
+ * By default, Camel registers internal services (components, producers, consumers, etc.) as JMX MBeans so that they can
+ * be monitored and controlled at runtime. Services that implement {@code NonManagedService} are silently skipped during
+ * this registration phase, which is appropriate for lightweight helper services, anonymous inner-class processors, or
+ * services that would expose no useful management attributes.
+ *
+ * @see Service
  */
 public interface NonManagedService {
 }

--- a/core/camel-api/src/main/java/org/apache/camel/Ordered.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Ordered.java
@@ -17,7 +17,13 @@
 package org.apache.camel;
 
 /**
- * Interface to be implemented by objects that should be orderable, such as with a {@link java.util.Collection}.
+ * Implemented by objects that carry an explicit ordering position within a sorted collection.
+ * <p/>
+ * Camel uses this interface wherever the evaluation or application sequence matters: {@link Processor} chains,
+ * interceptors, {@link org.apache.camel.spi.LifecycleStrategy} callbacks, and bean-method resolution all sort their
+ * participants by {@link #getOrder()}. Lower values run first; {@link #HIGHEST} ({@code Integer.MIN_VALUE}) gives the
+ * absolute earliest slot and {@link #LOWEST} gives a near-last slot (values above {@code LOWEST} are reserved for
+ * internal Camel use).
  */
 public interface Ordered {
 

--- a/core/camel-api/src/main/java/org/apache/camel/Route.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Route.java
@@ -32,12 +32,21 @@ import org.apache.camel.spi.RoutePolicy;
 import org.jspecify.annotations.Nullable;
 
 /**
- * A <a href="https://camel.apache.org/routes.html">Route</a> defines the processing used on an inbound message exchange
- * from a specific {@link org.apache.camel.Endpoint} within a {@link org.apache.camel.CamelContext}.
+ * A <a href="https://camel.apache.org/manual/routes.html">Route</a> defines the processing applied to an inbound
+ * {@link Exchange} arriving at a specific {@link Endpoint} within a {@link CamelContext}.
  * <p/>
- * Use the API from {@link org.apache.camel.CamelContext} to control the lifecycle of a route, such as starting and
- * stopping using the {@link org.apache.camel.spi.RouteController#startRoute(String)} and
- * {@link org.apache.camel.spi.RouteController#stopRoute(String)} methods.
+ * Each route has a unique id, an input {@link Endpoint}, and a chain of {@link Processor}s that transform or route the
+ * exchange. Routes are built using a DSL ({@link RoutesBuilder}, {@code RouteBuilder} in Java DSL, YAML DSL, XML DSL)
+ * and are registered in the {@link CamelContext} at startup.
+ * <p/>
+ * The lifecycle of a route (start, stop, suspend, resume) is managed through the
+ * {@link org.apache.camel.spi.RouteController}. A route can also carry optional
+ * {@link org.apache.camel.spi.RoutePolicy} objects that apply governance rules such as throttling or scheduling.
+ *
+ * @see RoutesBuilder
+ * @see CamelContext
+ * @see org.apache.camel.spi.RouteController
+ * @see org.apache.camel.spi.RoutePolicy
  */
 public interface Route extends RuntimeConfiguration {
 

--- a/core/camel-api/src/main/java/org/apache/camel/RouteAware.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RouteAware.java
@@ -19,8 +19,17 @@ package org.apache.camel;
 import org.jspecify.annotations.Nullable;
 
 /**
- * An interface to represent an object which wishes to be injected with a {@link Route} such as {@link Consumer} which
- * is the consumer for a route.
+ * Implemented by objects that wish to receive a reference to the {@link Route} they belong to.
+ * <p/>
+ * The framework injects the route after it is built but before consumers are started. The primary implementor is
+ * {@link Consumer}: the consumer attached to a route's input {@link Endpoint} is set as route-aware so that it can
+ * access route-level metadata (id, policy, etc.) at runtime.
+ * <p/>
+ * Custom {@link Processor}s and services may also implement this interface to obtain contextual route information
+ * without carrying an explicit route reference in their constructor.
+ *
+ * @see Route
+ * @see Consumer
  */
 public interface RouteAware {
 

--- a/core/camel-api/src/main/java/org/apache/camel/RouteConfigurationsBuilder.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RouteConfigurationsBuilder.java
@@ -17,8 +17,19 @@
 package org.apache.camel;
 
 /**
- * A route configurations builder is capable of building route configurations using the builder and model classes.
+ * Low-level SPI interface for objects that can contribute route configurations to a {@link CamelContext}.
+ * <p/>
+ * Route configurations are shared cross-cutting concerns (such as error handlers, interceptors, and on-exception
+ * clauses) that can be applied to multiple {@link Route}s without repeating them inside each individual route
+ * definition. They are built alongside routes using {@code RouteConfigurationBuilder} (the Java DSL subtype) or the
+ * YAML / XML equivalents.
+ * <p/>
+ * This interface is analogous to {@link RoutesBuilder} but targets configuration artifacts rather than executable
+ * routes. Implementations register the configurations in the {@link CamelContext} prior to route startup so that each
+ * route can resolve them by id.
  *
+ * @see   RoutesBuilder
+ * @see   CamelContext
  * @since 3.12
  */
 public interface RouteConfigurationsBuilder {

--- a/core/camel-api/src/main/java/org/apache/camel/RouteTemplateContext.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RouteTemplateContext.java
@@ -25,8 +25,20 @@ import org.apache.camel.spi.HasCamelContext;
 import org.jspecify.annotations.Nullable;
 
 /**
- * The context used during creating a {@link Route} from a route template.
+ * Contextual environment provided to a <a href="https://camel.apache.org/manual/route-template.html">route template</a>
+ * while it is being instantiated into a concrete {@link Route}.
+ * <p/>
+ * A route template is a parameterized route blueprint registered in the {@link CamelContext}. When the template is
+ * instantiated (for example by a Kamelet), the framework creates a {@code RouteTemplateContext} that carries the
+ * parameter bindings and a local bean repository. Template beans ({@link BeanSupplier}) declared inside the template
+ * are resolved through this context rather than the global registry, so each instantiation gets its own private set of
+ * beans.
+ * <p/>
+ * Implementors provide this context to the template engine; application developers typically interact with it only when
+ * writing custom {@code RouteTemplateParameterSource} or Kamelet binding code.
  *
+ * @see   CamelContext
+ * @see   org.apache.camel.spi.BeanRepository
  * @since 3.10
  */
 public interface RouteTemplateContext extends HasCamelContext {

--- a/core/camel-api/src/main/java/org/apache/camel/RoutesBuilder.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RoutesBuilder.java
@@ -19,12 +19,18 @@ package org.apache.camel;
 import java.util.Set;
 
 /**
- * A routes builder is capable of building routes using the builder and model classes.
+ * Low-level SPI interface for objects that can contribute {@link Route}s to a {@link CamelContext}.
  * <p/>
- * Eventually the routes are added to a {@link org.apache.camel.CamelContext} where they run inside.
+ * Implementations translate a route definition (from any DSL or model) into live {@link Route} instances and register
+ * them with the context. The actual routes become active after the context starts.
+ * <p/>
+ * This interface is not intended to be used directly by Camel application developers. Application code should extend
+ * {@code org.apache.camel.builder.RouteBuilder} (Java DSL) or use the YAML / XML DSLs instead, all of which implement
+ * this interface under the hood.
  *
- * This interface is not intended to be used by Camel end users. Instead, Camel users will use
- * <tt>org.apache.camel.builder.RouteBuilder</tt> to build routes in Java DSL.
+ * @see Route
+ * @see CamelContext
+ * @see RouteConfigurationsBuilder
  */
 public interface RoutesBuilder {
 

--- a/core/camel-api/src/main/java/org/apache/camel/RuntimeConfiguration.java
+++ b/core/camel-api/src/main/java/org/apache/camel/RuntimeConfiguration.java
@@ -19,8 +19,20 @@ package org.apache.camel;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Various runtime configuration options used by {@link org.apache.camel.CamelContext} and {@link Route} for cross
- * cutting functions such as tracing, delayer, stream cache and the like.
+ * Cross-cutting runtime configuration options shared by {@link CamelContext} and individual {@link Route}s.
+ * <p/>
+ * Settings on a {@link Route} override the same setting on the {@link CamelContext} for that route only, allowing
+ * fine-grained per-route tuning. Options covered include:
+ * <ul>
+ * <li>Stream caching (buffer non-repeatable streams to allow re-reading)</li>
+ * <li>Tracing (enable the backlog tracer for debugging)</li>
+ * <li>Message history (record the EIP node sequence an exchange passed through)</li>
+ * <li>Log mask (hide sensitive values in logs)</li>
+ * <li>Startup order and auto-startup behavior per route</li>
+ * </ul>
+ *
+ * @see CamelContext
+ * @see Route
  */
 public interface RuntimeConfiguration {
 

--- a/core/camel-api/src/main/java/org/apache/camel/StartupStep.java
+++ b/core/camel-api/src/main/java/org/apache/camel/StartupStep.java
@@ -17,9 +17,16 @@
 package org.apache.camel;
 
 /**
- * Recording state of steps during startup to capture execution time, and being able to emit events to diagnostic tools
- * such as Java Flight Recorder.
+ * Represents a single timed step in the {@link CamelContext} startup sequence, used for diagnostics and performance
+ * profiling.
+ * <p/>
+ * Steps are hierarchically nested (each step has a parent id) and are recorded by the
+ * {@link org.apache.camel.spi.StartupStepRecorder}. When Java Flight Recorder is on the classpath the recorder emits
+ * each step as a JFR event, making startup timings visible in tools such as JDK Mission Control. Steps are opened at
+ * the start of a discrete initialization phase and closed with {@link #endStep()} when the phase completes.
  *
+ * @see   org.apache.camel.spi.StartupStepRecorder
+ * @see   StartupListener
  * @since 3.8
  */
 public interface StartupStep {

--- a/core/camel-api/src/main/java/org/apache/camel/StartupSummaryLevel.java
+++ b/core/camel-api/src/main/java/org/apache/camel/StartupSummaryLevel.java
@@ -19,8 +19,14 @@ package org.apache.camel;
 import jakarta.xml.bind.annotation.XmlEnum;
 
 /**
- * Controls the level of information logged during startup (and shutdown) of {@link CamelContext}.
+ * Controls how much information {@link CamelContext} logs in its startup (and shutdown) summary.
+ * <p/>
+ * Set via {@code CamelContext.setStartupSummaryLevel(StartupSummaryLevel)} or the property
+ * {@code camel.main.startup-summary-level} in application configuration. The default is {@link #Default}, which logs a
+ * compact route overview. Choose {@link #Verbose} for full endpoint URI details, {@link #Brief} or {@link #Oneline}
+ * when conciseness is preferred, or {@link #Off} to suppress the summary entirely.
  *
+ * @see   CamelContext
  * @since 3.8
  */
 @XmlEnum

--- a/core/camel-api/src/main/java/org/apache/camel/TimerListener.java
+++ b/core/camel-api/src/main/java/org/apache/camel/TimerListener.java
@@ -17,9 +17,12 @@
 package org.apache.camel;
 
 /**
- * Listener for receiving timer events.
+ * Callback interface for objects that need to perform work on a recurring internal timer tick.
  * <p/>
- * For example to periodically update internal state.
+ * Implementations are registered with the {@link org.apache.camel.support.TimerListenerManager}, which fires
+ * {@link #onTimer()} at a fixed interval for all registered listeners. This is used internally by components such as
+ * the throttler and the load-balancer to periodically update rate-limiter windows or health counters without coupling
+ * to a scheduler component.
  *
  * @see org.apache.camel.support.TimerListenerManager
  */

--- a/core/camel-api/src/main/java/org/apache/camel/Traceable.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Traceable.java
@@ -17,8 +17,14 @@
 package org.apache.camel;
 
 /**
- * Traceable processors allowing easier tracing using constructed labels to help identify the processor and where it's
- * defined in the route model.
+ * Implemented by {@link Processor}s that want to expose a human-readable label used by the Camel tracing infrastructure
+ * to identify them in trace output and log messages.
+ * <p/>
+ * When the backlog tracer or message-history feature is active, Camel calls {@link #getTraceLabel()} on each processor
+ * to build a concise, path-style identifier such as {@code log:myLogger} or {@code to:direct:next}. The label is also
+ * shown in the startup route summary and in JMX management output.
+ *
+ * @see Processor
  */
 public interface Traceable {
 

--- a/core/camel-api/src/main/java/org/apache/camel/VetoCamelContextStartException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/VetoCamelContextStartException.java
@@ -19,11 +19,15 @@ package org.apache.camel;
 import java.util.Objects;
 
 /**
- * An exception to veto starting {@link CamelContext}.
+ * Thrown by a {@link org.apache.camel.spi.LifecycleStrategy} to abort the startup of a {@link CamelContext}.
  * <p/>
- * The option rethrowException can be used to control whether to rethrow this exception when starting CamelContext or
- * not.
+ * Any {@link org.apache.camel.spi.LifecycleStrategy} registered with the context can veto startup by throwing this
+ * exception from its {@code onContextStarting} callback. Whether the exception propagates out of
+ * {@link CamelContext#start()} is controlled by {@link #isRethrowException()}: when {@code true} (the default) the
+ * exception is re-thrown and the application sees a startup failure; when {@code false} the veto is silent and the
+ * context is simply not started.
  *
+ * @see CamelContext
  * @see org.apache.camel.spi.LifecycleStrategy
  */
 public class VetoCamelContextStartException extends Exception {


### PR DESCRIPTION
# Description

[CAMEL-23535](https://issues.apache.org/jira/browse/CAMEL-23535) asks for an audit and enhancement of the Javadoc in `core/camel-api` so that classes better explain what they are, what they do, and how they fit into the framework, with links to the relevant user-manual pages.

This PR is **batch 4** of that work. Batches 1, 2, and 3 are already merged.

| Batch | PR | Scope |
|---|---|---|
| 1 | #23311 | Lifecycle and context types |
| 2 | #23330 | Messaging core types |
| 3 | #23430 | Endpoint, component, producer, consumer types |
| **4** | **this PR** | **Routes, builders, startup, management, cross-cutting** |

## Changes

Class-level Javadoc expanded on 22 top-level types in `org.apache.camel`:

**Routes and builders:**
`Route`, `RoutesBuilder`, `RouteConfigurationsBuilder`, `RouteTemplateContext`, `RouteAware`, `NamedNode`, `NamedRoute`, `Navigate`, `RuntimeConfiguration`, `ErrorHandlerFactory`

**Lifecycle, startup, and management:**
`VetoCamelContextStartException`, `StartupStep`, `StartupSummaryLevel`, `ExtendedStartupListener`, `NonManagedService`

**Shared cross-cutting types:**
`Builder`, `LoggingLevel`, `ManagementMBeansLevel`, `ManagementStatisticsLevel`, `Ordered`, `Traceable`, `TimerListener`

Each updated docblock follows the same pattern established in the previous batches: a one-sentence what-it-is opener, a paragraph on the role in routing / lifecycle, sibling-type `{@link}` references, and (where a matching user-manual page exists) one `<a href>` link.

The change is **comment-only**: no signatures, behaviour, or runtime code is altered.

## Out of scope (follow-ups under CAMEL-23535)

- Batch 5: annotation and injection types (`BeanInject`, `Body`, `Header`, `Produce`, `Consume`, etc.) — ~20 types
- Batch 6: expression, predicate, and type-conversion types — ~10 types
- Batch 7+: remaining top-level types and `org.apache.camel.spi` package (266 files)

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-23535) filed for the change.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn formatter:format impsort:sort` locally and committed all changes.

---

_Claude Code on behalf of Adriano Machado_