### PR TITLE
CAMEL-23704: Use isolated exchange copy per tool in langchain4j-tools

### DIFF
--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsProducer.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsProducer.java
@@ -46,6 +46,7 @@ import org.apache.camel.TypeConverter;
 import org.apache.camel.component.langchain4j.tools.spec.CamelToolExecutorCache;
 import org.apache.camel.component.langchain4j.tools.spec.CamelToolSpecification;
 import org.apache.camel.support.DefaultProducer;
+import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,6 +120,8 @@ public class LangChain4jToolsProducer extends DefaultProducer {
             return null;
         }
 
+        final Exchange baseline = ExchangeHelper.createCopy(exchange, true);
+
         // First talk to the model to get the tools to be called
         int i = 0;
         do {
@@ -129,7 +132,7 @@ public class LangChain4jToolsProducer extends DefaultProducer {
             }
 
             // Only invoke the tools ... the response will be computed on the next loop
-            invokeTools(chatMessages, exchange, response, toolPair);
+            invokeTools(chatMessages, exchange, response, toolPair, baseline);
             LOG.debug("Finished iteration {}", i);
             i++;
         } while (true);
@@ -153,7 +156,8 @@ public class LangChain4jToolsProducer extends DefaultProducer {
     }
 
     private void invokeTools(
-            List<ChatMessage> chatMessages, Exchange exchange, Response<AiMessage> response, ToolPair toolPair) {
+            List<ChatMessage> chatMessages, Exchange exchange, Response<AiMessage> response, ToolPair toolPair,
+            Exchange baseline) {
         int i = 0;
         List<ToolExecutionRequest> toolExecutionRequests = response.content().toolExecutionRequests();
         for (ToolExecutionRequest toolExecutionRequest : toolExecutionRequests) {
@@ -167,12 +171,10 @@ public class LangChain4jToolsProducer extends DefaultProducer {
                 continue;
             }
 
-            // Reset route stop flag from previous tool invocation to prevent
-            // stop() EIP in one tool from short-circuiting subsequent tools
-            exchange.setRouteStop(false);
-
             final CamelToolSpecification camelToolSpecification = toolPair.callableTools().stream()
                     .filter(c -> c.getToolSpecification().name().equals(toolName)).findFirst().get();
+
+            final Exchange toolExchange = ExchangeHelper.createCopy(baseline, true);
 
             try {
                 TypeConverter typeConverter = endpoint.getCamelContext().getTypeConverter();
@@ -213,22 +215,24 @@ public class LangChain4jToolsProducer extends DefaultProducer {
                                 headerValue = value;
                             }
 
-                            exchange.getMessage().setHeader(name, headerValue);
+                            toolExchange.getMessage().setHeader(name, headerValue);
                         });
 
                 // Execute the consumer route
 
-                camelToolSpecification.getConsumer().getProcessor().process(exchange);
+                camelToolSpecification.getConsumer().getProcessor().process(toolExchange);
                 i++;
             } catch (Exception e) {
                 // How to handle this exception?
-                exchange.setException(e);
+                toolExchange.setException(e);
             }
+
+            ExchangeHelper.copyResults(exchange, toolExchange);
 
             chatMessages.add(new ToolExecutionResultMessage(
                     toolExecutionRequest.id(),
                     toolExecutionRequest.name(),
-                    exchange.getIn().getBody(String.class)));
+                    toolExchange.getIn().getBody(String.class)));
         }
 
         // Clear route stop flag after all tools so it does not leak

