### PR TITLE
CAMEL-23772: dataformat component honors global camel.dataformat.* configuration

### DIFF
--- a/components/camel-csv/pom.xml
+++ b/components/camel-csv/pom.xml
@@ -53,6 +53,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-dataformat</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-xml</artifactId>
             <scope>test</scope>
         </dependency>

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/component/DataFormatComponentConfigTest.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/component/DataFormatComponentConfigTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.csv.component;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.main.Main;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Verifies that a {@code dataformat:} component endpoint honors the global {@code camel.dataformat.csv.*} configuration
+ * (here {@code ignore-surrounding-spaces=true}) the same way the {@code unmarshal()} DSL does (CAMEL-23772).
+ */
+public class DataFormatComponentConfigTest {
+
+    @Test
+    public void testGlobalConfigAppliedToDataFormatComponent() throws Exception {
+        Main main = new Main();
+        main.configure().withBasePackageScan("org.apache.camel.dataformat.csv.component");
+        main.start();
+        try {
+            CamelContext camelContext = main.getCamelContext();
+            assertNotNull(camelContext);
+            assertEquals(1, camelContext.getRoutes().size());
+
+            MockEndpoint mock = camelContext.getEndpoint("mock:result", MockEndpoint.class);
+            mock.expectedMessageCount(1);
+            mock.assertIsSatisfied();
+
+            Object body = mock.getReceivedExchanges().get(0).getMessage().getBody();
+            assertNotNull(body);
+            // global camel.dataformat.csv.ignore-surrounding-spaces=true must be applied, so the
+            // surrounding spaces are stripped; without the fix the component ignores it and the
+            // spaces would be preserved
+            assertEquals("[[One], [Two], [Three]]", body.toString());
+        } finally {
+            main.stop();
+        }
+    }
+}

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/component/DataFormatComponentRoute.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/component/DataFormatComponentRoute.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.csv.component;
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class DataFormatComponentRoute extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        // use the dataformat: component instead of the unmarshal() DSL; it must honor the global
+        // camel.dataformat.csv.* configuration from application.properties (CAMEL-23772)
+        from("timer:tick?repeatCount=1")
+                .setBody().constant("One   \r\nTwo   \r\nThree   \r\n")
+                .to("dataformat:csv:unmarshal")
+                .to("mock:result");
+    }
+}

--- a/components/camel-dataformat/src/main/java/org/apache/camel/component/dataformat/DataFormatComponent.java
+++ b/components/camel-dataformat/src/main/java/org/apache/camel/component/dataformat/DataFormatComponent.java
@@ -16,15 +16,19 @@
  */
 package org.apache.camel.component.dataformat;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.ExtendedPropertyConfigurerGetter;
 import org.apache.camel.spi.PropertyConfigurer;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.PropertyBindingSupport;
