### PR TITLE
CAMEL-23669: camel-hl7: Missing reifier update for targetFormat

### DIFF
--- a/components/camel-hl7/src/test/java/org/apache/camel/component/hl7/HL7XmlDataFormatTest.java
+++ b/components/camel-hl7/src/test/java/org/apache/camel/component/hl7/HL7XmlDataFormatTest.java
@@ -111,6 +111,36 @@ public class HL7XmlDataFormatTest extends CamelTestSupport {
     }
 
     @Test
+    public void testUnmarshalXmlFormatViaModelDefinition() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:unmarshalXmlModel");
+        mock.expectedMessageCount(1);
+
+        String body = createHL7AsString();
+        template.sendBody("direct:unmarshalXmlModel", body);
+
+        MockEndpoint.assertIsSatisfied(context);
+        Object rawBody = mock.getReceivedExchanges().get(0).getIn().getBody();
+        assertNotNull(rawBody);
+        assertInstanceOf(Document.class, rawBody);
+        Document doc = (Document) rawBody;
+        assertEquals("ORM_O01", doc.getDocumentElement().getLocalName());
+    }
+
+    @Test
+    public void testRoundTripViaModelDefinition() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:roundtripModel");
+        mock.expectedMessageCount(1);
+
+        String body = createHL7AsString();
+        template.sendBody("direct:roundtripModel", body);
+
+        MockEndpoint.assertIsSatisfied(context);
+        String edi = mock.getReceivedExchanges().get(0).getIn().getBody(String.class);
+        assertTrue(edi.contains("MSH|^~\\&|"));
+        assertTrue(edi.contains("ORM^O01"));
+    }
+
+    @Test
     public void testRoundTripEdiToXmlToEdi() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:roundtrip");
         mock.expectedMessageCount(1);
@@ -139,6 +169,13 @@ public class HL7XmlDataFormatTest extends CamelTestSupport {
         final HL7DataFormat hl7Default = new HL7DataFormat();
         hl7Default.setValidate(false);
 
+        final org.apache.camel.model.dataformat.HL7DataFormat hl7XmlDef
+                = new org.apache.camel.model.dataformat.HL7DataFormat.Builder()
+                        .targetFormat("XML").validate(false).end();
+        final org.apache.camel.model.dataformat.HL7DataFormat hl7DefaultDef
+                = new org.apache.camel.model.dataformat.HL7DataFormat.Builder()
+                        .validate(false).end();
+
         return new RouteBuilder() {
             public void configure() {
                 from("direct:unmarshalOk").unmarshal().hl7(false).to("mock:unmarshal");
@@ -147,6 +184,9 @@ public class HL7XmlDataFormatTest extends CamelTestSupport {
                 from("direct:marshalFromDoc").marshal(hl7Default).to("mock:marshalFromDoc");
                 from("direct:marshalXmlOutput").marshal(hl7Xml).to("mock:marshalXmlOutput");
                 from("direct:roundtrip").unmarshal(hl7Xml).marshal(hl7Default).to("mock:roundtrip");
+
+                from("direct:unmarshalXmlModel").unmarshal(hl7XmlDef).to("mock:unmarshalXmlModel");
+                from("direct:roundtripModel").unmarshal(hl7XmlDef).marshal(hl7DefaultDef).to("mock:roundtripModel");
             }
         };
     }

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/HL7DataFormatReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/HL7DataFormatReifier.java
@@ -32,6 +32,7 @@ public class HL7DataFormatReifier extends DataFormatReifier<HL7DataFormat> {
     protected void prepareDataFormatConfig(Map<String, Object> properties) {
         properties.put("parser", asRef(definition.getParser()));
         properties.put("validate", definition.getValidate());
+        properties.put("targetFormat", definition.getTargetFormat());
     }
 
 }


### PR DESCRIPTION
Follows up https://github.com/apache/camel/pull/23714 - the 1st PR was missing an update on reifier to propagate a new property `targetFormat`, prevents it from working in YAML DSL

---

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).
https://issues.apache.org/jira/browse/CAMEL-23669

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

