### PR TITLE
CAMEL-23738: doc-sync camel-keycloak upgrade note to 4.18 guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -13,6 +13,17 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 
 == Upgrading from 4.18.1 to 4.18.3
 
+=== camel-keycloak
+
+The `KeycloakSecurityPolicy` route policy now always verifies the access token when one is present - signature,
+issuer and expiry for local JWT verification, or active state and issuer when token introspection is enabled -
+even when neither `requiredRoles` nor `requiredPermissions` is configured. Previously the token was only verified
+when at least one role or permission was required.
+
+Routes that attach a `KeycloakSecurityPolicy` without any roles or permissions and that previously forwarded an
+unverified or invalid token will now have such requests rejected with a `CamelAuthorizationException`. Provide a
+valid, verifiable token (or configure `requiredRoles` / `requiredPermissions`) for these routes.
+
 === camel-core
 
 The `org.apache.camel.support.DefaultHeaderFilterStrategy` changed default setting for lowercase from `false` to `true`.


### PR DESCRIPTION
Doc-sync follow-up for the camel-keycloak fix (CAMEL-23738).

The fix landed on `main` for 4.21.0 (#23958) and is backported to `camel-4.18.x` for 4.18.3 (#23981). The backport added the `camel-keycloak` behavior-change note to `camel-4x-upgrade-guide-4_18.adoc` on the 4.18.x branch.

Per the project's backport upgrade-guide policy, the version-specific upgrade guides for all releases live on `main` as canonical history. This PR adds the same `camel-keycloak` entry to `camel-4x-upgrade-guide-4_18.adoc` on `main` (under *Upgrading from 4.18.1 to 4.18.3*) so `main` stays in sync with what ships on `camel-4.18.x`.

Docs-only; no code change.

_Claude Code on behalf of Andrea Cosentino_