### PR TITLE
CAMEL-23719: camel-micrometer - when ProducerTemplate sends to a SEDA endpoint, Exchange.getFromRouteId() returns null

### DIFF
--- a/components/camel-micrometer/pom.xml
+++ b/components/camel-micrometer/pom.xml
@@ -78,6 +78,11 @@
             <artifactId>camel-test-spring-junit6</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifier.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifier.java
@@ -185,8 +185,7 @@ public class MicrometerExchangeEventNotifier extends AbstractMicrometerEventNoti
     protected void handleSentEvent(ExchangeSentEvent sentEvent) {
         String name = getNamingStrategy().getName(sentEvent.getExchange(), sentEvent.getEndpoint());
         Tags tags = getNamingStrategy().getTags(sentEvent, sentEvent.getEndpoint());
-        Timer timer = Timer.builder(name).tags(tags).description("Time taken to send message to the endpoint")
-                .register(getMeterRegistry());
+        Timer timer = getOrCreateTimer(name, tags, "Time taken to send message to the endpoint");
         timer.record(sentEvent.getTimeTaken(), TimeUnit.MILLISECONDS);
     }
 
@@ -201,9 +200,18 @@ public class MicrometerExchangeEventNotifier extends AbstractMicrometerEventNoti
         // Would have preferred LongTaskTimer, but you cannot set the FAILED_TAG once it is registered
         Timer.Sample sample = (Timer.Sample) doneEvent.getExchange().removeProperty("eventTimer:" + name);
         if (sample != null) {
-            sample.stop(getMeterRegistry().timer(name, tags));
+            Timer timer = getOrCreateTimer(name, tags, "Time taken for exchange processing");
+            sample.stop(timer);
         }
         setLastTimeExchange();
+    }
+
+    private Timer getOrCreateTimer(final String name, final Tags tags, final String description) {
+        Timer timer = getMeterRegistry().find(name).tags(tags).timer();
+        if (timer == null) {
+            timer = Timer.builder(name).tags(tags).description(description).register(getMeterRegistry());
+        }
+        return timer;
     }
 
     private void setLastTimeExchange() {

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierNamingStrategy.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierNamingStrategy.java
@@ -72,16 +72,13 @@ public interface MicrometerExchangeEventNotifierNamingStrategy {
                 uri = StringHelper.before(uri, "?", uri);
             }
         }
-        String routeId = event.getExchange().getFromRouteId();
-        if (routeId == null) {
-            routeId = "";
-        }
 
+        String routeId = event.getExchange().getFromRouteId();
         return Tags.of(
                 CAMEL_CONTEXT_TAG, event.getExchange().getContext().getName(),
                 KIND, KIND_EXCHANGE,
                 EVENT_TYPE_TAG, event.getClass().getSimpleName(),
-                ROUTE_ID_TAG, routeId,
+                ROUTE_ID_TAG, routeId != null ? routeId : "",
                 ENDPOINT_NAME, uri,
                 FAILED_TAG, Boolean.toString(event.getExchange().isFailed()));
     }

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierNamingStrategy.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierNamingStrategy.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.micrometer.eventnotifier;
 
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import io.micrometer.core.instrument.Meter;
@@ -24,7 +23,6 @@ import io.micrometer.core.instrument.Tags;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
-import org.apache.camel.Route;
 import org.apache.camel.spi.CamelEvent.ExchangeEvent;
 import org.apache.camel.util.StringHelper;
 
@@ -76,21 +74,9 @@ public interface MicrometerExchangeEventNotifierNamingStrategy {
         }
         String routeId = event.getExchange().getFromRouteId();
         if (routeId == null) {
-            final String finalUri = uri;
-            final Optional<Route> eventRoute = event.getExchange().getContext().getRoutes().stream()
-                    .filter(route -> finalUri.equals(route.getEndpoint().getEndpointBaseUri())).findFirst();
-
-            if (eventRoute.isEmpty()) {
-                return Tags.of(
-                        CAMEL_CONTEXT_TAG, event.getExchange().getContext().getName(),
-                        KIND, KIND_EXCHANGE,
-                        EVENT_TYPE_TAG, event.getClass().getSimpleName(),
-                        ENDPOINT_NAME, uri,
-                        FAILED_TAG, Boolean.toString(event.getExchange().isFailed()));
-            }
-
-            routeId = eventRoute.get().getId();
+            routeId = "";
         }
