### PR TITLE
CAMEL-21937: Reset route stop flag between tool invocations

### DIFF
--- a/components/camel-ai/camel-langchain4j-tools/src/main/docs/langchain4j-tools-component.adoc
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/docs/langchain4j-tools-component.adoc
@@ -168,6 +168,53 @@ List<ChatMessage> messages = new ArrayList<>();
         Exchange message = fluentTemplate.to("direct:test").withBody(messages).request(Exchange.class);
 ----
 
+=== Tool Names
+
+Each tool route is registered with a name that the LLM uses to invoke it. By default, the name is derived automatically
+from the `description` option by converting it to CamelCase. For example:
+
+[cols="1,1", options="header"]
+|===
+| Description | Generated Tool Name
+| `Query user database by user ID` | `QueryUserDatabaseByUserId`
+| `Get current promotions` | `GetCurrentPromotions`
+| `Amend an order by its ID` | `AmendAnOrderByItsID`
+|===
+
+You can override the generated name by setting the `name` option explicitly on the consumer endpoint:
+
+[source, java]
+----
+from("langchain4j-tools:test1?tags=orders&name=amendOrder&description=Amend an order by its ID&parameter.orderId=string")
+    .setBody(constant("order amended"));
+----
+
+=== Using stop() in Tool Routes
+
+Tool routes can use the `stop()` EIP to discontinue route processing early. When the LLM invokes multiple tools
+in parallel, each tool route executes independently — `stop()` in one tool does not affect the others.
+
+.Example with two tools where one uses stop():
+[source, java]
+----
+from("direct:chat")
+    .to("langchain4j-tools:test1?tags=orders")
+    .log("response is: ${body}");
+
+// Tool that uses stop() to end processing early
+from("langchain4j-tools:test1?tags=orders&description=Amend an order by its ID&parameter.orderId=string")
+    .setBody(constant("order amended"))
+    .stop();
+
+// Tool that returns JSON — executes independently
+from("langchain4j-tools:test1?tags=orders&description=Get current promotions")
+    .setBody(constant("{\"status\":\"ok\",\"promotions\":[\"10% off\"]}"));
+----
+
+When the LLM invokes both tools, each produces its own result. The `stop()` in the first tool does not
+prevent the second tool from executing, nor does it stop the calling route from continuing after the tools
+producer completes.
+
 === Using a specific Model
 
 The Camel LangChain4j tools component provides an abstraction for interacting with various types of Large Language Models (LLMs)

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsProducer.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsProducer.java
@@ -167,6 +167,10 @@ public class LangChain4jToolsProducer extends DefaultProducer {
                 continue;
             }
 
+            // Reset route stop flag from previous tool invocation to prevent
+            // stop() EIP in one tool from short-circuiting subsequent tools
+            exchange.setRouteStop(false);
+
             final CamelToolSpecification camelToolSpecification = toolPair.callableTools().stream()
                     .filter(c -> c.getToolSpecification().name().equals(toolName)).findFirst().get();
 
@@ -226,6 +230,10 @@ public class LangChain4jToolsProducer extends DefaultProducer {
                     toolExecutionRequest.name(),
                     exchange.getIn().getBody(String.class)));
         }
