### PR TITLE
chore: camel-spring-ws - exclude transitive opensaml dependencies

### DIFF
--- a/components/camel-spring-parent/camel-spring-ws/pom.xml
+++ b/components/camel-spring-parent/camel-spring-ws/pom.xml
@@ -116,6 +116,10 @@
                     <groupId>xalan</groupId>
                     <artifactId>xalan</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.opensaml</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -1036,6 +1036,12 @@ that namespace are no longer propagated as `Exchange` headers. Routes that relie
 header names from inbound SOAP headers can supply a custom `headerFilterStrategy` (via the new
 `headerFilterStrategy` endpoint option) to restore the previous behaviour.
 
+The transitive `org.opensaml` dependencies pulled in by `spring-ws-security` have been excluded.
+Camel's Spring-WS component does not use OpenSAML, and these artifacts are hosted on a third-party
+Maven repository (`build.shibboleth.net`) that has proven unreliable, causing intermittent CI and
+build failures. If your project depends on OpenSAML for SAML-based WS-Security, you will need to
+add the `org.opensaml` dependencies explicitly.
+
 === camel-lucene
 
 The Exchange header values exposed by `LuceneConstants` have been renamed to follow the standard


### PR DESCRIPTION
## Summary

- Exclude `org.opensaml:*` transitive dependencies from `spring-ws-security` in camel-spring-ws
- The OpenSAML artifacts are hosted on `build.shibboleth.net`, a third-party Maven repository that has proven unreliable, causing intermittent CI and build failures (see #24042)
- Camel's Spring-WS component does not use OpenSAML — the dependency is pulled in transitively through `wss4j → opensaml-saml-impl`

## Test plan

- [x] Verified no camel-spring-ws source code imports or references `org.opensaml`
- [ ] CI passes with the exclusion in place

_Claude Code on behalf of Claus Ibsen_