### PR TITLE
[CAMEL-23481] Replace retired Apache Derby with H2 in camel-spring-xml tests

### DIFF
--- a/components/camel-spring-parent/camel-spring-xml/pom.xml
+++ b/components/camel-spring-parent/camel-spring-xml/pom.xml
@@ -132,17 +132,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>${derby-version}</version>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2-version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbytools</artifactId>
-            <version>${derby-version}</version>
-            <scope>test</scope>
-        </dependency>        
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>

--- a/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/interceptor/MixedTransactionPropagationTest.xml
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/interceptor/MixedTransactionPropagationTest.xml
@@ -25,8 +25,8 @@
          http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
          http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
-    <jdbc:embedded-database id="dataSource" type="DERBY">
-    	<jdbc:script location="classpath:sql/init.sql" />
+    <jdbc:embedded-database id="dataSource" type="H2">
+        <jdbc:script location="classpath:sql/init.sql"/>
     </jdbc:embedded-database>
 
     <bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
@@ -50,3 +50,4 @@
     </bean>
 
 </beans>
+

--- a/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/interceptor/mixedPropagationTransactedTest.xml
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/interceptor/mixedPropagationTransactedTest.xml
@@ -25,8 +25,8 @@
          http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
          http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
-    <jdbc:embedded-database id="dataSource" type="DERBY">
-    	<jdbc:script location="classpath:sql/init.sql" />
+    <jdbc:embedded-database id="dataSource" type="H2">
+        <jdbc:script location="classpath:sql/init.sql"/>
     </jdbc:embedded-database>
 
     <bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">

--- a/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/interceptor/springTransactionalClientDataSourceMinimalConfiguration.xml
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/interceptor/springTransactionalClientDataSourceMinimalConfiguration.xml
@@ -27,8 +27,8 @@
 
     <!-- START SNIPPET: e1 -->
     <!-- this example uses JDBC so we define a data source -->
-    <jdbc:embedded-database id="dataSource" type="DERBY">
-    	<jdbc:script location="classpath:sql/init.sql" />
+    <jdbc:embedded-database id="dataSource" type="H2">
+        <jdbc:script location="classpath:sql/init.sql"/>
     </jdbc:embedded-database>
 
     <!-- spring transaction manager -->

--- a/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/interceptor/transactionalClientDataSource.xml
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/interceptor/transactionalClientDataSource.xml
@@ -27,8 +27,8 @@
 
     <!-- START SNIPPET: e1 -->
     <!-- datasource to the database -->
-    <jdbc:embedded-database id="dataSource" type="DERBY">
-    	<jdbc:script location="classpath:sql/init.sql" />
+    <jdbc:embedded-database id="dataSource" type="H2">
+        <jdbc:script location="classpath:sql/init.sql"/>
     </jdbc:embedded-database>
 
     <!-- spring transaction manager -->

--- a/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/interceptor/transactionalClientWithAnnotatedBeanTest.xml
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/interceptor/transactionalClientWithAnnotatedBeanTest.xml
@@ -33,8 +33,8 @@
     <tx:annotation-driven transaction-manager="txManager"/>
 
     <!-- datasource to the database -->
-    <jdbc:embedded-database id="dataSource" type="DERBY">
-    	<jdbc:script location="classpath:sql/init.sql" />
+    <jdbc:embedded-database id="dataSource" type="H2">
+        <jdbc:script location="classpath:sql/init.sql"/>
     </jdbc:embedded-database>
 
     <!-- spring transaction manager -->

--- a/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/issues/SpringTransactionErrorHandlerAndContextScopedOnExceptionIssueTest.xml
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/issues/SpringTransactionErrorHandlerAndContextScopedOnExceptionIssueTest.xml
@@ -27,8 +27,8 @@
     ">
 
     <!-- the data source -->
-    <jdbc:embedded-database id="dataSource" type="DERBY">
-    	<jdbc:script location="classpath:sql/init.sql" />
+    <jdbc:embedded-database id="dataSource" type="H2">
+        <jdbc:script location="classpath:sql/init.sql"/>
     </jdbc:embedded-database>
 
     <!-- spring transaction manager -->

--- a/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/xml/handler/ErrorHandlerDefinitionParser.xml
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/xml/handler/ErrorHandlerDefinitionParser.xml
@@ -55,7 +55,7 @@
     </camelContext>
     <!-- END SNIPPET: example -->
 
-    <jdbc:embedded-database id="dataSource" type="DERBY" />
+    <jdbc:embedded-database id="dataSource" type="H2"/>
 
     <!-- spring transaction manager -->
     <bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">


### PR DESCRIPTION
Migrate test database from Derby (retired Apache project) to H2. Updates test dependencies and 7 Spring XML configurations. All tests pass.

Made with help from AI tools.