### PR TITLE
CAMEL-19540: camel-pulsar - replace Thread.sleep in tests

### DIFF
--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/integration/PulsarSharedSubscriptionMessageDistributionIT.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/integration/PulsarSharedSubscriptionMessageDistributionIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.pulsar.integration;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.Endpoint;
@@ -59,6 +60,8 @@ public class PulsarSharedSubscriptionMessageDistributionIT extends PulsarITSuppo
     @EndpointInject("mock:result2")
     private MockEndpoint to2;
 
+    private final CountDownLatch lateConsumerReceived = new CountDownLatch(1);
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -69,7 +72,13 @@ public class PulsarSharedSubscriptionMessageDistributionIT extends PulsarITSuppo
                     LOGGER.info("Processing message {} on Thread {}", exchange.getIn().getHeader("message_id"),
                             Thread.currentThread());
                     try {
-                        Thread.sleep(1000);
+                        // hold each exchange until the late-starting consumer (route 2) has received a
+                        // message, so route 1 cannot drain the topic before route 2 comes online;
+                        // the wait must stay well below the 10s ackTimeoutMillis default so a held
+                        // (unacknowledged) message cannot hit the ack-timeout and be redelivered
+                        if (!lateConsumerReceived.await(5, TimeUnit.SECONDS)) {
+                            LOGGER.warn("Timed out waiting for the late-starting consumer to receive a message");
+                        }
                     } catch (InterruptedException e) {
                         LOGGER.info("Propagating interrupt");
                         Thread.currentThread().interrupt();
@@ -111,6 +120,7 @@ public class PulsarSharedSubscriptionMessageDistributionIT extends PulsarITSuppo
 
         to1.expectedMinimumMessageCount(1);
         to2.expectedMinimumMessageCount(1);
+        to2.whenAnyExchangeReceived(exchange -> lateConsumerReceived.countDown());
 
         for (int i = 0; i < NUMBER_OF_MESSAGES; i++) {
             producer.send("Hello World!");

--- a/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/integration/PulsarSharedSubscriptionMessageDistributionIT.java
+++ b/components/camel-pulsar/src/test/java/org/apache/camel/component/pulsar/integration/PulsarSharedSubscriptionMessageDistributionIT.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.pulsar.integration;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.Endpoint;
@@ -31,9 +30,12 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.ClientBuilderImpl;
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.awaitility.Awaitility.await;
 
 public class PulsarSharedSubscriptionMessageDistributionIT extends PulsarITSupport {
 
@@ -60,8 +62,6 @@ public class PulsarSharedSubscriptionMessageDistributionIT extends PulsarITSuppo
     @EndpointInject("mock:result2")
     private MockEndpoint to2;
 
-    private final CountDownLatch lateConsumerReceived = new CountDownLatch(1);
-
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -76,12 +76,9 @@ public class PulsarSharedSubscriptionMessageDistributionIT extends PulsarITSuppo
                         // message, so route 1 cannot drain the topic before route 2 comes online;
                         // the wait must stay well below the 10s ackTimeoutMillis default so a held
                         // (unacknowledged) message cannot hit the ack-timeout and be redelivered
-                        if (!lateConsumerReceived.await(5, TimeUnit.SECONDS)) {
-                            LOGGER.warn("Timed out waiting for the late-starting consumer to receive a message");
-                        }
-                    } catch (InterruptedException e) {
-                        LOGGER.info("Propagating interrupt");
-                        Thread.currentThread().interrupt();
+                        await().atMost(5, TimeUnit.SECONDS).until(() -> to2.getReceivedCounter() > 0);
+                    } catch (ConditionTimeoutException e) {
+                        LOGGER.warn("Timed out waiting for the late-starting consumer to receive a message");
                     }
                 }
             };
@@ -120,7 +117,6 @@ public class PulsarSharedSubscriptionMessageDistributionIT extends PulsarITSuppo
 
         to1.expectedMinimumMessageCount(1);
         to2.expectedMinimumMessageCount(1);
-        to2.whenAnyExchangeReceived(exchange -> lateConsumerReceived.countDown());
 
         for (int i = 0; i < NUMBER_OF_MESSAGES; i++) {
             producer.send("Hello World!");


### PR DESCRIPTION
# Description

Replaces the only `Thread.sleep` in the camel-pulsar test tree with deterministic synchronization (CAMEL-19540).

`PulsarSharedSubscriptionMessageDistributionIT` used a fixed `Thread.sleep(1000)` inside the shared route `Processor` as a pacing delay: it slowed route 1 down so the late-started route 2 could join the Shared subscription while messages were still pending. A fixed sleep is timing-dependent — too short on loaded CI machines (flaky failures), wasted time on fast ones.

The sleep is replaced with a bounded Awaitility wait inside the processor (as suggested in review — thanks @oscerd):

```java
await().atMost(5, TimeUnit.SECONDS).until(() -> to2.getReceivedCounter() > 0);
```

- Route 1's processing threads hold each exchange until the late-starting consumer (route 2) has demonstrably received a message, so route 1 cannot drain the topic before route 2 comes online. Once route 2 receives its first message, everything proceeds immediately — no fixed delay left.
- Route 2 cannot block itself: its exchanges reach the `mock:result2` endpoint (incrementing the received counter) before the route advances to the polling processor, so the condition is already true.
- The 5s bound is deliberately well below the consumer's default `ackTimeoutMillis` (10s), so a held (unacknowledged) message cannot hit ack-timeout redelivery mid-test. The old 1s sleep was likewise safely below that boundary.
- On timeout the processor logs a warning and lets the exchange complete; the existing `MockEndpoint.assertIsSatisfied(10, TimeUnit.SECONDS, ...)` assertions remain the failure gate.

Mechanically: with `consumerQueueSize=1` and `numberOfConsumerThreads=2`, route 1 pins at most ~2 unacked in-flight messages while waiting, so most of the 10 produced messages remain at the broker for route 2 — the hand-off the sleep previously approximated by timing.

# Testing

- `./mvnw install -Psourcecheck -pl components/camel-pulsar` — BUILD SUCCESS; 23/23 unit tests pass; formatter/impsort source checks pass.
- `grep -rn "Thread.sleep" components/camel-pulsar/src/test` — no hits remain.
- The changed test is a Testcontainers-based IT; it could not be executed in the local dev environment (no Docker daemon, and camel-pulsar sets `skipITs.aarch64=true` so Pulsar ITs are skipped on arm64 hosts by design). CI on amd64 exercises it.

_Claude Code on behalf of Anvith SG_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
