### PR TITLE
CAMEL-23538: Use testcontainers 2.0.3 on ppc64le via Maven profile

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4137,6 +4137,19 @@
 
     <profiles>
 
+        <!-- CAMEL-23538: testcontainers 2.0.4+ does not work on ppc64le CI -->
+        <profile>
+            <id>ppc64le-testcontainers</id>
+            <activation>
+                <os>
+                    <arch>ppc64le</arch>
+                </os>
+            </activation>
+            <properties>
+                <testcontainers-version>2.0.3</testcontainers-version>
+            </properties>
+        </profile>
+
         <profile>
             <id>nochecks</id>
             <activation>


### PR DESCRIPTION
## Summary

- Keep testcontainers at 2.0.5 by default (aligned with Spring Boot 4.1.0)
- Add a Maven profile that auto-activates on `ppc64le` and overrides to 2.0.3, which is the last version working on ASF Jenkins CI for that architecture
- The profile activates automatically based on the JVM's `os.arch` — no manual `-P` flag needed

Alternative approach to #23972 which downgrades globally.

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)