### PR TITLE
CAMEL-23651: sync muteException upgrade-guide entries into 4_18/4_14 guides on main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -13,6 +13,31 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 
 == Upgrading from 4.14.3 to 4.14.8
 
+=== camel-netty-http / camel-undertow - potential breaking change
+
+The `muteException` consumer option now defaults to `true` in `camel-netty-http` and
+`camel-undertow`, aligning these components with the other HTTP server components
+(`camel-http`, `camel-jetty`, `camel-servlet`, and `camel-platform-http`), which have
+been defaulting `muteException` to `true` for a long time.
+
+When an exchange fails processing on the consumer side, the HTTP response now has an
+empty body. Previously the response body contained the exception stack trace as
+`text/plain`.
+
+Routes that rely on the exception stack trace being present in the response body must
+set `muteException=false` explicitly on the endpoint or component after the upgrade:
+
+[source,text]
+----
+netty-http:http://0.0.0.0:8080/foo?muteException=false
+undertow:http://0.0.0.0:8080/foo?muteException=false
+----
+
+Note that `muteException` takes precedence over `transferException`, as it already does
+in the other HTTP server components. Routes using `transferException=true` on these two
+components must now also set `muteException=false` for the serialized exception to be
+returned in the response.
+
 === camel-core
 
 The `org.apache.camel.support.DefaultHeaderFilterStrategy` changed default setting for lowercase from `false` to `true`.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -13,6 +13,31 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 
 == Upgrading from 4.18.1 to 4.18.3
 
+=== camel-netty-http / camel-undertow - potential breaking change
+
+The `muteException` consumer option now defaults to `true` in `camel-netty-http` and
+`camel-undertow`, aligning these components with the other HTTP server components
+(`camel-http`, `camel-jetty`, `camel-servlet`, and `camel-platform-http`), which have
+been defaulting `muteException` to `true` for a long time.
+
+When an exchange fails processing on the consumer side, the HTTP response now has an
+empty body. Previously the response body contained the exception stack trace as
+`text/plain`.
+
+Routes that rely on the exception stack trace being present in the response body must
+set `muteException=false` explicitly on the endpoint or component after the upgrade:
+
+[source,text]
+----
+netty-http:http://0.0.0.0:8080/foo?muteException=false
+undertow:http://0.0.0.0:8080/foo?muteException=false
+----
+
+Note that `muteException` takes precedence over `transferException`, as it already does
+in the other HTTP server components. Routes using `transferException=true` on these two
+components must now also set `muteException=false` for the serialized exception to be
+returned in the response.
+
 === camel-keycloak
 
 The `KeycloakSecurityPolicy` route policy now always verifies the access token when one is present - signature,


### PR DESCRIPTION
## What

The `muteException` default flip for `camel-netty-http` / `camel-undertow` (CAMEL-23651) was backported to:
- `camel-4.18.x` — #23923 (ships in 4.18.3)
- `camel-4.14.x` — #23990 (ships in 4.14.8)

On each maintenance branch the upgrade-guide note was added to that release line's per-patch section. Per the project's **backport upgrade-guide policy**, the version-specific `camel-4x-upgrade-guide-4_XX.adoc` files on `main` are the canonical history across all releases, so the same entries must also live on `main`.

This PR adds the missing `camel-netty-http / camel-undertow` muteException note to:
- `camel-4x-upgrade-guide-4_18.adoc` → **Upgrading from 4.18.1 to 4.18.3**
- `camel-4x-upgrade-guide-4_14.adoc` → **Upgrading from 4.14.3 to 4.14.8**

(The `4_21` guide on main already has the entry from the original PR #23913.)

## Notes

- Docs-only; no code or generated files. The added entry contains no `xref:` links.
- Without this, main's 4_18/4_14 guides drift out of sync with what's actually shipping on the maintenance branches.

---
_Claude Code on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)