### PR TITLE
23317 stabilize flaky mail tests

### DIFF
--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailProducerUnsupportedCharsetTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailProducerUnsupportedCharsetTest.java
@@ -53,7 +53,7 @@ public class MailProducerUnsupportedCharsetTest extends CamelTestSupport {
         context.start();
 
         MockEndpoint mock = getMockEndpoint("mock:result");
-        mock.expectedBodiesReceived("Hello World\r\n", "Bye World\r\n");
+        mock.expectedBodiesReceivedInAnyOrder("Hello World\r\n", "Bye World\r\n");
         mock.allMessages().header("Content-Type").isEqualTo("text/plain");
 
         Map<String, Object> headers = new HashMap<>();

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/RawMailMessageTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/RawMailMessageTest.java
@@ -170,9 +170,9 @@ public class RawMailMessageTest extends CamelTestSupport {
         folder.close(true);
 
         await()
-            .atMost(500, TimeUnit.MILLISECONDS)
-            .alias("Await that the sent mail is ready in the Mailbox before starting the Camel route")
-            .untilAsserted(() -> assertEquals(1, user.getInbox().getNewMessageCount()));
+                .atMost(500, TimeUnit.MILLISECONDS)
+                .alias("Await that the sent mail is ready in the Mailbox before starting the Camel route")
+                .untilAsserted(() -> assertEquals(1, user.getInbox().getNewMessageCount()));
     }
 
     @Override

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/RawMailMessageTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/RawMailMessageTest.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.mail.Folder;
 import jakarta.mail.Message;
@@ -34,6 +35,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -166,6 +168,11 @@ public class RawMailMessageTest extends CamelTestSupport {
         // insert one signed message
         folder.appendMessages(messages);
         folder.close(true);
+
+        await()
+            .atMost(500, TimeUnit.MILLISECONDS)
+            .alias("Await that the sent mail is ready in the Mailbox before starting the Camel route")
+            .untilAsserted(() -> assertEquals(1, user.getInbox().getNewMessageCount()));
     }
 
     @Override


### PR DESCRIPTION
# Description

for RawMailMessageTest:
suspecting that the route can be started before the Mailbox is fully
ready. Thus adding an await to ensure the mail arrived. Note that
several other mail tests are using relatively similar strategy, even if
it is when Camel is sending the mail and not created through the java
API directly.

for MailProducerUnsupportedCharsetTest
there is no sync between the 2 started routes, so the route can finished
in a different order than they were started.

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

