### PR TITLE
docs: align adoc files to use [tabs] with YAML DSL examples

### DIFF
--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/aggregate-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/aggregate-eip.adoc
@@ -377,6 +377,11 @@ configured, which can be accessed using `getAggregateController()` method.
 Though it may be easier to configure a controller in the route using
 `aggregateController` as shown below:
 
+[tabs]
+====
+
+Java::
++
 [source,java]
 ----
 private AggregateController controller = new DefaultAggregateController();
@@ -387,6 +392,47 @@ from("direct:start")
       .aggregateController(controller)
       .to("mock:aggregated");
 ----
+
+XML::
++
+[source,xml]
+----
+<bean id="myController" class="org.apache.camel.processor.aggregate.DefaultAggregateController"/>
+
+<camelContext xmlns="http://camel.apache.org/schema/spring">
+    <route>
+        <from uri="direct:start"/>
+        <aggregate aggregationStrategy="myAppender" completionSize="10"
+                   aggregateController="myController">
+            <correlationExpression>
+                <header>id</header>
+            </correlationExpression>
+            <to uri="mock:result"/>
+        </aggregate>
+    </route>
+</camelContext>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - aggregate:
+            aggregateController: myController
+            aggregationStrategy: myAppender
+            completionSize: 10
+            correlationExpression:
+              header:
+                expression: id
+            steps:
+              - to:
+                  uri: mock:result
+----
+====
 
 Then there is API on `AggregateController` to force completion. For
 example, to complete a group with key foo:
@@ -404,29 +450,6 @@ There is also a method to complete all groups:
 [source,java]
 ----
 int groups = controller.forceCompletionOfAllGroups();
-----
-
-The controller can also be used in XML DSL using the `aggregateController` to
-refer to a bean with the controller implementation, which is looked up in the registry.
-
-When using Spring XML, you can create the bean with `<bean>` as shown:
-
-[source,xml]
-----
-<bean id="myController" class="org.apache.camel.processor.aggregate.DefaultAggregateController"/>
- 
-<camelContext xmlns="http://camel.apache.org/schema/spring">
-    <route>
-        <from uri="direct:start"/>
-        <aggregate aggregationStrategy="myAppender" completionSize="10"
-                   aggregateController="myController">
-            <correlationExpression>
-                <header>id</header>
-            </correlationExpression>
-            <to uri="mock:result"/>
-        </aggregate>
-    </route>
-</camelContext>
 ----
 
 There is also JMX API on the aggregator which is available under the processors node in the Camel JMX tree.
@@ -505,6 +528,11 @@ And then in the Camel route we create an instance of our bean, and then
 refer to the bean in the route using `bean` method from
 `org.apache.camel.builder.AggregationStrategies` as shown:
 
+[tabs]
+====
+
+Java::
++
 [source,java]
 ----
 private MyBodyAppender appender = new MyBodyAppender();
@@ -517,7 +545,47 @@ public void configure() throws Exception {
 }
 ----
 
-We can also provide the bean class type directly:
+XML::
++
+[source,xml]
+----
+<bean id="myAppender" class="com.foo.MyBodyAppender"/>
+
+<camelContext xmlns="http://camel.apache.org/schema/spring">
+    <route>
+        <from uri="direct:start"/>
+        <aggregate aggregationStrategy="myAppender" aggregationStrategyMethodName="append" completionSize="3">
+            <correlationExpression>
+                <constant>true</constant>
+            </correlationExpression>
+            <to uri="mock:result"/>
+        </aggregate>
+    </route>
+</camelContext>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - aggregate:
+            aggregationStrategy: myAppender
+            aggregationStrategyMethodName: append
+            completionSize: 3
+            correlationExpression:
+              constant:
+                expression: "true"
+            steps:
+              - to:
+                  uri: mock:result
+----
+====
+
+In Java DSL, you can also provide the bean class type directly:
 
 [source,java]
 ----
