### PR TITLE
CAMEL-23737: Improve discoverability of camel-pqc hybrid cryptography docs

### DIFF
--- a/components/camel-pqc/src/main/docs/pqc-component.adoc
+++ b/components/camel-pqc/src/main/docs/pqc-component.adoc
@@ -80,6 +80,16 @@ The component supports the following operations:
 - extractSecretKeyEncapsulation - Extract the encapsulation
 - extractSecretKeyFromEncapsulation - Extract the secret key from encapsulation
 
+**Hybrid Operations (classical + post-quantum):**
+
+- hybridSign - Create a hybrid signature combining a classical and a PQC signature
+- hybridVerify - Verify a hybrid signature (both components must be valid)
+- hybridGenerateSecretKeyEncapsulation - Generate a hybrid encapsulation and shared secret
+- hybridExtractSecretKeyEncapsulation - Extract the shared secret from a hybrid encapsulation
+- hybridExtractSecretKeyFromEncapsulation - Extract the secret key from a hybrid encapsulation
+
+See <<Hybrid Cryptography>> for configuration details and examples.
+
 **Key Lifecycle Operations:**
 
 - generateKeyPair - Generate a new PQC key pair
@@ -98,6 +108,8 @@ The component expects to find a KeyPair and a Signature Objects in to the Camel 
 In case the KeyPair and the Signature Objects are not in the registry, it will provide two instances of the Objects with default implementation.
 
 This will be true for standardized algorithms and for experimental ones.
+
+TIP: To combine a classical signature (ECDSA, Ed25519, RSA) with a PQC signature for defense-in-depth during the post-quantum transition, use the hybrid signature operations described in <<Hybrid Cryptography>>.
 
 == Examples
 
@@ -298,6 +310,8 @@ The component expects to find a KeyGenerator and a KeyPair in to the Camel Regis
 In case the KeyPair and the KeyGenerator Objects are not in the registry, it will provide two instances of the Objects with default implementation.
 
 This will be true for standardized algorithms and for experimental ones.
+
+TIP: To combine a classical key agreement (X25519, ECDH) with a PQC KEM (ML-KEM) for defense-in-depth, use the hybrid KEM operations described in <<Hybrid Cryptography>>.
 
 A possible flow of the operation could be the following:
 
@@ -2561,7 +2575,7 @@ The DataFormat supports streaming for large payloads, avoiding memory issues:
 [source,java]
 --------------------------------------------------------------------------------
 from("file:large-files?noop=true")
-    .streamCache(true)e)  // Enable stream caching if needed
+    .streamCache(true)  // Enable stream caching if needed
     .marshal(pqcFormat)
     .to("file:encrypted");
 --------------------------------------------------------------------------------
@@ -2646,7 +2660,7 @@ Security.addProvider(new BouncyCastlePQCProvider());
 --------------------------------------------------------------------------------
 pqcFormat.setBufferSize(16384);
 // or
-from("file:large.streamCache(true)rue).marshal(pqcFormat)...
+from("file:large-files?noop=true").streamCache(true).marshal(pqcFormat)...
 --------------------------------------------------------------------------------
 
 === Dependencies


### PR DESCRIPTION
## Description

The `camel-pqc` **Hybrid Cryptography** documentation already exists and is comprehensive (hybrid signatures, hybrid KEM, recommended NIST combinations, v2 wire format — since ~4.19). This PR is therefore a small **discoverability / cleanup** change rather than new hybrid content:

- Add a **Hybrid Operations** entry to the top-level *Supported Operations* list (it previously listed only signature / KEM / lifecycle operations).
- Cross-reference the *Hybrid Cryptography* section (via this doc's own `<<...>>` convention) from the *Signature and Verification* and *Key Encapsulation and Extraction* sections.
- Drive-by: fix two corrupted `streamCache` code snippets in the *PQC DataFormat* section.

## JIRA

https://issues.apache.org/jira/browse/CAMEL-23737 — re-scoped from the original "add hybrid docs" wording after investigation found the hybrid content already exists.

## Testing

Documentation-only change to `pqc-component.adoc` (manually-maintained prose; no generated files affected).

---
_Submitted by Claude Code on behalf of Andrea Cosentino._