### PR TITLE
CAMEL-23481: Replace retired Apache Derby in Camel

### DIFF
--- a/components/camel-file/src/main/docs/file-component.adoc
+++ b/components/camel-file/src/main/docs/file-component.adoc
@@ -617,8 +617,8 @@ need to use the class
   <class>org.apache.camel.processor.idempotent.jpa.MessageProcessed</class>
 
   <properties>
-    <property name="openjpa.ConnectionURL" value="jdbc:derby:target/idempotentTest;create=true"/>
-    <property name="openjpa.ConnectionDriverName" value="org.apache.derby.jdbc.EmbeddedDriver"/>
+    <property name="openjpa.ConnectionURL" value="jdbc:h2:./target/idempotentTest"/>
+    <property name="openjpa.ConnectionDriverName" value="org.h2.Driver"/>
     <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema"/>
     <property name="openjpa.Log" value="DefaultLevel=WARN, Tool=INFO"/>
     <property name="openjpa.Multithreaded" value="true"/>

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/transactional-client.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/transactional-client.adoc
@@ -297,7 +297,7 @@ Spring XML::
 [source,xml]
 ----
 <!-- this example uses JDBC so we define a data source -->
-<jdbc:embedded-database id="dataSource" type="DERBY">
+<jdbc:embedded-database id="dataSource" type="H2">
     <jdbc:script location="classpath:sql/init.sql" />
 </jdbc:embedded-database>
 

--- a/dsl/camel-kamelet-main/src/main/resources/camel-main-known-dependencies.properties
+++ b/dsl/camel-kamelet-main/src/main/resources/camel-main-known-dependencies.properties
@@ -26,7 +26,6 @@ org.springframework.jdbc.datasource.SimpleDriverDataSource = camel:sql
 spring.datasource.url = org.springframework.boot:spring-boot-starter-jdbc:${spring-boot-version}
 
 quarkus.datasource.db-kind\=db2 = io.quarkus:quarkus-jdbc-db2:${quarkus-version}
-quarkus.datasource.db-kind\=derby = io.quarkus:quarkus-jdbc-derby:${quarkus-version}
 quarkus.datasource.db-kind\=h2 = io.quarkus:quarkus-jdbc-h2:${quarkus-version}
 quarkus.datasource.db-kind\=mariadb = io.quarkus:quarkus-jdbc-mariadb:${quarkus-version}
 quarkus.datasource.db-kind\=mssql = io.quarkus:quarkus-jdbc-mssql:${quarkus-version}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -138,7 +138,6 @@
         <datasonnet-mapper-version>3.0.1.3</datasonnet-mapper-version>
         <debezium-version>3.5.2.Final</debezium-version>
         <debezium-mysql-connector-version>9.7.0</debezium-mysql-connector-version>
-        <derby-version>10.16.1.1</derby-version>
         <dhis2-version>3.0.2</dhis2-version>
         <digitalocean-api-client-version>2.17</digitalocean-api-client-version>
         <directory-watcher-version>0.19.1</directory-watcher-version>
@@ -4325,7 +4324,6 @@
                             <systemPropertyVariables>
                                 <javax.xml.accessExternalSchema>file,http,https</javax.xml.accessExternalSchema>
                                 <javax.xml.accessExternalDTD>file,http</javax.xml.accessExternalDTD>
-                                <derby.stream.error.file>target/derby.log</derby.stream.error.file>
                                 <java.awt.headless>${java.awt.headless}</java.awt.headless>
                                 <java.util.logging.config.file>${basedir}/target/test-classes/logging.properties
                                 </java.util.logging.config.file>

--- a/tests/camel-streamcaching-test/pom.xml
+++ b/tests/camel-streamcaching-test/pom.xml
@@ -62,9 +62,6 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <systemPropertyVariables>
-                        <derby.stream.error.file>target/derby.log</derby.stream.error.file>
-                    </systemPropertyVariables>
                     <!-- run with low memory to test stream caching should avoid OOME -->
                     <argLine>-XX:MaxDirectMemorySize=512k</argLine>
                 </configuration>


### PR DESCRIPTION
Final cleanup of references to Derby that are no longer needed.
- Updating some component doc to use H2 instead of Derby in
  - `components/camel-file/src/main/docs/file-component.adoc`
  - `core/camel-core-engine/src/main/docs/modules/eips/pages/transactional-client.adoc`
- Removing `<derby-version>` from `parent/pom.xml` as no module needs it any longer
- Removing Derby from `camel-main-known-dependencies.properties`

Made with help from AI tools.
