### PR TITLE
CAMEL-23630: Document camel-dapr 4.18.x consumer header change in 4.18 upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -950,6 +950,39 @@ must therefore carry the value in a non-`Camel`-prefixed application header and
 map it to the appropriate `CamelSolrField.*` / `CamelSolrParam.*` header in the
 route between the transport `from` and the `solr:` `to`.
 
+=== camel-dapr - potential breaking change
+
+The `dapr` component now ships a default `DaprHeaderFilterStrategy` (extending
+`DefaultHeaderFilterStrategy`) and exposes it via the standard `headerFilterStrategy`
+endpoint/component option, aligning the component with the rest of the Camel component
+catalog (`camel-iggy`, `camel-kafka`, `camel-jms`, ...). The strategy filters headers
+starting with `Camel` / `camel` (case-insensitive) in both directions.
+
+In addition, the `dapr-pubsub` consumer no longer copies the inbound CloudEvent's
+`pubsubName` and `topic` into the `CamelDaprPubSubName` (`DaprConstants.PUBSUB_NAME`)
+and `CamelDaprTopic` (`DaprConstants.TOPIC`) message headers. These two constants are
+producer-direction routing headers: they are read back on the producer side by
+`DaprConfigurationOptionsProxy` and take precedence over the endpoint-configured
+`pubSubName` / `topic`. Setting them on a consumed exchange caused a route such as
+
+[source,java]
+----
+from("dapr-pubsub:configured-pubsub:configured-topic")
+    .to("dapr-pubsub:configured-pubsub:another-topic");
+----
+
+to carry the inbound pubsubName / topic into the producer hop instead of using the
+configured destination. The remaining CloudEvent metadata headers (`CamelDaprID`,
+`CamelDaprSource`, `CamelDaprType`, `CamelDaprSpecificVersion`,
+`CamelDaprDataContentType`, `CamelDaprBinaryData`, `CamelDaprTime`,
+`CamelDaprTraceParent`, `CamelDaprTraceState`) are unchanged and are still set on the
+inbound exchange.
+
+Because a `dapr-pubsub` consumer subscribes to a single, fixed `pubSubName` / `topic`,
+the removed headers were redundant with the endpoint configuration. Routes that relied
+on reading `CamelDaprPubSubName` / `CamelDaprTopic` from a consumed exchange should read
+the configured destination from the endpoint URI instead.
+
 == Upgrading from 4.18.0 to 4.18.1
 
 === camel-bom


### PR DESCRIPTION
## Documentation sync: camel-dapr (CAMEL-23630) — 4.18 upgrade guide

Adds the `camel-dapr` upgrade note to `camel-4x-upgrade-guide-4_18.adoc` (under **Upgrading from 4.18.1 to 4.18.3**) on `main`.

Doc-sync follow-up to the 4.18.x backport (#23889) of #23886. Per the project's backport upgrade-guide policy, the version-specific upgrade guides on `main` are the canonical history across all release lines, so a change shipping in a 4.18.x patch must also be documented in the `4_18` guide on `main` — not only in the `4_21` guide (where #23886 already added it).

The note mirrors the `4_21` entry: the new `DaprHeaderFilterStrategy` / `headerFilterStrategy` option, and the removal of the producer-direction `CamelDaprPubSubName` / `CamelDaprTopic` headers from consumed `dapr-pubsub` exchanges.

> The matching `4_14` guide entry (for the 4.14.x backport #23905) is in a separate follow-up: #23907 (this PR had already merged when the 4.14.x backport was prepared).

- **Original PR:** #23886
- **4.18.x backport:** #23889
- **Docs-only change** — no code or build impact.

---

_Prepared by Claude Code on behalf of Andrea Cosentino_ · 🤖 Generated with [Claude Code](https://claude.com/claude-code)
