### PR TITLE
CAMEL-23630: Document camel-dapr 4.14.x consumer header change in 4.14 upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -859,6 +859,39 @@ must therefore carry the value in a non-`Camel`-prefixed application header and
 map it to the appropriate `CamelSolrField.*` / `CamelSolrParam.*` header in the
 route between the transport `from` and the `solr:` `to`.
 
+=== camel-dapr - potential breaking change
+
+The `dapr` component now ships a default `DaprHeaderFilterStrategy` (extending
+`DefaultHeaderFilterStrategy`) and exposes it via the standard `headerFilterStrategy`
+endpoint/component option, aligning the component with the rest of the Camel component
+catalog (`camel-iggy`, `camel-kafka`, `camel-jms`, ...). The strategy filters headers
+starting with `Camel` / `camel` (case-insensitive) in both directions.
+
+In addition, the `dapr-pubsub` consumer no longer copies the inbound CloudEvent's
+`pubsubName` and `topic` into the `CamelDaprPubSubName` (`DaprConstants.PUBSUB_NAME`)
+and `CamelDaprTopic` (`DaprConstants.TOPIC`) message headers. These two constants are
+producer-direction routing headers: they are read back on the producer side by
+`DaprConfigurationOptionsProxy` and take precedence over the endpoint-configured
+`pubSubName` / `topic`. Setting them on a consumed exchange caused a route such as
+
+[source,java]
+----
+from("dapr-pubsub:configured-pubsub:configured-topic")
+    .to("dapr-pubsub:configured-pubsub:another-topic");
+----
+
+to carry the inbound pubsubName / topic into the producer hop instead of using the
+configured destination. The remaining CloudEvent metadata headers (`CamelDaprID`,
+`CamelDaprSource`, `CamelDaprType`, `CamelDaprSpecificVersion`,
+`CamelDaprDataContentType`, `CamelDaprBinaryData`, `CamelDaprTime`,
+`CamelDaprTraceParent`, `CamelDaprTraceState`) are unchanged and are still set on the
+inbound exchange.
+
+Because a `dapr-pubsub` consumer subscribes to a single, fixed `pubSubName` / `topic`,
+the removed headers were redundant with the endpoint configuration. Routes that relied
+on reading `CamelDaprPubSubName` / `CamelDaprTopic` from a consumed exchange should read
+the configured destination from the endpoint URI instead.
+
 == Upgrading from 4.14.2 to 4.14.3
 
 === camel-tika


### PR DESCRIPTION
## Documentation sync: camel-dapr (CAMEL-23630) — 4.14 upgrade guide

Adds the `camel-dapr` upgrade note to `camel-4x-upgrade-guide-4_14.adoc` (under **Upgrading from 4.14.3 to 4.14.8**) on `main`.

Follow-up to the 4.14.x backport (#23905) of #23886. Per the project's backport upgrade-guide policy, the version-specific upgrade guides on `main` are the canonical history across all release lines, so a change shipping in a 4.14.x patch must also be documented in the `4_14` guide on `main`.

This is the 4.14 counterpart to the `4_18` entry (#23891, merged) and the `4_21` entry (#23886). The note mirrors them: the new `DaprHeaderFilterStrategy` / `headerFilterStrategy` option, and the removal of the producer-direction `CamelDaprPubSubName` / `CamelDaprTopic` headers from consumed `dapr-pubsub` exchanges.

- **Original PR:** #23886 (4.21.0)
- **4.14.x backport:** #23905 (4.14.8)
- **Docs-only change** — no code or build impact.

---

_Prepared by Claude Code on behalf of Andrea Cosentino_ · 🤖 Generated with [Claude Code](https://claude.com/claude-code)
