### PR TITLE
[backport camel-4.18.x] CAMEL-23730: Fix export dry-run failing with NoSuchBeanException for bean references

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Run.java
@@ -706,8 +706,7 @@ public class Run extends CamelCommand {
             }
             main.addInitialProperty(EXPORT, "true");
             // enable stub in silent mode so we do not use real components
-            //we need i.e. transformers to not be stubbed since https://github.com/apache/camel/pull/21931
-            main.setStubPattern("component:*");
+            main.setStubPattern("*");
             // do not run for very long in silent run
             main.addInitialProperty("camel.main.autoStartup", "false");
             main.addInitialProperty("camel.main.durationMaxSeconds", "-1");

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/KameletMain.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/KameletMain.java
@@ -518,8 +518,8 @@ public class KameletMain extends MainCommandLineSupport {
         infos.forEach(LOG::info);
 
         answer.getCamelContextExtension().setRegistry(registry);
-        if (silent || "*".equals(stubPattern)) {
-            registry.addBeanRepository(new StubBeanRepository(stubPattern));
+        if (silent || "*".equals(stubPattern) || "component:*".equals(stubPattern)) {
+            registry.addBeanRepository(new StubBeanRepository("*"));
         }
 
         // load camel component and custom health-checks

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DependencyDownloaderTransformerResolver.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DependencyDownloaderTransformerResolver.java
@@ -85,7 +85,12 @@ public final class DependencyDownloaderTransformerResolver extends DefaultTransf
             return true;
         }
 
-        boolean stubbed = PatternHelper.matchPatterns(name, stubPattern.split(","));
+        boolean stubbed = false;
+        for (String n : stubPattern.split(",")) {
+            if (n.startsWith("transformer:")) {
+                stubbed |= PatternHelper.matchPattern(name, n.substring(12));
+            }
+        }
         return !stubbed;
     }
 

--- a/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/StubBeanRepositoryTest.java
+++ b/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/StubBeanRepositoryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.main;
+
+import org.apache.camel.main.download.StubBeanRepository;
+import org.apache.camel.spi.AggregationRepository;
+import org.apache.camel.spi.IdempotentRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class StubBeanRepositoryTest {
+
+    @Test
+    public void testWildcardPatternStubsBeanReferences() {
+        StubBeanRepository repo = new StubBeanRepository("*");
+
+        assertNotNull(repo.lookupByNameAndType("myAggRepo", AggregationRepository.class));
+        assertNotNull(repo.lookupByNameAndType("myIdempotentRepo", IdempotentRepository.class));
+    }
+
+    @Test
+    public void testComponentPatternDoesNotStubBeanReferences() {
+        StubBeanRepository repo = new StubBeanRepository("component:*");
+
+        assertNull(repo.lookupByNameAndType("myAggRepo", AggregationRepository.class));
+        assertNull(repo.lookupByNameAndType("myIdempotentRepo", IdempotentRepository.class));
+    }
+}

--- a/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/DependencyDownloaderTransformerResolverTest.java
+++ b/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/DependencyDownloaderTransformerResolverTest.java
@@ -25,14 +25,16 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DependencyDownloaderTransformerResolverTest {
 
     @Test
     void stubTransformerShouldHaveNameSet() {
         SimpleCamelContext context = new SimpleCamelContext();
+        // transformers require "transformer:" prefix to be stubbed
         DependencyDownloaderTransformerResolver resolver
-                = new DependencyDownloaderTransformerResolver(context, "*", true);
+                = new DependencyDownloaderTransformerResolver(context, "transformer:*", true);
 
         // use a name not in the catalog to avoid triggering artifact download
         String transformerName = "test-stub:application-json";
@@ -45,6 +47,19 @@ public class DependencyDownloaderTransformerResolverTest {
 
         TransformerKey resultKey = TransformerKey.createFrom(transformer);
         assertNotNull(resultKey);
+    }
+
+    @Test
+    void wildcardPatternShouldNotStubTransformers() {
+        SimpleCamelContext context = new SimpleCamelContext();
+        // stub pattern "*" should NOT stub transformers (only components)
+        DependencyDownloaderTransformerResolver resolver
+                = new DependencyDownloaderTransformerResolver(context, "*", true);
+
+        // transformer is not stubbed so resolve will throw for unknown names
+        String transformerName = "test-stub:application-json";
+        TransformerKey key = new TransformerKey(transformerName);
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(key, context));
     }
 
     @Test


### PR DESCRIPTION
## Backport of #23920

Cherry-pick of #23920 onto `camel-4.18.x`.

**Original PR:** #23920 - CAMEL-23730: Fix export dry-run failing with NoSuchBeanException for bean references
**Original author:** @davsclaus
**Target branch:** `camel-4.18.x`

### Original description

Align DependencyDownloaderTransformerResolver with language and dataformat resolvers by requiring the `transformer:` prefix to stub transformers. This allows reverting Run.java back to `stubPattern("*")` for export dry-run, so StubBeanRepository is properly registered and bean references (aggregationRepository, idempotentRepository, etc.) are stubbed correctly.

**Backport note:** Adjusted StubBeanRepository import path (`o.a.c.main.download` on 4.18.x vs `o.a.c.main.stub` on main).

_Claude Code on behalf of Claus Ibsen_