### PR TITLE
CAMEL-23771: Java route dump should skip auto generated IDs

### DIFF
--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDumpDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDumpDevConsole.java
@@ -84,7 +84,7 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
                 } else if ("yaml".equals(format)) {
                     dump = mrb.dumpRouteAsYaml(true, "true".equals(uriAsParameters));
                 } else if ("java".equals(format)) {
-                    dump = mrb.dumpRouteAsJava(true);
+                    dump = mrb.dumpRouteAsJava(true, false);
                 }
             } catch (Exception e) {
                 // ignore
@@ -136,7 +136,7 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
                     dump = mrb.dumpRouteAsYaml(true, "true".equals(uriAsParameters), false, true);
                 } else if ("java".equals(format)) {
                     jo.put("format", "java");
-                    dump = mrb.dumpRouteAsJava(true);
+                    dump = mrb.dumpRouteAsJava(true, false);
                 }
                 if (dump != null) {
                     JsonArray code;

--- a/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedCamelContextMBean.java
+++ b/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedCamelContextMBean.java
@@ -263,6 +263,9 @@ public interface ManagedCamelContextMBean extends ManagedPerformanceCounterMBean
     @ManagedOperation(description = "Dumps the routes as Java DSL")
     String dumpRoutesAsJava(boolean resolvePlaceholders) throws Exception;
 
+    @ManagedOperation(description = "Dumps the routes as Java DSL")
+    String dumpRoutesAsJava(boolean resolvePlaceholders, boolean generatedIds) throws Exception;
+
     /**
      * Creates the endpoint by the given uri
      *

--- a/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedRouteMBean.java
+++ b/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedRouteMBean.java
@@ -161,6 +161,9 @@ public interface ManagedRouteMBean extends ManagedPerformanceCounterMBean {
     @ManagedOperation(description = "Dumps the route as Java DSL")
     String dumpRouteAsJava(boolean resolvePlaceholders) throws Exception;
 
+    @ManagedOperation(description = "Dumps the route as Java DSL")
+    String dumpRouteAsJava(boolean resolvePlaceholders, boolean generatedIds) throws Exception;
+
     @ManagedOperation(description = "Dumps the route stats as XML")
     String dumpRouteStatsAsXml(boolean fullStats, boolean includeProcessors) throws Exception;
 

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedCamelContext.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedCamelContext.java
@@ -642,6 +642,11 @@ public class ManagedCamelContext extends ManagedPerformanceCounter implements Ti
 
     @Override
     public String dumpRoutesAsJava(boolean resolvePlaceholders) throws Exception {
+        return dumpRoutesAsJava(resolvePlaceholders, true);
+    }
+
+    @Override
+    public String dumpRoutesAsJava(boolean resolvePlaceholders, boolean generatedIds) throws Exception {
         List<RouteDefinition> routes = context.getCamelContextExtension().getContextPlugin(Model.class).getRouteDefinitions();
         if (routes.isEmpty()) {
             return null;
@@ -650,7 +655,7 @@ public class ManagedCamelContext extends ManagedPerformanceCounter implements Ti
         RoutesDefinition def = new RoutesDefinition();
         def.setRoutes(routes);
 
-        return PluginHelper.getModelToJavaDumper(context).dumpModelAsJava(context, def, resolvePlaceholders, true);
+        return PluginHelper.getModelToJavaDumper(context).dumpModelAsJava(context, def, resolvePlaceholders, generatedIds);
     }
 
     @Override

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedRoute.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedRoute.java
@@ -501,10 +501,16 @@ public class ManagedRoute extends ManagedPerformanceCounter implements TimerList
 
     @Override
     public String dumpRouteAsJava(boolean resolvePlaceholders) throws Exception {
+        return dumpRouteAsJava(resolvePlaceholders, true);
+    }
+
+    @Override
+    public String dumpRouteAsJava(boolean resolvePlaceholders, boolean generatedIds) throws Exception {
         String id = route.getId();
         RouteDefinition def = context.getCamelContextExtension().getContextPlugin(Model.class).getRouteDefinition(id);
         if (def != null) {
-            return PluginHelper.getModelToJavaDumper(context).dumpModelAsJava(context, def, resolvePlaceholders, true);
+            return PluginHelper.getModelToJavaDumper(context).dumpModelAsJava(context, def, resolvePlaceholders,
+                    generatedIds);
         }
 
         return null;

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedFromRestGetTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedFromRestGetTest.java
@@ -76,8 +76,8 @@ public class ManagedFromRestGetTest extends ManagementTestSupport {
 
         String xml2 = (String) mbeanServer.invoke(on, "dumpRoutesAsXml", null, null);
         log.info(xml2);
-        // and we should have rest in the routes that indicate its from a rest dsl
-        assertTrue(xml2.contains("rest=\"true\""));
+        // rest/template/kamelet are @XmlTransient so not in XML dump
+        assertFalse(xml2.contains("rest=\"true\""));
 
         // routes are inlined
         assertFalse(xml2.matches("[\\S\\s]* <to id=\"to[0-9]+\" uri=\"direct:hello\"/>[\\S\\s]*"));

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedFromRestPlaceholderTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedFromRestPlaceholderTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -76,8 +77,8 @@ public class ManagedFromRestPlaceholderTest extends ManagementTestSupport {
 
         String xml2 = (String) mbeanServer.invoke(on, "dumpRoutesAsXml", null, null);
         log.info(xml2);
-        // and we should have rest in the routes that indicate its from a rest dsl
-        assertTrue(xml2.contains("rest=\"true\""));
+        // rest/template/kamelet are @XmlTransient so not in XML dump
+        assertFalse(xml2.contains("rest=\"true\""));
 
         // there should be 3 routes (inlined)
         assertEquals(3, context.getRouteDefinitions().size());


### PR DESCRIPTION
## Summary

- Adds `dumpRouteAsJava(boolean resolvePlaceholders, boolean generatedIds)` overload to `ManagedRouteMBean` and `ManagedCamelContextMBean`
- Updates `RouteDumpDevConsole` to pass `generatedIds=false` for Java format (matching XML/YAML behavior)
- Auto-generated node IDs like `.id("setBody1")` and `.id("log1")` are no longer included in Java DSL dump output
- Fixes two tests broken by CAMEL-23763 (`rest` attribute made `@XmlTransient` on `RouteDefinition`)

**Before:**
```java
from("timer:tick?period=1000")
    .routeId("timer-log")
    .setBody(simple("Hello Camel!"))
        .id("setBody1")
    .log("${body}")
        .id("log1");
```

**After:**
```java
from("timer:tick?period=1000")
    .routeId("timer-log")
    .setBody(simple("Hello Camel!"))
    .log("${body}");
```

## Test plan

- [x] `ManagedFromRestGetTest` and `ManagedFromRestPlaceholderTest` pass after updating assertions for `@XmlTransient` rest attribute
- [ ] `camel cmd route-dump --format=java` should not include auto-generated IDs
- [ ] TUI source viewer `J` key should show clean Java DSL without generated IDs
- [ ] User-assigned IDs (e.g., `.routeId("timer-log")`) are still included

_Claude Code on behalf of Claus Ibsen_