### PR TITLE
fix(ci): assemble camel-jbang multi-arch image with buildx imagetools

### DIFF
--- a/dsl/camel-jbang/camel-jbang-container/Makefile
+++ b/dsl/camel-jbang/camel-jbang-container/Makefile
@@ -80,9 +80,9 @@ images-push:
 	@echo "####### Pushing Camel JBang (CLI) $(IMAGE_PUSH) container image..."
 	for i in $(ARCH_VERSIONS); do \
 		docker push $(IMAGE_PUSH)-$$i ; \
-		docker manifest create $(IMAGE_PUSH) -a $(IMAGE_PUSH)-$$i; \
 	done
-	docker manifest push $(IMAGE_PUSH) --purge
+	docker buildx imagetools create -t $(IMAGE_PUSH) \
+		$(foreach arch,$(ARCH_VERSIONS),$(IMAGE_PUSH)-$(arch))
 
 images-release: images-build-all images-push-all images-check-all
 


### PR DESCRIPTION
## Problem

`make ... images-push-all` in `dsl/camel-jbang/camel-jbang-container` fails during the 4.20.0 release with:

```
docker.io/apache/camel-jbang:4.20.0-arm64 is a manifest list
make[1]: *** [Makefile:81: images-push] Error 1
```

The `images-push` target assembled the per-arch tags into the multi-arch tag with `docker manifest create`. On a host using the **containerd image store** (the default in recent Docker, e.g. 29.x), `docker buildx build --load` stores each built image as an **OCI image index** (`application/vnd.oci.image.index.v1+json`) — even for a single platform — and additionally attaches a buildx provenance **attestation manifest**. The pushed `:VERSION-<arch>` tags are therefore manifest lists, and `docker manifest create` refuses manifest-list members, hence the failure. (The Makefile worked under the classic image store, where `--load` yields a plain image manifest.)

## Fix

Replace the `docker manifest create` loop + `docker manifest push --purge` with `docker buildx imagetools create`, which:

- accepts **index sources** and merges their child manifests,
- preserves the buildx attestations, and
- pushes the resulting manifest list directly (so no separate `docker manifest push` is needed).

This works on both the classic and the containerd image stores.

```diff
 	for i in $(ARCH_VERSIONS); do \
 		docker push $(IMAGE_PUSH)-$$i ; \
-		docker manifest create $(IMAGE_PUSH) -a $(IMAGE_PUSH)-$$i; \
 	done
-	docker manifest push $(IMAGE_PUSH) --purge
+	docker buildx imagetools create -t $(IMAGE_PUSH) \
+		$(foreach arch,$(ARCH_VERSIONS),$(IMAGE_PUSH)-$(arch))
```

The same `images-push` target is reused by `images-push-all` for the bare `:VERSION`, `:VERSION-17-jdk` and `:VERSION-21-jdk` tags, so all three are covered by this one change.

## Verification

Expansion verified without publishing:

```
$ make -n CAMEL_VERSION=4.20.0 images-push
...
docker buildx imagetools create -t docker.io/apache/camel-jbang:4.20.0 \
	docker.io/apache/camel-jbang:4.20.0-amd64 docker.io/apache/camel-jbang:4.20.0-arm64
```

The real push to the official `docker.io/apache/camel-jbang` repo is intentionally left to the release operator.

---
_Generated by Claude Code on behalf of Andrea Cosentino_