### PR TITLE
CAMEL-23727: camel-jbang - Add mouse scroll support for TUI shell panel

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -59,6 +59,7 @@ import dev.tamboui.tui.event.Event;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.KeyModifiers;
+import dev.tamboui.tui.event.MouseEvent;
 import dev.tamboui.tui.event.PasteEvent;
 import dev.tamboui.tui.event.TickEvent;
 import dev.tamboui.widgets.Clear;
@@ -405,6 +406,11 @@ public class CamelMonitor extends CamelCommand {
                 return true;
             }
             if (handleTabKeys(ke)) {
+                return true;
+            }
+        }
+        if (event instanceof MouseEvent me) {
+            if (shellPanel.isOpen() && shellPanel.handleMouseEvent(me)) {
                 return true;
             }
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanel.java
@@ -35,6 +35,8 @@ import dev.tamboui.text.Span;
 import dev.tamboui.text.Text;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.MouseEvent;
+import dev.tamboui.tui.event.MouseEventKind;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.block.Title;
@@ -71,6 +73,7 @@ import org.jline.utils.AttributedStyle;
 class ShellPanel {
 
     private static final int[] SPLIT_PERCENTS = { 25, 50, 75 };
+    private static final int MOUSE_SCROLL_LINES = 3;
 
     private boolean visible;
     private int splitIndex = 1; // default 50%
@@ -84,6 +87,7 @@ class ShellPanel {
     private int lastHeight;
     private int scrollOffset;
     private int lastHistorySize;
+    private Rect lastArea;
     private volatile boolean shellExited;
 
     void setContext(MonitorContext ctx) {
@@ -160,6 +164,28 @@ class ShellPanel {
         return true;
     }
 
+    boolean handleMouseEvent(MouseEvent me) {
+        if (!visible || lastArea == null) {
+            return false;
+        }
+        int mx = me.x();
+        int my = me.y();
+        if (mx < lastArea.x() || mx >= lastArea.x() + lastArea.width()
+                || my < lastArea.y() || my >= lastArea.y() + lastArea.height()) {
+            return false;
+        }
+        if (me.kind() == MouseEventKind.SCROLL_UP) {
+            int histSize = screenTerminal != null ? getHistorySize(screenTerminal) : 0;
+            scrollOffset = Math.min(scrollOffset + MOUSE_SCROLL_LINES, histSize);
+            return true;
+        }
+        if (me.kind() == MouseEventKind.SCROLL_DOWN) {
+            scrollOffset = Math.max(0, scrollOffset - MOUSE_SCROLL_LINES);
+            return true;
+        }
+        return false;
+    }
+
     void render(Frame frame, Rect area) {
         if (!visible) {
             return;
@@ -169,6 +195,8 @@ class ShellPanel {
             close();
             return;
         }
+
+        lastArea = area;
 
         // Render border matching other tabs
         Block block = Block.builder()

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiBackendHelper.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiBackendHelper.java
@@ -35,10 +35,10 @@ final class TuiBackendHelper {
         if (activeTerminal != null) {
             Backend backend = createBackendForTerminal(activeTerminal);
             if (backend != null) {
-                return TuiRunner.create(TuiConfig.builder().backend(backend).build());
+                return TuiRunner.create(TuiConfig.builder().backend(backend).mouseCapture(true).build());
             }
         }
-        return TuiRunner.create();
+        return TuiRunner.create(TuiConfig.builder().mouseCapture(true).build());
     }
 
     private static Backend createBackendForTerminal(Terminal terminal) {


### PR DESCRIPTION
## Summary

Adds mouse wheel scroll support to the TUI shell panel, addressing point 3 of CAMEL-23727.

### Changes

- **TuiBackendHelper**: Enable `mouseCapture(true)` on the TUI backend so mouse events are captured instead of escaping to native terminal scrollback
- **ShellPanel**: Add `handleMouseEvent()` that scrolls the virtual terminal history by 3 lines per mouse wheel tick, with hit-testing against the panel area
- **CamelMonitor**: Wire mouse event dispatch to the shell panel

Mouse wheel up/down now scrolls through the shell panel history (same buffer used by Shift+PgUp/PgDn). Regular typing resets scroll to live view.

Fixes point 3 of https://issues.apache.org/jira/browse/CAMEL-23727