### PR TITLE
CAMEL-23194: Fix JMS shutdown deadlock that hangs CI builds

### DIFF
--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/reply/QueueReplyManager.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/reply/QueueReplyManager.java
@@ -18,6 +18,8 @@ package org.apache.camel.component.jms.reply;
 
 import java.math.BigInteger;
 import java.util.Random;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
@@ -98,7 +100,13 @@ public class QueueReplyManager extends ReplyManagerSupport {
 
     private final class DestinationResolverDelegate implements DestinationResolver {
         private final DestinationResolver delegate;
-        private Destination destination;
+        // Use a dedicated lock instead of BaseService.lock to avoid deadlock
+        // during shutdown: BaseService.stop() holds its lock while calling
+        // doStop() -> listenerContainer.destroy() -> doShutdown() which waits
+        // for listener threads to finish. If a listener thread needs to resolve
+        // the destination, it would deadlock trying to acquire BaseService.lock.
+        private final Lock destinationLock = new ReentrantLock();
+        private volatile Destination destination;
 
         DestinationResolverDelegate(DestinationResolver delegate) {
             this.delegate = delegate;
@@ -109,7 +117,12 @@ public class QueueReplyManager extends ReplyManagerSupport {
                 Session session, String destinationName,
                 boolean pubSubDomain)
                 throws JMSException {
-            QueueReplyManager.this.lock.lock();
+            // fast path: destination already resolved
+            Destination answer = destination;
+            if (answer != null) {
+                return answer;
+            }
+            destinationLock.lock();
             try {
                 // resolve the reply to destination
                 if (destination == null) {
@@ -117,7 +130,7 @@ public class QueueReplyManager extends ReplyManagerSupport {
                     setReplyTo(destination);
                 }
             } finally {
-                QueueReplyManager.this.lock.unlock();
+                destinationLock.unlock();
             }
             return destination;
         }

--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/reply/QueueReplyManager.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/reply/QueueReplyManager.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.component.sjms.reply;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
@@ -65,7 +68,10 @@ public class QueueReplyManager extends ReplyManagerSupport {
 
     private final class DestinationResolverDelegate implements DestinationCreationStrategy {
         private final DestinationCreationStrategy delegate;
-        private Destination destination;
+        // Use a dedicated lock instead of BaseService.lock to avoid deadlock
+        // during shutdown (same issue as CAMEL-23194 in camel-jms)
+        private final Lock destinationLock = new ReentrantLock();
+        private volatile Destination destination;
 
         DestinationResolverDelegate(DestinationCreationStrategy delegate) {
             this.delegate = delegate;
@@ -73,7 +79,12 @@ public class QueueReplyManager extends ReplyManagerSupport {
 
         @Override
         public Destination createDestination(Session session, String destinationName, boolean topic) throws JMSException {
-            QueueReplyManager.this.lock.lock();
+            // fast path: destination already resolved
+            Destination answer = destination;
+            if (answer != null) {
+                return answer;
+            }
+            destinationLock.lock();
             try {
                 // resolve the reply to destination
                 if (destination == null) {
@@ -81,7 +92,7 @@ public class QueueReplyManager extends ReplyManagerSupport {
                     setReplyTo(destination);
                 }
             } finally {
-                QueueReplyManager.this.lock.unlock();
+                destinationLock.unlock();
             }
             return destination;
         }


### PR DESCRIPTION
Root cause: deadlock between BaseService.lock and Spring's lifecycleMonitor during CamelContext shutdown in afterAll.

Thread 1 (afterAll -> context.stop()):
  AbstractCamelContext.doStop()
    -> JmsProducer.doStop()
      -> ReplyManagerSupport.doStop()
        -> DefaultMessageListenerContainer.doShutdown()
          -> Object.wait() <- blocked, waiting for listener thread

Thread 2 (QueueReplyManager listener):
  DestinationResolverDelegate.resolveDestinationName()
    -> BaseService.lock <- blocked, held by Thread 1

Introduced by CAMEL-20199 (Oct 2024) which migrated synchronized blocks to ReentrantLock. Before: BaseService.stop() used synchronized(lock) on a private Object, while the inner class used synchronized(QueueReplyManager.this) on the instance monitor — two independent locks. After: both became QueueReplyManager.this.lock (the same inherited ReentrantLock), creating the circular wait.

Fix: DestinationResolverDelegate now uses a dedicated ReentrantLock instead of BaseService.lock, restoring the original two-lock design. Added volatile + fast-path for the destination field.

Applied to both camel-jms and camel-sjms which share the same pattern via their respective QueueReplyManager classes.

# Description

currently most if the 4.18.x builds ends up stucked until timeout, see [CAMEL-23710](https://issues.apache.org/jira/browse/CAMEL-23710)

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

