### PR TITLE
ci: fix malformed camel-web3j table in 4_18 upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -751,6 +751,9 @@ The Exchange header constants in `Web3jConstants` have been renamed to follow th
 Camel naming convention used across the rest of the component catalog. The Java
 field names are unchanged; only the header string values have changed:
 
+[options="header"]
+|===
+| Constant | Previous value | New value
 | `Web3jConstants.ID` | `ID` | `CamelWeb3jId`
 | `Web3jConstants.OPERATION` | `OPERATION` | `CamelWeb3jOperation`
 | `Web3jConstants.AT_BLOCK` | `AT_BLOCK` | `CamelWeb3jAtBlock`


### PR DESCRIPTION
## CI Fix

**Failed run:** [PR doc validation on apache/camel#23615](https://github.com/apache/camel/actions/runs/26624412242) (`docs/CAMEL-23577-guide-doc-sync`)

### Root cause

The `camel-web3j` entry in `docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc` is missing its opening table delimiter. The section jumps straight from the intro paragraph to the data rows, with only a closing `|===` and **no** `[options="header"]` / opening `|===` / `| Constant | Previous value | New value` header row:

```
field names are unchanged; only the header string values have changed:

| `Web3jConstants.ID` | `ID` | `CamelWeb3jId`        <-- no opening |=== above this
...
|===
```

Asciidoctor reports `table missing leading separator; recovering automatically`, and its table-recovery then **cascades** into the following tables in the same file (`camel-solr`, `camel-cxf`, `camel-dns`), which are themselves well-formed.

### Why it was latent here

The camel-website Antora validation only aggregates each repository's **`main`** branch, never the maintenance branches — so this broken table on `camel-4.18.x` was never exercised. It surfaced only when the 4_18 entries were doc-synced to `main` (PR #23615), failing that PR's *PR doc validation* check. The equivalent table is well-formed on `main` (4_21 guide) and on `camel-4.14.x`; only this 4_18 copy lost its opening delimiter during the web3j 4.18.x backport (#23501).

### Fix applied

Restored the three missing lines (`[options="header"]`, `|===`, header row) so the table renders correctly. Verified: no remaining malformed tables in the file, `|===` delimiters balanced. Documentation only — no code changes, so no Maven build is required.

Tracker: CAMEL-23577

_Claude Code on behalf of Andrea Cosentino_