### PR TITLE
CAMEL-23686: Fix clock reset on wrong exchange in PooledProcessorExchangeFactory

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/PooledProcessorExchangeFactory.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/PooledProcessorExchangeFactory.java
@@ -72,8 +72,8 @@ public class PooledProcessorExchangeFactory extends PrototypeProcessorExchangeFa
             }
         }
 
-        // reset exchange for reuse
-        ((ResetableClock) exchange.getClock()).reset();
+        // reset the copy's clock for reuse
+        ((ResetableClock) answer.getClock()).reset();
         ExchangeHelper.copyResults(answer, exchange);
         return answer;
     }
@@ -96,8 +96,8 @@ public class PooledProcessorExchangeFactory extends PrototypeProcessorExchangeFa
             }
         }
 
-        // reset exchange for reuse
-        ((ResetableClock) exchange.getClock()).reset();
+        // reset the copy's clock for reuse
+        ((ResetableClock) answer.getClock()).reset();
 
         ExchangeHelper.copyResults(answer, exchange);
         // do not reuse message id on copy


### PR DESCRIPTION
[CAMEL-23686](https://issues.apache.org/jira/browse/CAMEL-23686)

## Summary

- Fix `createCopy()` and `createCorrelatedCopy()` resetting the **original** exchange's clock instead of the **copy's** clock

## Problem

In `PooledProcessorExchangeFactory`, both `createCopy()` (line 76) and `createCorrelatedCopy()` (line 100) called:
```java
((ResetableClock) exchange.getClock()).reset();  // resets ORIGINAL
```

This should be:
```java
((ResetableClock) answer.getClock()).reset();    // resets COPY
```

The `create()` method (line 130) was already correct. The bug meant copy exchanges carried stale timestamps from the pool while the original exchange's clock was incorrectly reset mid-processing.

## Test plan

- [x] Existing unit tests pass
- [x] Verified `create()` method already uses correct pattern