### PR TITLE
CAMEL-23759: camel-spring-ws - sync upgrade-guide entry to 4.18/4.14 guides on main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -13,6 +13,17 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 
 == Upgrading from 4.14.3 to 4.14.8
 
+=== camel-spring-ws - potential breaking change
+
+The `spring-ws` consumer now applies a `HeaderFilterStrategy` to the SOAP headers it maps onto the
+Camel `Exchange`. The default `headerFilterStrategy` is a new `SpringWebserviceHeaderFilterStrategy`
+that filters header names starting with `Camel` / `camel` (case-insensitive) in both the inbound and
+outbound directions, aligning the component with the rest of the Camel component catalog
+(`camel-cxf`, `camel-mail`, `camel-coap`, ...). SOAP header element and attribute names that fall in
+that namespace are no longer propagated as `Exchange` headers. Routes that relied on receiving such
+header names from inbound SOAP headers can supply a custom `headerFilterStrategy` (via the new
+`headerFilterStrategy` endpoint option) to restore the previous behaviour.
+
 === camel-netty-http / camel-undertow - potential breaking change
 
 The `muteException` consumer option now defaults to `true` in `camel-netty-http` and

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -13,6 +13,17 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 
 == Upgrading from 4.18.1 to 4.18.3
 
+=== camel-spring-ws - potential breaking change
+
+The `spring-ws` consumer now applies a `HeaderFilterStrategy` to the SOAP headers it maps onto the
+Camel `Exchange`. The default `headerFilterStrategy` is a new `SpringWebserviceHeaderFilterStrategy`
+that filters header names starting with `Camel` / `camel` (case-insensitive) in both the inbound and
+outbound directions, aligning the component with the rest of the Camel component catalog
+(`camel-cxf`, `camel-mail`, `camel-coap`, ...). SOAP header element and attribute names that fall in
+that namespace are no longer propagated as `Exchange` headers. Routes that relied on receiving such
+header names from inbound SOAP headers can supply a custom `headerFilterStrategy` (via the new
+`headerFilterStrategy` endpoint option) to restore the previous behaviour.
+
 === camel-netty-http / camel-undertow - potential breaking change
 
 The `muteException` consumer option now defaults to `true` in `camel-netty-http` and


### PR DESCRIPTION
## Description

Documentation sync follow-up for **CAMEL-23759** (camel-spring-ws inbound SOAP header filtering, merged for 4.21.0 in #24030).

Per the backport upgrade-guide policy, the version-specific `camel-4x-upgrade-guide-4_XX.adoc` files on `main` are the canonical history. The camel-spring-ws change is fixVersioned for **4.18.3** and **4.14.8**, so this adds the matching `camel-spring-ws` entry to:

- `camel-4x-upgrade-guide-4_18.adoc` (Upgrading from 4.18.1 to 4.18.3)
- `camel-4x-upgrade-guide-4_14.adoc` (Upgrading from 4.14.3 to 4.14.8)

The code backports to the `camel-4.18.x` / `camel-4.14.x` branches will follow.

_Claude Code on behalf of Andrea Cosentino._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
