### PR TITLE
chore: increase CI build log tail from 50 to 500 lines

### DIFF
--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -834,9 +834,9 @@ main() {
     # Show end of build log
     if [[ -f "$log" ]]; then
       echo ""
-      echo "Last 50 lines of build log:"
+      echo "Last 500 lines of build log:"
       echo "------------------------------------------------------------"
-      tail -50 "$log"
+      tail -500 "$log"
       echo "------------------------------------------------------------"
       echo ""
     else


### PR DESCRIPTION
The incremental build action only shows the last 50 lines of each failed module's log, which often truncates the actual stack trace making it impossible to diagnose failures. Increase the tail to 500 lines.