### PR TITLE
chore: fix broken xref to moved spring beans section

### DIFF
--- a/dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc
+++ b/dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc
@@ -111,7 +111,7 @@ Here's an example `camel.xml` file, which defines both the routes and beans used
 
 A `my-route` route is referring to `greeter` bean which is defined using Spring `<bean>` element.
 
-More examples can be found in xref:manual:ROOT:camel-jbang.adoc#_using_spring_beans_in_camel_xml_dsl[Camel JBang] page.
+More examples can be found in xref:manual:ROOT:camel-jbang-beans.adoc#_using_spring_beans_xml_in_camel_xml_dsl[Camel JBang] page.
 
 === Using bean with constructors
 


### PR DESCRIPTION
## Summary
- Fix broken cross-reference in `java-xml-io-dsl.adoc` — the `Using Spring beans in Camel XML DSL` section moved from `camel-jbang.adoc` to `camel-jbang-beans.adoc` on main, breaking the fragment link on 4.18.x
- Already correct on 4.14.x

## Test plan
- [ ] Website build link checker passes for `components/4.18.x/others/java-xml-io-dsl.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)