### PR TITLE
CAMEL-23689: Deprecate camel-headersmap

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/others/headersmap.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/others/headersmap.json
@@ -4,7 +4,7 @@
     "name": "headersmap",
     "title": "Headersmap",
     "description": "Fast case-insensitive headers map implementation",
-    "deprecated": false,
+    "deprecated": true,
     "firstVersion": "2.20.0",
     "label": "core",
     "supportLevel": "Stable",

--- a/components/camel-headersmap/pom.xml
+++ b/components/camel-headersmap/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>camel-headersmap</artifactId>
     <packaging>jar</packaging>
-    <name>Camel :: Headers Map</name>
+    <name>Camel :: Headers Map (deprecated)</name>
     <description>Fast case-insensitive headers map implementation</description>
 
     <properties>

--- a/components/camel-headersmap/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-headersmap/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -3,5 +3,5 @@ name=headersmap
 groupId=org.apache.camel
 artifactId=camel-headersmap
 version=4.21.0-SNAPSHOT
-projectName=Camel :: Headers Map
+projectName=Camel :: Headers Map (deprecated)
 projectDescription=Fast case-insensitive headers map implementation

--- a/components/camel-headersmap/src/generated/resources/headersmap.json
+++ b/components/camel-headersmap/src/generated/resources/headersmap.json
@@ -4,7 +4,7 @@
     "name": "headersmap",
     "title": "Headersmap",
     "description": "Fast case-insensitive headers map implementation",
-    "deprecated": false,
+    "deprecated": true,
     "firstVersion": "2.20.0",
     "label": "core",
     "supportLevel": "Stable",

--- a/components/camel-headersmap/src/main/docs/headersmap.adoc
+++ b/components/camel-headersmap/src/main/docs/headersmap.adoc
@@ -1,13 +1,22 @@
-= Headersmap Component
+= Headersmap Component (deprecated)
 :doctitle: Headersmap
 :shortname: headersmap
 :artifactid: camel-headersmap
 :description: Fast case-insensitive headers map implementation
 :since: 2.20
-:supportlevel: Stable
+:supportlevel: Stable-deprecated
+:deprecated: *deprecated*
 :tabs-sync-option:
 
 *Since Camel {since}*
+
+[NOTE]
+====
+This component is deprecated. Since Camel 4.21, the default `CaseInsensitiveMap` in camel-core
+uses a custom O(1) hash table with zero-allocation lookups, making this component unnecessary.
+Simply remove the `camel-headersmap` dependency — the core implementation now provides equivalent
+or better performance without any external library.
+====
 
 The Headersmap component is a faster implementation of a case-insensitive map which can be plugged in
 and used by Camel at runtime to have slight faster performance in the Camel Message headers.

--- a/components/camel-headersmap/src/main/java/org/apache/camel/component/headersmap/FastHeadersMapFactory.java
+++ b/components/camel-headersmap/src/main/java/org/apache/camel/component/headersmap/FastHeadersMapFactory.java
@@ -25,7 +25,11 @@ import org.apache.camel.spi.annotations.JdkService;
 /**
  * A faster {@link HeadersMapFactory} which is using the {@link com.cedarsoftware.util.CaseInsensitiveMap} map
  * implementation.
+ *
+ * @deprecated use the default {@code DefaultHeadersMapFactory} from camel-core which now provides O(1) hash-based
+ *             lookups. This component will be removed in a future release.
  */
+@Deprecated
 @JdkService(HeadersMapFactory.FACTORY)
 public class FastHeadersMapFactory implements HeadersMapFactory {
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -1761,6 +1761,13 @@ from("langchain4j-tools:test1?tags=user&description=Query user by number&paramet
 Additionally, `camel-langchain4j-agent` now extracts primitive values (`int`, `long`, `double`, `boolean`,
 `String`) from tool arguments instead of setting raw `JsonNode` objects as headers.
 
+=== Deprecation of camel-headersmap
+
+The component camel-headersmap is deprecated. Since Camel 4.21, the default `CaseInsensitiveMap` in camel-core
+uses a custom O(1) hash table with zero-allocation lookups and header key deduplication, making the external
+cedarsoftware `java-util` dependency unnecessary. Simply remove the `camel-headersmap` dependency from your
+project — the core implementation now provides equivalent or better performance.
+
 === Deprecation of camel-paho
 
 The components camel-paho is deprecated. There were no new release since 2020 of the Java client, last non-regulatory commit was in 2022.


### PR DESCRIPTION
[CAMEL-23689](https://issues.apache.org/jira/browse/CAMEL-23689)

## Summary

- Deprecate `camel-headersmap` now that the core `CaseInsensitiveMap` provides O(1) hash-based lookups (CAMEL-23691)
- Add `@Deprecated` annotation to `FastHeadersMapFactory`
- Mark module as `(deprecated)` in pom.xml name and docs
- Add deprecation notice to the upgrade guide