### PR TITLE
CAMEL-23672: Fix getJsonObject ignoring timeout parameter

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/ActionBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/ActionBaseCommand.java
@@ -46,7 +46,7 @@ abstract class ActionBaseCommand extends CamelCommand {
 
     protected static JsonObject getJsonObject(Path outputFile, long timeout) {
         StopWatch watch = new StopWatch();
-        while (watch.taken() < 5000) {
+        while (watch.taken() < timeout) {
             File f = outputFile.toFile();
             try {
                 // give time for response to be ready


### PR DESCRIPTION
## Summary

- Fix bug in `ActionBaseCommand.getJsonObject(Path, long)` where the `timeout` parameter was ignored and a hardcoded `5000ms` was used instead. This caused `camel cmd send --infra` to time out prematurely (after 5s instead of the intended 30s), breaking `InfrastructureITCase.sendMessageTest`.

## Test plan

- [ ] Existing `InfrastructureITCase.sendMessageTest` should now pass (sends to FTP infra with sufficient timeout)
- [ ] Verify `CamelReceiveAction` also benefits (same two-arg `getJsonObject` caller)
- [ ] One-arg callers unaffected (still default to 5000ms)

_Claude Code on behalf of Claus Ibsen_