### PR TITLE
CAMEL-23744: Update XML Encryption docs examples to AES-256-GCM (off 3DES)

### DIFF
--- a/components/camel-xmlsecurity/src/main/docs/xmlSecurity-dataformat.adoc
+++ b/components/camel-xmlsecurity/src/main/docs/xmlSecurity-dataformat.adoc
@@ -59,6 +59,12 @@ The default Key Cipher Algorithm is now
 that use RSA v1.5 as the key cipher algorithm will be rejected unless it
 has been explicitly configured as the key cipher algorithm.
 
+=== Data Cipher Algorithm
+
+The default data (payload) Cipher Algorithm is `XMLCipher.AES_256_GCM`.
+Usage of `XMLCipher.TRIPLEDES` (3DES) is discouraged as it is a legacy cipher; prefer an
+AES-GCM algorithm such as `XMLCipher.AES_256_GCM` (the default) or `XMLCipher.AES_128_GCM`.
+
 == Marshal
 
 To encrypt the payload, the `marshal` processor needs to be
@@ -95,7 +101,7 @@ from("direct:start")
 String tagXPATH = "//cheesesites/italy/cheese";
 boolean secureTagContent = true;
 ...
-String passPhrase = "Just another 24 Byte key";
+String passPhrase = "Just another 32 Byte key for AES";
 from("direct:start")
     .marshal().xmlSecurity(tagXPATH, secureTagContent, passPhrase)
     .unmarshal().xmlSecurity(tagXPATH, secureTagContent, passPhrase)
@@ -110,8 +116,8 @@ import org.apache.xml.security.encryption.XMLCipher;
 ....
 String tagXPATH = "//cheesesites/italy/cheese";
 boolean secureTagContent = true;
-String passPhrase = "Just another 24 Byte key";
-String algorithm= XMLCipher.TRIPLEDES;
+String passPhrase = "Just another 32 Byte key for AES";
+String algorithm = XMLCipher.AES_256_GCM;
 from("direct:start")
     .marshal().xmlSecurity(tagXPATH, secureTagContent, passPhrase, algorithm)
     .unmarshal().xmlSecurity(tagXPATH, secureTagContent, passPhrase, algorithm)


### PR DESCRIPTION
## Description

`XMLSecurityDataFormat`'s data-cipher default is already `XMLCipher.AES_256_GCM`, but `xmlSecurity-dataformat.adoc` had drifted:

- Both `passPhrase` examples used a **24-byte** key (`"Just another 24 Byte key"`), sized for 3DES. The passphrase becomes the raw key (`new SecretKeySpec(passPhrase, "AES")`), so 24 bytes is invalid for the AES-256-GCM default (needs 32) — the first example was effectively broken.
- One example explicitly demonstrated `XMLCipher.TRIPLEDES`, implicitly recommending a legacy cipher.

This **docs-only** PR:
- Updates both `passPhrase` examples to a 32-byte key for the AES-256-GCM default.
- Switches the explicit example from `TRIPLEDES` to `AES_256_GCM`.
- Adds a **Data Cipher Algorithm** note (default is AES-256-GCM; 3DES is legacy/discouraged), mirroring the existing *Key Cipher Algorithm* note.

The 3DES code path is unchanged and remains available for explicit opt-in (route-author's choice per the Camel security model). Derived from a PQC-readiness review.

## JIRA
https://issues.apache.org/jira/browse/CAMEL-23744

---
_Submitted by Claude Code on behalf of Andrea Cosentino._