### PR TITLE
ci: register LogCaptureAppender programmatically in netty/netty-http tests (4.14.x)

### DIFF
--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/LogCaptureTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/LogCaptureTest.java
@@ -18,18 +18,42 @@ package org.apache.camel.component.netty.http;
 
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
- * This test ensures LogCaptureAppender is configured properly
+ * This test ensures LogCaptureAppender can capture log events programmatically.
  */
+@Isolated
 public class LogCaptureTest {
+
+    private LogCaptureAppender appender;
+
+    @BeforeEach
+    void setUp() {
+        appender = new LogCaptureAppender("capture", null, null);
+        appender.start();
+        Logger logger = (Logger) LogManager.getLogger(ResourceLeakDetector.class);
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Logger logger = (Logger) LogManager.getLogger(ResourceLeakDetector.class);
+        logger.removeAppender(appender);
+        appender.stop();
+        LogCaptureAppender.reset();
+    }
+
     @Test
     public void testCapture() {
         InternalLoggerFactory.getInstance(ResourceLeakDetector.class).error("testError");
         assertFalse(LogCaptureAppender.getEvents().isEmpty());
-        LogCaptureAppender.reset();
     }
 }

--- a/components/camel-netty-http/src/test/resources/log4j2.properties
+++ b/components/camel-netty-http/src/test/resources/log4j2.properties
@@ -15,7 +15,6 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-configuration.packages=org.apache.camel.component.netty.http
 appender.file.type = File
 appender.file.name = file
 appender.file.fileName = target/camel-netty-http-test.log
@@ -25,11 +24,6 @@ appender.out.type = Console
 appender.out.name = out
 appender.out.layout.type = PatternLayout
 appender.out.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %m%n
-appender.capture.type=LogCaptureAppender
-appender.capture.name=capture
-
-logger.leak.name = io.netty.util.ResourceLeakDetector
-logger.leak.appenderRef.capture.ref = capture
 
 rootLogger.level = INFO
 rootLogger.appenderRef.file.ref = file

--- a/components/camel-netty/src/test/java/org/apache/camel/component/netty/LogCaptureTest.java
+++ b/components/camel-netty/src/test/java/org/apache/camel/component/netty/LogCaptureTest.java
@@ -19,6 +19,10 @@ package org.apache.camel.component.netty;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.apache.camel.processor.errorhandler.DefaultErrorHandler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 
@@ -26,16 +30,34 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * This test ensures LogCaptureAppender is configured properly
+ * This test ensures LogCaptureAppender can capture log events programmatically.
  */
 @Isolated
 public class LogCaptureTest {
+
+    private LogCaptureAppender appender;
+
+    @BeforeEach
+    void setUp() {
+        appender = new LogCaptureAppender("capture", null, null);
+        appender.start();
+        Logger logger = (Logger) LogManager.getLogger(ResourceLeakDetector.class);
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Logger logger = (Logger) LogManager.getLogger(ResourceLeakDetector.class);
+        logger.removeAppender(appender);
+        appender.stop();
+        LogCaptureAppender.reset();
+    }
+
     @Test
     public void testCapture() {
         InternalLoggerFactory.getInstance(ResourceLeakDetector.class).error("testError");
         assertFalse(LogCaptureAppender.getEvents(ResourceLeakDetector.class).isEmpty());
         assertTrue(LogCaptureAppender.hasEventsFor(ResourceLeakDetector.class));
         assertTrue(LogCaptureAppender.getEvents(DefaultErrorHandler.class).isEmpty());
-        LogCaptureAppender.reset();
     }
 }

--- a/components/camel-netty/src/test/resources/log4j2.properties
+++ b/components/camel-netty/src/test/resources/log4j2.properties
@@ -15,7 +15,6 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-configuration.packages=org.apache.camel.component.netty
 appender.file.type = File
 appender.file.name = file
 appender.file.fileName = target/camel-netty-test.log
@@ -25,12 +24,5 @@ appender.out.type = Console
 appender.out.name = out
 appender.out.layout.type = PatternLayout
 appender.out.layout.pattern = %d [%-35.35t] %-5p %-30.30c{1} - %m%n
-appender.capture.type=LogCaptureAppender
-appender.capture.name=capture
-
-logger.leak.name = io.netty.util.ResourceLeakDetector
-logger.leak.appenderRef.capture.ref = capture
-logger.errorHandler.name = org.apache.camel.processor.errorhandler.DefaultErrorHandler
-logger.errorHandler.appenderRef.capture.ref = capture
 rootLogger.level = INFO
 rootLogger.appenderRef.file.ref = file


### PR DESCRIPTION
## Problem

On `camel-4.14.x`, `LogCaptureTest.testCapture` fails **deterministically** in both `camel-netty` and `camel-netty-http`:

```
LogCaptureTest.testCapture:32 expected: <false> but was: <true>
```

i.e. `LogCaptureAppender.getEvents()` is empty — the appender captures nothing. The test relies on a properties-based log4j2 setup (`configuration.packages` + a custom `LogCaptureAppender` wired to the `io.netty.util.ResourceLeakDetector` logger) that no longer works on this branch. It is **pre-existing** and unrelated to any functional change; it surfaces on any PR that triggers the netty/netty-http test suites (e.g. the CAMEL-23651 backport #23990).

## Fix

`main` already fixed this by registering the appender **programmatically** in the test (`@BeforeEach` adds a `LogCaptureAppender` to the `ResourceLeakDetector` logger, `@AfterEach` removes it, the test is `@Isolated`) and removing the brittle properties config. This backports that fix to `camel-4.14.x` for both modules.

Test-only change (2 test classes + 2 `log4j2.properties`). Verified locally: `LogCaptureTest` passes in `camel-netty` and `camel-netty-http` after the change.

## Why this matters

This unblocks docs/test regeneration and the netty test suites for all `camel-4.14.x` PRs — in particular the CAMEL-23651 backport #23990, which is currently red on this pre-existing failure.

---
_Claude Code on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)