### PR TITLE
CAMEL-23682: expose common UndertowOptions on UndertowHostOptions

### DIFF
--- a/components/camel-undertow/src/main/docs/undertow-component.adoc
+++ b/components/camel-undertow/src/main/docs/undertow-component.adoc
@@ -61,6 +61,39 @@ include::partial$component-endpoint-headers.adoc[]
 // component options: END
 
 
+== Host Options
+
+The `hostOptions` component option allows configuring the underlying Undertow server.
+These options apply to all endpoints sharing the same host and port.
+
+[width="100%",cols="2,1,5",options="header"]
+|===
+| Option | Type | Description
+
+| `workerThreads` | `Integer` | The number of worker threads to use in the Undertow host.
+| `ioThreads` | `Integer` | The number of I/O threads to use in the Undertow host.
+| `bufferSize` | `Integer` | The buffer size of the Undertow host.
+| `directBuffers` | `Boolean` | Whether the Undertow host should use direct buffers.
+| `http2Enabled` | `Boolean` | Whether the Undertow host should use the HTTP/2 protocol.
+| `maxEntitySize` | `Long` | The maximum size of the HTTP entity body, in bytes. Requests with a body larger than this will be rejected.
+| `multipartMaxEntitySize` | `Long` | The maximum size of a multipart HTTP entity body, in bytes. Multipart requests larger than this will be rejected.
+| `maxHeaderSize` | `Integer` | The maximum size of an HTTP request header, in bytes. Requests with headers larger than this will be rejected.
+| `noRequestTimeout` | `Integer` | The amount of time in milliseconds a connection can be idle with no current requests before it is closed.
+| `idleTimeout` | `Integer` | The idle timeout in milliseconds after which the channel will be closed.
+| `requestParseTimeout` | `Integer` | The maximum time in milliseconds to parse an HTTP request.
+| `maxParameters` | `Integer` | The maximum number of query and path parameters that will be parsed.
+| `maxHeaders` | `Integer` | The maximum number of HTTP headers that will be parsed.
+|===
+
+Configuration example:
+
+[source,properties]
+----
+camel.component.undertow.host-options.max-entity-size = 10485760
+camel.component.undertow.host-options.max-header-size = 65536
+camel.component.undertow.host-options.no-request-timeout = 30000
+----
+
 == Usage
 
 === Message Headers

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHost.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/DefaultUndertowHost.java
@@ -96,6 +96,30 @@ public class DefaultUndertowHost implements UndertowHost {
                     if (options.getHttp2Enabled() != null) {
                         builder.setServerOption(UndertowOptions.ENABLE_HTTP2, options.getHttp2Enabled());
                     }
+                    if (options.getMaxEntitySize() != null) {
+                        builder.setServerOption(UndertowOptions.MAX_ENTITY_SIZE, options.getMaxEntitySize());
+                    }
+                    if (options.getMultipartMaxEntitySize() != null) {
+                        builder.setServerOption(UndertowOptions.MULTIPART_MAX_ENTITY_SIZE, options.getMultipartMaxEntitySize());
+                    }
+                    if (options.getMaxHeaderSize() != null) {
+                        builder.setServerOption(UndertowOptions.MAX_HEADER_SIZE, options.getMaxHeaderSize());
+                    }
+                    if (options.getNoRequestTimeout() != null) {
+                        builder.setServerOption(UndertowOptions.NO_REQUEST_TIMEOUT, options.getNoRequestTimeout());
+                    }
+                    if (options.getIdleTimeout() != null) {
+                        builder.setServerOption(UndertowOptions.IDLE_TIMEOUT, options.getIdleTimeout());
+                    }
+                    if (options.getRequestParseTimeout() != null) {
+                        builder.setServerOption(UndertowOptions.REQUEST_PARSE_TIMEOUT, options.getRequestParseTimeout());
+                    }
+                    if (options.getMaxParameters() != null) {
+                        builder.setServerOption(UndertowOptions.MAX_PARAMETERS, options.getMaxParameters());
+                    }
+                    if (options.getMaxHeaders() != null) {
+                        builder.setServerOption(UndertowOptions.MAX_HEADERS, options.getMaxHeaders());
+                    }
                 }
 
                 if (consumer != null && consumer.isRest()) {

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHostOptions.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHostOptions.java
@@ -33,6 +33,22 @@ public final class UndertowHostOptions {
     private Boolean directBuffers;
     @Metadata(description = "Set if the Undertow host should use http2 protocol.")
     private Boolean http2Enabled;
+    @Metadata(description = "The maximum size of the HTTP entity body, in bytes. Requests with a body larger than this will be rejected.")
+    private Long maxEntitySize;
+    @Metadata(description = "The maximum size of a multipart HTTP entity body, in bytes. Multipart requests larger than this will be rejected.")
+    private Long multipartMaxEntitySize;
+    @Metadata(description = "The maximum size of an HTTP request header, in bytes. Requests with headers larger than this will be rejected.")
+    private Integer maxHeaderSize;
+    @Metadata(description = "The amount of time in milliseconds a connection can be idle with no current requests before it is closed.")
+    private Integer noRequestTimeout;
+    @Metadata(description = "The idle timeout in milliseconds after which the channel will be closed.")
+    private Integer idleTimeout;
+    @Metadata(description = "The maximum time in milliseconds to parse an HTTP request.")
+    private Integer requestParseTimeout;
+    @Metadata(description = "The maximum number of query and path parameters that will be parsed.")
+    private Integer maxParameters;
+    @Metadata(description = "The maximum number of HTTP headers that will be parsed.")
+    private Integer maxHeaders;
 
     public UndertowHostOptions() {
     }
@@ -75,6 +91,70 @@ public final class UndertowHostOptions {
 
     public void setHttp2Enabled(Boolean http2Enabled) {
         this.http2Enabled = http2Enabled;
+    }
+
+    public Long getMaxEntitySize() {
+        return maxEntitySize;
+    }
+
+    public void setMaxEntitySize(Long maxEntitySize) {
+        this.maxEntitySize = maxEntitySize;
+    }
+
+    public Long getMultipartMaxEntitySize() {
+        return multipartMaxEntitySize;
+    }
+
+    public void setMultipartMaxEntitySize(Long multipartMaxEntitySize) {
+        this.multipartMaxEntitySize = multipartMaxEntitySize;
+    }
+
+    public Integer getMaxHeaderSize() {
+        return maxHeaderSize;
+    }
+
+    public void setMaxHeaderSize(Integer maxHeaderSize) {
+        this.maxHeaderSize = maxHeaderSize;
+    }
+
+    public Integer getNoRequestTimeout() {
+        return noRequestTimeout;
+    }
+
+    public void setNoRequestTimeout(Integer noRequestTimeout) {
+        this.noRequestTimeout = noRequestTimeout;
+    }
+
+    public Integer getIdleTimeout() {
+        return idleTimeout;
+    }
+
+    public void setIdleTimeout(Integer idleTimeout) {
+        this.idleTimeout = idleTimeout;
+    }
+
+    public Integer getRequestParseTimeout() {
+        return requestParseTimeout;
+    }
+
+    public void setRequestParseTimeout(Integer requestParseTimeout) {
+        this.requestParseTimeout = requestParseTimeout;
+    }
+
+    public Integer getMaxParameters() {
+        return maxParameters;
+    }
+
+    public void setMaxParameters(Integer maxParameters) {
+        this.maxParameters = maxParameters;
+    }
+
+    public Integer getMaxHeaders() {
+        return maxHeaders;
+    }
+
+    public void setMaxHeaders(Integer maxHeaders) {
+        this.maxHeaders = maxHeaders;
     }
 
 }

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowMaxEntitySizeTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowMaxEntitySizeTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.undertow;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class UndertowMaxEntitySizeTest extends BaseUndertowTest {
+
+    private static final long MAX_ENTITY_SIZE = 1024L;
+
+    @Test
+    public void testRequestWithinLimit() {
+        String body = "A".repeat((int) MAX_ENTITY_SIZE);
+        String response = template.requestBodyAndHeader(
+                "http://localhost:{{port}}/myapp", body, Exchange.HTTP_METHOD, "POST", String.class);
+        assertEquals("OK", response);
+    }
+
+    @Test
+    public void testRequestExceedingLimit() {
+        String body = "A".repeat((int) MAX_ENTITY_SIZE + 1);
+        assertThrows(CamelExecutionException.class,
+                () -> template.requestBodyAndHeader(
+                        "http://localhost:{{port}}/myapp", body, Exchange.HTTP_METHOD, "POST", String.class));
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        UndertowComponent component = context.getComponent("undertow", UndertowComponent.class);
+
+        UndertowHostOptions hostOptions = new UndertowHostOptions();
+        hostOptions.setMaxEntitySize(MAX_ENTITY_SIZE);
+
+        component.setHostOptions(hostOptions);
+
+        return context;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("undertow:http://localhost:{{port}}/myapp")
+                        .setBody().constant("OK");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Add 8 new typed fields to `UndertowHostOptions` (`maxEntitySize`, `multipartMaxEntitySize`, `maxHeaderSize`, `noRequestTimeout`, `idleTimeout`, `requestParseTimeout`, `maxParameters`, `maxHeaders`) following the existing `http2Enabled` pattern
- Wire each option in `DefaultUndertowHost` via `builder.setServerOption()`
- Document all host options (existing and new) in `undertow-component.adoc`
- Add integration test for `maxEntitySize`

_Claude Code on behalf of Federico Mariani_