### PR TITLE
CAMEL-23535: camel-api - batches 5+6: enhance class-level javadoc for annotations, bean binding, and expressions

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/BeanConfigInject.java
+++ b/core/camel-api/src/main/java/org/apache/camel/BeanConfigInject.java
@@ -23,9 +23,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to indicate an injection point of a configuration bean (obtained from the {@link org.apache.camel.spi.Registry},
- * or a new instance is created) into a POJO.
+ * Marks a field, method, constructor, or parameter as an injection point for a configuration bean.
+ * <p/>
+ * {@link #value()} specifies the root property prefix (e.g. {@code camel.component.mycomp}). During bean
+ * post-processing Camel first looks for an existing instance in the {@link org.apache.camel.spi.Registry}; if none is
+ * found it creates a new instance of the declared type and binds all matching properties from that prefix using Camel's
+ * property-binding mechanism. This is the standard way to inject typed configuration objects into components and custom
+ * services.
  *
+ * @see   BeanInject
+ * @see   PropertyInject
  * @since 3.2
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/camel-api/src/main/java/org/apache/camel/BeanInject.java
+++ b/core/camel-api/src/main/java/org/apache/camel/BeanInject.java
@@ -23,9 +23,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to indicate an injection point of a bean obtained from the {@link org.apache.camel.spi.Registry}, into a POJO.
+ * Marks a field, method, constructor, or parameter as an injection point for a bean obtained from the Camel
+ * <a href="https://camel.apache.org/manual/registry.html">{@link org.apache.camel.spi.Registry}</a>.
+ * <p/>
+ * When Camel performs bean post-processing it resolves the injection by looking up the registry: by name if
+ * {@link #value()} is set, or by type if no name is provided. The resolved bean is then injected at the annotated site.
+ * If no matching bean is found an exception is thrown at startup.
  *
- * If no name is specified then the lookup is anonymous and based on lookup up by the type.
+ * @see   BeanConfigInject
+ * @see   PropertyInject
+ * @see   BindToRegistry
+ * @since 3.2
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Documented

--- a/core/camel-api/src/main/java/org/apache/camel/Body.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Body.java
@@ -23,7 +23,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a parameter as being the body of an inbound {@link Message}
+ * Marks a method parameter as the payload of the inbound {@link Message} when Camel performs
+ * <a href="https://camel.apache.org/manual/bean-binding.html">bean binding</a>.
+ * <p/>
+ * When a bean method is invoked via the Bean EIP or {@link Consume}, Camel maps the exchange to the method parameters.
+ * A parameter annotated with {@code @Body} receives {@link Message#getBody()}, optionally converted to the declared
+ * parameter type via the {@link TypeConverter} infrastructure.
+ *
+ * @see Header
+ * @see Headers
+ * @see ExchangeProperty
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Documented

--- a/core/camel-api/src/main/java/org/apache/camel/EndpointConsumerResolver.java
+++ b/core/camel-api/src/main/java/org/apache/camel/EndpointConsumerResolver.java
@@ -17,8 +17,14 @@
 package org.apache.camel;
 
 /**
- * An interface to represent an object that can be resolved as a consumer {@link Endpoint}
+ * Implemented by objects that can be resolved to a consumer-facing {@link Endpoint}.
+ * <p/>
+ * The DSL and annotation processor call {@link #resolve(CamelContext)} to obtain a concrete {@link Endpoint} when an
+ * object used in a {@code from()} clause is not itself an endpoint URI string. This allows richer types (for example,
+ * enum constants or wrapper objects) to be used as route input descriptors without requiring string parsing.
  *
+ * @see   EndpointProducerResolver
+ * @see   Endpoint
  * @since 3.1
  */
 public interface EndpointConsumerResolver {

--- a/core/camel-api/src/main/java/org/apache/camel/EndpointProducerResolver.java
+++ b/core/camel-api/src/main/java/org/apache/camel/EndpointProducerResolver.java
@@ -17,8 +17,14 @@
 package org.apache.camel;
 
 /**
- * An interface to represent an object that can be resolved as a producer {@link Endpoint}
+ * Implemented by objects that can be resolved to a producer-facing {@link Endpoint}.
+ * <p/>
+ * The DSL and annotation processor call {@link #resolve(CamelContext)} to obtain a concrete {@link Endpoint} when an
+ * object used in a {@code to()} clause is not itself an endpoint URI string. This allows richer types (for example,
+ * enum constants or wrapper objects) to be used as route destinations without requiring string parsing.
  *
+ * @see   EndpointConsumerResolver
+ * @see   Endpoint
  * @since 3.1
  */
 public interface EndpointProducerResolver {

--- a/core/camel-api/src/main/java/org/apache/camel/ExchangeProperties.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExchangeProperties.java
@@ -23,8 +23,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a parameter as being an injection point of the exchange properties of an {@link Exchange}
+ * Marks a method parameter as the entire exchange-property map of the current {@link Exchange} when Camel performs
+ * <a href="https://camel.apache.org/manual/bean-binding.html">bean binding</a>.
+ * <p/>
+ * The parameter type should be {@code Map<String, Object>} (or a compatible super-type). Unlike
+ * {@link ExchangeProperty}, which injects a single named property, {@code @ExchangeProperties} gives the method direct
+ * access to all exchange properties at once.
  *
+ * @see ExchangeProperty
  * @see Exchange#getProperties()
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/camel-api/src/main/java/org/apache/camel/ExchangeProperty.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExchangeProperty.java
@@ -23,9 +23,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a parameter as being an injection point of a property of an {@link org.apache.camel.Exchange}
+ * Marks a method parameter as a named exchange property when Camel performs
+ * <a href="https://camel.apache.org/manual/bean-binding.html">bean binding</a>.
+ * <p/>
+ * Exchange properties are key-value pairs stored on the {@link Exchange} (not on the {@link Message}), surviving across
+ * multiple processing steps for the lifetime of the exchange. They are typically used for internal routing state and
+ * correlation data. The {@link #value()} attribute names the property to inject; the value is converted to the declared
+ * parameter type via the {@link TypeConverter} infrastructure.
  *
- * @see org.apache.camel.Exchange#getProperty(String)
+ * @see ExchangeProperties
+ * @see Exchange#getProperty(String)
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Documented

--- a/core/camel-api/src/main/java/org/apache/camel/ExpressionFactory.java
+++ b/core/camel-api/src/main/java/org/apache/camel/ExpressionFactory.java
@@ -17,8 +17,15 @@
 package org.apache.camel;
 
 /**
- * A factory for creating {@link Expression}
+ * Deferred factory for creating an {@link Expression} within a {@link CamelContext}.
+ * <p/>
+ * Being a {@link FunctionalInterface}, implementations are typically supplied as lambdas or method references wherever
+ * a context-aware expression must be constructed lazily, for example when wiring EIP definitions during route startup.
+ * The factory receives the context so it can resolve language services, registries, or configuration values needed to
+ * build the expression.
  *
+ * @see   Expression
+ * @see   PredicateFactory
  * @since 3.0
  */
 @FunctionalInterface

--- a/core/camel-api/src/main/java/org/apache/camel/Handler.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Handler.java
@@ -23,8 +23,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a method on a POJO as being the preferred method to invoke when Camel looks for methods to invoke using the
- * {@link org.apache.camel.component.bean.BeanEndpoint BeanEndpoint}.
+ * Marks a method on a bean as the preferred handler for
+ * <a href="https://camel.apache.org/manual/bean-binding.html">bean binding</a>.
+ * <p/>
+ * When Camel invokes a bean via the Bean EIP or {@link Consume} and the bean has multiple public methods, it uses
+ * heuristics to select the best match. Annotating exactly one method with {@code @Handler} short-circuits that
+ * selection: Camel always calls the annotated method without ambiguity checks or reflection-based scoring. Only one
+ * method per class should carry this annotation.
+ *
+ * @see Consume
+ * @see Body
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Documented

--- a/core/camel-api/src/main/java/org/apache/camel/Header.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Header.java
@@ -23,8 +23,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a parameter as being a header on an inbound {@link Message}
+ * Marks a method parameter as a named header from the inbound {@link Message} when Camel performs
+ * <a href="https://camel.apache.org/manual/bean-binding.html">bean binding</a>.
+ * <p/>
+ * The {@link #value()} attribute names the header to inject. Camel converts the header value to the declared parameter
+ * type via the {@link TypeConverter} infrastructure. If the header is absent the parameter receives {@code null} (or
+ * the primitive default).
  *
+ * @see Body
+ * @see Headers
  * @see Message#getHeader(String)
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/camel-api/src/main/java/org/apache/camel/Headers.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Headers.java
@@ -23,8 +23,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a parameter as being an injection point of the headers of an inbound {@link Message}
+ * Marks a method parameter as the entire header map of the inbound {@link Message} when Camel performs
+ * <a href="https://camel.apache.org/manual/bean-binding.html">bean binding</a>.
+ * <p/>
+ * The parameter type should be {@code Map<String, Object>} (or a compatible super-type). Unlike {@link Header}, which
+ * injects a single named header, {@code @Headers} gives the method direct access to all headers at once, useful when
+ * the set of headers to process is dynamic or unknown at compile time.
  *
+ * @see Header
+ * @see Body
  * @see Message#getHeaders()
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/camel-api/src/main/java/org/apache/camel/PredicateFactory.java
+++ b/core/camel-api/src/main/java/org/apache/camel/PredicateFactory.java
@@ -17,8 +17,15 @@
 package org.apache.camel;
 
 /**
- * A factory for creating {@link Predicate}
+ * Deferred factory for creating a {@link Predicate} within a {@link CamelContext}.
+ * <p/>
+ * Being a {@link FunctionalInterface}, implementations are typically supplied as lambdas or method references wherever
+ * a context-aware predicate must be constructed lazily, for example when wiring filter or choice EIP definitions during
+ * route startup. The factory receives the context so it can resolve language services or configuration values needed to
+ * build the predicate.
  *
+ * @see   Predicate
+ * @see   ExpressionFactory
  * @since 3.8
  */
 @FunctionalInterface

--- a/core/camel-api/src/main/java/org/apache/camel/StaticExpression.java
+++ b/core/camel-api/src/main/java/org/apache/camel/StaticExpression.java
@@ -19,8 +19,15 @@ package org.apache.camel;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Marked if the {@link Expression} or {@link Predicate} is based from a constant value (ie is static).
+ * Marker for an {@link Expression} whose value is a compile-time or configuration-time constant.
+ * <p/>
+ * A static expression always evaluates to the same result regardless of the {@link Exchange}, so the framework can
+ * optimize it: it is evaluated once, the result is cached, and no per-exchange evaluation overhead is incurred.
+ * Implementations must expose the constant through {@link #getValue()} and allow it to be overwritten via
+ * {@link #setValue(Object)} (for example, when a property placeholder is resolved at startup).
  *
+ * @see   Expression
+ * @see   Predicate
  * @since 3.7
  */
 public interface StaticExpression extends Expression {

--- a/core/camel-api/src/main/java/org/apache/camel/TimeoutMap.java
+++ b/core/camel-api/src/main/java/org/apache/camel/TimeoutMap.java
@@ -19,7 +19,16 @@ package org.apache.camel;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Represents a map of values which timeout after a period of inactivity.
+ * A map whose entries expire automatically after a configurable period of inactivity.
+ * <p/>
+ * Entries are added via {@link #put(Object, Object, long)} with an individual timeout in milliseconds. A background
+ * {@link Service} thread periodically scans the map and evicts entries whose timeout has elapsed, notifying any
+ * registered {@link Listener}. This is used internally by components that need session or correlation state with
+ * automatic cleanup, such as the aggregator's in-memory repository and the idempotent consumer.
+ *
+ * @param <K> the key type
+ * @param <V> the value type
+ * @see       Service
  */
 public interface TimeoutMap<K, V> extends Service {
 

--- a/core/camel-api/src/main/java/org/apache/camel/Variable.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Variable.java
@@ -23,8 +23,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a parameter as being a variable
+ * Marks a method parameter as a named <a href="https://camel.apache.org/manual/variables.html">variable</a> when Camel
+ * performs <a href="https://camel.apache.org/manual/bean-binding.html">bean binding</a>.
+ * <p/>
+ * Variables are an exchange-scoped store (separate from headers and exchange properties) introduced in Camel 4.4 to
+ * provide a cleaner namespace for application data that should not pollute message headers. The {@link #value()}
+ * attribute names the variable to inject; the value is converted to the declared parameter type via the
+ * {@link TypeConverter} infrastructure.
  *
+ * @see   Variables
  * @see   Exchange#getVariable(String)
  * @since 4.4
  */

--- a/core/camel-api/src/main/java/org/apache/camel/VariableAware.java
+++ b/core/camel-api/src/main/java/org/apache/camel/VariableAware.java
@@ -19,8 +19,15 @@ package org.apache.camel;
 import org.jspecify.annotations.Nullable;
 
 /**
- * An interface to represent an object that supports variables.
+ * Implemented by objects that carry a <a href="https://camel.apache.org/manual/variables.html">variables</a> store.
+ * <p/>
+ * Variables are a key-value namespace on the {@link Exchange} (separate from message headers and exchange properties)
+ * introduced in Camel 4.4. This interface is the read/write contract for that store and is used internally by the
+ * framework and by EIP implementations that need to get or set variables programmatically.
  *
+ * @see   Variable
+ * @see   Variables
+ * @see   Exchange
  * @since 4.4
  */
 public interface VariableAware {

--- a/core/camel-api/src/main/java/org/apache/camel/Variables.java
+++ b/core/camel-api/src/main/java/org/apache/camel/Variables.java
@@ -23,8 +23,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a parameter as being an injection point of the variables
+ * Marks a method parameter as the entire <a href="https://camel.apache.org/manual/variables.html">variables</a> map of
+ * the current {@link Exchange} when Camel performs <a href="https://camel.apache.org/manual/bean-binding.html">bean
+ * binding</a>.
+ * <p/>
+ * The parameter type should be {@code Map<String, Object>} (or a compatible super-type). Unlike {@link Variable}, which
+ * injects a single named variable, {@code @Variables} gives the method direct access to all variables at once.
  *
+ * @see   Variable
  * @see   Exchange#getVariables()
  * @since 4.4
  */

--- a/core/camel-api/src/main/java/org/apache/camel/spi/UuidGenerator.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/UuidGenerator.java
@@ -22,14 +22,14 @@ package org.apache.camel.spi;
 public interface UuidGenerator {
 
     /**
-     * Generates an UUID string representation.
+     * Generates a UUID string representation.
      *
      * @return the unique id.
      */
     String generateUuid();
 
     /**
-     * Generates an UUID string representation to be used as exchange id.
+     * Generates a UUID string representation to be used as exchange id.
      *
      * @return the unique exchange id
      */


### PR DESCRIPTION
# Description

[CAMEL-23535](https://issues.apache.org/jira/browse/CAMEL-23535) asks for an audit and enhancement of the Javadoc in `core/camel-api` so that classes better explain what they are, what they do, and how they fit into the framework, with links to the relevant user-manual pages.

This PR covers **batches 5 and 6** of that work. The previous batches are already merged:

| Batch | PR | Scope |
|---|---|---|
| 1 | #23311 | Lifecycle and context types |
| 2 | #23330 | Messaging core types |
| 3 | #23430 | Endpoint, component, producer, consumer types |
| 4 | #23720 | Routes, builders, startup, management, cross-cutting |
| **5+6** | **this PR** | **Bean binding annotations, injection, expressions** |

## Changes

Class-level Javadoc expanded on 17 top-level types in `org.apache.camel`:

**Batch 5 — Bean binding annotations and injection (13 types):**

- **Method parameter annotations:** `Body`, `Header`, `Headers`, `ExchangeProperty`, `ExchangeProperties`, `Variable`, `Variables` — each now explains which part of the exchange it injects, the type-conversion step, and cross-references its sibling annotations
- **Bean method selection:** `Handler` — clarifies the method-disambiguation role and the single-method constraint
- **Dependency injection:** `BeanInject`, `BeanConfigInject` — expand the registry-lookup and property-binding mechanics respectively
- **Endpoint resolution:** `EndpointConsumerResolver`, `EndpointProducerResolver` — explain the `from()`/`to()` DSL use case for non-URI objects
- **Variable store contract:** `VariableAware` — describes the variables namespace introduced in Camel 4.4

**Batch 6 — Expressions, predicates, type support (4 types):**

- `ExpressionFactory`, `PredicateFactory` — describe the deferred/lazy factory pattern and the `@FunctionalInterface` lambda use
- `StaticExpression` — explains the constant-value optimization and startup-time property-placeholder resolution
- `TimeoutMap` — describes the eviction mechanism and internal use cases (aggregator, idempotent consumer)

The change is **comment-only**: no signatures, behaviour, or runtime code is altered.

## Out of scope (follow-ups under CAMEL-23535)

- ~65 remaining top-level `org.apache.camel` types (templates, routing annotations, miscellaneous exceptions, etc.)
- `org.apache.camel.spi` package (266 files)

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-23535) filed for the change.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn formatter:format impsort:sort` locally and committed all changes.

---

_Claude Code on behalf of Adriano Machado_