@@ -555,35 +623,14 @@ public class MyBodyAppender {
 }
 ----
 
-If you are using XML DSL, then we need to declare a `<bean>` with the bean:
-
-[source,xml]
-----
-<bean id="myAppender" class="com.foo.MyBodyAppender"/>
-----
-
-And in the Camel route we use `aggregationStrategy` to refer to the bean by its
-id, and the `strategyMethodName` can be used to define the method name
-to call:
-
-[source,xml]
-----
-<camelContext xmlns="http://camel.apache.org/schema/spring">
-    <route>
-        <from uri="direct:start"/>
-        <aggregate aggregationStrategy="myAppender" aggregationStrategyMethodName="append" completionSize="3">
-            <correlationExpression>
-                <constant>true</constant>
-            </correlationExpression>
-            <to uri="mock:result"/>
-        </aggregate>
-    </route>
-</camelContext>
-----
-
-When using XML DSL, you can also specify the bean class directly in `aggregationStrategy`
+When using XML or YAML DSL, you can also specify the bean class directly in `aggregationStrategy`
 using the `#class:` syntax as shown:
 
+[tabs]
+====
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -597,8 +644,26 @@ using the `#class:` syntax as shown:
 </route>
 ----
 
-You can use this in XML DSL when you are not using the classic Spring XML files (
-where you use XML only for Camel routes).
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - aggregate:
+            aggregationStrategy: "#class:com.foo.MyBodyAppender"
+            aggregationStrategyMethodName: append
+            completionSize: 3
+            correlationExpression:
+              constant:
+                expression: "true"
+            steps:
+              - to:
+                  uri: mock:result
+----
+====
 
 === Aggregating when no data
 
@@ -647,9 +712,14 @@ If we didn't do this, then on timeout the append method would normally not be
 invoked, meaning the xref:content-enricher.adoc[Content Enricher] did
 not merge/change the message.
 
-In XML DSL you would configure the `strategyMethodAllowNull` option and
+In XML and YAML DSL you would configure the `strategyMethodAllowNull` option and
 set it to `true` as shown below:
 
+[tabs]
+====
+
+XML::
++
 [source,xml]
 ----
 <camelContext xmlns="http://camel.apache.org/schema/spring">
@@ -667,6 +737,28 @@ set it to `true` as shown below:
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - aggregate:
+            aggregationStrategy: myAppender
+            aggregationStrategyMethodName: append
+            aggregationStrategyMethodAllowNull: true
+            completionSize: 3
+            correlationExpression:
+              constant:
+                expression: "true"
+            steps:
+              - to:
+                  uri: mock:result
+----
+====
 
 === Aggregating with different body types
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/dead-letter-channel.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/dead-letter-channel.adoc
@@ -46,6 +46,15 @@ Spring XML::
               deadLetterUri="log:dead?level=ERROR"/>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- errorHandler:
+    deadLetterChannel:
+      deadLetterUri: "log:dead?level=ERROR"
+----
+
 ====
 
 Pay attention to Spring XML DSL. The type attribute is used to declare which error handler to use, here its `DeadLetterChannel`.
@@ -164,6 +173,18 @@ Spring XML::
 </errorHandler>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- errorHandler:
+    deadLetterChannel:
+      deadLetterUri: jms:queue:dead
+      redeliveryPolicy:
+        maximumRedeliveries: 3
+        redeliveryDelay: "5000"
+----
+
 ====
 
 The Dead Letter error handler will clear the caused exception (`setException(null)`), by moving the caused exception to a property on the xref:manual::exchange.adoc[Exchange], with the key `Exchange.EXCEPTION_CAUGHT`.
@@ -224,6 +245,19 @@ And in XML, you set `useOriginalMessage=true` on the `<errorHandler>` as shown:
 </errorHandler>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- errorHandler:
