### PR TITLE
chore: add IntelliJ issue navigation for CAMEL tickets and fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,12 @@ target
 *.ipr
 *.iws
 .idea
+!.idea/vcs.xml
 .DS_Store
 .classpath
 .ekstazi
 .project
-.settings
+.settings/
 .checkstyle
 *.log
 test-salesforce-login.properties

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="CAMEL-(\d+)" />
+          <option name="linkRegexp" value="https://issues.apache.org/jira/projects/CAMEL/issues/CAMEL-$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
# Description

Add `.idea/vcs.xml` to configure IntelliJ IDEA issue navigation, linking the `CAMEL-\d+` pattern to the ASF JIRA project. This lets the IDE turn every `CAMEL-XXXX` reference in commit messages, code comments, and changelogs into a clickable link.

Also update `.gitignore` to:
- Add a negation rule (`!.idea/vcs.xml`) so the file is tracked despite the broad `.idea` exclusion.
- Fix the `.settings` entry to use a trailing slash (`.settings/`) so only the directory is excluded, not files that happen to start with `.settings`.

_Claude Code on behalf of Adriano Machado_

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.