### PR TITLE
CAMEL-19517: camel-cxf - replace Thread.sleep with Awaitility in tests

### DIFF
--- a/components/camel-cxf/camel-cxf-spring-soap/pom.xml
+++ b/components/camel-cxf/camel-cxf-spring-soap/pom.xml
@@ -226,6 +226,13 @@
             <version>${jettison-version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfOneWayRouteTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfOneWayRouteTest.java
@@ -17,7 +17,8 @@
 package org.apache.camel.component.cxf;
 
 import java.io.ByteArrayOutputStream;
-import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.xml.ws.Service;
 
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -51,13 +53,13 @@ public class CxfOneWayRouteTest extends CamelSpringTestSupport {
     private static final String ROUTER_ADDRESS = "http://localhost:" + CXFTestSupport.getPort1() + "/CxfOneWayRouteTest/router";
 
     private static Exception bindingException;
-    private static boolean bindingDone;
+    private static final AtomicBoolean BINDING_DONE = new AtomicBoolean();
     private static boolean onCompeletedCalled;
 
     @BeforeEach
     public void setup() {
         bindingException = null;
-        bindingDone = false;
+        BINDING_DONE.set(false);
         onCompeletedCalled = false;
     }
 
@@ -84,10 +86,7 @@ public class CxfOneWayRouteTest extends CamelSpringTestSupport {
         client.greetMeOneWay("lemac");
 
         // may need to wait until the oneway call completes
-        long waitUntil = System.nanoTime() + Duration.ofMillis(10000).toMillis();
-        while (!bindingDone && System.nanoTime() < waitUntil) {
-            Thread.sleep(1000);
-        }
+        await().atMost(10, TimeUnit.SECONDS).untilTrue(BINDING_DONE);
 
         MockEndpoint.assertIsSatisfied(context);
         assertTrue(onCompeletedCalled, "UnitOfWork done should be called");
@@ -132,7 +131,7 @@ public class CxfOneWayRouteTest extends CamelSpringTestSupport {
                 bindingException = e;
                 throw e;
             } finally {
-                bindingDone = true;
+                BINDING_DONE.set(true);
             }
         }
 

--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfPayloadProviderRouterTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfPayloadProviderRouterTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.cxf;
 
+import java.util.concurrent.TimeUnit;
+
 import jakarta.xml.ws.Endpoint;
 import jakarta.xml.ws.Service;
 
@@ -37,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -117,9 +120,11 @@ public class CxfPayloadProviderRouterTest extends AbstractCXFGreeterRouterTest {
         icp.setCalled(false);
         greeter.greetMeOneWay("call greetMe OneWay !");
         assertFalse(icp.isCalled(), "An unnecessary inbound message");
-        // wait a few seconds for the async oneway service to be invoked
-        Thread.sleep(3000);
-        assertEquals(++ic, implementor.getInvocationCount(), "The target service not invoked");
+        // wait for the async oneway service to be invoked
+        final int expectedCount = ++ic;
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals(expectedCount, implementor.getInvocationCount(),
+                        "The target service not invoked"));
     }
 
     static class VerifyInboundInterceptor extends AbstractPhaseInterceptor<Message> {

--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/soap/headers/CxfMessageHeadersRelayTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/soap/headers/CxfMessageHeadersRelayTest.java
@@ -318,7 +318,6 @@ public class CxfMessageHeadersRelayTest {
         Me me = new Me();
         me.setFirstName("john");
         me.setLastName("Doh");
-        Thread.sleep(5000);
         Me response = proxy.outOutOfBandHeader(me);
         assertEquals("pass", response.getFirstName(), "Expected the out out of band header *not* to propagate but it did");
         validateReturnedOutOfBandHeader(proxy, false);
@@ -364,8 +363,6 @@ public class CxfMessageHeadersRelayTest {
 
     @Test
     public void testOutHeaderCXFClientNoRelay() throws Exception {
-        Thread.sleep(5000);
-
         HeaderService s = new HeaderService(
                 getClass().getClassLoader().getResource("soap_header.wsdl"),
                 HeaderService.SERVICE);


### PR DESCRIPTION
# Description

Replaces test-synchronization `Thread.sleep` calls in `camel-cxf` tests with [Awaitility](https://github.com/awaitility/awaitility), per the project guideline in AGENTS.md.

- `CxfOneWayRouteTest`: polling `while`-loop → `await().untilTrue(AtomicBoolean)`
- `CxfPayloadProviderRouterTest`: `Thread.sleep(3000)` → `await().untilAsserted(...)` on `implementor.getInvocationCount()`
- `CxfMessageHeadersRelayTest`: removed two stray unused `Thread.sleep(5000)` calls
- `camel-cxf-spring-soap/pom.xml`: added `org.awaitility:awaitility` test dependency

Remaining `Thread.sleep` calls (in `GreeterImplWithSleep`, `CxfConsumerContinuationTimeoutTest`, the `*ClientDisconnected` tests, `MyProcessor`) are intentionally left — they simulate slow business logic the tests exercise, not test synchronization.

Verified locally:
`mvn test -pl components/camel-cxf/camel-cxf-spring-soap -Dtest="CxfOneWayRouteTest,CxfPayloadProviderRouterTest,CxfMessageHeadersRelayTest"` → 26 passed, 0 failed.

JIRA: [CAMEL-19517](https://issues.apache.org/jira/browse/CAMEL-19517)

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-19517) filed for the change.