### PR TITLE
ci: restore camel-jbang xref links on camel-4.18.x

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-upgrade-recipes-tool.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-upgrade-recipes-tool.adoc
@@ -20,7 +20,7 @@ To upgrade to the latest version of Camel, you can either execute the following 
 $ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.apache.camel.upgrade:camel-upgrade-recipes:LATEST -Drewrite.activeRecipes=org.apache.camel.upgrade.CamelMigrationRecipe
 ----
 
-or use the Camel CLI xref:camel-jbang-projects.adoc#_automated_updates_openrewrite[update] action:
+or use camel-jbang xref:camel-jbang.adoc#_update[update] action:
 
 [source,bas]
 ----

--- a/dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc
+++ b/dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc
@@ -111,7 +111,7 @@ Here's an example `camel.xml` file, which defines both the routes and beans used
 
 A `my-route` route is referring to `greeter` bean which is defined using Spring `<bean>` element.
 
-More examples can be found in xref:manual:ROOT:camel-jbang-beans.adoc#_using_spring_beans_xml_in_camel_xml_dsl[Camel CLI] page.
+More examples can be found in xref:manual:ROOT:camel-jbang.adoc#_using_spring_beans_in_camel_xml_dsl[Camel JBang] page.
 
 === Using bean with constructors
 


### PR DESCRIPTION
## Problem

The docs `xref-check` goal currently fails on **every** `camel-4.18.x` PR that regenerates docs, with two unresolved xrefs:

- `docs/user-manual/modules/ROOT/pages/camel-upgrade-recipes-tool.adoc` → `xref:camel-jbang-projects.adoc#_automated_updates_openrewrite[...]`
- `dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc` → `xref:manual:ROOT:camel-jbang-beans.adoc#_using_spring_beans_xml_in_camel_xml_dsl[...]`

## Cause

Commit `2d0c8fa35e7` ("Fix broken xref links after Camel CLI documentation restructuring") was backported to `camel-4.18.x`. On `main` the Camel CLI documentation was split (`camel-jbang.adoc` → `camel-jbang-projects.adoc`, `camel-jbang-beans.adoc`, …) and that commit repointed the two xrefs to the new split pages.

However, the CLI documentation **restructuring itself was not backported** to `camel-4.18.x`, where `camel-jbang.adoc` is still a single page and the split pages do not exist. So the backported xref "fix" points at pages that are absent on this branch, breaking `xref-check`.

I verified: `camel-jbang-projects.adoc` and `camel-jbang-beans.adoc` are **missing** on `camel-4.18.x` (present only on `main`), while `camel-jbang.adoc` exists on `camel-4.18.x`.

## Fix

Revert `2d0c8fa35e7` on `camel-4.18.x`, restoring the xrefs to `camel-jbang.adoc` with the anchors that exist on this branch (`#_update` and `#_using_spring_beans_in_camel_xml_dsl` — both verified present in `camel-jbang.adoc`). `xref-check` validates the target page, so pointing back at the existing single page resolves both failures.

## Verification

Full `mvn clean install -Pregen -DskipTests` reactor build on `camel-4.18.x` + this change: `xref-check` reports **0 unresolved xrefs**, `BUILD SUCCESS`.

This unblocks docs regeneration for all open `camel-4.18.x` PRs.

---
_Claude Code on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)