### PR TITLE
CAMEL-19551: add assertions to JPA transacted tests

### DIFF
--- a/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaTransactedTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaTransactedTest.java
@@ -40,16 +40,22 @@ public class JpaTransactedTest extends AbstractJpaTest {
     @Test
     public void testTransactedMulticast() throws Exception {
         template.sendBody("direct:multicast", new SendEmail("test@example.org"));
+
+        assertEntityInDB(2);
     }
 
     @Test
     public void testTransactedRecipientList() throws Exception {
         template.sendBody("direct:recipient", new SendEmail("test@example.org"));
+
+        assertEntityInDB(2);
     }
 
     @Test
     public void testTransactedEnrich() throws Exception {
         template.sendBody("direct:enrich", new SendEmail("test@example.org"));
+
+        assertEntityInDB(2);
     }
 
     @Override


### PR DESCRIPTION
# Description

Addresses CAMEL-19551 by adding explicit assertions to JPA transacted tests that previously executed routes without verifying any observable outcome.

The following tests did not contain assertions:

* testTransactedMulticast
* testTransactedRecipientList
* testTransactedEnrich

Each test now verifies that the expected entities are persisted in the database after route execution using `assertEntityInDB(2)`.

This improves test clarity and aligns the tests with the goal of CAMEL-19551, ensuring tests contain meaningful assertions rather than only executing code paths.

This is a test-only change and does not modify component behavior.

Validation:

Ran:

`./mvnw -pl components/camel-jpa -Dtest=JpaTransactedTest test`

Results:

* Tests run: 4
* Failures: 0
* Errors: 0

# Target

* [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

* [x] JIRA issue: CAMEL-19551

# Apache Camel coding standards and style

* [x] I checked that each commit in the pull request has a meaningful subject line and body.

* [x] I ran the relevant module tests locally and verified they pass.