+
         return Tags.of(
                 CAMEL_CONTEXT_TAG, event.getExchange().getContext().getName(),
                 KIND, KIND_EXCHANGE,

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierNamingStrategy.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierNamingStrategy.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.micrometer.eventnotifier;
 
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import io.micrometer.core.instrument.Meter;
@@ -23,6 +24,7 @@ import io.micrometer.core.instrument.Tags;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
+import org.apache.camel.Route;
 import org.apache.camel.spi.CamelEvent.ExchangeEvent;
 import org.apache.camel.util.StringHelper;
 
@@ -73,22 +75,29 @@ public interface MicrometerExchangeEventNotifierNamingStrategy {
             }
         }
         String routeId = event.getExchange().getFromRouteId();
-        if (routeId != null) {
-            return Tags.of(
-                    CAMEL_CONTEXT_TAG, event.getExchange().getContext().getName(),
-                    KIND, KIND_EXCHANGE,
-                    EVENT_TYPE_TAG, event.getClass().getSimpleName(),
-                    ROUTE_ID_TAG, routeId,
-                    ENDPOINT_NAME, uri,
-                    FAILED_TAG, Boolean.toString(event.getExchange().isFailed()));
-        } else {
-            return Tags.of(
-                    CAMEL_CONTEXT_TAG, event.getExchange().getContext().getName(),
-                    KIND, KIND_EXCHANGE,
-                    EVENT_TYPE_TAG, event.getClass().getSimpleName(),
-                    ENDPOINT_NAME, uri,
-                    FAILED_TAG, Boolean.toString(event.getExchange().isFailed()));
+        if (routeId == null) {
+            final String finalUri = uri;
+            final Optional<Route> eventRoute = event.getExchange().getContext().getRoutes().stream()
+                    .filter(route -> finalUri.equals(route.getEndpoint().getEndpointBaseUri())).findFirst();
+
+            if (eventRoute.isEmpty()) {
+                return Tags.of(
+                        CAMEL_CONTEXT_TAG, event.getExchange().getContext().getName(),
+                        KIND, KIND_EXCHANGE,
+                        EVENT_TYPE_TAG, event.getClass().getSimpleName(),
+                        ENDPOINT_NAME, uri,
+                        FAILED_TAG, Boolean.toString(event.getExchange().isFailed()));
+            }
+
+            routeId = eventRoute.get().getId();
         }
+        return Tags.of(
+                CAMEL_CONTEXT_TAG, event.getExchange().getContext().getName(),
+                KIND, KIND_EXCHANGE,
+                EVENT_TYPE_TAG, event.getClass().getSimpleName(),
+                ROUTE_ID_TAG, routeId,
+                ENDPOINT_NAME, uri,
+                FAILED_TAG, Boolean.toString(event.getExchange().isFailed()));
     }
 
     default Tags getInflightExchangesTags(CamelContext camelContext, String routeId) {

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierNamingStrategyTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierNamingStrategyTest.java
@@ -16,12 +16,34 @@
  */
 package org.apache.camel.component.micrometer.eventnotifier;
 
+import java.util.List;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Route;
+import org.apache.camel.impl.event.ExchangeSentEvent;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.camel.component.micrometer.MicrometerConstants.CAMEL_CONTEXT_TAG;
+import static org.apache.camel.component.micrometer.MicrometerConstants.ENDPOINT_NAME;
+import static org.apache.camel.component.micrometer.MicrometerConstants.EVENT_TYPE_TAG;
+import static org.apache.camel.component.micrometer.MicrometerConstants.FAILED_TAG;
+import static org.apache.camel.component.micrometer.MicrometerConstants.KIND;
+import static org.apache.camel.component.micrometer.MicrometerConstants.KIND_EXCHANGE;
+import static org.apache.camel.component.micrometer.MicrometerConstants.ROUTE_ID_TAG;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class MicrometerExchangeEventNotifierNamingStrategyTest {
+
+    private static final String CONTEXT_NAME = "testContext";
+    private static final String ENDPOINT_URI = "seda://in";
+    private static final String ROUTE_ID = "someId";
 
     @Test
     void testDefaultFormatName() {
@@ -55,6 +77,85 @@ class MicrometerExchangeEventNotifierNamingStrategyTest {
         String result = strategy.getInflightExchangesName();
 
         assertEquals("CamelExchangesInflight", result);
+    }
+
+    @Test
+    void getTagsWhenRouteIdIsPresentShouldIncludeRouteIdTag() {
+        final var strategy = MicrometerExchangeEventNotifierNamingStrategy.DEFAULT;
+        final var exchange = mock(Exchange.class);
+        final var context = mock(CamelContext.class);
+        final var endpoint = mock(Endpoint.class);
+
+        when(exchange.getFromRouteId()).thenReturn("existingRoute");
+        when(exchange.getContext()).thenReturn(context);
+        when(exchange.isFailed()).thenReturn(false);
+        when(context.getName()).thenReturn(CONTEXT_NAME);
+        when(endpoint.toString()).thenReturn(ENDPOINT_URI);
+
+        final var event = new ExchangeSentEvent(exchange, endpoint, 10L);
+        final var tags = strategy.getTags(event, endpoint);
+
+        assertThat(tagValue(tags, ROUTE_ID_TAG)).isEqualTo("existingRoute");
+        assertThat(tagValue(tags, EVENT_TYPE_TAG)).isEqualTo("ExchangeSentEvent");
+    }
+
+    @Test
+    void getTagsWhenRouteIdIsNullAndRouteMatchesEndpointShouldResolveRouteIdTag() {
+        final var strategy = MicrometerExchangeEventNotifierNamingStrategy.DEFAULT;
+        final var exchange = mock(Exchange.class);
+        final var context = mock(CamelContext.class);
+        final var routeEndpoint = mock(Endpoint.class);
+        final var route = mock(Route.class);
+        final var endpoint = mock(Endpoint.class);
+
+        when(exchange.getFromRouteId()).thenReturn(null);
+        when(exchange.getContext()).thenReturn(context);
+        when(exchange.isFailed()).thenReturn(false);
+        when(context.getName()).thenReturn(CONTEXT_NAME);
+        when(context.getRoutes()).thenReturn(List.of(route));
+        when(route.getId()).thenReturn(ROUTE_ID);
+        when(route.getEndpoint()).thenReturn(routeEndpoint);
+        when(routeEndpoint.getEndpointBaseUri()).thenReturn(ENDPOINT_URI);
+        when(endpoint.toString()).thenReturn(ENDPOINT_URI + "?timeout=1000");
+
+        final var event = new ExchangeSentEvent(exchange, endpoint, 10L);
+        final var tags = strategy.getTags(event, endpoint);
+
+        assertThat(tagValue(tags, ROUTE_ID_TAG)).isEqualTo(ROUTE_ID);
+        assertThat(tagValue(tags, ENDPOINT_NAME)).isEqualTo(ENDPOINT_URI);
+    }
+
+    @Test
+    void getTagsWhenRouteIdIsNullAndNoRouteMatchesShouldOmitRouteIdTag() {
+        final var strategy = MicrometerExchangeEventNotifierNamingStrategy.DEFAULT;
+        final var exchange = mock(Exchange.class);
+        final var context = mock(CamelContext.class);
+        final var endpoint = mock(Endpoint.class);
+
+        when(exchange.getFromRouteId()).thenReturn(null);
+        when(exchange.getContext()).thenReturn(context);
+        when(exchange.isFailed()).thenReturn(true);
+        when(context.getName()).thenReturn(CONTEXT_NAME);
+        when(context.getRoutes()).thenReturn(List.of());
+        when(endpoint.toString()).thenReturn("mock://other");
+
+        final var event = new ExchangeSentEvent(exchange, endpoint, 10L);
+        final var tags = strategy.getTags(event, endpoint);
+
+        assertThat(tagValue(tags, ROUTE_ID_TAG)).isNull();
+        assertThat(tagValue(tags, CAMEL_CONTEXT_TAG)).isEqualTo(CONTEXT_NAME);
+        assertThat(tagValue(tags, KIND)).isEqualTo(KIND_EXCHANGE);
+        assertThat(tagValue(tags, EVENT_TYPE_TAG)).isEqualTo("ExchangeSentEvent");
+        assertThat(tagValue(tags, ENDPOINT_NAME)).isEqualTo("mock://other");
+        assertThat(tagValue(tags, FAILED_TAG)).isEqualTo("true");
+    }
+
+    private static String tagValue(final Tags tags, final String key) {
+        return tags.stream()
+                .filter(tag -> key.equals(tag.getKey()))
+                .map(Tag::getValue)
+                .findFirst()
+                .orElse(null);
     }
 
 }

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierNamingStrategyTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierNamingStrategyTest.java
@@ -16,14 +16,11 @@
  */
 package org.apache.camel.component.micrometer.eventnotifier;
 
-import java.util.List;
-
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
-import org.apache.camel.Route;
 import org.apache.camel.impl.event.ExchangeSentEvent;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +40,6 @@ class MicrometerExchangeEventNotifierNamingStrategyTest {
 
     private static final String CONTEXT_NAME = "testContext";
     private static final String ENDPOINT_URI = "seda://in";
-    private static final String ROUTE_ID = "someId";
 
     @Test
     void testDefaultFormatName() {
@@ -80,7 +76,7 @@ class MicrometerExchangeEventNotifierNamingStrategyTest {
     }
 
     @Test
-    void getTagsWhenRouteIdIsPresentShouldIncludeRouteIdTag() {
+    void getTagsWhenFromRouteIdIsNotNullShouldIncludeRouteIdTag() {
         final var strategy = MicrometerExchangeEventNotifierNamingStrategy.DEFAULT;
         final var exchange = mock(Exchange.class);
         final var context = mock(CamelContext.class);
@@ -100,33 +96,7 @@ class MicrometerExchangeEventNotifierNamingStrategyTest {
     }
 
     @Test
-    void getTagsWhenRouteIdIsNullAndRouteMatchesEndpointShouldResolveRouteIdTag() {
-        final var strategy = MicrometerExchangeEventNotifierNamingStrategy.DEFAULT;
-        final var exchange = mock(Exchange.class);
-        final var context = mock(CamelContext.class);
-        final var routeEndpoint = mock(Endpoint.class);
-        final var route = mock(Route.class);
-        final var endpoint = mock(Endpoint.class);
-
-        when(exchange.getFromRouteId()).thenReturn(null);
-        when(exchange.getContext()).thenReturn(context);
-        when(exchange.isFailed()).thenReturn(false);
-        when(context.getName()).thenReturn(CONTEXT_NAME);
-        when(context.getRoutes()).thenReturn(List.of(route));
-        when(route.getId()).thenReturn(ROUTE_ID);
-        when(route.getEndpoint()).thenReturn(routeEndpoint);
-        when(routeEndpoint.getEndpointBaseUri()).thenReturn(ENDPOINT_URI);
-        when(endpoint.toString()).thenReturn(ENDPOINT_URI + "?timeout=1000");
-
-        final var event = new ExchangeSentEvent(exchange, endpoint, 10L);
-        final var tags = strategy.getTags(event, endpoint);
-
-        assertThat(tagValue(tags, ROUTE_ID_TAG)).isEqualTo(ROUTE_ID);
-        assertThat(tagValue(tags, ENDPOINT_NAME)).isEqualTo(ENDPOINT_URI);
-    }
-
-    @Test
-    void getTagsWhenRouteIdIsNullAndNoRouteMatchesShouldOmitRouteIdTag() {
+    void getTagsWhenFromRouteIdIsNullShouldUseEmptyRouteIdTag() {
         final var strategy = MicrometerExchangeEventNotifierNamingStrategy.DEFAULT;
         final var exchange = mock(Exchange.class);
         final var context = mock(CamelContext.class);
@@ -136,13 +106,12 @@ class MicrometerExchangeEventNotifierNamingStrategyTest {
         when(exchange.getContext()).thenReturn(context);
         when(exchange.isFailed()).thenReturn(true);
         when(context.getName()).thenReturn(CONTEXT_NAME);
-        when(context.getRoutes()).thenReturn(List.of());
         when(endpoint.toString()).thenReturn("mock://other");
 
         final var event = new ExchangeSentEvent(exchange, endpoint, 10L);
         final var tags = strategy.getTags(event, endpoint);
 
-        assertThat(tagValue(tags, ROUTE_ID_TAG)).isNull();
+        assertThat(tagValue(tags, ROUTE_ID_TAG)).isEmpty();
         assertThat(tagValue(tags, CAMEL_CONTEXT_TAG)).isEqualTo(CONTEXT_NAME);
         assertThat(tagValue(tags, KIND)).isEqualTo(KIND_EXCHANGE);
         assertThat(tagValue(tags, EVENT_TYPE_TAG)).isEqualTo("ExchangeSentEvent");

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierProducerTemplateTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/eventnotifier/MicrometerExchangeEventNotifierProducerTemplateTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.micrometer.eventnotifier;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.instrument.util.HierarchicalNameMapper;
+import io.micrometer.jmx.JmxMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.micrometer.CamelJmxConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.component.micrometer.MicrometerConstants.DEFAULT_CAMEL_EXCHANGE_EVENT_METER_NAME;
+import static org.apache.camel.component.micrometer.MicrometerConstants.ROUTE_ID_TAG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MicrometerExchangeEventNotifierProducerTemplateTest extends AbstractMicrometerEventNotifierTest {
+
+    private PrometheusMeterRegistry prometheusRegistry;
+
+    private static final String DIRECT_TRIGGER = "direct:trigger";
+    private static final String SEDA_WORKER = "seda:worker";
+    private static final String MOCK_RESULT = "mock:result";
+    private static final String PRODUCER_ROUTE_ID = "producer-route";
+    private static final String WORKER_ROUTE_ID = "worker-route";
+
+    @Override
+    protected AbstractMicrometerEventNotifier<?> getEventNotifier() {
+        return new MicrometerExchangeEventNotifier();
+    }
+
+    @Override
+    public void addRegistry() {
+        meterRegistry = new CompositeMeterRegistry();
+        meterRegistry.add(new SimpleMeterRegistry());
+        prometheusRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        meterRegistry.add(prometheusRegistry);
+        meterRegistry.add(new JmxMeterRegistry(CamelJmxConfig.DEFAULT, Clock.SYSTEM, HierarchicalNameMapper.DEFAULT));
+    }
+
+    @Test
+    void notify_whenProducerTemplateAndRouteExchangesAreMixed_shouldRegisterTimersWithConsistentTagKeys() throws Exception {
+        final var mock = getMockEndpoint(MOCK_RESULT);
+        mock.expectedMessageCount(2);
+
+        template.sendBody(DIRECT_TRIGGER, "from-route");
+        template.sendBody(SEDA_WORKER, "from-producer-template");
+
+        mock.assertIsSatisfied();
+
+        final var exchangeEventTimers = meterRegistry.getMeters().stream()
+                .map(Meter::getId)
+                .filter(id -> DEFAULT_CAMEL_EXCHANGE_EVENT_METER_NAME.equals(id.getName()))
+                .toList();
+
+        final var tagKeySets = exchangeEventTimers.stream()
+                .map(id -> id.getTags().stream().map(Tag::getKey).sorted().toList())
+                .distinct()
+                .toList();
+
+        assertThat(exchangeEventTimers).isNotEmpty();
+        assertThat(tagKeySets).hasSize(1);
+        assertThat(exchangeEventTimers)
+                .allSatisfy(id -> assertThat(id.getTags().stream().map(Tag::getKey))
+                        .contains(ROUTE_ID_TAG));
+        assertThat(prometheusRegistry.scrape()).isNotBlank();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from(DIRECT_TRIGGER).routeId(PRODUCER_ROUTE_ID)
+                        .to(SEDA_WORKER);
+                from(SEDA_WORKER).routeId(WORKER_ROUTE_ID)
+                        .to(MOCK_RESULT);
+            }
+        };
+    }
+
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -18,6 +18,13 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 The library used for Camel Grok component has been migrated from no more maintained `io.krakens:java-grok` to its fork `io.github.whatap:java-grok`.
 It implies small differences listed https://github.com/whatap/java-grok#what-is-different-from-iokrakensjava-grok[here].
 
+=== camel-micrometer
+
+The `MicrometerExchangeEventNotifier` now always includes the `routeId` tag on exchange event metrics.
+When `fromRouteId` is not available (for example, on Exchanges created by `ProducerTemplate`), the tag value is an empty string instead of omitting the tag.
+This ensures Prometheus-compatible metric export when Route triggered and ProducerTemplate Exchanges are mixed.
+Dashboards or alerts that assumed the `routeId` label was absent must be updated to treat `routeId=""` accordingly.
+
 === camel-core
 
 ==== Simple language: internal builder classes reorganized


### PR DESCRIPTION
# Description

The goal of this PR is to ensure that the Prometheus Event Notification happens when a RouteId is configured in the destination Route of a message sent through a ProducerTemplate.

## Current Scenario

When a project is configured to use `quarkus-micrometer-registry-prometheus` and a message is sent to a `SEDA` endpoint through `ProducerTemplate`, the following warning appears in the logs:

```
2026-06-08 14:32:45,577 WARN  [org.apache.camel.support.EventHelper] (Camel (camel-6) thread #21 - seda://producer) Error notifying event C99DFEF70A95789-0000000000000001 exchange completed took: 3ms. This exception will be ignored.: java.lang.IllegalArgumentException: Prometheus requires that all meters with the same name have the same set of tag keys. There is already an existing meter named 'camel_exchange_event_notifier_seconds' containing tag keys [camelContext, endpointName, eventType, failed, kind]. The meter you are attempting to register has keys [camelContext, endpointName, eventType, failed, kind, routeId].
        at io.micrometer.prometheus.PrometheusMeterRegistry.lambda$throwExceptionOnRegistrationFailure$19(PrometheusMeterRegistry.java:619)
        at io.micrometer.core.instrument.MeterRegistry.meterRegistrationFailed(MeterRegistry.java:1291)
        at io.micrometer.prometheus.PrometheusMeterRegistry.lambda$applyToCollector$18(PrometheusMeterRegistry.java:593)
        at java.base/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1956)
        at io.micrometer.prometheus.PrometheusMeterRegistry.applyToCollector(PrometheusMeterRegistry.java:579)
        at io.micrometer.prometheus.PrometheusMeterRegistry.newTimer(PrometheusMeterRegistry.java:328)
        at io.micrometer.core.instrument.MeterRegistry.lambda$timer$6(MeterRegistry.java:379)
        at io.micrometer.core.instrument.MeterRegistry.getOrCreateMeter(MeterRegistry.java:725)
        at io.micrometer.core.instrument.MeterRegistry.registerMeterIfNecessary(MeterRegistry.java:652)
        at io.micrometer.core.instrument.MeterRegistry.timer(MeterRegistry.java:377)
        at io.micrometer.core.instrument.Timer$Builder.register(Timer.java:471)
        at io.micrometer.core.instrument.Timer$Builder.register(Timer.java:465)
        at io.micrometer.core.instrument.composite.CompositeTimer.registerNewMeter(CompositeTimer.java:205)
        at io.micrometer.core.instrument.composite.CompositeTimer.registerNewMeter(CompositeTimer.java:35)
        at io.micrometer.core.instrument.composite.AbstractCompositeMeter.add(AbstractCompositeMeter.java:67)
        at java.base/java.lang.Iterable.forEach(Iterable.java:75)
        at java.base/java.util.Collections$SetFromMap.forEach(Collections.java:6060)
        at io.micrometer.core.instrument.composite.CompositeMeterRegistry.lambda$new$0(CompositeMeterRegistry.java:67)
        at io.micrometer.core.instrument.composite.CompositeMeterRegistry.lock(CompositeMeterRegistry.java:189)
        at io.micrometer.core.instrument.composite.CompositeMeterRegistry.lambda$new$1(CompositeMeterRegistry.java:67)
        at io.micrometer.core.instrument.MeterRegistry.getOrCreateMeter(MeterRegistry.java:735)
        at io.micrometer.core.instrument.MeterRegistry.registerMeterIfNecessary(MeterRegistry.java:652)
        at io.micrometer.core.instrument.MeterRegistry.timer(MeterRegistry.java:377)
        at io.micrometer.core.instrument.MeterRegistry.timer(MeterRegistry.java:534)
        at org.apache.camel.component.micrometer.eventnotifier.MicrometerExchangeEventNotifier.handleDoneEvent(MicrometerExchangeEventNotifier.java:204)
        at org.apache.camel.component.micrometer.eventnotifier.MicrometerExchangeEventNotifier.notify(MicrometerExchangeEventNotifier.java:179)
        at org.apache.camel.support.EventHelper.doNotifyEvent(EventHelper.java:1575)
        at org.apache.camel.support.EventHelper.notifyExchangeDone(EventHelper.java:783)
        at org.apache.camel.impl.engine.DefaultUnitOfWork.done(DefaultUnitOfWork.java:280)
        at org.apache.camel.support.UnitOfWorkHelper.doneUow(UnitOfWorkHelper.java:53)
        at org.apache.camel.impl.engine.CamelInternalProcessor$UnitOfWorkProcessorAdvice.after(CamelInternalProcessor.java:1178)
        at org.apache.camel.impl.engine.CamelInternalProcessor$UnitOfWorkProcessorAdvice.after(CamelInternalProcessor.java:1115)
        at org.apache.camel.impl.engine.AdviceIterator.runAfterTask(AdviceIterator.java:45)
        at org.apache.camel.impl.engine.AdviceIterator.runAfterTasks(AdviceIterator.java:39)
        at org.apache.camel.impl.engine.CamelInternalProcessor$AsyncAfterTask.done(CamelInternalProcessor.java:263)
        at org.apache.camel.AsyncCallback.run(AsyncCallback.java:44)
        at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.doRun(DefaultReactiveExecutor.java:202)
        at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.executeReactiveWork(DefaultReactiveExecutor.java:192)
        at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.tryExecuteReactiveWork(DefaultReactiveExecutor.java:169)
        at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.schedule(DefaultReactiveExecutor.java:143)
        at org.apache.camel.impl.engine.DefaultReactiveExecutor.scheduleMain(DefaultReactiveExecutor.java:59)
        at org.apache.camel.processor.Pipeline.process(Pipeline.java:162)
        at org.apache.camel.impl.engine.CamelInternalProcessor.processNonTransacted(CamelInternalProcessor.java:385)
        at org.apache.camel.impl.engine.CamelInternalProcessor.process(CamelInternalProcessor.java:361)
        at org.apache.camel.component.seda.SedaConsumer.sendToConsumers(SedaConsumer.java:351)
        at org.apache.camel.component.seda.SedaConsumer.processPolledExchange(SedaConsumer.java:267)
        at org.apache.camel.component.seda.SedaConsumer.doRun(SedaConsumer.java:210)
        at org.apache.camel.component.seda.SedaConsumer.run(SedaConsumer.java:146)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base/java.lang.Thread.run(Thread.java:1474)
```

The issue seems to be caused by recent changes in the Micrometer framework, as reported in the Quarkus 3.35 Release Notes:
https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.35#micrometer-prometheus-registry


A reproducer can be found in [this repository](https://github.com/fernandobalieiro/camel-event-notifier-reproducer). The message will appear by either running the project in Quarkus dev mode and invoking http://localhost:8080/hello endpoint or by executing the `ProducerRouteIT` test.

1. Clone the repository:
```bash
git clone https://github.com/fernandobalieiro/camel-event-notifier-reproducer
```
2. Start the server:
```bash
./mvnw quarkus:dev
```
3. Invoke the endpoint:
```bash
curl http://localhost:8080/hello
```
Or execute the integration tests directly:

```bash
 ./mvnw verify -DskipITs=false
```

The warning message containing the stack trace should appear in the logs.

## Expected Scenario

The event should be properly registered and no warning message should be visible in the logs.

## Consideration

I'm aware that this is maybe not the best approach, as the solution requires iterating over all routes to retrieve the target routeId, so I'm open to suggestions.


# Target

- [X] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.