### PR TITLE
[CAMEL-23481] Replace retired Apache Derby with H2 in camel-quartz tests

### DIFF
--- a/components/camel-quartz/pom.xml
+++ b/components/camel-quartz/pom.xml
@@ -106,17 +106,11 @@
 
         <!-- for persistent test -->
         <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>${derby-version}</version>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2-version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbytools</artifactId>
-            <version>${derby-version}</version>
-            <scope>test</scope>
-        </dependency>        
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzConsumerClusteredAppDatabase.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzConsumerClusteredAppDatabase.xml
@@ -25,8 +25,8 @@
        http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
   <!-- the embedded persistent storage for quartz -->
-  <jdbc:embedded-database id="{{testClassSimpleName}}" type="DERBY">
-    <jdbc:script location="classpath:tables_derby.sql"/>
+  <jdbc:embedded-database id="{{testClassSimpleName}}" type="H2">
+    <jdbc:script location="classpath:tables_h2.sql"/>
   </jdbc:embedded-database>
 
 </beans>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzConsumerClusteredAppOne.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzConsumerClusteredAppOne.xml
@@ -26,9 +26,9 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <bean id="quartzDataSource" class="org.apache.commons.dbcp2.BasicDataSource">
-    <property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+    <property name="driverClassName" value="org.h2.Driver" />
     <!-- refer the embedded database we setup inside SpringQuartzConsumerClusteredAppDatabase.xml -->
-    <property name="url" value="jdbc:derby:memory:{{testClassSimpleName}}" />
+    <property name="url" value="jdbc:h2:mem:{{testClassSimpleName}}" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzConsumerClusteredAppTwo.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzConsumerClusteredAppTwo.xml
@@ -26,9 +26,9 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <bean id="quartzDataSource" class="org.apache.commons.dbcp2.BasicDataSource">
-    <property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+    <property name="driverClassName" value="org.h2.Driver" />
     <!-- refer the embedded database we setup inside SpringQuartzConsumerClusteredAppDatabase.xml -->
-    <property name="url" value="jdbc:derby:memory:{{testClassSimpleName}}" />
+    <property name="url" value="jdbc:h2:mem:{{testClassSimpleName}}" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzConsumerRecoveryClusteredAppOne.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzConsumerRecoveryClusteredAppOne.xml
@@ -26,9 +26,9 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <bean id="quartzDataSource" class="org.apache.commons.dbcp2.BasicDataSource">
-    <property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+    <property name="driverClassName" value="org.h2.Driver" />
     <!-- refer the embedded database we setup inside SpringQuartzConsumerClusteredAppDatabase.xml -->
-    <property name="url" value="jdbc:derby:memory:{{testClassSimpleName}}" />
+    <property name="url" value="jdbc:h2:mem:{{testClassSimpleName}}" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzConsumerRecoveryClusteredAppTwo.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzConsumerRecoveryClusteredAppTwo.xml
@@ -26,9 +26,9 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <bean id="quartzDataSource" class="org.apache.commons.dbcp2.BasicDataSource">
-    <property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+    <property name="driverClassName" value="org.h2.Driver" />
     <!-- refer the embedded database we setup inside SpringQuartzConsumerClusteredAppDatabase.xml -->
-    <property name="url" value="jdbc:derby:memory:{{testClassSimpleName}}" />
+    <property name="url" value="jdbc:h2:mem:{{testClassSimpleName}}" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartAppChangeCronExpressionTest1.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartAppChangeCronExpressionTest1.xml
@@ -26,9 +26,9 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <bean id="quartzDataSource" class="org.apache.commons.dbcp2.BasicDataSource">
-    <property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+    <property name="driverClassName" value="org.h2.Driver" />
     <!-- refer the embedded database we setup inside SpringQuartzConsumerClusteredAppDatabase.xml -->
-    <property name="url" value="jdbc:derby:memory:{{testClassSimpleName}}" />
+    <property name="url" value="jdbc:h2:mem:{{testClassSimpleName}}" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartAppChangeCronExpressionTest2.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartAppChangeCronExpressionTest2.xml
@@ -26,9 +26,9 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <bean id="quartzDataSource" class="org.apache.commons.dbcp2.BasicDataSource">
-    <property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+    <property name="driverClassName" value="org.h2.Driver" />
     <!-- refer the embedded database we setup inside SpringQuartzConsumerClusteredAppDatabase.xml -->
