### PR TITLE
CAMEL-23686: Fix dev profile overriding user properties

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
@@ -617,7 +617,8 @@ public abstract class BaseMainSupport extends BaseService {
         // configure the profile with pre-configured settings
         step = recorder.beginStep(BaseMainSupport.class, "configureMain", "Profile Configure");
         doInitFileConfigurations(camelContext, mainConfigurationProperties);
-        ProfileConfigurer.configureMain(camelContext, mainConfigurationProperties.getProfile(), mainConfigurationProperties);
+        ProfileConfigurer.configureMain(camelContext, mainConfigurationProperties.getProfile(), mainConfigurationProperties,
+                autoConfiguredProperties);
         recorder.endStep(step);
 
         // configure main listener

--- a/core/camel-main/src/main/java/org/apache/camel/main/DefaultConfigurationConfigurer.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/DefaultConfigurationConfigurer.java
@@ -352,12 +352,8 @@ public final class DefaultConfigurationConfigurer {
         camelContext.getGlobalEndpointConfiguration().setBridgeErrorHandler(config.isEndpointBridgeErrorHandler());
         camelContext.getGlobalEndpointConfiguration().setLazyStartProducer(config.isEndpointLazyStartProducer());
 
-        if (config.isMessageHistory()) {
-            camelContext.setMessageHistory(true);
-        }
-        if (config.isSourceLocationEnabled()) {
-            camelContext.setSourceLocationEnabled(true);
-        }
+        camelContext.setMessageHistory(config.isMessageHistory());
+        camelContext.setSourceLocationEnabled(config.isSourceLocationEnabled());
 
         camelContext.setTracing(config.isTracing());
         camelContext.setTracingStandby(config.isTracingStandby());

--- a/core/camel-main/src/main/java/org/apache/camel/main/ProfileConfigurer.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/ProfileConfigurer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.main;
 
+import java.util.Properties;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.ManagementStatisticsLevel;
 import org.slf4j.Logger;
@@ -33,11 +35,13 @@ public class ProfileConfigurer {
     /**
      * Configures camel-main to run in given profile
      *
-     * @param camelContext the camel context
-     * @param profile      the profile
-     * @param config       the main configuration
+     * @param camelContext   the camel context
+     * @param profile        the profile
+     * @param config         the main configuration
+     * @param autoConfigured properties that were explicitly configured by the user (may be null)
      */
-    public static void configureMain(CamelContext camelContext, String profile, MainConfigurationProperties config) {
+    public static void configureMain(
+            CamelContext camelContext, String profile, MainConfigurationProperties config, Properties autoConfigured) {
         if (profile == null || profile.isBlank()) {
             // no profile is active
             return;
@@ -72,17 +76,19 @@ public class ProfileConfigurer {
             config.securityConfig().setPolicy("fail");
         }
 
-        configureCommon(camelContext, profile, config);
+        configureCommon(camelContext, profile, config, autoConfigured);
     }
 
     /**
      * Configures camel in general (standalone, quarkus, spring-boot etc) to run in given profile
      *
-     * @param camelContext the camel context
-     * @param profile      the profile
-     * @param config       the core configuration
+     * @param camelContext   the camel context
+     * @param profile        the profile
+     * @param config         the core configuration
+     * @param autoConfigured properties that were explicitly configured by the user (may be null)
      */
-    public static void configureCommon(CamelContext camelContext, String profile, DefaultConfigurationProperties<?> config) {
+    public static void configureCommon(
+            CamelContext camelContext, String profile, DefaultConfigurationProperties<?> config, Properties autoConfigured) {
         camelContext.getCamelContextExtension().setProfile(profile);
 
         if (profile == null || profile.isBlank()) {
@@ -91,23 +97,30 @@ public class ProfileConfigurer {
         }
 
         if ("dev".equals(profile)) {
-            // always enable developer console as it is needed by camel-cli-connector
-            config.setDevConsoleEnabled(true);
-            // and enable a bunch of other stuff that gives more details for developers
-            config.setCamelEventsTimestampEnabled(true);
-            config.setLoadHealthChecks(true);
-            config.setSourceLocationEnabled(true);
-            config.setModeline(true);
-            config.setLoadStatisticsEnabled(true);
-            config.setMessageHistory(true);
-            config.setInflightRepositoryBrowseEnabled(true);
-            config.setMessageSizeEnabled(true);
-            config.setEndpointRuntimeStatisticsEnabled(true);
-            config.setJmxManagementStatisticsLevel(ManagementStatisticsLevel.Extended);
-            config.setJmxUpdateRouteEnabled(true);
-            config.setShutdownLogInflightExchangesOnTimeout(false);
-            config.setShutdownTimeout(10);
-            config.setStartupRecorder("backlog");
+            // enable developer features as defaults — user properties can override any of these
+            setIfNotConfigured(autoConfigured, "camel.main.devConsoleEnabled", () -> config.setDevConsoleEnabled(true));
+            setIfNotConfigured(autoConfigured, "camel.main.camelEventsTimestampEnabled",
+                    () -> config.setCamelEventsTimestampEnabled(true));
+            setIfNotConfigured(autoConfigured, "camel.main.loadHealthChecks", () -> config.setLoadHealthChecks(true));
+            setIfNotConfigured(autoConfigured, "camel.main.sourceLocationEnabled",
+                    () -> config.setSourceLocationEnabled(true));
+            setIfNotConfigured(autoConfigured, "camel.main.modeline", () -> config.setModeline(true));
+            setIfNotConfigured(autoConfigured, "camel.main.loadStatisticsEnabled",
+                    () -> config.setLoadStatisticsEnabled(true));
+            setIfNotConfigured(autoConfigured, "camel.main.messageHistory", () -> config.setMessageHistory(true));
+            setIfNotConfigured(autoConfigured, "camel.main.inflightRepositoryBrowseEnabled",
+                    () -> config.setInflightRepositoryBrowseEnabled(true));
+            setIfNotConfigured(autoConfigured, "camel.main.messageSizeEnabled", () -> config.setMessageSizeEnabled(true));
+            setIfNotConfigured(autoConfigured, "camel.main.endpointRuntimeStatisticsEnabled",
+                    () -> config.setEndpointRuntimeStatisticsEnabled(true));
+            setIfNotConfigured(autoConfigured, "camel.main.jmxManagementStatisticsLevel",
+                    () -> config.setJmxManagementStatisticsLevel(ManagementStatisticsLevel.Extended));
+            setIfNotConfigured(autoConfigured, "camel.main.jmxUpdateRouteEnabled",
+                    () -> config.setJmxUpdateRouteEnabled(true));
+            setIfNotConfigured(autoConfigured, "camel.main.shutdownLogInflightExchangesOnTimeout",
+                    () -> config.setShutdownLogInflightExchangesOnTimeout(false));
+            setIfNotConfigured(autoConfigured, "camel.main.shutdownTimeout", () -> config.setShutdownTimeout(10));
+            setIfNotConfigured(autoConfigured, "camel.main.startupRecorder", () -> config.setStartupRecorder("backlog"));
         }
 
         if ("prod".equals(profile)) {
@@ -117,6 +130,12 @@ public class ProfileConfigurer {
         // no special configuration for other kind of profiles
 
         LOG.info("The application is starting with profile: {}", profile);
+    }
+
+    private static void setIfNotConfigured(Properties autoConfigured, String key, Runnable setter) {
+        if (autoConfigured == null || !autoConfigured.containsKey(key)) {
+            setter.run();
+        }
     }
 
 }


### PR DESCRIPTION
[CAMEL-23686](https://issues.apache.org/jira/browse/CAMEL-23686)

## Summary

- Fix dev profile unconditionally overriding user-configured properties like `camel.main.messageHistory=false`
- `ProfileConfigurer` now checks `autoConfiguredProperties` to skip settings the user explicitly set
- `DefaultConfigurationConfigurer` applies `messageHistory` and `sourceLocationEnabled` unconditionally (not only when true)

## Problem

The dev profile in `ProfileConfigurer.configureCommon()` unconditionally set `messageHistory=true` and other settings, running AFTER user properties were loaded. This meant `camel.main.messageHistory=false` in `application.properties` had no effect.

With pooled exchanges, this caused `DefaultMessageHistory` instances to accumulate unbounded — 2.95M instances consuming 236MB in a 60s test, ballooning heap from 75MB (prod profile) to 696MB (dev profile).

## Changes

- **`ProfileConfigurer.java`**: `setIfNotConfigured()` helper checks `autoConfiguredProperties` before applying dev profile defaults
- **`BaseMainSupport.java`**: Pass `autoConfiguredProperties` to `ProfileConfigurer.configureMain()`
- **`DefaultConfigurationConfigurer.java`**: Change asymmetric if-guards (`if (config.isX()) { set(true); }`) to unconditional application (`set(config.isX())`)

## Test plan

- [x] `MainTest` (11 tests) — pass
- [x] `MainSecurityPolicyTest` (35 tests) — pass, including dev profile security policy tests
- [x] All camel-main tests (230 tests) — pass