### PR TITLE
CAMEL-23763: Make rest/template/kamelet on RouteDefinition @XmlTransient

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-xml-io.xsd
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camel-xml-io.xsd
@@ -11659,7 +11659,6 @@ The group name for this route. Multiple routes can belong to the same group.
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="kamelet" type="xs:boolean"/>
         <xs:attribute name="logMask" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">
@@ -11697,7 +11696,6 @@ or not.
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="rest" type="xs:boolean"/>
         <xs:attribute name="routeConfigurationId" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">
@@ -11754,7 +11752,6 @@ Whether stream caching is enabled on this route. Default value: false
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="template" type="xs:boolean"/>
         <xs:attribute name="trace" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/RouteDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/RouteDefinition.java
@@ -1290,12 +1290,11 @@ public class RouteDefinition extends OutputDefinition<RouteDefinition>
     /**
      * This route is created from REST DSL
      */
+    @XmlTransient
     public void setRest(Boolean rest) {
         this.rest = rest;
     }
 
-    @XmlAttribute
-    @Metadata(label = "advanced")
     public Boolean isRest() {
         return rest;
     }
@@ -1303,12 +1302,11 @@ public class RouteDefinition extends OutputDefinition<RouteDefinition>
     /**
      * This route is created from a route template (or from a Kamelet).
      */
+    @XmlTransient
     public void setTemplate(Boolean template) {
         this.template = template;
     }
 
-    @XmlAttribute
-    @Metadata(label = "advanced")
     public Boolean isTemplate() {
         return template;
     }
@@ -1316,12 +1314,11 @@ public class RouteDefinition extends OutputDefinition<RouteDefinition>
     /**
      * This route is created from a Kamelet.
      */
+    @XmlTransient
     public void setKamelet(Boolean kamelet) {
         this.kamelet = kamelet;
     }
 
-    @XmlAttribute
-    @Metadata(label = "advanced")
     public Boolean isKamelet() {
         return kamelet;
     }

--- a/core/camel-xml-io/src/generated/java/org/apache/camel/xml/in/ModelParser.java
+++ b/core/camel-xml-io/src/generated/java/org/apache/camel/xml/in/ModelParser.java
@@ -922,11 +922,8 @@ public class ModelParser extends BaseParser {
                 case "errorHandler": def.setErrorHandler(doParseErrorHandlerDefinition()); yield true;
                 case "from": def.setInput(doParseFromDefinition()); yield true;
                 case "inputType": def.setInputType(doParseInputTypeDefinition()); yield true;
-                case "kamelet": def.setKamelet(Boolean.valueOf(doParseText())); yield true;
                 case "outputType": def.setOutputType(doParseOutputTypeDefinition()); yield true;
-                case "rest": def.setRest(Boolean.valueOf(doParseText())); yield true;
                 case "routeProperty": doAdd(doParsePropertyDefinition(), def.getRouteProperties(), def::setRouteProperties); yield true;
-                case "template": def.setTemplate(Boolean.valueOf(doParseText())); yield true;
                 default: yield outputDefinitionElementHandler().accept(def, key);
             }, noValueHandler());
     }

--- a/core/camel-xml-io/src/generated/java/org/apache/camel/xml/out/ModelWriter.java
+++ b/core/camel-xml-io/src/generated/java/org/apache/camel/xml/out/ModelWriter.java
@@ -1588,9 +1588,6 @@ public class ModelWriter extends BaseWriter {
     protected void doWriteRouteDefinition(String name, RouteDefinition def) throws IOException {
         startElement(name);
         doWriteProcessorDefinitionAttributes(def);
-        doWriteAttribute("template", toString(def.isTemplate()), null);
-        doWriteAttribute("kamelet", toString(def.isKamelet()), null);
-        doWriteAttribute("rest", toString(def.isRest()), null);
         doWriteAttribute("group", def.getGroup(), null);
         doWriteAttribute("nodePrefixId", def.getNodePrefixId(), null);
         doWriteAttribute("routeConfigurationId", def.getRouteConfigurationId(), null);


### PR DESCRIPTION
## Summary

- Mark `rest`, `template`, and `kamelet` boolean fields on `RouteDefinition` as `@XmlTransient` (on their setters) instead of `@XmlAttribute` (on their getters). These are runtime transient flags that should never be serialized to XML.
- The `@XmlAttribute` annotation caused the XML `ModelWriter` to emit spurious attributes like `kamelet="false"` on the `<route>` element, and the `kamelet` element handler in `ModelParser` shadowed the `KameletDefinition` EIP child element, breaking XML round-trip (parse → write → re-parse).
- Regenerated `ModelParser`, `ModelWriter`, `camel-spring.xsd`, and `camel-xml-io.xsd`.

## Test plan

- [x] Existing `ModelWriterTest` round-trip tests pass (they no longer produce spurious attributes)
- [ ] Verify a route with `<kamelet name="my-processor"/>` child element survives XML round-trip

_Claude Code on behalf of Claus Ibsen_

Co-Authored-By: Claude <noreply@anthropic.com>