### PR TITLE
CAMEL-23676: Fix `NatsProducerReplyToIT` and `NatsConsumerWithRedeliveryIT` tests

### DIFF
--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerWithRedeliveryIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerWithRedeliveryIT.java
@@ -38,8 +38,8 @@ public class NatsConsumerWithRedeliveryIT extends NatsITSupport {
         mockResultEndpoint.setExpectedMessageCount(1);
         mockResultEndpoint.setAssertPeriod(1000);
 
-        template.requestBody("direct:send", "test");
-        template.requestBody("direct:send", "golang");
+        template.sendBody("direct:send", "test");
+        template.sendBody("direct:send", "golang");
 
         exception.setExpectedMessageCount(1);
 

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsProducerReplyToIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsProducerReplyToIT.java
@@ -53,7 +53,7 @@ public class NatsProducerReplyToIT extends NatsITSupport {
             public void configure() {
                 from(startUri).to(middleUri).to(resultUri);
 
-                from(middleUri)
+                from(middleUri + "?exchangePattern=InOut")
                         .transform(simple("Bye ${body}"));
             }
         };


### PR DESCRIPTION
# Description

Fix two integration tests broken by CAMEL-23676 (`camel-nats - Only send reply when exchange pattern is InOut`).

That commit changed `NatsConsumer` to only publish a reply to `msg.getReplyTo()` when `exchange.getPattern().isOutCapable()`. Since `NatsEndpoint` defaults to `InOnly`, consumer exchanges are `InOnly` by default and the reply is never published unless the endpoint URI explicitly sets `exchangePattern=InOut`.

Both failing tests use `template.requestBody(...)`, which creates an `InOut` exchange on the producer side. The NATS producer therefore calls `connection.request()`, attaching a reply-to inbox to the message. The consumer receives the message, but because its exchange is `InOnly`, the `isOutCapable()` check fails and the reply is never sent. The producer then blocks until the 20-second `requestTimeout` fires, causing the test to fail with an `ExchangeTimedOutException`.

Changes:

- `NatsProducerReplyToIT`: add `?exchangePattern=InOut` to the consumer route URI so the consumer creates `InOut` exchanges and the reply is published back to the producer.
- `NatsConsumerWithRedeliveryIT`: switch from `template.requestBody(...)` to `template.sendBody(...)`. The test only checks that messages reach `mock:result` and `mock:exception`; it never inspects the reply value. Using `sendBody` creates an `InOnly` exchange, so the NATS producer calls `connection.publish()` (no reply-to) and the consumer processes the message without needing to reply.

This pattern is consistent with `NatsConsumerReplyToIT` and `NatsConsumerReplyToInOnlyIT` introduced by CAMEL-23676 to demonstrate correct usage of the new behavior.

_Claude Code on behalf of Adriano Machado_

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-23676) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.