### PR TITLE
CAMEL-23564: Make OTEL_BAGGAGE_* headers visible in Baggage.current() without traceProcessors

### DIFF
--- a/components/camel-opentelemetry2/src/main/java/org/apache/camel/opentelemetry2/TraceProcessorsOtelInterceptStrategy.java
+++ b/components/camel-opentelemetry2/src/main/java/org/apache/camel/opentelemetry2/TraceProcessorsOtelInterceptStrategy.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.opentelemetry2;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import io.opentelemetry.api.baggage.Baggage;
@@ -36,6 +37,8 @@ import org.apache.camel.telemetry.SpanStorageManagerExchange;
  * custom Opentelemetry activity in the processor to be available.
  */
 public class TraceProcessorsOtelInterceptStrategy implements InterceptStrategy {
+
+    private static final String BAGGAGE_HEADER_PREFIX = "OTEL_BAGGAGE_";
 
     // NOTE: this is an implementation detail that the interceptor should not know.
     // We are temporarily using this to evaluate as a patch for a context leak problem we're suffering.
@@ -63,7 +66,7 @@ public class TraceProcessorsOtelInterceptStrategy implements InterceptStrategy {
             Span activeSpan = spanStorage.peek(exchange);
             if (activeSpan != null) {
                 OpenTelemetrySpanAdapter otelSpan = (OpenTelemetrySpanAdapter) activeSpan;
-                Baggage baggage = getBaggageFromProperties(otelSpan.getBaggage(), exchange);
+                Baggage baggage = collectBaggage(otelSpan.getBaggage(), exchange);
                 try (Scope scope = otelSpan.getSpan().makeCurrent();
                      Scope baggageScope = baggage.makeCurrent()) {
                     processor.process(exchange);
@@ -78,7 +81,7 @@ public class TraceProcessorsOtelInterceptStrategy implements InterceptStrategy {
             Span activeSpan = spanStorage.peek(exchange);
             if (activeSpan != null) {
                 OpenTelemetrySpanAdapter otelSpan = (OpenTelemetrySpanAdapter) activeSpan;
-                Baggage baggage = getBaggageFromProperties(otelSpan.getBaggage(), exchange);
+                Baggage baggage = collectBaggage(otelSpan.getBaggage(), exchange);
                 try (Scope scope = otelSpan.getSpan().makeCurrent();
                      Scope baggageScope = baggage.makeCurrent()) {
                     return processor.process(exchange, doneSync -> {
@@ -101,26 +104,34 @@ public class TraceProcessorsOtelInterceptStrategy implements InterceptStrategy {
         }
     }
 
-    // We inspect the exchange in order to find any baggage variable
+    private Baggage collectBaggage(Baggage baggage, Exchange exchange) {
+        baggage = getBaggageFromProperties(baggage, exchange);
+        baggage = getBaggageFromHeaders(baggage, exchange);
+        return baggage;
+    }
+
     private Baggage getBaggageFromProperties(Baggage baggage, Exchange exchange) {
         for (String propertyKey : exchange.getProperties().keySet()) {
-            String key = getBaggageVar(propertyKey);
-            if (key != null) {
+            if (propertyKey != null && propertyKey.startsWith(org.apache.camel.telemetry.Tracer.BAGGAGE_PROPERTY)) {
+                String key = propertyKey.substring(org.apache.camel.telemetry.Tracer.BAGGAGE_PROPERTY.length());
                 String value = exchange.getProperty(propertyKey) == null
                         ? null : exchange.getProperty(propertyKey).toString();
                 baggage = baggage.toBuilder().put(key, value).build();
             }
         }
-
         return baggage;
     }
 
-    private String getBaggageVar(String key) {
-        if (key == null || !key.startsWith(org.apache.camel.telemetry.Tracer.BAGGAGE_PROPERTY)) {
-            return null;
+    private Baggage getBaggageFromHeaders(Baggage baggage, Exchange exchange) {
+        for (Map.Entry<String, Object> entry : exchange.getMessage().getHeaders().entrySet()) {
+            String headerKey = entry.getKey();
+            if (headerKey != null && headerKey.startsWith(BAGGAGE_HEADER_PREFIX)) {
+                String key = headerKey.substring(BAGGAGE_HEADER_PREFIX.length());
+                String value = entry.getValue() == null ? null : entry.getValue().toString();
+                baggage = baggage.toBuilder().put(key, value).build();
+            }
         }
-
-        return key.substring(org.apache.camel.telemetry.Tracer.BAGGAGE_PROPERTY.length());
+        return baggage;
     }
 
 }

--- a/components/camel-opentelemetry2/src/test/java/org/apache/camel/opentelemetry2/BaggageHeaderWithoutProcessorSpansTest.java
+++ b/components/camel-opentelemetry2/src/test/java/org/apache/camel/opentelemetry2/BaggageHeaderWithoutProcessorSpansTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.opentelemetry2;
+
+import java.io.IOException;
+import java.util.Map;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Tracer;
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelContextAware;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.opentelemetry2.CamelOpenTelemetryExtension.OtelTrace;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that OTEL_BAGGAGE_* headers set in a route are visible in Baggage.current() inside processors without
+ * requiring traceProcessors=true (CAMEL-23564).
+ */
+public class BaggageHeaderWithoutProcessorSpansTest extends OpenTelemetryTracerTestSupport {
+
+    Tracer tracer = otelExtension.getOpenTelemetry().getTracer("baggageTest");
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        OpenTelemetryTracer tst = new OpenTelemetryTracer();
+        tst.setTracer(tracer);
+        tst.setContextPropagators(otelExtension.getOpenTelemetry().getPropagators());
+        // traceProcessors is NOT enabled — the default
+        CamelContext context = super.createCamelContext();
+        CamelContextAware.trySetCamelContext(tst, context);
+        tst.init(context);
+        return context;
+    }
+
+    @Test
+    void testBaggageHeaderVisibleWithoutProcessorSpans() throws IOException {
+        template.sendBody("direct:start", "my-body");
+        Map<String, OtelTrace> traces = otelExtension.getTraces();
+        assertEquals(1, traces.size());
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start")
+                        .routeId("start")
+                        .setHeader("OTEL_BAGGAGE_BusinessReference", constant("REF-42"))
+                        .process(new Processor() {
+                            @Override
+                            public void process(Exchange exchange) throws Exception {
+                                assertEquals("REF-42", Baggage.current().getEntryValue("BusinessReference"));
+                            }
+                        })
+                        .to("log:info");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- `TraceProcessorsOtelInterceptStrategy` now also reads `OTEL_BAGGAGE_*` exchange headers (in addition to `CamelBaggage_*` properties) when setting up the processor scope, so baggage set via `.setHeader("OTEL_BAGGAGE_X", ...)` is visible in `Baggage.current()` inside subsequent processors without requiring `traceProcessors=true`.
- Adds a test (`BaggageHeaderWithoutProcessorSpansTest`) that reproduces the exact scenario from the issue: setting an `OTEL_BAGGAGE_BusinessReference` header and verifying it's accessible via `Baggage.current()` with the default `traceProcessors=false` setting.

**Depends on:** #23843 (CAMEL-23709)

## Test plan

- [x] New `BaggageHeaderWithoutProcessorSpansTest` passes — verifies `OTEL_BAGGAGE_*` headers are visible in `Baggage.current()` without `traceProcessors=true`
- [x] All 27 existing `camel-opentelemetry2` tests pass
- [x] Existing `BaggageSettingTest` (using `CamelBaggage_*` properties with `traceProcessors=true`) still passes

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)