### PR TITLE
fix(test-infra): handle both old and new CLI version output

### DIFF
--- a/test-infra/camel-test-infra-cli/src/main/java/org/apache/camel/test/infra/cli/services/CliLocalContainerService.java
+++ b/test-infra/camel-test-infra-cli/src/main/java/org/apache/camel/test/infra/cli/services/CliLocalContainerService.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -241,7 +243,10 @@ public class CliLocalContainerService implements CliService, ContainerService<Cl
                         version = StringHelper.between(versionSummary, "camel-version = ", "\n").trim();
                     }
                     if (version == null) {
-                        version = StringHelper.between(versionSummary, "Camel CLI version:", "\n").trim();
+                        Matcher m = Pattern.compile("Camel (?:CLI|JBang) version:\\s*(.+)").matcher(versionSummary);
+                        if (m.find()) {
+                            version = m.group(1).trim();
+                        }
                     }
                     return version;
                 });


### PR DESCRIPTION
The `version()` method in `CliLocalContainerService` was changed to look for `"Camel CLI version:"` (commit 47b1e09) but older launcher JARs still output `"Camel JBang version:"` (pre-rebrand). When the new string isn't found, `StringHelper.between()` returns null and `.trim()` throws an NPE during `initialize()`.

Accept both `"Camel CLI version:"` and `"Camel JBang version:"` strings, and guard against null before calling `trim()`.