### PR TITLE
CAMEL-21935 camel-jbang - kubernetes plugin fails to run when knativeservice.enabled=true in openshift

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-kubernetes.adoc
@@ -281,8 +281,6 @@ Use https://knative.dev/docs/serving/[Knative serving] for serverless workloads 
 
 NOTE: Disabled by default — enable with `--trait knative-service.enabled=true`.
 
-WARN: Currently does not work on OpenShift.
-
 [cols="2m,1m,5a"]
 |===
 |Property | Type | Description
@@ -737,13 +735,15 @@ Quick start for local development with Minikube (Camel 4.10+):
 ----
 minikube start --addons registry --driver=docker
 eval $(minikube -p minikube docker-env)
-camel kubernetes run demo.camel.yaml --cluster-type=minikube \
-  --build-property=quarkus.kubernetes.image-pull-policy=Never \
-  --image-registry "$(kubectl -n kube-system get service registry -o jsonpath='{.spec.clusterIP}')" \
-  --image-builder=docker
+camel kubernetes run demo.camel.yaml
 ----
 
-IMPORTANT: The `--build-property=quarkus.kubernetes.image-pull-policy=Never` flag is required for Minikube deployments.
+== Deployment tips and troubleshooting
 
-NOTE: Docker multi-platform build is used. Follow the https://docs.docker.com/build/building/multi-platform/#build-multi-platform-images[Docker multi-platform requirements].
+* If there is any error with `camel kubernetes run`, set `--verbose` to display additional logging.
 
+* You may want to examine the generated maven project in `.camel-jbang-run/<name>`.
+
+* If there are issues building the container image or deploying the kubernetes manifests, consider disabling the kubernetes cluster detection with `--disable-auto`.
+
+* Note that Docker multi-platform build is used. It requires to have followed these https://docs.docker.com/build/building/multi-platform/#build-multi-platform-images[Docker requirements].

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExport.java
@@ -522,6 +522,8 @@ public class KubernetesExport extends Export {
             return "localhost:5001";
         } else if (ClusterType.MINIKUBE.isEqualTo(clusterType)) {
             return "localhost:5000";
+        } else if (ClusterType.OPENSHIFT.isEqualTo(clusterType)) {
+            return "image-registry.openshift-image-registry.svc:5000";
         }
 
         return null;

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesRun.java
@@ -726,6 +726,7 @@ public class KubernetesRun extends KubernetesBaseCommand {
         }
         // suppress maven transfer progress
         args.add("-ntp");
+        args.add("-DskipTests");
         args.add("--file");
         args.add(new File(workingDir, "pom.xml").getAbsolutePath());
 
@@ -751,7 +752,8 @@ public class KubernetesRun extends KubernetesBaseCommand {
             // will generate the regular Deployment, so we have to disable the jkube resources task to not run and not generate the deployment.yml
             // apply the knative service manifest and specify the knative service.yml
             args.add("-Djkube.skip.resource=true");
-            args.add(prefix + ":build");
+            // run the "package" task instead of k8s:deploy
+            args.add("package");
             args.add(prefix + ":apply");
             if (isOpenshift) {
                 args.add("-Djkube.openshiftManifest=src/main/jkube/service.yml");
@@ -801,6 +803,10 @@ public class KubernetesRun extends KubernetesBaseCommand {
             if (ClusterType.MINIKUBE == cluster) {
                 this.imageBuilder = "docker";
                 this.imagePush = false;
+            } else if (ClusterType.OPENSHIFT == cluster) {
+                if (ObjectHelper.isEmpty(imageGroup)) {
+                    this.imageGroup = client().getNamespace();
+                }
             }
             if (verbose) {
                 printer().println(this.clusterType);

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/ContainerTrait.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/main/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/traits/ContainerTrait.java
@@ -86,14 +86,13 @@ public class ContainerTrait extends BaseTrait {
         }
         container.withResources(resourceRequirementsBuilder.build());
 
-        io.fabric8.kubernetes.api.model.Container cc = container.build();
         context.doWithKnativeServices(s -> s.editOrNewSpec()
                 .editOrNewTemplate()
                 .editOrNewMetadata()
                 .addToLabels(KUBERNETES_LABEL_NAME, context.getName())
                 .endMetadata()
                 .editOrNewSpec()
-                .addToContainers(cc)
+                .addToContainers(container.build())
                 .endSpec()
                 .endTemplate()
                 .endSpec());

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/src/test/java/org/apache/camel/dsl/jbang/core/commands/kubernetes/KubernetesExportTest.java
@@ -487,7 +487,8 @@ class KubernetesExportTest extends KubernetesExportBaseTestSupport {
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
         Assertions.assertEquals("route-service", deployment.getMetadata().getName());
         Assertions.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Assertions.assertEquals("route-service:1.0-SNAPSHOT", container.getImage());
+        Assertions.assertEquals("image-registry.openshift-image-registry.svc:5000/route-service:1.0-SNAPSHOT",
+                container.getImage());
         Assertions.assertEquals(1, container.getPorts().size());
         Assertions.assertEquals("http", container.getPorts().get(0).getName());
         Assertions.assertEquals(8080, container.getPorts().get(0).getContainerPort());
@@ -498,8 +499,10 @@ class KubernetesExportTest extends KubernetesExportBaseTestSupport {
         Assertions.assertEquals("1.0-SNAPSHOT", model.getVersion());
 
         Properties props = model.getProperties();
-        Assertions.assertEquals("route-service:1.0-SNAPSHOT", props.get("jkube.image.name"));
-        Assertions.assertEquals("route-service:1.0-SNAPSHOT", props.get("jkube.container-image.name"));
+        Assertions.assertEquals("image-registry.openshift-image-registry.svc:5000/route-service:1.0-SNAPSHOT",
+                props.get("jkube.image.name"));
+        Assertions.assertEquals("image-registry.openshift-image-registry.svc:5000/route-service:1.0-SNAPSHOT",
+                props.get("jkube.container-image.name"));
 
         Route route = getRoute(rt);
         Assertions.assertEquals("route-service", route.getMetadata().getName());


### PR DESCRIPTION
* Set the correct image registry and group when building in openshift

https://issues.apache.org/jira/browse/CAMEL-21935

The [#23804](https://github.com/apache/camel/pull/23804) fixed the missing container image in the contrainer trait.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

