### PR TITLE
CAMEL-23686: Lighten DefaultUnitOfWork route stack allocation

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultUnitOfWork.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultUnitOfWork.java
@@ -16,13 +16,13 @@
  */
 package org.apache.camel.impl.engine;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
@@ -57,9 +57,10 @@ public class DefaultUnitOfWork implements UnitOfWork {
     final boolean useBreadcrumb;
 
     private final CamelContext context;
-    private final Deque<Route> routes = new ConcurrentLinkedDeque<>();
-    private final Lock lock = new ReentrantLock();
     private final Logger log;
+    private Route route;
+    private Deque<Route> routeStack;
+    private final Lock lock = new ReentrantLock();
     private Exchange exchange;
     private List<Synchronization> synchronizations;
     private Message originalInMessage;
@@ -163,7 +164,10 @@ public class DefaultUnitOfWork implements UnitOfWork {
     @Override
     public void reset() {
         this.exchange = null;
-        routes.clear();
+        this.route = null;
+        if (routeStack != null) {
+            routeStack.clear();
+        }
         if (synchronizations != null) {
             synchronizations.clear();
         }
@@ -367,44 +371,62 @@ public class DefaultUnitOfWork implements UnitOfWork {
 
     @Override
     public Route getRoute() {
-        return routes.peek();
+        return route;
     }
 
     @Override
     public void pushRoute(Route route) {
-        routes.push(route);
+        if (this.route == null) {
+            this.route = route;
+        } else {
+            if (routeStack == null) {
+                routeStack = new ArrayDeque<>();
+            }
+            routeStack.push(this.route);
+            this.route = route;
+        }
     }
 
     @Override
     public Route popRoute() {
-        return routes.poll();
+        Route old = this.route;
+        if (routeStack != null && !routeStack.isEmpty()) {
+            this.route = routeStack.pop();
+        } else {
+            this.route = null;
+        }
+        return old;
     }
 
     @Override
     public int routeStackLevel() {
-        return routes.size();
+        return (route != null ? 1 : 0) + (routeStack != null ? routeStack.size() : 0);
     }
 
     public int routeStackLevel(boolean includeRouteTemplate, boolean includeKamelet) {
         if (includeKamelet && includeRouteTemplate) {
-            return routes.size();
+            return routeStackLevel();
         }
 
         int level = 0;
-        for (Route r : routes) {
-            if (r.isCreatedByKamelet()) {
-                if (includeKamelet) {
-                    level++;
-                }
-            } else if (r.isCreatedByRouteTemplate()) {
-                if (includeRouteTemplate) {
-                    level++;
-                }
-            } else {
-                level++;
+        if (route != null) {
+            level += countRoute(route, includeRouteTemplate, includeKamelet);
+        }
+        if (routeStack != null) {
+            for (Route r : routeStack) {
+                level += countRoute(r, includeRouteTemplate, includeKamelet);
             }
         }
         return level;
+    }
+
+    private static int countRoute(Route r, boolean includeRouteTemplate, boolean includeKamelet) {
+        if (r.isCreatedByKamelet()) {
+            return includeKamelet ? 1 : 0;
+        } else if (r.isCreatedByRouteTemplate()) {
+            return includeRouteTemplate ? 1 : 0;
+        }
+        return 1;
     }
 
     @Override


### PR DESCRIPTION
[CAMEL-23686](https://issues.apache.org/jira/browse/CAMEL-23686)

## Summary

- Replace `ConcurrentLinkedDeque<Route>` with a single `Route` field + lazily-created `ArrayDeque` for nested routes
- Saves ~72 bytes per exchange in the common single-route case

## Problem

Every `DefaultUnitOfWork` eagerly allocated a `ConcurrentLinkedDeque<Route>` (24 bytes + Node objects) even though most exchanges only traverse a single route. In a high-throughput pipeline processing ~1M exchanges/sec, this adds up to significant GC pressure.

## Changes

- `Route route` field holds the current/top route (common case: single route)
- `Deque<Route> routeStack` is lazily created only when `pushRoute()` is called while a route is already set (nested routes via `direct:`, kamelets, etc.)
- `pushRoute()` / `popRoute()` / `getRoute()` / `routeStackLevel()` updated accordingly
- `reset()` clears both fields
- Extracted `countRoute()` helper for the filtered `routeStackLevel(boolean, boolean)` variant

## Test plan

- [x] 43 UnitOfWork-related tests pass
- [x] 230 camel-main tests pass
- [x] Verified nested route scenarios still work (direct, kamelets, route templates)