### PR TITLE
[CAMEL-23481] Replace retired Apache Derby with H2 in camel-spring-jdbc

### DIFF
--- a/components/camel-spring-parent/camel-spring-jdbc/pom.xml
+++ b/components/camel-spring-parent/camel-spring-jdbc/pom.xml
@@ -62,16 +62,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>${derby-version}</version>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2-version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbytools</artifactId>
-            <version>${derby-version}</version>
-            <scope>test</scope>
-        </dependency>        
+
     </dependencies>
 </project>

--- a/components/camel-spring-parent/camel-spring-jdbc/src/test/java/org/apache/camel/component/spring/jdbc/AbstractJdbcTestSupport.java
+++ b/components/camel-spring-parent/camel-spring-jdbc/src/test/java/org/apache/camel/component/spring/jdbc/AbstractJdbcTestSupport.java
@@ -34,7 +34,7 @@ public abstract class AbstractJdbcTestSupport extends CamelTestSupport {
     public void setupResources() {
         db = new EmbeddedDatabaseBuilder()
                 .setName(getClass().getSimpleName())
-                .setType(EmbeddedDatabaseType.DERBY)
+                .setType(EmbeddedDatabaseType.H2)
                 .addScript("sql/init.sql").build();
     }
 

--- a/components/camel-spring-parent/camel-spring-jdbc/src/test/resources/camelContext.xml
+++ b/components/camel-spring-parent/camel-spring-jdbc/src/test/resources/camelContext.xml
@@ -25,23 +25,23 @@
        http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
     ">
-  
-  <!-- START SNIPPET: example -->  
-  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
-    <route>
-			 <!-- trigger every second -->
-       <from uri="timer://kickoff?period=1000"/>
-       <setBody>
-         <constant>select * from customer</constant>
-       </setBody>
-       <to uri="spring-jdbc:testdb"/>
-       <to uri="mock:result"/>
-    </route>
-  </camelContext>
-  
-  <!-- Just add a demo to show how to bind a data source for camel in Spring-->
-  <jdbc:embedded-database id="testdb" type="DERBY">
-  	<jdbc:script location="classpath:sql/init.sql"/>
-  </jdbc:embedded-database>
-  <!-- END SNIPPET: example -->
+
+    <!-- START SNIPPET: example -->  
+    <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+        <route>
+            <!-- trigger every second -->
+            <from uri="timer://kickoff?period=1000"/>
+            <setBody>
+                <constant>select * from customer</constant>
+            </setBody>
+            <to uri="spring-jdbc:testdb"/>
+            <to uri="mock:result"/>
+        </route>
+    </camelContext>
+
+    <!-- Just add a demo to show how to bind a data source for camel in Spring-->
+    <jdbc:embedded-database id="testdb" type="H2">
+        <jdbc:script location="classpath:sql/init.sql"/>
+    </jdbc:embedded-database>
+    <!-- END SNIPPET: example -->
 </beans>

--- a/components/camel-spring-parent/camel-spring-jdbc/src/test/resources/sql/init.sql
+++ b/components/camel-spring-parent/camel-spring-jdbc/src/test/resources/sql/init.sql
@@ -24,4 +24,4 @@ create table tableWithAutoIncr (id int not null GENERATED ALWAYS AS IDENTITY, co
 insert into tableWithAutoIncr (content) values ('value1');
 
 create table tableWithClob (id varchar(15), picture clob(10M));
-insert into tableWithClob values ('id1', cast('\x0123456789ABCDEF' as clob));
+insert into tableWithClob values ('id1', cast(X'0123456789ABCDEF' as clob));


### PR DESCRIPTION
Apache Derby is a retired project, so replaced it with H2 database for testing. H2 is actively maintained and already widely used in other Camel components like `camel-sql`.

Changes:
- Updated `pom.xml` to use H2 instead of Derby dependencies
- Changed `EmbeddedDatabaseType` from DERBY to H2 in tests
- Updated SQL init script to use H2-compatible binary literal syntax
- All tests passing with H2

Made with help from AI tools.