### PR TITLE
CAMEL-23671: Fix ManagePluginsITCase expected output after plugin list refactor

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ManagePluginsITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ManagePluginsITCase.java
@@ -23,7 +23,7 @@ public class ManagePluginsITCase extends JBangTestSupport {
 
     @Test
     public void testPluginInstallation() throws InterruptedException {
-        checkCommandOutputs("plugin get --all", "Supported plugins:");
+        checkCommandOutputs("plugin get --all", "Bundled plugins:");
         execute("plugin add generate");
         checkCommandOutputs("plugin get", "generate");
         checkCommandOutputs("generate -h", "Generate REST DSL source code from OpenApi specification");


### PR DESCRIPTION
## Summary

- Fix `ManagePluginsITCase.testPluginInstallation` which broke after CAMEL-23615 changed `plugin get --all` to delegate to `PluginList`, changing the output header from "Supported plugins:" to "Bundled plugins:"

## Test plan

- [ ] `ManagePluginsITCase.testPluginInstallation` passes with the updated expected string

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)