### PR TITLE
CAMEL-23760: camel-oauth - sync upgrade-guide entry to 4.18/4.14 guides on main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -13,6 +13,13 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 
 == Upgrading from 4.14.3 to 4.14.8
 
+=== camel-oauth
+
+`UserProfile` token verification now fails closed when no JWK set is available: a signed token can no
+longer be accepted when the configured JWK set is missing or empty, since its signature cannot be
+verified in that case. Deployments with a correctly resolved JWK set are unaffected; this aligns the
+legacy `UserProfile` path with the `JwtTokenValidator` SPI path.
+
 === camel-spring-ws - potential breaking change
 
 The `spring-ws` consumer now applies a `HeaderFilterStrategy` to the SOAP headers it maps onto the

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -13,6 +13,13 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 
 == Upgrading from 4.18.1 to 4.18.3
 
+=== camel-oauth
+
+`UserProfile` token verification now fails closed when no JWK set is available: a signed token can no
+longer be accepted when the configured JWK set is missing or empty, since its signature cannot be
+verified in that case. Deployments with a correctly resolved JWK set are unaffected; this aligns the
+legacy `UserProfile` path with the `JwtTokenValidator` SPI path.
+
 === camel-spring-ws - potential breaking change
 
 The `spring-ws` consumer now applies a `HeaderFilterStrategy` to the SOAP headers it maps onto the


### PR DESCRIPTION
## Description

Documentation sync follow-up for **CAMEL-23760** (camel-oauth `UserProfile` JWK-set fail-closed verification, merged for 4.21.0 in #24032).

Per the backport upgrade-guide policy, the version-specific `camel-4x-upgrade-guide-4_XX.adoc` files on `main` are the canonical history. The camel-oauth change is fixVersioned for **4.18.3** and **4.14.8**, so this adds the matching `camel-oauth` entry to:

- `camel-4x-upgrade-guide-4_18.adoc` (Upgrading from 4.18.1 to 4.18.3)
- `camel-4x-upgrade-guide-4_14.adoc` (Upgrading from 4.14.3 to 4.14.8)

The code backports to the `camel-4.18.x` / `camel-4.14.x` branches will follow.

_Claude Code on behalf of Andrea Cosentino._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