-    <property name="url" value="jdbc:derby:memory:{{testClassSimpleName}}" />
+    <property name="url" value="jdbc:h2:mem:{{testClassSimpleName}}" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartAppChangeCronExpressionTest3.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartAppChangeCronExpressionTest3.xml
@@ -26,9 +26,9 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <bean id="quartzDataSource" class="org.apache.commons.dbcp2.BasicDataSource">
-    <property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+    <property name="driverClassName" value="org.h2.Driver" />
     <!-- refer the embedded database we setup inside SpringQuartzConsumerClusteredAppDatabase.xml -->
-    <property name="url" value="jdbc:derby:memory:{{testClassSimpleName}}" />
+    <property name="url" value="jdbc:h2:mem:{{testClassSimpleName}}" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartAppChangeOptionsTest1.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartAppChangeOptionsTest1.xml
@@ -26,9 +26,9 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <bean id="quartzDataSource" class="org.apache.commons.dbcp2.BasicDataSource">
-    <property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+    <property name="driverClassName" value="org.h2.Driver" />
     <!-- refer the embedded database we setup inside SpringQuartzConsumerClusteredAppDatabase.xml -->
-    <property name="url" value="jdbc:derby:memory:{{testClassSimpleName}}" />
+    <property name="url" value="jdbc:h2:mem:{{testClassSimpleName}}" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartAppChangeOptionsTest2.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartAppChangeOptionsTest2.xml
@@ -26,9 +26,9 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <bean id="quartzDataSource" class="org.apache.commons.dbcp2.BasicDataSource">
-    <property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+    <property name="driverClassName" value="org.h2.Driver" />
     <!-- refer the embedded database we setup inside SpringQuartzConsumerClusteredAppDatabase.xml -->
-    <property name="url" value="jdbc:derby:memory:{{testClassSimpleName}}" />
+    <property name="url" value="jdbc:h2:mem:{{testClassSimpleName}}" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartTest.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreRestartTest.xml
@@ -27,7 +27,7 @@
     ">
 
   <!-- the persistent store for quartz -->
-  <jdbc:embedded-database id="{{testClassSimpleName}}" type="DERBY">
+  <jdbc:embedded-database id="{{testClassSimpleName}}" type="H2">
     <!-- do not load script as database alreaady exists -->
   </jdbc:embedded-database>
 

--- a/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreTest.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/component/quartz/SpringQuartzPersistentStoreTest.xml
@@ -27,8 +27,8 @@
     ">
 
   <!-- the persistent store for quartz -->
-  <jdbc:embedded-database id="{{testClassSimpleName}}" type="DERBY">
-    <jdbc:script location="classpath:tables_derby.sql"/>
+  <jdbc:embedded-database id="{{testClassSimpleName}}" type="H2">
+    <jdbc:script location="classpath:tables_h2.sql"/>
   </jdbc:embedded-database>
 
   <bean id="quartz" class="org.apache.camel.component.quartz.QuartzComponent">

--- a/components/camel-quartz/src/test/resources/org/apache/camel/routepolicy/quartz/SpringQuartzClusteredAppDatabase.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/routepolicy/quartz/SpringQuartzClusteredAppDatabase.xml
@@ -25,8 +25,8 @@
        http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
   <!-- the embedded persistent storage for quartz -->
-  <jdbc:embedded-database id="SpringQuartzTwoAppsClusteredFailoverTest" type="DERBY">
-    <jdbc:script location="classpath:tables_derby.sql"/>
+  <jdbc:embedded-database id="SpringQuartzTwoAppsClusteredFailoverTest" type="H2">
+    <jdbc:script location="classpath:tables_h2.sql"/>
   </jdbc:embedded-database>
 
 </beans>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/routepolicy/quartz/SpringQuartzClusteredAppOne.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/routepolicy/quartz/SpringQuartzClusteredAppOne.xml
