### PR TITLE
CAMEL-23762: camel-whatsapp - document webhookSecret option in 4.21/4.18/4.14 upgrade guides

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -56,6 +56,13 @@ in the other HTTP server components. Routes using `transferException=true` on th
 components must now also set `muteException=false` for the serialized exception to be
 returned in the response.
 
+=== camel-whatsapp
+
+The `camel-whatsapp` webhook consumer now supports optional verification of inbound webhook event
+callbacks via the new `webhookSecret` endpoint option. When set, event callbacks whose
+`X-Hub-Signature-256` HMAC-SHA256 signature is missing or invalid are rejected with HTTP 403; when
+the option is not set, behaviour is unchanged.
+
 === camel-core
 
 The `org.apache.camel.support.DefaultHeaderFilterStrategy` changed default setting for lowercase from `false` to `true`.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -67,6 +67,13 @@ Routes that attach a `KeycloakSecurityPolicy` without any roles or permissions a
 unverified or invalid token will now have such requests rejected with a `CamelAuthorizationException`. Provide a
 valid, verifiable token (or configure `requiredRoles` / `requiredPermissions`) for these routes.
 
+=== camel-whatsapp
+
+The `camel-whatsapp` webhook consumer now supports optional verification of inbound webhook event
+callbacks via the new `webhookSecret` endpoint option. When set, event callbacks whose
+`X-Hub-Signature-256` HMAC-SHA256 signature is missing or invalid are rejected with HTTP 403; when
+the option is not set, behaviour is unchanged.
+
 === camel-core
 
 The `org.apache.camel.support.DefaultHeaderFilterStrategy` changed default setting for lowercase from `false` to `true`.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -1102,6 +1102,13 @@ Maven repository (`build.shibboleth.net`) that has proven unreliable, causing in
 build failures. If your project depends on OpenSAML for SAML-based WS-Security, you will need to
 add the `org.opensaml` dependencies explicitly.
 
+=== camel-whatsapp
+
+The `camel-whatsapp` webhook consumer now supports optional verification of inbound webhook event
+callbacks via the new `webhookSecret` endpoint option. When set, event callbacks whose
+`X-Hub-Signature-256` HMAC-SHA256 signature is missing or invalid are rejected with HTTP 403; when
+the option is not set, behaviour is unchanged.
+
 === camel-lucene
 
 The Exchange header values exposed by `LuceneConstants` have been renamed to follow the standard


### PR DESCRIPTION
Documents the new opt-in `webhookSecret` option (X-Hub-Signature-256 verification) of `camel-whatsapp` in the version-specific upgrade guides on `main`.

## Context

The `webhookSecret` option ships on `main` (4.21.0, #24034) and is backported to:
- `camel-4.18.x` — #24084
- `camel-4.14.x` — #24086

Per the backport upgrade-guide policy, all version-specific `camel-4x-upgrade-guide-4_XX.adoc` files live on `main` and act as the canonical history. This PR adds a short `=== camel-whatsapp` note to:

- `camel-4x-upgrade-guide-4_21.adoc`
- `camel-4x-upgrade-guide-4_18.adoc`
- `camel-4x-upgrade-guide-4_14.adoc`

The note describes the new **opt-in** option (default behaviour unchanged): when set, inbound webhook event callbacks with a missing or invalid `X-Hub-Signature-256` signature are rejected with HTTP 403.

Docs-only change.

---
_Claude Code on behalf of Andrea Cosentino_