--- a/components/camel-ai/camel-langchain4j-tools/src/test/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolMultipleCallsTest.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/test/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolMultipleCallsTest.java
@@ -47,7 +47,7 @@ public class LangChain4jToolMultipleCallsTest extends CamelTestSupport {
             .build();
 
     private volatile boolean intermediateCalled = false;
-    private volatile boolean intermediateHasValidBody = false;
+    private volatile boolean intermediateIsolated = false;
 
     @Override
     protected void setupResources() throws Exception {
@@ -82,10 +82,15 @@ public class LangChain4jToolMultipleCallsTest extends CamelTestSupport {
                         .process(exchange -> {
                             String body = exchange.getIn().getBody(String.class);
                             intermediateCalled = true;
-                            if (exchange.getIn().getHeader("longitude", String.class).contains("0") &&
-                                    exchange.getIn().getHeader("latitude", String.class).contains("51") &&
-                                    body.contains("51.50758961965397") && body.contains("-0.13388057363742217")) {
-                                intermediateHasValidBody = true;
+                            // CAMEL-23704: the forecast tool must see its own argument headers but not
+                            // inherit the previous tool's 'name' header or output body (it receives the
+                            // original incoming chat messages)
+                            boolean ownHeaders = exchange.getIn().getHeader("longitude", String.class).contains("0")
+                                    && exchange.getIn().getHeader("latitude", String.class).contains("51");
+                            boolean noHeaderLeak = exchange.getIn().getHeader("name") == null;
+                            boolean originalBody = body != null && body.contains("meteorologist");
+                            if (ownHeaders && noHeaderLeak && originalBody) {
+                                intermediateIsolated = true;
                             }
                         })
                         .setBody(simple("""
@@ -135,6 +140,6 @@ public class LangChain4jToolMultipleCallsTest extends CamelTestSupport {
         // depending on the reasoning model used to test, the result is different, but we asked for Celcius degree and 3 should be part of it
         Assertions.assertThat(responseContent).containsIgnoringCase("3");
         Assertions.assertThat(intermediateCalled).isTrue();
-        Assertions.assertThat(intermediateHasValidBody).isTrue();
+        Assertions.assertThat(intermediateIsolated).isTrue();
     }
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -34,6 +34,18 @@ endpoint URI, which could leave the data format incompletely configured. This al
 `marshal()` / `unmarshal()` DSL, which already honors the global configuration. Options specified on the endpoint URI
 continue to take precedence over the global configuration.
 
+=== camel-langchain4j-tools
+
+When the LLM requests multiple tool invocations within a single request, each tool is now invoked on its
+own independent copy of the exchange (similar to the multicast/splitter patterns) instead of sharing a single
+exchange across all tools. This guarantees complete isolation: the message body, argument headers, and any
+exception produced by one tool no longer leak into subsequent tool invocations of the same request.
+
+As a consequence, a tool route no longer receives the previous tool's output as its message body, nor the
+previous tool's argument headers. Each tool route starts from the original incoming exchange and only sees
+its own declared arguments as headers. Routes that (intentionally or accidentally) relied on this leaked state
+between tools must be adjusted to carry such data explicitly.
+
 === camel-core
 
 ==== Simple language: internal builder classes reorganized


### PR DESCRIPTION
### CAMEL-23704

`LangChain4jToolsProducer.invokeTools()` reused a single `Exchange` across all tool invocations within a request. As a result, one tool's message body, accumulated argument headers, and exceptions leaked into subsequent tool invocations.

#### Changes
- Snapshot the original incoming exchange once (`toolsChat`) and reuse it as a clean **baseline** across all LLM iterations.
- Invoke each tool on its **own independent copy** of that baseline (`ExchangeHelper.createCopy`), mirroring the multicast/splitter isolation pattern.
- Copy each tool's outcome back onto the parent exchange with `ExchangeHelper.copyResults`, so the producer output still reflects the (last) tool's result body and declared argument headers — no accumulation across tools ("last tool wins").
- Exceptions are kept on the tool's own exchange and propagated to the parent without affecting sibling tools.

#### Behavior change
A tool route no longer receives the previous tool's output as its body, nor the previous tool's argument headers. Documented in the 4.21 upgrade guide.

#### Note on the test
`LangChain4jToolMultipleCallsTest` previously asserted that the second tool's body contained the first tool's output — i.e. it codified the exact leak this ticket reports (the loop and the test both landed in `050af78ca`). It has been updated to assert isolation: each tool sees its own argument headers, does **not** inherit the previous tool's `name` header, and receives the original incoming body.

#### Relation to CAMEL-21937
This change was rebased on top of CAMEL-21937 (*Reset route stop flag between tool invocations*). The per-tool exchange isolation introduced here subsumes the **per-iteration** `ROUTE_STOP` reset from that fix — since every tool now runs on its own copy of the baseline exchange, a `stop()` in one tool route can no longer reach sibling tools, so that per-iteration reset was removed as dead code. The **post-loop** `exchange.setRouteStop(false)` is **kept**, because `ExchangeHelper.copyResults` propagates the last tool's `routeStop` onto the parent exchange and it must not leak into the calling route. `LangChain4jToolStopEipTest` continues to pass.

#### Testing
`mvn test -pl components/camel-ai/camel-langchain4j-tools` — all green (39 tests, including `LangChain4jToolStopEipTest`).

_Reported by Claude Code on behalf of Karol Krawczyk_