### PR TITLE
CAMEL-23783: harden camel-schematron rules TransformerFactory against XXE (backport to 4.18.x)

### DIFF
--- a/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/SchematronEndpoint.java
+++ b/components/camel-schematron/src/main/java/org/apache/camel/component/schematron/SchematronEndpoint.java
@@ -20,7 +20,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.Templates;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.URIResolver;
 
@@ -167,7 +169,7 @@ public class SchematronEndpoint extends DefaultEndpoint {
         }
     }
 
-    private void createTransformerFactory() throws ClassNotFoundException {
+    private void createTransformerFactory() throws ClassNotFoundException, TransformerConfigurationException {
         // provide the class loader of this component to work in OSGi environments
         Class<TransformerFactory> factoryClass
                 = getCamelContext().getClassResolver().resolveMandatoryClass(SAXON_TRANSFORMER_FACTORY_CLASS_NAME,
@@ -175,6 +177,12 @@ public class SchematronEndpoint extends DefaultEndpoint {
 
         LOG.debug("Using TransformerFactoryClass {}", factoryClass);
         transformerFactory = getCamelContext().getInjector().newInstance(factoryClass);
+        // Harden the rules-compilation factory against XXE / external resource access, consistent with the
+        // SAXParserFactory hardening in SchematronProcessorFactory. The ISO skeleton stylesheets are resolved
+        // from the classpath via the URIResolver set below, so legitimate rule compilation is unaffected.
+        transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         transformerFactory.setURIResolver(new ClassPathURIResolver(Constants.SCHEMATRON_TEMPLATES_ROOT_DIR, this.uriResolver));
         transformerFactory.setAttribute(LINE_NUMBERING, true);
     }

--- a/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/SchematronTransformerFactoryHardeningTest.java
+++ b/components/camel-schematron/src/test/java/org/apache/camel/component/schematron/SchematronTransformerFactoryHardeningTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.schematron;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that the schematron rules-compilation {@code TransformerFactory} is hardened. Resolving a schematron
+ * endpoint compiles its rules, so these tests assert on endpoint resolution: legitimate rules (whose ISO skeleton
+ * stylesheets resolve from the classpath via the URIResolver) still compile, while rules referencing an external entity
+ * are refused rather than having the entity resolved.
+ */
+public class SchematronTransformerFactoryHardeningTest {
+
+    @Test
+    void legitimateRulesStillCompileWithHardenedFactory() throws Exception {
+        try (CamelContext ctx = new DefaultCamelContext()) {
+            ctx.start();
+            assertDoesNotThrow(
+                    () -> ctx.getEndpoint("schematron:sch/schematron-1.sch", SchematronEndpoint.class),
+                    "Legitimate schematron rules must still compile after enabling secure processing");
+        }
+    }
+
+    @Test
+    void externalEntityInRulesIsNotResolved() throws Exception {
+        try (CamelContext ctx = new DefaultCamelContext()) {
+            ctx.start();
+            // Without the hardening this rules file compiles (the external entity is expanded into the assert text);
+            // with FEATURE_SECURE_PROCESSING + accessExternalDTD="" the parser refuses the entity, so compilation
+            // (triggered on endpoint resolution) must fail instead of resolving it.
+            assertThrows(Exception.class,
+                    () -> ctx.getEndpoint("schematron:sch/schematron-xxe.sch", SchematronEndpoint.class),
+                    "Schematron rules referencing an external entity must fail rather than resolve the entity");
+        }
+    }
+}

--- a/components/camel-schematron/src/test/resources/sch/schematron-xxe.sch
+++ b/components/camel-schematron/src/test/resources/sch/schematron-xxe.sch
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE sch:schema [
+  <!ENTITY xxe SYSTEM "file:///etc/hostname">
+]>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+    <sch:pattern>
+        <sch:rule context="/">
+            <sch:assert test="true()">&xxe;</sch:assert>
+        </sch:rule>
+    </sch:pattern>
+</sch:schema>


### PR DESCRIPTION
Backport of CAMEL-23783 to the `camel-4.18.x` maintenance branch (main PR: apache/camel#24105).

Hardens the Schematron rules-compilation `TransformerFactory` against XXE / external-resource resolution: `SchematronEndpoint.createTransformerFactory()` now enables `FEATURE_SECURE_PROCESSING` and sets `accessExternalDTD` / `accessExternalStylesheet` to empty, matching the already-hardened `SchematronProcessorFactory` (`SAXParserFactory`) on this branch. The bundled ISO skeleton stylesheets resolve from the classpath via the existing `ClassPathURIResolver`, so legitimate rule compilation is unaffected.

## Changes
- `createTransformerFactory()` hardening (clean cherry-pick of the main commit).
- New `SchematronTransformerFactoryHardeningTest`: legitimate rules still compile; external-entity rules are refused.

## Notes
- **Potential breaking change** for Schematron rules that intentionally reference external DTDs/entities/stylesheets (the XXE vector); inline the content instead. The upgrade-guide entry lives on `main` (#24105), per the project's backport-docs convention.
- `camel-schematron` module tests pass (14) on this branch.

Jira: https://issues.apache.org/jira/browse/CAMEL-23783

_Claude Code on behalf of Andrea Cosentino_
