### PR TITLE
CAMEL-23698: Do not append trailing ? to URI when query string is empty

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -443,7 +443,7 @@ public final class URISupport {
         if (before != null) {
             s = before;
         }
-        if (query != null) {
+        if (query != null && !query.isEmpty()) {
             s = s + "?" + query;
         }
         if (!s.contains("#") && uri.getFragment() != null) {

--- a/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
@@ -186,6 +186,14 @@ public class URISupportTest {
     }
 
     @Test
+    public void testCreateURIWithQueryEmptyQueryString() throws Exception {
+        URI uri = new URI("https://api.example.com/users/myuser/repos");
+        URI resultUri = URISupport.createURIWithQuery(uri, "");
+        assertNotNull(resultUri);
+        assertEquals("https://api.example.com/users/myuser/repos", resultUri.toString());
+    }
+
+    @Test
     public void testNormalizeEndpointWithEqualSignInParameter() throws Exception {
         String out = URISupport.normalizeUri("jms:queue:foo?selector=somekey='somevalue'&foo=bar");
         assertNotNull(out);


### PR DESCRIPTION
## Summary

- Fix `URISupport.createURIWithQuery()` to not append a bare `?` when the query string is empty
- When `camel-rest-openapi` produces a REST call from an OpenAPI spec with optional query parameters that are not set, the URL ended with a trailing `?` (e.g., `/users/myuser/repos?` instead of `/users/myuser/repos`)
- Some HTTP servers and proxies treat `/resource` and `/resource?` differently, so this can cause issues

## Root Cause

`URISupport.createURIWithQuery()` checked `if (query != null)` before appending `?` + query, but did not check if the query string was empty. Changed to `if (query != null && !query.isEmpty())`.

## Test plan

- [x] Added `testCreateURIWithQueryEmptyQueryString` in `URISupportTest` verifying no trailing `?` is appended for empty query strings
- [x] Existing `URISupportTest` tests pass (null query and non-empty query cases)

_Claude Code on behalf of Claus Ibsen_