### PR TITLE
camel-test-junit6: Make more test configuration methods public for framework extensibility

### DIFF
--- a/components/camel-test/camel-test-junit6/src/main/java/org/apache/camel/test/junit6/CamelContextConfiguration.java
+++ b/components/camel-test/camel-test-junit6/src/main/java/org/apache/camel/test/junit6/CamelContextConfiguration.java
@@ -319,7 +319,7 @@ public class CamelContextConfiguration {
     /**
      * A supplier that classes can use to create a {@link RouteBuilder} to define the routes for testing
      */
-    protected CamelContextConfiguration withRoutesSupplier(
+    public CamelContextConfiguration withRoutesSupplier(
             RoutesSupplier routesSupplier) {
         this.routesSupplier = routesSupplier;
         return this;
@@ -348,7 +348,7 @@ public class CamelContextConfiguration {
      *
      * @param postProcessor the post-test processor to use
      */
-    protected CamelContextConfiguration withPostProcessor(
+    public CamelContextConfiguration withPostProcessor(
             PostProcessor postProcessor) {
         this.postProcessor = postProcessor;
         return this;

--- a/components/camel-test/camel-test-junit6/src/main/java/org/apache/camel/test/junit6/TestExecutionConfiguration.java
+++ b/components/camel-test/camel-test-junit6/src/main/java/org/apache/camel/test/junit6/TestExecutionConfiguration.java
@@ -163,7 +163,7 @@ public class TestExecutionConfiguration {
      * @return     <tt>true</tt> per class, <tt>false</tt> per test.
      */
     @Deprecated(since = "4.7.0")
-    protected TestExecutionConfiguration withCreateCamelContextPerClass(boolean createCamelContextPerClass) {
+    public TestExecutionConfiguration withCreateCamelContextPerClass(boolean createCamelContextPerClass) {
         this.createCamelContextPerClass = createCamelContextPerClass;
         return this;
     }


### PR DESCRIPTION
Motivation for this is to clean up and remove some old hacks in the Camel Quarkus test framework.