### PR TITLE
[backport camel-4.18.x] CAMEL-23698: Do not append trailing ? to URI when query string is empty

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -443,7 +443,7 @@ public final class URISupport {
         if (before != null) {
             s = before;
         }
-        if (query != null) {
+        if (query != null && !query.isEmpty()) {
             s = s + "?" + query;
         }
         if (!s.contains("#") && uri.getFragment() != null) {

--- a/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
@@ -186,6 +186,14 @@ public class URISupportTest {
     }
 
     @Test
+    public void testCreateURIWithQueryEmptyQueryString() throws Exception {
+        URI uri = new URI("https://api.example.com/users/myuser/repos");
+        URI resultUri = URISupport.createURIWithQuery(uri, "");
+        assertNotNull(resultUri);
+        assertEquals("https://api.example.com/users/myuser/repos", resultUri.toString());
+    }
+
+    @Test
     public void testNormalizeEndpointWithEqualSignInParameter() throws Exception {
         String out = URISupport.normalizeUri("jms:queue:foo?selector=somekey='somevalue'&foo=bar");
         assertNotNull(out);


### PR DESCRIPTION
## Backport of #23797

Cherry-pick of #23797 onto `camel-4.18.x`.

**Original PR:** #23797 - CAMEL-23698: Do not append trailing ? to URI when query string is empty
**Original author:** @davsclaus
**Target branch:** `camel-4.18.x`

### Original description

- Fix `URISupport.createURIWithQuery()` to not append a bare `?` when the query string is empty
- When `camel-rest-openapi` produces a REST call from an OpenAPI spec with optional query parameters that are not set, the URL ended with a trailing `?` (e.g., `/users/myuser/repos?` instead of `/users/myuser/repos`)
- Some HTTP servers and proxies treat `/resource` and `/resource?` differently, so this can cause issues

_Claude Code on behalf of Claus Ibsen_