### PR TITLE
chore: remove broken xref examples sentence from java-xml-io-dsl docs

### DIFF
--- a/dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc
+++ b/dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc
@@ -111,8 +111,6 @@ Here's an example `camel.xml` file, which defines both the routes and beans used
 
 A `my-route` route is referring to `greeter` bean which is defined using Spring `<bean>` element.
 
-More examples can be found in xref:manual:ROOT:camel-jbang-beans.adoc#_using_spring_beans_xml_in_camel_xml_dsl[Camel CLI] page.
-
 === Using bean with constructors
 
 When beans must be created with constructor arguments, then this is made easier in Camel 4.1 onwards.


### PR DESCRIPTION
## Summary

- Remove the sentence referencing examples on the `camel-jbang-beans.adoc` page which does not exist on `camel-4.18.x` (the CLI docs split was only done on `main`)
- This fixes the `xref-check` failure on the `camel-4.18.x` branch

Supersedes #23973

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)