### PR TITLE
[CAMEL-23481] replace retired Apache Derby with H2 in camel-mybatis tests

### DIFF
--- a/components/camel-mybatis/pom.xml
+++ b/components/camel-mybatis/pom.xml
@@ -53,15 +53,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>${derby-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbytools</artifactId>
-            <version>${derby-version}</version>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2-version}</version>
             <scope>test</scope>
         </dependency>        
         <dependency>

--- a/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisInsertWithRollbackTest.java
+++ b/components/camel-mybatis/src/test/java/org/apache/camel/component/mybatis/MyBatisInsertWithRollbackTest.java
@@ -26,6 +26,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MyBatisInsertWithRollbackTest extends MyBatisTestSupport {
 
+    @Override
+    protected String getCreateStatement() {
+        // Add NOT NULL constraints to ensure inserting null values throws a
+        // constraint violation exception.
+        // This makes the rollback test work correctly across different
+        // databases (Derby, H2, etc.). Derby was by default throwing an
+        // exception when inserting a null value, but H2 is not.
+        return "create table ACCOUNT (ACC_ID INTEGER NOT NULL, "
+               + "ACC_FIRST_NAME VARCHAR(255) NOT NULL, "
+               + "ACC_LAST_NAME VARCHAR(255) NOT NULL, "
+               + "ACC_EMAIL VARCHAR(255) NOT NULL)";
+    }
+
     @Test
     public void testInsert() throws Exception {
         getMockEndpoint("mock:commit").expectedMessageCount(0);

--- a/components/camel-mybatis/src/test/resources/SqlMapConfig.xml
+++ b/components/camel-mybatis/src/test/resources/SqlMapConfig.xml
@@ -38,8 +38,8 @@
         <environment id="development">
             <transactionManager type="JDBC"/>
             <dataSource type="POOLED">
-                <property name="driver" value="org.apache.derby.jdbc.EmbeddedDriver"/>
-                <property name="url" value="jdbc:derby:memory:mybatis;create=true"/>
+                <property name="driver" value="org.h2.Driver"/>
+                <property name="url" value="jdbc:h2:mem:mybatis;DB_CLOSE_DELAY=-1"/>
             </dataSource>
         </environment>
     </environments>


### PR DESCRIPTION
Replace Derby dependencies with H2 in `pom.xml` and update `SqlMapConfig.xml` to use H2 driver (`org.h2.Driver`) and JDBC URL (`jdbc:h2:mem:mybatis`).

Fix `MyBatisInsertWithRollbackTest` by adding `NOT NULL` constraints to table schema. This ensures null inserts trigger constraint violations (and thus rollback) on H2, matching the behaviour previously exhibited by Derby.

All unit tests pass.

Made with help from AI tools.