### PR TITLE
CAMEL-20227: Fix Pausable EIP losing messages due to Kafka offset advancement

### DIFF
--- a/components/camel-kafka/src/main/docs/kafka-component.adoc
+++ b/components/camel-kafka/src/main/docs/kafka-component.adoc
@@ -295,6 +295,10 @@ In this example, consuming messages can pause (by calling the Kafka's Consumer p
 IMPORTANT: The pausable EIP is meant to be used as a support mechanism when *there is an exception* somewhere in the route that prevents the exchange from being processed. More specifically,
 the check called by the `pausable` EIP should be used to test for transient conditions preventing the exchange from being processed.
 
+NOTE: When using pausable consumers, it is recommended to set `autoCommitEnable=false` and `allowManualCommit=true`
+so that offsets are only committed after successful processing. With `autoCommitEnable=true`, Kafka may auto-commit
+offsets for records that were polled but not yet processed, which can lead to message loss during pause/resume cycles.
+
 NOTE: most users should prefer using the xref:manual::route-policy.adoc[RoutePolicy], which offers better control of the route.
 
 === Kafka Headers propagation

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/errorhandler/KafkaConsumerListener.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/errorhandler/KafkaConsumerListener.java
@@ -32,7 +32,6 @@ public class KafkaConsumerListener implements ConsumerListener<Object, Processin
     private SeekPolicy seekPolicy;
 
     private Predicate<?> afterConsumeEval;
-    private boolean paused;
 
     public Consumer<?, ?> getConsumer() {
         return consumer;
@@ -57,40 +56,36 @@ public class KafkaConsumerListener implements ConsumerListener<Object, Processin
 
     @Override
     public boolean afterConsume(@SuppressWarnings("unused") Object ignored) {
-        if (paused) {
-            if (afterConsumeEval.test(null)) {
-                LOG.warn("State changed, therefore resuming the consumer");
-                consumer.resume(consumer.assignment());
-
-                return true;
-            }
-
-            LOG.warn("The consumer is not yet resumable");
-            return false;
+        boolean resume = afterConsumeEval.test(null);
+        if (resume) {
+            LOG.debug("Resuming consumer");
+            consumer.resume(consumer.assignment());
+        } else {
+            LOG.debug("Pausing consumer");
+            consumer.pause(consumer.assignment());
+            seekConsumer();
         }
-
-        // It's not paused, so we can continue processing
-        return true;
+        return resume;
     }
 
     @Override
     public boolean afterProcess(ProcessingResult result) {
         if (result.isFailed()) {
-            LOG.warn("Pausing consumer due to error on the last processing");
+            LOG.debug("Pausing consumer due to last processing error");
             consumer.pause(consumer.assignment());
-            paused = true;
-
-            if (seekPolicy == SeekPolicy.BEGINNING) {
-                LOG.debug("Seeking from the beginning of topic");
-                consumer.seekToBeginning(consumer.assignment());
-            } else if (seekPolicy == SeekPolicy.END) {
-                LOG.debug("Seeking from the end off the topic");
-                consumer.seekToEnd(consumer.assignment());
-            }
-
+            seekConsumer();
             return false;
         }
-
         return true;
+    }
+
+    protected void seekConsumer() {
+        if (seekPolicy == SeekPolicy.BEGINNING) {
+            LOG.debug("Seeking to beginning of topic");
+            consumer.seekToBeginning(consumer.assignment());
+        } else if (seekPolicy == SeekPolicy.END) {
+            LOG.debug("Seeking to end of topic");
+            consumer.seekToEnd(consumer.assignment());
+        }
     }
 }


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Claus Ibsen_

Fixes the Pausable EIP with Kafka consumer losing messages when the consumer is paused and later resumed. The root cause was that `KafkaConsumerListener.afterConsume()` never called `consumer.pause()` or seeked back to committed offsets, so `consumer.poll()` kept advancing offsets for records that were never processed.

- Rewrite `afterConsume()` to always evaluate the resume predicate, call `consumer.pause()` + `seekConsumer()` when pausing, and `consumer.resume()` when resuming
- Remove the `paused` boolean flag that prevented proper predicate evaluation
- Extract `seekConsumer()` helper shared between `afterConsume` and `afterProcess`
- Use Kafka's native `consumer.pause()` so `poll()` returns empty records during pause (no `Thread.sleep` needed)

Prior partial fix (`869e870952c2`) only added a `paused` flag without addressing the offset advancement. A full fix existed on the unmerged `origin/kafka-pause` branch — this PR adapts that fix to current `main` with the cleaner `consumer.pause()` approach.

## Test plan

- [ ] Existing `KafkaPausableConsumerIT` passes — verifies all messages are received after pause/resume
- [ ] Existing `KafkaPausableConsumerCircuitBreakerIT` passes
- [ ] Verify no messages are lost when `autoCommitEnable=true` during pause/resume cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)