### PR TITLE
CAMEL-23672: Add stub endpoint detection, direction arrows, and TUI History improvements

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/spi/BacklogTracerEventMessage.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/BacklogTracerEventMessage.java
@@ -204,6 +204,13 @@ public interface BacklogTracerEventMessage extends BacklogEventMessage {
     boolean isRemoteEndpoint();
 
     /**
+     * Whether the endpoint is a stub endpoint.
+     *
+     * @since 4.21
+     */
+    boolean isStubEndpoint();
+
+    /**
      * Gets the endpoint remote address such as URL, hostname, connection-string, or cloud region, that are component
      * specific.
      *

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/debugger/BacklogTracer.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/debugger/BacklogTracer.java
@@ -26,6 +26,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePropertyKey;
 import org.apache.camel.NamedNode;
@@ -178,7 +179,14 @@ public class BacklogTracer extends ServiceSupport implements org.apache.camel.sp
         if ((first || last) && fromRouteId != null) {
             Route route = camelContext.getRoute(fromRouteId);
             if (route != null && route.getConsumer() != null) {
-                event.setEndpointUri(route.getConsumer().getEndpoint().getEndpointUri());
+                Endpoint ep = route.getConsumer().getEndpoint();
+                String endpointUri = ep.getEndpointUri();
+                event.setEndpointUri(endpointUri);
+                event.setRemoteEndpoint(ep.isRemote());
+                if ((endpointUri != null && endpointUri.startsWith("stub:"))
+                        || "StubEndpoint".equals(ep.getClass().getSimpleName())) {
+                    event.setStubEndpoint(true);
+                }
             }
         }
         // synthetic events are snapshots, mark done immediately so elapsed doesn't keep growing

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/debugger/DefaultBacklogTracerEventMessage.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/debugger/DefaultBacklogTracerEventMessage.java
@@ -58,6 +58,7 @@ public final class DefaultBacklogTracerEventMessage implements BacklogTracerEven
     private final String threadName;
     private String endpointUri;
     private boolean remoteEndpoint;
+    private boolean stubEndpoint;
     private String endpointServiceUrl;
     private String endpointServiceProtocol;
     private Map<String, String> endpointServiceMetadata;
@@ -292,6 +293,15 @@ public final class DefaultBacklogTracerEventMessage implements BacklogTracerEven
         this.remoteEndpoint = remoteEndpoint;
     }
 
+    @Override
+    public boolean isStubEndpoint() {
+        return stubEndpoint;
+    }
+
+    public void setStubEndpoint(boolean stubEndpoint) {
+        this.stubEndpoint = stubEndpoint;
+    }
+
     public void setEndpointUri(String endpointUri) {
         this.endpointUri = endpointUri;
         // dirty flag
@@ -370,6 +380,7 @@ public final class DefaultBacklogTracerEventMessage implements BacklogTracerEven
         if (endpointUri != null) {
             sb.append(prefix).append("  <endpointUri>").append(endpointUri).append("</endpointUri>\n");
             sb.append(prefix).append("  <remoteEndpoint>").append(remoteEndpoint).append("</remoteEndpoint>\n");
+            sb.append(prefix).append("  <stubEndpoint>").append(stubEndpoint).append("</stubEndpoint>\n");
         }
         if (toNode != null) {
             sb.append(prefix).append("  <toNode>").append(toNode).append("</toNode>\n");
@@ -562,6 +573,7 @@ public final class DefaultBacklogTracerEventMessage implements BacklogTracerEven
         if (endpointUri != null) {
             jo.put("endpointUri", endpointUri);
             jo.put("remoteEndpoint", remoteEndpoint);
+            jo.put("stubEndpoint", stubEndpoint);
         }
         if (routeId != null) {
             jo.put("routeId", routeId);

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/CamelInternalProcessor.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/CamelInternalProcessor.java
@@ -727,11 +727,12 @@ public class CamelInternalProcessor extends DelegateAsyncProcessor implements In
             String uri = null;
             boolean remote = true;
             Endpoint endpoint = null;
+            Endpoint consumerEndpoint = null;
             if ((data.isFirst() || data.isLast())) {
                 if (route.getConsumer() != null) {
-                    // get the actual resolved uri
-                    uri = route.getConsumer().getEndpoint().getEndpointUri();
-                    remote = route.getConsumer().getEndpoint().isRemote();
+                    consumerEndpoint = route.getConsumer().getEndpoint();
+                    uri = consumerEndpoint.getEndpointUri();
+                    remote = consumerEndpoint.isRemote();
                     endpoint = route.getEndpoint();
                 } else {
                     uri = routeDefinition.getEndpointUrl();
@@ -741,6 +742,11 @@ public class CamelInternalProcessor extends DelegateAsyncProcessor implements In
                 data.setEndpointUri(uri);
             }
             data.setRemoteEndpoint(remote);
+            if ((uri != null && uri.startsWith("stub:"))
+                    || (consumerEndpoint != null
+                            && "StubEndpoint".equals(consumerEndpoint.getClass().getSimpleName()))) {
+                data.setStubEndpoint(true);
+            }
             if (endpoint instanceof EndpointServiceLocation esl) {
                 data.setEndpointServiceUrl(esl.getServiceUrl());
                 data.setEndpointServiceProtocol(esl.getServiceProtocol());
@@ -1015,6 +1021,7 @@ public class CamelInternalProcessor extends DelegateAsyncProcessor implements In
             String uri = null;
             boolean remote = true;
             Endpoint endpoint = notifier.after(exchange);
+            Endpoint resolvedEndpoint = endpoint;
             if (endpoint != null) {
                 uri = endpoint.getEndpointUri();
                 remote = endpoint.isRemote();
@@ -1023,9 +1030,9 @@ public class CamelInternalProcessor extends DelegateAsyncProcessor implements In
                 // pseudo first/last event (the from in the route)
                 Route route = camelContext.getRoute(routeDefinition.getRouteId());
                 if (route != null && route.getConsumer() != null) {
-                    // get the actual resolved uri
-                    uri = route.getConsumer().getEndpoint().getEndpointUri();
-                    remote = route.getConsumer().getEndpoint().isRemote();
+                    resolvedEndpoint = route.getConsumer().getEndpoint();
+                    uri = resolvedEndpoint.getEndpointUri();
+                    remote = resolvedEndpoint.isRemote();
                 } else {
                     uri = routeDefinition.getEndpointUrl();
                 }
@@ -1034,6 +1041,11 @@ public class CamelInternalProcessor extends DelegateAsyncProcessor implements In
                 data.setEndpointUri(uri);
             }
             data.setRemoteEndpoint(remote);
+            if ((uri != null && uri.startsWith("stub:"))
+                    || (resolvedEndpoint != null
+                            && "StubEndpoint".equals(resolvedEndpoint.getClass().getSimpleName()))) {
+                data.setStubEndpoint(true);
+            }
             if (endpoint instanceof EndpointServiceLocation esl) {
                 data.setEndpointServiceUrl(esl.getServiceUrl());
                 data.setEndpointServiceProtocol(esl.getServiceProtocol());

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BeansTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BeansTab.java
@@ -515,4 +515,40 @@ class BeansTab implements MonitorTab {
                 - `Esc` — back
                 """;
     }
+
+    @Override
+    public JsonObject getTableDataAsJson() {
+        List<BeanData> beans = sortedBeans();
+        if (beans.isEmpty()) {
+            return null;
+        }
+        JsonObject result = new JsonObject();
+        result.put("tab", "Beans");
+        JsonArray rows = new JsonArray();
+        for (BeanData b : beans) {
+            JsonObject row = new JsonObject();
+            row.put("name", b.name);
+            row.put("type", b.type);
+            row.put("internal", b.internal);
+            if (b.properties != null && !b.properties.isEmpty()) {
+                JsonArray props = new JsonArray();
+                for (BeanData.Property p : b.properties) {
+                    JsonObject prop = new JsonObject();
+                    prop.put("name", p.name);
+                    prop.put("type", p.type);
+                    if (p.value != null) {
+                        prop.put("value", p.value);
+                    }
+                    props.add(prop);
+                }
+                row.put("properties", props);
+            }
+            rows.add(row);
+        }
+        result.put("rows", rows);
+        result.put("totalRows", beans.size());
+        Integer sel = tableState.selected();
+        result.put("selectedIndex", sel != null ? sel : -1);
+        return result;
+    }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
@@ -730,4 +730,53 @@ class BrowseTab implements MonitorTab {
                 - `Esc` — back to endpoint list
                 """;
     }
+
+    @Override
+    public JsonObject getTableDataAsJson() {
+        if (selectedEndpoint != null && !messages.isEmpty()) {
+            JsonObject result = new JsonObject();
+            result.put("tab", "Browse Messages");
+            result.put("endpoint", selectedEndpoint.uri);
+            JsonArray rows = new JsonArray();
+            for (MessageData m : messages) {
+                JsonObject row = new JsonObject();
+                row.put("position", m.position);
+                row.put("exchangeId", m.exchangeId);
+                row.put("exchangePattern", m.exchangePattern);
+                row.put("timestamp", m.timestamp);
+                if (m.body != null) {
+                    row.put("body", m.body);
+                }
+                if (m.headers != null && !m.headers.isEmpty()) {
+                    row.put("headers", new JsonObject(m.headers));
+                }
+                rows.add(row);
+            }
+            result.put("rows", rows);
+            result.put("totalRows", messages.size());
+            Integer sel = messageTableState.selected();
+            result.put("selectedIndex", sel != null ? sel : -1);
+            return result;
+        }
+        List<EndpointData> endpoints = sortedEndpoints();
+        if (endpoints.isEmpty()) {
+            return null;
+        }
+        JsonObject result = new JsonObject();
+        result.put("tab", "Browse");
+        JsonArray rows = new JsonArray();
+        for (EndpointData e : endpoints) {
+            JsonObject row = new JsonObject();
+            row.put("uri", e.uri);
+            row.put("queueSize", e.queueSize);
+            row.put("firstTimestamp", e.firstTimestamp);
+            row.put("lastTimestamp", e.lastTimestamp);
+            rows.add(row);
+        }
+        result.put("rows", rows);
+        result.put("totalRows", endpoints.size());
+        Integer sel = endpointTableState.selected();
+        result.put("selectedIndex", sel != null ? sel : -1);
+        return result;
+    }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
@@ -327,8 +327,9 @@ class BrowseTab implements MonitorTab {
 
         if (rows.isEmpty()) {
             rows.add(Row.from(
+                    Cell.from(""),
                     Cell.from(Span.styled("No messages", Style.EMPTY.dim())),
-                    Cell.from(""), Cell.from(""), Cell.from("")));
+                    Cell.from(""), Cell.from("")));
         }
 
         String uri = selectedEndpoint != null ? selectedEndpoint.uri : "";

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -2892,6 +2892,22 @@ public class CamelMonitor extends CamelCommand {
         return diagramTab.getTopologyDataAsJson();
     }
 
+    void setLogLevel(String level) {
+        logTab.setLogLevel(level);
+    }
+
+    boolean setTabFilter(String tabName, String filter) {
+        if (tabName != null) {
+            navigateToTab(tabName);
+        }
+        MonitorTab tab = activeTab();
+        return tab != null && tab.setFilter(filter);
+    }
+
+    String toggleTraceDisplay(String section, Boolean enabled) {
+        return historyTab.toggleDisplaySection(section, enabled);
+    }
+
     JsonObject sendMessage(String endpoint, String body, String headers) {
         if (ctx.selectedPid == null) {
             return null;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -2884,6 +2884,14 @@ public class CamelMonitor extends CamelCommand {
         return diagramTab.getTableDataAsJson();
     }
 
+    void selectTraceExchange(String exchangeId) {
+        historyTab.selectTraceExchange(exchangeId);
+    }
+
+    JsonObject getTopologyData() {
+        return diagramTab.getTopologyDataAsJson();
+    }
+
     JsonObject sendMessage(String endpoint, String body, String headers) {
         if (ctx.selectedPid == null) {
             return null;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ClasspathTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ClasspathTab.java
@@ -424,4 +424,35 @@ class ClasspathTab implements MonitorTab {
                 - `Esc` — clear filter or back
                 """;
     }
+
+    @Override
+    public JsonObject getTableDataAsJson() {
+        List<FilteredEntry> entries = filteredEntries;
+        if (entries.isEmpty()) {
+            return null;
+        }
+        JsonObject result = new JsonObject();
+        result.put("tab", "Classpath");
+        JsonArray rows = new JsonArray();
+        for (FilteredEntry fe : entries) {
+            JarEntry j = fe.entry();
+            JsonObject row = new JsonObject();
+            if (j.groupId() != null) {
+                row.put("groupId", j.groupId());
+            }
+            if (j.artifactId() != null) {
+                row.put("artifactId", j.artifactId());
+            }
+            if (j.version() != null) {
+                row.put("version", j.version());
+            }
+            row.put("path", j.fullPath());
+            rows.add(row);
+        }
+        result.put("rows", rows);
+        result.put("totalRows", entries.size());
+        Integer sel = listState.selected();
+        result.put("selectedIndex", sel != null ? sel : -1);
+        return result;
+    }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ClasspathTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ClasspathTab.java
@@ -347,6 +347,18 @@ class ClasspathTab implements MonitorTab {
     }
 
     @Override
+    public boolean setFilter(String filter) {
+        fuzzyFilter.clearFilter();
+        if (filter != null && !filter.isEmpty()) {
+            for (char c : filter.toCharArray()) {
+                fuzzyFilter.appendChar(c);
+            }
+        }
+        refilter();
+        return true;
+    }
+
+    @Override
     public SelectionContext getSelectionContext() {
         return null;
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
@@ -648,6 +648,41 @@ class DiagramSupport {
                     Scrollbar.horizontal(),
                     vChunks.get(1), hScrollState);
         }
+
+        renderTreePreview(frame, hChunks.get(0));
+    }
+
+    private void renderTreePreview(Frame frame, Rect area) {
+        String routeId = getSelectedRouteId();
+        if (routeId == null) {
+            return;
+        }
+        RouteDiagramLayoutEngine.LayoutRoute routeLayout = routeLayouts.get(routeId);
+        if (routeLayout == null || routeLayout.nodes.isEmpty()) {
+            return;
+        }
+
+        int previewW = Math.min(38, area.width() / 3);
+        int previewH = Math.min(10, area.height() / 2);
+        if (previewW < 10 || previewH < 4 || area.width() < 40 || area.height() < 12) {
+            return;
+        }
+
+        int previewX = area.x() + area.width() - previewW - 1;
+        int previewY = area.y() + area.height() - previewH - 1;
+        Rect previewRect = new Rect(previewX, previewY, previewW, previewH);
+
+        frame.renderWidget(Clear.INSTANCE, previewRect);
+
+        Block previewBlock = Block.builder()
+                .borderType(BorderType.ROUNDED)
+                .title(Title.from(Line.from(Span.styled(" Route ", Style.EMPTY.dim()))))
+                .build();
+        frame.renderWidget(previewBlock, previewRect);
+
+        Rect innerRect = previewBlock.inner(previewRect);
+        List<Line> treeLines = RouteTreePreview.buildTree(routeLayout, innerRect.height(), innerRect.width());
+        frame.renderWidget(Paragraph.builder().text(Text.from(treeLines)).build(), innerRect);
     }
 
     // ---- Route EIP node selection ----

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
@@ -1281,12 +1281,26 @@ class DiagramSupport {
                 List<TopologyAsciiRenderer.NodeBox> boxes
                         = computeNodeBoxes(finalTopoResult, finalNodeW, false);
                 nodeBoxes = boxes;
-                // Select the first highlighted route in topology
+                // Select the route box matching the current step
+                String stepRouteId = null;
+                if (clampedStep >= 0 && clampedStep < nodeOrder.size()) {
+                    stepRouteId = nodeRouteMap.get(nodeOrder.get(clampedStep));
+                }
                 int selIdx = -1;
-                for (int i = 0; i < boxes.size(); i++) {
-                    if (visitedRouteIds.contains(boxes.get(i).routeId())) {
-                        selIdx = i;
-                        break;
+                if (stepRouteId != null) {
+                    for (int i = 0; i < boxes.size(); i++) {
+                        if (stepRouteId.equals(boxes.get(i).routeId())) {
+                            selIdx = i;
+                            break;
+                        }
+                    }
+                }
+                if (selIdx < 0) {
+                    for (int i = 0; i < boxes.size(); i++) {
+                        if (visitedRouteIds.contains(boxes.get(i).routeId())) {
+                            selIdx = i;
+                            break;
+                        }
                     }
                 }
                 selectedNodeIndex = selIdx >= 0 ? selIdx : (boxes.isEmpty() ? -1 : 0);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
@@ -1237,6 +1237,36 @@ class DiagramSupport {
             }
         }
 
+        // Expand visited routes by following topology edges where the trace contains
+        // a to-node matching the edge's endpoint (e.g. to6 sends to kafka:notifications
+        // → follow edge to notification route)
+        Set<String> tracedNodeIds = new HashSet<>(nodeOrder);
+        Map<String, List<RouteDiagramLayoutEngine.NodeInfo>> routeNodeMap = new HashMap<>();
+        for (RouteDiagramLayoutEngine.RouteInfo ri : routes) {
+            routeNodeMap.put(ri.routeId, ri.nodes);
+        }
+        boolean expanded = true;
+        while (expanded) {
+            expanded = false;
+            for (TopologyEdgeInfo te : tEdges) {
+                if (te.fromRouteId != null && te.toRouteId != null && te.endpoint != null
+                        && visitedRouteIds.contains(te.fromRouteId)
+                        && !visitedRouteIds.contains(te.toRouteId)) {
+                    List<RouteDiagramLayoutEngine.NodeInfo> fromNodes = routeNodeMap.get(te.fromRouteId);
+                    if (fromNodes != null) {
+                        for (RouteDiagramLayoutEngine.NodeInfo ni : fromNodes) {
+                            if (ni.id != null && tracedNodeIds.contains(ni.id)
+                                    && ni.uri != null && ni.uri.contains(te.endpoint)) {
+                                visitedRouteIds.add(te.toRouteId);
+                                expanded = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         // Add parent scope nodes to highlight info for routes with highlighted children
         Set<String> allNodeIds = new LinkedHashSet<>(highlightInfo.getNodeIds());
         for (RouteDiagramLayoutEngine.RouteInfo ri : routes) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
@@ -90,6 +90,13 @@ class DiagramSupport {
     private String cachedPid;
     private volatile boolean preloading;
 
+    // History diagram state
+    private boolean historyMode;
+    private List<RouteDiagramLayoutEngine.LayoutRoute> historyRouteLayouts = Collections.emptyList();
+    private List<String> historyNodeOrder = Collections.emptyList();
+    private int historyStepIndex;
+    private boolean historyFailed;
+
     List<String> getLines() {
         return lines;
     }
@@ -254,6 +261,19 @@ class DiagramSupport {
         scrollX = 0;
     }
 
+    void scrollLeft() {
+        scrollX = Math.max(0, scrollX - 1);
+    }
+
+    void scrollRight() {
+        scrollX++;
+    }
+
+    void scrollHome() {
+        scrollY = 0;
+        scrollX = 0;
+    }
+
     void toggleDiagram(Runnable loadTrigger) {
         if (showDiagram) {
             close();
@@ -293,6 +313,11 @@ class DiagramSupport {
         selectedEipNodeIndex = -1;
         scrollY = 0;
         scrollX = 0;
+        historyMode = false;
+        historyRouteLayouts = Collections.emptyList();
+        historyNodeOrder = Collections.emptyList();
+        historyStepIndex = 0;
+        historyFailed = false;
     }
 
     boolean hasCachedData(String pid) {
@@ -1227,6 +1252,320 @@ class DiagramSupport {
         }
 
         renderRoutes(ctx, routes, false, nodeIds, hlStyle);
+    }
+
+    void loadHighlightedNativeDiagramInBackground(
+            MonitorContext ctx, String pid,
+            String[] messageHistory, boolean failed) {
+        JsonObject jo = requestRouteStructure(ctx, pid);
+        if (jo == null) {
+            applyResult(ctx, List.of("(No response from integration)"));
+            return;
+        }
+
+        RouteDiagramHelper.HighlightStyle hlStyle = failed
+                ? RouteDiagramHelper.HighlightStyle.FAIL
+                : RouteDiagramHelper.HighlightStyle.SUCCESS;
+        RouteDiagramHelper.HighlightInfo highlightInfo
+                = RouteDiagramHelper.parseMessageHistory(messageHistory, hlStyle);
+        Set<String> nodeIds = new LinkedHashSet<>(highlightInfo.getNodeIds());
+
+        List<RouteDiagramLayoutEngine.RouteInfo> routes = RouteDiagramHelper.parseRoutes(jo);
+        if (routes.isEmpty()) {
+            applyResult(ctx, List.of("(No routes in response)"));
+            return;
+        }
+
+        for (RouteDiagramLayoutEngine.RouteInfo ri : routes) {
+            boolean routeHasHighlight = ri.nodes.stream().anyMatch(n -> n.id != null && nodeIds.contains(n.id));
+            if (routeHasHighlight) {
+                addParentNodes(ri.nodes, nodeIds);
+            }
+        }
+
+        RouteDiagramHelper.HighlightInfo fullHighlight
+                = new RouteDiagramHelper.HighlightInfo(nodeIds, highlightInfo.getRouteOrder(), hlStyle);
+        routes = RouteDiagramHelper.filterAndOrderRoutes(routes, fullHighlight);
+        if (routes.isEmpty()) {
+            applyResult(ctx, List.of("(No routes contain highlighted nodes)"));
+            return;
+        }
+
+        RouteDiagramLayoutEngine.NodeLabelMode labelMode = showDescription
+                ? RouteDiagramLayoutEngine.NodeLabelMode.DESCRIPTION
+                : RouteDiagramLayoutEngine.NodeLabelMode.CODE;
+        RouteDiagramLayoutEngine engine = new RouteDiagramLayoutEngine(
+                RouteDiagramLayoutEngine.DEFAULT_BOX_WIDTH, RouteDiagramLayoutEngine.DEFAULT_FONT_SIZE,
+                labelMode);
+
+        List<RouteDiagramLayoutEngine.LayoutRoute> layouts = new ArrayList<>();
+        for (RouteDiagramLayoutEngine.RouteInfo r : routes) {
+            RouteDiagramLayoutEngine.LayoutRoute lr = engine.layoutRoute(r, 0);
+            normalizeRouteLayoutY(lr);
+            layouts.add(lr);
+        }
+
+        // Build nodeId visit order from messageHistory (preserving sequence, deduped)
+        List<String> nodeOrder = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        for (String h : messageHistory) {
+            int bracket = h.indexOf('[');
+            int end = h.indexOf(']');
+            if (bracket >= 0 && end > bracket) {
+                String nodeId = h.substring(bracket + 1, end);
+                if (!nodeId.isEmpty() && seen.add(nodeId)) {
+                    nodeOrder.add(nodeId);
+                }
+            }
+        }
+
+        boolean isFailed = failed;
+        if (ctx.runner == null) {
+            return;
+        }
+        ctx.runner.runOnRenderThread(() -> {
+            historyMode = true;
+            historyRouteLayouts = layouts;
+            historyNodeOrder = nodeOrder;
+            historyStepIndex = nodeOrder.size() - 1;
+            historyFailed = isFailed;
+            scrollY = 0;
+            scrollX = 0;
+            showDiagram = true;
+            lines = Collections.emptyList();
+        });
+    }
+
+    boolean isHistoryMode() {
+        return historyMode;
+    }
+
+    boolean hasHistoryData() {
+        return !historyRouteLayouts.isEmpty();
+    }
+
+    int getHistoryStepIndex() {
+        return historyStepIndex;
+    }
+
+    int getHistoryStepCount() {
+        return historyNodeOrder.size();
+    }
+
+    void historyNavigateDown() {
+        if (historyStepIndex < historyNodeOrder.size() - 1) {
+            historyStepIndex++;
+        }
+    }
+
+    void historyNavigateUp() {
+        if (historyStepIndex > 0) {
+            historyStepIndex--;
+        }
+    }
+
+    void renderNativeHistoryDiagram(Frame frame, Rect area, String title) {
+        Block block = Block.builder()
+                .borderType(BorderType.ROUNDED)
+                .title(title)
+                .build();
+        frame.renderWidget(block, area);
+
+        Rect inner = block.inner(area);
+
+        int nw = RouteDiagramLayoutEngine.DEFAULT_BOX_WIDTH * RouteDiagramLayoutEngine.SCALE;
+
+        // Build the progressive highlight set: nodes up to current step
+        Set<String> activeHighlight = new LinkedHashSet<>();
+        for (int i = 0; i <= historyStepIndex && i < historyNodeOrder.size(); i++) {
+            activeHighlight.add(historyNodeOrder.get(i));
+        }
+        // Also add parent/scope nodes for highlighted children
+        for (RouteDiagramLayoutEngine.LayoutRoute lr : historyRouteLayouts) {
+            Set<String> parentIds = new LinkedHashSet<>();
+            for (RouteDiagramLayoutEngine.LayoutNode ln : lr.nodes) {
+                if (ln.id != null && activeHighlight.contains(ln.id) && ln.parentNode != null
+                        && ln.parentNode.id != null && !"route".equals(ln.parentNode.type)) {
+                    parentIds.add(ln.parentNode.id);
+                }
+            }
+            activeHighlight.addAll(parentIds);
+        }
+
+        // Find the currently selected nodeId and which route it belongs to
+        String currentNodeId = historyStepIndex >= 0 && historyStepIndex < historyNodeOrder.size()
+                ? historyNodeOrder.get(historyStepIndex) : null;
+
+        // Calculate total height across all route diagrams
+        int totalRows = 0;
+        int totalCols = 0;
+        List<Integer> routeHeights = new ArrayList<>();
+        for (RouteDiagramLayoutEngine.LayoutRoute lr : historyRouteLayouts) {
+            var probe = new org.apache.camel.dsl.jbang.core.commands.tui.diagram.RouteDiagramWidget(
+                    lr, nw, -1, 0, 0, false);
+            int h = probe.getTotalRows();
+            routeHeights.add(h);
+            totalRows += h + 1; // +1 gap between routes
+            totalCols = Math.max(totalCols, probe.getTotalCols());
+        }
+
+        int visibleLines = Math.max(1, inner.height() - 1);
+        int visibleCols = Math.max(1, inner.width() - 1);
+        lastVisibleHeight = visibleLines;
+        lastVisibleWidth = visibleCols;
+
+        int maxVScroll = Math.max(0, totalRows - visibleLines);
+        int maxHScroll = Math.max(0, totalCols - visibleCols);
+        scrollY = Math.min(scrollY, maxVScroll);
+        scrollX = Math.min(scrollX, maxHScroll);
+
+        // Find the selected node's position for auto-scroll
+        int selectedRouteOffset = 0;
+        int selectedNodeIdx = -1;
+        RouteDiagramLayoutEngine.LayoutRoute selectedLayout = null;
+        for (int ri = 0; ri < historyRouteLayouts.size(); ri++) {
+            RouteDiagramLayoutEngine.LayoutRoute lr = historyRouteLayouts.get(ri);
+            int nodeIdx = 0;
+            for (RouteDiagramLayoutEngine.LayoutNode ln : lr.nodes) {
+                if (!"route".equals(ln.type)) {
+                    if (ln.id != null && ln.id.equals(currentNodeId)) {
+                        selectedNodeIdx = nodeIdx;
+                        selectedLayout = lr;
+                        break;
+                    }
+                    nodeIdx++;
+                }
+            }
+            if (selectedNodeIdx >= 0) {
+                break;
+            }
+            selectedRouteOffset += routeHeights.get(ri) + 1;
+        }
+
+        // Auto-scroll to keep selected node visible
+        if (selectedNodeIdx >= 0 && selectedLayout != null) {
+            var scrollProbe = new org.apache.camel.dsl.jbang.core.commands.tui.diagram.RouteDiagramWidget(
+                    selectedLayout, nw, selectedNodeIdx, 0, 0, false);
+            // Get the selected node's row in the stacked layout
+            // The node boxes are populated during render, so we estimate from layout data
+            for (RouteDiagramLayoutEngine.LayoutNode ln : selectedLayout.nodes) {
+                if (ln.id != null && ln.id.equals(currentNodeId)) {
+                    int nodeRow = selectedRouteOffset + ln.y / 20; // Y_SCALE = 20
+                    if (nodeRow < scrollY) {
+                        scrollY = Math.max(0, nodeRow - 2);
+                    } else if (nodeRow >= scrollY + visibleLines) {
+                        scrollY = Math.min(maxVScroll, nodeRow - visibleLines + 4);
+                    }
+                    break;
+                }
+            }
+        }
+
+        List<Rect> vChunks = Layout.vertical()
+                .constraints(Constraint.fill(), Constraint.length(1))
+                .split(inner);
+
+        List<Rect> hChunks = Layout.horizontal()
+                .constraints(Constraint.fill(), Constraint.length(1))
+                .split(vChunks.get(0));
+
+        // Render each route diagram stacked vertically
+        int yOffset = 0;
+        for (int ri = 0; ri < historyRouteLayouts.size(); ri++) {
+            RouteDiagramLayoutEngine.LayoutRoute lr = historyRouteLayouts.get(ri);
+
+            // Determine selected node index within this route
+            int nodeIdxInRoute = -1;
+            if (currentNodeId != null) {
+                int idx = 0;
+                for (RouteDiagramLayoutEngine.LayoutNode ln : lr.nodes) {
+                    if (!"route".equals(ln.type)) {
+                        if (ln.id != null && ln.id.equals(currentNodeId)) {
+                            nodeIdxInRoute = idx;
+                            break;
+                        }
+                        idx++;
+                    }
+                }
+            }
+
+            var widget = new org.apache.camel.dsl.jbang.core.commands.tui.diagram.RouteDiagramWidget(
+                    lr, nw, nodeIdxInRoute, scrollX, scrollY - yOffset, false,
+                    Collections.emptyMap(), false, Collections.emptyMap(),
+                    activeHighlight, historyFailed);
+
+            frame.renderWidget(widget, hChunks.get(0));
+
+            yOffset += routeHeights.get(ri) + 1;
+        }
+
+        // Scrollbars
+        vScrollState.contentLength(totalRows);
+        vScrollState.viewportContentLength(visibleLines);
+        vScrollState.position(scrollY);
+        frame.renderStatefulWidget(
+                Scrollbar.builder().build(),
+                hChunks.get(1), vScrollState);
+
+        if (totalCols > visibleCols) {
+            hScrollState.contentLength(totalCols);
+            hScrollState.viewportContentLength(visibleCols);
+            hScrollState.position(scrollX);
+            frame.renderStatefulWidget(
+                    Scrollbar.horizontal(),
+                    vChunks.get(1), hScrollState);
+        }
+
+        // Tree preview for the route containing the selected node
+        if (selectedLayout != null) {
+            renderTreePreview(frame, hChunks.get(0), selectedLayout, currentNodeId);
+        }
+    }
+
+    private void renderTreePreview(
+            Frame frame, Rect area,
+            RouteDiagramLayoutEngine.LayoutRoute routeLayout, String highlightNodeId) {
+        if (routeLayout == null || routeLayout.nodes.isEmpty()) {
+            return;
+        }
+        int previewW = Math.min(38, area.width() / 3);
+        int previewH = Math.min(10, area.height() / 2);
+        if (previewW < 12 || previewH < 4 || area.width() < 40 || area.height() < 12) {
+            return;
+        }
+
+        int px = area.x() + area.width() - previewW - 1;
+        int py = area.y() + area.height() - previewH - 1;
+        Rect previewRect = new Rect(px, py, previewW, previewH);
+
+        frame.renderWidget(Clear.INSTANCE, previewRect);
+
+        Block previewBlock = Block.builder()
+                .borderType(BorderType.ROUNDED)
+                .title(Title.from(Line.from(Span.styled(" Structure ", Style.EMPTY.dim()))))
+                .build();
+        frame.renderWidget(previewBlock, previewRect);
+
+        Rect innerRect = previewBlock.inner(previewRect);
+        if (innerRect.height() < 1 || innerRect.width() < 4) {
+            return;
+        }
+
+        // Find the TreeNode matching the highlighted nodeId
+        RouteDiagramLayoutEngine.TreeNode selectedTreeNode = null;
+        if (highlightNodeId != null) {
+            for (RouteDiagramLayoutEngine.LayoutNode ln : routeLayout.nodes) {
+                if (ln.treeNode != null && highlightNodeId.equals(ln.id)) {
+                    selectedTreeNode = ln.treeNode;
+                    break;
+                }
+            }
+        }
+
+        List<Line> treeLines = RouteTreePreview.buildTree(
+                routeLayout, innerRect.height(), innerRect.width(), selectedTreeNode);
+        frame.renderWidget(
+                Paragraph.builder().text(Text.from(treeLines)).build(), innerRect);
     }
 
     void loadAllDiagramsInBackground(

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
@@ -1151,7 +1151,7 @@ class DiagramSupport {
 
     void loadHighlightedNativeDiagramInBackground(
             MonitorContext ctx, String pid,
-            String[] messageHistory, boolean failed) {
+            String[] messageHistory, boolean failed, int initialStepIndex) {
         // Single IPC call: topology + route structures
         JsonObject jo = requestRouteTopology(ctx, pid, false, true);
         if (jo == null) {
@@ -1248,6 +1248,8 @@ class DiagramSupport {
 
         // Compute topology nodeBoxes for selection
         boolean isFailed = failed;
+        int clampedStep = initialStepIndex >= 0 && initialStepIndex < nodeOrder.size()
+                ? initialStepIndex : nodeOrder.size() - 1;
         TopologyLayoutResult finalTopoResult = topoResult;
         int finalNodeW = nodeW;
         List<TopologyLayoutNode> finalTopoNodes = topoNodes;
@@ -1259,7 +1261,7 @@ class DiagramSupport {
         ctx.runner.runOnRenderThread(() -> {
             historyMode = true;
             historyNodeOrder = nodeOrder;
-            historyStepIndex = nodeOrder.size() - 1;
+            historyStepIndex = clampedStep;
             historyFailed = isFailed;
             historyNodeRouteMap = nodeRouteMap;
             historyRouteIds = visitedRouteIds;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
@@ -17,10 +17,13 @@
 package org.apache.camel.dsl.jbang.core.commands.tui;
 
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -86,10 +89,16 @@ class DiagramSupport {
 
     // History diagram state
     private boolean historyMode;
-    private List<RouteDiagramLayoutEngine.LayoutRoute> historyRouteLayouts = Collections.emptyList();
     private List<String> historyNodeOrder = Collections.emptyList();
     private int historyStepIndex;
     private boolean historyFailed;
+
+    // History drill-down state (topology → route navigation)
+    private boolean historyTopologyMode;
+    private String historyDrillDownRouteId;
+    private final Deque<String> historyNavigationStack = new ArrayDeque<>();
+    private Map<String, String> historyNodeRouteMap = Collections.emptyMap();
+    private Set<String> historyRouteIds = Collections.emptySet();
 
     boolean isShowDiagram() {
         return showDiagram;
@@ -300,10 +309,14 @@ class DiagramSupport {
         scrollY = 0;
         scrollX = 0;
         historyMode = false;
-        historyRouteLayouts = Collections.emptyList();
         historyNodeOrder = Collections.emptyList();
         historyStepIndex = 0;
         historyFailed = false;
+        historyTopologyMode = false;
+        historyDrillDownRouteId = null;
+        historyNavigationStack.clear();
+        historyNodeRouteMap = Collections.emptyMap();
+        historyRouteIds = Collections.emptySet();
     }
 
     boolean hasCachedData(String pid) {
@@ -1139,38 +1152,48 @@ class DiagramSupport {
     void loadHighlightedNativeDiagramInBackground(
             MonitorContext ctx, String pid,
             String[] messageHistory, boolean failed) {
-        JsonObject jo = requestRouteStructure(ctx, pid);
+        // Single IPC call: topology + route structures
+        JsonObject jo = requestRouteTopology(ctx, pid, false, true);
         if (jo == null) {
             close();
             return;
         }
 
-        RouteDiagramHelper.HighlightStyle hlStyle = failed
-                ? RouteDiagramHelper.HighlightStyle.FAIL
-                : RouteDiagramHelper.HighlightStyle.SUCCESS;
-        RouteDiagramHelper.HighlightInfo highlightInfo
-                = RouteDiagramHelper.parseMessageHistory(messageHistory, hlStyle);
-        Set<String> nodeIds = new LinkedHashSet<>(highlightInfo.getNodeIds());
+        // Parse topology layout
+        TopologyLayoutResult topoResult = null;
+        int nodeW = 0;
+        List<TopologyLayoutNode> topoNodes = Collections.emptyList();
+        List<TopologyLayoutEdge> topoEdges = Collections.emptyList();
+        List<TopologyNodeInfo> tNodes = TopologyHelper.parseNodes(jo);
+        List<TopologyEdgeInfo> tEdges = TopologyHelper.parseEdges(jo);
+        if (!tNodes.isEmpty()) {
+            TopologyLayoutEngine topoEngine = new TopologyLayoutEngine();
+            topoResult = topoEngine.layout(tNodes, tEdges);
+            normalizeTopologyLayoutY(topoResult);
+            nodeW = topoEngine.getNodeWidth();
+            topoNodes = topoResult.nodes;
+            topoEdges = topoResult.edges;
+        }
 
+        // Parse and layout all routes
         List<RouteDiagramLayoutEngine.RouteInfo> routes = RouteDiagramHelper.parseRoutes(jo);
         if (routes.isEmpty()) {
             close();
             return;
         }
 
-        for (RouteDiagramLayoutEngine.RouteInfo ri : routes) {
-            boolean routeHasHighlight = ri.nodes.stream().anyMatch(n -> n.id != null && nodeIds.contains(n.id));
-            if (routeHasHighlight) {
-                addParentNodes(ri.nodes, nodeIds);
+        Set<String> externalUris = parseExternalUris(jo);
+        if (!externalUris.isEmpty()) {
+            for (RouteDiagramLayoutEngine.RouteInfo r : routes) {
+                for (RouteDiagramLayoutEngine.NodeInfo ni : r.nodes) {
+                    if (!ni.remote) {
+                        String baseUri = getBaseUri(ni);
+                        if (baseUri != null && externalUris.contains(baseUri)) {
+                            ni.remote = true;
+                        }
+                    }
+                }
             }
-        }
-
-        RouteDiagramHelper.HighlightInfo fullHighlight
-                = new RouteDiagramHelper.HighlightInfo(nodeIds, highlightInfo.getRouteOrder(), hlStyle);
-        routes = RouteDiagramHelper.filterAndOrderRoutes(routes, fullHighlight);
-        if (routes.isEmpty()) {
-            close();
-            return;
         }
 
         RouteDiagramLayoutEngine.NodeLabelMode labelMode = showDescription
@@ -1180,37 +1203,93 @@ class DiagramSupport {
                 RouteDiagramLayoutEngine.DEFAULT_BOX_WIDTH, RouteDiagramLayoutEngine.DEFAULT_FONT_SIZE,
                 labelMode);
 
-        List<RouteDiagramLayoutEngine.LayoutRoute> layouts = new ArrayList<>();
+        Map<String, RouteDiagramLayoutEngine.LayoutRoute> routeMap = new LinkedHashMap<>();
         for (RouteDiagramLayoutEngine.RouteInfo r : routes) {
             RouteDiagramLayoutEngine.LayoutRoute lr = engine.layoutRoute(r, 0);
             normalizeRouteLayoutY(lr);
-            layouts.add(lr);
+            routeMap.put(r.routeId, lr);
         }
 
-        // Build nodeId visit order from messageHistory (preserving sequence, deduped)
+        // Parse message history: build nodeId visit order and nodeId→routeId mapping
+        RouteDiagramHelper.HighlightStyle hlStyle = failed
+                ? RouteDiagramHelper.HighlightStyle.FAIL
+                : RouteDiagramHelper.HighlightStyle.SUCCESS;
+        RouteDiagramHelper.HighlightInfo highlightInfo
+                = RouteDiagramHelper.parseMessageHistory(messageHistory, hlStyle);
+
         List<String> nodeOrder = new ArrayList<>();
-        Set<String> seen = new LinkedHashSet<>();
+        Map<String, String> nodeRouteMap = new LinkedHashMap<>();
+        Set<String> visitedRouteIds = new LinkedHashSet<>();
+        Set<String> seenNodes = new LinkedHashSet<>();
         for (String h : messageHistory) {
             int bracket = h.indexOf('[');
             int end = h.indexOf(']');
             if (bracket >= 0 && end > bracket) {
+                String routeId = h.substring(0, bracket);
                 String nodeId = h.substring(bracket + 1, end);
-                if (!nodeId.isEmpty() && seen.add(nodeId)) {
+                if (!nodeId.isEmpty() && seenNodes.add(nodeId)) {
                     nodeOrder.add(nodeId);
+                    nodeRouteMap.put(nodeId, routeId);
+                }
+                if (!routeId.isEmpty()) {
+                    visitedRouteIds.add(routeId);
                 }
             }
         }
 
+        // Add parent scope nodes to highlight info for routes with highlighted children
+        Set<String> allNodeIds = new LinkedHashSet<>(highlightInfo.getNodeIds());
+        for (RouteDiagramLayoutEngine.RouteInfo ri : routes) {
+            boolean routeHasHighlight = ri.nodes.stream().anyMatch(n -> n.id != null && allNodeIds.contains(n.id));
+            if (routeHasHighlight) {
+                addParentNodes(ri.nodes, allNodeIds);
+            }
+        }
+
+        // Compute topology nodeBoxes for selection
         boolean isFailed = failed;
+        TopologyLayoutResult finalTopoResult = topoResult;
+        int finalNodeW = nodeW;
+        List<TopologyLayoutNode> finalTopoNodes = topoNodes;
+        List<TopologyLayoutEdge> finalTopoEdges = topoEdges;
+
         if (ctx.runner == null) {
             return;
         }
         ctx.runner.runOnRenderThread(() -> {
             historyMode = true;
-            historyRouteLayouts = layouts;
             historyNodeOrder = nodeOrder;
             historyStepIndex = nodeOrder.size() - 1;
             historyFailed = isFailed;
+            historyNodeRouteMap = nodeRouteMap;
+            historyRouteIds = visitedRouteIds;
+            historyTopologyMode = true;
+            historyDrillDownRouteId = null;
+            historyNavigationStack.clear();
+
+            // Store topology data
+            topologyLayout = finalTopoResult;
+            topologyNodeWidth = finalNodeW;
+            topologyNodes = finalTopoNodes;
+            topologyEdges = finalTopoEdges;
+            routeLayouts = routeMap;
+
+            // Initialize topology node selection
+            if (finalTopoResult != null) {
+                List<TopologyAsciiRenderer.NodeBox> boxes
+                        = computeNodeBoxes(finalTopoResult, finalNodeW, false);
+                nodeBoxes = boxes;
+                // Select the first highlighted route in topology
+                int selIdx = -1;
+                for (int i = 0; i < boxes.size(); i++) {
+                    if (visitedRouteIds.contains(boxes.get(i).routeId())) {
+                        selIdx = i;
+                        break;
+                    }
+                }
+                selectedNodeIndex = selIdx >= 0 ? selIdx : (boxes.isEmpty() ? -1 : 0);
+            }
+
             scrollY = 0;
             scrollX = 0;
             showDiagram = true;
@@ -1222,7 +1301,7 @@ class DiagramSupport {
     }
 
     boolean hasHistoryData() {
-        return !historyRouteLayouts.isEmpty();
+        return !historyNodeOrder.isEmpty();
     }
 
     int getHistoryStepIndex() {
@@ -1236,60 +1315,117 @@ class DiagramSupport {
     void historyNavigateDown() {
         if (historyStepIndex < historyNodeOrder.size() - 1) {
             historyStepIndex++;
+            handleHistoryRouteTransition();
         }
     }
 
     void historyNavigateUp() {
         if (historyStepIndex > 0) {
             historyStepIndex--;
+            handleHistoryRouteTransition();
         }
     }
 
-    void renderNativeHistoryDiagram(Frame frame, Rect area, String title) {
+    private void handleHistoryRouteTransition() {
+        if (historyTopologyMode || historyDrillDownRouteId == null) {
+            return;
+        }
+        String nodeId = historyNodeOrder.get(historyStepIndex);
+        String nodeRoute = historyNodeRouteMap.get(nodeId);
+        if (nodeRoute != null && !nodeRoute.equals(historyDrillDownRouteId)) {
+            historyNavigationStack.push(historyDrillDownRouteId);
+            historyDrillDownRouteId = nodeRoute;
+            scrollY = 0;
+            scrollX = 0;
+        }
+    }
+
+    boolean isHistoryTopologyMode() {
+        return historyTopologyMode;
+    }
+
+    String getHistoryDrillDownRouteId() {
+        return historyDrillDownRouteId;
+    }
+
+    Deque<String> getHistoryNavigationStack() {
+        return historyNavigationStack;
+    }
+
+    void historyEnterDrillDown() {
+        String selectedRoute = getSelectedRouteId();
+        if (selectedRoute == null && !historyRouteIds.isEmpty()) {
+            selectedRoute = historyRouteIds.iterator().next();
+        }
+        if (selectedRoute == null) {
+            return;
+        }
+        historyTopologyMode = false;
+        historyDrillDownRouteId = selectedRoute;
+        historyNavigationStack.clear();
+
+        // Set step index to the first node in this route
+        for (int i = 0; i < historyNodeOrder.size(); i++) {
+            String nRoute = historyNodeRouteMap.get(historyNodeOrder.get(i));
+            if (selectedRoute.equals(nRoute)) {
+                historyStepIndex = i;
+                break;
+            }
+        }
+        scrollY = 0;
+        scrollX = 0;
+    }
+
+    void historyReturnToTopology() {
+        historyTopologyMode = true;
+        historyDrillDownRouteId = null;
+        historyNavigationStack.clear();
+        scrollY = 0;
+        scrollX = 0;
+        // Restore topology selection to highlight the current route
+        if (historyStepIndex >= 0 && historyStepIndex < historyNodeOrder.size()) {
+            String nodeId = historyNodeOrder.get(historyStepIndex);
+            String nodeRoute = historyNodeRouteMap.get(nodeId);
+            if (nodeRoute != null) {
+                for (int i = 0; i < nodeBoxes.size(); i++) {
+                    if (nodeRoute.equals(nodeBoxes.get(i).routeId())) {
+                        selectedNodeIndex = i;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    void historyGoBack() {
+        if (!historyNavigationStack.isEmpty()) {
+            historyDrillDownRouteId = historyNavigationStack.pop();
+            scrollY = 0;
+            scrollX = 0;
+        } else {
+            historyReturnToTopology();
+        }
+    }
+
+    void renderHistoryTopologyDiagram(Frame frame, Rect area, Line title) {
+        if (topologyLayout == null) {
+            return;
+        }
+
         Block block = Block.builder()
                 .borderType(BorderType.ROUNDED)
-                .title(title)
+                .title(Title.from(title))
                 .build();
         frame.renderWidget(block, area);
 
         Rect inner = block.inner(area);
 
-        int nw = RouteDiagramLayoutEngine.DEFAULT_BOX_WIDTH * RouteDiagramLayoutEngine.SCALE;
+        var widget = new org.apache.camel.dsl.jbang.core.commands.tui.diagram.TopologyDiagramWidget(
+                topologyLayout, topologyNodeWidth, selectedNodeIndex, scrollX, scrollY,
+                false, showDescription, historyRouteIds, historyFailed);
 
-        // Build the progressive highlight set: nodes up to current step
-        Set<String> activeHighlight = new LinkedHashSet<>();
-        for (int i = 0; i <= historyStepIndex && i < historyNodeOrder.size(); i++) {
-            activeHighlight.add(historyNodeOrder.get(i));
-        }
-        // Also add parent/scope nodes for highlighted children
-        for (RouteDiagramLayoutEngine.LayoutRoute lr : historyRouteLayouts) {
-            Set<String> parentIds = new LinkedHashSet<>();
-            for (RouteDiagramLayoutEngine.LayoutNode ln : lr.nodes) {
-                if (ln.id != null && activeHighlight.contains(ln.id) && ln.parentNode != null
-                        && ln.parentNode.id != null && !"route".equals(ln.parentNode.type)) {
-                    parentIds.add(ln.parentNode.id);
-                }
-            }
-            activeHighlight.addAll(parentIds);
-        }
-
-        // Find the currently selected nodeId and which route it belongs to
-        String currentNodeId = historyStepIndex >= 0 && historyStepIndex < historyNodeOrder.size()
-                ? historyNodeOrder.get(historyStepIndex) : null;
-
-        // Calculate total height across all route diagrams
-        int totalRows = 0;
-        int totalCols = 0;
-        List<Integer> routeHeights = new ArrayList<>();
-        for (RouteDiagramLayoutEngine.LayoutRoute lr : historyRouteLayouts) {
-            var probe = new org.apache.camel.dsl.jbang.core.commands.tui.diagram.RouteDiagramWidget(
-                    lr, nw, -1, 0, 0, false);
-            int h = probe.getTotalRows();
-            routeHeights.add(h);
-            totalRows += h + 1; // +1 gap between routes
-            totalCols = Math.max(totalCols, probe.getTotalCols());
-        }
-
+        int totalRows = widget.getTotalRows();
+        int totalCols = widget.getTotalCols();
         int visibleLines = Math.max(1, inner.height() - 1);
         int visibleCols = Math.max(1, inner.width() - 1);
         lastVisibleHeight = visibleLines;
@@ -1300,38 +1436,121 @@ class DiagramSupport {
         scrollY = Math.min(scrollY, maxVScroll);
         scrollX = Math.min(scrollX, maxHScroll);
 
-        // Find the selected node's position for auto-scroll
-        int selectedRouteOffset = 0;
-        int selectedNodeIdx = -1;
-        RouteDiagramLayoutEngine.LayoutRoute selectedLayout = null;
-        for (int ri = 0; ri < historyRouteLayouts.size(); ri++) {
-            RouteDiagramLayoutEngine.LayoutRoute lr = historyRouteLayouts.get(ri);
-            int nodeIdx = 0;
-            for (RouteDiagramLayoutEngine.LayoutNode ln : lr.nodes) {
-                if (!"route".equals(ln.type)) {
-                    if (ln.id != null && ln.id.equals(currentNodeId)) {
-                        selectedNodeIdx = nodeIdx;
-                        selectedLayout = lr;
-                        break;
-                    }
-                    nodeIdx++;
-                }
-            }
-            if (selectedNodeIdx >= 0) {
-                break;
-            }
-            selectedRouteOffset += routeHeights.get(ri) + 1;
+        var finalWidget = new org.apache.camel.dsl.jbang.core.commands.tui.diagram.TopologyDiagramWidget(
+                topologyLayout, topologyNodeWidth, selectedNodeIndex, scrollX, scrollY,
+                false, showDescription, historyRouteIds, historyFailed);
+
+        List<Rect> vChunks = Layout.vertical()
+                .constraints(Constraint.fill(), Constraint.length(1))
+                .split(inner);
+
+        List<Rect> hChunks = Layout.horizontal()
+                .constraints(Constraint.fill(), Constraint.length(1))
+                .split(vChunks.get(0));
+
+        frame.renderWidget(finalWidget, hChunks.get(0));
+
+        List<TopologyAsciiRenderer.NodeBox> widgetBoxes = new ArrayList<>();
+        for (var nb : finalWidget.getNodeBoxes()) {
+            widgetBoxes.add(new TopologyAsciiRenderer.NodeBox(
+                    nb.routeId(), nb.startRow(), nb.endRow(), nb.startCol(), nb.endCol(), nb.layer()));
+        }
+        if (!widgetBoxes.isEmpty()) {
+            nodeBoxes = widgetBoxes;
         }
 
+        vScrollState.contentLength(totalRows);
+        vScrollState.viewportContentLength(visibleLines);
+        vScrollState.position(scrollY);
+        frame.renderStatefulWidget(
+                Scrollbar.builder().build(),
+                hChunks.get(1), vScrollState);
+
+        if (totalCols > visibleCols) {
+            hScrollState.contentLength(totalCols);
+            hScrollState.viewportContentLength(visibleCols);
+            hScrollState.position(scrollX);
+            frame.renderStatefulWidget(
+                    Scrollbar.horizontal(),
+                    vChunks.get(1), hScrollState);
+        }
+    }
+
+    void renderHistoryRouteDiagram(Frame frame, Rect area, Line title, String routeId) {
+        RouteDiagramLayoutEngine.LayoutRoute routeLayout = routeLayouts.get(routeId);
+        if (routeLayout == null) {
+            return;
+        }
+
+        Block block = Block.builder()
+                .borderType(BorderType.ROUNDED)
+                .title(Title.from(title))
+                .build();
+        frame.renderWidget(block, area);
+
+        Rect inner = block.inner(area);
+        int nw = RouteDiagramLayoutEngine.DEFAULT_BOX_WIDTH * RouteDiagramLayoutEngine.SCALE;
+
+        // Build progressive highlight set filtered to this route
+        Set<String> activeHighlight = new LinkedHashSet<>();
+        String currentNodeId = historyStepIndex >= 0 && historyStepIndex < historyNodeOrder.size()
+                ? historyNodeOrder.get(historyStepIndex) : null;
+        for (int i = 0; i <= historyStepIndex && i < historyNodeOrder.size(); i++) {
+            String nid = historyNodeOrder.get(i);
+            String nRoute = historyNodeRouteMap.get(nid);
+            if (routeId.equals(nRoute)) {
+                activeHighlight.add(nid);
+            }
+        }
+        // Add parent/scope nodes
+        Set<String> parentIds = new LinkedHashSet<>();
+        for (RouteDiagramLayoutEngine.LayoutNode ln : routeLayout.nodes) {
+            if (ln.id != null && activeHighlight.contains(ln.id) && ln.parentNode != null
+                    && ln.parentNode.id != null && !"route".equals(ln.parentNode.type)) {
+                parentIds.add(ln.parentNode.id);
+            }
+        }
+        activeHighlight.addAll(parentIds);
+
+        // Find selected EIP node index within this route
+        int selIdx = -1;
+        if (currentNodeId != null && routeId.equals(historyNodeRouteMap.get(currentNodeId))) {
+            int idx = 0;
+            for (RouteDiagramLayoutEngine.LayoutNode ln : routeLayout.nodes) {
+                if (!"route".equals(ln.type)) {
+                    if (ln.id != null && ln.id.equals(currentNodeId)) {
+                        selIdx = idx;
+                        break;
+                    }
+                    idx++;
+                }
+            }
+        }
+
+        Map<String, String> linkable = computeLinkableEndpoints(routeId);
+        Map<String, String> routeDescs = showDescription ? computeRouteDescriptions() : Collections.emptyMap();
+
+        var widget = new org.apache.camel.dsl.jbang.core.commands.tui.diagram.RouteDiagramWidget(
+                routeLayout, nw, selIdx, scrollX, scrollY, false, linkable,
+                showDescription, routeDescs, activeHighlight, historyFailed);
+
+        int totalRows = widget.getTotalRows();
+        int totalCols = widget.getTotalCols();
+        int visibleLines = Math.max(1, inner.height() - 1);
+        int visibleCols = Math.max(1, inner.width() - 1);
+        lastVisibleHeight = visibleLines;
+        lastVisibleWidth = visibleCols;
+
+        int maxVScroll = Math.max(0, totalRows - visibleLines);
+        int maxHScroll = Math.max(0, totalCols - visibleCols);
+        scrollY = Math.min(scrollY, maxVScroll);
+        scrollX = Math.min(scrollX, maxHScroll);
+
         // Auto-scroll to keep selected node visible
-        if (selectedNodeIdx >= 0 && selectedLayout != null) {
-            var scrollProbe = new org.apache.camel.dsl.jbang.core.commands.tui.diagram.RouteDiagramWidget(
-                    selectedLayout, nw, selectedNodeIdx, 0, 0, false);
-            // Get the selected node's row in the stacked layout
-            // The node boxes are populated during render, so we estimate from layout data
-            for (RouteDiagramLayoutEngine.LayoutNode ln : selectedLayout.nodes) {
+        if (selIdx >= 0 && currentNodeId != null) {
+            for (RouteDiagramLayoutEngine.LayoutNode ln : routeLayout.nodes) {
                 if (ln.id != null && ln.id.equals(currentNodeId)) {
-                    int nodeRow = selectedRouteOffset + ln.y / 20; // Y_SCALE = 20
+                    int nodeRow = ln.y / 20;
                     if (nodeRow < scrollY) {
                         scrollY = Math.max(0, nodeRow - 2);
                     } else if (nodeRow >= scrollY + visibleLines) {
@@ -1342,6 +1561,10 @@ class DiagramSupport {
             }
         }
 
+        var finalWidget = new org.apache.camel.dsl.jbang.core.commands.tui.diagram.RouteDiagramWidget(
+                routeLayout, nw, selIdx, scrollX, scrollY, false, linkable,
+                showDescription, routeDescs, activeHighlight, historyFailed);
+
         List<Rect> vChunks = Layout.vertical()
                 .constraints(Constraint.fill(), Constraint.length(1))
                 .split(inner);
@@ -1350,37 +1573,10 @@ class DiagramSupport {
                 .constraints(Constraint.fill(), Constraint.length(1))
                 .split(vChunks.get(0));
 
-        // Render each route diagram stacked vertically
-        int yOffset = 0;
-        for (int ri = 0; ri < historyRouteLayouts.size(); ri++) {
-            RouteDiagramLayoutEngine.LayoutRoute lr = historyRouteLayouts.get(ri);
+        frame.renderWidget(finalWidget, hChunks.get(0));
 
-            // Determine selected node index within this route
-            int nodeIdxInRoute = -1;
-            if (currentNodeId != null) {
-                int idx = 0;
-                for (RouteDiagramLayoutEngine.LayoutNode ln : lr.nodes) {
-                    if (!"route".equals(ln.type)) {
-                        if (ln.id != null && ln.id.equals(currentNodeId)) {
-                            nodeIdxInRoute = idx;
-                            break;
-                        }
-                        idx++;
-                    }
-                }
-            }
+        eipNodeBoxes = new ArrayList<>(finalWidget.getNodeBoxes());
 
-            var widget = new org.apache.camel.dsl.jbang.core.commands.tui.diagram.RouteDiagramWidget(
-                    lr, nw, nodeIdxInRoute, scrollX, scrollY - yOffset, false,
-                    Collections.emptyMap(), false, Collections.emptyMap(),
-                    activeHighlight, historyFailed);
-
-            frame.renderWidget(widget, hChunks.get(0));
-
-            yOffset += routeHeights.get(ri) + 1;
-        }
-
-        // Scrollbars
         vScrollState.contentLength(totalRows);
         vScrollState.viewportContentLength(visibleLines);
         vScrollState.position(scrollY);
@@ -1397,56 +1593,8 @@ class DiagramSupport {
                     vChunks.get(1), hScrollState);
         }
 
-        // Tree preview for the route containing the selected node
-        if (selectedLayout != null) {
-            renderTreePreview(frame, hChunks.get(0), selectedLayout, currentNodeId);
-        }
-    }
-
-    private void renderTreePreview(
-            Frame frame, Rect area,
-            RouteDiagramLayoutEngine.LayoutRoute routeLayout, String highlightNodeId) {
-        if (routeLayout == null || routeLayout.nodes.isEmpty()) {
-            return;
-        }
-        int previewW = Math.min(38, area.width() / 3);
-        int previewH = Math.min(10, area.height() / 2);
-        if (previewW < 12 || previewH < 4 || area.width() < 40 || area.height() < 12) {
-            return;
-        }
-
-        int px = area.x() + area.width() - previewW - 1;
-        int py = area.y() + area.height() - previewH - 1;
-        Rect previewRect = new Rect(px, py, previewW, previewH);
-
-        frame.renderWidget(Clear.INSTANCE, previewRect);
-
-        Block previewBlock = Block.builder()
-                .borderType(BorderType.ROUNDED)
-                .title(Title.from(Line.from(Span.styled(" Structure ", Style.EMPTY.dim()))))
-                .build();
-        frame.renderWidget(previewBlock, previewRect);
-
-        Rect innerRect = previewBlock.inner(previewRect);
-        if (innerRect.height() < 1 || innerRect.width() < 4) {
-            return;
-        }
-
-        // Find the TreeNode matching the highlighted nodeId
-        RouteDiagramLayoutEngine.TreeNode selectedTreeNode = null;
-        if (highlightNodeId != null) {
-            for (RouteDiagramLayoutEngine.LayoutNode ln : routeLayout.nodes) {
-                if (ln.treeNode != null && highlightNodeId.equals(ln.id)) {
-                    selectedTreeNode = ln.treeNode;
-                    break;
-                }
-            }
-        }
-
-        List<Line> treeLines = RouteTreePreview.buildTree(
-                routeLayout, innerRect.height(), innerRect.width(), selectedTreeNode);
-        frame.renderWidget(
-                Paragraph.builder().text(Text.from(treeLines)).build(), innerRect);
+        renderMinimap(frame, hChunks.get(0), routeId);
+        renderTreePreview(frame, hChunks.get(0), routeId);
     }
 
     void loadAllDiagramsInBackground(

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
@@ -30,10 +30,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
-import dev.tamboui.text.CharWidth;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
 import dev.tamboui.text.Text;
@@ -45,7 +43,6 @@ import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.scrollbar.Scrollbar;
 import dev.tamboui.widgets.scrollbar.ScrollbarState;
-import org.apache.camel.diagram.RouteDiagramAsciiRenderer;
 import org.apache.camel.diagram.RouteDiagramHelper;
 import org.apache.camel.diagram.RouteDiagramLayoutEngine;
 import org.apache.camel.diagram.TopologyAsciiRenderer;
@@ -67,9 +64,6 @@ class DiagramSupport {
     private boolean showDiagram;
     private boolean topologyMode;
     private boolean showDescription;
-    private List<RouteDiagramAsciiRenderer.CounterPos> counterPositions = Collections.emptyList();
-    private Set<Integer> routeTitleRows = Collections.emptySet();
-    private List<String> lines = Collections.emptyList();
     private int scrollY;
     private int scrollX;
     private final ScrollbarState vScrollState = new ScrollbarState();
@@ -96,10 +90,6 @@ class DiagramSupport {
     private List<String> historyNodeOrder = Collections.emptyList();
     private int historyStepIndex;
     private boolean historyFailed;
-
-    List<String> getLines() {
-        return lines;
-    }
 
     boolean isShowDiagram() {
         return showDiagram;
@@ -178,10 +168,7 @@ class DiagramSupport {
     }
 
     boolean hasDiagramData() {
-        if (topologyLayout != null || !routeLayouts.isEmpty()) {
-            return true;
-        }
-        return !lines.isEmpty();
+        return topologyLayout != null || !routeLayouts.isEmpty();
     }
 
     boolean hasNativeLayout() {
@@ -301,7 +288,6 @@ class DiagramSupport {
 
     void invalidateCache() {
         cachedPid = null;
-        lines = Collections.emptyList();
         nodeBoxes = Collections.emptyList();
         topologyNodes = Collections.emptyList();
         topologyEdges = Collections.emptyList();
@@ -1134,72 +1120,6 @@ class DiagramSupport {
         frame.renderWidget(minimap, innerRect);
     }
 
-    // ---- Rendering (legacy text) ----
-
-    void renderDiagram(Frame frame, Rect area, String title) {
-        Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
-                .title(title)
-                .build();
-
-        int maxWidth = 0;
-        for (String line : lines) {
-            maxWidth = Math.max(maxWidth, CharWidth.of(line));
-        }
-
-        Rect inner = block.inner(area);
-        int visibleLines = Math.max(1, inner.height() - 1);
-        int visibleCols = Math.max(1, inner.width() - 1);
-        lastVisibleHeight = visibleLines;
-        lastVisibleWidth = visibleCols;
-
-        int maxVScroll = Math.max(0, lines.size() - visibleLines);
-        int maxHScroll = Math.max(0, maxWidth - visibleCols);
-        scrollY = Math.min(scrollY, maxVScroll);
-        scrollX = Math.min(scrollX, maxHScroll);
-
-        List<Line> rendered = new ArrayList<>();
-        int end = Math.min(scrollY + visibleLines, lines.size());
-        for (int i = scrollY; i < end; i++) {
-            String line = lines.get(i);
-            if (scrollX > 0) {
-                line = scrollX < line.length() ? line.substring(scrollX) : "";
-            }
-            rendered.add(styleDiagramLine(line, i, scrollX));
-        }
-
-        frame.renderWidget(block, area);
-
-        List<Rect> vChunks = Layout.vertical()
-                .constraints(Constraint.fill(), Constraint.length(1))
-                .split(inner);
-
-        List<Rect> hChunks = Layout.horizontal()
-                .constraints(Constraint.fill(), Constraint.length(1))
-                .split(vChunks.get(0));
-
-        Paragraph paragraph = Paragraph.builder()
-                .text(Text.from(rendered))
-                .build();
-        frame.renderWidget(paragraph, hChunks.get(0));
-
-        vScrollState.contentLength(lines.size());
-        vScrollState.viewportContentLength(visibleLines);
-        vScrollState.position(scrollY);
-        frame.renderStatefulWidget(
-                Scrollbar.builder().build(),
-                hChunks.get(1), vScrollState);
-
-        if (maxWidth > visibleCols) {
-            hScrollState.contentLength(maxWidth);
-            hScrollState.viewportContentLength(visibleCols);
-            hScrollState.position(scrollX);
-            frame.renderStatefulWidget(
-                    Scrollbar.horizontal(),
-                    vChunks.get(1), hScrollState);
-        }
-    }
-
     // ---- Async loading ----
 
     boolean beginLoad() {
@@ -1211,47 +1131,9 @@ class DiagramSupport {
     }
 
     void setLoadingPlaceholder() {
-        lines = List.of("(Loading diagram...)");
         showDiagram = true;
         scrollY = 0;
         scrollX = 0;
-    }
-
-    void loadHighlightedDiagramInBackground(
-            MonitorContext ctx, String pid,
-            String[] messageHistory, RouteDiagramHelper.HighlightStyle hlStyle) {
-        JsonObject jo = requestRouteStructure(ctx, pid);
-        if (jo == null) {
-            applyResult(ctx, List.of("(No response from integration)"));
-            return;
-        }
-
-        RouteDiagramHelper.HighlightInfo highlightInfo
-                = RouteDiagramHelper.parseMessageHistory(messageHistory, hlStyle);
-        Set<String> nodeIds = new LinkedHashSet<>(highlightInfo.getNodeIds());
-
-        List<RouteDiagramLayoutEngine.RouteInfo> routes = RouteDiagramHelper.parseRoutes(jo);
-        if (routes.isEmpty()) {
-            applyResult(ctx, List.of("(No routes in response)"));
-            return;
-        }
-
-        for (RouteDiagramLayoutEngine.RouteInfo ri : routes) {
-            boolean routeHasHighlight = ri.nodes.stream().anyMatch(n -> n.id != null && nodeIds.contains(n.id));
-            if (routeHasHighlight) {
-                addParentNodes(ri.nodes, nodeIds);
-            }
-        }
-
-        RouteDiagramHelper.HighlightInfo fullHighlight
-                = new RouteDiagramHelper.HighlightInfo(nodeIds, highlightInfo.getRouteOrder(), hlStyle);
-        routes = RouteDiagramHelper.filterAndOrderRoutes(routes, fullHighlight);
-        if (routes.isEmpty()) {
-            applyResult(ctx, List.of("(No routes contain highlighted nodes)"));
-            return;
-        }
-
-        renderRoutes(ctx, routes, false, nodeIds, hlStyle);
     }
 
     void loadHighlightedNativeDiagramInBackground(
@@ -1259,7 +1141,7 @@ class DiagramSupport {
             String[] messageHistory, boolean failed) {
         JsonObject jo = requestRouteStructure(ctx, pid);
         if (jo == null) {
-            applyResult(ctx, List.of("(No response from integration)"));
+            close();
             return;
         }
 
@@ -1272,7 +1154,7 @@ class DiagramSupport {
 
         List<RouteDiagramLayoutEngine.RouteInfo> routes = RouteDiagramHelper.parseRoutes(jo);
         if (routes.isEmpty()) {
-            applyResult(ctx, List.of("(No routes in response)"));
+            close();
             return;
         }
 
@@ -1287,7 +1169,7 @@ class DiagramSupport {
                 = new RouteDiagramHelper.HighlightInfo(nodeIds, highlightInfo.getRouteOrder(), hlStyle);
         routes = RouteDiagramHelper.filterAndOrderRoutes(routes, fullHighlight);
         if (routes.isEmpty()) {
-            applyResult(ctx, List.of("(No routes contain highlighted nodes)"));
+            close();
             return;
         }
 
@@ -1332,7 +1214,6 @@ class DiagramSupport {
             scrollY = 0;
             scrollX = 0;
             showDiagram = true;
-            lines = Collections.emptyList();
         });
     }
 
@@ -1678,96 +1559,6 @@ class DiagramSupport {
         });
     }
 
-    void loadRouteDiagramInBackground(
-            MonitorContext ctx, String pid,
-            String routeId, boolean metrics) {
-        JsonObject jo = requestRouteStructure(ctx, pid);
-        if (jo == null) {
-            applyResult(ctx, List.of("(No response from integration)"));
-            return;
-        }
-
-        List<RouteDiagramLayoutEngine.RouteInfo> routes = RouteDiagramHelper.parseRoutes(jo);
-        if (routes.isEmpty()) {
-            applyResult(ctx, List.of("(No routes in response)"));
-            return;
-        }
-
-        if (routeId != null) {
-            routes.removeIf(r -> !routeId.equals(r.routeId));
-        }
-
-        renderRoutes(ctx, routes, metrics, null, null);
-    }
-
-    void loadTopologyDiagramInBackground(
-            MonitorContext ctx, String pid, boolean metrics, boolean external) {
-        JsonObject jo = requestRouteTopology(ctx, pid, external, false);
-        if (jo == null) {
-            applyResult(ctx, List.of("(No response from integration)"));
-            return;
-        }
-
-        List<TopologyNodeInfo> nodes = TopologyHelper.parseNodes(jo);
-        List<TopologyEdgeInfo> edges = TopologyHelper.parseEdges(jo);
-        if (external) {
-            TopologyHelper.addExternalEndpoints(nodes, edges, jo);
-        }
-        if (nodes.isEmpty()) {
-            applyResult(ctx, List.of("(No routes in response)"));
-            return;
-        }
-
-        TopologyLayoutEngine engine = new TopologyLayoutEngine();
-        TopologyLayoutResult result = engine.layout(nodes, edges);
-
-        TopologyAsciiRenderer renderer = new TopologyAsciiRenderer(
-                engine.getNodeWidth(), true, metrics, showDescription);
-        String text = renderer.renderDiagramPlain(result);
-
-        List<String> resultLines = new ArrayList<>();
-        List<RouteDiagramAsciiRenderer.CounterPos> positions = new ArrayList<>();
-        String[] rawLines = text.split("\n", -1);
-        int[] rowMapping = new int[rawLines.length];
-        int newRow = 0;
-        for (int i = 0; i < rawLines.length; i++) {
-            if (!rawLines[i].isEmpty()) {
-                rowMapping[i] = newRow++;
-                resultLines.add(rawLines[i]);
-            } else {
-                rowMapping[i] = -1;
-            }
-        }
-
-        for (TopologyAsciiRenderer.CounterPos cp : renderer.getCounterPositions()) {
-            if (cp.row() >= 0 && cp.row() < rowMapping.length && rowMapping[cp.row()] >= 0) {
-                RouteDiagramAsciiRenderer.CounterType mapped = switch (cp.type()) {
-                    case OK -> RouteDiagramAsciiRenderer.CounterType.OK;
-                    case FAIL -> RouteDiagramAsciiRenderer.CounterType.FAIL;
-                    case TRIGGER -> RouteDiagramAsciiRenderer.CounterType.HIGHLIGHT_SUCCESS;
-                    case EXTERNAL -> RouteDiagramAsciiRenderer.CounterType.EXTERNAL;
-                };
-                positions.add(new RouteDiagramAsciiRenderer.CounterPos(
-                        rowMapping[cp.row()], cp.col(), cp.length(), mapped));
-            }
-        }
-
-        List<TopologyAsciiRenderer.NodeBox> boxes = new ArrayList<>();
-        for (TopologyAsciiRenderer.NodeBox nb : renderer.getNodeBoxes()) {
-            int mappedStart = (nb.startRow() >= 0 && nb.startRow() < rowMapping.length)
-                    ? rowMapping[nb.startRow()] : -1;
-            int mappedEnd = (nb.endRow() >= 0 && nb.endRow() < rowMapping.length)
-                    ? rowMapping[nb.endRow()] : -1;
-            if (mappedStart >= 0 && mappedEnd >= 0) {
-                boxes.add(new TopologyAsciiRenderer.NodeBox(
-                        nb.routeId(), mappedStart, mappedEnd, nb.startCol(), nb.endCol(), nb.layer()));
-            }
-        }
-
-        applyResult(ctx, resultLines, positions, Collections.emptySet(), boxes,
-                result.nodes, result.edges);
-    }
-
     private JsonObject requestRouteTopology(MonitorContext ctx, String pid, boolean external, boolean routes) {
         Path outputFile = ctx.getOutputFile(pid);
         PathUtils.deleteFile(outputFile);
@@ -1789,68 +1580,6 @@ class DiagramSupport {
         return jo;
     }
 
-    private void renderRoutes(
-            MonitorContext ctx,
-            List<RouteDiagramLayoutEngine.RouteInfo> routes, boolean metrics,
-            Set<String> highlightNodeIds, RouteDiagramHelper.HighlightStyle hlStyle) {
-        RouteDiagramLayoutEngine.NodeLabelMode labelMode = showDescription
-                ? RouteDiagramLayoutEngine.NodeLabelMode.DESCRIPTION
-                : RouteDiagramLayoutEngine.NodeLabelMode.CODE;
-        RouteDiagramLayoutEngine engine = new RouteDiagramLayoutEngine(
-                RouteDiagramLayoutEngine.DEFAULT_BOX_WIDTH, RouteDiagramLayoutEngine.DEFAULT_FONT_SIZE,
-                labelMode);
-
-        List<String> result = new ArrayList<>();
-        List<RouteDiagramAsciiRenderer.CounterPos> positions = new ArrayList<>();
-        Set<Integer> titleRows = new HashSet<>();
-
-        int currentY = RouteDiagramLayoutEngine.PADDING;
-        for (RouteDiagramLayoutEngine.RouteInfo r : routes) {
-            if (!result.isEmpty()) {
-                result.add("");
-                result.add("");
-            }
-
-            int titleRow = result.size();
-
-            RouteDiagramLayoutEngine.LayoutRoute lr = engine.layoutRoute(r, currentY);
-            currentY = lr.maxY + RouteDiagramLayoutEngine.V_GAP;
-
-            RouteDiagramAsciiRenderer asciiRenderer = new RouteDiagramAsciiRenderer(
-                    RouteDiagramLayoutEngine.DEFAULT_BOX_WIDTH * RouteDiagramLayoutEngine.SCALE, true, metrics);
-            String ascii;
-            if (highlightNodeIds != null && hlStyle != null) {
-                ascii = asciiRenderer.renderDiagram(List.of(lr),
-                        lr.maxY + RouteDiagramLayoutEngine.V_GAP, highlightNodeIds, hlStyle);
-            } else {
-                ascii = asciiRenderer.renderDiagram(List.of(lr),
-                        lr.maxY + RouteDiagramLayoutEngine.V_GAP);
-            }
-            List<RouteDiagramAsciiRenderer.CounterPos> origPositions = asciiRenderer.getCounterPositions();
-
-            String[] rawLines = ascii.split("\n", -1);
-            int[] rowMapping = new int[rawLines.length];
-            int newRow = result.size();
-            for (int i = 0; i < rawLines.length; i++) {
-                if (!rawLines[i].isEmpty()) {
-                    rowMapping[i] = newRow++;
-                    result.add(rawLines[i]);
-                } else {
-                    rowMapping[i] = -1;
-                }
-            }
-            for (RouteDiagramAsciiRenderer.CounterPos cp : origPositions) {
-                if (cp.row() >= 0 && cp.row() < rowMapping.length && rowMapping[cp.row()] >= 0) {
-                    positions.add(new RouteDiagramAsciiRenderer.CounterPos(
-                            rowMapping[cp.row()], cp.col(), cp.length(), cp.type()));
-                }
-            }
-            titleRows.add(titleRow);
-        }
-
-        applyResult(ctx, result, positions, titleRows);
-    }
-
     private JsonObject requestRouteStructure(MonitorContext ctx, String pid) {
         Path outputFile = ctx.getOutputFile(pid);
         PathUtils.deleteFile(outputFile);
@@ -1867,220 +1596,6 @@ class DiagramSupport {
         JsonObject jo = pollJsonResponse(outputFile, 5000);
         PathUtils.deleteFile(outputFile);
         return jo;
-    }
-
-    private void applyResult(MonitorContext ctx, List<String> resultLines) {
-        applyResult(ctx, resultLines, Collections.emptyList(), Collections.emptySet(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-    }
-
-    private void applyResult(
-            MonitorContext ctx, List<String> resultLines,
-            List<RouteDiagramAsciiRenderer.CounterPos> positions, Set<Integer> titleRows) {
-        applyResult(ctx, resultLines, positions, titleRows,
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-    }
-
-    private void applyResult(
-            MonitorContext ctx, List<String> resultLines,
-            List<RouteDiagramAsciiRenderer.CounterPos> positions, Set<Integer> titleRows,
-            List<TopologyAsciiRenderer.NodeBox> resultNodeBoxes,
-            List<TopologyLayoutNode> resultTopologyNodes,
-            List<TopologyLayoutEdge> resultTopologyEdges) {
-        if (ctx.runner == null) {
-            return;
-        }
-        ctx.runner.runOnRenderThread(() -> {
-            if (!showDiagram) {
-                return;
-            }
-            lines = resultLines;
-            counterPositions = positions;
-            routeTitleRows = titleRows;
-            topologyNodes = resultTopologyNodes;
-            topologyEdges = resultTopologyEdges;
-
-            // Preserve selection across refreshes by matching routeId
-            String prevSelectedRouteId = getSelectedRouteId();
-            if (prevSelectedRouteId == null && pendingSelectionRouteId != null) {
-                prevSelectedRouteId = pendingSelectionRouteId;
-            }
-            pendingSelectionRouteId = null;
-            nodeBoxes = resultNodeBoxes;
-            if (prevSelectedRouteId != null && !resultNodeBoxes.isEmpty()) {
-                int newIdx = -1;
-                for (int i = 0; i < resultNodeBoxes.size(); i++) {
-                    if (prevSelectedRouteId.equals(resultNodeBoxes.get(i).routeId())) {
-                        newIdx = i;
-                        break;
-                    }
-                }
-                selectedNodeIndex = newIdx >= 0 ? newIdx : 0;
-            } else if (!resultNodeBoxes.isEmpty() && selectedNodeIndex < 0) {
-                selectedNodeIndex = findTopLeftNode(resultNodeBoxes);
-            } else if (resultNodeBoxes.isEmpty()) {
-                selectedNodeIndex = -1;
-            }
-        });
-    }
-
-    // ---- Diagram styling ----
-
-    private Line styleDiagramLine(String text, int row, int hScrollX) {
-        if (routeTitleRows.contains(row)) {
-            return Line.from(Span.styled(text, Style.EMPTY.fg(Color.WHITE).bold()));
-        }
-
-        // Check if this row is within the selected node
-        int selStartCol = -1;
-        int selEndCol = -1;
-        if (selectedNodeIndex >= 0 && selectedNodeIndex < nodeBoxes.size()) {
-            TopologyAsciiRenderer.NodeBox box = nodeBoxes.get(selectedNodeIndex);
-            if (row >= box.startRow() && row <= box.endRow()) {
-                selStartCol = box.startCol() - hScrollX;
-                selEndCol = box.endCol() - hScrollX;
-            }
-        }
-
-        List<int[]> counterRanges = new ArrayList<>();
-        for (RouteDiagramAsciiRenderer.CounterPos cp : counterPositions) {
-            if (cp.row() == row) {
-                int start = cp.col() - hScrollX;
-                int end = start + cp.length();
-                if (end > 0 && start < text.length()) {
-                    start = Math.max(0, start);
-                    end = Math.min(end, text.length());
-                    int colorFlag = switch (cp.type()) {
-                        case OK, HIGHLIGHT_SUCCESS -> 1; // green
-                        case EXTERNAL -> 3; // cyan
-                        default -> 2; // red
-                    };
-                    counterRanges.add(new int[] { start, end, colorFlag });
-                }
-            }
-        }
-
-        List<Span> spans = new ArrayList<>();
-        int idx = 0;
-        while (idx < text.length()) {
-            int open = text.indexOf('[', idx);
-            if (open < 0) {
-                addStyledSegment(spans, text, idx, text.length(), counterRanges, Color.WHITE);
-                break;
-            }
-            int close = text.indexOf(']', open);
-            if (close < 0) {
-                addStyledSegment(spans, text, idx, text.length(), counterRanges, Color.WHITE);
-                break;
-            }
-            if (open > idx) {
-                addStyledSegment(spans, text, idx, open, counterRanges, Color.GRAY);
-            }
-            String tag = text.substring(open + 1, close);
-            Color tagColor = getDiagramNodeColor(tag);
-            spans.add(Span.styled("[" + tag + "]", Style.EMPTY.fg(tagColor).bold()));
-
-            int afterTag = close + 1;
-            int nextOpen = text.indexOf('[', afterTag);
-            int labelEnd = nextOpen >= 0 ? nextOpen : text.length();
-            if (afterTag < labelEnd) {
-                addStyledSegment(spans, text, afterTag, labelEnd, counterRanges, Color.WHITE);
-            }
-            idx = labelEnd;
-        }
-
-        // Apply selection highlighting as background overlay
-        if (selStartCol >= 0 && selEndCol >= 0) {
-            spans = applySelectionHighlight(spans, selStartCol, selEndCol);
-        }
-
-        return Line.from(spans);
-    }
-
-    private static List<Span> applySelectionHighlight(List<Span> spans, int startCol, int endCol) {
-        List<Span> result = new ArrayList<>();
-        int pos = 0;
-        for (Span span : spans) {
-            String content = span.content();
-            int spanStart = pos;
-            int spanEnd = pos + content.length();
-            pos = spanEnd;
-
-            if (spanEnd <= startCol || spanStart >= endCol + 1) {
-                result.add(span);
-                continue;
-            }
-
-            // Split span at selection boundaries
-            if (spanStart < startCol) {
-                result.add(Span.styled(content.substring(0, startCol - spanStart), span.style()));
-            }
-            int hlStart = Math.max(0, startCol - spanStart);
-            int hlEnd = Math.min(content.length(), endCol + 1 - spanStart);
-            if (hlStart < hlEnd) {
-                Style hlStyle = span.style().bg(Color.DARK_GRAY);
-                result.add(Span.styled(content.substring(hlStart, hlEnd), hlStyle));
-            }
-            if (spanStart + content.length() > endCol + 1) {
-                result.add(Span.styled(content.substring(endCol + 1 - spanStart), span.style()));
-            }
-        }
-        return result;
-    }
-
-    private static void addStyledSegment(
-            List<Span> spans, String text, int from, int to, List<int[]> counterRanges, Color defaultColor) {
-        int pos = from;
-        while (pos < to) {
-            int[] cr = findNextCounterRange(counterRanges, pos, to);
-            if (cr != null) {
-                if (pos < cr[0]) {
-                    spans.add(Span.styled(text.substring(pos, cr[0]), Style.EMPTY.fg(defaultColor)));
-                }
-                int counterEnd = Math.min(cr[1], to);
-                Color counterColor = cr[2] == 1 ? Color.GREEN : cr[2] == 3 ? Color.CYAN : Color.LIGHT_RED;
-                spans.add(Span.styled(text.substring(cr[0], counterEnd), Style.EMPTY.fg(counterColor).bold()));
-                pos = counterEnd;
-            } else {
-                spans.add(Span.styled(text.substring(pos, to), Style.EMPTY.fg(defaultColor)));
-                pos = to;
-            }
-        }
-    }
-
-    private static int[] findNextCounterRange(List<int[]> ranges, int pos, int limit) {
-        int[] best = null;
-        for (int[] range : ranges) {
-            if (range[1] > pos && range[0] < limit) {
-                int start = Math.max(range[0], pos);
-                if (best == null || start < best[0]) {
-                    best = new int[] { start, range[1], range[2] };
-                }
-            }
-        }
-        return best;
-    }
-
-    static Color getDiagramNodeColor(String type) {
-        if (type == null) {
-            return Color.GRAY;
-        }
-        return switch (type) {
-            case "from" -> Color.GREEN;
-            case "to", "toD", "wireTap", "enrich", "pollEnrich" -> Color.CYAN;
-            case "choice", "when", "otherwise" -> Color.YELLOW;
-            case "marshal", "unmarshal", "transform", "setBody", "setHeader", "setProperty",
-                    "convertBodyTo", "removeHeader", "removeHeaders", "removeProperty", "removeProperties" ->
-                Color.CYAN;
-            case "bean", "process", "log", "script", "delay" -> Color.MAGENTA;
-            case "filter", "split", "aggregate", "multicast", "recipientList",
-                    "routingSlip", "dynamicRouter", "loadBalance",
-                    "circuitBreaker", "saga", "doTry", "doCatch", "doFinally",
-                    "onException", "onCompletion", "intercept",
-                    "loop", "resequence", "throttle", "kamelet", "pipeline", "threads" ->
-                Color.rgb(0x89, 0x57, 0xE5);
-            default -> Color.GRAY;
-        };
     }
 
     static void addParentNodes(List<RouteDiagramLayoutEngine.NodeInfo> nodes, Set<String> nodeIds) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
@@ -1246,10 +1246,24 @@ class DiagramSupport {
             }
         }
 
+        // Map initialStepIndex (index into messageHistory) to nodeOrder index
+        int resolvedStep = nodeOrder.size() - 1;
+        if (initialStepIndex >= 0 && initialStepIndex < messageHistory.length) {
+            String h = messageHistory[initialStepIndex];
+            int br = h.indexOf('[');
+            int en = h.indexOf(']');
+            if (br >= 0 && en > br) {
+                String nid = h.substring(br + 1, en);
+                int idx = nodeOrder.indexOf(nid);
+                if (idx >= 0) {
+                    resolvedStep = idx;
+                }
+            }
+        }
+        final int clampedStep = resolvedStep;
+
         // Compute topology nodeBoxes for selection
         boolean isFailed = failed;
-        int clampedStep = initialStepIndex >= 0 && initialStepIndex < nodeOrder.size()
-                ? initialStepIndex : nodeOrder.size() - 1;
         TopologyLayoutResult finalTopoResult = topoResult;
         int finalNodeW = nodeW;
         List<TopologyLayoutNode> finalTopoNodes = topoNodes;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
@@ -1333,7 +1333,14 @@ class DiagramSupport {
         String nodeId = historyNodeOrder.get(historyStepIndex);
         String nodeRoute = historyNodeRouteMap.get(nodeId);
         if (nodeRoute != null && !nodeRoute.equals(historyDrillDownRouteId)) {
-            historyNavigationStack.push(historyDrillDownRouteId);
+            if (historyNavigationStack.contains(nodeRoute)) {
+                while (!historyNavigationStack.isEmpty() && !nodeRoute.equals(historyNavigationStack.peek())) {
+                    historyNavigationStack.pop();
+                }
+                historyNavigationStack.pop();
+            } else {
+                historyNavigationStack.push(historyDrillDownRouteId);
+            }
             historyDrillDownRouteId = nodeRoute;
             scrollY = 0;
             scrollX = 0;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
@@ -192,6 +192,58 @@ class DiagramSupport {
         return topologyNodeWidth;
     }
 
+    JsonObject getTopologyDataAsJson() {
+        TopologyLayoutResult layout = topologyLayout;
+        if (layout == null || layout.nodes.isEmpty()) {
+            return null;
+        }
+        JsonObject result = new JsonObject();
+
+        JsonArray nodesArr = new JsonArray();
+        for (TopologyLayoutNode node : layout.nodes) {
+            JsonObject n = new JsonObject();
+            n.put("routeId", node.routeId);
+            if (node.nodeType != null) {
+                n.put("nodeType", node.nodeType);
+            }
+            n.put("layer", node.layer);
+            if (node.description != null) {
+                n.put("description", node.description);
+            }
+            if (node.from != null) {
+                n.put("from", node.from);
+            }
+            if (node.connectionType != null) {
+                n.put("connectionType", node.connectionType);
+            }
+            n.put("exchangesTotal", node.exchangesTotal);
+            n.put("exchangesFailed", node.exchangesFailed);
+            nodesArr.add(n);
+        }
+        result.put("nodes", nodesArr);
+
+        JsonArray edgesArr = new JsonArray();
+        for (TopologyLayoutEdge edge : layout.edges) {
+            JsonObject e = new JsonObject();
+            e.put("from", edge.from.routeId);
+            e.put("to", edge.to.routeId);
+            if (edge.endpoint != null) {
+                e.put("endpoint", edge.endpoint);
+            }
+            if (edge.connectionType != null) {
+                e.put("connectionType", edge.connectionType);
+            }
+            e.put("selfLoop", edge.selfLoop);
+            e.put("backEdge", edge.backEdge);
+            edgesArr.add(e);
+        }
+        result.put("edges", edgesArr);
+
+        result.put("totalNodes", layout.nodes.size());
+        result.put("totalEdges", layout.edges.size());
+        return result;
+    }
+
     RouteDiagramLayoutEngine.LayoutRoute getRouteLayout(String routeId) {
         return routeLayouts.get(routeId);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
@@ -653,7 +653,10 @@ class DiagramSupport {
     }
 
     private void renderTreePreview(Frame frame, Rect area) {
-        String routeId = getSelectedRouteId();
+        renderTreePreview(frame, area, getSelectedRouteId());
+    }
+
+    private void renderTreePreview(Frame frame, Rect area, String routeId) {
         if (routeId == null) {
             return;
         }
@@ -681,7 +684,13 @@ class DiagramSupport {
         frame.renderWidget(previewBlock, previewRect);
 
         Rect innerRect = previewBlock.inner(previewRect);
-        List<Line> treeLines = RouteTreePreview.buildTree(routeLayout, innerRect.height(), innerRect.width());
+        RouteDiagramLayoutEngine.TreeNode selectedTreeNode = null;
+        var selectedBox = getSelectedEipNodeBox();
+        if (selectedBox != null && selectedBox.layoutNode() != null) {
+            selectedTreeNode = selectedBox.layoutNode().treeNode;
+        }
+        List<Line> treeLines = RouteTreePreview.buildTree(
+                routeLayout, innerRect.height(), innerRect.width(), selectedTreeNode);
         frame.renderWidget(Paragraph.builder().text(Text.from(treeLines)).build(), innerRect);
     }
 
@@ -1069,6 +1078,7 @@ class DiagramSupport {
         }
 
         renderMinimap(frame, hChunks.get(0), currentRouteId);
+        renderTreePreview(frame, hChunks.get(0), currentRouteId);
     }
 
     private void renderMinimap(Frame frame, Rect area, String currentRouteId) {
@@ -1082,7 +1092,7 @@ class DiagramSupport {
         }
 
         int mapX = area.x() + area.width() - mapW - 1;
-        int mapY = area.y() + area.height() - mapH - 1;
+        int mapY = area.y();
         Rect mapRect = new Rect(mapX, mapY, mapW, mapH);
 
         frame.renderWidget(Clear.INSTANCE, mapRect);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -820,6 +820,10 @@ class DiagramTab implements MonitorTab {
         return null;
     }
 
+    JsonObject getTopologyDataAsJson() {
+        return diagram.getTopologyDataAsJson();
+    }
+
     private Line buildBreadcrumbTitle() {
         Style nameStyle = Style.EMPTY.fg(Color.YELLOW).bold();
         List<Span> spans = new ArrayList<>();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -860,7 +860,8 @@ class DiagramTab implements MonitorTab {
                 diagram.scrollToSelectedEipNode();
             }
         });
-        sourceViewer.loadSource(ctx, routeId, 0);
+        var rl = diagram.getRouteLayout(routeId);
+        sourceViewer.loadSource(ctx, routeId, 0, rl != null ? rl.source : null);
     }
 
     private void loadSourceForSelectedNode() {
@@ -881,7 +882,8 @@ class DiagramTab implements MonitorTab {
                 sourceViewer.hide();
             }
         });
-        sourceViewer.loadSource(ctx, drillDownRouteId, targetLine);
+        var rl2 = diagram.getRouteLayout(drillDownRouteId);
+        sourceViewer.loadSource(ctx, drillDownRouteId, targetLine, rl2 != null ? rl2.source : null);
     }
 
     private int findClosestEipNode(int sourceLine) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -817,15 +817,7 @@ class DiagramTab implements MonitorTab {
 
     @Override
     public JsonObject getTableDataAsJson() {
-        List<String> lines = diagram.getLines();
-        if (lines == null || lines.isEmpty()) {
-            return null;
-        }
-        JsonObject result = new JsonObject();
-        result.put("tab", "Diagram");
-        result.put("diagram", String.join("\n", lines));
-        result.put("lines", lines.size());
-        return result;
+        return null;
     }
 
     private Line buildBreadcrumbTitle() {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -889,8 +889,10 @@ class DiagramTab implements MonitorTab {
         if (boxes.isEmpty()) {
             return -1;
         }
-        int bestIdx = -1;
-        int bestDist = Integer.MAX_VALUE;
+        int bestBeforeIdx = -1;
+        int bestBeforeDist = Integer.MAX_VALUE;
+        int bestAfterIdx = -1;
+        int bestAfterDist = Integer.MAX_VALUE;
         for (int i = 0; i < boxes.size(); i++) {
             var box = boxes.get(i);
             if (box.layoutNode() == null || box.layoutNode().treeNode == null) {
@@ -900,13 +902,24 @@ class DiagramTab implements MonitorTab {
             if (nodeLine <= 0) {
                 continue;
             }
-            int dist = Math.abs(nodeLine - sourceLine);
-            if (dist < bestDist) {
-                bestDist = dist;
-                bestIdx = i;
+            if (nodeLine == sourceLine) {
+                return i;
+            }
+            if (nodeLine < sourceLine) {
+                int dist = sourceLine - nodeLine;
+                if (dist < bestBeforeDist) {
+                    bestBeforeDist = dist;
+                    bestBeforeIdx = i;
+                }
+            } else {
+                int dist = nodeLine - sourceLine;
+                if (dist < bestAfterDist) {
+                    bestAfterDist = dist;
+                    bestAfterIdx = i;
+                }
             }
         }
-        return bestIdx;
+        return bestBeforeIdx >= 0 ? bestBeforeIdx : bestAfterIdx;
     }
 
     private static int numWidth(long... values) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -770,6 +770,18 @@ class DiagramTab implements MonitorTab {
                                 Navigation history is maintained as a stack: pressing `Esc` goes
                                 back to the previous route, and eventually back to the topology view.
 
+                                ## Route Structure Preview
+
+                                A compact tree structure preview appears in the bottom-right corner
+                                of the diagram area — like a minimap of the route's EIP structure.
+
+                                In **topology mode**, the preview shows the structure of the currently
+                                selected route and updates as you navigate between route boxes.
+
+                                In **drill-down mode**, the preview highlights the currently selected
+                                EIP node (shown in yellow) as you navigate with arrow keys, giving
+                                you an at-a-glance view of where you are in the route.
+
                                 ## Keys
 
                                 **Topology view:**

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -65,9 +65,15 @@ class DiagramTab implements MonitorTab {
             return true;
         }
 
-        // Source viewer toggle
+        // Source viewer toggle (drill-down mode)
         if (!topologyMode && diagram.isShowDiagram() && ke.isChar('c')) {
             loadSourceForSelectedNode();
+            return true;
+        }
+
+        // Source viewer toggle (topology mode)
+        if (topologyMode && diagram.isShowDiagram() && ke.isChar('c')) {
+            loadSourceForSelectedTopologyRoute();
             return true;
         }
 
@@ -633,6 +639,7 @@ class DiagramTab implements MonitorTab {
                 hint(spans, "↑↓←→", "navigate");
                 hint(spans, "Enter", "drill-down");
                 hint(spans, "PgUp/PgDn", "page");
+                hint(spans, "c", "source");
             } else {
                 diagram.renderFooterHints(spans);
             }
@@ -726,8 +733,8 @@ class DiagramTab implements MonitorTab {
 
                                 When metrics are enabled, each route box shows exchange counts:
                                 - **Green** number — successful exchanges
-                                - **Red** number with `!` — failed exchanges
-                                - Combined as `3748/12!` means 3748 ok and 12 failed
+                                - **Red** number — failed exchanges
+                                - Combined as `3748/12` means 3748 ok and 12 failed
 
                                 ## External Systems
 
@@ -768,13 +775,24 @@ class DiagramTab implements MonitorTab {
                                 **Topology view:**
                                 - `↑↓←→` — navigate between route boxes
                                 - `Enter` — drill down into selected route
+                                - `c` — show route source code
                                 - `Esc` — close diagram
 
                                 **Route diagram:**
                                 - `↑↓←→` — navigate between EIP nodes
                                 - `Enter` — jump to linked route (when `↵` indicator shown)
+                                - `c` — show source code at selected node
                                 - `Esc` — go back (previous route or topology)
                                 - `t` — jump back to topology view
+
+                                **Source view:**
+                                - `↑↓` — move cursor between lines
+                                - `Ctrl+↑↓` — scroll viewport without moving cursor
+                                - `←→` — horizontal scroll
+                                - `PgUp/PgDn` — page jump
+                                - `Home/End` — go to top/bottom
+                                - `Enter` — select the closest diagram node at cursor line
+                                - `Esc/c` — close source view
 
                                 **Common:**
                                 - `m` — toggle metrics on/off (default: on)
@@ -815,6 +833,36 @@ class DiagramTab implements MonitorTab {
         return Line.from(spans);
     }
 
+    private void loadSourceForSelectedTopologyRoute() {
+        String routeId = diagram.getSelectedRouteId();
+        if (routeId == null) {
+            return;
+        }
+        IntegrationInfo info = ctx.findSelectedIntegration();
+        if (info == null || info.routes.stream().noneMatch(r -> routeId.equals(r.routeId))) {
+            return;
+        }
+        sourceViewer.setOnLineSelected(sourceLine -> {
+            sourceViewer.hide();
+            routeNavigationStack.clear();
+            drillDownRouteId = routeId;
+            topologyMode = false;
+            diagram.setTopologyMode(false);
+            diagram.selectFromNode(routeId);
+            diagram.resetScroll();
+            diagram.endLoad();
+            if (diagram.getRouteLayout(routeId) == null) {
+                reloadDiagram();
+            }
+            int bestIdx = findClosestEipNode(sourceLine);
+            if (bestIdx >= 0) {
+                diagram.setSelectedEipNodeIndex(bestIdx);
+                diagram.scrollToSelectedEipNode();
+            }
+        });
+        sourceViewer.loadSource(ctx, routeId, 0);
+    }
+
     private void loadSourceForSelectedNode() {
         if (drillDownRouteId == null) {
             return;
@@ -825,7 +873,40 @@ class DiagramTab implements MonitorTab {
                 && selected.layoutNode().treeNode != null) {
             targetLine = selected.layoutNode().treeNode.info.line;
         }
+        sourceViewer.setOnLineSelected(sourceLine -> {
+            int bestIdx = findClosestEipNode(sourceLine);
+            if (bestIdx >= 0) {
+                diagram.setSelectedEipNodeIndex(bestIdx);
+                diagram.scrollToSelectedEipNode();
+                sourceViewer.hide();
+            }
+        });
         sourceViewer.loadSource(ctx, drillDownRouteId, targetLine);
+    }
+
+    private int findClosestEipNode(int sourceLine) {
+        var boxes = diagram.getEipNodeBoxes();
+        if (boxes.isEmpty()) {
+            return -1;
+        }
+        int bestIdx = -1;
+        int bestDist = Integer.MAX_VALUE;
+        for (int i = 0; i < boxes.size(); i++) {
+            var box = boxes.get(i);
+            if (box.layoutNode() == null || box.layoutNode().treeNode == null) {
+                continue;
+            }
+            int nodeLine = box.layoutNode().treeNode.info.line;
+            if (nodeLine <= 0) {
+                continue;
+            }
+            int dist = Math.abs(nodeLine - sourceLine);
+            if (dist < bestDist) {
+                bestDist = dist;
+                bestIdx = i;
+            }
+        }
+        return bestIdx;
     }
 
     private static int numWidth(long... values) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
@@ -79,24 +79,61 @@ class ErrorsTab implements MonitorTab {
     @Override
     public boolean handleKeyEvent(KeyEvent ke) {
         if (diagram.isShowDiagram() && diagram.isHistoryMode() && diagram.hasHistoryData()) {
-            if (ke.isUp()) {
-                diagram.historyNavigateUp();
-                return true;
-            }
-            if (ke.isDown()) {
-                diagram.historyNavigateDown();
-                return true;
-            }
-            if (ke.isLeft()) {
-                diagram.scrollLeft();
-                return true;
-            }
-            if (ke.isRight()) {
-                diagram.scrollRight();
-                return true;
+            if (diagram.isHistoryTopologyMode()) {
+                if (ke.isUp()) {
+                    diagram.selectNodeUp();
+                    diagram.scrollToSelectedNode();
+                    return true;
+                }
+                if (ke.isDown()) {
+                    diagram.selectNodeDown();
+                    diagram.scrollToSelectedNode();
+                    return true;
+                }
+                if (ke.isLeft()) {
+                    diagram.selectNodeLeft();
+                    diagram.scrollToSelectedNode();
+                    return true;
+                }
+                if (ke.isRight()) {
+                    diagram.selectNodeRight();
+                    diagram.scrollToSelectedNode();
+                    return true;
+                }
+                if (ke.isConfirm()) {
+                    diagram.historyEnterDrillDown();
+                    return true;
+                }
+            } else {
+                if (ke.isUp()) {
+                    diagram.historyNavigateUp();
+                    return true;
+                }
+                if (ke.isDown()) {
+                    diagram.historyNavigateDown();
+                    return true;
+                }
+                if (ke.isLeft()) {
+                    diagram.scrollLeft();
+                    return true;
+                }
+                if (ke.isRight()) {
+                    diagram.scrollRight();
+                    return true;
+                }
+                if (ke.isChar('t')) {
+                    diagram.historyReturnToTopology();
+                    return true;
+                }
             }
             if (ke.isHome()) {
                 diagram.scrollHome();
+                return true;
+            }
+            if (ke.isCharIgnoreCase('n')) {
+                diagram.setShowDescription(!diagram.isShowDescription());
+                diagram.endLoad();
+                loadDiagramForSelectedError();
                 return true;
             }
         }
@@ -173,6 +210,10 @@ class ErrorsTab implements MonitorTab {
 
     @Override
     public boolean handleEscape() {
+        if (diagram.isShowDiagram() && diagram.isHistoryMode() && !diagram.isHistoryTopologyMode()) {
+            diagram.historyGoBack();
+            return true;
+        }
         return diagram.handleEscape();
     }
 
@@ -196,13 +237,19 @@ class ErrorsTab implements MonitorTab {
             return;
         }
 
-        if (diagram.isShowDiagram()) {
-            if (diagram.isHistoryMode() && diagram.hasHistoryData()) {
-                String diagramTitle = String.format(" Error Diagram — step %d/%d ",
-                        diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount());
-                diagram.renderNativeHistoryDiagram(frame, area, diagramTitle);
-                return;
+        if (diagram.isShowDiagram() && diagram.isHistoryMode() && diagram.hasHistoryData()) {
+            if (diagram.isHistoryTopologyMode()) {
+                Line title = Line.from(Span.styled(
+                        String.format(" Error Topology — step %d/%d ",
+                                diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount()),
+                        Style.EMPTY.fg(Color.WHITE)));
+                diagram.renderHistoryTopologyDiagram(frame, area, title);
+            } else {
+                String routeId = diagram.getHistoryDrillDownRouteId();
+                Line title = buildErrorBreadcrumbTitle();
+                diagram.renderHistoryRouteDiagram(frame, area, title, routeId);
             }
+            return;
         }
 
         List<ErrorInfo> sorted = applyFilter(info.errors);
@@ -279,9 +326,18 @@ class ErrorsTab implements MonitorTab {
     public void renderFooter(List<Span> spans) {
         if (diagram.isShowDiagram()) {
             if (diagram.isHistoryMode() && diagram.hasHistoryData()) {
-                hint(spans, "Esc", "close");
-                hint(spans, "↑↓", "step through path");
-                hint(spans, "←→", "h-scroll");
+                if (diagram.isHistoryTopologyMode()) {
+                    hint(spans, "Esc", "close");
+                    hint(spans, "↑↓←→", "navigate");
+                    hint(spans, "Enter", "drill-down");
+                    hint(spans, "n", "description" + (diagram.isShowDescription() ? " [on]" : ""));
+                } else {
+                    hint(spans, "Esc", "back");
+                    hint(spans, "↑↓", "step through path");
+                    hint(spans, "←→", "h-scroll");
+                    hint(spans, "t", "topology");
+                    hint(spans, "n", "description" + (diagram.isShowDescription() ? " [on]" : ""));
+                }
                 return;
             }
             diagram.renderFooterHints(spans);
@@ -432,6 +488,26 @@ class ErrorsTab implements MonitorTab {
         }
         boolean filterVal = "true".equals(handledFilter);
         return (int) info.errors.stream().filter(e -> e.handled == filterVal).count();
+    }
+
+    private Line buildErrorBreadcrumbTitle() {
+        Style nameStyle = Style.EMPTY.fg(Color.YELLOW).bold();
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.styled(" Error [", Style.EMPTY.fg(Color.WHITE)));
+        var stack = diagram.getHistoryNavigationStack();
+        if (stack.isEmpty()) {
+            spans.add(Span.styled(diagram.getHistoryDrillDownRouteId(), nameStyle));
+        } else {
+            for (var it = stack.descendingIterator(); it.hasNext();) {
+                spans.add(Span.styled(it.next(), nameStyle));
+                spans.add(Span.styled(" → ", Style.EMPTY.fg(Color.GRAY)));
+            }
+            spans.add(Span.styled(diagram.getHistoryDrillDownRouteId(), nameStyle));
+        }
+        spans.add(Span.styled(String.format("] — step %d/%d ",
+                diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount()),
+                Style.EMPTY.fg(Color.WHITE)));
+        return Line.from(spans);
     }
 
     // ---- Diagram ----

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
@@ -544,7 +544,7 @@ class ErrorsTab implements MonitorTab {
 
         ctx.runner.scheduler().execute(() -> {
             try {
-                diagram.loadHighlightedNativeDiagramInBackground(ctx, pid, messageHistory, true);
+                diagram.loadHighlightedNativeDiagramInBackground(ctx, pid, messageHistory, true, -1);
             } finally {
                 diagram.endLoad();
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
@@ -35,7 +35,6 @@ import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
-import org.apache.camel.diagram.RouteDiagramHelper;
 import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
@@ -79,6 +78,28 @@ class ErrorsTab implements MonitorTab {
 
     @Override
     public boolean handleKeyEvent(KeyEvent ke) {
+        if (diagram.isShowDiagram() && diagram.isHistoryMode() && diagram.hasHistoryData()) {
+            if (ke.isUp()) {
+                diagram.historyNavigateUp();
+                return true;
+            }
+            if (ke.isDown()) {
+                diagram.historyNavigateDown();
+                return true;
+            }
+            if (ke.isLeft()) {
+                diagram.scrollLeft();
+                return true;
+            }
+            if (ke.isRight()) {
+                diagram.scrollRight();
+                return true;
+            }
+            if (ke.isHome()) {
+                diagram.scrollHome();
+                return true;
+            }
+        }
         if (diagram.handleScrollKeys(ke)) {
             return true;
         }
@@ -175,9 +196,13 @@ class ErrorsTab implements MonitorTab {
             return;
         }
 
-        if (diagram.isShowDiagram() && diagram.hasDiagramData()) {
-            diagram.renderDiagram(frame, area, " Error Diagram ");
-            return;
+        if (diagram.isShowDiagram()) {
+            if (diagram.isHistoryMode() && diagram.hasHistoryData()) {
+                String diagramTitle = String.format(" Error Diagram — step %d/%d ",
+                        diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount());
+                diagram.renderNativeHistoryDiagram(frame, area, diagramTitle);
+                return;
+            }
         }
 
         List<ErrorInfo> sorted = applyFilter(info.errors);
@@ -253,25 +278,30 @@ class ErrorsTab implements MonitorTab {
     @Override
     public void renderFooter(List<Span> spans) {
         if (diagram.isShowDiagram()) {
-            diagram.renderFooterHints(spans);
-        } else {
-            hint(spans, "Esc", "back");
-            hint(spans, "↑↓", "navigate");
-            hint(spans, "PgUp/Dn", "scroll detail");
-            if (!wordWrap) {
+            if (diagram.isHistoryMode() && diagram.hasHistoryData()) {
+                hint(spans, "Esc", "close");
+                hint(spans, "↑↓", "step through path");
                 hint(spans, "←→", "h-scroll");
+                return;
             }
-            hint(spans, "Home/End", "top/end");
-            hint(spans, "s", "sort");
-            hint(spans, "d", "diagram");
-            hint(spans, "D", "text diagram");
-            hint(spans, "f", "handled [" + handledFilter + "]");
-            hint(spans, "p", "properties [" + (showProperties ? "on" : "off") + "]");
-            hint(spans, "v", "variables [" + (showVariables ? "on" : "off") + "]");
-            hint(spans, "h", "headers [" + (showHeaders ? "on" : "off") + "]");
-            hint(spans, "b", "body [" + (showBody ? "on" : "off") + "]");
-            hint(spans, "w", "wrap [" + (wordWrap ? "on" : "off") + "]");
+            diagram.renderFooterHints(spans);
+            return;
         }
+        hint(spans, "Esc", "back");
+        hint(spans, "↑↓", "navigate");
+        hint(spans, "PgUp/Dn", "scroll detail");
+        if (!wordWrap) {
+            hint(spans, "←→", "h-scroll");
+        }
+        hint(spans, "Home/End", "top/end");
+        hint(spans, "s", "sort");
+        hint(spans, "d", "diagram");
+        hint(spans, "f", "handled [" + handledFilter + "]");
+        hint(spans, "p", "properties [" + (showProperties ? "on" : "off") + "]");
+        hint(spans, "v", "variables [" + (showVariables ? "on" : "off") + "]");
+        hint(spans, "h", "headers [" + (showHeaders ? "on" : "off") + "]");
+        hint(spans, "b", "body [" + (showBody ? "on" : "off") + "]");
+        hint(spans, "w", "wrap [" + (wordWrap ? "on" : "off") + "]");
     }
 
     private void renderDetail(Frame frame, Rect area, ErrorInfo ei) {
@@ -438,8 +468,7 @@ class ErrorsTab implements MonitorTab {
 
         ctx.runner.scheduler().execute(() -> {
             try {
-                diagram.loadHighlightedDiagramInBackground(
-                        ctx, pid, messageHistory, RouteDiagramHelper.HighlightStyle.FAIL);
+                diagram.loadHighlightedNativeDiagramInBackground(ctx, pid, messageHistory, true);
             } finally {
                 diagram.endLoad();
             }
@@ -534,17 +563,32 @@ class ErrorsTab implements MonitorTab {
                 - **NullPointerException**: A processor received unexpected null data.
                   Check if the message body or headers are populated correctly.
 
+                ## Error Diagram
+
+                Press `d` in the detail view to open a visual route diagram showing
+                the path the failed exchange took through the route. Visited nodes are
+                highlighted in red to trace the error path.
+
+                Use `Up/Down` arrow keys to step through the visited nodes one by one —
+                the diagram progressively highlights each step in order, showing exactly
+                how the exchange flowed through the route before failing. The current
+                step is shown with a selection highlight. Use `Left/Right` to scroll
+                the diagram horizontally if it extends beyond the screen.
+
+                Press `Esc` to close the diagram and return to the detail view.
+
                 ## Keys
 
-                - `Up/Down` — select error
+                - `Up/Down` — select error (list) / navigate path steps (diagram)
                 - `Enter` — view error details
+                - `d` — show error diagram (in detail view)
                 - `h` — toggle headers
                 - `b` — toggle body
                 - `p` — toggle properties
                 - `v` — toggle variables
                 - `s` — cycle sort column
                 - `S` — reverse sort order
-                - `Esc` — back to list
+                - `Esc` — back to list / close diagram
                 """;
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryEntry.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryEntry.java
@@ -34,6 +34,8 @@ class HistoryEntry {
     boolean first;
     boolean last;
     boolean failed;
+    boolean remoteEndpoint;
+    boolean stubEndpoint;
     int nodeLevel;
     long elapsed;
     long epochMs;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -18,6 +18,7 @@ package org.apache.camel.dsl.jbang.core.commands.tui;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +80,8 @@ class HistoryTab implements MonitorTab {
     private boolean traceWordWrap = true;
     private int traceDetailScroll;
     private int traceDetailHScroll;
+
+    private boolean showDescription;
 
     private boolean showWaterfall;
     private int waterfallScroll;
@@ -166,6 +169,11 @@ class HistoryTab implements MonitorTab {
                 historyDetailHScroll += 4;
                 return true;
             }
+        }
+
+        if (ke.isCharIgnoreCase('n')) {
+            showDescription = !showDescription;
+            return true;
         }
 
         if (tracerActive && traceDetailView) {
@@ -398,6 +406,7 @@ class HistoryTab implements MonitorTab {
             if (!showWaterfall && !traceWordWrap) {
                 hint(spans, "←→", "h-scroll");
             }
+            hint(spans, "n", "description" + (showDescription ? " [on]" : ""));
             hint(spans, "g", "waterfall" + (showWaterfall ? " [on]" : ""));
             if (!showWaterfall) {
                 hint(spans, "d", "diagram");
@@ -411,6 +420,7 @@ class HistoryTab implements MonitorTab {
             hint(spans, "Esc", "back");
             hint(spans, "↑↓", "navigate");
             hint(spans, "s", "sort");
+            hint(spans, "n", "description" + (showDescription ? " [on]" : ""));
             hint(spans, "d", "diagram");
             hint(spans, "Enter", "details");
             hintLast(spans, "F5", "refresh");
@@ -421,6 +431,7 @@ class HistoryTab implements MonitorTab {
             if (!showWaterfall && !historyWordWrap) {
                 hint(spans, "←→", "h-scroll");
             }
+            hint(spans, "n", "description" + (showDescription ? " [on]" : ""));
             hint(spans, "g", "waterfall" + (showWaterfall ? " [on]" : ""));
             if (!showWaterfall) {
                 hint(spans, "d", "diagram");
@@ -575,7 +586,7 @@ class HistoryTab implements MonitorTab {
             rows.add(Row.from(
                     Cell.from(s.timestamp != null ? truncate(s.timestamp, 12) : ""),
                     Cell.from(Span.styled(
-                            s.routeId != null ? truncate(s.routeId, 15) : "",
+                            s.routeId != null ? truncate(s.routeId, 20) : "",
                             Style.EMPTY.fg(Color.CYAN))),
                     Cell.from(Span.styled(s.status, statusStyle)),
                     rightCell(s.elapsed + "ms", 10),
@@ -618,16 +629,18 @@ class HistoryTab implements MonitorTab {
                 .constraints(Constraint.length(10), Constraint.length(1), Constraint.fill())
                 .split(area);
 
+        Map<String, String> descMap = showDescription ? getRouteDescriptions() : Collections.emptyMap();
         List<Row> rows = new ArrayList<>();
         for (TraceEntry entry : steps) {
+            String desc = showDescription ? descMap.get(entry.routeId) : null;
             rows.add(buildStepRow(
                     entry.direction, entry.first, entry.last, entry.failed,
-                    entry.timestamp, entry.routeId, entry.nodeId, entry.processor, entry.elapsed));
+                    entry.timestamp, entry.routeId, entry.nodeId, entry.processor, desc, entry.elapsed));
         }
 
         String stepTitle = String.format(" Trace [%s] ", truncate(traceSelectedExchangeId, 30));
         frame.renderStatefulWidget(
-                buildStepTable(rows, stepTitle), chunks.get(0), traceStepTableState);
+                buildStepTable(rows, stepTitle, showDescription), chunks.get(0), traceStepTableState);
 
         if (showWaterfall) {
             renderWaterfall(frame, chunks.get(2), steps.stream().map(WaterfallStep::fromTrace).toList());
@@ -848,16 +861,18 @@ class HistoryTab implements MonitorTab {
                 .constraints(Constraint.length(10), Constraint.length(1), Constraint.fill())
                 .split(area);
 
+        Map<String, String> descMap = showDescription ? getRouteDescriptions() : Collections.emptyMap();
         List<Row> rows = new ArrayList<>();
         for (HistoryEntry entry : current) {
+            String desc = showDescription ? descMap.get(entry.routeId) : null;
             rows.add(buildStepRow(
                     entry.direction, entry.first, entry.last, entry.failed,
-                    entry.timestamp, entry.routeId, entry.nodeId, entry.processor, entry.elapsed));
+                    entry.timestamp, entry.routeId, entry.nodeId, entry.processor, desc, entry.elapsed));
         }
 
         Title historyTitle = buildHistoryTitle(current);
         frame.renderStatefulWidget(
-                buildStepTable(rows, historyTitle), chunks.get(0), historyTableState);
+                buildStepTable(rows, historyTitle, showDescription), chunks.get(0), historyTableState);
 
         if (showWaterfall) {
             renderWaterfall(frame, chunks.get(2), current.stream().map(WaterfallStep::fromHistory).toList());
@@ -908,6 +923,20 @@ class HistoryTab implements MonitorTab {
         historyDetailHScroll = hScroll[0];
     }
 
+    private Map<String, String> getRouteDescriptions() {
+        IntegrationInfo info = ctx.findSelectedIntegration();
+        if (info == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> map = new HashMap<>();
+        for (RouteInfo ri : info.routes) {
+            if (ri.routeId != null && ri.description != null && !ri.description.isEmpty()) {
+                map.put(ri.routeId, ri.description);
+            }
+        }
+        return map;
+    }
+
     // ---- Shared helpers ----
 
     private List<String> getTraceExchangeIds() {
@@ -951,32 +980,32 @@ class HistoryTab implements MonitorTab {
 
     private static Row buildStepRow(
             String direction, boolean first, boolean last, boolean failed,
-            String timestamp, String routeId, String nodeId, String processor, long elapsed) {
+            String timestamp, String routeId, String nodeId, String processor,
+            String description, long elapsed) {
         Style dirStyle;
-        if (first) {
-            dirStyle = Style.EMPTY.fg(Color.GREEN);
-        } else if (last) {
+        if (first || last || !direction.isBlank()) {
             dirStyle = failed ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.GREEN);
         } else {
             dirStyle = failed ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY;
         }
         String elapsedStr = elapsed >= 0 ? elapsed + "ms" : "";
+        String display = description != null ? description : (processor != null ? processor : "");
         return Row.from(
                 Cell.from(Span.styled(direction, dirStyle)),
                 Cell.from(timestamp != null ? truncate(timestamp, 12) : ""),
-                Cell.from(Span.styled(routeId != null ? truncate(routeId, 15) : "", Style.EMPTY.fg(Color.CYAN))),
+                Cell.from(Span.styled(routeId != null ? truncate(routeId, 20) : "", Style.EMPTY.fg(Color.CYAN))),
                 Cell.from(nodeId != null ? truncate(nodeId, 15) : ""),
-                Cell.from(processor != null ? processor : ""),
+                Cell.from(display),
                 rightCell(elapsedStr, 10));
     }
 
-    private static Table buildStepTable(List<Row> rows, Object title) {
+    private static Table buildStepTable(List<Row> rows, Object title, boolean descriptionMode) {
         Row header = Row.from(
                 Cell.from(Span.styled("", Style.EMPTY.bold())),
                 Cell.from(Span.styled("TIME", Style.EMPTY.bold())),
                 Cell.from(Span.styled("ROUTE", Style.EMPTY.bold())),
                 Cell.from(Span.styled("ID", Style.EMPTY.bold())),
-                Cell.from(Span.styled("PROCESSOR", Style.EMPTY.bold())),
+                Cell.from(Span.styled(descriptionMode ? "DESCRIPTION" : "PROCESSOR", Style.EMPTY.bold())),
                 rightCell("ELAPSED", 10, Style.EMPTY.bold()));
         Block block = title instanceof Title t
                 ? Block.builder().borderType(BorderType.ROUNDED).title(t).build()
@@ -1322,17 +1351,33 @@ class HistoryTab implements MonitorTab {
                 took:
 
                 ```
-                 RouteId        NodeId     Processor            Elapsed
-                 timer-to-log   timer1     from[timer:hello]    0ms
-                 timer-to-log   setBody1   setBody[simple]      0ms
-                 timer-to-log   choice1    choice               0ms
-                 timer-to-log   when1      when[simple]         0ms
-                 timer-to-log   log1       log[HIGH: ${body}]   0ms
+                      RouteId        NodeId     Processor            Elapsed
+                 *->  timer-to-log   timer1     from[timer:hello]    0ms
+                      timer-to-log   setBody1   setBody[simple]      0ms
+                      timer-to-log   choice1    choice               0ms
+                      timer-to-log   when1      when[simple]         0ms
+                 --->  timer-to-log   to1       to[kafka:orders]     2ms
+                      timer-to-log   log1       log[HIGH: ${body}]   0ms
+                 <-*  timer-to-log   timer1     from[timer:hello]    3ms
                 ```
 
                 This tells you the message entered via the timer, went through setBody,
                 reached a choice node, matched the `when` condition, and was logged.
                 The elapsed time for each step helps identify bottlenecks.
+
+                ## Direction Arrows
+
+                The first column shows direction arrows that indicate the type
+                of each step:
+
+                - `*-->` — First step of a route consuming from a **remote** endpoint (e.g., Kafka, HTTP)
+                - `*-> ` — First step of a route consuming from a **local** endpoint (e.g., timer, direct)
+                - `<--*` — Last step of a route with a **remote** consumer endpoint
+                - `<-* ` — Last step of a route with a **local** consumer endpoint
+                - `--->` — A step that sends to a **remote** endpoint (e.g., `to[kafka:orders]`)
+                - `~-->` — First step or send to a **stub** endpoint (running with `--stub` mode)
+                - `<--~` — Last step of a route with a **stub** consumer endpoint
+                - _(blank)_ — A regular processing step (log, setBody, choice, etc.)
 
                 **Exchange Content** — Toggle these sections to inspect the message:
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -1608,6 +1608,62 @@ class HistoryTab implements MonitorTab {
         }
     }
 
+    String toggleDisplaySection(String section, Boolean enabled) {
+        boolean tracerActive = !traces.get().isEmpty();
+        boolean newValue;
+        switch (section) {
+            case "headers" -> {
+                if (tracerActive) {
+                    showTraceHeaders = enabled != null ? enabled : !showTraceHeaders;
+                    newValue = showTraceHeaders;
+                } else {
+                    showHistoryHeaders = enabled != null ? enabled : !showHistoryHeaders;
+                    newValue = showHistoryHeaders;
+                }
+            }
+            case "properties" -> {
+                if (tracerActive) {
+                    showTraceProperties = enabled != null ? enabled : !showTraceProperties;
+                    newValue = showTraceProperties;
+                } else {
+                    showHistoryProperties = enabled != null ? enabled : !showHistoryProperties;
+                    newValue = showHistoryProperties;
+                }
+            }
+            case "variables" -> {
+                if (tracerActive) {
+                    showTraceVariables = enabled != null ? enabled : !showTraceVariables;
+                    newValue = showTraceVariables;
+                } else {
+                    showHistoryVariables = enabled != null ? enabled : !showHistoryVariables;
+                    newValue = showHistoryVariables;
+                }
+            }
+            case "body" -> {
+                if (tracerActive) {
+                    showTraceBody = enabled != null ? enabled : !showTraceBody;
+                    newValue = showTraceBody;
+                } else {
+                    showHistoryBody = enabled != null ? enabled : !showHistoryBody;
+                    newValue = showHistoryBody;
+                }
+            }
+            case "wrap" -> {
+                if (tracerActive) {
+                    traceWordWrap = enabled != null ? enabled : !traceWordWrap;
+                    newValue = traceWordWrap;
+                } else {
+                    historyWordWrap = enabled != null ? enabled : !historyWordWrap;
+                    newValue = historyWordWrap;
+                }
+            }
+            default -> {
+                return null;
+            }
+        }
+        return section + "=" + (newValue ? "on" : "off");
+    }
+
     @Override
     public JsonObject getTableDataAsJson() {
         JsonObject result = new JsonObject();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -49,6 +49,8 @@ import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
 import org.apache.camel.util.TimeUtils;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 
 import static org.apache.camel.dsl.jbang.core.commands.tui.MonitorContext.*;
@@ -1595,5 +1597,156 @@ class HistoryTab implements MonitorTab {
                 - `F5` — refresh data
                 - `Esc` — back to list / close diagram
                 """;
+    }
+
+    void selectTraceExchange(String exchangeId) {
+        if (exchangeId != null && traceSortedExchangeIds.contains(exchangeId)) {
+            traceSelectedExchangeId = exchangeId;
+            traceDetailView = true;
+            traceStepTableState.select(0);
+            traceDetailScroll = 0;
+        }
+    }
+
+    @Override
+    public JsonObject getTableDataAsJson() {
+        JsonObject result = new JsonObject();
+        boolean tracerActive = !traces.get().isEmpty();
+        if (tracerActive) {
+            if (traceDetailView && traceSelectedExchangeId != null) {
+                result.put("tab", "Trace Steps");
+                List<TraceEntry> steps = getTraceSteps(traceSelectedExchangeId);
+                JsonArray rows = new JsonArray();
+                for (TraceEntry t : steps) {
+                    JsonObject row = new JsonObject();
+                    row.put("exchangeId", t.exchangeId);
+                    row.put("routeId", t.routeId);
+                    row.put("nodeId", t.nodeId);
+                    row.put("processor", t.processor);
+                    row.put("elapsed", t.elapsed);
+                    row.put("timestamp", t.timestamp);
+                    row.put("direction", t.direction);
+                    row.put("status", t.status);
+                    row.put("failed", t.failed);
+                    row.put("first", t.first);
+                    row.put("last", t.last);
+                    if (t.body != null) {
+                        row.put("body", t.body);
+                    }
+                    if (t.bodyType != null) {
+                        row.put("bodyType", t.bodyType);
+                    }
+                    if (t.exception != null) {
+                        row.put("exception", t.exception);
+                    }
+                    if (t.nodeLabel != null) {
+                        row.put("nodeLabel", t.nodeLabel);
+                    }
+                    if (t.nodeShortName != null) {
+                        row.put("nodeShortName", t.nodeShortName);
+                    }
+                    if (t.location != null) {
+                        row.put("location", t.location);
+                    }
+                    if (t.threadName != null) {
+                        row.put("threadName", t.threadName);
+                    }
+                    row.put("nodeLevel", t.nodeLevel);
+                    if (t.headers != null && !t.headers.isEmpty()) {
+                        row.put("headers", new JsonObject(t.headers));
+                    }
+                    if (t.headerTypes != null && !t.headerTypes.isEmpty()) {
+                        row.put("headerTypes", new JsonObject(t.headerTypes));
+                    }
+                    if (t.exchangeProperties != null && !t.exchangeProperties.isEmpty()) {
+                        row.put("exchangeProperties", new JsonObject(t.exchangeProperties));
+                    }
+                    if (t.exchangeVariables != null && !t.exchangeVariables.isEmpty()) {
+                        row.put("exchangeVariables", new JsonObject(t.exchangeVariables));
+                    }
+                    rows.add(row);
+                }
+                result.put("rows", rows);
+                result.put("totalRows", steps.size());
+                result.put("exchangeId", traceSelectedExchangeId);
+                Integer sel = traceStepTableState.selected();
+                result.put("selectedIndex", sel != null ? sel : -1);
+            } else {
+                result.put("tab", "Traces");
+                List<String> exchangeIds = getTraceExchangeIds();
+                JsonArray rows = new JsonArray();
+                for (String eid : exchangeIds) {
+                    JsonObject row = new JsonObject();
+                    row.put("exchangeId", eid);
+                    rows.add(row);
+                }
+                result.put("rows", rows);
+                result.put("totalRows", exchangeIds.size());
+                Integer sel = traceTableState.selected();
+                result.put("selectedIndex", sel != null ? sel : -1);
+            }
+        } else {
+            result.put("tab", "History");
+            List<HistoryEntry> entries = historyEntries;
+            JsonArray rows = new JsonArray();
+            for (int i = 0; i < entries.size(); i++) {
+                HistoryEntry h = entries.get(i);
+                JsonObject row = new JsonObject();
+                row.put("step", i + 1);
+                row.put("exchangeId", h.exchangeId);
+                row.put("routeId", h.routeId);
+                row.put("nodeId", h.nodeId);
+                row.put("processor", h.processor);
+                row.put("elapsed", h.elapsed);
+                row.put("timestamp", h.timestamp);
+                row.put("direction", h.direction);
+                row.put("first", h.first);
+                row.put("last", h.last);
+                row.put("failed", h.failed);
+                if (h.body != null) {
+                    row.put("body", h.body);
+                }
+                if (h.bodyType != null) {
+                    row.put("bodyType", h.bodyType);
+                }
+                if (h.exception != null) {
+                    row.put("exception", h.exception);
+                }
+                if (h.nodeLabel != null) {
+                    row.put("nodeLabel", h.nodeLabel);
+                }
+                if (h.nodeShortName != null) {
+                    row.put("nodeShortName", h.nodeShortName);
+                }
+                if (h.location != null) {
+                    row.put("location", h.location);
+                }
+                if (h.threadName != null) {
+                    row.put("threadName", h.threadName);
+                }
+                row.put("nodeLevel", h.nodeLevel);
+                if (h.fromRouteId != null) {
+                    row.put("fromRouteId", h.fromRouteId);
+                }
+                if (h.headers != null && !h.headers.isEmpty()) {
+                    row.put("headers", new JsonObject(h.headers));
+                }
+                if (h.headerTypes != null && !h.headerTypes.isEmpty()) {
+                    row.put("headerTypes", new JsonObject(h.headerTypes));
+                }
+                if (h.exchangeProperties != null && !h.exchangeProperties.isEmpty()) {
+                    row.put("exchangeProperties", new JsonObject(h.exchangeProperties));
+                }
+                if (h.exchangeVariables != null && !h.exchangeVariables.isEmpty()) {
+                    row.put("exchangeVariables", new JsonObject(h.exchangeVariables));
+                }
+                rows.add(row);
+            }
+            result.put("rows", rows);
+            result.put("totalRows", entries.size());
+            Integer sel = historyTableState.selected();
+            result.put("selectedIndex", sel != null ? sel : -1);
+        }
+        return result;
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -758,9 +758,10 @@ class HistoryTab implements MonitorTab {
 
         Map<String, String> descMap = showDescription ? getRouteDescriptions() : Collections.emptyMap();
         List<Row> rows = new ArrayList<>();
-        for (TraceEntry entry : steps) {
+        for (int i = 0; i < steps.size(); i++) {
+            TraceEntry entry = steps.get(i);
             String desc = showDescription ? descMap.get(entry.routeId) : null;
-            rows.add(buildStepRow(
+            rows.add(buildStepRow(i + 1,
                     entry.direction, entry.first, entry.last, entry.failed,
                     entry.timestamp, entry.routeId, entry.nodeId, entry.processor, desc, entry.elapsed));
         }
@@ -1011,9 +1012,10 @@ class HistoryTab implements MonitorTab {
 
         Map<String, String> descMap = showDescription ? getRouteDescriptions() : Collections.emptyMap();
         List<Row> rows = new ArrayList<>();
-        for (HistoryEntry entry : current) {
+        for (int i = 0; i < current.size(); i++) {
+            HistoryEntry entry = current.get(i);
             String desc = showDescription ? descMap.get(entry.routeId) : null;
-            rows.add(buildStepRow(
+            rows.add(buildStepRow(i + 1,
                     entry.direction, entry.first, entry.last, entry.failed,
                     entry.timestamp, entry.routeId, entry.nodeId, entry.processor, desc, entry.elapsed));
         }
@@ -1129,6 +1131,7 @@ class HistoryTab implements MonitorTab {
     }
 
     private static Row buildStepRow(
+            int stepNumber,
             String direction, boolean first, boolean last, boolean failed,
             String timestamp, String routeId, String nodeId, String processor,
             String description, long elapsed) {
@@ -1141,6 +1144,7 @@ class HistoryTab implements MonitorTab {
         String elapsedStr = elapsed >= 0 ? elapsed + "ms" : "";
         String display = description != null ? description : (processor != null ? processor : "");
         return Row.from(
+                rightCell(String.valueOf(stepNumber), 3),
                 Cell.from(Span.styled(direction, dirStyle)),
                 Cell.from(timestamp != null ? truncate(timestamp, 12) : ""),
                 Cell.from(Span.styled(routeId != null ? truncate(routeId, 25) : "", Style.EMPTY.fg(Color.CYAN))),
@@ -1151,6 +1155,7 @@ class HistoryTab implements MonitorTab {
 
     private static Table buildStepTable(List<Row> rows, Object title, boolean descriptionMode) {
         Row header = Row.from(
+                rightCell("#", 3, Style.EMPTY.bold()),
                 Cell.from(Span.styled("", Style.EMPTY.bold())),
                 Cell.from(Span.styled("TIME", Style.EMPTY.bold())),
                 Cell.from(Span.styled("ROUTE", Style.EMPTY.bold())),
@@ -1164,6 +1169,7 @@ class HistoryTab implements MonitorTab {
                 .rows(rows)
                 .header(header)
                 .widths(
+                        Constraint.length(3),
                         Constraint.length(4),
                         Constraint.length(12),
                         Constraint.length(15),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -574,6 +574,7 @@ class HistoryTab implements MonitorTab {
 
         String[] messageHistory;
         boolean failed;
+        int initialStep = -1;
 
         boolean tracerActive = !traces.get().isEmpty();
         if (tracerActive) {
@@ -601,6 +602,12 @@ class HistoryTab implements MonitorTab {
             }
             TraceEntry lastStep = steps.get(steps.size() - 1);
             failed = lastStep.failed;
+            if (traceDetailView) {
+                Integer sel = traceStepTableState.selected();
+                if (sel != null && sel >= 0 && sel < steps.size()) {
+                    initialStep = sel;
+                }
+            }
         } else {
             List<HistoryEntry> entries = historyEntries;
             if (entries.isEmpty()) {
@@ -620,6 +627,10 @@ class HistoryTab implements MonitorTab {
                 }
             }
             failed = lastEntry.failed;
+            Integer sel = historyTableState.selected();
+            if (sel != null && sel >= 0 && sel < entries.size()) {
+                initialStep = sel;
+            }
         }
 
         String pid = ctx.selectedPid;
@@ -627,9 +638,10 @@ class HistoryTab implements MonitorTab {
         diagram.setLoadingPlaceholder();
 
         boolean isFailed = failed;
+        int step = initialStep;
         ctx.runner.scheduler().execute(() -> {
             try {
-                diagram.loadHighlightedNativeDiagramInBackground(ctx, pid, messageHistory, isFailed);
+                diagram.loadHighlightedNativeDiagramInBackground(ctx, pid, messageHistory, isFailed, step);
             } finally {
                 diagram.endLoad();
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -48,7 +48,6 @@ import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
-import org.apache.camel.diagram.RouteDiagramHelper;
 import org.apache.camel.util.TimeUtils;
 import org.apache.camel.util.json.Jsoner;
 
@@ -110,6 +109,28 @@ class HistoryTab implements MonitorTab {
 
     @Override
     public boolean handleKeyEvent(KeyEvent ke) {
+        if (diagram.isShowDiagram() && diagram.isHistoryMode() && diagram.hasHistoryData()) {
+            if (ke.isUp()) {
+                diagram.historyNavigateUp();
+                return true;
+            }
+            if (ke.isDown()) {
+                diagram.historyNavigateDown();
+                return true;
+            }
+            if (ke.isLeft()) {
+                diagram.scrollLeft();
+                return true;
+            }
+            if (ke.isRight()) {
+                diagram.scrollRight();
+                return true;
+            }
+            if (ke.isHome()) {
+                diagram.scrollHome();
+                return true;
+            }
+        }
         if (diagram.handleScrollKeys(ke)) {
             return true;
         }
@@ -377,9 +398,17 @@ class HistoryTab implements MonitorTab {
             return;
         }
 
-        if (diagram.isShowDiagram() && diagram.hasDiagramData()) {
-            diagram.renderDiagram(frame, area, " History Diagram ");
-            return;
+        if (diagram.isShowDiagram()) {
+            if (diagram.isHistoryMode() && diagram.hasHistoryData()) {
+                String diagramTitle = String.format(" History Diagram — step %d/%d ",
+                        diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount());
+                diagram.renderNativeHistoryDiagram(frame, area, diagramTitle);
+                return;
+            }
+            if (diagram.hasDiagramData()) {
+                diagram.renderDiagram(frame, area, " History Diagram ");
+                return;
+            }
         }
 
         boolean tracerActive = !traces.get().isEmpty();
@@ -404,6 +433,13 @@ class HistoryTab implements MonitorTab {
     @Override
     public void renderFooter(List<Span> spans) {
         if (diagram.isShowDiagram()) {
+            if (diagram.isHistoryMode() && diagram.hasHistoryData()) {
+                hint(spans, "Esc", "close");
+                hint(spans, "↑↓", "step through path");
+                hint(spans, "←→", "h-scroll");
+                hint(spans, "n", "description" + (showDescription ? " [on]" : ""));
+                return;
+            }
             diagram.renderFooterHints(spans);
             return;
         }
@@ -515,15 +551,13 @@ class HistoryTab implements MonitorTab {
         }
 
         String pid = ctx.selectedPid;
-        RouteDiagramHelper.HighlightStyle style = failed
-                ? RouteDiagramHelper.HighlightStyle.FAIL
-                : RouteDiagramHelper.HighlightStyle.SUCCESS;
 
         diagram.setLoadingPlaceholder();
 
+        boolean isFailed = failed;
         ctx.runner.scheduler().execute(() -> {
             try {
-                diagram.loadHighlightedDiagramInBackground(ctx, pid, messageHistory, style);
+                diagram.loadHighlightedNativeDiagramInBackground(ctx, pid, messageHistory, isFailed);
             } finally {
                 diagram.endLoad();
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -1459,17 +1459,51 @@ class HistoryTab implements MonitorTab {
                 - **Finding bottlenecks**: Look for steps with high elapsed times
                 - **Understanding failures**: See exactly where in the route a failure occurred
 
+                ## Route Diagram
+
+                Press `d` to open the route diagram for the selected exchange.
+                The diagram shows the route structure as a visual flowchart with
+                box-drawing characters, highlighting the path the exchange took
+                through the route in green (or red for failed exchanges).
+
+                **Progressive Path Highlighting** — Use `Up/Down` to step through
+                the exchange's journey node by node. As you navigate forward, each
+                visited node lights up progressively in green, creating a visual
+                replay of the message's path. Stepping backward removes the
+                highlight from the last node. The currently selected node is
+                shown with a dark background.
+
+                **Multi-route exchanges** — When an exchange spans multiple routes
+                (e.g., via `direct` or `seda` endpoints), all involved routes are
+                shown stacked vertically. The diagram auto-scrolls to keep the
+                current step visible.
+
+                **Route Structure Preview** — A compact tree view appears in the
+                bottom-right corner showing the full route hierarchy. The currently
+                selected node is highlighted, helping you maintain orientation in
+                large routes. This is the same minimap available on the Routes and
+                Diagram tabs.
+
+                Press `Esc` to close the diagram and return to the exchange list.
+
                 ## Keys
 
-                - `Up/Down` — select exchange
+                - `Up/Down` — select exchange (or step through path in diagram)
                 - `Enter` — view exchange details
+                - `d` — toggle route diagram
+                - `n` — toggle description mode
+                - `g` — toggle waterfall view
                 - `h` — toggle headers
                 - `b` — toggle body
                 - `p` — toggle properties
                 - `v` — toggle variables
+                - `w` — toggle word wrap
                 - `s` — cycle sort column
                 - `S` — reverse sort order
-                - `Esc` — back to list
+                - `Left/Right` — horizontal scroll (diagram or detail)
+                - `PgUp/PgDn` — page scroll
+                - `F5` — refresh data
+                - `Esc` — back to list / close diagram
                 """;
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -123,13 +123,17 @@ class HistoryTab implements MonitorTab {
         if (ke.isPageUp() || ke.isKey(KeyCode.PAGE_UP)) {
             if (tracerActive && traceDetailView) {
                 if (showWaterfall) {
-                    waterfallScroll = Math.max(0, waterfallScroll - 10);
+                    for (int i = 0; i < 10; i++) {
+                        traceStepTableState.selectPrevious();
+                    }
                 } else {
                     traceDetailScroll = Math.max(0, traceDetailScroll - 5);
                 }
             } else {
                 if (showWaterfall) {
-                    waterfallScroll = Math.max(0, waterfallScroll - 10);
+                    for (int i = 0; i < 10; i++) {
+                        historyTableState.selectPrevious();
+                    }
                 } else {
                     historyDetailScroll = Math.max(0, historyDetailScroll - 5);
                 }
@@ -139,13 +143,18 @@ class HistoryTab implements MonitorTab {
         if (ke.isPageDown() || ke.isKey(KeyCode.PAGE_DOWN)) {
             if (tracerActive && traceDetailView) {
                 if (showWaterfall) {
-                    waterfallScroll += 10;
+                    List<TraceEntry> steps = getTraceSteps(traceSelectedExchangeId);
+                    for (int i = 0; i < 10; i++) {
+                        traceStepTableState.selectNext(steps.size());
+                    }
                 } else {
                     traceDetailScroll += 5;
                 }
             } else {
                 if (showWaterfall) {
-                    waterfallScroll += 10;
+                    for (int i = 0; i < 10; i++) {
+                        historyTableState.selectNext(historyEntries.size());
+                    }
                 } else {
                     historyDetailScroll += 5;
                 }
@@ -408,8 +417,8 @@ class HistoryTab implements MonitorTab {
             }
             hint(spans, "n", "description" + (showDescription ? " [on]" : ""));
             hint(spans, "g", "waterfall" + (showWaterfall ? " [on]" : ""));
+            hint(spans, "d", "diagram");
             if (!showWaterfall) {
-                hint(spans, "d", "diagram");
                 hint(spans, "p", "properties" + (showTraceProperties ? " [on]" : " [off]"));
                 hint(spans, "v", "variables" + (showTraceVariables ? " [on]" : " [off]"));
                 hint(spans, "h", "headers" + (showTraceHeaders ? " [on]" : " [off]"));
@@ -433,8 +442,8 @@ class HistoryTab implements MonitorTab {
             }
             hint(spans, "n", "description" + (showDescription ? " [on]" : ""));
             hint(spans, "g", "waterfall" + (showWaterfall ? " [on]" : ""));
+            hint(spans, "d", "diagram");
             if (!showWaterfall) {
-                hint(spans, "d", "diagram");
                 hint(spans, "p", "properties" + (showHistoryProperties ? " [on]" : " [off]"));
                 hint(spans, "v", "variables" + (showHistoryVariables ? " [on]" : " [off]"));
                 hint(spans, "h", "headers" + (showHistoryHeaders ? " [on]" : " [off]"));
@@ -586,7 +595,7 @@ class HistoryTab implements MonitorTab {
             rows.add(Row.from(
                     Cell.from(s.timestamp != null ? truncate(s.timestamp, 12) : ""),
                     Cell.from(Span.styled(
-                            s.routeId != null ? truncate(s.routeId, 20) : "",
+                            s.routeId != null ? truncate(s.routeId, 25) : "",
                             Style.EMPTY.fg(Color.CYAN))),
                     Cell.from(Span.styled(s.status, statusStyle)),
                     rightCell(s.elapsed + "ms", 10),
@@ -638,12 +647,14 @@ class HistoryTab implements MonitorTab {
                     entry.timestamp, entry.routeId, entry.nodeId, entry.processor, desc, entry.elapsed));
         }
 
-        String stepTitle = String.format(" Trace [%s] ", truncate(traceSelectedExchangeId, 30));
+        String stepTitle = String.format(" Trace [%s] — %d steps ", truncate(traceSelectedExchangeId, 30), steps.size());
         frame.renderStatefulWidget(
                 buildStepTable(rows, stepTitle, showDescription), chunks.get(0), traceStepTableState);
 
         if (showWaterfall) {
-            renderWaterfall(frame, chunks.get(2), steps.stream().map(WaterfallStep::fromTrace).toList());
+            Integer sel = traceStepTableState.selected();
+            renderWaterfall(frame, chunks.get(2), steps.stream().map(WaterfallStep::fromTrace).toList(),
+                    sel != null ? sel : -1);
         } else {
             renderTraceStepDetail(frame, chunks.get(2), steps);
         }
@@ -716,13 +727,19 @@ class HistoryTab implements MonitorTab {
         }
     }
 
-    private void renderWaterfall(Frame frame, Rect area, List<WaterfallStep> allSteps) {
+    private void renderWaterfall(Frame frame, Rect area, List<WaterfallStep> allSteps, int selectedIndex) {
         // Copy the elapsed from matching last entries onto first entries
         // (first entries have elapsed=0, the total is on the last entry)
         List<WaterfallStep> forward = new ArrayList<>();
-        for (WaterfallStep e : allSteps) {
+        // Map original allSteps index to forward index for selection highlight
+        int selectedForwardIndex = -1;
+        for (int idx = 0; idx < allSteps.size(); idx++) {
+            WaterfallStep e = allSteps.get(idx);
             if ("<--".equals(e.direction)) {
                 continue;
+            }
+            if (idx == selectedIndex) {
+                selectedForwardIndex = forward.size();
             }
             if (e.first) {
                 long totalElapsed = e.elapsed;
@@ -789,11 +806,20 @@ class HistoryTab implements MonitorTab {
 
         int barMaxWidth = Math.max(10, inner.width() - labelWidth - 12);
 
+        // Auto-scroll to keep selected step visible
+        if (selectedForwardIndex >= 0) {
+            if (selectedForwardIndex < waterfallScroll) {
+                waterfallScroll = selectedForwardIndex;
+            } else if (selectedForwardIndex >= waterfallScroll + visibleLines) {
+                waterfallScroll = selectedForwardIndex - visibleLines + 1;
+            }
+        }
+
         int end = Math.min(waterfallScroll + visibleLines, forward.size());
         List<Line> lines = new ArrayList<>();
         for (int i = waterfallScroll; i < end; i++) {
             lines.add(renderWaterfallStep(forward.get(i), labelWidth, barMaxWidth,
-                    maxElapsed, minDuration, maxDuration));
+                    maxElapsed, minDuration, maxDuration, i == selectedForwardIndex));
         }
 
         List<Rect> hChunks = Layout.horizontal()
@@ -813,7 +839,8 @@ class HistoryTab implements MonitorTab {
 
     private static Line renderWaterfallStep(
             WaterfallStep entry, int labelWidth, int maxBarWidth,
-            long maxElapsed, long minDuration, long maxDuration) {
+            long maxElapsed, long minDuration, long maxDuration, boolean selected) {
+        String indicator = selected ? ">> " : "   ";
         String indent = "  ".repeat(entry.nodeLevel);
         String label = indent + entry.label();
         if (label.length() > labelWidth) {
@@ -832,8 +859,11 @@ class HistoryTab implements MonitorTab {
         String durationStr = entry.elapsed + "ms";
         int pad = Math.max(1, 8 - durationStr.length());
 
+        Style labelStyle = selected ? Style.EMPTY.fg(Color.CYAN).bold() : Style.EMPTY.fg(Color.CYAN);
+
         return Line.from(
-                Span.styled(label, Style.EMPTY.fg(Color.CYAN)),
+                Span.styled(indicator, Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(label, labelStyle),
                 Span.styled(bar, bandStyle),
                 Span.raw(" ".repeat(pad)),
                 Span.styled(durationStr, isRoute ? Style.EMPTY.dim() : Style.EMPTY.fg(Color.WHITE).bold()));
@@ -875,7 +905,9 @@ class HistoryTab implements MonitorTab {
                 buildStepTable(rows, historyTitle, showDescription), chunks.get(0), historyTableState);
 
         if (showWaterfall) {
-            renderWaterfall(frame, chunks.get(2), current.stream().map(WaterfallStep::fromHistory).toList());
+            Integer sel = historyTableState.selected();
+            renderWaterfall(frame, chunks.get(2), current.stream().map(WaterfallStep::fromHistory).toList(),
+                    sel != null ? sel : -1);
         } else {
             renderHistoryDetail(frame, chunks.get(2), current);
         }
@@ -993,7 +1025,7 @@ class HistoryTab implements MonitorTab {
         return Row.from(
                 Cell.from(Span.styled(direction, dirStyle)),
                 Cell.from(timestamp != null ? truncate(timestamp, 12) : ""),
-                Cell.from(Span.styled(routeId != null ? truncate(routeId, 20) : "", Style.EMPTY.fg(Color.CYAN))),
+                Cell.from(Span.styled(routeId != null ? truncate(routeId, 25) : "", Style.EMPTY.fg(Color.CYAN))),
                 Cell.from(nodeId != null ? truncate(nodeId, 15) : ""),
                 Cell.from(display),
                 rightCell(elapsedStr, 10));
@@ -1043,7 +1075,7 @@ class HistoryTab implements MonitorTab {
         }
 
         List<Span> spans = new ArrayList<>();
-        spans.add(Span.raw(" History of last completed ("));
+        spans.add(Span.raw(" History of last completed — " + entries.size() + " steps ("));
         boolean failed = last.failed;
         spans.add(Span.styled("status:" + (failed ? "failed" : "success"),
                 failed ? Style.EMPTY.fg(Color.LIGHT_RED).bold() : Style.EMPTY.fg(Color.GREEN).bold()));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -110,24 +110,62 @@ class HistoryTab implements MonitorTab {
     @Override
     public boolean handleKeyEvent(KeyEvent ke) {
         if (diagram.isShowDiagram() && diagram.isHistoryMode() && diagram.hasHistoryData()) {
-            if (ke.isUp()) {
-                diagram.historyNavigateUp();
-                return true;
-            }
-            if (ke.isDown()) {
-                diagram.historyNavigateDown();
-                return true;
-            }
-            if (ke.isLeft()) {
-                diagram.scrollLeft();
-                return true;
-            }
-            if (ke.isRight()) {
-                diagram.scrollRight();
-                return true;
+            if (diagram.isHistoryTopologyMode()) {
+                if (ke.isUp()) {
+                    diagram.selectNodeUp();
+                    diagram.scrollToSelectedNode();
+                    return true;
+                }
+                if (ke.isDown()) {
+                    diagram.selectNodeDown();
+                    diagram.scrollToSelectedNode();
+                    return true;
+                }
+                if (ke.isLeft()) {
+                    diagram.selectNodeLeft();
+                    diagram.scrollToSelectedNode();
+                    return true;
+                }
+                if (ke.isRight()) {
+                    diagram.selectNodeRight();
+                    diagram.scrollToSelectedNode();
+                    return true;
+                }
+                if (ke.isConfirm()) {
+                    diagram.historyEnterDrillDown();
+                    return true;
+                }
+            } else {
+                if (ke.isUp()) {
+                    diagram.historyNavigateUp();
+                    return true;
+                }
+                if (ke.isDown()) {
+                    diagram.historyNavigateDown();
+                    return true;
+                }
+                if (ke.isLeft()) {
+                    diagram.scrollLeft();
+                    return true;
+                }
+                if (ke.isRight()) {
+                    diagram.scrollRight();
+                    return true;
+                }
+                if (ke.isChar('t')) {
+                    diagram.historyReturnToTopology();
+                    return true;
+                }
             }
             if (ke.isHome()) {
                 diagram.scrollHome();
+                return true;
+            }
+            if (ke.isCharIgnoreCase('n')) {
+                showDescription = !showDescription;
+                diagram.setShowDescription(showDescription);
+                diagram.endLoad();
+                loadDiagramForCurrentView();
                 return true;
             }
         }
@@ -320,6 +358,10 @@ class HistoryTab implements MonitorTab {
 
     @Override
     public boolean handleEscape() {
+        if (diagram.isShowDiagram() && diagram.isHistoryMode() && !diagram.isHistoryTopologyMode()) {
+            diagram.historyGoBack();
+            return true;
+        }
         if (diagram.handleEscape()) {
             return true;
         }
@@ -399,9 +441,17 @@ class HistoryTab implements MonitorTab {
         }
 
         if (diagram.isShowDiagram() && diagram.isHistoryMode() && diagram.hasHistoryData()) {
-            String diagramTitle = String.format(" History Diagram — step %d/%d ",
-                    diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount());
-            diagram.renderNativeHistoryDiagram(frame, area, diagramTitle);
+            if (diagram.isHistoryTopologyMode()) {
+                Line title = Line.from(Span.styled(
+                        String.format(" History Topology — step %d/%d ",
+                                diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount()),
+                        Style.EMPTY.fg(Color.WHITE)));
+                diagram.renderHistoryTopologyDiagram(frame, area, title);
+            } else {
+                String routeId = diagram.getHistoryDrillDownRouteId();
+                Line title = buildHistoryBreadcrumbTitle();
+                diagram.renderHistoryRouteDiagram(frame, area, title, routeId);
+            }
             return;
         }
 
@@ -428,10 +478,18 @@ class HistoryTab implements MonitorTab {
     public void renderFooter(List<Span> spans) {
         if (diagram.isShowDiagram()) {
             if (diagram.isHistoryMode() && diagram.hasHistoryData()) {
-                hint(spans, "Esc", "close");
-                hint(spans, "↑↓", "step through path");
-                hint(spans, "←→", "h-scroll");
-                hint(spans, "n", "description" + (showDescription ? " [on]" : ""));
+                if (diagram.isHistoryTopologyMode()) {
+                    hint(spans, "Esc", "close");
+                    hint(spans, "↑↓←→", "navigate");
+                    hint(spans, "Enter", "drill-down");
+                    hint(spans, "n", "description" + (showDescription ? " [on]" : ""));
+                } else {
+                    hint(spans, "Esc", "back");
+                    hint(spans, "↑↓", "step through path");
+                    hint(spans, "←→", "h-scroll");
+                    hint(spans, "t", "topology");
+                    hint(spans, "n", "description" + (showDescription ? " [on]" : ""));
+                }
                 return;
             }
             diagram.renderFooterHints(spans);
@@ -482,6 +540,26 @@ class HistoryTab implements MonitorTab {
             }
             hintLast(spans, "F5", "refresh");
         }
+    }
+
+    private Line buildHistoryBreadcrumbTitle() {
+        Style nameStyle = Style.EMPTY.fg(Color.YELLOW).bold();
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.styled(" History [", Style.EMPTY.fg(Color.WHITE)));
+        var stack = diagram.getHistoryNavigationStack();
+        if (stack.isEmpty()) {
+            spans.add(Span.styled(diagram.getHistoryDrillDownRouteId(), nameStyle));
+        } else {
+            for (var it = stack.descendingIterator(); it.hasNext();) {
+                spans.add(Span.styled(it.next(), nameStyle));
+                spans.add(Span.styled(" → ", Style.EMPTY.fg(Color.GRAY)));
+            }
+            spans.add(Span.styled(diagram.getHistoryDrillDownRouteId(), nameStyle));
+        }
+        spans.add(Span.styled(String.format("] — step %d/%d ",
+                diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount()),
+                Style.EMPTY.fg(Color.WHITE)));
+        return Line.from(spans);
     }
 
     // ---- Diagram loading ----

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -398,17 +398,11 @@ class HistoryTab implements MonitorTab {
             return;
         }
 
-        if (diagram.isShowDiagram()) {
-            if (diagram.isHistoryMode() && diagram.hasHistoryData()) {
-                String diagramTitle = String.format(" History Diagram — step %d/%d ",
-                        diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount());
-                diagram.renderNativeHistoryDiagram(frame, area, diagramTitle);
-                return;
-            }
-            if (diagram.hasDiagramData()) {
-                diagram.renderDiagram(frame, area, " History Diagram ");
-                return;
-            }
+        if (diagram.isShowDiagram() && diagram.isHistoryMode() && diagram.hasHistoryData()) {
+            String diagramTitle = String.format(" History Diagram — step %d/%d ",
+                    diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount());
+            diagram.renderNativeHistoryDiagram(frame, area, diagramTitle);
+            return;
         }
 
         boolean tracerActive = !traces.get().isEmpty();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/LogTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/LogTab.java
@@ -507,6 +507,12 @@ class LogTab implements MonitorTab {
         frame.renderStatefulWidget(list, popup, logLevelListState);
     }
 
+    void setLogLevel(String level) {
+        if (ctx.selectedPid != null) {
+            sendLoggerLevelAction(ctx.selectedPid, level);
+        }
+    }
+
     private void sendLoggerLevelAction(String pid, String level) {
         JsonObject root = new JsonObject();
         root.put("action", "logger");

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
@@ -434,4 +434,37 @@ class MemoryTab implements MonitorTab {
         int empty = width - filled;
         return GAUGE_FILLED.repeat(Math.max(0, filled)) + GAUGE_EMPTY.repeat(Math.max(0, empty));
     }
+
+    @Override
+    public JsonObject getTableDataAsJson() {
+        IntegrationInfo info = ctx.findSelectedIntegration();
+        if (info == null) {
+            return null;
+        }
+        JsonObject result = new JsonObject();
+        result.put("tab", "Memory");
+        JsonObject data = new JsonObject();
+        data.put("heapMemUsed", info.heapMemUsed);
+        data.put("heapMemCommitted", info.heapMemCommitted);
+        data.put("heapMemMax", info.heapMemMax);
+        data.put("nonHeapMemUsed", info.nonHeapMemUsed);
+        data.put("nonHeapMemCommitted", info.nonHeapMemCommitted);
+        if (info.oldGenUsed > 0) {
+            data.put("oldGenUsed", info.oldGenUsed);
+            data.put("oldGenCommitted", info.oldGenCommitted);
+            data.put("oldGenMax", info.oldGenMax);
+        }
+        if (info.metaspaceUsed > 0) {
+            data.put("metaspaceUsed", info.metaspaceUsed);
+            data.put("metaspaceCommitted", info.metaspaceCommitted);
+            data.put("metaspaceMax", info.metaspaceMax);
+        }
+        data.put("gcCollectionCount", info.gcCollectionCount);
+        data.put("gcCollectionTime", info.gcCollectionTime);
+        data.put("loadedClassCount", info.loadedClassCount);
+        data.put("threadCount", info.threadCount);
+        data.put("peakThreadCount", info.peakThreadCount);
+        result.put("snapshot", data);
+        return result;
+    }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
@@ -47,6 +47,8 @@ import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
 
 import static org.apache.camel.dsl.jbang.core.commands.tui.MonitorContext.*;
 
@@ -985,5 +987,67 @@ class MetricsTab implements MonitorTab {
                 - `s` — cycle sort column (in table mode)
                 - `S` — reverse sort order
                 """;
+    }
+
+    @Override
+    public JsonObject getTableDataAsJson() {
+        IntegrationInfo info = ctx.findSelectedIntegration();
+        if (info == null || info.meters.isEmpty()) {
+            return null;
+        }
+        JsonObject result = new JsonObject();
+        result.put("tab", "Metrics");
+        JsonArray rows = new JsonArray();
+        for (MicrometerMeterInfo m : info.meters) {
+            JsonObject row = new JsonObject();
+            row.put("type", m.type);
+            row.put("name", m.name);
+            if (m.description != null) {
+                row.put("description", m.description);
+            }
+            if (m.count != null) {
+                row.put("count", m.count);
+            }
+            if (m.value != null) {
+                row.put("value", m.value);
+            }
+            if (m.mean != null) {
+                row.put("mean", m.mean);
+            }
+            if (m.max != null) {
+                row.put("max", m.max);
+            }
+            if (m.total != null) {
+                row.put("total", m.total);
+            }
+            if (m.activeTasks != null) {
+                row.put("activeTasks", m.activeTasks);
+            }
+            if (m.meanDouble != null) {
+                row.put("meanDouble", m.meanDouble);
+            }
+            if (m.maxDouble != null) {
+                row.put("maxDouble", m.maxDouble);
+            }
+            if (m.totalDouble != null) {
+                row.put("totalDouble", m.totalDouble);
+            }
+            if (!m.tags.isEmpty()) {
+                JsonArray tags = new JsonArray();
+                for (String[] tag : m.tags) {
+                    JsonObject t = new JsonObject();
+                    t.put("key", tag[0]);
+                    t.put("value", tag.length > 1 ? tag[1] : "");
+                    tags.add(t);
+                }
+                row.put("tags", tags);
+            }
+            rows.add(row);
+        }
+        result.put("rows", rows);
+        result.put("totalRows", info.meters.size());
+        Integer sel = tableState.selected();
+        result.put("selectedIndex", sel != null ? sel : -1);
+        return result;
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorTab.java
@@ -58,4 +58,8 @@ interface MonitorTab {
     default JsonObject getTableDataAsJson() {
         return null;
     }
+
+    default boolean setFilter(String filter) {
+        return false;
+    }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RouteTreePreview.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RouteTreePreview.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.tui;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import org.apache.camel.diagram.RouteDiagramLayoutEngine.LayoutRoute;
+import org.apache.camel.diagram.RouteDiagramLayoutEngine.TreeNode;
+
+class RouteTreePreview {
+
+    private static final Set<String> STRUCTURAL_TYPES = Set.of(
+            "choice", "multicast", "split", "filter", "doTry", "doCatch", "doFinally",
+            "loadBalance", "recipientList", "circuitBreaker", "onFallback",
+            "when", "otherwise", "loop", "pipeline", "saga", "step",
+            "aggregate", "resequence", "routingSlip", "dynamicRouter",
+            "throttle", "threads", "onException", "onCompletion",
+            "intercept", "interceptFrom", "interceptSendToEndpoint");
+
+    private RouteTreePreview() {
+    }
+
+    static List<Line> buildTree(LayoutRoute layout, int maxLines, int maxWidth) {
+        if (layout == null || layout.nodes.isEmpty()) {
+            return List.of(Line.from(Span.styled("(no structure)", Style.EMPTY.dim())));
+        }
+
+        TreeNode root = layout.nodes.get(0).treeNode;
+        if (root == null) {
+            return List.of(Line.from(Span.styled("(no structure)", Style.EMPTY.dim())));
+        }
+
+        List<Line> result = new ArrayList<>();
+        // Render root node (the "from" node)
+        addLine(result, " ", root, maxLines, maxWidth);
+        // Render children
+        addChildren(root.children, " ", result, maxLines, maxWidth);
+        return result;
+    }
+
+    private static void addChildren(
+            List<TreeNode> children, String parentIndent,
+            List<Line> result, int maxLines, int maxWidth) {
+        for (int i = 0; i < children.size(); i++) {
+            if (result.size() >= maxLines) {
+                return;
+            }
+            boolean last = (i == children.size() - 1);
+
+            if (result.size() >= maxLines - 1 && !last) {
+                result.add(Line.from(Span.styled(parentIndent + "...", Style.EMPTY.dim())));
+                return;
+            }
+
+            String connector = last ? "└─" : "├─";
+            String childCont = last ? "  " : "│ ";
+
+            TreeNode child = children.get(i);
+            addLine(result, parentIndent + connector, child, maxLines, maxWidth);
+            addChildren(child.children, parentIndent + childCont, result, maxLines, maxWidth);
+        }
+    }
+
+    private static void addLine(
+            List<Line> result, String prefix, TreeNode node, int maxLines, int maxWidth) {
+        if (result.size() >= maxLines) {
+            return;
+        }
+        String label = buildLabel(node);
+
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.styled(prefix, Style.EMPTY.fg(Color.DARK_GRAY)));
+        spans.add(styledLabel(node.info.type, truncate(label, maxWidth - prefix.length())));
+        result.add(Line.from(spans));
+    }
+
+    private static Span styledLabel(String type, String text) {
+        if ("from".equals(type)) {
+            return Span.styled(text, Style.EMPTY.fg(Color.YELLOW));
+        } else if (STRUCTURAL_TYPES.contains(type)) {
+            return Span.styled(text, Style.EMPTY.fg(Color.CYAN));
+        }
+        return Span.raw(text);
+    }
+
+    private static String buildLabel(TreeNode node) {
+        String type = node.info.type;
+        if (type == null) {
+            return "?";
+        }
+
+        String code = node.info.code;
+        if (code != null && !code.isEmpty()) {
+            if (code.startsWith(type + "[") || code.startsWith(type + "(")) {
+                return code;
+            }
+            if (STRUCTURAL_TYPES.contains(type)) {
+                return type;
+            }
+            return type + ": " + code;
+        }
+        return type;
+    }
+
+    private static String truncate(String text, int maxLen) {
+        if (maxLen <= 0) {
+            return "";
+        }
+        if (text.length() <= maxLen) {
+            return text;
+        }
+        if (maxLen <= 3) {
+            return text.substring(0, maxLen);
+        }
+        return text.substring(0, maxLen - 3) + "...";
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RouteTreePreview.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RouteTreePreview.java
@@ -41,6 +41,10 @@ class RouteTreePreview {
     }
 
     static List<Line> buildTree(LayoutRoute layout, int maxLines, int maxWidth) {
+        return buildTree(layout, maxLines, maxWidth, null);
+    }
+
+    static List<Line> buildTree(LayoutRoute layout, int maxLines, int maxWidth, TreeNode selectedNode) {
         if (layout == null || layout.nodes.isEmpty()) {
             return List.of(Line.from(Span.styled("(no structure)", Style.EMPTY.dim())));
         }
@@ -51,16 +55,14 @@ class RouteTreePreview {
         }
 
         List<Line> result = new ArrayList<>();
-        // Render root node (the "from" node)
-        addLine(result, " ", root, maxLines, maxWidth);
-        // Render children
-        addChildren(root.children, " ", result, maxLines, maxWidth);
+        addLine(result, " ", root, maxLines, maxWidth, selectedNode);
+        addChildren(root.children, " ", result, maxLines, maxWidth, selectedNode);
         return result;
     }
 
     private static void addChildren(
             List<TreeNode> children, String parentIndent,
-            List<Line> result, int maxLines, int maxWidth) {
+            List<Line> result, int maxLines, int maxWidth, TreeNode selectedNode) {
         for (int i = 0; i < children.size(); i++) {
             if (result.size() >= maxLines) {
                 return;
@@ -76,31 +78,39 @@ class RouteTreePreview {
             String childCont = last ? "  " : "│ ";
 
             TreeNode child = children.get(i);
-            addLine(result, parentIndent + connector, child, maxLines, maxWidth);
-            addChildren(child.children, parentIndent + childCont, result, maxLines, maxWidth);
+            addLine(result, parentIndent + connector, child, maxLines, maxWidth, selectedNode);
+            addChildren(child.children, parentIndent + childCont, result, maxLines, maxWidth, selectedNode);
         }
     }
 
     private static void addLine(
-            List<Line> result, String prefix, TreeNode node, int maxLines, int maxWidth) {
+            List<Line> result, String prefix, TreeNode node,
+            int maxLines, int maxWidth, TreeNode selectedNode) {
         if (result.size() >= maxLines) {
             return;
         }
         String label = buildLabel(node);
+        boolean selected = (node == selectedNode);
 
         List<Span> spans = new ArrayList<>();
         spans.add(Span.styled(prefix, Style.EMPTY.fg(Color.DARK_GRAY)));
-        spans.add(styledLabel(node.info.type, truncate(label, maxWidth - prefix.length())));
+        spans.add(styledLabel(node.info.type, truncate(label, maxWidth - prefix.length()), selected));
         result.add(Line.from(spans));
     }
 
-    private static Span styledLabel(String type, String text) {
+    private static Span styledLabel(String type, String text, boolean selected) {
+        Style style;
         if ("from".equals(type)) {
-            return Span.styled(text, Style.EMPTY.fg(Color.YELLOW));
+            style = Style.EMPTY.fg(Color.YELLOW);
         } else if (STRUCTURAL_TYPES.contains(type)) {
-            return Span.styled(text, Style.EMPTY.fg(Color.CYAN));
+            style = Style.EMPTY.fg(Color.CYAN);
+        } else {
+            style = Style.EMPTY;
         }
-        return Span.raw(text);
+        if (selected) {
+            style = Style.EMPTY.fg(Color.YELLOW).bold().bg(Color.DARK_GRAY);
+        }
+        return Span.styled(text, style);
     }
 
     private static String buildLabel(TreeNode node) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
@@ -1384,7 +1384,8 @@ class RoutesTab implements MonitorTab {
                 diagram.scrollToSelectedEipNode();
             }
         });
-        sourceViewer.loadSource(ctx, routeId, 0);
+        var rl = diagram.getRouteLayout(routeId);
+        sourceViewer.loadSource(ctx, routeId, 0, rl != null ? rl.source : null);
     }
 
     private void loadSourceForSelectedTopologyRoute() {
@@ -1415,7 +1416,8 @@ class RoutesTab implements MonitorTab {
                 diagram.scrollToSelectedEipNode();
             }
         });
-        sourceViewer.loadSource(ctx, routeId, 0);
+        var rl2 = diagram.getRouteLayout(routeId);
+        sourceViewer.loadSource(ctx, routeId, 0, rl2 != null ? rl2.source : null);
     }
 
     private void loadSourceForSelectedNode() {
@@ -1436,7 +1438,8 @@ class RoutesTab implements MonitorTab {
                 sourceViewer.hide();
             }
         });
-        sourceViewer.loadSource(ctx, drillDownRouteId, targetLine);
+        var rl3 = diagram.getRouteLayout(drillDownRouteId);
+        sourceViewer.loadSource(ctx, drillDownRouteId, targetLine, rl3 != null ? rl3.source : null);
     }
 
     private int findClosestEipNode(int sourceLine) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
@@ -1566,6 +1566,18 @@ class RoutesTab implements MonitorTab {
                 Navigation history is maintained as a stack: pressing `Esc` goes
                 back to the previous route, and eventually back to the topology view.
 
+                ## Route Structure Preview
+
+                A compact tree structure preview appears in the bottom-right corner
+                of the diagram area — like a minimap of the route's EIP structure.
+
+                In **topology mode**, the preview shows the structure of the currently
+                selected route and updates as you navigate between route boxes.
+
+                In **drill-down mode**, the preview highlights the currently selected
+                EIP node (shown in yellow) as you navigate with arrow keys, giving
+                you an at-a-glance view of where you are in the route.
+
                 ## Source View
 
                 Press `c` to see the original route source code (YAML, XML, or Java).

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
@@ -109,6 +109,12 @@ class RoutesTab implements MonitorTab {
             return true;
         }
 
+        // Source viewer toggle (topology mode)
+        if (topologyMode && diagram.isShowDiagram() && ke.isChar('c')) {
+            loadSourceForSelectedTopologyRoute();
+            return true;
+        }
+
         // Topology node navigation
         if (diagram.isShowDiagram() && topologyMode && diagram.hasDiagramData()
                 && !diagram.getNodeBoxes().isEmpty()) {
@@ -654,6 +660,7 @@ class RoutesTab implements MonitorTab {
                 hint(spans, "↑↓←→", "navigate");
                 hint(spans, "Enter", "drill-down");
                 hint(spans, "PgUp/PgDn", "page");
+                hint(spans, "c", "source");
             } else {
                 diagram.renderFooterHints(spans);
             }
@@ -1356,7 +1363,59 @@ class RoutesTab implements MonitorTab {
         Integer sel = routeTableState.selected();
         RouteInfo selectedRoute = (sel != null && sel >= 0 && sel < sortedRoutes.size())
                 ? sortedRoutes.get(sel) : sortedRoutes.get(0);
-        sourceViewer.loadSource(ctx, selectedRoute.routeId, 0);
+        String routeId = selectedRoute.routeId;
+        sourceViewer.setOnLineSelected(sourceLine -> {
+            sourceViewer.hide();
+            // Open drill-down diagram for this route
+            topologyMode = false;
+            drillDownRouteId = routeId;
+            routeNavigationStack.clear();
+            diagram.setTopologyMode(false);
+            diagram.selectFromNode(routeId);
+            if (diagram.hasCachedData(ctx.selectedPid)) {
+                diagram.showCached();
+            } else {
+                loadDiagram(true);
+            }
+            // Select the closest EIP node after diagram is available
+            int bestIdx = findClosestEipNode(sourceLine);
+            if (bestIdx >= 0) {
+                diagram.setSelectedEipNodeIndex(bestIdx);
+                diagram.scrollToSelectedEipNode();
+            }
+        });
+        sourceViewer.loadSource(ctx, routeId, 0);
+    }
+
+    private void loadSourceForSelectedTopologyRoute() {
+        String routeId = diagram.getSelectedRouteId();
+        if (routeId == null) {
+            return;
+        }
+        IntegrationInfo info = ctx.findSelectedIntegration();
+        if (info == null || info.routes.stream().noneMatch(r -> routeId.equals(r.routeId))) {
+            return;
+        }
+        sourceViewer.setOnLineSelected(sourceLine -> {
+            sourceViewer.hide();
+            // Switch to drill-down for this route
+            routeNavigationStack.clear();
+            drillDownRouteId = routeId;
+            topologyMode = false;
+            diagram.setTopologyMode(false);
+            diagram.selectFromNode(routeId);
+            diagram.resetScroll();
+            diagram.endLoad();
+            if (diagram.getRouteLayout(routeId) == null) {
+                reloadDiagram();
+            }
+            int bestIdx = findClosestEipNode(sourceLine);
+            if (bestIdx >= 0) {
+                diagram.setSelectedEipNodeIndex(bestIdx);
+                diagram.scrollToSelectedEipNode();
+            }
+        });
+        sourceViewer.loadSource(ctx, routeId, 0);
     }
 
     private void loadSourceForSelectedNode() {
@@ -1369,7 +1428,40 @@ class RoutesTab implements MonitorTab {
                 && selected.layoutNode().treeNode != null) {
             targetLine = selected.layoutNode().treeNode.info.line;
         }
+        sourceViewer.setOnLineSelected(sourceLine -> {
+            int bestIdx = findClosestEipNode(sourceLine);
+            if (bestIdx >= 0) {
+                diagram.setSelectedEipNodeIndex(bestIdx);
+                diagram.scrollToSelectedEipNode();
+                sourceViewer.hide();
+            }
+        });
         sourceViewer.loadSource(ctx, drillDownRouteId, targetLine);
+    }
+
+    private int findClosestEipNode(int sourceLine) {
+        var boxes = diagram.getEipNodeBoxes();
+        if (boxes.isEmpty()) {
+            return -1;
+        }
+        int bestIdx = -1;
+        int bestDist = Integer.MAX_VALUE;
+        for (int i = 0; i < boxes.size(); i++) {
+            var box = boxes.get(i);
+            if (box.layoutNode() == null || box.layoutNode().treeNode == null) {
+                continue;
+            }
+            int nodeLine = box.layoutNode().treeNode.info.line;
+            if (nodeLine <= 0) {
+                continue;
+            }
+            int dist = Math.abs(nodeLine - sourceLine);
+            if (dist < bestDist) {
+                bestDist = dist;
+                bestIdx = i;
+            }
+        }
+        return bestIdx;
     }
 
     @Override
@@ -1460,6 +1552,13 @@ class RoutesTab implements MonitorTab {
                 ## Source View
 
                 Press `c` to see the original route source code (YAML, XML, or Java).
+                A `>>` cursor highlights the current line. When opened from a diagram
+                node, the matching source line is positioned at 2/3 of the viewport.
+
+                Use `↑↓` to move the cursor, `Ctrl+↑↓` to scroll the viewport without
+                moving the cursor. Press `Enter` to select the closest diagram node at
+                the cursor line — this closes the source view and highlights that node
+                in the diagram.
 
                 ## Keys
 
@@ -1477,6 +1576,7 @@ class RoutesTab implements MonitorTab {
                 **Topology view:**
                 - `↑↓←→` — navigate between route boxes
                 - `Enter` — drill down into selected route
+                - `c` — show route source code
                 - `Esc` — close diagram (back to route table)
                 - `m` — toggle metrics on/off
                 - `e` — toggle external systems on/off
@@ -1485,11 +1585,20 @@ class RoutesTab implements MonitorTab {
                 **Route diagram (drill-down):**
                 - `↑↓←→` — navigate between EIP nodes
                 - `Enter` — jump to linked route (when `↵` indicator shown)
+                - `c` — show source code at selected node
                 - `Esc` — go back (previous route or topology)
                 - `t` — jump back to topology view
-                - `c` — show source code
                 - `m` — toggle metrics
                 - `n` — toggle description labels
+
+                **Source view:**
+                - `↑↓` — move cursor between lines
+                - `Ctrl+↑↓` — scroll viewport without moving cursor
+                - `←→` — horizontal scroll
+                - `PgUp/PgDn` — page jump
+                - `Home/End` — go to top/bottom
+                - `Enter` — select the closest diagram node at cursor line
+                - `Esc/c` — close source view
                 """;
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
@@ -1444,8 +1444,11 @@ class RoutesTab implements MonitorTab {
         if (boxes.isEmpty()) {
             return -1;
         }
-        int bestIdx = -1;
-        int bestDist = Integer.MAX_VALUE;
+        // Prefer the closest node at or before the cursor line
+        int bestBeforeIdx = -1;
+        int bestBeforeDist = Integer.MAX_VALUE;
+        int bestAfterIdx = -1;
+        int bestAfterDist = Integer.MAX_VALUE;
         for (int i = 0; i < boxes.size(); i++) {
             var box = boxes.get(i);
             if (box.layoutNode() == null || box.layoutNode().treeNode == null) {
@@ -1455,13 +1458,24 @@ class RoutesTab implements MonitorTab {
             if (nodeLine <= 0) {
                 continue;
             }
-            int dist = Math.abs(nodeLine - sourceLine);
-            if (dist < bestDist) {
-                bestDist = dist;
-                bestIdx = i;
+            if (nodeLine == sourceLine) {
+                return i;
+            }
+            if (nodeLine < sourceLine) {
+                int dist = sourceLine - nodeLine;
+                if (dist < bestBeforeDist) {
+                    bestBeforeDist = dist;
+                    bestBeforeIdx = i;
+                }
+            } else {
+                int dist = nodeLine - sourceLine;
+                if (dist < bestAfterDist) {
+                    bestAfterDist = dist;
+                    bestAfterIdx = i;
+                }
             }
         }
-        return bestIdx;
+        return bestBeforeIdx >= 0 ? bestBeforeIdx : bestAfterIdx;
     }
 
     @Override

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
@@ -225,6 +225,10 @@ class SourceViewer {
      * Load source for a route, scrolling to the given source line number.
      */
     void loadSource(MonitorContext ctx, String routeId, int targetLine) {
+        loadSource(ctx, routeId, targetLine, null);
+    }
+
+    void loadSource(MonitorContext ctx, String routeId, int targetLine, String sourceLocationHint) {
         if (ctx.selectedPid == null || ctx.runner == null) {
             return;
         }
@@ -232,6 +236,13 @@ class SourceViewer {
         String pid = ctx.selectedPid;
         String cacheKey = pid + ":" + routeId;
         CachedSource cached = sourceCache.get(cacheKey);
+        if (cached == null && sourceLocationHint != null) {
+            String locKey = pid + ":loc:" + sourceLocationHint;
+            cached = sourceCache.get(locKey);
+            if (cached != null) {
+                sourceCache.put(cacheKey, cached);
+            }
+        }
         if (cached != null) {
             applyCached(ctx, routeId, cached, targetLine);
             return;
@@ -364,8 +375,12 @@ class SourceViewer {
         }
 
         SyntaxHighlighter.Language lang = SyntaxHighlighter.detectLanguage(sourceLocation);
+        CachedSource cached = new CachedSource(result, codeLines, sourceLocation, lang);
         String cacheKey = pid + ":" + routeId;
-        sourceCache.put(cacheKey, new CachedSource(result, codeLines, sourceLocation, lang));
+        sourceCache.put(cacheKey, cached);
+        if (sourceLocation != null) {
+            sourceCache.put(pid + ":loc:" + sourceLocation, cached);
+        }
 
         applyResult(ctx, routeId, sourceLocation, result, codeLines, scrollTo, cursorLine);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
@@ -19,9 +19,9 @@ package org.apache.camel.dsl.jbang.core.commands.tui;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntConsumer;
 
@@ -68,7 +68,7 @@ class SourceViewer {
     private final ScrollbarState hScrollState = new ScrollbarState();
     private final AtomicBoolean loading = new AtomicBoolean(false);
     private IntConsumer onLineSelected;
-    private final Map<String, CachedSource> sourceCache = new HashMap<>();
+    private final Map<String, CachedSource> sourceCache = new ConcurrentHashMap<>();
 
     private record CachedSource(
             List<String> lines, List<JsonObject> codeData,

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
@@ -19,7 +19,9 @@ package org.apache.camel.dsl.jbang.core.commands.tui;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntConsumer;
 
@@ -66,6 +68,12 @@ class SourceViewer {
     private final ScrollbarState hScrollState = new ScrollbarState();
     private final AtomicBoolean loading = new AtomicBoolean(false);
     private IntConsumer onLineSelected;
+    private final Map<String, CachedSource> sourceCache = new HashMap<>();
+
+    private record CachedSource(
+            List<String> lines, List<JsonObject> codeData,
+            String sourceLocation, SyntaxHighlighter.Language language) {
+    }
 
     boolean isVisible() {
         return visible;
@@ -86,6 +94,7 @@ class SourceViewer {
         selectedLine = -1;
         pendingScroll = false;
         onLineSelected = null;
+        sourceCache.clear();
     }
 
     void setOnLineSelected(IntConsumer callback) {
@@ -219,6 +228,15 @@ class SourceViewer {
         if (ctx.selectedPid == null || ctx.runner == null) {
             return;
         }
+
+        String pid = ctx.selectedPid;
+        String cacheKey = pid + ":" + routeId;
+        CachedSource cached = sourceCache.get(cacheKey);
+        if (cached != null) {
+            applyCached(ctx, routeId, cached, targetLine);
+            return;
+        }
+
         if (!loading.compareAndSet(false, true)) {
             return;
         }
@@ -229,7 +247,6 @@ class SourceViewer {
         scrollX = 0;
         visible = true;
 
-        String pid = ctx.selectedPid;
         ctx.runner.scheduler().execute(() -> {
             try {
                 loadInBackground(ctx, pid, routeId, targetLine);
@@ -237,6 +254,40 @@ class SourceViewer {
                 loading.set(false);
             }
         });
+    }
+
+    private void applyCached(MonitorContext ctx, String routeId, CachedSource cached, int targetLine) {
+        int matchIdx = -1;
+        for (int i = 0; i < cached.codeData.size(); i++) {
+            Integer lineNum = cached.codeData.get(i).getInteger("line");
+            if (targetLine > 0 && lineNum != null && lineNum == targetLine) {
+                matchIdx = i;
+                break;
+            }
+            Boolean match = cached.codeData.get(i).getBoolean("match");
+            if (targetLine <= 0 && Boolean.TRUE.equals(match) && matchIdx < 0) {
+                matchIdx = i;
+            }
+        }
+
+        int cursorLine;
+        if (matchIdx >= 0) {
+            cursorLine = matchIdx;
+        } else {
+            cursorLine = findLicenseHeaderEnd(cached.codeData);
+        }
+
+        String displayLoc = cached.sourceLocation != null
+                ? FileUtil.stripPath(LoggerHelper.sourceNameOnly(cached.sourceLocation)) : null;
+        title = displayLoc != null ? routeId + "  " + displayLoc : routeId;
+        language = cached.language;
+        lines = cached.lines;
+        codeData = cached.codeData;
+        selectedLine = Math.max(0, cursorLine);
+        scrollY = 0;
+        scrollX = 0;
+        pendingScroll = true;
+        visible = true;
     }
 
     private void loadInBackground(MonitorContext ctx, String pid, String routeId, int targetLine) {
@@ -311,6 +362,11 @@ class SourceViewer {
             cursorLine = findLicenseHeaderEnd(codeLines);
             scrollTo = cursorLine;
         }
+
+        SyntaxHighlighter.Language lang = SyntaxHighlighter.detectLanguage(sourceLocation);
+        String cacheKey = pid + ":" + routeId;
+        sourceCache.put(cacheKey, new CachedSource(result, codeLines, sourceLocation, lang));
+
         applyResult(ctx, routeId, sourceLocation, result, codeLines, scrollTo, cursorLine);
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
@@ -21,8 +21,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.IntConsumer;
 
 import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -52,13 +54,18 @@ class SourceViewer {
 
     private boolean visible;
     private List<String> lines = Collections.emptyList();
+    private List<JsonObject> codeData = Collections.emptyList();
     private String title;
     private SyntaxHighlighter.Language language = SyntaxHighlighter.Language.PLAIN;
     private int scrollY;
     private int scrollX;
+    private int selectedLine = -1;
+    private int lastVisibleLines;
+    private boolean pendingScroll;
     private final ScrollbarState vScrollState = new ScrollbarState();
     private final ScrollbarState hScrollState = new ScrollbarState();
     private final AtomicBoolean loading = new AtomicBoolean(false);
+    private IntConsumer onLineSelected;
 
     boolean isVisible() {
         return visible;
@@ -66,14 +73,23 @@ class SourceViewer {
 
     void hide() {
         visible = false;
+        onLineSelected = null;
     }
 
     void reset() {
         visible = false;
         lines = Collections.emptyList();
+        codeData = Collections.emptyList();
         title = null;
         scrollY = 0;
         scrollX = 0;
+        selectedLine = -1;
+        pendingScroll = false;
+        onLineSelected = null;
+    }
+
+    void setOnLineSelected(IntConsumer callback) {
+        this.onLineSelected = callback;
     }
 
     boolean handleKeyEvent(KeyEvent ke) {
@@ -82,25 +98,46 @@ class SourceViewer {
         }
         if (ke.isChar('c') || ke.isCancel()) {
             visible = false;
+            onLineSelected = null;
             return true;
         }
-        if (ke.isUp()) {
+        if (ke.isKey(KeyCode.UP) && ke.hasCtrl()) {
             scrollY = Math.max(0, scrollY - 1);
-        } else if (ke.isDown()) {
+        } else if (ke.isKey(KeyCode.DOWN) && ke.hasCtrl()) {
             scrollY++;
+        } else if (ke.isUp()) {
+            selectedLine = Math.max(0, selectedLine - 1);
+        } else if (ke.isDown()) {
+            if (!lines.isEmpty()) {
+                selectedLine = Math.min(lines.size() - 1, selectedLine + 1);
+            }
         } else if (ke.isPageUp() || ke.isKey(KeyCode.PAGE_UP)) {
-            scrollY = Math.max(0, scrollY - 20);
+            int page = Math.max(1, lastVisibleLines);
+            selectedLine = Math.max(0, selectedLine - page);
         } else if (ke.isPageDown() || ke.isKey(KeyCode.PAGE_DOWN)) {
-            scrollY += 20;
+            int page = Math.max(1, lastVisibleLines);
+            if (!lines.isEmpty()) {
+                selectedLine = Math.min(lines.size() - 1, selectedLine + page);
+            }
         } else if (ke.isLeft()) {
             scrollX = Math.max(0, scrollX - 1);
         } else if (ke.isRight()) {
             scrollX++;
         } else if (ke.isHome()) {
-            scrollY = 0;
+            selectedLine = 0;
             scrollX = 0;
         } else if (ke.isEnd()) {
-            scrollY = Integer.MAX_VALUE;
+            if (!lines.isEmpty()) {
+                selectedLine = lines.size() - 1;
+            }
+        } else if (ke.isConfirm() && onLineSelected != null) {
+            if (selectedLine >= 0 && selectedLine < codeData.size()) {
+                Integer lineNum = codeData.get(selectedLine).getInteger("line");
+                if (lineNum != null) {
+                    onLineSelected.accept(lineNum);
+                }
+            }
+            return true;
         } else {
             return false;
         }
@@ -120,10 +157,28 @@ class SourceViewer {
         }
 
         int visibleLines = inner.height();
+        lastVisibleLines = visibleLines;
         int maxScroll = Math.max(0, lines.size() - visibleLines);
+
+        // On initial load, position selected line at 2/3 of viewport
+        if (pendingScroll && selectedLine >= 0) {
+            int twoThirds = visibleLines * 2 / 3;
+            scrollY = Math.max(0, selectedLine - twoThirds);
+            pendingScroll = false;
+        }
+
+        // Auto-scroll to keep selected line visible
+        if (selectedLine >= 0) {
+            if (selectedLine < scrollY) {
+                scrollY = selectedLine;
+            } else if (selectedLine >= scrollY + visibleLines) {
+                scrollY = selectedLine - visibleLines + 1;
+            }
+        }
         scrollY = Math.min(scrollY, maxScroll);
 
-        int maxLineWidth = lines.stream().mapToInt(String::length).max().orElse(0);
+        int cursorWidth = 3;
+        int maxLineWidth = lines.stream().mapToInt(String::length).max().orElse(0) + cursorWidth;
         int maxHScroll = Math.max(0, maxLineWidth - inner.width());
         scrollX = Math.min(scrollX, maxHScroll);
 
@@ -131,7 +186,8 @@ class SourceViewer {
         List<Line> visible = new ArrayList<>();
         for (int i = scrollY; i < end; i++) {
             String raw = lines.get(i);
-            visible.add(highlightSourceLine(raw, scrollX));
+            boolean isSelected = (i == selectedLine);
+            visible.add(highlightSourceLine(raw, scrollX, isSelected));
         }
         frame.renderWidget(Paragraph.builder().text(Text.from(visible)).build(), inner);
 
@@ -147,9 +203,13 @@ class SourceViewer {
 
     void renderFooter(List<Span> spans) {
         MonitorContext.hint(spans, "Esc/c", "close");
-        MonitorContext.hint(spans, "↑↓", "scroll");
+        MonitorContext.hint(spans, "↑↓", "navigate");
+        MonitorContext.hint(spans, "Ctrl+↑↓", "scroll");
         MonitorContext.hint(spans, "←→", "horizontal");
         MonitorContext.hint(spans, "PgUp/PgDn", "page");
+        if (onLineSelected != null) {
+            MonitorContext.hint(spans, "Enter", "select node");
+        }
     }
 
     /**
@@ -194,13 +254,14 @@ class SourceViewer {
         PathUtils.deleteFile(outputFile);
 
         if (jo == null) {
-            applyResult(ctx, routeId, null, List.of("(No response from integration)"), 0);
+            applyResult(ctx, routeId, null, List.of("(No response from integration)"), Collections.emptyList(), 0, -1);
             return;
         }
 
         JsonArray routes = (JsonArray) jo.get("routes");
         if (routes == null || routes.isEmpty()) {
-            applyResult(ctx, routeId, null, List.of("(No source available for route: " + routeId + ")"), 0);
+            applyResult(ctx, routeId, null, List.of("(No source available for route: " + routeId + ")"),
+                    Collections.emptyList(), 0, -1);
             return;
         }
 
@@ -208,7 +269,8 @@ class SourceViewer {
         String sourceLocation = objToString(routeObj.get("source"));
         List<JsonObject> codeLines = routeObj.getCollection("code");
         if (codeLines == null || codeLines.isEmpty()) {
-            applyResult(ctx, routeId, sourceLocation, List.of("(No source code available)"), 0);
+            applyResult(ctx, routeId, sourceLocation, List.of("(No source code available)"),
+                    Collections.emptyList(), 0, -1);
             return;
         }
 
@@ -241,15 +303,20 @@ class SourceViewer {
         }
 
         int scrollTo;
+        int cursorLine;
         if (matchIdx >= 0) {
-            scrollTo = Math.max(0, matchIdx - 2);
+            cursorLine = matchIdx;
+            scrollTo = matchIdx;
         } else {
-            scrollTo = findLicenseHeaderEnd(codeLines);
+            cursorLine = findLicenseHeaderEnd(codeLines);
+            scrollTo = cursorLine;
         }
-        applyResult(ctx, routeId, sourceLocation, result, scrollTo);
+        applyResult(ctx, routeId, sourceLocation, result, codeLines, scrollTo, cursorLine);
     }
 
-    private void applyResult(MonitorContext ctx, String routeId, String location, List<String> resultLines, int scrollTo) {
+    private void applyResult(
+            MonitorContext ctx, String routeId, String location,
+            List<String> resultLines, List<JsonObject> codeLines, int scrollTo, int cursorLine) {
         if (ctx.runner == null) {
             return;
         }
@@ -261,11 +328,14 @@ class SourceViewer {
             title = displayLoc != null ? routeId + "  " + displayLoc : routeId;
             language = SyntaxHighlighter.detectLanguage(location);
             lines = resultLines;
-            scrollY = scrollTo;
+            codeData = codeLines;
+            selectedLine = Math.max(0, cursorLine);
+            scrollY = 0;
+            pendingScroll = true;
         });
     }
 
-    private Line highlightSourceLine(String raw, int hSkip) {
+    private Line highlightSourceLine(String raw, int hSkip, boolean isSelected) {
         int prefixEnd = 0;
         while (prefixEnd < raw.length() && (raw.charAt(prefixEnd) == ' ' || Character.isDigit(raw.charAt(prefixEnd)))) {
             prefixEnd++;
@@ -277,10 +347,22 @@ class SourceViewer {
         Line highlighted = SyntaxHighlighter.highlightLine(code, language);
 
         List<Span> spans = new ArrayList<>();
-        if (!prefix.isEmpty()) {
-            spans.add(Span.styled(prefix, Style.EMPTY.dim()));
+        Style selBg = Style.EMPTY.bg(Color.DARK_GRAY);
+        if (isSelected) {
+            spans.add(Span.styled(">> ", Style.EMPTY.fg(Color.YELLOW).bold()));
+            if (!prefix.isEmpty()) {
+                spans.add(Span.styled(prefix, Style.EMPTY.fg(Color.YELLOW).bold().bg(Color.DARK_GRAY)));
+            }
+            for (Span s : highlighted.spans()) {
+                spans.add(Span.styled(s.content(), s.style().patch(selBg)));
+            }
+        } else {
+            spans.add(Span.raw("   "));
+            if (!prefix.isEmpty()) {
+                spans.add(Span.styled(prefix, Style.EMPTY.dim()));
+            }
+            spans.addAll(highlighted.spans());
         }
-        spans.addAll(highlighted.spans());
 
         Line full = Line.from(spans);
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StartupTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StartupTab.java
@@ -418,4 +418,31 @@ class StartupTab implements MonitorTab {
                 - `Esc` — back
                 """;
     }
+
+    @Override
+    public JsonObject getTableDataAsJson() {
+        if (steps.isEmpty()) {
+            return null;
+        }
+        JsonObject result = new JsonObject();
+        result.put("tab", "Startup");
+        JsonArray rows = new JsonArray();
+        for (StartupStep s : steps) {
+            JsonObject row = new JsonObject();
+            row.put("id", s.id);
+            row.put("parentId", s.parentId);
+            row.put("level", s.level);
+            row.put("name", s.name);
+            row.put("type", s.type);
+            if (s.description != null) {
+                row.put("description", s.description);
+            }
+            row.put("beginTime", s.beginTime);
+            row.put("duration", s.duration);
+            rows.add(row);
+        }
+        result.put("rows", rows);
+        result.put("totalRows", steps.size());
+        return result;
+    }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StatusParser.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StatusParser.java
@@ -553,12 +553,19 @@ final class StatusParser {
             entry.timestamp = tsObj.toString();
         }
 
+        entry.remoteEndpoint = json.getBooleanOrDefault("remoteEndpoint", false);
+        entry.stubEndpoint = json.getBooleanOrDefault("stubEndpoint", false);
+
         if (entry.first || entry.last) {
             entry.nodeLevel = Math.max(0, entry.nodeLevel - 1);
         }
         String indent = "  ".repeat(entry.nodeLevel);
         if (entry.first) {
-            entry.direction = "-->";
+            if (entry.stubEndpoint) {
+                entry.direction = "~-->";
+            } else {
+                entry.direction = entry.remoteEndpoint ? "*-->" : "*-> ";
+            }
             String uri = json.getString("endpointUri");
             if (uri != null) {
                 entry.processor = indent + "from[" + uri + "]";
@@ -566,10 +573,20 @@ final class StatusParser {
                 entry.processor = indent + (entry.nodeLabel != null ? entry.nodeLabel : "");
             }
         } else if (entry.last) {
-            entry.direction = "<--";
+            if (entry.stubEndpoint) {
+                entry.direction = "<--~";
+            } else {
+                entry.direction = entry.remoteEndpoint ? "<--*" : "<-* ";
+            }
             entry.processor = indent + (entry.nodeLabel != null ? entry.nodeLabel : "");
         } else {
-            entry.direction = "  >";
+            if (entry.stubEndpoint) {
+                entry.direction = "~-->";
+            } else if (entry.remoteEndpoint) {
+                entry.direction = "--->";
+            } else {
+                entry.direction = "    ";
+            }
             entry.processor = indent + (entry.nodeLabel != null ? entry.nodeLabel : "");
         }
 
@@ -618,6 +635,9 @@ final class StatusParser {
         entry.failed = json.getBooleanOrDefault("failed", false);
         entry.nodeLevel = json.getIntegerOrDefault("nodeLevel", 0);
 
+        entry.remoteEndpoint = json.getBooleanOrDefault("remoteEndpoint", false);
+        entry.stubEndpoint = json.getBooleanOrDefault("stubEndpoint", false);
+
         Object elapsedObj = json.get("elapsed");
         if (elapsedObj instanceof Number n) {
             entry.elapsed = n.longValue();
@@ -626,11 +646,25 @@ final class StatusParser {
         }
 
         if (entry.first) {
-            entry.direction = "-->";
+            if (entry.stubEndpoint) {
+                entry.direction = "~-->";
+            } else {
+                entry.direction = entry.remoteEndpoint ? "*-->" : "*-> ";
+            }
         } else if (entry.last) {
-            entry.direction = "<--";
+            if (entry.stubEndpoint) {
+                entry.direction = "<--~";
+            } else {
+                entry.direction = entry.remoteEndpoint ? "<--*" : "<-* ";
+            }
         } else {
-            entry.direction = "  >";
+            if (entry.stubEndpoint) {
+                entry.direction = "~-->";
+            } else if (entry.remoteEndpoint) {
+                entry.direction = "--->";
+            } else {
+                entry.direction = "    ";
+            }
         }
 
         if (entry.first || entry.last) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TraceEntry.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TraceEntry.java
@@ -35,6 +35,8 @@ class TraceEntry {
     boolean first;
     boolean last;
     boolean failed;
+    boolean remoteEndpoint;
+    boolean stubEndpoint;
     int nodeLevel;
     long elapsed;
     long epochMs;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiMcpServer.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiMcpServer.java
@@ -411,6 +411,34 @@ class TuiMcpServer {
                         "body", propDef("string", "Message body to send"),
                         "headers", propDef("string", "Message headers as key=value pairs separated by newlines")),
                 List.of("endpoint")));
+        toolList.add(toolDef(
+                "tui_set_log_level",
+                "Changes the runtime log level of the selected integration. "
+                                     + "This sends a command to the running Camel application to change "
+                                     + "the root logger level.",
+                Map.of("level", propDef("string",
+                        "Log level to set: ERROR, WARN, INFO, DEBUG, or TRACE")),
+                List.of("level")));
+        toolList.add(toolDef(
+                "tui_filter",
+                "Sets or clears the fuzzy text filter on a tab that supports typing-to-filter. "
+                              + "Currently supported on the Classpath tab. "
+                              + "Use an empty string to clear the filter.",
+                Map.of("filter", propDef("string",
+                        "Filter text to apply. Empty string clears the filter."),
+                        "tab", propDef("string",
+                                "Tab name to filter (e.g. 'Classpath'). If omitted, uses the active tab.")),
+                List.of("filter")));
+        toolList.add(toolDef(
+                "tui_toggle_trace_display",
+                "Toggles which sections are visible in the History tab's detail view. "
+                                            + "Controls what data is shown when inspecting trace steps or history entries.",
+                Map.of("section", propDef("string",
+                        "Section to toggle: headers, properties, variables, body, or wrap"),
+                        "enabled", propDef("boolean",
+                                "If provided, forces the section on (true) or off (false). "
+                                                      + "If omitted, toggles the current state.")),
+                List.of("section")));
 
         JsonObject result = new JsonObject();
         result.put("tools", toolList);
@@ -453,6 +481,9 @@ class TuiMcpServer {
                 case "tui_get_history" -> callGetHistory(args);
                 case "tui_get_topology" -> callGetTopology();
                 case "tui_send_message" -> callSendMessage(args);
+                case "tui_set_log_level" -> callSetLogLevel(args);
+                case "tui_filter" -> callFilter(args);
+                case "tui_toggle_trace_display" -> callToggleTraceDisplay(args);
                 default -> {
                     isError = true;
                     yield "Unknown tool: " + toolName;
@@ -1004,6 +1035,43 @@ class TuiMcpServer {
             return "Error: no integration selected or PID unavailable";
         }
         return Jsoner.serialize(response);
+    }
+
+    private String callSetLogLevel(Map<String, Object> args) {
+        String level = (String) args.get("level");
+        if (level == null || level.isBlank()) {
+            return "Error: level is required (ERROR, WARN, INFO, DEBUG, TRACE)";
+        }
+        level = level.toUpperCase();
+        if (!"ERROR".equals(level) && !"WARN".equals(level) && !"INFO".equals(level)
+                && !"DEBUG".equals(level) && !"TRACE".equals(level)) {
+            return "Error: invalid level '" + level + "'. Must be ERROR, WARN, INFO, DEBUG, or TRACE";
+        }
+        monitor.setLogLevel(level);
+        return "Log level set to " + level;
+    }
+
+    private String callFilter(Map<String, Object> args) {
+        String filter = args.get("filter") instanceof String s ? s : "";
+        String tab = args.get("tab") instanceof String s ? s : null;
+        boolean applied = monitor.setTabFilter(tab, filter);
+        if (!applied) {
+            return "This tab does not support text filtering";
+        }
+        return filter.isEmpty() ? "Filter cleared" : "Filter set to: " + filter;
+    }
+
+    private String callToggleTraceDisplay(Map<String, Object> args) {
+        String section = (String) args.get("section");
+        if (section == null || section.isBlank()) {
+            return "Error: section is required (headers, properties, variables, body, wrap)";
+        }
+        Boolean enabled = args.get("enabled") instanceof Boolean b ? b : null;
+        String result = monitor.toggleTraceDisplay(section, enabled);
+        if (result == null) {
+            return "Error: unknown section '" + section + "'. Must be headers, properties, variables, body, or wrap";
+        }
+        return result;
     }
 
     private static JsonArray toJsonArray(List<String> list) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiMcpServer.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiMcpServer.java
@@ -382,6 +382,28 @@ class TuiMcpServer {
                                    + "Shows the ASCII/Unicode art diagram of routes and their connections.",
                 Map.of()));
         toolList.add(toolDef(
+                "tui_get_history",
+                "Returns rich trace and history data from the History tab as structured JSON. "
+                                   + "Includes ALL exchange details: body with type, headers with types, "
+                                   + "exchange properties, exchange variables, thread name, source location, "
+                                   + "node level, and node labels. Much richer than tui_get_table on History. "
+                                   + "Returns different shapes depending on the History tab's current mode: "
+                                   + "Traces (exchange ID list), Trace Steps (per-step detail), "
+                                   + "or History (message history steps).",
+                Map.of("exchangeId", propDef("string",
+                        "If provided, returns trace steps for this specific exchange ID. "
+                                                       + "Otherwise returns data for the current History tab view."))));
+        toolList.add(toolDef(
+                "tui_get_topology",
+                "Returns the route topology as a structured JSON graph with nodes and edges arrays. "
+                                    + "Each node has: routeId, nodeType (route/external-in/external-out/trigger), "
+                                    + "layer, description, from (consumer URI), exchangesTotal, exchangesFailed. "
+                                    + "Each edge has: from (routeId), to (routeId), endpoint, connectionType, "
+                                    + "selfLoop, backEdge. "
+                                    + "Use this instead of tui_get_diagram when you need to reason about "
+                                    + "route connectivity programmatically.",
+                Map.of()));
+        toolList.add(toolDef(
                 "tui_send_message",
                 "Sends a message to a Camel endpoint in the selected integration. "
                                     + "Uses the file-based IPC protocol to deliver the message directly.",
@@ -428,6 +450,8 @@ class TuiMcpServer {
                 case "tui_get_log" -> callGetLog(args);
                 case "tui_get_errors" -> callGetErrors();
                 case "tui_get_diagram" -> callGetDiagram();
+                case "tui_get_history" -> callGetHistory(args);
+                case "tui_get_topology" -> callGetTopology();
                 case "tui_send_message" -> callSendMessage(args);
                 default -> {
                     isError = true;
@@ -943,6 +967,27 @@ class TuiMcpServer {
         JsonObject data = monitor.getDiagramData();
         if (data == null) {
             return "No diagram available. Navigate to the Diagram tab first.";
+        }
+        return Jsoner.serialize(data);
+    }
+
+    private String callGetHistory(Map<String, Object> args) {
+        String exchangeId = args.get("exchangeId") instanceof String s ? s : null;
+        if (exchangeId != null && !exchangeId.isBlank()) {
+            monitor.navigateToTab("History");
+            monitor.selectTraceExchange(exchangeId);
+        }
+        JsonObject data = monitor.getTableData("History");
+        if (data == null) {
+            return "No history data available. Ensure the History tab has data.";
+        }
+        return Jsoner.serialize(data);
+    }
+
+    private String callGetTopology() {
+        JsonObject data = monitor.getTopologyData();
+        if (data == null) {
+            return "No topology data available. The Diagram tab may not have loaded yet.";
         }
         return Jsoner.serialize(data);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/DiagramColors.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/DiagramColors.java
@@ -32,6 +32,8 @@ public final class DiagramColors {
     static final Style FROM_LABEL_STYLE = Style.EMPTY.fg(Color.GRAY);
     static final Style METRICS_OK_STYLE = Style.EMPTY.fg(Color.GREEN);
     static final Style METRICS_FAIL_STYLE = Style.EMPTY.fg(Color.LIGHT_RED).bold();
+    static final Color HIGHLIGHT_OK_COLOR = Color.GREEN;
+    static final Color HIGHLIGHT_FAIL_COLOR = Color.LIGHT_RED;
 
     // Unicode box-drawing characters
     static final char H = '─';

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/RouteDiagramWidget.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/RouteDiagramWidget.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
@@ -61,6 +62,8 @@ public class RouteDiagramWidget implements Widget {
     private final boolean showDescription;
     private final Map<String, String> routeDescriptions;
     private final String currentRouteLabel;
+    private final Set<String> highlightNodeIds;
+    private final boolean highlightFailed;
 
     private final List<EipNodeBox> nodeBoxes = new ArrayList<>();
 
@@ -89,6 +92,17 @@ public class RouteDiagramWidget implements Widget {
                               int selectedNodeIndex, int scrollX, int scrollY,
                               boolean showMetrics, Map<String, String> linkableEndpoints,
                               boolean showDescription, Map<String, String> routeDescriptions) {
+        this(layoutRoute, nodeWidth, selectedNodeIndex, scrollX, scrollY, showMetrics,
+             linkableEndpoints, showDescription, routeDescriptions,
+             Collections.emptySet(), false);
+    }
+
+    public RouteDiagramWidget(
+                              LayoutRoute layoutRoute, int nodeWidth,
+                              int selectedNodeIndex, int scrollX, int scrollY,
+                              boolean showMetrics, Map<String, String> linkableEndpoints,
+                              boolean showDescription, Map<String, String> routeDescriptions,
+                              Set<String> highlightNodeIds, boolean highlightFailed) {
         this.layoutRoute = layoutRoute;
         this.nodeWidth = nodeWidth;
         this.boxWidth = Math.max(MIN_BOX_WIDTH, nodeWidth / X_DIVISOR);
@@ -99,6 +113,8 @@ public class RouteDiagramWidget implements Widget {
         this.linkableEndpoints = linkableEndpoints;
         this.showDescription = showDescription;
         this.routeDescriptions = routeDescriptions;
+        this.highlightNodeIds = highlightNodeIds;
+        this.highlightFailed = highlightFailed;
         if (showDescription) {
             String desc = null;
             for (LayoutNode ln : layoutRoute.nodes) {
@@ -167,8 +183,14 @@ public class RouteDiagramWidget implements Widget {
         int nodeIdx = nodeBoxes.size();
         boolean selected = nodeIdx == selectedNodeIndex;
         boolean external = isExternalEndpoint(node);
+        boolean highlighted = node.id != null && highlightNodeIds.contains(node.id);
 
-        Color eipColor = getEipColor(node.type);
+        Color eipColor;
+        if (highlighted) {
+            eipColor = highlightFailed ? HIGHLIGHT_FAIL_COLOR : HIGHLIGHT_OK_COLOR;
+        } else {
+            eipColor = getEipColor(node.type);
+        }
         Style borderStyle = Style.EMPTY.fg(eipColor);
         if (selected) {
             borderStyle = borderStyle.patch(SELECTION_STYLE);
@@ -238,7 +260,11 @@ public class RouteDiagramWidget implements Widget {
         boolean external = isExternalEndpoint(to);
         boolean dashed = (showMetrics && total == 0) || external;
 
-        drawArrowPath(buffer, area, fromCx, fromBottom, toCx, toTop, dashed, external);
+        boolean bothHighlighted = !highlightNodeIds.isEmpty()
+                && from.id != null && highlightNodeIds.contains(from.id)
+                && to.id != null && highlightNodeIds.contains(to.id);
+
+        drawArrowPath(buffer, area, fromCx, fromBottom, toCx, toTop, dashed, external, bothHighlighted);
         drawCounters(buffer, area, toCx, toTop, stat);
     }
 
@@ -252,13 +278,16 @@ public class RouteDiagramWidget implements Widget {
         long total = stat != null ? stat.exchangesTotal : 0;
         boolean dashed = showMetrics && total == 0;
 
-        drawArrowPath(buffer, area, fromCx, fromRow, toCx, toTop, dashed, false);
+        boolean highlighted = !highlightNodeIds.isEmpty()
+                && to.id != null && highlightNodeIds.contains(to.id);
+
+        drawArrowPath(buffer, area, fromCx, fromRow, toCx, toTop, dashed, false, highlighted);
         drawCounters(buffer, area, toCx, toTop, stat);
     }
 
     private void drawArrowPath(
             Buffer buffer, Rect area, int fromCx, int fromRow, int toCx, int toRow,
-            boolean dashed, boolean external) {
+            boolean dashed, boolean external, boolean highlighted) {
         if (fromRow >= toRow) {
             return;
         }
@@ -266,7 +295,9 @@ public class RouteDiagramWidget implements Widget {
         char vChar = dashed ? DASH_V : V;
         char hChar = dashed ? DASH_H : H;
         Style edgeStyle;
-        if (external) {
+        if (highlighted) {
+            edgeStyle = Style.EMPTY.fg(highlightFailed ? HIGHLIGHT_FAIL_COLOR : HIGHLIGHT_OK_COLOR);
+        } else if (external) {
             edgeStyle = Style.EMPTY.fg(EXTERNAL_COLOR);
         } else if (dashed) {
             edgeStyle = Style.EMPTY.fg(Color.DARK_GRAY);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/TopologyDiagramWidget.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/TopologyDiagramWidget.java
@@ -17,7 +17,9 @@
 package org.apache.camel.dsl.jbang.core.commands.tui.diagram;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
@@ -45,6 +47,8 @@ public class TopologyDiagramWidget implements Widget {
     private final int scrollY;
     private final boolean showMetrics;
     private final boolean showDescription;
+    private final Set<String> highlightRouteIds;
+    private final boolean highlightFailed;
 
     private final List<NodeBox> nodeBoxes = new ArrayList<>();
 
@@ -55,6 +59,15 @@ public class TopologyDiagramWidget implements Widget {
                                  TopologyLayoutResult layout, int nodeWidth,
                                  int selectedNodeIndex, int scrollX, int scrollY,
                                  boolean showMetrics, boolean showDescription) {
+        this(layout, nodeWidth, selectedNodeIndex, scrollX, scrollY, showMetrics, showDescription,
+             Collections.emptySet(), false);
+    }
+
+    public TopologyDiagramWidget(
+                                 TopologyLayoutResult layout, int nodeWidth,
+                                 int selectedNodeIndex, int scrollX, int scrollY,
+                                 boolean showMetrics, boolean showDescription,
+                                 Set<String> highlightRouteIds, boolean highlightFailed) {
         this.layout = layout;
         this.nodeWidth = nodeWidth;
         this.boxWidth = Math.max(MIN_BOX_WIDTH, nodeWidth / X_DIVISOR);
@@ -63,6 +76,8 @@ public class TopologyDiagramWidget implements Widget {
         this.scrollY = scrollY;
         this.showMetrics = showMetrics;
         this.showDescription = showDescription;
+        this.highlightRouteIds = highlightRouteIds;
+        this.highlightFailed = highlightFailed;
     }
 
     public List<NodeBox> getNodeBoxes() {
@@ -150,9 +165,17 @@ public class TopologyDiagramWidget implements Widget {
         int nodeIdx = nodeBoxes.size();
         boolean selected = nodeIdx == selectedNodeIndex;
 
+        boolean highlighted = !ext && node.routeId != null && highlightRouteIds.contains(node.routeId);
+
         char hChar = ext ? DASH_H : H;
         char vChar = ext ? DASH_V : V;
-        Style borderStyle = ext ? DASHED_BORDER_STYLE : BORDER_STYLE;
+        Style borderStyle;
+        if (highlighted) {
+            Color hlColor = highlightFailed ? HIGHLIGHT_FAIL_COLOR : HIGHLIGHT_OK_COLOR;
+            borderStyle = Style.EMPTY.fg(hlColor).bold();
+        } else {
+            borderStyle = ext ? DASHED_BORDER_STYLE : BORDER_STYLE;
+        }
         if (selected) {
             borderStyle = borderStyle.patch(SELECTION_STYLE);
         }
@@ -197,7 +220,10 @@ public class TopologyDiagramWidget implements Widget {
             } else if (showMetrics && i == lines.size() - 1 && node.exchangesTotal > 0) {
                 drawMetricsLine(buffer, area, r, textCol, text, node, selected);
             } else if (i == 0 && !ext) {
-                writeText(buffer, area, r, textCol, text, style(ROUTE_ID_STYLE, selected));
+                Style idStyle = highlighted
+                        ? Style.EMPTY.fg(highlightFailed ? HIGHLIGHT_FAIL_COLOR : HIGHLIGHT_OK_COLOR).bold()
+                        : ROUTE_ID_STYLE;
+                writeText(buffer, area, r, textCol, text, style(idStyle, selected));
             } else {
                 writeText(buffer, area, r, textCol, text, style(FROM_LABEL_STYLE, selected));
             }
@@ -237,7 +263,15 @@ public class TopologyDiagramWidget implements Widget {
         boolean dashed = isExternal(edge.from) || isExternal(edge.to);
         char vChar = dashed ? DASH_V : V;
         char hChar = dashed ? DASH_H : H;
-        Style edgeStyle = dashed ? DASHED_BORDER_STYLE : Style.EMPTY.fg(Color.GRAY);
+        boolean edgeHighlighted = !dashed
+                && edge.from.routeId != null && highlightRouteIds.contains(edge.from.routeId)
+                && edge.to.routeId != null && highlightRouteIds.contains(edge.to.routeId);
+        Style edgeStyle;
+        if (edgeHighlighted) {
+            edgeStyle = Style.EMPTY.fg(highlightFailed ? HIGHLIGHT_FAIL_COLOR : HIGHLIGHT_OK_COLOR);
+        } else {
+            edgeStyle = dashed ? DASHED_BORDER_STYLE : Style.EMPTY.fg(Color.GRAY);
+        }
 
         if (fromCx == toCx) {
             for (int r = fromBottom; r < toTop - 1; r++) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/TopologyDiagramWidget.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/TopologyDiagramWidget.java
@@ -134,7 +134,7 @@ public class TopologyDiagramWidget implements Widget {
                     if (!sb.isEmpty()) {
                         sb.append("/");
                     }
-                    sb.append(node.exchangesFailed).append("!");
+                    sb.append(node.exchangesFailed);
                 }
                 lines.add(sb.toString());
             } else if (!ext) {
@@ -212,7 +212,7 @@ public class TopologyDiagramWidget implements Widget {
         long ok = node.exchangesTotal - node.exchangesFailed;
         if (ok > 0 && node.exchangesFailed > 0) {
             String okStr = String.valueOf(ok);
-            String failStr = node.exchangesFailed + "!";
+            String failStr = String.valueOf(node.exchangesFailed);
             writeText(buffer, area, row, col, okStr, style(METRICS_OK_STYLE, selected));
             int slashCol = col + okStr.length();
             writeText(buffer, area, row, slashCol, "/", style(Style.EMPTY.fg(Color.GRAY), selected));


### PR DESCRIPTION
## Summary
- Add `isStubEndpoint()` to `BacklogTracerEventMessage` API to detect stub endpoints in tracer events
- Detect stub endpoints in `CamelInternalProcessor` and `BacklogTracer` by checking endpoint class name (works in both explicit `stub:` and shadow mode)
- Add direction arrows in TUI History tab to distinguish endpoint types:
  - `*-->` / `<--*` remote first/last
  - `*->` / `<-*` local first/last
  - `~-->` / `<--~` stub first/last
  - `--->` send to remote endpoint
  - `~-->` send to stub endpoint
- Add `n` toggle for route description display in History tab
- Add step count to History and Trace detail titles
- Add `>>` selection indicator in waterfall view with auto-scroll
- PageUp/PageDown now jump 10 steps in waterfall mode
- Show `d` diagram hint in footer when waterfall is active
- Wider route column (25 chars)
- Updated F1 help text with arrow documentation

## Test plan
- [x] Build `camel-api`, `camel-base-engine`, and `camel-jbang-plugin-tui`
- [ ] Run route-topology example with `--stub` and verify `~-->` / `<--~` arrows appear for stub endpoints
- [ ] Verify `*-->` / `<--*` arrows for real remote endpoints (without `--stub`)
- [ ] Verify `--->` arrows on regular `to[kafka:...]` steps
- [ ] Verify `n` toggle shows route descriptions
- [ ] Verify waterfall `>>` indicator follows cursor
- [ ] Verify PageUp/PageDown jumps in waterfall mode
- [ ] Verify `d` diagram hint visible in waterfall mode

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)