+
+        // Clear route stop flag after all tools so it does not leak
+        // into the calling route and prevent subsequent steps from executing
+        exchange.setRouteStop(false);
     }
 
     /**

--- a/components/camel-ai/camel-langchain4j-tools/src/test/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolStopEipTest.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/test/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolStopEipTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.langchain4j.tools;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.infra.openai.mock.OpenAIMock;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that using the stop() EIP in a tool route does not break parallel tool invocations.
+ *
+ * When the LLM requests multiple tools in a single response, each tool route must execute independently. Previously,
+ * using stop() in one tool route would cause the ROUTE_STOP flag to leak into subsequent tool invocations, preventing
+ * them from executing and returning the wrong result.
+ */
+public class LangChain4jToolStopEipTest extends CamelTestSupport {
+
+    protected ChatModel chatModel;
+
+    @RegisterExtension
+    static OpenAIMock openAIMock = new OpenAIMock().builder()
+            .when("please amend 123, and get me the promotions\n")
+            .invokeTool("AmendAnOrderByItsID")
+            .withParam("orderId", "123")
+            .andInvokeTool("GetCurrentPromotions")
+            .build();
+
+    private volatile boolean amendOrderCalled = false;
+    private volatile boolean getPromotionsCalled = false;
+    private volatile String getPromotionsBody = null;
+    private volatile boolean routeContinuedAfterTools = false;
+
+    @Override
+    protected void setupResources() throws Exception {
+        super.setupResources();
+        chatModel = ToolsHelper.createModel(openAIMock.getBaseUrl());
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        LangChain4jToolsComponent component
+                = context.getComponent(LangChain4jTools.SCHEME, LangChain4jToolsComponent.class);
+        component.getConfiguration().setChatModel(chatModel);
+        return context;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:test")
+                        .to("langchain4j-tools:test1?tags=orders")
+                        .process(exchange -> routeContinuedAfterTools = true);
+
+                // Tool1: uses stop() mid-way — must not leak ROUTE_STOP to Tool2
+                from("langchain4j-tools:test1?tags=orders&description=Amend an order by its ID&parameter.orderId=string")
+                        .process(exchange -> {
+                            amendOrderCalled = true;
+                        })
+                        .setBody(constant("order amended"))
+                        .stop();
+
+                // Tool2: returns JSON content — must execute independently despite Tool1's stop()
+                from("langchain4j-tools:test1?tags=orders&description=Get current promotions")
+                        .setBody(constant("{\"status\":\"ok\",\"promotions\":[\"10% off\"]}"))
+                        .process(exchange -> {
+                            getPromotionsCalled = true;
+                            getPromotionsBody = exchange.getIn().getBody(String.class);
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testParallelToolsWithStopEip() {
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(new SystemMessage("You are an assistant that helps with orders and promotions."));
+        messages.add(new UserMessage("please amend 123, and get me the promotions\n"));
+
+        Exchange result = fluentTemplate.to("direct:test").withBody(messages).request(Exchange.class);
+
+        assertThat(result).isNotNull();
+
+        // Both tool routes must have been called
+        assertThat(amendOrderCalled).as("AmendOrder tool should have been called").isTrue();
+        assertThat(getPromotionsCalled).as("GetPromotions tool should have been called").isTrue();
+
+        // GetPromotions must return its own body, not AmendOrder's body
+        assertThat(getPromotionsBody).as("GetPromotions should return its own body, not AmendOrder's")
+                .contains("promotions")
+                .doesNotContain("order amended");
+
+        // The final response should contain the promotions data
+        String responseContent = result.getMessage().getBody(String.class);
+        assertThat(responseContent).isNotNull();
+        assertThat(responseContent).contains("promotions");
+
+        // The calling route must continue after the tools producer —
+        // stop() in a tool route must not leak into the response exchange
+        assertThat(routeContinuedAfterTools).as("Route should continue after tools producer").isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `stop()` EIP in langchain4j tool routes causing subsequent parallel tool invocations to be short-circuited
- When the LLM invokes multiple tools in a single response, the `ROUTE_STOP` flag from one tool's `stop()` leaked into the shared exchange, preventing subsequent tools from executing and returning incorrect results
- The flag also leaked into the calling route after all tools completed, stopping further routing
- Add `exchange.setRouteStop(false)` before each tool invocation and after the loop in `invokeTools()`
- Add test `LangChain4jToolStopEipTest` covering parallel tool invocations where one tool uses `stop()`
- Document tool name auto-derivation from description (CamelCase conversion), the `name` override option, and using `stop()` in tool routes

## Test plan
- [x] New test `LangChain4jToolStopEipTest` verifies both tools execute independently when one uses `stop()`
- [x] Test verifies the calling route continues after the tools producer (no ROUTE_STOP leakage)
- [x] All 39 existing tests in camel-langchain4j-tools pass (no regressions)

## Follow-up
- [CAMEL-23704](https://issues.apache.org/jira/browse/CAMEL-23704): Use correlated exchange copy for full isolation between tool invocations (body, headers, exceptions)

_Claude Code on behalf of Claus Ibsen_