### PR TITLE
[camel-4.18.x] Fix transformer name normalization for catalog lookup during export

### DIFF
--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DependencyDownloaderTransformerResolver.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DependencyDownloaderTransformerResolver.java
@@ -48,7 +48,9 @@ public final class DependencyDownloaderTransformerResolver extends DefaultTransf
     @Override
     public Transformer resolve(TransformerKey key, CamelContext context) {
         String name = key.toString();
-        TransformerModel model = catalog.transformerModel(name);
+        // catalog stores transformer names in normalized (dash-separated) format
+        String normalizedName = normalize(key);
+        TransformerModel model = catalog.transformerModel(normalizedName);
         if (model != null) {
             downloadLoader(model.getGroupId(), model.getArtifactId(), model.getVersion());
         }
@@ -63,7 +65,7 @@ public final class DependencyDownloaderTransformerResolver extends DefaultTransf
         }
 
         if (answer == null) {
-            List<String> suggestion = SuggestSimilarHelper.didYouMean(catalog.findTransformerNames(), name);
+            List<String> suggestion = SuggestSimilarHelper.didYouMean(catalog.findTransformerNames(), normalizedName);
             if (suggestion != null && !suggestion.isEmpty()) {
                 String s = String.join(", ", suggestion);
                 throw new IllegalArgumentException("Cannot find transformer with name: " + name + ". Did you mean: " + s);

--- a/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/DependencyDownloaderTransformerResolverTest.java
+++ b/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/DependencyDownloaderTransformerResolverTest.java
@@ -16,9 +16,11 @@
  */
 package org.apache.camel.main.download;
 
+import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.apache.camel.impl.engine.SimpleCamelContext;
 import org.apache.camel.spi.Transformer;
 import org.apache.camel.spi.TransformerKey;
+import org.apache.camel.tooling.model.TransformerModel;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,5 +45,21 @@ public class DependencyDownloaderTransformerResolverTest {
 
         TransformerKey resultKey = TransformerKey.createFrom(transformer);
         assertNotNull(resultKey);
+    }
+
+    @Test
+    void catalogLookupShouldNormalizeColonSeparatedNames() {
+        DefaultCamelCatalog catalog = new DefaultCamelCatalog();
+        DependencyDownloaderTransformerResolver resolver
+                = new DependencyDownloaderTransformerResolver(new SimpleCamelContext(), "*", true);
+
+        // transformer names use colon format (e.g., aws2-ddb:application-json)
+        // but the catalog stores them in dash format (aws2-ddb-application-json)
+        String colonName = "aws2-ddb:application-json";
+        String normalizedName = resolver.normalize(new TransformerKey(colonName));
+
+        TransformerModel model = catalog.transformerModel(normalizedName);
+        assertNotNull(model, "Catalog should find transformer using normalized name: " + normalizedName);
+        assertNotNull(model.getArtifactId(), "Transformer model should have artifactId");
     }
 }


### PR DESCRIPTION
Cherry-pick of #23780 to `camel-4.18.x`.

## Summary

- Normalize transformer names before catalog lookup in `DependencyDownloaderTransformerResolver`
- Transformer names use colon-separated format (`aws2-ddb:application-json`) but the catalog stores them in dash-separated format (`aws2-ddb-application-json`)
- The `normalize(key)` method from `TransformerResolver` already handles this conversion — it just wasn't being called before the catalog lookup

## Test plan

- [x] Added `catalogLookupShouldNormalizeColonSeparatedNames()` test
- [x] Existing `stubTransformerShouldHaveNameSet()` test still passes