### PR TITLE
chore: fix section title level in camel-jbang-configuration.adoc

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-configuration.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-configuration.adoc
@@ -3,7 +3,7 @@
 This page covers configuring the Camel CLI — available options, configuration commands, and how to set up your environment.
 
 // jbang options: START
-=== Camel CLI configurations
+== Camel CLI configurations
 The camel.jbang supports 48 options, which are listed below.
 
 [width="100%",cols="2,5,^1,2",options="header"]


### PR DESCRIPTION
## Summary
- Fix section title `=== Camel CLI configurations` (level 2) to `==` (level 1) — it sits directly under the document title `=` (level 0), skipping a level, which causes the Antora build to fail with `section title out of sequence: expected level 1, got level 2`

## Test plan
- [ ] Antora build passes without the `section title out of sequence` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)