### PR TITLE
[backport camel-4.14.x] CAMEL-23588: camel-undertow - filter the legacy websocket.* exchange-header prefix

### DIFF
--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHeaderFilterStrategy.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHeaderFilterStrategy.java
@@ -25,6 +25,18 @@ import org.apache.camel.support.http.HttpUtil;
  */
 public class UndertowHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
 
+    /**
+     * Legacy {@code websocket.*} Exchange-header prefix used by {@code UndertowConstants} for the dispatch and event
+     * headers ({@code websocket.connectionKey}, {@code websocket.connectionKey.list}, {@code websocket.sendToAll},
+     * {@code websocket.eventType}, {@code websocket.eventTypeEnum}, {@code websocket.channel},
+     * {@code websocket.exchange}). Added to the in/out filter prefixes (CAMEL-23588) so the undertow boundary does not
+     * propagate these values onto outbound wire frames or map them in from inbound HTTP-style headers. This is
+     * defence-in-depth — cross-component routes that flow an untrusted message into an undertow producer should also
+     * {@code .removeHeaders("websocket.*")} at the trust boundary, because the producer reads these headers via
+     * {@code in.getHeader(...)} which bypasses the {@code HeaderFilterStrategy}.
+     */
+    static final String WEBSOCKET_FILTER_STARTS_WITH = "websocket.";
+
     public UndertowHeaderFilterStrategy() {
         initialize();
     }
@@ -34,9 +46,10 @@ public class UndertowHeaderFilterStrategy extends DefaultHeaderFilterStrategy {
 
         setLowerCase(true);
 
-        // filter headers begin with "Camel" or "org.apache.camel"
-        // must ignore case for Http based transports
-        setOutFilterStartsWith(CAMEL_FILTER_STARTS_WITH);
-        setInFilterStartsWith(CAMEL_FILTER_STARTS_WITH);
+        // filter headers that begin with "Camel" / "camel" (ignoring case for HTTP-based
+        // transports) and the legacy "websocket." prefix used by UndertowConstants
+        // (CAMEL-23588), in both the inbound and outbound directions
+        setOutFilterStartsWith("Camel", "camel", WEBSOCKET_FILTER_STARTS_WITH);
+        setInFilterStartsWith("Camel", "camel", WEBSOCKET_FILTER_STARTS_WITH);
     }
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -1047,6 +1047,53 @@ default `HttpHeaderFilterStrategy` filters headers starting with `Camel` / `came
 (case-insensitive). Routes that relied on receiving `Camel`-prefixed header names from WebSocket
 query parameters can supply a custom `headerFilterStrategy` to restore the previous behaviour.
 
+=== camel-undertow - potential breaking change
+
+`UndertowHeaderFilterStrategy` now also filters the legacy `websocket.*`
+Exchange-header prefix (in addition to the `Camel*` / `camel*` /
+`org.apache.camel.*` prefixes it already filtered). This applies to both the
+in (wire -> exchange) and out (exchange -> wire) directions and follows the
+dedicated-filter-strategy shape used by CAMEL-23532 for
+`camel-vertx-websocket` / `camel-atmosphere-websocket` / `camel-iggy`.
+
+The constants in `UndertowConstants` (`CONNECTION_KEY`, `CONNECTION_KEY_LIST`,
+`SEND_TO_ALL`, `EVENT_TYPE`, `EVENT_TYPE_ENUM`, `CHANNEL`, `EXCHANGE`) keep
+their existing string values (`websocket.connectionKey`,
+`websocket.connectionKey.list`, `websocket.sendToAll`, etc.) because they are
+part of the undertow component's externally-visible API contract; routes
+referencing them (symbolically or by literal value) continue to work
+unchanged within an undertow route.
+
+The behaviour change applies at undertow's transport boundary:
+
+* Outbound (exchange -> wire): if an exchange ends up at an undertow producer
+  carrying an Exchange header whose name starts with `websocket.`, that
+  header will no longer be propagated onto the outbound HTTP/websocket
+  request as a wire-level header.
+* Inbound (wire -> exchange): if an undertow consumer receives a request
+  whose wire-level headers include a name starting with `websocket.`, that
+  header will no longer be mapped into the resulting Camel exchange.
+
+Note that the `HeaderFilterStrategy` only governs the transport boundary; it
+does not prevent cross-component header injection (for example, an
+`http -> undertow` route where the HTTP consumer maps an attacker-supplied
+`websocket.connectionKey` header into the exchange and the undertow producer
+then reads it via `in.getHeader(...)` to dispatch to a specific peer). For
+defence in depth at the trust boundary, route authors should explicitly strip
+these headers from untrusted inbound traffic, for example:
+
+[source,java]
+----
+from("jetty:http://0.0.0.0:8080/api")
+    .removeHeaders("websocket.*")
+    .to("undertow:ws://internal-broker/notifications");
+----
+
+Routes that intentionally relied on undertow mapping `websocket.*` wire
+headers in or out can supply a custom `headerFilterStrategy` endpoint option
+to restore the previous behaviour.
+
+
 === camel-aws2-sqs
 
 `Sqs2HeaderFilterStrategy` now also configures an inbound filter aligned with the existing


### PR DESCRIPTION
Backport to `camel-4.14.x` of CAMEL-23588 (main commit `d5a717dd0f8`).

## Note: adapted, not a verbatim backport

On `camel-4.14.x`, `UndertowHeaderFilterStrategy` is the **`@deprecated`** implementation extending `DefaultHeaderFilterStrategy` (on main / 4.18.x it was rewritten to extend `HttpHeaderFilterStrategy`). A verbatim cherry-pick is therefore impossible. The change is adapted to 4.14.x's structure: the existing `initialize()` now adds the legacy `websocket.` prefix to the in/out filter prefixes (alongside `Camel` / `camel`).

The `DefaultHeaderFilterStrategy.doFiltering` `lowerCase` fallback matches the prefix case-insensitively, so `websocket.*` headers (in any case) are filtered in both directions — behaviour equivalent to main.

## Changes

- `UndertowHeaderFilterStrategy`: add `WEBSOCKET_FILTER_STARTS_WITH = "websocket."` and include it in `setOutFilterStartsWith` / `setInFilterStartsWith`.
- `camel-4x-upgrade-guide-4_14.adoc`: add the `camel-undertow` "potential breaking change" entry, grouped with the existing `camel-vertx-websocket` / `camel-atmosphere-websocket` (CAMEL-23532) family.

The matching entry will be synced to the `4_14` upgrade guide on `main` in a separate doc-sync PR, per the upgrade-guide policy.

---
_Claude Code on behalf of Andrea Cosentino_