@@ -26,9 +26,9 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <bean id="quartzDataSource" class="org.apache.commons.dbcp2.BasicDataSource">
-    <property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+    <property name="driverClassName" value="org.h2.Driver" />
     <!-- refer the embedded database we setup inside SpringQuartzClusteredAppDatabase.xml -->
-    <property name="url" value="jdbc:derby:memory:SpringQuartzTwoAppsClusteredFailoverTest" />
+    <property name="url" value="jdbc:h2:mem:SpringQuartzTwoAppsClusteredFailoverTest" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/components/camel-quartz/src/test/resources/org/apache/camel/routepolicy/quartz/SpringQuartzClusteredAppTwo.xml
+++ b/components/camel-quartz/src/test/resources/org/apache/camel/routepolicy/quartz/SpringQuartzClusteredAppTwo.xml
@@ -26,9 +26,9 @@
        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <bean id="quartzDataSource" class="org.apache.commons.dbcp2.BasicDataSource">
-    <property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+    <property name="driverClassName" value="org.h2.Driver" />
     <!-- refer the embedded database we setup inside SpringQuartzClusteredAppDatabase.xml -->
-    <property name="url" value="jdbc:derby:memory:SpringQuartzTwoAppsClusteredFailoverTest" />
+    <property name="url" value="jdbc:h2:mem:SpringQuartzTwoAppsClusteredFailoverTest" />
     <property name="username" value="sa" />
     <property name="password" value="" />
   </bean>

--- a/components/camel-quartz/src/test/resources/tables_h2.sql
+++ b/components/camel-quartz/src/test/resources/tables_h2.sql
@@ -16,56 +16,25 @@
 --
 
 --
--- Apache Derby scripts by Steve Stewart, updated by Ronald Pomeroy
--- Based on Srinivas Venkatarangaiah's file for Cloudscape
+-- H2 database schema for Quartz Scheduler
+-- Based on the official Quartz distribution schema
+-- Adapted from: https://github.com/quartz-scheduler/quartz
 --
--- Known to work with Apache Derby 10.0.2.1, or 10.6.2.1
+-- H2 Setup Notes:
+-- * Use org.quartz.impl.jdbcjobstore.StdJDBCDelegate as the driver delegate
+-- * MVCC mode is enabled by default in H2 2.x and provides row-level locking for clustering
 --
--- Updated by Zemian Deng <saltnlight5@gmail.com> on 08/21/2011
---   * Fixed nullable fields on qrtz_simprop_triggers table.
---   * Added Derby QuickStart comments and drop tables statements.
---
--- DerbyDB + Quartz Quick Guide:
--- * Derby comes with Oracle JDK! For Java6, it default install into C:/Program Files/Sun/JavaDB on Windows.
--- 1. Create a derby.properties file under JavaDB directory, and have the following:
---    derby.connection.requireAuthentication = true
---    derby.authentication.provider = BUILTIN
---    derby.user.quartz=quartz123
--- 2. Start the DB server by running bin/startNetworkServer script.
--- 3. On a new terminal, run bin/ij tool to bring up an SQL prompt, then run:
---    connect 'jdbc:derby://localhost:1527/quartz;user=quartz;password=quartz123;create=true';
---    run 'quartz/docs/dbTables/tables_derby.sql';
--- Now in quartz.properties, you may use these properties:
---    org.quartz.dataSource.quartzDataSource.driver = org.apache.derby.jdbc.ClientDriver
---    org.quartz.dataSource.quartzDataSource.URL = jdbc:derby://localhost:1527/quartz
---    org.quartz.dataSource.quartzDataSource.user = quartz
---    org.quartz.dataSource.quartzDataSource.password = quartz123
---
-
--- Auto drop and reset tables
--- Derby doesn't support if exists condition on table drop, so user must manually do this step if needed to.
--- drop table qrtz_fired_triggers;
--- drop table qrtz_paused_trigger_grps;
--- drop table qrtz_scheduler_state;
--- drop table qrtz_locks;
--- drop table qrtz_simple_triggers;
--- drop table qrtz_simprop_triggers;
--- drop table qrtz_cron_triggers;
--- drop table qrtz_blob_triggers;
--- drop table qrtz_triggers;
--- drop table qrtz_job_details;
--- drop table qrtz_calendars;
 
 create table qrtz_job_details (
 sched_name varchar(120) not null,
 job_name varchar(200) not null,
 job_group varchar(200) not null,
-description varchar(250) ,
+description varchar(250),
 job_class_name varchar(250) not null,
-is_durable varchar(5) not null,
-is_nonconcurrent varchar(5) not null,
-is_update_data varchar(5) not null,
-requests_recovery varchar(5) not null,
+is_durable boolean not null,
+is_nonconcurrent boolean not null,
+is_update_data boolean not null,
+requests_recovery boolean not null,
 job_data blob,
 primary key (sched_name,job_name,job_group)
 );