+    deadLetterChannel:
+      deadLetterUri: jms:queue:dead
+      useOriginalMessage: true
+      redeliveryPolicy:
+        maximumRedeliveries: 5
+        redeliveryDelay: "5000"
+----
+
 ====
 
 Then the messages routed to the `jms:queue:dead` is the original input.
@@ -271,6 +305,18 @@ And in XML DSL, you specify a bean id via `onRedeliveryRef` on the `<errorHandle
               deadLetterUri="jms:queue:dead">
   <redeliveryPolicy maximumRedeliveries="3"/>
 </errorHandler>
+----
+
+YAML::
++
+[source,yaml]
+----
+- errorHandler:
+    deadLetterChannel:
+      deadLetterUri: jms:queue:dead
+      onRedeliveryRef: myRedeliveryProcessor
+      redeliveryPolicy:
+        maximumRedeliveries: 3
 ----
 
 ====
@@ -321,6 +367,16 @@ Configuring this from Spring XML is done with the `onPrepareFailureRef` to refer
 <errorHandler id="dlc" type="DeadLetterChannel" deadLetterUri="jms:dead" onPrepareFailureRef="myPrepare"/>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- errorHandler:
+    deadLetterChannel:
+      deadLetterUri: jms:dead
+      onPrepareFailureRef: myPrepare
+----
+
 ====
 
 === Calling a processor when an exception occurred
@@ -364,6 +420,16 @@ Configuring this from Spring XML is done with the `onExceptionOccurredRef` to re
 <bean id="myErrorLogger" class="com.foo.OnErrorLogger"/>
 
 <errorHandler id="dlc" type="DeadLetterChannel" deadLetterUri="jms:dead" onExceptionOccurredRef="myErrorLogger"/>
+----
+
+YAML::
++
+[source,yaml]
+----
+- errorHandler:
+    deadLetterChannel:
+      deadLetterUri: jms:dead
+      onExceptionOccurredRef: myErrorLogger
 ----
 ====
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/filter-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/filter-eip.adoc
@@ -131,6 +131,11 @@ YAML::
 Here is another example of calling a xref:languages:bean-language.adoc[method on a bean]
 to define the filter behavior:
 
+[tabs]
+====
+
+Java::
++
 [source,java]
 ----
 from("direct:start")
@@ -140,22 +145,8 @@ from("direct:start")
     .to("mock:all");
 ----
 
-And then bean can have a method that returns a `boolean` as the predicate:
-
-[source,java]
-----
-public static class MyBean {
-
-    public boolean isGoldCustomer(@Header("level") String level) {
-        return level.equals("gold");
-    }
-
-}
-----
-
-And in XML we can call the bean in `<method>` where we can specify the FQN class name
-of the bean as shown:
-
+XML::
++
 [source,xml]
 ----
 <route>
@@ -168,8 +159,8 @@ of the bean as shown:
 </route>
 ----
 
-And similar in YAML DSL:
-
+YAML::
++
 [source,yaml]
 ----
 - route:
@@ -186,6 +177,20 @@ And similar in YAML DSL:
                   uri: mock:gold
         - to:
             uri: mock:all
+----
+====
+
+The bean can have a method that returns a `boolean` as the predicate:
+
+[source,java]
+----
+public static class MyBean {
+
+    public boolean isGoldCustomer(@Header("level") String level) {
+        return level.equals("gold");
+    }
+
+}
 ----
 
 === Filtering with status property

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-history.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-history.adoc
@@ -329,6 +329,27 @@ of the `<errorHandler>` as shown:
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- errorHandler:
+    defaultErrorHandler:
+      redeliveryPolicy:
+        logExhaustedMessageHistory: false
+        logExhaustedMessageBody: true
+- route:
+    from:
+      uri: jms:cheese
+      steps:
+        - to:
+            uri: bean:validate
+        - to:
+            uri: bean:transform
+        - to:
+            uri: jms:wine
+----
+
 ====
 
 == MessageHistory API

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/transactional-client.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/transactional-client.adoc
@@ -261,6 +261,42 @@ Spring XML::
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: activemq:queue:inbox
+      steps:
+        - transacted:
+            ref: txRequired
+        - to:
+            uri: direct:audit
+        - to:
+            uri: direct:order
+        - to:
+            uri: activemq:queue:order
+- route:
+    from:
+      uri: direct:audit
+      steps:
+        - transacted:
+            ref: txRequiresNew
+        - bean:
+            ref: auditLogService
+            method: insertAuditLog
+- route:
+    from:
+      uri: direct:order
+      steps:
+        - transacted:
+            ref: txMandatory
+        - bean:
+            ref: orderService
+            method: insertOrder
+----
 ====
 
 Notice how the ref attribute on `<transacted>` refers to the corresponding bean id of the transaction policy.
@@ -363,6 +399,46 @@ Spring XML::
 
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:okay
+      steps:
+        - transacted: {}
+        - setBody:
+            expression:
+              constant:
+                expression: Tiger in Action
+        - bean:
+            ref: bookService
+        - setBody:
+            expression:
+              constant:
+                expression: Elephant in Action
+        - bean:
+            ref: bookService
+- route:
+    from:
+      uri: direct:fail
+      steps:
+        - transacted: {}
+        - setBody:
+            expression:
+              constant:
+                expression: Tiger in Action
+        - bean:
+            ref: bookService
+        - setBody:
+            expression:
+              constant:
+                expression: Donkey in Action
+        - bean:
+            ref: bookService
+----
 ====
 
 That is all that is needed to configure a Camel route as being transacted.
@@ -437,5 +513,20 @@ Spring XML::
         <to uri="mock:result"/>
     </route>
 </camelContext>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: activemq:queue:okay
+      steps:
+        - transacted: {}
+        - process:
+            ref: myProcessor
+        - to:
+            uri: mock:result
 ----
 ====

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/constant-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/constant-language.adoc
@@ -33,6 +33,20 @@ include::partial$language-options.adoc[]
 The `setHeader` EIP can utilize a constant
 expression like:
 
+[tabs]
+====
+
+Java::
++
+[source,java]
+----
+from("seda:a")
+  .setHeader("theHeader", constant("the value"))
+  .to("mock:b");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -44,18 +58,27 @@ expression like:
 </route>
 ----
 
-in this case, the message coming from the seda:a
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: seda:a
+      steps:
+        - setHeader:
+            name: theHeader
+            expression:
+              constant:
+                expression: the value
+        - to:
+            uri: mock:b
+----
+====
+
+In this case, the message coming from the seda:a
 endpoint will have the header with key `theHeader`
 set its value as `the value` (string type).
-
-And the same example using Java DSL:
-
-[source,java]
-----
-from("seda:a")
-  .setHeader("theHeader", constant("the value"))
-  .to("mock:b");
-----
 
 === Specifying type of value
 
@@ -64,6 +87,11 @@ as a `String` value, which happens when using XML or YAML DSL:
 
 For example to set a header with `int` type you can do:
 
+[tabs]
+====
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -74,6 +102,25 @@ For example to set a header with `int` type you can do:
   <to uri="mock:b"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: seda:a
+      steps:
+        - setHeader:
+            name: zipCode
+            expression:
+              constant:
+                resultType: int
+                expression: "90210"
+        - to:
+            uri: mock:b
+----
+====
 
 
 == Loading constant from external resource

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/exchangeProperty-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/exchangeProperty-language.adoc
@@ -25,6 +25,18 @@ include::partial$language-options.adoc[]
 
 The `recipientList` EIP can utilize a exchangeProperty like:
 
+[tabs]
+====
+
+Java::
++
+[source,java]
+----
+from("direct:a").recipientList(exchangeProperty("myProperty"));
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -35,15 +47,23 @@ The `recipientList` EIP can utilize a exchangeProperty like:
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:a
+      steps:
+        - recipientList:
+            expression:
+              exchangeProperty:
+                expression: myProperty
+----
+====
+
 In this case, the list of recipients are contained in the property
 'myProperty'.
-
-And the same example in Java DSL:
-
-[source,java]
-----
-from("direct:a").recipientList(exchangeProperty("myProperty"));
-----
 
 == Dependencies
 

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/header-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/header-language.adoc
@@ -25,6 +25,18 @@ include::partial$language-options.adoc[]
 
 The `recipientList` EIP can utilize a header:
 
+[tabs]
+====
+
+Java::
++
+[source,java]
+----
+from("direct:a").recipientList(header("myHeader"));
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -35,15 +47,23 @@ The `recipientList` EIP can utilize a header:
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:a
+      steps:
+        - recipientList:
+            expression:
+              header:
+                expression: myHeader
+----
+====
+
 In this case, the list of recipients are contained in the header
 'myHeader'.
-
-And the same example in Java DSL:
-
-[source,java]
-----
-from("direct:a").recipientList(header("myHeader"));
-----
 
 == Dependencies
 

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/ref-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/ref-language.adoc
@@ -25,9 +25,21 @@ include::partial$language-options.adoc[]
 
 == Example usage
 
-The Splitter EIP in XML DSL can utilize a custom
-expression using `<ref>` like:
+The Splitter EIP can utilize a custom
+expression using `ref` like:
 
+[tabs]
+====
+
+Java::
++
+[source,java]
+----
+from("seda:a").split().ref("myExpression").to("seda:b");
+----
+
+XML::
++
 [source,xml]
 ----
 <bean id="myExpression" class="com.mycompany.MyCustomExpression"/>
@@ -35,23 +47,34 @@ expression using `<ref>` like:
 <route>
   <from uri="seda:a"/>
   <split>
-    <ref>myExpression</ref>   
+    <ref>myExpression</ref>
     <to uri="mock:b"/>
-  </split>     
+  </split>
 </route>
 ----
 
-in this case, the message coming from the seda:a
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: seda:a
+      steps:
+        - split:
+            expression:
+              ref:
+                expression: myExpression
+            steps:
+              - to:
+                  uri: mock:b
+----
+====
+
+In this case, the message coming from the seda:a
 endpoint will be split using a custom
 `Expression` which has the id `myExpression` in the
 xref:manual:ROOT:registry.adoc[Registry].
-
-And the same example using Java DSL:
-
-[source,java]
-----
-from("seda:a").split().ref("myExpression").to("seda:b");
-----
 
 == Dependencies
 

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/variable-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/variable-language.adoc
@@ -25,6 +25,18 @@ include::partial$language-options.adoc[]
 
 The `recipientList` EIP can utilize a variable:
 
+[tabs]
+====
+
+Java::
++
+[source,java]
+----
+from("direct:a").recipientList(variable("myVar"));
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -35,15 +47,23 @@ The `recipientList` EIP can utilize a variable:
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:a
+      steps:
+        - recipientList:
+            expression:
+              variable:
+                expression: myVar
+----
+====
+
 In this case, the list of recipients are contained in the variable
 'myVar'.
-
-And the same example in Java DSL:
-
-[source,java]
-----
-from("direct:a").recipientList(variable("myVar"));
-----
 
 == Dependencies
 

--- a/docs/user-manual/modules/ROOT/pages/architecture.adoc
+++ b/docs/user-manual/modules/ROOT/pages/architecture.adoc
@@ -24,8 +24,15 @@ A route has exactly one input xref:endpoint.adoc[endpoint],
 and 0, 1 or more output xref:endpoint.adoc[endpoints].
 
 You use Camel xref:dsl.adoc[DSL] to _code_ the xref:routes.adoc[routes].
-For example the route below is coded in xref:java-dsl.adoc[Java DSL]:
+For example the route below can be coded in xref:java-dsl.adoc[Java DSL],
+xref:components:others:java-xml-io-dsl.adoc[XML DSL],
+or xref:components:others:yaml-dsl.adoc[YAML DSL]:
 
+[tabs]
+====
+
+Java::
++
 [source,java]
 ----
 public class MyRoute extends RouteBuilder {
@@ -37,8 +44,8 @@ public class MyRoute extends RouteBuilder {
 }
 ----
 
-You can also use xref:components:others:java-xml-io-dsl.adoc[XML DSL] to _code_ the xref:routes.adoc[routes].
-
+XML::
++
 [source,xml]
 ----
 <route>
@@ -47,8 +54,8 @@ You can also use xref:components:others:java-xml-io-dsl.adoc[XML DSL] to _code_ 
 </route>
 ----
 
-For low-code users then xref:components:others:yaml-dsl.adoc[YAML DSL] is also possible:
-
+YAML::
++
 [source,yaml]
 ----
 - route:
@@ -58,3 +65,4 @@ For low-code users then xref:components:others:yaml-dsl.adoc[YAML DSL] is also p
         - to:
             uri: activemq:queue:cheese
 ----
+====

--- a/docs/user-manual/modules/ROOT/pages/endpoint.adoc
+++ b/docs/user-manual/modules/ROOT/pages/endpoint.adoc
@@ -187,19 +187,26 @@ separate the parameters. However, `&` also is a reserved character in XML.
 Because of this, you have to replace all `&` in your URIs by `+&amp;+` when
 using the XML DSL to configure Camel routes.
 
-An example: this snippet of code in Java DSL:
+For example, the following is the same endpoint URI in Java DSL and XML DSL
+where `&` has been replaced with `+&amp;+`:
 
+[tabs]
+====
+
+Java::
++
 [source,java]
 ----
 from("timer://myTimer?fixedRate=true&delay=0&period=2000")
 ----
 
-... matches this example in the XML syntax where `&` has been replaced with `+&amp;+`
-
+XML::
++
 [source,xml]
 ----
 <from uri="timer://myTimer?fixedRate=true&amp;delay=0&amp;period=2000"/>
 ----
+====
 
 === Configuring parameter values using raw values, such as passwords
 

--- a/docs/user-manual/modules/ROOT/pages/error-handler.adoc
+++ b/docs/user-manual/modules/ROOT/pages/error-handler.adoc
@@ -76,15 +76,20 @@ or in Spring XML DSL:
 
 === No Error Handler
 
-The no error handler is to be used for disabling error handling in Java DSL:
+The no error handler is to be used for disabling error handling.
 
+[tabs]
+====
+
+Java::
++
 [source,java]
 ----
 errorHandler(noErrorHandler());
 ----
 
-And in Spring XML DSL:
-
+Spring XML::
++
 [source,xml]
 ----
 <camel:errorHandler id="noErrorHandler" type="NoErrorHandler"/>
@@ -93,6 +98,7 @@ And in Spring XML DSL:
   ...
 </camel:camelContext>
 ----
+====
 
 === TransactionErrorHandler
 

--- a/docs/user-manual/modules/ROOT/pages/http-session-handling.adoc
+++ b/docs/user-manual/modules/ROOT/pages/http-session-handling.adoc
@@ -107,6 +107,42 @@ Spring XML::
   <bean id="instanceCookieHandler" class="org.apache.camel.http.common.cookie.InstanceCookieHandler"/>
   <bean id="exchangeCookieHandler" class="org.apache.camel.http.common.cookie.ExchangeCookieHandler"/>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct://proxy
+      steps:
+        - to:
+            uri: cxfrs://bean://rsClientProxy
+        - convertBodyTo:
+            type: java.lang.String
+        - to:
+            uri: cxfrs://bean://rsClientProxy
+- route:
+    from:
+      uri: direct://proxyinstance
+      steps:
+        - to:
+            uri: "cxfrs://bean://rsClientProxy?cookieHandler=#instanceCookieHandler"
+        - convertBodyTo:
+            type: java.lang.String
+        - to:
+            uri: "cxfrs://bean://rsClientProxy?cookieHandler=#instanceCookieHandler"
+- route:
+    from:
+      uri: direct://proxyexchange
+      steps:
+        - to:
+            uri: "cxfrs://bean://rsClientProxy?cookieHandler=#exchangeCookieHandler"
+        - convertBodyTo:
+            type: java.lang.String
+        - to:
+            uri: "cxfrs://bean://rsClientProxy?cookieHandler=#exchangeCookieHandler"
+----
 ====
 
 Both `CookieHandler` implementations support setting a CookiePolicy to control the policy for storing

--- a/docs/user-manual/modules/ROOT/pages/simplescheduledroutepolicy.adoc
+++ b/docs/user-manual/modules/ROOT/pages/simplescheduledroutepolicy.adoc
@@ -88,8 +88,13 @@ created it can be wired into the camel route as follows.
 
 == Using the SimpleScheduledRoutePolicy
 
-The `SimpleScheduledRoutePolicy` can be used in Java DSL as show:
+The `SimpleScheduledRoutePolicy` can be used as shown:
 
+[tabs]
+====
+
+Java::
++
 [source,java]
 ----
 SimpleScheduledRoutePolicy policy = new SimpleScheduledRoutePolicy();
@@ -97,15 +102,15 @@ long startTime = System.currentTimeMillis() + 3000L;
 policy.setRouteStartDate(new Date(startTime));
 policy.setRouteStartRepeatCount(1);
 policy.setRouteStartRepeatInterval(3000);
-                
+
 from("direct:start")
    .routeId("test")
    .routePolicy(policy)
    .to("mock:success");
 ----
 
-And in Spring XML:
-
+XML::
++
 [source,xml]
 ----
 <bean id="date" class="org.apache.camel.routepolicy.quartz.SimpleDate"/>
@@ -113,9 +118,9 @@ And in Spring XML:
 <bean id="startPolicy" class="org.apache.camel.routepolicy.quartz.SimpleScheduledRoutePolicy">
     <property name="routeStartDate" ref="date"/>
     <property name="routeStartRepeatCount" value="1"/>
-    <property name="routeStartRepeatInterval" value="3000"/>      
-</bean> 
-    
+    <property name="routeStartRepeatInterval" value="3000"/>
+</bean>
+
 <camelContext xmlns="http://camel.apache.org/schema/spring">
     <route id="myroute" routePolicyRef="startPolicy">
         <from uri="direct:start"/>
@@ -123,6 +128,21 @@ And in Spring XML:
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: myroute
+    routePolicyRef: startPolicy
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: mock:success
+----
+====
 
 == Dependency
 


### PR DESCRIPTION
## Summary

- Added YAML DSL tabs to `[tabs]` blocks that were missing them across 15 EIP, language, and user manual documentation files
- Wrapped standalone Java/XML code snippet pairs into proper `[tabs]` blocks where they documented route definitions
- All YAML DSL snippets were generated using `camel_transform_route` MCP tool and validated with `camel_validate_yaml_dsl`

### Files changed

**EIP docs** (5 files): aggregate-eip, dead-letter-channel, filter-eip, message-history, transactional-client
**Language docs** (5 files): constant, exchangeProperty, header, ref, variable
**User manual docs** (5 files): architecture, endpoint, error-handler, http-session-handling, simplescheduledroutepolicy

### What was NOT changed

Tab blocks containing only configuration snippets (CamelContext attributes, `application.properties`, Java API calls, Spring bean definitions) were intentionally left without YAML tabs, as they don't have YAML DSL equivalents.

## Test plan

- [ ] Verify adoc rendering (tab blocks render correctly with all 3 DSL tabs)
- [ ] Spot-check YAML DSL snippets match their Java/XML counterparts

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)