### PR TITLE
camel-jbang - Show 'Camel' instead of 'PicocliCommandRegistry' in shell completions

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Shell.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Shell.java
@@ -57,7 +57,13 @@ public class Shell extends CamelCommand {
 
     @Override
     public Integer doCall() throws Exception {
-        PicocliCommandRegistry registry = new PicocliCommandRegistry(CamelJBangMain.getCommandLine());
+        // TODO: replace with new PicocliCommandRegistry(commandLine, "Camel") when JLine merges #1947
+        PicocliCommandRegistry registry = new PicocliCommandRegistry(CamelJBangMain.getCommandLine()) {
+            @Override
+            public String name() {
+                return "Camel";
+            }
+        };
 
         String homeDir = HomeHelper.resolveHomeDir();
         Path history = Paths.get(homeDir, ".camel-jbang-history");

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanel.java
@@ -283,7 +283,13 @@ class ShellPanel {
 
     private void runShell(LineDisciplineTerminal terminal) {
         try {
-            PicocliCommandRegistry registry = new PicocliCommandRegistry(CamelJBangMain.getCommandLine());
+            // TODO: replace with new PicocliCommandRegistry(commandLine, "Camel") when JLine merges #1947
+            PicocliCommandRegistry registry = new PicocliCommandRegistry(CamelJBangMain.getCommandLine()) {
+                @Override
+                public String name() {
+                    return "Camel";
+                }
+            };
             String camelVersion = VersionHelper.extractCamelVersion();
 
             // Redirect command output (printer()) through the virtual terminal


### PR DESCRIPTION
## Summary

The shell completion group header shows **"PicocliCommandRegistry"** which is the JLine class name. Override `name()` to return **"Camel"** instead.

Applied to both `Shell.java` (standalone `camel shell`) and `ShellPanel.java` (TUI embedded shell).

A JLine PR ([jline/jline3#1947](https://github.com/jline/jline3/pull/1947)) adds a constructor parameter for this. Once merged and released, the override can be replaced with `new PicocliCommandRegistry(commandLine, "Camel")`.

_Claude Code on behalf of Guillaume Nodet_