@@ -112,25 +81,23 @@ primary key (sched_name,trigger_name,trigger_group),
 foreign key (sched_name,trigger_name,trigger_group) references qrtz_triggers(sched_name,trigger_name,trigger_group)
 );
 
-create table qrtz_simprop_triggers
-  (
-    sched_name varchar(120) not null,
-    trigger_name varchar(200) not null,
-    trigger_group varchar(200) not null,
-    str_prop_1 varchar(512),
-    str_prop_2 varchar(512),
-    str_prop_3 varchar(512),
-    int_prop_1 int,
-    int_prop_2 int,
-    long_prop_1 bigint,
-    long_prop_2 bigint,
-    dec_prop_1 numeric(13,4),
-    dec_prop_2 numeric(13,4),
-    bool_prop_1 varchar(5),
-    bool_prop_2 varchar(5),
-    primary key (sched_name,trigger_name,trigger_group),
-    foreign key (sched_name,trigger_name,trigger_group)
-    references qrtz_triggers(sched_name,trigger_name,trigger_group)
+create table qrtz_simprop_triggers (
+sched_name varchar(120) not null,
+trigger_name varchar(200) not null,
+trigger_group varchar(200) not null,
+str_prop_1 varchar(512),
+str_prop_2 varchar(512),
+str_prop_3 varchar(512),
+int_prop_1 int,
+int_prop_2 int,
+long_prop_1 bigint,
+long_prop_2 bigint,
+dec_prop_1 numeric(13,4),
+dec_prop_2 numeric(13,4),
+bool_prop_1 boolean,
+bool_prop_2 boolean,
+primary key (sched_name,trigger_name,trigger_group),
+foreign key (sched_name,trigger_name,trigger_group) references qrtz_triggers(sched_name,trigger_name,trigger_group)
 );
 
 create table qrtz_blob_triggers(
@@ -149,10 +116,9 @@ calendar blob not null,
 primary key (sched_name,calendar_name)
 );
 
-create table qrtz_paused_trigger_grps
-  (
-    sched_name varchar(120) not null,
-    trigger_group varchar(200) not null,
+create table qrtz_paused_trigger_grps (
+sched_name varchar(120) not null,
+trigger_group varchar(200) not null,
 primary key (sched_name,trigger_group)
 );
 
@@ -168,24 +134,21 @@ priority integer not null,
 state varchar(16) not null,
 job_name varchar(200),
 job_group varchar(200),
-is_nonconcurrent varchar(5),
-requests_recovery varchar(5),
+is_nonconcurrent boolean,
+requests_recovery boolean,
 primary key (sched_name,entry_id)
 );
 
-create table qrtz_scheduler_state
-  (
-    sched_name varchar(120) not null,
-    instance_name varchar(200) not null,
-    last_checkin_time bigint not null,
-    checkin_interval bigint not null,
+create table qrtz_scheduler_state (
+sched_name varchar(120) not null,
+instance_name varchar(200) not null,
+last_checkin_time bigint not null,
+checkin_interval bigint not null,
 primary key (sched_name,instance_name)
 );
 
-create table qrtz_locks
-  (
-    sched_name varchar(120) not null,
-    lock_name varchar(40) not null,
+create table qrtz_locks (
+sched_name varchar(120) not null,
+lock_name varchar(40) not null,
 primary key (sched_name,lock_name)
 );
-


### PR DESCRIPTION
Replace Apache Derby (retired project) with H2 database for all Quartz component tests. 
Update dependencies, SQL schema, and 15 Spring XML test configurations. 
All 101 tests pass.

Made with help from AI tools.