+import org.apache.camel.support.PropertyConfigurerHelper;
 import org.apache.camel.util.StringHelper;
 
 /**
@@ -47,6 +51,7 @@ public class DataFormatComponent extends DefaultComponent {
         // create new data format as it is configured from the given parameters
         String name = StringHelper.before(remaining, ":");
         DataFormat df = getCamelContext().createDataFormat(name);
+        boolean created = df != null;
         if (df == null) {
             // if not, try to lookup existing data format
             df = getCamelContext().resolveDataFormat(name);
@@ -58,7 +63,15 @@ public class DataFormatComponent extends DefaultComponent {
         // find configurer if any
         PropertyConfigurer configurer = PluginHelper.getConfigurerResolver(getCamelContext())
                 .resolvePropertyConfigurer(name + "-dataformat", getCamelContext());
-        // bind properties to data format
+
+        // when a brand-new instance was created, first copy any global camel.dataformat.<name>.*
+        // configuration from the auto-configured data format onto it, so the dataformat: component
+        // honors global configuration the same way the marshal()/unmarshal() DSL does (CAMEL-22352)
+        if (created) {
+            copyGlobalConfiguration(name, df, configurer);
+        }
+
+        // bind the endpoint parameters; these take precedence over the global configuration
         PropertyBindingSupport.Builder builder = new PropertyBindingSupport.Builder();
         builder.withConfigurer(configurer);
         builder.bind(getCamelContext(), df, parameters);
@@ -68,5 +81,46 @@ public class DataFormatComponent extends DefaultComponent {
         endpoint.setOperation(operation);
         setProperties(endpoint, parameters);
         return endpoint;
+    }
+
+    /**
+     * Copies the configuration of an auto-configured data format (e.g. set up via global
+     * {@code camel.dataformat.<name>.*} properties) onto the newly created data format instance, so that
+     * {@code dataformat:} endpoints honor global configuration. The endpoint URI parameters are bound afterwards and
+     * therefore take precedence over the copied values.
+     */
+    private void copyGlobalConfiguration(String name, DataFormat target, PropertyConfigurer configurer) {
+        CamelContext context = getCamelContext();
+        // only relevant when a generic data format has been auto-configured, e.g. via camel.dataformat.<name>.*
+        if (!context.getDataFormatNames().contains(name)) {
+            return;
+        }
+        DataFormat template = context.resolveDataFormat(name);
+        if (template == null || template == target) {
+            return;
+        }
+        PropertyConfigurer getter = configurer;
+        if (getter == null) {
+            getter = PropertyConfigurerHelper.resolvePropertyConfigurer(context, template);
+        }
+        if (getter instanceof ExtendedPropertyConfigurerGetter eg) {
+            Map<String, Object> properties = new LinkedHashMap<>();
+            for (String key : eg.getAllOptions(template).keySet()) {
+                Object value = eg.getOptionValue(template, key, true);
+                if (value != null) {
+                    properties.put(key, value);
+                }
+            }
+            if (!properties.isEmpty()) {
+                PropertyBindingSupport.build()
+                        .withCamelContext(context)
+                        .withTarget(target)
+                        .withReference(true)
+                        .withIgnoreCase(true)
+                        .withConfigurer(configurer)
+                        .withProperties(properties)
+                        .bind();
+            }
+        }
     }
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -25,6 +25,15 @@ When `fromRouteId` is not available (for example, on Exchanges created by `Produ
 This ensures Prometheus-compatible metric export when Route triggered and ProducerTemplate Exchanges are mixed.
 Dashboards or alerts that assumed the `routeId` label was absent must be updated to treat `routeId=""` accordingly.
 
+=== camel-dataformat
+
+The `dataformat:` component now applies the global `camel.dataformat.<name>.*` configuration (for example from
+`application.properties`) when it creates the data format instance. Previously a `dataformat:` endpoint such as
+`to("dataformat:beanio:unmarshal")` ignored this global configuration and used only the options provided on the
+endpoint URI, which could leave the data format incompletely configured. This aligns the component with the
+`marshal()` / `unmarshal()` DSL, which already honors the global configuration. Options specified on the endpoint URI
+continue to take precedence over the global configuration.
+
 === camel-core
 
 ==== Simple language: internal builder classes reorganized


### PR DESCRIPTION
## Summary

`dataformat:` component endpoints (e.g. `to("dataformat:beanio:unmarshal")`) ignored the global `camel.dataformat.<name>.*` configuration from `application.properties`, while the equivalent fluent DSL (`unmarshal().beanio(...)`) already honored it. The two paths behaved inconsistently, and the component path could throw at runtime (e.g. `IllegalArgumentException: Stream name not configured` for BeanIO).

Reported while analysing [camel-quarkus#7651](https://github.com/apache/camel-quarkus/issues/7651); the root cause is in Camel core.

## Root cause

`DataFormatComponent.createEndpoint()` calls `createDataFormat(name)`, which returns a fresh, **unconfigured** instance, and then binds only the endpoint URI parameters. It never copies the options of the auto-configured "template" data format (the one set up from `camel.dataformat.<name>.*`, resolvable via `resolveDataFormat(name)` and listed in `getDataFormatNames()`).

`DataFormatReifier.configureDataFormat()` already does this for the `marshal()`/`unmarshal()` DSL path (CAMEL-22352), but the component uses a different code path that was never updated.

## Fix

When the component creates a brand-new data format instance, it now harvests the auto-configured template's option values (via the same `ExtendedPropertyConfigurerGetter` mechanism the reifier uses) and binds them onto the new instance **before** binding the endpoint URI parameters — so URI parameters keep precedence over the global configuration. The shared template instance itself is never mutated.

The change is intentionally contained to `camel-dataformat`. `AbstractCamelContext.createDataFormat()` is deliberately left unchanged, since it must keep returning a clean instance for the reifier and other callers.

## Tests

Added `DataFormatComponentConfigTest` in `camel-csv` (mirroring the CAMEL-22352 `MainCsvTest`): a `Main`-based route using `to("dataformat:csv:unmarshal")` with `camel.dataformat.csv.ignore-surrounding-spaces=true` in `application.properties`. It asserts the global option is applied (surrounding spaces stripped) — this fails without the fix and passes with it. The existing `MainCsvTest` (reifier path) still passes.

## Docs

Added a `camel-dataformat` entry to the 4.21 upgrade guide describing the behavior alignment.

## Build

Full-reactor `mvn clean install -Dquickly` passes. No generated/catalog/DSL files changed (there is no `@UriParam` surface change).

---
_Claude Code on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
