### PR TITLE
CAMEL-23782: harden camel-leveldb aggregation-repository key deserialization with an ObjectInputFilter

### DIFF
--- a/components/camel-leveldb/src/main/java/org/apache/camel/component/leveldb/serializer/DefaultLevelDBSerializer.java
+++ b/components/camel-leveldb/src/main/java/org/apache/camel/component/leveldb/serializer/DefaultLevelDBSerializer.java
@@ -30,6 +30,12 @@ import org.apache.camel.util.ClassLoadingAwareObjectInputStream;
 
 public class DefaultLevelDBSerializer extends AbstractLevelDBSerializer {
 
+    // Keys are always serialized as a java.lang.String (see serializeKey). Restrict key deserialization
+    // to String only and apply JEP-290 graph-shape limits as defense-in-depth, consistent with the
+    // ObjectInputFilter applied on the exchange deserialization path.
+    private static final String KEY_DESERIALIZATION_FILTER
+            = "java.lang.String;maxdepth=2;maxrefs=100;maxbytes=1048576;!*";
+
     @Override
     public byte[] serializeKey(String key) throws IOException {
         try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -42,6 +48,7 @@ public class DefaultLevelDBSerializer extends AbstractLevelDBSerializer {
     @Override
     public String deserializeKey(byte[] buffer) throws IOException {
         try (final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(buffer))) {
+            ois.setObjectInputFilter(ObjectInputFilter.Config.createFilter(KEY_DESERIALIZATION_FILTER));
             return (String) ois.readObject();
         } catch (ClassNotFoundException e) {
             //this should not happen because serialized content should be String

--- a/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/DefaultLevelDBSerializerKeyFilterTest.java
+++ b/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/DefaultLevelDBSerializerKeyFilterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.leveldb;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectOutputStream;
+import java.util.HashMap;
+
+import org.apache.camel.component.leveldb.serializer.DefaultLevelDBSerializer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that {@link DefaultLevelDBSerializer#deserializeKey(byte[])} applies an ObjectInputFilter: legitimate String
+ * keys still round-trip, while a crafted non-String object graph is rejected (defense-in-depth for the aggregation
+ * repository key path).
+ */
+public class DefaultLevelDBSerializerKeyFilterTest {
+
+    private final DefaultLevelDBSerializer serializer = new DefaultLevelDBSerializer();
+
+    @Test
+    public void testStringKeyRoundTrip() throws IOException {
+        String key = "my-correlation-key-123";
+        byte[] bytes = serializer.serializeKey(key);
+        assertEquals(key, serializer.deserializeKey(bytes), "A String key must still deserialize correctly");
+    }
+
+    @Test
+    public void testNonStringKeyIsRejectedByFilter() throws IOException {
+        // A malicious actor could place a non-String (object-graph) payload where a key is expected.
+        byte[] payload;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            HashMap<String, String> notAKey = new HashMap<>();
+            notAKey.put("k", "v");
+            oos.writeObject(notAKey);
+            payload = baos.toByteArray();
+        }
+
+        // The ObjectInputFilter must reject any class other than java.lang.String.
+        assertThrows(InvalidClassException.class, () -> serializer.deserializeKey(payload),
+                "A non-String key payload must be rejected by the deserialization filter");
+    }
+}


### PR DESCRIPTION
This applies an `ObjectInputFilter` to the aggregation-repository **key** deserialization path in `DefaultLevelDBSerializer`, closing a defense-in-depth gap. The exchange path already installs a filter (via `deserializeExchange(..., deserializationFilter)`), but `deserializeKey(byte[])` read key bytes through a raw `ObjectInputStream` with no filter.

Keys are always serialized as a `java.lang.String` (`serializeKey(String)`), so the filter is scoped to `java.lang.String` plus JEP-290 graph-shape limits (`maxdepth`/`maxrefs`/`maxbytes`), consistent with the exchange-path filter style. Legitimate String keys still round-trip; any other (object-graph) payload is rejected.

## Changes
- `DefaultLevelDBSerializer.deserializeKey` installs a `String`-scoped `ObjectInputFilter`.
- New unit test `DefaultLevelDBSerializerKeyFilterTest` covering the String round-trip and rejection of a non-String payload.

## Notes
- No public API change; the `@Deprecated` `LevelDBSerializer` / `LevelDBCamelCodec` interfaces are untouched.
- Not a breaking change: the repository reads keys as plain UTF-8 strings (`LevelDBAggregationRepository.getKeys()`), so this hardens a latent sink reachable via the deprecated codec or custom serializer use — no upgrade-guide entry needed.
- Verified with the `camel-leveldb` module tests (78 passed) and a full `mvn clean install -DskipTests` reactor build (BUILD SUCCESS).

Jira: https://issues.apache.org/jira/browse/CAMEL-23782

_Claude Code on behalf of Andrea Cosentino_
