### PR TITLE
CAMEL-23629: docs - sync camel-irc 4.18 and 4.14 upgrade-guide entries to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -803,6 +803,44 @@ The generated Endpoint DSL header accessors on each component's
 `openstackOperation()`, `password()` -> `openstackKeystonePassword()`,
 `adminPassword()` -> `openstackNovaAdminPassword()`, etc.).
 
+=== camel-irc - potential breaking change
+
+The Exchange header constants in `IrcConstants` have been renamed to follow the
+Camel naming convention used across the rest of the component catalog. The Java
+field names are unchanged; only the header string values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `IrcConstants.IRC_MESSAGE_TYPE`     | `irc.messageType`     | `CamelIrcMessageType`
+| `IrcConstants.IRC_TARGET`           | `irc.target`          | `CamelIrcTarget`
+| `IrcConstants.IRC_SEND_TO`          | `irc.sendTo`          | `CamelIrcSendTo`
+| `IrcConstants.IRC_USER_KICKED`      | `irc.user.kicked`     | `CamelIrcUserKicked`
+| `IrcConstants.IRC_USER_HOST`        | `irc.user.host`       | `CamelIrcUserHost`
+| `IrcConstants.IRC_USER_NICK`        | `irc.user.nick`       | `CamelIrcUserNick`
+| `IrcConstants.IRC_USER_SERVERNAME`  | `irc.user.servername` | `CamelIrcUserServername`
+| `IrcConstants.IRC_USER_USERNAME`    | `irc.user.username`   | `CamelIrcUserUsername`
+| `IrcConstants.IRC_NUM`              | `irc.num`             | `CamelIrcNum`
+| `IrcConstants.IRC_VALUE`            | `irc.value`           | `CamelIrcValue`
+|===
+
+Routes that reference the constant symbolically (for example
+`header(IrcConstants.IRC_SEND_TO)` or
+`setHeader(IrcConstants.IRC_TARGET, ...)`) continue to work without changes.
+Routes that set or read the header by its literal string value (for example
+`setHeader("irc.sendTo", ...)`) must be updated to use the new value:
+
+[source,java]
+----
+// before
+template.sendBodyAndHeader("irc:bot@irc.server.org/#chan", "hello",
+    "irc.sendTo", "#otherchan");
+
+// after
+template.sendBodyAndHeader("irc:bot@irc.server.org/#chan", "hello",
+    "CamelIrcSendTo", "#otherchan");
+----
+
 === camel-mongodb-gridfs - potential breaking change
 
 The Exchange header values exposed by `GridFsConstants` have been renamed to follow the standard

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -905,6 +905,44 @@ Routes that set the header by its literal string value (for example
 As a consequence, the generated Endpoint DSL header accessor `await()` on
 `MiloClientHeaderNameBuilder` has been renamed to `miloAwait()`.
 
+=== camel-irc - potential breaking change
+
+The Exchange header constants in `IrcConstants` have been renamed to follow the
+Camel naming convention used across the rest of the component catalog. The Java
+field names are unchanged; only the header string values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `IrcConstants.IRC_MESSAGE_TYPE`     | `irc.messageType`     | `CamelIrcMessageType`
+| `IrcConstants.IRC_TARGET`           | `irc.target`          | `CamelIrcTarget`
+| `IrcConstants.IRC_SEND_TO`          | `irc.sendTo`          | `CamelIrcSendTo`
+| `IrcConstants.IRC_USER_KICKED`      | `irc.user.kicked`     | `CamelIrcUserKicked`
+| `IrcConstants.IRC_USER_HOST`        | `irc.user.host`       | `CamelIrcUserHost`
+| `IrcConstants.IRC_USER_NICK`        | `irc.user.nick`       | `CamelIrcUserNick`
+| `IrcConstants.IRC_USER_SERVERNAME`  | `irc.user.servername` | `CamelIrcUserServername`
+| `IrcConstants.IRC_USER_USERNAME`    | `irc.user.username`   | `CamelIrcUserUsername`
+| `IrcConstants.IRC_NUM`              | `irc.num`             | `CamelIrcNum`
+| `IrcConstants.IRC_VALUE`            | `irc.value`           | `CamelIrcValue`
+|===
+
+Routes that reference the constant symbolically (for example
+`header(IrcConstants.IRC_SEND_TO)` or
+`setHeader(IrcConstants.IRC_TARGET, ...)`) continue to work without changes.
+Routes that set or read the header by its literal string value (for example
+`setHeader("irc.sendTo", ...)`) must be updated to use the new value:
+
+[source,java]
+----
+// before
+template.sendBodyAndHeader("irc:bot@irc.server.org/#chan", "hello",
+    "irc.sendTo", "#otherchan");
+
+// after
+template.sendBodyAndHeader("irc:bot@irc.server.org/#chan", "hello",
+    "CamelIrcSendTo", "#otherchan");
+----
+
 === camel-mongodb-gridfs
 
 The Exchange header values exposed by `GridFsConstants` have been renamed to follow the standard


### PR DESCRIPTION
This PR syncs the `camel-irc` Exchange header rename upgrade-guide entry (CAMEL-23629) into the version-specific `4_18` and `4_14` upgrade guides on `main`.

## Background

The `camel-irc` header constant rename was backported to `camel-4.18.x` and `camel-4.14.x` (fixVersions 4.14.8, 4.18.3, 4.21.0). Those backports added the `=== camel-irc - potential breaking change` entry to `camel-4x-upgrade-guide-4_18.adoc` / `camel-4x-upgrade-guide-4_14.adoc` **on the maintenance branches**.

Per the project's upgrade-guide policy, the `camel-4x-upgrade-guide-4_XX.adoc` files on `main` are the canonical cross-release history across all release lines. The `4_18` and `4_14` guides on `main` were missing the `camel-irc` entry (only the `4_21` guide carried it). This PR closes that drift so `main` reflects what actually shipped on the maintenance branches.

## Changes

- Add the `camel-irc` "potential breaking change" entry to `camel-4x-upgrade-guide-4_18.adoc` on `main` (verbatim from `camel-4.18.x`).
- Add the same entry to `camel-4x-upgrade-guide-4_14.adoc` on `main` (verbatim from `camel-4.14.x`).

Docs-only; no code changes.

---
_Claude Code on behalf of Andrea Cosentino_