### PR TITLE
CAMEL-23731: Upgrade to Spring Boot 3.5.15

### DIFF
--- a/components/camel-spring-parent/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/bean/CamelDirectSender.java
+++ b/components/camel-spring-parent/camel-spring-ws/src/main/java/org/apache/camel/component/spring/ws/bean/CamelDirectSender.java
@@ -42,9 +42,8 @@ public class CamelDirectSender implements WebServiceMessageSender {
     }
 
     @Override
-    public boolean supports(URI uri) {
+    public boolean supports(URI uri, UriSource uriSource) {
         try {
-            // Just check if it throws an exception on parsing the destination
             CamelDirectConnection.destination(uri);
             return true;
         } catch (URISyntaxException e) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -89,14 +89,14 @@
         <build-helper-maven-plugin-version>3.6.1</build-helper-maven-plugin-version>
         <bytebuddy-version>1.18.4</bytebuddy-version>
         <c3p0-version>0.12.0</c3p0-version>
-        <caffeine-version>3.2.3</caffeine-version>
+        <caffeine-version>3.2.4</caffeine-version>
         <californium-version>3.14.0</californium-version>
         <californium-scandium-version>3.11.0</californium-scandium-version>
         <!-- jbang edit command which uses embedded kamelets catalog -->
         <camel-lsp-version>1.34.0</camel-lsp-version>
         <camel-kamelets-catalog-version>4.17.0</camel-kamelets-catalog-version>
         <camunda-version>7.24.0</camunda-version>
-        <cassandra-driver-version>4.19.2</cassandra-driver-version>
+        <cassandra-driver-version>4.19.3</cassandra-driver-version>
         <jta-api-1.2-version>1.2</jta-api-1.2-version>
         <cglib-version>3.3.0</cglib-version>
         <!-- This is exclusively required in camel-aws-xray as the dependency is leaking a build time annotation
@@ -193,7 +193,7 @@
         <jakarta-jms-api-version>3.1.0</jakarta-jms-api-version>
         <jakarta-persistence-api-version>3.2.0</jakarta-persistence-api-version>
         <jakarta-json-api-version>2.1.3</jakarta-json-api-version>
-        <jakarta-json-bind-api-version>3.0.1</jakarta-json-bind-api-version>
+        <jakarta-json-bind-api-version>3.0.2</jakarta-json-bind-api-version>
         <jakarta-transaction-api-version>2.0.1</jakarta-transaction-api-version>
         <jakarta-jws-api-version>3.0.0</jakarta-jws-api-version>
         <jaxb-core-version>4.0.5</jaxb-core-version>
@@ -223,7 +223,7 @@
         <graphql-java-version>25.0</graphql-java-version>
         <greenmail-version>2.1.8</greenmail-version>
         <grizzly-websockets-version>2.4.4</grizzly-websockets-version>
-        <groovy-version>4.0.31</groovy-version>
+        <groovy-version>4.0.32</groovy-version>
         <grpc-version>1.79.0</grpc-version>
         <grpc-google-auth-library-version>1.41.0</grpc-google-auth-library-version>
         <grpc-java-jwt-version>4.5.0</grpc-java-jwt-version>
@@ -272,7 +272,7 @@
         <ivy-version>2.5.3</ivy-version>
         <jackson-databind-nullable-version>0.2.9</jackson-databind-nullable-version>
         <jackson-jq-version>1.6.0</jackson-jq-version>
-        <jackson2-version>2.21.2</jackson2-version>
+        <jackson2-version>2.21.4</jackson2-version>
         <jackson2-annotations-version>2.21</jackson2-annotations-version>
         <jackrabbit-version>2.22.3</jackrabbit-version>
         <jasminb-jsonapi-version>0.15</jasminb-jsonapi-version>
@@ -298,7 +298,7 @@
         <jakarta-xml-soap-api-version>3.0.2</jakarta-xml-soap-api-version>
         <jakarta-xml-ws-api-version>4.0.2</jakarta-xml-ws-api-version>
         <glassfish-javax-json>1.1.4</glassfish-javax-json>
-        <glassfish-jaxb-runtime-version>4.0.6</glassfish-jaxb-runtime-version>
+        <glassfish-jaxb-runtime-version>4.0.9</glassfish-jaxb-runtime-version>
         <jaxb2-maven-plugin-version>4.1.0</jaxb2-maven-plugin-version>
         <jaxp-ri-version>1.4.5</jaxp-ri-version>
         <jboss-el-api_3.0_spec-version>2.0.0.Final</jboss-el-api_3.0_spec-version>
@@ -328,7 +328,7 @@
         <jolt-version>0.1.8</jolt-version>
         <jool-version>0.9.15</jool-version>
         <!-- jooq 3.20 is Java 21+ only so we need to be 3.19.x -->
-        <jooq-version>3.19.32</jooq-version>
+        <jooq-version>3.19.35</jooq-version>
         <joor-version>0.9.15</joor-version>
         <jose4j-version>0.9.3</jose4j-version>
         <johnzon-version>2.0.2</johnzon-version>
@@ -369,7 +369,7 @@
         <!-- virtual dependency only used by Eclipse m2e -->
         <lifecycle-mapping-version>1.0.0</lifecycle-mapping-version>
         <log4j2-version>2.25.4</log4j2-version>
-        <logback-version>1.5.32</logback-version>
+        <logback-version>1.5.34</logback-version>
         <lucene-version>9.12.3</lucene-version>
         <lightcouch-version>0.2.0</lightcouch-version>
         <littleproxy-version>2.6.0</littleproxy-version>
@@ -401,8 +401,8 @@
         <maven-wagon-version>3.5.2</maven-wagon-version>
         <maven-war-plugin-version>3.5.1</maven-war-plugin-version>
         <metrics-version>4.2.38</metrics-version>
-        <micrometer-version>1.15.11</micrometer-version>
-        <micrometer-tracing-version>1.5.11</micrometer-tracing-version>
+        <micrometer-version>1.15.12</micrometer-version>
+        <micrometer-tracing-version>1.5.12</micrometer-tracing-version>
         <microprofile-config-version>3.1</microprofile-config-version>
         <milo-version>1.1.1</milo-version>
         <milvus-client-version>2.6.14</milvus-client-version>
@@ -422,7 +422,7 @@
         <narayana-version>5.13.1.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
         <neo4j-version>6.0.2</neo4j-version>
-        <netty-version>4.1.132.Final</netty-version>
+        <netty-version>4.1.135.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.5.9</networknt-json-schema-validator-version>
         <nimbus-jose-jwt>10.7</nimbus-jose-jwt>
@@ -494,7 +494,7 @@
         <sisu-maven-plugin-version>1.0.0</sisu-maven-plugin-version>
         <slack-api-model-version>1.47.0</slack-api-model-version>
         <slf4j-api-version>2.0.17</slf4j-api-version>
-        <slf4j-version>2.0.17</slf4j-version>
+        <slf4j-version>2.0.18</slf4j-version>
         <smack-version>4.3.5</smack-version>
         <smallrye-config-version>3.16.0</smallrye-config-version>
         <smallrye-health-version>4.3.0</smallrye-health-version>
@@ -510,15 +510,15 @@
         <spock-version>2.4-groovy-4.0</spock-version>
         <spring-ai-version>1.1.2</spring-ai-version>
         <spring-cloud-config-version>4.3.0</spring-cloud-config-version>
-        <spring-batch-version>5.2.5</spring-batch-version>
-        <spring-boot-version>3.5.14</spring-boot-version>
-        <spring-data-redis-version>3.5.5</spring-data-redis-version>
-        <spring-ldap-version>3.3.7</spring-ldap-version>
+        <spring-batch-version>5.2.6</spring-batch-version>
+        <spring-boot-version>3.5.15</spring-boot-version>
+        <spring-data-redis-version>3.5.12</spring-data-redis-version>
+        <spring-ldap-version>3.3.8</spring-ldap-version>
         <spring-vault-core-version>3.2.0</spring-vault-core-version>
-        <spring-version>6.2.17</spring-version>
+        <spring-version>6.2.19</spring-version>
         <spring-rabbitmq-version>3.2.9</spring-rabbitmq-version>
-        <spring-security-version>6.5.10</spring-security-version>
-        <spring-ws-version>4.1.3</spring-ws-version>
+        <spring-security-version>6.5.11</spring-security-version>
+        <spring-ws-version>4.1.4</spring-ws-version>
         <sql-maven-plugin-version>3.0.0</sql-maven-plugin-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>
         <squareup-okhttp5-version>5.3.2</squareup-okhttp5-version>


### PR DESCRIPTION
## Summary

Upgrade to Spring Boot 3.5.15 and align dependency versions managed in `parent/pom.xml`:

- spring-boot 3.5.14 → 3.5.15
- spring-framework 6.2.17 → 6.2.19
- spring-security 6.5.10 → 6.5.11
- spring-batch 5.2.5 → 5.2.6
- spring-data-redis 3.5.5 → 3.5.12
- spring-ldap 3.3.7 → 3.3.8
- spring-ws 4.1.3 → 4.1.4
- jackson 2.21.2 → 2.21.4
- netty 4.1.132.Final → 4.1.135.Final
- slf4j 2.0.17 → 2.0.18
- logback 1.5.32 → 1.5.34
- groovy 4.0.31 → 4.0.32
- caffeine 3.2.3 → 3.2.4
- micrometer 1.15.11 → 1.15.12
- micrometer-tracing 1.5.11 → 1.5.12
- glassfish-jaxb-runtime 4.0.6 → 4.0.9
- jakarta-json-bind-api 3.0.1 → 3.0.2
- cassandra-driver 4.19.2 → 4.19.3
- jooq 3.19.32 → 3.19.35

Also fixes `CamelDirectSender` compilation: Spring WS 4.1.4 added a new `supports(URI, UriSource)` method to the `WebServiceMessageSender` interface.