### PR TITLE
ci: keep java-xml-io-dsl spring-beans xref on camel-jbang.adoc (4.18.x)

### DIFF
--- a/dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc
+++ b/dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc
@@ -111,7 +111,10 @@ Here's an example `camel.xml` file, which defines both the routes and beans used
 
 A `my-route` route is referring to `greeter` bean which is defined using Spring `<bean>` element.
 
-More examples can be found in xref:manual:ROOT:camel-jbang-beans.adoc#_using_spring_beans_xml_in_camel_xml_dsl[Camel JBang] page.
+// camel-4.18.x: keep this link pointing at camel-jbang.adoc. The Camel CLI docs were split into
+// separate pages (camel-jbang-beans, camel-jbang-projects, ...) on main only; those pages do not
+// exist on this maintenance branch, so re-pointing the link there breaks the docs reference check.
+More examples can be found in xref:manual:ROOT:camel-jbang.adoc#_using_spring_beans_in_camel_xml_dsl[Camel JBang] page.
 
 === Using bean with constructors
 


### PR DESCRIPTION
## Problem

The docs `xref-check` goal fails again on **every** `camel-4.18.x` PR that regenerates docs, with one unresolved xref:

- `dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc` → `xref:manual:ROOT:camel-jbang-beans.adoc#_using_spring_beans_xml_in_camel_xml_dsl[...]`

## Cause

`#23954` (`96717a7eedd`, "chore: fix broken xref to moved spring beans section") repointed this xref to `camel-jbang-beans.adoc`. As its own commit message notes, the section was moved there **on main** as part of the Camel CLI documentation restructuring (`camel-jbang.adoc` split into `camel-jbang-beans.adoc`, `camel-jbang-projects.adoc`, …).

That restructuring was **not backported to `camel-4.18.x`**, where `camel-jbang.adoc` is still a single page and the split pages do not exist (verified: `camel-jbang-beans.adoc` is absent on this branch). So the main-correct fix is wrong here and breaks `xref-check`.

This is the **second** time this exact xref has been broken on 4.18.x — `#23934` fixed the same class of issue (it had also repointed `camel-upgrade-recipes-tool.adoc` and this file to the split pages). `#23954` re-introduced it for the spring-beans link.

## Fix

- Revert `#23954` on `camel-4.18.x`, restoring the xref to `camel-jbang.adoc#_using_spring_beans_in_camel_xml_dsl` — page and anchor both verified present on this branch.
- Add a short guard comment above the link explaining the 4.18.x constraint, so it is not re-pointed at the main-only split pages again on this maintenance branch.

## Note for maintainers

Please do **not** apply the main-style CLI-doc xref fixes to `camel-4.18.x` unless the split pages themselves are backported. On this branch the content lives in `camel-jbang.adoc`. The durable alternative would be to backport the CLI documentation split to 4.18.x; until then these links must stay on `camel-jbang.adoc`.

## Verification

The docs tree is byte-identical (apart from the new comment, which contains no `xref:` token) to the state proven green by `#23934`'s full `-Pregen` reactor build (0 unresolved xrefs). This unblocks docs regeneration for all open `camel-4.18.x` PRs, including the muteException backport #23923.

---
_Claude Code on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)