### PR TITLE
CAMEL-23754: Backport CustomJarsITCase fix to camel-4.18.x

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CustomJarsITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CustomJarsITCase.java
@@ -26,15 +26,16 @@ public class CustomJarsITCase extends JBangTestSupport {
 
     @Test
     public void testCustomJars() throws IOException {
-        copyResourceInDataFolder(TestResources.CIRCUIT_BREAKER);
+        copyResourceInDataFolder(TestResources.CUSTOM_JAR);
         Assertions
-                .assertThatCode(() -> execute(String.format("run %s/CircuitBreakerRoute.java --dep=camel-timer", mountPoint())))
+                .assertThatCode(() -> execute(
+                        String.format("run %s/CustomJar.java --max-seconds=30", mountPoint())))
                 .as("the application without dependency will cause error")
-                .hasStackTraceContaining("Failed to create route: circuitBreaker")
-                .hasStackTraceContaining(
-                        "Cannot find camel-resilience4j or camel-microprofile-fault-tolerance on the classpath.");
-        executeBackground(String.format("run %s/CircuitBreakerRoute.java --dep=camel-timer,camel-resilience4j", mountPoint()));
-        checkLogContains("timer called");
-        checkLogContains("Fallback message", 10);
+                .hasStackTraceContaining("Compilation error");
+
+        executeBackground(
+                String.format("run %s/CustomJar.java --dep=org.apache.commons:commons-text:1.15.0", mountPoint()));
+
+        checkLogContains("Random password");
     }
 }

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -104,6 +104,7 @@ public abstract class JBangTestSupport {
         DIR_ROUTE("FromDirectoryRoute.java", "/jbang/it/from-source-dir/FromDirectoryRoute.java"),
         SERVER_ROUTE("server.yaml", "/jbang/it/server.yaml"),
         CIRCUIT_BREAKER("CircuitBreakerRoute.java", "/jbang/it/CircuitBreakerRoute.java"),
+        CUSTOM_JAR("CustomJar.java", "/jbang/it/CustomJar.java"),
         SRC_MAPPING_DATA("data.json", "/jbang/it/data-mapping/src/data.json"),
         SRC_MAPPING_TEMPLATE("transform.yaml", "/jbang/it/data-mapping/src/transform.yaml"),
         COMP_MAPPING_DATA("data.xml", "/jbang/it/data-mapping/components/data.xml"),

--- a/dsl/camel-jbang/camel-jbang-it/src/test/resources/jbang/it/CustomJar.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/resources/jbang/it/CustomJar.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+
+import org.apache.commons.text.RandomStringGenerator;
+
+public class CustomJar extends RouteBuilder {
+    @Override
+    public void configure() {
+        from("timer:x?repeatCount=1")
+                .log("timer called")
+                .process(new Processor() {
+                    @Override
+                    public void process(Exchange exchange) throws Exception {
+                        RandomStringGenerator alphanumeric = RandomStringGenerator.builder()
+                                .withinRange('0', '9')
+                                .withinRange('A', 'Z')
+                                .withinRange('a', 'z')
+                                .build();
+                        exchange.getMessage().setBody(alphanumeric.generate(8));
+                    }
+                })
+                .log("Random password: ${body}");
+    }
+}


### PR DESCRIPTION
# Description

This PR fixes `CustomJarsITCase` on the `camel-4.18.x` branch.

The current implementation of `CustomJarsITCase` uses `CircuitBreakerRoute.java` and verifies that running the route without the required dependency fails with an expected error. The test expects route startup to fail with:

* `Failed to create route: circuitBreaker`
* `Cannot find camel-resilience4j or camel-microprofile-fault-tolerance on the classpath`

However, according to the Jenkins failures reported in CAMEL-23754, the route starts successfully and reaches route execution, causing the assertions to fail. The test has failed on the last 27 Jenkins CI builds reported in CAMEL-23754.

The changes in this PR are based on the implementation introduced on the `main` branch as part of CAMEL-23104.

## Investigation

While investigating the issue, I compared the `camel-4.18.x` implementation with the current implementation on the `main` branch.

I found that under CAMEL-23104, the original CircuitBreaker-based test was replaced on `main` because the previous approach was failing locally. Instead of relying on CircuitBreaker dependency resolution behavior, the test was redesigned to verify custom dependency loading directly using a dedicated `CustomJar.java` route.

The new approach validates two scenarios:

1. Running a route that depends on an external library without providing the dependency results in a compilation failure.
2. Running the same route with the required dependency succeeds and executes correctly.

This provides a more direct validation of custom dependency loading and avoids relying on CircuitBreaker-specific startup behavior.

## Changes

Backport the `main` branch implementation of `CustomJarsITCase` to `camel-4.18.x` by:

* Replacing the CircuitBreaker-based test with the CustomJar-based test.
* Adding `CustomJar.java` as a test resource.
* Adding the `CUSTOM_JAR` test resource entry to `JBangTestSupport`.

The updated test verifies that:

* Execution fails with a compilation error when the required external dependency is missing.
* Execution succeeds when `org.apache.commons:commons-text` is provided.
* The route runs successfully and produces the expected output.

This aligns the `camel-4.18.x` implementation with the version currently used on the `main` branch and is intended to address the failing test reported in CAMEL-23754.

# Target

* [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)
* [x] I checked that the commit is targeting the correct maintenance branch (`camel-4.18.x`)

# Tracking

* [x] I checked there is a JIRA issue filed for the change: CAMEL-23754

# Apache Camel coding standards and style

* [x] I checked that each commit in the pull request has a meaningful subject line and body.

* [ ] I have run `mvn clean install -DskipTests` locally from the root folder and committed all auto-generated changes.
