### PR TITLE
[CAMEL-23481] Replace retired Apache Derby with H2 in camel-itest

### DIFF
--- a/tests/camel-itest/pom.xml
+++ b/tests/camel-itest/pom.xml
@@ -177,17 +177,11 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- some TX tests using iBatis -->
+        <!-- some TX tests using H2 -->
         <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>${derby-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbytools</artifactId>
-            <version>${derby-version}</version>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -400,9 +394,6 @@
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <systemPropertyVariables>
-                                <derby.stream.error.file>target/derby.log</derby.stream.error.file>
-                            </systemPropertyVariables>
                             <excludes>
                                 <!-- exclude doc tests as they dont work on CI server -->
                                 <exclude>**/*DocumentationTest.*</exclude>

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsXaTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsXaTest.java
@@ -16,20 +16,19 @@
  */
 package org.apache.camel.itest.sql;
 
-import java.sql.DriverManager;
+import java.sql.Connection;
 import java.sql.SQLException;
+
+import javax.sql.DataSource;
 
 import org.apache.camel.itest.utils.extensions.JmsServiceExtension;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.apache.camel.test.junit6.TestSupport.deleteDirectory;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JMS with JDBC idempotent consumer test using XA.
@@ -40,21 +39,23 @@ public class FromJmsToJdbcIdempotentConsumerToJmsXaTest extends FromJmsToJdbcIde
     @RegisterExtension
     public static JmsServiceExtension jmsServiceExtension = JmsServiceExtension.createExtension();
 
-    @BeforeEach
-    public void cleanupDirectories() {
-        deleteDirectory("target/testdb");
-    }
-
     @AfterEach
-    public void shutdownDatabase() {
-        // shutdown the embedded Derby database so that the next test becomes a clean initial state
+    public void shutdownDatabaseAndCleanup() {
+        // Drop all objects first to clear all data, then shutdown and delete files
         try {
-            DriverManager.getConnection("jdbc:derby:target/testdb;shutdown=true");
-            fail("Should have thrown exception");
+            DataSource dataSource = context.getRegistry().lookupByNameAndType(getDatasourceName(), DataSource.class);
+            try (Connection conn = dataSource.getConnection()) {
+                // Drop all tables and data
+                conn.createStatement().execute("DROP ALL OBJECTS");
+                // Then shutdown database to release file locks
+                conn.createStatement().execute("SHUTDOWN");
+            }
         } catch (SQLException e) {
-            // a successful shutdown always results in an SQLException to indicate that Derby has shut down and that there is no other exception.
-            assertEquals("Database 'target/testdb' shutdown.", e.getMessage());
+            // Ignore - database might already be closed or not exist yet
         }
+
+        // Delete the database files after shutdown
+        deleteDirectory("target/testdb");
     }
 
     @Override

--- a/tests/camel-itest/src/test/resources/logging.properties
+++ b/tests/camel-itest/src/test/resources/logging.properties
@@ -16,7 +16,7 @@
 ## ---------------------------------------------------------------------------
 
 ############################################################
-#  	Default Logging Configuration File
+# Default Logging Configuration File
 #
 # You can use a different file by specifying a filename
 # with the java.util.logging.config.file system property.
@@ -24,7 +24,7 @@
 ############################################################
 
 ############################################################
-#  	Global properties
+# Global properties
 ############################################################
 
 # "handlers" specifies a comma separated list of log Handler

--- a/tests/camel-itest/src/test/resources/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsTest.xml
+++ b/tests/camel-itest/src/test/resources/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsTest.xml
@@ -60,5 +60,5 @@
     </bean>
 
     <!-- datasource used to create the database tables -->
-    <jdbc:embedded-database id="myNonXADataSource" type="DERBY"/>
+    <jdbc:embedded-database id="myNonXADataSource" type="H2"/>
 </beans>

--- a/tests/camel-itest/src/test/resources/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsXaTest.xml
+++ b/tests/camel-itest/src/test/resources/org/apache/camel/itest/sql/FromJmsToJdbcIdempotentConsumerToJmsXaTest.xml
@@ -64,8 +64,8 @@
     </bean>
 
     <!-- XA datasource used to create the database tables -->
-    <bean id="myXADataSource" class="org.apache.derby.jdbc.EmbeddedXADataSource">
-        <property name="databaseName" value="target/testdb;create=true"/>
+    <bean id="myXADataSource" class="org.h2.jdbcx.JdbcDataSource">
+        <property name="url" value="jdbc:h2:file:./target/testdb"/>
         <property name="user" value="sa"/>
         <property name="password" value=""/>
     </bean>


### PR DESCRIPTION
Replace Apache Derby database with H2 in integration tests since Derby is now a retired Apache project.

Changes:
- Updated pom.xml to use H2 instead of Derby dependencies
- Changed embedded database type from DERBY to H2 in non-XA test config
- Replaced Derby EmbeddedXADataSource with H2 JdbcDataSource for XA tests
- Updated XA test cleanup to use H2's DROP ALL OBJECTS and SHUTDOWN commands
- Maintained file-based storage for proper XA transaction durability

All 10 tests (5 non-XA + 5 XA) pass successfully with H2.

Made with help from AI tools.