### PR TITLE
chore(dsl): Jbang run, skip on sutdown metrics 

### DIFF
--- a/components/camel-micrometer-prometheus/src/main/java/org/apache/camel/component/micrometer/prometheus/MicrometerPrometheus.java
+++ b/components/camel-micrometer-prometheus/src/main/java/org/apache/camel/component/micrometer/prometheus/MicrometerPrometheus.java
@@ -515,10 +515,9 @@ public class MicrometerPrometheus extends ServiceSupport implements CamelMetrics
         String[] scrapes = meterRegistry.scrape().split("\n");
         for (String s : scrapes) {
             if (matchesFilter(s, filters)) {
-                // We put on warn level to make sure it is printed even if the log is
-                // at higher levels. Important: we also include a start and end tag to make sure the
+                // we include a start and end tag to make sure the
                 // scraper can more easily identify the metric content.
-                LOG.warn("#METRIC-START#" + s + "#METRIC-END#");
+                LOG.info("#METRIC-START#" + s + "#METRIC-END#");
             }
         }
     }

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/json/AbstractMicrometerService.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/json/AbstractMicrometerService.java
@@ -249,11 +249,10 @@ public class AbstractMicrometerService extends ServiceSupport {
                 .map(AbstractMicrometerService::convertMeterToMap)
                 .forEach(logEntry -> {
                     try {
-                        // We put on warn level to make sure it is printed even if the log is
-                        // at higher levels. Important: we also include a start and end tag to make sure the
+                        // we include a start and end tag to make sure the
                         // scraper can more easily identify the metric content.
                         String metric = "#METRIC-START#" + mapper.writeValueAsString(logEntry) + "#METRIC-END#";
-                        LOG.warn(metric);
+                        LOG.info(metric);
                     } catch (Exception e) {
                         LOG.error("Error logging metric " + logEntry.get("name"), e);
                     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -1183,6 +1183,7 @@ public class Run extends CamelCommand {
 
         if (serverOptions.observe) {
             dependencies.add("camel:observability-services");
+            main.addOverrideProperty("camel.metrics.logMetricsOnShutdown", "false");
         }
         if (!dependencies.isEmpty()) {
             var joined = String.join(",", dependencies);


### PR DESCRIPTION
# Description

Altough this feature is enabled by default in the observability services component, it makes sense to disable during development cycles (aka `camel run`)

To avoid any potential misunderstanding, we better lower the level of logging. This information is not really a logic warning, but used by any tool that may scrape logging after the application is shut down.

Closes CAMEL-23650

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

