### PR TITLE
CAMEL-21935: Fix Knative Service missing container image on OpenShift

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitHelper.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/TraitHelper.java
@@ -306,6 +306,7 @@ public final class TraitHelper {
         buildProperties.add("jkube.container-image.name=%s".formatted(imageToUse));
 
         Container containerTrait = Optional.ofNullable(traitsSpec.getContainer()).orElseGet(Container::new);
+        containerTrait.setImage(imageToUse);
 
         if (containerTrait.getImagePullPolicy() != null) {
             var imagePullPolicy = containerTrait.getImagePullPolicy().getValue();

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
@@ -206,7 +206,7 @@ class KubernetesExportTest extends KubernetesExportBaseTestSupport {
         Assertions.assertEquals("route", labels.get("camel.apache.org/app"));
         Assertions.assertEquals("route", containers.get(0).getName());
         Assertions.assertEquals("route", matchLabels.get(BaseTrait.KUBERNETES_LABEL_NAME));
-        Assertions.assertNull(containers.get(0).getImage());
+        Assertions.assertEquals("quay.io/camel-test/route:1.0-SNAPSHOT", containers.get(0).getImage());
 
         Model model = readMavenModel();
         Assertions.assertEquals("org.example.project", model.getGroupId());
@@ -299,7 +299,7 @@ class KubernetesExportTest extends KubernetesExportBaseTestSupport {
         Assertions.assertEquals("route", labels.get(BaseTrait.KUBERNETES_LABEL_NAME));
         Assertions.assertEquals("route", containers.get(0).getName());
         Assertions.assertEquals("route", matchLabels.get(BaseTrait.KUBERNETES_LABEL_NAME));
-        Assertions.assertNull(containers.get(0).getImage());
+        Assertions.assertEquals("camel-test/route:1.0-SNAPSHOT", containers.get(0).getImage());
 
         Model model = readMavenModel();
         Assertions.assertEquals("org.example.project", model.getGroupId());
@@ -340,7 +340,7 @@ class KubernetesExportTest extends KubernetesExportBaseTestSupport {
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
         Assertions.assertEquals("route", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertNull(container.getImage());
+        Assertions.assertEquals("route:1.0-SNAPSHOT", container.getImage());
         Assertions.assertEquals(1, container.getPorts().size());
         Assertions.assertEquals("http", container.getPorts().get(0).getName());
         Assertions.assertEquals(8080, container.getPorts().get(0).getContainerPort());
@@ -380,7 +380,7 @@ class KubernetesExportTest extends KubernetesExportBaseTestSupport {
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
         Assertions.assertEquals("route-service", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertNull(container.getImage());
+        Assertions.assertEquals("route-service:1.0-SNAPSHOT", container.getImage());
         Assertions.assertEquals(1, container.getPorts().size());
         Assertions.assertEquals("http", container.getPorts().get(0).getName());
         Assertions.assertEquals(8080, container.getPorts().get(0).getContainerPort());
@@ -429,7 +429,7 @@ class KubernetesExportTest extends KubernetesExportBaseTestSupport {
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
         Assertions.assertEquals("route-service", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertNull(container.getImage());
+        Assertions.assertEquals("route-service:1.0-SNAPSHOT", container.getImage());
         Assertions.assertEquals(1, container.getPorts().size());
         Assertions.assertEquals("http", container.getPorts().get(0).getName());
         Assertions.assertEquals(8080, container.getPorts().get(0).getContainerPort());
@@ -487,7 +487,7 @@ class KubernetesExportTest extends KubernetesExportBaseTestSupport {
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
         Assertions.assertEquals("route-service", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertNull(container.getImage());
+        Assertions.assertEquals("route-service:1.0-SNAPSHOT", container.getImage());
         Assertions.assertEquals(1, container.getPorts().size());
         Assertions.assertEquals("http", container.getPorts().get(0).getName());
         Assertions.assertEquals(8080, container.getPorts().get(0).getContainerPort());
@@ -548,7 +548,8 @@ class KubernetesExportTest extends KubernetesExportBaseTestSupport {
         Deployment deployment = getDeployment(rt);
         Assertions.assertEquals("route-service", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertNull(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
+        Assertions.assertEquals("route-service:1.0.0",
+                deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
         Assertions.assertEquals("IfNotPresent",
                 deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().size());
@@ -841,7 +842,8 @@ class KubernetesExportTest extends KubernetesExportBaseTestSupport {
         Deployment deployment = getDeployment(rt);
         Assertions.assertEquals("demo-app", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertNull(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
+        Assertions.assertEquals("quay.io/camel/demo-app:1.0",
+                deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
 
         Model model = readMavenModel();
         Assertions.assertEquals("org.example.project", model.getGroupId());
@@ -872,7 +874,7 @@ class KubernetesExportTest extends KubernetesExportBaseTestSupport {
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
         Assertions.assertEquals("route-service", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertNull(container.getImage());
+        Assertions.assertEquals("route-service:1.0-SNAPSHOT", container.getImage());
         Assertions.assertEquals(2, container.getPorts().size());
         Assertions.assertEquals("jolokia", container.getPorts().get(1).getName());
         Assertions.assertEquals(8778, container.getPorts().get(1).getContainerPort());


### PR DESCRIPTION
## Summary

- Fix Knative Service manifest getting a bare image name (e.g., `http-log:1.0-SNAPSHOT`) instead of the full registry URL when deploying to OpenShift with `--trait knative-service.enabled=true`
- Root cause: commit `089356d392b5` (CAMEL-21903) stopped setting the container image on the Container trait, only setting JKube build properties. This works for Deployments (JKube reads the properties), but breaks Knative Services (generated entirely by traits code, not JKube)

## Root Cause

`TraitHelper.configureContainerImage()` sets `jkube.image.name` and `jkube.container-image.name` as Maven build properties but no longer calls `containerTrait.setImage(imageToUse)`. Since `ContainerTrait.apply()` only sets the image on the container when `containerTrait.getImage()` is not empty, the Knative Service ends up with no image reference — Knative then resolves the bare artifact name against Docker Hub and fails with 401 Unauthorized.

## Fix

Re-add `containerTrait.setImage(imageToUse)` in `TraitHelper.configureContainerImage()` so both Deployments and Knative Services get the correct image. The JKube build properties remain as-is for Maven CI/CD overridability.

## Test plan

- [x] Updated all `KubernetesExportTest` assertions from `assertNull(container.getImage())` to expect the correct image value
- [x] All existing tests pass

_Claude Code on behalf of Claus Ibsen_