### PR TITLE
chore: downgrade protobuf-version to 4.34.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,8 @@ updates:
       - dependency-name: "org.apache.logging.log4j:*"
       # This is a virtual plugin which doesn't really exist
       - dependency-name: "org.eclipse.m2e:lifecycle-mapping"
+      # Managed manually - gencode version must be <= the lowest runtime version across Spring Boot and Quarkus
+      - dependency-name: "com.google.protobuf:*"
     groups:
       Micrometer:
         patterns: ["io.micrometer:*"]

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -435,7 +435,7 @@
         <pooled-jms-version>3.2.2</pooled-jms-version>
         <properties-maven-plugin-version>1.3.0</properties-maven-plugin-version>
         <proto-google-common-protos-version>2.72.0</proto-google-common-protos-version>
-        <protobuf-version>4.35.1</protobuf-version>
+        <protobuf-version>4.34.2</protobuf-version>
         <protobuf-maven-plugin-version>4.1.3</protobuf-maven-plugin-version>
         <prowide-version>SRU2025-10.3.9</prowide-version>
         <pubnub-version>13.4.0</pubnub-version>


### PR DESCRIPTION
Relates to:

* https://github.com/apache/camel-quarkus/issues/8681
* The Salesforce project in camel-spring-boot-examples fails with [errors](https://issues.apache.org/jira/browse/CAMEL-23758) similar to those described in the above issue

Protobuf gencode version must be <= the runtime version used by consumers. Spring Boot uses 4.34.2 and Quarkus uses 4.35.0, so aligning to 4.34.2 ensures generated stubs are compatible with both frameworks without errors.

Excluded com.google.protobuf from Dependabot to manage this manually and avoid inadvertent bumps that break framework compatibility. Perhaps protobuf is something we bump when we do Spring Boot dependency alignment.


